### PR TITLE
Adding implicit try-expr to throwing main

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1952,14 +1952,14 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
 
   if (mainFunction->hasThrows()) {
     auto *tryExpr = new (context) TryExpr(
-        SourceLoc(), callExpr, context.TheEmptyTupleType, /*implicit=*/true);
+        callExpr->getLoc(), callExpr, context.TheEmptyTupleType, /*implicit=*/true);
     returnedExpr = tryExpr;
   } else {
     returnedExpr = callExpr;
   }
 
   auto *returnStmt =
-      new (context) ReturnStmt(SourceLoc(), callExpr, /*Implicit=*/true);
+      new (context) ReturnStmt(SourceLoc(), returnedExpr, /*Implicit=*/true);
 
   SmallVector<ASTNode, 1> stmts;
   stmts.push_back(returnStmt);

--- a/test/attr/ApplicationMain/attr_main_throws.swift
+++ b/test/attr/ApplicationMain/attr_main_throws.swift
@@ -1,8 +1,16 @@
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend -dump-ast -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-AST
 
 @main
 struct MyBase {
-  static func main() throws { 
+  static func main() throws {
   }
 }
 
+// CHECK-AST: (func_decl implicit "$main()" interface type='(MyBase.Type) -> () throws -> ()' access=internal type
+// CHECK-AST-NEXT:  (parameter "self")
+// CHECK-AST-NEXT:  (parameter_list)
+// CHECK-AST-NEXT:  (brace_stmt implicit
+// CHECK-AST-NEXT:    (return_stmt implicit
+// CHECK-AST-NEXT:      (try_expr implicit
+// CHECK-AST-NEXT:        (call_expr implicit type='()'


### PR DESCRIPTION
Synthesizing the body of a throwing main didn't take into account the
implicit try. We were creating one, then just leaving it off. This patch
actually passes the modified AST branch through to the emitted return
statement, rather than just keeping the call.

As a separate note, I hit an assert saying that a source range must
either be completely invalid or completely valid when just passing the
invalid SourceLoc to the TryExpr. I've changed it to just take the
SourceLoc from the implicit CallExpr, which should be the same as the
invalid SourceLoc, but seems to inherit it from another place.