### PR TITLE
[AutoDiff] NFC: document test suite.

### DIFF
--- a/test/AutoDiff/README.md
+++ b/test/AutoDiff/README.md
@@ -1,0 +1,6 @@
+# Differentiable Programming Test Suite
+
+This directory tests differentiable programming in Swift, described in
+`docs/DifferentiableProgramming.md`.
+
+Tests are categorized in subdirectories mimicking the directories in `test/`.

--- a/test/AutoDiff/compiler_crashers/README.md
+++ b/test/AutoDiff/compiler_crashers/README.md
@@ -1,0 +1,5 @@
+This directory tests compiler crashers related to differentiable programming in
+Swift.
+
+`lit.local.cfg` checks for `asserts` as a `lit` available feature, so there is
+no need to add `REQUIRES: asserts` to individual test files.

--- a/test/AutoDiff/compiler_crashers/lit.local.cfg
+++ b/test/AutoDiff/compiler_crashers/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'asserts' not in config.available_features:
+    config.unsupported = True

--- a/test/AutoDiff/compiler_crashers/sr13866-library-evolution-mode-tbdgen-crasher-protocool-requirement.swift
+++ b/test/AutoDiff/compiler_crashers/sr13866-library-evolution-mode-tbdgen-crasher-protocool-requirement.swift
@@ -1,5 +1,4 @@
 // RUN: not --crash %target-swift-frontend -c -enable-library-evolution %s
-// REQUIRES: asserts
 
 // SR-13866: TBDGen crasher on protocol with differentiable requirement
 

--- a/test/AutoDiff/compiler_crashers/tf1181-apply-opened-opened-existential-argument.swift
+++ b/test/AutoDiff/compiler_crashers/tf1181-apply-opened-opened-existential-argument.swift
@@ -1,5 +1,4 @@
 // RUN: not --crash %target-swift-frontend -disable-availability-checking -emit-sil -verify %s
-// REQUIRES: asserts
 
 // TF-1181: Differentiation transform crash for `apply` with opened existential arguments.
 

--- a/test/AutoDiff/compiler_crashers_fixed/README.md
+++ b/test/AutoDiff/compiler_crashers_fixed/README.md
@@ -1,0 +1,5 @@
+This directory tests fixed compiler crashers related to differentiable
+programming in Swift.
+
+`lit.local.cfg` checks for `asserts` as a `lit` available feature, so there is
+no need to add `REQUIRES: asserts` to individual test files.

--- a/test/AutoDiff/compiler_crashers_fixed/lit.local.cfg
+++ b/test/AutoDiff/compiler_crashers_fixed/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'asserts' not in config.available_features:
+    config.unsupported = True

--- a/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar71319547-generated-decls-shall-not-be-resilient.swift
@@ -6,7 +6,6 @@
 
 import _Differentiation
 
-
 // Assertion failed: (mainPullbackStruct->getType() == pbStructLoweredType), function run, file swift/lib/SILOptimizer/Differentiation/PullbackCloner.cpp, line 1899.
 // Stack dump:
 // 1.	Swift version 5.3-dev (LLVM 618cb952e0f199a, Swift d74c261f098665c)
@@ -19,7 +18,6 @@ import _Differentiation
 public func i_have_a_pullback_struct(_ x: Float) -> Float {
   return x
 }
-
 
 // Assertion failed: (v->getType().isObject()), function operator(), file swift/lib/SIL/Utils/ValueUtils.cpp, line 22.
 // Stack dump:

--- a/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -enable-resilience -emit-sil -verify %s
-// REQUIRES: asserts
 
 // SR-12641: SILGen verification error regarding `ImmutableAddressUseVerifier` and AutoDiff-generated code.
 

--- a/test/AutoDiff/compiler_crashers_fixed/sr12642-differentiable-derivation-redeclared-property.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12642-differentiable-derivation-redeclared-property.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
-// REQUIRES: asserts
 
 // SR-12642: Crash regarding `Differentiable` derived conformances and
 // redeclared properties. This crash surfaced only briefly during the

--- a/test/AutoDiff/compiler_crashers_fixed/sr12656-differentiation-opaque-result-type.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12656-differentiation-opaque-result-type.swift
@@ -1,5 +1,4 @@
 // RUN: not %target-swift-frontend -disable-availability-checking -emit-sil -verify %s
-// REQUIRES: asserts
 
 // SR-12656: Differentiation transform crashes for original function with opaque
 // result type.

--- a/test/AutoDiff/compiler_crashers_fixed/sr12732-optimize-partial-apply-convention-thin-only.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12732-optimize-partial-apply-convention-thin-only.swift
@@ -1,5 +1,4 @@
 // RUN: %target-build-swift -Osize %s
-// REQUIRES: asserts
 
 // SR-12732: Fix `partial_apply` optimization.
 

--- a/test/AutoDiff/compiler_crashers_fixed/sr13305-noderivative-inout-parameter.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr13305-noderivative-inout-parameter.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
-// REQUIRES: asserts
 
 import _Differentiation
 

--- a/test/AutoDiff/compiler_crashers_fixed/sr13411-tangent-value-category-mismatch.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr13411-tangent-value-category-mismatch.swift
@@ -1,5 +1,4 @@
 // RUN: %target-build-swift %s
-// REQUIRES: asserts
 
 // SR-13411: Semantic member getter pullback generation crash due to tangent value category mismatch
 
@@ -9,4 +8,3 @@ struct Dense: Differentiable {
   @differentiable
   var bias: Float?
 }
-

--- a/test/AutoDiff/compiler_crashers_fixed/sr13865-library-evolution-mode-crasher-property-differentiation.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr13865-library-evolution-mode-crasher-property-differentiation.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -c -enable-library-evolution %s
-// REQUIRES: asserts
 
 // SR-13865: AutoDiff crasher on property derivatives in library evolution mode.
 

--- a/test/AutoDiff/compiler_crashers_fixed/sr13933-vjpcloner-apply-multiple-consuming-users.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr13933-vjpcloner-apply-multiple-consuming-users.swift
@@ -1,5 +1,4 @@
 // RUN: %target-build-swift %s
-// REQUIRES: asserts
 
 // SR-13933: Fix "multiple consuming users" ownership error caused by
 // `VJPCloner::visitApply` related to `@differentiable`-function-typed callees.

--- a/test/AutoDiff/compiler_crashers_fixed/tf1160-derivative-usable-from-inline-mismatch.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1160-derivative-usable-from-inline-mismatch.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -c %s -verify
-// REQUIRES: asserts
 
 // TF-1160: Linker error for `@usableFromInline` derivative function but
 // non-`@usableFromInline` internal original function.

--- a/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1167-differentiable-attr-override-match.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
-// REQUIRES: asserts
 
 // TF-1167: `OverrideMatcher::match` crash due to meaningless assertion:
 // `assert(false)`. The assertion was triggered when parameter indices

--- a/test/AutoDiff/compiler_crashers_fixed/tf1232-autodiff-generated-declaration-mangling.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1232-autodiff-generated-declaration-mangling.swift
@@ -1,5 +1,4 @@
 // RUN: %target-build-swift -g %s
-// REQUIRES: asserts
 
 // TF-1232: IRGenDebugInfo crash due to lack of proper mangling for
 // AutoDiff-generated declarations: linear map structs and branching trace

--- a/test/AutoDiff/compiler_crashers_fixed/tf1315-pullback-subset-parameter-thunk-generation.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/tf1315-pullback-subset-parameter-thunk-generation.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil %s
-// REQUIRES: asserts
 
 // TF-1315: Pullback subset thunk generation crash due to unmapped parameter
 // index for `inout` differentiability parameters.


### PR DESCRIPTION
Add README files explaining the differentiable programming test suite.

Add `lit.local.cfg` files so individual tests do not need to add
`REQUIRES: asserts` in these directories:

- `test/AutoDiff/compiler_crashers`
- `test/AutoDiff/compiler_crashers_fixed`

---

Motivation: it is important for `compiler_crashers` and `compiler_crashers_fixed` tests to require assertions enabled, because many of these tests crash on compiler assertions.