### PR TITLE
[cxx-interop] Fix forward declared nested structs. 

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3374,6 +3374,11 @@ namespace {
         }
 
         if (isa<TypeDecl>(member)) {
+          // Only import definitions. Otherwise, we might add the same member
+          // twice.
+          if (auto tagDecl = dyn_cast<clang::TagDecl>(nd))
+            if (tagDecl->getDefinition() != tagDecl)
+              continue;
           // A struct nested inside another struct will either be logically
           // a sibling of the outer struct, or contained inside of it, depending
           // on if it has a declaration name or not.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3539,7 +3539,7 @@ namespace {
           decl->needsImplicitDefaultConstructor()) {
         clang::CXXConstructorDecl *ctor =
             clangSema.DeclareImplicitDefaultConstructor(
-                const_cast<clang::CXXRecordDecl *>(decl));
+                const_cast<clang::CXXRecordDecl *>(decl->getDefinition()));
         if (!ctor->isDeleted())
           clangSema.DefineImplicitDefaultConstructor(clang::SourceLocation(),
                                                      ctor);

--- a/test/Interop/Cxx/class/Inputs/nested-records.h
+++ b/test/Interop/Cxx/class/Inputs/nested-records.h
@@ -45,6 +45,12 @@ struct S10 {
   };
 };
 
+struct HasForwardDeclaredNestedType {
+  struct ForwardDeclaredType;
+  struct NormalSubType { };
+  struct ForwardDeclaredType { };
+};
+
 // TODO: Nested class templates (SR-13853).
 
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_NESTED_RECORDS_H

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -55,3 +55,10 @@
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
+
+// CHECK: struct HasForwardDeclaredNestedType {
+// CHECK:   struct NormalSubType {
+// CHECK:   }
+// CHECK:   struct ForwardDeclaredType {
+// CHECK:   }
+// CHECK: }

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -58,7 +58,10 @@
 
 // CHECK: struct HasForwardDeclaredNestedType {
 // CHECK:   struct NormalSubType {
+// CHECK:     init()
 // CHECK:   }
 // CHECK:   struct ForwardDeclaredType {
+// CHECK:     init()
 // CHECK:   }
+// CHECK:   init()
 // CHECK: }


### PR DESCRIPTION
First, this actually fixes an assertion for forward declared nested structs (where the forward declared child would be added to the parent twice). Second, it fixes a separate issue where the forward declared struct would get the implicit ctor instead of the def. 