### PR TITLE
[sil-combine] Update RefToRawPointer simplifications for ossa.

### DIFF
--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -544,21 +544,6 @@ bb0(%0 : $@thin U.Type, %1 : $C):
   return %6 : $(U, U, U)
 }
 
-// RefToRawPointer pointer consumption.
-//
-// (ref_to_raw_pointer (unchecked_ref_cast x))
-//    -> (ref_to_raw_pointer x)
-// CHECK-LABEL: sil @ref_to_raw_pointer_unchecked_ref_cast_composition : $@convention(thin) (C) -> Builtin.RawPointer
-// CHECK: bb0
-// CHECK-NEXT: ref_to_raw_pointer
-// CHECK-NEXT: return
-sil @ref_to_raw_pointer_unchecked_ref_cast_composition : $@convention(thin) (C) -> Builtin.RawPointer {
-bb0(%0 : $C):
-  %1 = unchecked_ref_cast %0 : $C to $Builtin.NativeObject
-  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
-  return %2 : $Builtin.RawPointer
-}
-
 // CHECK-LABEL: sil @downcast_upcast_roundtrip
 // CHECK: bb0
 // CHECK-NEXT: return
@@ -2342,30 +2327,11 @@ bb0(%0: $MyClass):
   return %3 : $Builtin.NativeObject
 }
 
-// CHECK-LABEL: sil @collapse_existential_pack_unpack_ref_to_raw_pointer
-// CHECK:       bb0([[Ref:%.*]]: $MyClass):
-// CHECK-NOT:     init_existential_ref
-// CHECK-NOT:     open_existential_ref
-// CHECK:         ref_to_raw_pointer [[Ref]]
-
-sil @collapse_existential_pack_unpack_ref_to_raw_pointer : $@convention(thin) (MyClass) -> () {
-bb0(%0: $MyClass):
-  %1 = init_existential_ref %0 : $MyClass : $MyClass, $AnyObject
-  %2 = open_existential_ref %1 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
-  %3 = ref_to_raw_pointer %2 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject to $Builtin.RawPointer
-  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Builtin.Word
-  %5 = integer_literal $Builtin.Word, 5
-  store %5 to %4: $*Builtin.Word
-  %6 = tuple ()
-  return %6 : $()
-}
-
 // CHECK-LABEL: sil @load_fixlifetime_address
 // CHECK:          [[Stck:%.*]] = alloc_stack
 // CHECK-NOT:                     fix_lifetime [[Stck]]#1
 // CHECK:       [[StckVal:%.*]] = load [[Stck]]
 // CHECK:                         fix_lifetime [[StckVal]]
-
 sil @load_fixlifetime_address : $@convention(thin) (Builtin.NativeObject) -> () {
 bb0(%0: $Builtin.NativeObject):
   %1 = alloc_stack $Builtin.NativeObject
@@ -2376,20 +2342,6 @@ bb0(%0: $Builtin.NativeObject):
   return %6 : $()
 }
 
-// CHECK-LABEL:     sil @collapse_to_unchecked_trivial_bit_cast
-// CHECK:           bb0([[Ref:%.*]]: $Optional<MyClass>):
-// CHECK:             unchecked_trivial_bit_cast [[Ref]]
-// CHECK-NOT:         unchecked_ref_cast
-// CHECK-NOT:         ref_to_raw_pointer
-// CHECK:             return
-// (ref_to_raw_pointer (unchecked_ref_cast x)) -> (unchecked_trivial_bit_cast x)
-sil @collapse_to_unchecked_trivial_bit_cast : $@convention(thin) (Optional<MyClass>) -> (Builtin.RawPointer) {
-bb0(%0 : $Optional<MyClass>):
-  %1 = unchecked_ref_cast %0 : $Optional<MyClass> to $Builtin.NativeObject
-  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
-  return %2 : $Builtin.RawPointer
-}
-
 struct GenContainer<T> {
 }
 
@@ -2398,12 +2350,11 @@ bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*GenContai
   unreachable
 }
 
-
-// CHECK-LABEL:   sil @remove_dead_code_after_cond_fail
+// CHECK-LABEL:   sil @remove_dead_code_after_cond_fail :
 // CHECK:           [[Ref:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK-NEXT:      cond_fail [[Ref]]
 // CHECK-NEXT:      unreachable
-
+// CHECK: } // end sil function 'remove_dead_code_after_cond_fail'
 sil @remove_dead_code_after_cond_fail : $@convention(thin) () -> (Int32) {
 bb0:
   %0 = integer_literal $Builtin.Int32, -2

--- a/test/SILOptimizer/sil_combine_casts.sil
+++ b/test/SILOptimizer/sil_combine_casts.sil
@@ -3,10 +3,13 @@
 sil_stage canonical
 
 import Builtin
+import Swift
 
 class Klass {}
 
 sil @returnInt : $@convention(thin) () -> Builtin.Int32
+sil @use_anyobject : $@convention(thin) (@guaranteed AnyObject) -> ()
+sil @use_nativeobject : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 
 // CHECK-LABEL: sil @optimize_convert_escape_to_noescape :
 // CHECK: [[FN:%.*]] = function_ref @returnInt
@@ -37,3 +40,164 @@ bb0:
   %4 = apply %2() : $@noescape @callee_guaranteed () -> Builtin.Int32
   return %4 : $Builtin.Int32
 }
+
+//////////////////////////////
+// ref_to_raw_pointer tests //
+//////////////////////////////
+
+// RefToRawPointer pointer consumption.
+//
+// (ref_to_raw_pointer (unchecked_ref_cast x))
+//    -> (ref_to_raw_pointer x)
+//
+// CHECK-LABEL: sil @ref_to_raw_pointer_unchecked_ref_cast_composition : $@convention(thin) (@guaranteed Klass) -> Builtin.RawPointer
+// CHECK: bb0
+// CHECK-NEXT: ref_to_raw_pointer
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'ref_to_raw_pointer_unchecked_ref_cast_composition'
+sil @ref_to_raw_pointer_unchecked_ref_cast_composition : $@convention(thin) (@guaranteed Klass) -> Builtin.RawPointer {
+bb0(%0 : $Klass):
+  %1 = unchecked_ref_cast %0 : $Klass to $Builtin.NativeObject
+  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil [ossa] @ref_to_raw_pointer_unchecked_ref_cast_composition_ossa_guaranteed : $@convention(thin) (@guaranteed Klass) -> Builtin.RawPointer
+// CHECK: bb0
+// CHECK-NEXT: ref_to_raw_pointer
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'ref_to_raw_pointer_unchecked_ref_cast_composition_ossa_guaranteed'
+sil [ossa] @ref_to_raw_pointer_unchecked_ref_cast_composition_ossa_guaranteed : $@convention(thin) (@guaranteed Klass) -> Builtin.RawPointer {
+bb0(%0 : @guaranteed $Klass):
+  %1 = unchecked_ref_cast %0 : $Klass to $Builtin.NativeObject
+  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil [ossa] @ref_to_raw_pointer_unchecked_ref_cast_composition_ossa_owned : $@convention(thin) (@owned Klass) -> Builtin.RawPointer
+// CHECK: bb0([[ARG:%.*]] : @owned
+// CHECK-NEXT: [[RESULT:%.*]] = ref_to_raw_pointer [[ARG]]
+// CHECK-NEXT: [[CAST:%.*]] = unchecked_ref_cast [[ARG]]
+// CHECK-NEXT: destroy_value [[CAST]]
+// CHECK-NEXT: return [[RESULT]]
+// CHECK: } // end sil function 'ref_to_raw_pointer_unchecked_ref_cast_composition_ossa_owned'
+sil [ossa] @ref_to_raw_pointer_unchecked_ref_cast_composition_ossa_owned : $@convention(thin) (@owned Klass) -> Builtin.RawPointer {
+bb0(%0 : @owned $Klass):
+  %1 = unchecked_ref_cast %0 : $Klass to $Builtin.NativeObject
+  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
+  destroy_value %1 : $Builtin.NativeObject
+  return %2 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: sil @collapse_existential_pack_unpack_ref_to_raw_pointer :
+// CHECK:       bb0([[Ref:%.*]] : $Klass):
+// CHECK-NOT:     init_existential_ref
+// CHECK-NOT:     open_existential_ref
+// CHECK:         ref_to_raw_pointer [[Ref]]
+// CHECK: } // end sil function 'collapse_existential_pack_unpack_ref_to_raw_pointer'
+sil @collapse_existential_pack_unpack_ref_to_raw_pointer : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : $Klass):
+  %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
+  %2 = open_existential_ref %1 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %3 = ref_to_raw_pointer %2 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Builtin.Word
+  %5 = integer_literal $Builtin.Word, 5
+  store %5 to %4: $*Builtin.Word
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @collapse_existential_pack_unpack_ref_to_raw_pointer_ossa_guaranteed :
+// CHECK:       bb0([[Ref:%.*]] : @guaranteed $Klass):
+// CHECK-NOT:     init_existential_ref
+// CHECK-NOT:     open_existential_ref
+// CHECK:         ref_to_raw_pointer [[Ref]]
+// CHECK: } // end sil function 'collapse_existential_pack_unpack_ref_to_raw_pointer_ossa_guaranteed'
+sil [ossa] @collapse_existential_pack_unpack_ref_to_raw_pointer_ossa_guaranteed : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
+  %2 = open_existential_ref %1 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %3 = ref_to_raw_pointer %2 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Builtin.Word
+  %5 = integer_literal $Builtin.Word, 5
+  store %5 to [trivial] %4: $*Builtin.Word
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// We need to hoist the ref_to_raw_pointer above the init_existential_ref since
+// that is where %0 is live.
+//
+// CHECK-LABEL: sil [ossa] @collapse_existential_pack_unpack_ref_to_raw_pointer_ossa_owned :
+// CHECK:       bb0([[ARG:%.*]] : @owned $Klass):
+// CHECK-NOT:     init_existential_ref
+// CHECK-NOT:     open_existential_ref
+// CHECK:         [[PTR:%.*]] = ref_to_raw_pointer [[ARG]]
+// CHECK:         [[FORWARDED_ARG:%.*]] = init_existential_ref [[ARG]]
+// CHECK:         destroy_value [[FORWARDED_ARG]]
+// CHECK: } // end sil function 'collapse_existential_pack_unpack_ref_to_raw_pointer_ossa_owned'
+sil [ossa] @collapse_existential_pack_unpack_ref_to_raw_pointer_ossa_owned : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
+  %f = function_ref @use_anyobject : $@convention(thin) (@guaranteed AnyObject) -> ()
+  apply %f(%1) : $@convention(thin) (@guaranteed AnyObject) -> ()
+  %2 = open_existential_ref %1 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %3 = ref_to_raw_pointer %2 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject to $Builtin.RawPointer
+  %4 = pointer_to_address %3 : $Builtin.RawPointer to [strict] $*Builtin.Word
+  %5 = integer_literal $Builtin.Word, 5
+  store %5 to [trivial] %4: $*Builtin.Word
+  destroy_value %2 : $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
+  %6 = tuple ()
+  return %6 : $()
+}
+
+
+// (ref_to_raw_pointer (unchecked_ref_cast x)) -> (unchecked_trivial_bit_cast x)
+//
+// CHECK-LABEL:     sil @collapse_to_unchecked_trivial_bit_cast :
+// CHECK:           bb0([[Ref:%.*]] : $Optional<Klass>):
+// CHECK:             unchecked_trivial_bit_cast [[Ref]]
+// CHECK-NOT:         unchecked_ref_cast
+// CHECK-NOT:         ref_to_raw_pointer
+// CHECK:           } // end sil function 'collapse_to_unchecked_trivial_bit_cast'
+sil @collapse_to_unchecked_trivial_bit_cast : $@convention(thin) (Optional<Klass>) -> (Builtin.RawPointer) {
+bb0(%0 : $Optional<Klass>):
+  %1 = unchecked_ref_cast %0 : $Optional<Klass> to $Builtin.NativeObject
+  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL:     sil [ossa] @collapse_to_unchecked_trivial_bit_cast_ossa_guaranteed :
+// CHECK:           bb0([[Ref:%.*]] : @guaranteed $Optional<Klass>):
+// CHECK:             unchecked_trivial_bit_cast [[Ref]]
+// CHECK-NOT:         unchecked_ref_cast
+// CHECK-NOT:         ref_to_raw_pointer
+// CHECK:           } // end sil function 'collapse_to_unchecked_trivial_bit_cast_ossa_guaranteed'
+sil [ossa] @collapse_to_unchecked_trivial_bit_cast_ossa_guaranteed : $@convention(thin) (@guaranteed Optional<Klass>) -> (Builtin.RawPointer) {
+bb0(%0 : @guaranteed $Optional<Klass>):
+  %1 = unchecked_ref_cast %0 : $Optional<Klass> to $Builtin.NativeObject
+  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
+}
+
+// We need to make sure that we hoist unchecked_trivial_bit_cast above
+// unchecked_ref_cast since we are not eliminating it here due to an additional
+// user.
+//
+// CHECK-LABEL:     sil [ossa] @collapse_to_unchecked_trivial_bit_cast_ossa_owned :
+// CHECK:           bb0([[ARG:%.*]] : @owned $Optional<Klass>):
+// CHECK:             [[RESULT:%.*]] = unchecked_trivial_bit_cast [[ARG]]
+// CHECK:             [[FORWARDED_ARG:%.*]] = unchecked_ref_cast [[ARG]]
+// CHECK:             destroy_value [[FORWARDED_ARG]]
+// CHECK:             return [[RESULT]]
+// CHECK:           } // end sil function 'collapse_to_unchecked_trivial_bit_cast_ossa_owned'
+sil [ossa] @collapse_to_unchecked_trivial_bit_cast_ossa_owned : $@convention(thin) (@owned Optional<Klass>) -> (Builtin.RawPointer) {
+bb0(%0 : @owned $Optional<Klass>):
+  %1 = unchecked_ref_cast %0 : $Optional<Klass> to $Builtin.NativeObject
+  %f = function_ref @use_nativeobject : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  apply %f(%1) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
+  %2 = ref_to_raw_pointer %1 : $Builtin.NativeObject to $Builtin.RawPointer
+  destroy_value %1 : $Builtin.NativeObject
+  return %2 : $Builtin.RawPointer
+}
+


### PR DESCRIPTION
These are always safe in OSSA since what we are doing here is hoisting the
ref_to_raw_pointer up the def-use chain without deleting any instructions unless
we know that they do not have any uses (in a strict sense so destroy_value is
considered a use). E.x.:

```
%0 = ...
%1 = unchecked_ref_cast %0
%2 = ref_to_raw_pointer %1
```

->

```
%0 = ...
%1 = unchecked_ref_cast %0
%2 = ref_to_raw_pointer %0
```

Notice, how we are actually not changing %1 at all. Instead we are just moving
an instantaneous use earlier. One thing that is important to realize is that
this /does/ cause us to need to put the ref_to_raw_pointer at the insert
location of %0 since %0's lifetime ends at the unchecked_ref_cast if the value
is owned.

NOTE: I also identified the tests from sil_combine.sil that had to do with these
simplifications and extracted them into sil_combine_casts.sil and did the
ossa/non-ossa tests side by side. I am trying to fix up the SILCombine tests as
I update stuff, so if I find opportunities to move tests into a more descriptive
sub-file, I am going to do so.

As an aside, to make it easier to transition SILCombine away from using a
central builder, I added a withBuilder method that creates a new SILBuilder at a
requested insertPt and uses the same context as the main builder of
SILCombine. It also through the usage of auto makes really concise pieces of
code. Today to do this just using builder, we would do:

```
SILBuilderWithScope builder(insertPt, Builder);
builder.createInst1(insertPt->getLoc(), ...);
builder.createInst2(insertPt->getLoc(), ...);
builder.createInst3(insertPt->getLoc(), ...);
auto *finalValue = builder.createInst4(insertPt->getLoc(), ...);
```

Thats a lot of typing and wastes a really commonly used temp name (builder) in
the local scope! Instead, using this API, one can write:

auto *finalValue = withBuilder(insertPt, [&](auto &b, auto l) {
  b.createInst1(l, ...);
  b.createInst2(l, ...);
  b.createInst3(l, ...);
  return b.createInst4(l, ...);
});

There is significantly less to type and auto handles the types for us. The
withBuilder construct is just syntactic since we always inline it.
