### PR TITLE
[build] Use Xcode toolchain Python executables

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -484,8 +484,8 @@ function set_build_options_for_host() {
               -DPython3_EXECUTABLE="$(xcrun -f python3)"
             )
             lldb_cmake_options+=(
-              -DPython2_EXECUTABLE=$(xcrun -f python2.7)
-              -DPython3_EXECUTABLE=$(xcrun -f python3)
+              -DPython2_EXECUTABLE="$(xcrun -f python2.7)"
+              -DPython3_EXECUTABLE="$(xcrun -f python3)"
             )
             case ${host} in
                 macosx-x86_64)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -483,6 +483,10 @@ function set_build_options_for_host() {
               -DPython2_EXECUTABLE="$(xcrun -f python2.7)"
               -DPython3_EXECUTABLE="$(xcrun -f python3)"
             )
+            lldb_cmake_options+=(
+              -DPython2_EXECUTABLE=$(xcrun -f python2.7)
+              -DPython3_EXECUTABLE=$(xcrun -f python3)
+            )
             case ${host} in
                 macosx-x86_64)
                     SWIFT_HOST_TRIPLE="x86_64-apple-macosx${DARWIN_DEPLOYMENT_VERSION_OSX}"


### PR DESCRIPTION
Set `Python3_EXECUTABLE` for lldb, to match the CMake config already being used for Swift.

This ensures that the Xcode Python is used, which is consistent with Swift. Without this, a Homebrew Python will be used for lldb.
