### PR TITLE
[rebranch][ClangImporter] Keep using the buffer start address as map key

### DIFF
--- a/lib/ClangImporter/ClangSourceBufferImporter.cpp
+++ b/lib/ClangImporter/ClangSourceBufferImporter.cpp
@@ -43,7 +43,7 @@ SourceLoc ClangSourceBufferImporter::resolveSourceLocation(
   auto buffer = clangSrcMgr.getBufferOrFake(clangFileID);
   unsigned mirrorID;
 
-  auto mirrorIter = mirroredBuffers.find(clangFileID);
+  auto mirrorIter = mirroredBuffers.find(buffer.getBufferStart());
   if (mirrorIter != mirroredBuffers.end()) {
     mirrorID = mirrorIter->second;
   } else {
@@ -53,7 +53,7 @@ SourceLoc ClangSourceBufferImporter::resolveSourceLocation(
                                        /*RequiresNullTerminator=*/true)
     };
     mirrorID = swiftSourceManager.addNewSourceBuffer(std::move(mirrorBuffer));
-    mirroredBuffers[clangFileID] = mirrorID;
+    mirroredBuffers[buffer.getBufferStart()] = mirrorID;
   }
   loc = swiftSourceManager.getLocForOffset(mirrorID, decomposedLoc.second);
 

--- a/lib/ClangImporter/ClangSourceBufferImporter.h
+++ b/lib/ClangImporter/ClangSourceBufferImporter.h
@@ -44,7 +44,7 @@ class ClangSourceBufferImporter {
   // IntrusiveRefCntPtr to stay a ref-counting pointer.
   SmallVector<llvm::IntrusiveRefCntPtr<const clang::SourceManager>, 4>
     sourceManagersWithDiagnostics;
-  llvm::DenseMap<clang::FileID, unsigned> mirroredBuffers;
+  llvm::DenseMap<const char *, unsigned> mirroredBuffers;
   SourceManager &swiftSourceManager;
 
 public:


### PR DESCRIPTION
Fixes asserts related to virtual files.

rdar://71497407