### PR TITLE
[Concurrency] Improve data-race detection for locals and globals

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2015,6 +2015,20 @@ private:
   }
 };
 
+// Find nested functions and perform effects checking on them.
+struct LocalFunctionEffectsChecker : ASTWalker {
+  bool walkToDeclPre(Decl *D) override {
+    if (auto func = dyn_cast<AbstractFunctionDecl>(D)) {
+      if (func->getDeclContext()->isLocalContext())
+        TypeChecker::checkFunctionEffects(func);
+
+      return false;
+    }
+
+    return true;
+  }
+};
+
 } // end anonymous namespace
 
 void TypeChecker::checkTopLevelEffects(TopLevelCodeDecl *code) {
@@ -2026,6 +2040,7 @@ void TypeChecker::checkTopLevelEffects(TopLevelCodeDecl *code) {
     checker.setTopLevelThrowWithoutTry();
 
   code->getBody()->walk(checker);
+  code->getBody()->walk(LocalFunctionEffectsChecker());
 }
 
 void TypeChecker::checkFunctionEffects(AbstractFunctionDecl *fn) {
@@ -2045,7 +2060,9 @@ void TypeChecker::checkFunctionEffects(AbstractFunctionDecl *fn) {
 
   if (auto body = fn->getBody()) {
     body->walk(checker);
+    body->walk(LocalFunctionEffectsChecker());
   }
+
   if (auto ctor = dyn_cast<ConstructorDecl>(fn))
     if (auto superInit = ctor->getSuperInitCall())
       superInit->walk(checker);
@@ -2056,6 +2073,7 @@ void TypeChecker::checkInitializerEffects(Initializer *initCtx,
   auto &ctx = initCtx->getASTContext();
   CheckEffectsCoverage checker(ctx, Context::forInitializer(initCtx));
   init->walk(checker);
+  init->walk(LocalFunctionEffectsChecker());
 }
 
 /// Check the correctness of effects within the given enum
@@ -2070,6 +2088,7 @@ void TypeChecker::checkEnumElementEffects(EnumElementDecl *elt, Expr *E) {
   auto &ctx = elt->getASTContext();
   CheckEffectsCoverage checker(ctx, Context::forEnumElementInitializer(elt));
   E->walk(checker);
+  E->walk(LocalFunctionEffectsChecker());
 }
 
 void TypeChecker::checkPropertyWrapperEffects(
@@ -2077,6 +2096,7 @@ void TypeChecker::checkPropertyWrapperEffects(
   auto &ctx = binding->getASTContext();
   CheckEffectsCoverage checker(ctx, Context::forPatternBinding(binding));
   expr->walk(checker);
+  expr->walk(LocalFunctionEffectsChecker());
 }
 
 bool TypeChecker::canThrow(Expr *expr) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2068,8 +2068,10 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
     performAbstractFuncDeclDiagnostics(AFD);
 
   TypeChecker::computeCaptures(AFD);
-  checkFunctionActorIsolation(AFD);
-  TypeChecker::checkFunctionEffects(AFD);
+  if (!AFD->getDeclContext()->isLocalContext()) {
+    checkFunctionActorIsolation(AFD);
+    TypeChecker::checkFunctionEffects(AFD);
+  }
 
   return hadError ? errorBody() : body;
 }

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -196,7 +196,7 @@ extension Collection {
       var submitted = 0
 
       func submitNext() async throws {
-        await group.add {
+        await group.add { [submitted,i] in
           let value = await try transform(self[i])
           return (submitted, value)
         }


### PR DESCRIPTION
Improve data-race detection for local variables and global/static variables
* Only diagnose these cases at all, not (e.g.) class instance members
* For local functions, they run concurrently if they were referenced somewhere
  that runs concurrently

The latter required moving checking of both actor isolation and effects
for local functions to the point at which their enclosing (non-local)
functions are checked, because we need to reason about the
type-checked bodies of local functions.
