### PR TITLE
[SourceKit] Fix asan failure in ConformingMethodList request

### DIFF
--- a/include/swift/IDE/IDERequests.h
+++ b/include/swift/IDE/IDERequests.h
@@ -234,7 +234,7 @@ public:
 //----------------------------------------------------------------------------//
 struct ProtocolNameOwner {
   DeclContext *DC;
-  StringRef Name;
+  std::string Name;
   ProtocolNameOwner(DeclContext *DC, StringRef Name): DC(DC), Name(Name) {}
 
   friend llvm::hash_code hash_value(const ProtocolNameOwner &CI) {


### PR DESCRIPTION
Fix ASAN `heap-use-after-free` failure.

rdar://problem/72605086
