### PR TITLE
[5.4][diagnostics] warn about future reservation of 'await' keyword

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1223,6 +1223,9 @@ NOTE(super_in_closure_with_capture_here,none,
      "'self' explicitly captured here", ())
 
 ERROR(try_before_await,none, "'await' must precede 'try'", ())
+WARNING(warn_await_keyword,none, 
+      "future versions of Swift reserve the word 'await'; "
+      "if this name is unavoidable, use backticks to escape it", ())
 
 // Tuples and parenthesized expressions
 ERROR(expected_expr_in_expr_list,none,

--- a/test/Compatibility/unescaped_await.swift
+++ b/test/Compatibility/unescaped_await.swift
@@ -1,0 +1,68 @@
+// RUN: %target-typecheck-verify-swift
+    // now check that the fix-its, if applied, will fix the warnings.
+// RUN: %empty-directory(%t.scratch)
+// RUN: cp %s %t.scratch/fixits.swift
+// RUN: %target-swift-frontend -typecheck %t.scratch/fixits.swift -fixit-all -emit-fixits-path %t.scratch/fixits.remap 2> /dev/null
+// RUN: %{python} %utils/apply-fixit-edits.py %t.scratch
+// RUN: %target-swift-frontend -typecheck %t.scratch/fixits.swift -warnings-as-errors
+// RUN: %target-swift-frontend -typecheck %t.scratch/fixits.swift -warnings-as-errors -enable-experimental-concurrency
+
+// REQUIRES: concurrency
+
+func await(_ f : () -> Void) {}
+
+func ordinaryCalls() {
+  await({})
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  await {}
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  let _ = `await`
+  let _ = `await`({})
+  
+  let _ = await
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  let k = Klass()
+  k.await()
+  _ = k.await
+}
+
+func localVar() {
+  var await = 1
+
+  let two = await + await
+  // expected-warning@-1 2 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+  
+  _ = await==two-await
+  // expected-warning@-1 2 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  takesInout(await: &await)
+}
+
+func takesUnitFunc(_ f : () -> Void) {}
+
+func takesInout(await : inout Int) {
+  await += 1
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+}
+
+class Klass {
+  init() { await() }
+  // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+
+  func await() {
+
+    takesUnitFunc(await)
+    // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+  }
+
+  func method() {
+    let _ = self.await
+    self.await()
+
+    await()
+    // expected-warning@-1 {{future versions of Swift reserve the word 'await'; if this name is unavoidable, use backticks to escape it}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of 179474e185795070d4e0e9b4c6931223dfec86a8 from #35153 for 5.4 release.

We'd like to have this warning land in the 5.4 release to give folks a heads-up (and some assistance) in upgrading their code that uses `await` in certain contexts that would be parsed differently if concurrency extensions are enabled.

Resolves rdar://67000350