### PR TITLE
[5.4] test: xfail failing sourcekitd tests in CI

### DIFF
--- a/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_clangmodule.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar72466352
+
 import ClangFW
 import SwiftFW
 

--- a/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
+++ b/test/SourceKit/CodeComplete/complete_checkdeps_swiftmodule.swift
@@ -1,4 +1,4 @@
-// REQUIRES: rdar72439700
+// REQUIRES: rdar72466352
 
 import ClangFW
 import SwiftFW


### PR DESCRIPTION
Cherry-pick of #35159 into `release/5.4`

rdar://72466352
