### PR TITLE
[5.4] Disable building the experimental _Concurrency module.

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1109,7 +1109,7 @@ def create_argument_parser():
                 ' features.')
 
     option('--enable-experimental-concurrency', toggle_true,
-           default=True,
+           default=False,
            help='Enable experimental Swift concurrency model.')
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
It's not meant to be used in Swift 5.4
