### PR TITLE
[Concurrency] `await try` -> `try await`

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1223,7 +1223,7 @@ ERROR(super_in_closure_with_capture,none,
 NOTE(super_in_closure_with_capture_here,none,
      "'self' explicitly captured here", ())
 
-ERROR(try_before_await,none, "'await' must precede 'try'", ())
+WARNING(await_before_try,none, "'try' must precede 'await'", ())
 WARNING(warn_await_keyword,none, 
       "future versions of Swift reserve the word 'await'; "
       "if this name is unavoidable, use backticks to escape it", ())

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -98,7 +98,7 @@ public func withUnsafeContinuation<T>(
 public func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeThrowingContinuation<T>) -> Void
 ) async throws -> T {
-  return await try Builtin.withUnsafeThrowingContinuation {
+  return try await Builtin.withUnsafeThrowingContinuation {
     fn(UnsafeThrowingContinuation<T>($0))
   }
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -122,7 +122,7 @@ extension Task {
     /// and throwing a specific error or using `checkCancellation` the error
     /// thrown out of the task will be re-thrown here.
     public func get() async throws -> Success {
-      return await try _taskFutureGetThrowing(task)
+      return try await _taskFutureGetThrowing(task)
     }
 
     /// Attempt to cancel the task.

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -86,7 +86,7 @@ extension Task {
         //   (although there should be none left by that time)
         defer { group.cancelAll() }
 
-        let result = await try body(&group)
+        let result = try await body(&group)
 
         /// Drain all remaining tasks by awaiting on them;
         /// Their failures are ignored;
@@ -98,7 +98,7 @@ extension Task {
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(groupTask))
 
-    return await try Handle<BodyResult>(task: groupTask).get()
+    return try await Handle<BodyResult>(task: groupTask).get()
   }
 
   /// A task group serves as storage for dynamically started tasks.
@@ -122,7 +122,7 @@ extension Task {
     /// Add a child task to the group.
     ///
     /// ### Error handling
-    /// Operations are allowed to `throw`, in which case the `await try next()`
+    /// Operations are allowed to `throw`, in which case the `try await next()`
     /// invocation corresponding to the failed task will re-throw the given task.
     ///
     /// The `add` function will never (re-)throw errors from the `operation`.
@@ -155,13 +155,13 @@ extension Task {
     ///
     /// Await on a single completion:
     ///
-    ///     if let first = await try group.next() {
+    ///     if let first = try await group.next() {
     ///        return first
     ///     }
     ///
     /// Wait and collect all group child task completions:
     ///
-    ///     while let first = await try group.next() {
+    ///     while let first = try await group.next() {
     ///        collected += value
     ///     }
     ///     return collected
@@ -253,7 +253,7 @@ extension Task.Group {
     //
     // Failures of tasks are ignored.
     while !self.isEmpty {
-      _ = await try? self.next()
+      _ = try? await self.next()
       // TODO: Should a failure cause a cancellation of the task group?
       //       This looks very much like supervision trees,
       //       where one may have various decisions depending on use cases...

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -8,16 +8,16 @@ import ObjCConcurrency
 func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await slowServer.doSomethingSlow("mail")
   let _: Bool = await slowServer.checkAvailability()
-  let _: String = await try slowServer.findAnswer()
-  let _: String = await try slowServer.findAnswerFailingly()
+  let _: String = try await slowServer.findAnswer()
+  let _: String = try await slowServer.findAnswerFailingly()
 
-  let (aOpt, b) = await try slowServer.findQAndA()
+  let (aOpt, b) = try await slowServer.findQAndA()
   if let a = aOpt { // make sure aOpt is optional
     print(a)
   }
   let _: String = b // make sure b is non-optional
 
-  let _: String = await try slowServer.findAnswer()
+  let _: String = try await slowServer.findAnswer()
 
   let _: Void = await slowServer.doSomethingFun("jump")
   let _: (Int) -> Void = slowServer.completionHandler
@@ -29,8 +29,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = slowServer.doSomethingConflicted("thinking")
   // expected-error@-1{{call is 'async' but is not marked with 'await'}}{{16-16=await }}
 
-  let _: String? = await try slowServer.fortune()
-  let _: Int = await try slowServer.magicNumber(withSeed: 42)
+  let _: String? = try await slowServer.fortune()
+  let _: Int = try await slowServer.magicNumber(withSeed: 42)
 
   await slowServer.serverRestart("localhost")
   await slowServer.serverRestart("localhost", atPriority: 0.8)

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -70,7 +70,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
 
   // Wait until all of the workers have finished.
   for worker in workers {
-    await try! worker.get()
+    try! await worker.get()
   }
 
   // Clear out the scratch buffer.

--- a/test/Concurrency/Runtime/async_taskgroup_add_handle_completion.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_add_handle_completion.swift
@@ -20,7 +20,7 @@ func completeSlowly(n: Int) async -> Int {
 
 /// Tasks complete AFTER they are next() polled.
 func test_sum_nextOnPending() async {
-  let sum = await try! Task.withGroup(resultType: Int.self) { (group) async -> Int in
+  let sum = try! await Task.withGroup(resultType: Int.self) { (group) async -> Int in
     let firstHandle = await group.add {
       let res = await completeSlowly(n: 1)
       return res
@@ -34,16 +34,16 @@ func test_sum_nextOnPending() async {
       return res
     }
 
-    let first = await try! firstHandle.get()
+    let first = try! await firstHandle.get()
     print("firstHandle.get(): \(first)")
-    let second = await try! secondHandle.get()
+    let second = try! await secondHandle.get()
     print("secondHandle.get(): \(second)")
-    let third = await try! thirdHandle.get()
+    let third = try! await thirdHandle.get()
     print("thirdHandle.get(): \(third)")
 
     var sum = 0
     print("before group.next(), sum: \(sum)")
-    while let n = await try! group.next() {
+    while let n = try! await group.next() {
       assert(n <= 3, "Unexpected value: \(n)! Expected <= 3")
       print("next: \(n)")
       sum += n

--- a/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
@@ -17,7 +17,7 @@ func asyncEcho(_ value: Int) async -> Int {
 }
 
 func test_taskGroup_isEmpty() async {
-  _ = await try! Task.withGroup(resultType: Int.self) { (group) async -> Int in
+  _ = try! await Task.withGroup(resultType: Int.self) { (group) async -> Int in
     // CHECK: before add: isEmpty=true
     print("before add: isEmpty=\(group.isEmpty)")
 
@@ -30,7 +30,7 @@ func test_taskGroup_isEmpty() async {
     print("while add running, outside: isEmpty=\(group.isEmpty)")
 
     // CHECK: next: 1
-    while let value = await try! group.next() {
+    while let value = try! await group.next() {
       print("next: \(value)")
     }
 

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -9,7 +9,7 @@ import Dispatch
 func test_skipCallingNext_butInvokeCancelAll() async {
   let numbers = [1, 1]
 
-  let result = await try! Task.withGroup(resultType: Int.self) { (group) async -> Int in
+  let result = try! await Task.withGroup(resultType: Int.self) { (group) async -> Int in
     for n in numbers {
       print("group.add { \(n) }")
       await group.add { () async -> Int in

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
@@ -9,7 +9,7 @@ import func Foundation.sleep
 func test_skipCallingNext() async {
   let numbers = [1, 1]
 
-  let result = await try! Task.withGroup(resultType: Int.self) { (group) async -> Int in
+  let result = try! await Task.withGroup(resultType: Int.self) { (group) async -> Int in
     for n in numbers {
       print("group.add { \(n) }")
       await group.add { () async -> Int in

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
@@ -16,7 +16,7 @@ func test_sum_nextOnCompleted() async {
     let numbers = [1, 2, 3, 4, 5]
     let expected = numbers.reduce(0, +)
 
-    let sum = await try! Task.withGroup(resultType: Int.self) { (group) async -> Int in
+    let sum = try! await Task.withGroup(resultType: Int.self) { (group) async -> Int in
       for n in numbers {
         await group.add { () async -> Int in
           print("  complete group.add { \(n) }")
@@ -30,7 +30,7 @@ func test_sum_nextOnCompleted() async {
 
       var sum = 0
       do {
-        while let r = await try group.next() {
+        while let r = try await group.next() {
           fputs("error: \(#function)[\(#file):\(#line)]: next: \(r)\n", stderr)
           print("next: \(r)")
 //          DispatchQueue.main.sync { // TODO: remove once executors/actors are a thing

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_pending.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_pending.swift
@@ -18,7 +18,7 @@ func test_sum_nextOnPending() async {
   let numbers = [1, 2, 3]
   let expected = numbers.reduce(0, +)
 
-  let sum = await try! Task.withGroup(resultType: Int.self) { (group) async -> Int in
+  let sum = try! await Task.withGroup(resultType: Int.self) { (group) async -> Int in
     for n in numbers {
       await group.add {
         let res = await completeSlowly(n: n)
@@ -28,7 +28,7 @@ func test_sum_nextOnPending() async {
 
     var sum = 0
     print("before group.next(), sum: \(sum)")
-    while let n = await try! group.next() {
+    while let n = try! await group.next() {
       assert(numbers.contains(n), "Unexpected value: \(n)! Expected any of \(numbers)")
       print("next: \(n)")
       sum += n

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -26,13 +26,13 @@ async throws -> Int {
 
 func test_taskGroup_throws() async {
   do {
-    let got = await try Task.withGroup(resultType: Int.self) {
+    let got = try await Task.withGroup(resultType: Int.self) {
       group async throws -> Int in
       await group.add { await one() }
-      await group.add { await try boom()  }
+      await group.add { try await boom()  }
 
       do {
-        while let r = await try group.next() {
+        while let r = try await group.next() {
           print("next: \(r)")
         }
       } catch {
@@ -43,7 +43,7 @@ func test_taskGroup_throws() async {
           return 3
         }
 
-        guard let got = await try! group.next() else {
+        guard let got = try! await group.next() else {
           print("task group failed to get 3 (:\(#line))")
           return 0
         }
@@ -53,7 +53,7 @@ func test_taskGroup_throws() async {
         if got == 1 {
           // the previous 1 completed before the 3 we just submitted,
           // we still want to see that three so let's await for it
-          guard let third = await try! group.next() else {
+          guard let third = try! await group.next() else {
             print("task group failed to get 3 (:\(#line))")
             return got
           }

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -14,13 +14,13 @@ func boom() async throws -> Int { throw Boom() }
 
 func test_taskGroup_throws_rethrows() async {
   do {
-    let got = await try Task.withGroup(resultType: Int.self) { (group) async throws -> Int in
+    let got = try await Task.withGroup(resultType: Int.self) { (group) async throws -> Int in
       await group.add { await echo(1) }
       await group.add { await echo(2) }
-      await group.add { await try boom() }
+      await group.add { try await boom() }
 
       do {
-        while let r = await try group.next() {
+        while let r = try await group.next() {
           print("next: \(r)")
         }
       } catch {

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -56,7 +56,7 @@ func testSimple(
 
     do {
       print("+ Reader waiting for the result")
-      let result = await try taskHandle.get()
+      let result = try await taskHandle.get()
       completed = true
       print("+ Normal return: \(result)")
       assert(result == "Hello \(name) from async world!")

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -39,7 +39,7 @@ func asyncFib(_ n: Int) async -> Int {
   // Sleep a random amount of time waiting on the result producing a result.
   usleep(UInt32.random(in: 0..<100) * 1000)
 
-  let result = await try! first.get() + second.get()
+  let result = try! await first.get() + second.get()
 
   // Sleep a random amount of time before producing a result.
   usleep(UInt32.random(in: 0..<100) * 1000)

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -7,7 +7,7 @@ enum PictureData {
 }
 
 func test_cancellation_checkCancellation() async throws {
-  await try Task.checkCancellation()
+  try await Task.checkCancellation()
 }
 
 func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
@@ -26,7 +26,7 @@ func test_cancellation_withCancellationHandler(_ anything: Any) async -> Picture
   let handle = Task.runDetached { () -> PictureData in
     let file = SomeFile()
 
-    return await try Task.withCancellationHandler(
+    return try await Task.withCancellationHandler(
       handler: { file.close() },
       operation: {
       await test_cancellation_guard_isCancelled(file)

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -26,7 +26,7 @@ func buyVegetables(
 
 // returns 1 or more vegetables or throws an error
 func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
-  await try withUnsafeThrowingContinuation { continuation in
+  try await withUnsafeThrowingContinuation { continuation in
     var veggies: [Vegetable] = []
 
     buyVegetables(
@@ -54,11 +54,11 @@ func test_unsafeContinuations() async {
 }
 
 func test_unsafeThrowingContinuations() async {
-  let _: String = await try withUnsafeThrowingContinuation { continuation in
+  let _: String = try await withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
   }
 
-  let _: String = await try withUnsafeThrowingContinuation { continuation in
+  let _: String = try await withUnsafeThrowingContinuation { continuation in
     continuation.resume(throwing: MyError())
   }
 
@@ -72,17 +72,17 @@ func test_detached() async throws {
     await someAsyncFunc() // able to call async functions
   }
 
-  let result: String = await try handle.get()
+  let result: String = try await handle.get()
   _ = result
 }
 
 func test_detached_throwing() async -> String {
   let handle: Task.Handle<String> = Task.runDetached() {
-    await try someThrowingAsyncFunc() // able to call async functions
+    try await someThrowingAsyncFunc() // able to call async functions
   }
 
   do {
-    return await try handle.get()
+    return try await handle.get()
   } catch {
     print("caught: \(error)")
   }

--- a/test/Concurrency/async_throwing.swift
+++ b/test/Concurrency/async_throwing.swift
@@ -15,22 +15,22 @@ func asyncThrows() async throws {
 
 // T = Int
 func asyncRethrows(fn : () async throws -> Int) async rethrows -> Int {
-  return await try fn()
+  return try await fn()
 }
 
 // T = String
 func asyncRethrows(fn : () async throws -> String) async rethrows -> String {
-  return await try fn()
+  return try await fn()
 }
 
 // Generic. NOTE the 'rethrows'
 func invoke<T>(fn : () async throws -> T) async rethrows -> T {
-  return await try fn()
+  return try await fn()
 }
 
 // NOTE the 'rethrows'
 func invokeAuto<T>(_ val : @autoclosure () async throws -> T) async rethrows -> T {
-  return await try val()
+  return try await val()
 }
 
 func normalTask() async -> Int {
@@ -88,37 +88,37 @@ func asyncTest() async {
   let _ = await invoke(fn: normalTask) // ok
 
   let _ = await asyncRethrows(fn: normalTask)
-  let _ = await try! asyncRethrows(fn: normalTask) // expected-warning{{no calls to throwing functions occur within 'try' expression}}
-  let _ = await try? asyncRethrows(fn: normalTask) // expected-warning{{no calls to throwing functions occur within 'try' expression}}
+  let _ = try! await asyncRethrows(fn: normalTask) // expected-warning{{no calls to throwing functions occur within 'try' expression}}
+  let _ = try? await asyncRethrows(fn: normalTask) // expected-warning{{no calls to throwing functions occur within 'try' expression}}
   
-  let _ = await try! asyncRethrows(fn: throwingTask)
-  let _ = await try? asyncRethrows(fn: throwingTask)
-  let _ = await try! asyncThrows()
-  let _ = await try? asyncThrows()
+  let _ = try! await asyncRethrows(fn: throwingTask)
+  let _ = try? await asyncRethrows(fn: throwingTask)
+  let _ = try! await asyncThrows()
+  let _ = try? await asyncThrows()
 
   //////////
   // some auto-closure tests
 
   let _ = await invokeAuto("intuitive")
-  let _ = await try! invokeAuto(await throwingTask())
-  let _ = await try? invokeAuto(await throwingTask())
-  let _ = await invokeAuto(await try! throwingTask())
-  let _ = await invokeAuto(await try? throwingTask())
+  let _ = try! await invokeAuto(await throwingTask())
+  let _ = try? await invokeAuto(await throwingTask())
+  let _ = await invokeAuto(try! await throwingTask())
+  let _ = await invokeAuto(try? await throwingTask())
 
   let _ = await invokeAuto(try! throwingTask()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
   let _ = await invokeAuto(try? throwingTask()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
 
-  let _ = await invokeAuto(await try! throwingTask())
-  let _ = await invokeAuto(await try? throwingTask())
+  let _ = await invokeAuto(try! await throwingTask())
+  let _ = await invokeAuto(try? await throwingTask())
   /////////
 
   do {
-    let _ = await try asyncThrows()
-    let _ = await try asyncRethrows(fn: throwingTask)
+    let _ = try await asyncThrows()
+    let _ = try await asyncRethrows(fn: throwingTask)
 
     //////
     // more auto-closure tests
-    
+
     // expected-note@+6 {{did you mean to disable error propagation?}}
     // expected-note@+5 {{did you mean to handle error as optional value?}}
     // expected-note@+4 {{did you mean to use 'try'?}}
@@ -127,9 +127,9 @@ func asyncTest() async {
     // expected-error@+1 2 {{call can throw but is not marked with 'try'}}
     let _ = await invokeAuto(throwingTask())
 
-    let _ = await try invokeAuto(throwingTask()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
+    let _ = try await invokeAuto(throwingTask()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}
     let _ = try invokeAuto(await throwingTask()) // expected-error{{call is 'async' but is not marked with 'await'}}
-    let _ = await try invokeAuto(await throwingTask())
+    let _ = try await invokeAuto(await throwingTask())
   } catch {
     // ignore
   }

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -19,7 +19,7 @@ public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
 // CHECK: tail call swiftcc void @swift_task_future_wait(
 public func testThis(_ task: __owned SomeClass) async {
   do {
-    let _ = await try task_future_wait(task)
+    let _ = try await task_future_wait(task)
   } catch _ {
     print("error")
   }

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -93,7 +93,7 @@ public func usesWithUnsafeContinuation() async {
 
 // CHECK-LABEL: sil [ossa] @$s4test34usesWithUnsafeThrowingContinuationyyYKF : $@convention(thin) @async () -> @error Error {
 public func usesWithUnsafeThrowingContinuation() async throws {
-  let _: Int = await try Builtin.withUnsafeThrowingContinuation { c in }
+  let _: Int = try await Builtin.withUnsafeThrowingContinuation { c in }
 
   // CHECK: [[FN:%.*]] = function_ref @$s4test34usesWithUnsafeThrowingContinuationyyYKFyBcXEfU_ : $@convention(thin) (Builtin.RawUnsafeContinuation) -> ()
   // CHECK: [[TMP:%.*]] = convert_function [[FN]] : $@convention(thin) (Builtin.RawUnsafeContinuation) -> () to $@convention(thin) @noescape (Builtin.RawUnsafeContinuation) -> ()

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -52,11 +52,11 @@ func testAsyncLetWithThrows(cond: Bool) async throws -> String {
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test0A14AsyncLetThrowsSSyYKF : $@convention(thin) @async () -> (@owned String, @error Error) {
 func testAsyncLetThrows() async throws -> String {
-  async let s = await try getStringThrowingly()
+  async let s = try await getStringThrowingly()
 
   // CHECK: [[RUN_CHILD_TASK:%.*]] = function_ref @$s12_Concurrency22_taskFutureGetThrowingyxBoYKlF : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> (@out τ_0_0, @error Error)
   // CHECK: try_apply [[RUN_CHILD_TASK]]<String>
-  return await try s
+  return try await s
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test0A14DecomposeAwait4condSiSb_tYF : $@convention(thin) @async (Bool) -> Int {

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -34,7 +34,7 @@ actor class MyActor {
   // CHECK:      } // end sil function '$s4test7MyActorC0A13AsyncFunctionyyYKF'
   func testAsyncFunction() async throws {
     await callee(p)
-    await try throwingCallee(p)
+    try await throwingCallee(p)
   }
 
   // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0A22ConsumingAsyncFunctionyyYF : $@convention(method) @async (@owned MyActor) -> () {

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -39,16 +39,16 @@ func testSlowServer(slowServer: SlowServer) async throws {
   // CHECK: [[RESULT:%.*]] = load [take] [[RESUME_BUF]]
   // CHECK: destroy_value [[RESULT]]
   // CHECK: dealloc_stack [[RESUME_BUF]]
-  let _: String = await try slowServer.findAnswer()
+  let _: String = try await slowServer.findAnswer()
 
   // CHECK: objc_method {{.*}} $@convention(objc_method) (NSString, @convention(block) () -> (), SlowServer) -> ()
   // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[VOID_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage UnsafeContinuation<()>) -> ()
   await slowServer.serverRestart("somewhere")
 
   // CHECK: [[BLOCK_IMPL:%.*]] = function_ref @[[NSSTRING_INT_THROW_COMPLETION_BLOCK:.*]] : $@convention(c) (@inout_aliasable @block_storage UnsafeThrowingContinuation<(String, Int)>, Optional<NSString>, Int, Optional<NSError>) -> ()
-  let (_, _): (String, Int) = await try slowServer.findMultipleAnswers()
+  let (_, _): (String, Int) = try await slowServer.findMultipleAnswers()
 
-  let (_, _): (Bool, Bool) = await try slowServer.findDifferentlyFlavoredBooleans()
+  let (_, _): (Bool, Bool) = try await slowServer.findDifferentlyFlavoredBooleans()
 
   // CHECK: [[ERROR]]([[ERROR_VALUE:%.*]] : @owned $Error):
   // CHECK:   dealloc_stack [[RESUME_BUF]]
@@ -57,7 +57,7 @@ func testSlowServer(slowServer: SlowServer) async throws {
   // CHECK:   throw [[ERROR_VALUE]]
 
   let _: String = await slowServer.findAnswerNullably("foo")
-  let _: String = await try slowServer.doSomethingDangerousNullably("foo")
+  let _: String = try await slowServer.doSomethingDangerousNullably("foo")
 }
 
 // CHECK: sil{{.*}}@[[INT_COMPLETION_BLOCK]]

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -19,11 +19,11 @@ func testSlowServing(p: SlowServing) async throws {
     // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (NSString) -> (), τ_0_0) -> ()
     let _: String = await p.requestString()
     // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Optional<NSString>, Optional<NSError>) -> (), τ_0_0) -> ()
-    let _: String = await try p.tryRequestString()
+    let _: String = try await p.tryRequestString()
     // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Int, NSString) -> (), τ_0_0) -> ()
     let _: (Int, String) = await p.requestIntAndString()
     // CHECK: objc_method {{.*}} $@convention(objc_method) <τ_0_0 where τ_0_0 : SlowServing> (@convention(block) (Int, Optional<NSString>, Optional<NSError>) -> (), τ_0_0) -> ()
-    let _: (Int, String) = await try p.tryRequestIntAndString()
+    let _: (Int, String) = try await p.tryRequestIntAndString()
 }
 
 class SlowSwiftServer: NSObject, SlowServing {

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -34,7 +34,7 @@ func chopVegetables() async throws -> [String] { [] }
 func marinateMeat() async -> String { "MEAT" }
 
 func cook() async throws {
-  async let veggies = await try chopVegetables(), meat = await marinateMeat()
-  _ = await try veggies
+  async let veggies = try await chopVegetables(), meat = await marinateMeat()
+  _ = try await veggies
   _ = await meat
 }

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -85,8 +85,8 @@ enum HomeworkError : Error {
 }
 
 func testThrowingAndAsync() async throws {
-  _ = await try throwingAndAsync()
-  _ = try await throwingAndAsync() // expected-error{{'await' must precede 'try'}}{{11-17=}}{{7-7=await }}
+  _ = try await throwingAndAsync()
+  _ = await try throwingAndAsync() // expected-warning{{'try' must precede 'await'}}{{7-13=}}{{17-17=await }}
   _ = await (try throwingAndAsync())
   _ = try (await throwingAndAsync())
 
@@ -100,12 +100,12 @@ func testThrowingAndAsync() async throws {
 
 func testExhaustiveDoCatch() async {
   do {
-    _ = await try throwingAndAsync()
+    _ = try await throwingAndAsync()
   } catch {
   }
 
   do {
-    _ = await try throwingAndAsync()
+    _ = try await throwingAndAsync()
     // expected-error@-1{{errors thrown from here are not handled because the enclosing catch is not exhaustive}}
   } catch let e as HomeworkError {
   }
@@ -113,7 +113,7 @@ func testExhaustiveDoCatch() async {
   // Ensure that we infer 'async' through an exhaustive do-catch.
   let fn = {
     do {
-      _ = await try throwingAndAsync()
+      _ = try await throwingAndAsync()
     } catch {
     }
   }
@@ -123,7 +123,7 @@ func testExhaustiveDoCatch() async {
   // Ensure that we infer 'async' through a non-exhaustive do-catch.
   let fn2 = {
     do {
-      _ = await try throwingAndAsync()
+      _ = try await throwingAndAsync()
     } catch let e as HomeworkError {
     }
   }
@@ -139,11 +139,11 @@ func testStringInterpolation() async throws {
 }
 
 func invalidAsyncFunction() async {
-  _ = await try throwingAndAsync() // expected-error {{errors thrown from here are not handled}}
+  _ = try await throwingAndAsync() // expected-error {{errors thrown from here are not handled}}
 }
 
 func validAsyncFunction() async throws {
-  _ = await try throwingAndAsync()
+  _ = try await throwingAndAsync()
 }
 
 // Async let checking
@@ -177,7 +177,7 @@ func testAsyncLet() async throws {
 
   _ = await x1 // expected-error{{reading 'async let' can throw but is not marked with 'try'}}
   _ = await x2
-  _ = await try x3
+  _ = try await x3
   _ = await x4
   _ = await x5
 }


### PR DESCRIPTION
The `try await` ordering is both easier to read and indicates the order
of operations better, because the suspension point occurs first and
then one can observe a thrown error.
