### PR TITLE
Adding async-main support

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -349,6 +349,11 @@ void swift_continuation_throwingResumeWithError(/* +1 */ SwiftError *error,
 extern "C" SWIFT_CC(swift)
 void swift_continuation_logFailedCheck(const char *message);
 
+/// Drain the queue
+/// If the binary links CoreFoundation, uses CFRunLoopRun
+/// Otherwise it uses dispatchMain.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_asyncMainDrainQueue();
 }
 
 #endif

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1936,7 +1936,7 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
   Expr *returnedExpr;
 
   if (mainFunction->hasAsync()) {
-    // Pass main into _runAsyncMain(_ asyncFunc: () async -> ())
+    // Pass main into _runAsyncMain(_ asyncFunc: () async throws -> ())
     // Resulting $main looks like:
     // $main() { _runAsyncMain(main) }
     auto *concurrencyModule = context.getLoadedModule(context.Id_Concurrency);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1935,7 +1935,31 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
 
   Expr *returnedExpr;
 
-  if (mainFunction->hasThrows()) {
+  if (mainFunction->hasAsync()) {
+    // Pass main into _runAsyncMain(_ asyncFunc: () async -> ())
+    // Resulting $main looks like:
+    // $main() { _runAsyncMain(main) }
+    auto *concurrencyModule = context.getLoadedModule(context.Id_Concurrency);
+    assert(concurrencyModule != nullptr && "Failed to find Concurrency module");
+
+    SmallVector<ValueDecl *, 1> decls;
+    concurrencyModule->lookupQualified(
+        concurrencyModule,
+        DeclNameRef(context.getIdentifier("_runAsyncMain")),
+        NL_QualifiedDefault | NL_IncludeUsableFromInline,
+        decls);
+    assert(!decls.empty() && "Failed to find _runAsyncMain");
+    FuncDecl *runner = cast<FuncDecl>(decls[0]);
+
+    auto asyncRunnerDeclRef = ConcreteDeclRef(runner, substitutionMap);
+
+    DeclRefExpr *funcExpr = new (context) DeclRefExpr(asyncRunnerDeclRef,
+                                                      DeclNameLoc(),
+                                                      /*implicit=*/true);
+    funcExpr->setType(runner->getInterfaceType());
+    auto *callExpr = CallExpr::createImplicit(context, funcExpr, memberRefExpr, {});
+    returnedExpr = callExpr;
+  } else if (mainFunction->hasThrows()) {
     auto *tryExpr = new (context) TryExpr(
         callExpr->getLoc(), callExpr, context.TheEmptyTupleType, /*implicit=*/true);
     returnedExpr = tryExpr;

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -22,6 +22,10 @@
 #include "TaskPrivate.h"
 #include "AsyncCall.h"
 
+#include <dispatch/dispatch.h>
+
+#include <dlfcn.h>
+
 using namespace swift;
 using FutureFragment = AsyncTask::FutureFragment;
 using GroupFragment = AsyncTask::GroupFragment;
@@ -527,4 +531,13 @@ bool swift::swift_task_isCancelled(AsyncTask *task) {
 SWIFT_CC(swift)
 void swift::swift_continuation_logFailedCheck(const char *message) {
   swift_reportError(0, message);
+}
+
+void swift::swift_task_asyncMainDrainQueue() {
+  auto runLoop =
+      reinterpret_cast<void (*)(void)>(dlsym(RTLD_SELF, "CFRunLoopRun"));
+  if (runLoop)
+    runLoop();
+  else
+    dispatch_main();
 }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -535,7 +535,7 @@ void swift::swift_continuation_logFailedCheck(const char *message) {
 
 void swift::swift_task_asyncMainDrainQueue() {
   auto runLoop =
-      reinterpret_cast<void (*)(void)>(dlsym(RTLD_SELF, "CFRunLoopRun"));
+      reinterpret_cast<void (*)(void)>(dlsym(RTLD_DEFAULT, "CFRunLoopRun"));
   if (runLoop)
     runLoop();
   else

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -24,7 +24,9 @@
 
 #include <dispatch/dispatch.h>
 
+#if !defined(_WIN32)
 #include <dlfcn.h>
+#endif
 
 using namespace swift;
 using FutureFragment = AsyncTask::FutureFragment;
@@ -534,10 +536,17 @@ void swift::swift_continuation_logFailedCheck(const char *message) {
 }
 
 void swift::swift_task_asyncMainDrainQueue() {
+#if !defined(_WIN32)
   auto runLoop =
       reinterpret_cast<void (*)(void)>(dlsym(RTLD_DEFAULT, "CFRunLoopRun"));
   if (runLoop)
     runLoop();
   else
     dispatch_main();
+#else
+  // TODO: I don't have a windows box to get this working right now.
+  //       We need to either pull in the CFRunLoop if it's available, or do
+  //       something that will drain the main queue. Exploding for now.
+  abort();
+#endif
 }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -323,6 +323,9 @@ func isTaskCancelled(_ task: Builtin.NativeObject) -> Bool
 @_silgen_name("swift_task_runAndBlockThread")
 public func runAsyncAndBlock(_ asyncFun: @escaping () async -> ())
 
+@_silgen_name("swift_task_runAndBlockThread")
+public func _runAsyncMain(_ asyncFun: () async throws -> ())
+
 @_silgen_name("swift_task_future_wait")
 func _taskFutureWait(
   on task: Builtin.NativeObject

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -323,8 +323,20 @@ func isTaskCancelled(_ task: Builtin.NativeObject) -> Bool
 @_silgen_name("swift_task_runAndBlockThread")
 public func runAsyncAndBlock(_ asyncFun: @escaping () async -> ())
 
-@_silgen_name("swift_task_runAndBlockThread")
-public func _runAsyncMain(_ asyncFun: () async throws -> ())
+@_silgen_name("swift_task_asyncMainDrainQueue")
+public func _asyncMainDrainQueue() -> Never
+
+public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
+  let _ = Task.runDetached {
+    do {
+      await try asyncFun()
+      exit(EXIT_SUCCESS)
+    } catch {
+      _errorInMain(error)
+    }
+  }
+  _asyncMainDrainQueue()
+}
 
 @_silgen_name("swift_task_future_wait")
 func _taskFutureWait(

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -329,8 +329,8 @@ public func _asyncMainDrainQueue() -> Never
 public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
   let _ = Task.runDetached {
     do {
-      await try asyncFun()
-      exit(EXIT_SUCCESS)
+      try await asyncFun()
+      exit(0)
     } catch {
       _errorInMain(error)
     }

--- a/stdlib/public/SwiftShims/_SwiftConcurrency.h
+++ b/stdlib/public/SwiftShims/_SwiftConcurrency.h
@@ -25,6 +25,10 @@ typedef struct _SwiftContext {
   struct _SwiftContext *parentContext;
 } _SwiftContext;
 
+void exit(int);
+
+#define EXIT_SUCCESS 0
+
 #ifdef __cplusplus
 } // extern "C"
 } // namespace swift

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -4,6 +4,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
 
 func asyncFunc() async {
   print("Hello World!")

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -dump-ast -enable-experimental-concurrency -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-AST
+// REQUIRES: concurrency
+
+func asyncFunc() async { }
+
+@main struct MyProgram {
+  static func main() async {
+    await asyncFunc()
+  }
+}
+
+
+// CHECK-AST-LABEL: "main()" interface
+// CHECK-AST:       (await_expr type='()'
+// CHECK-AST-NEXT:    (call_expr type='()'
+// CHECK-AST-NEXT:       (declref_expr type='() async -> ()'
+// CHECK-AST-SAME:        decl=async_main.(file).asyncFunc()@
+
+// CHECK-AST-LABEL: (func_decl implicit "$main()" interface
+// CHECK-AST:       (brace_stmt
+// CHECK-AST-NEXT:    (return_stmt implicit
+// CHECK-AST-NEXT:      (call_expr implicit type='()'
+// CHECK-AST-NEXT:        (declref_expr implicit
+// CHECK-AST-SAME:             type='(() async throws -> ()) -> ()'
+// CHECK-AST-SAME:             decl=_Concurrency.(file)._runAsyncMain
+// CHECK-AST-SAME:             function_ref=single
+// CHECK-AST-NEXT:        (paren_expr implicit type='(() async throws -> ())'
+// CHECK-AST-NEXT:          (function_conversion_expr implicit type='() async throws -> ()'
+// CHECK-AST-NEXT:          (dot_syntax_call_expr
+// CHECK-AST-NEXT:          (autoclosure_expr implicit type='(MyProgram.Type) -> () async -> ()'

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -1,7 +1,13 @@
 // RUN: %target-swift-frontend -dump-ast -enable-experimental-concurrency -parse-as-library %s | %FileCheck %s --check-prefix=CHECK-AST
-// REQUIRES: concurrency
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -Xfrontend -parse-as-library %s -o %t_binary
+// RUN: %target-run %t_binary | %FileCheck %s --check-prefix=CHECK-EXEC
 
-func asyncFunc() async { }
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+
+func asyncFunc() async {
+  print("Hello World!")
+}
 
 @main struct MyProgram {
   static func main() async {
@@ -9,6 +15,7 @@ func asyncFunc() async { }
   }
 }
 
+// CHECK-EXEC: Hello World!
 
 // CHECK-AST-LABEL: "main()" interface
 // CHECK-AST:       (await_expr type='()'

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -21,7 +21,7 @@ func asyncFunc() async { }
 // CHECK-AST-NEXT:    (return_stmt implicit
 // CHECK-AST-NEXT:      (call_expr implicit type='()'
 // CHECK-AST-NEXT:        (declref_expr implicit
-// CHECK-AST-SAME:             type='(() async throws -> ()) -> ()'
+// CHECK-AST-SAME:             type='(@escaping () async throws -> ()) -> ()'
 // CHECK-AST-SAME:             decl=_Concurrency.(file)._runAsyncMain
 // CHECK-AST-SAME:             function_ref=single
 // CHECK-AST-NEXT:        (paren_expr implicit type='(() async throws -> ())'

--- a/test/Concurrency/async_main_throws_prints_error.swift
+++ b/test/Concurrency/async_main_throws_prints_error.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios
 
 enum Err : Error { case noGood }
 

--- a/test/Concurrency/async_main_throws_prints_error.swift
+++ b/test/Concurrency/async_main_throws_prints_error.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -Xfrontend -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main  > %t/log 2>&1 || true
+// RUN: %FileCheck %s < %t/log
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+
+enum Err : Error { case noGood }
+
+func asyncFunc() async throws {
+  throw Err.noGood
+}
+
+// CHECK: Fatal error: Error raised at top level: main.Err.noGood
+@main struct MyProgram {
+  static func main() async throws {
+    try await asyncFunc()
+  }
+}


### PR DESCRIPTION
This patch adds the async-main start-point for programs.
When a `static func main() async` is inserted into the main program, it
gets called through `_runAsyncMain` instead of calling directly. This
starts the program in an async context, which is good because then we
can do async stuff from there.

The following code

```
@main struct MyProgram {
  static func main() async {
    // async code
  }
}
```

is turned into

```
@main struct MyProgram {
  static func $main() {
    _runAsyncMain(main)
  }

  static func main() async {
    // async code
  }
}
```

_runAsyncMain code-gen's to the same thing as runAsyncAndBlock, which
emits a call to `swift_task_runAndBlockThread`.

Resolves: rdar://71828636