### PR TITLE
Disable subclass_existentials.swift test because it's failing on Ubun…

### DIFF
--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -15,6 +15,7 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
+// REQUIRES: rdar72636579
 
 import StdlibUnittest
 


### PR DESCRIPTION
…tu 20.04, 18.04 and CentOS 8