### PR TITLE
Platform: add D3D12 to modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -153,6 +153,35 @@ module WinSDK [system] {
     }
   }
 
+  module DirectX {
+    module Direct3D12 {
+      header "d3d12.h"
+      export *
+
+      link "d3d12.lib"
+      link "dxgi.lib"
+    }
+
+    module XAudio29 {
+      header "xaudio2.h"
+      header "xaudio2fx.h"
+      export *
+
+      link "xaudio2.lib"
+    }
+
+    // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was
+    // part of Vista.
+    module XInput14 {
+      header "Xinput.h"
+      export *
+
+      link "xinputuap.lib"
+    }
+
+    link "dxguid.lib"
+  }
+
   // FIXME(compnerd) this is a hack for the HWND typedef for DbgHelp
   module __DirectX {
     header "directmanipulation.h"


### PR DESCRIPTION
Add the DirectX 12 header to the modulemap for the Windows SDK.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
