### PR TITLE
[cxx-interop] Using shadow with class template.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4457,8 +4457,10 @@ namespace {
         return nullptr;
       
       Decl *SwiftDecl = Impl.importDecl(decl->getUnderlyingDecl(), getActiveSwiftVersion());
+      if (!SwiftDecl)
+        return nullptr;
+
       const TypeDecl *SwiftTypeDecl = dyn_cast<TypeDecl>(SwiftDecl);
-      
       if (!SwiftTypeDecl)
         return nullptr;
       

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -189,4 +189,10 @@ struct StructWithCopyConstructorAndSubobjectCopyConstructorAndValue {
       : member(other.member) {}
 };
 
+template<class> struct DependentParent { struct Child { }; };
+
+struct HasUnsupportedUsingShadow : DependentParent<int> {
+  using typename DependentParent<int>::Child;
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_TYPE_CLASSIFICATION_H


### PR DESCRIPTION
Fail correctly if we can't import a shadow decl properly. We can probably support this in the future, but right now, it's more important that we don't crash while importing.

This is a draft because we currently don't fail here. This is a fix that will be needed once other PRs land. _This is not yet ready to be reviewed or merged._