### PR TITLE
[CSBindings] Refactor literal protocol requirement handling

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4789,6 +4789,10 @@ private:
       return !Bindings.empty() || !Defaults.empty() || isDirectHole();
     }
 
+    /// Determines whether this type variable could be `nil`,
+    /// which means that all of its bindings should be optional.
+    bool canBeNil() const;
+
     /// Determine whether attempting this type variable should be
     /// delayed until the rest of the constraint system is considered
     /// "fully bound" meaning constraints, which affect completeness
@@ -4974,6 +4978,28 @@ private:
     void addDefault(Constraint *constraint);
 
     void addLiteral(Constraint *constraint);
+
+    /// Determines whether the given literal protocol is "covered"
+    /// by the given binding - type of the binding could either be
+    /// equal (in canonical sense) to the protocol's default type,
+    /// or conform to a protocol.
+    ///
+    /// \param literal The literal protocol requirement to check.
+    ///
+    /// \param binding The binding to check for coverage.
+    ///
+    /// \param canBeNil The flag that determines whether given type
+    /// variable requires all of its bindings to be optional.
+    ///
+    /// \param isDirectRequirement The flag that determines whether
+    /// this literal conformance requirement is associated with the
+    /// current type variable or it's inferred.
+    ///
+    /// \returns true if binding covers given literal protocol.
+    bool isLiteralCoveredBy(ProtocolDecl *literal,
+                            PotentialBinding &binding,
+                            bool canBeNil,
+                            bool isDirectRequirement) const;
 
     /// Add a potential binding to the list of bindings,
     /// coalescing supertype bounds when we are able to compute the meet.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -66,12 +66,6 @@ class SolutionApplicationTarget;
 
 } // end namespace constraints
 
-namespace unittest {
-
-class SemaTest;
-
-} // end namespace unittest
-
 // Forward declare some TypeChecker related functions
 // so they could be made friends of ConstraintSystem.
 namespace TypeChecker {
@@ -2025,8 +2019,6 @@ enum class SolutionApplicationToFunctionResult {
 /// Constraint systems are typically generated given an (untyped) expression.
 class ConstraintSystem {
   ASTContext &Context;
-
-  friend class swift::unittest::SemaTest;
 
 public:
   DeclContext *DC;
@@ -4625,7 +4617,8 @@ public:
       ConstraintKind bodyResultConstraintKind,
       ConstraintLocatorBuilder locator);
 
-private:
+public: // binding inference logic is public for unit testing.
+
   /// The kind of bindings that are permitted.
   enum class AllowedBindingKind : uint8_t {
     /// Only the exact type.
@@ -4763,7 +4756,6 @@ private:
     bool viableAsBinding() const { return !isCovered() && hasDefaultType(); }
   };
 
-private:
   struct PotentialBindings {
     using BindingScore =
         std::tuple<bool, bool, bool, bool, bool, unsigned char, int>;
@@ -5157,7 +5149,6 @@ public:
   Optional<Type> checkTypeOfBinding(TypeVariableType *typeVar, Type type) const;
   Optional<PotentialBindings> determineBestBindings();
 
-public:
   /// Infer bindings for the given type variable based on current
   /// state of the constraint system.
   PotentialBindings inferBindingsFor(TypeVariableType *typeVar,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4729,6 +4729,10 @@ public: // binding inference logic is public for unit testing.
     /// this points to the source of the binding.
     mutable Constraint *CoveredBy = nullptr;
 
+    LiteralRequirement(Constraint *source, Type defaultTy, bool isDirect)
+        : Source(source), DefaultType(defaultTy),
+          IsDirectRequirement(isDirect) {}
+
     Constraint *getSource() const { return Source; }
 
     ProtocolDecl *getProtocol() const { return Source->getProtocol(); }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -644,9 +644,6 @@ void ConstraintSystem::PotentialBindings::addPotentialBinding(
       return;
   }
 
-  if (auto *literalProtocol = binding.getDefaultedLiteralProtocol())
-    foundLiteralBinding(literalProtocol);
-
   // If the type variable can't bind to an lvalue, make sure the
   // type we pick isn't an lvalue.
   if (!TypeVar->getImpl().canBindToLValue() &&

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -664,19 +664,16 @@ void ConstraintSystem::PotentialBindings::addLiteral(Constraint *constraint) {
   // doesn't have a default type.
   if (protocol->isSpecificProtocol(
           KnownProtocolKind::ExpressibleByNilLiteral)) {
-    Literals.insert({protocol,
-                     {.Source = constraint,
-                      .DefaultType = Type(),
-                      .IsDirectRequirement = isDirect}});
+    Literals.insert(
+        {protocol, LiteralRequirement(constraint,
+                                      /*DefaultType=*/Type(), isDirect)});
     return;
   }
 
   // Check whether any of the existing bindings covers this literal
   // protocol.
-  LiteralRequirement literal{.Source = constraint,
-                             .DefaultType =
-                                 TypeChecker::getDefaultType(protocol, CS.DC),
-                             .IsDirectRequirement = isDirect};
+  LiteralRequirement literal(
+      constraint, TypeChecker::getDefaultType(protocol, CS.DC), isDirect);
 
   {
     bool allowsNil = canBeNil();

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2287,11 +2287,31 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
     return;
 
   auto bindings = cs.inferBindingsFor(typeVar);
-  if (bindings.isHole() || bindings.involvesTypeVariables() ||
-      bindings.Bindings.size() != 1)
+
+  auto numBindings =
+      bindings.Bindings.size() + bindings.getNumViableLiteralBindings();
+  if (bindings.isHole() || bindings.involvesTypeVariables() || numBindings != 1)
     return;
 
-  auto conversionType = bindings.Bindings[0].BindingType;
+  Type conversionType;
+
+  // There is either a single direct/transitive binding, or
+  // a single literal default.
+  if (!bindings.Bindings.empty()) {
+    conversionType = bindings.Bindings[0].BindingType;
+  } else {
+    for (const auto &literal : bindings.Literals) {
+      auto *coveredBy = std::get<2>(literal.second);
+      if (coveredBy)
+        continue;
+
+      if (auto defaultTy = TypeChecker::getDefaultType(literal.first, cs.DC)) {
+        conversionType = defaultTy;
+        break;
+      }
+    }
+  }
+
   auto constraints = cs.CG.gatherConstraints(
       typeVar,
       ConstraintGraph::GatheringKind::EquivalenceClass,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2301,12 +2301,8 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
     conversionType = bindings.Bindings[0].BindingType;
   } else {
     for (const auto &literal : bindings.Literals) {
-      auto *coveredBy = std::get<2>(literal.second);
-      if (coveredBy)
-        continue;
-
-      if (auto defaultTy = TypeChecker::getDefaultType(literal.first, cs.DC)) {
-        conversionType = defaultTy;
+      if (literal.second.viableAsBinding()) {
+        conversionType = literal.second.getDefaultType();
         break;
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5331,9 +5331,8 @@ TypeVarBindingProducer::TypeVarBindingProducer(
     ConstraintSystem::PotentialBindings &bindings)
     : BindingProducer(bindings.CS, bindings.TypeVar->getImpl().getLocator()),
       TypeVar(bindings.TypeVar),
-      CanBeNil(llvm::any_of(bindings.Protocols, [](Constraint *constraint) {
-        auto *protocol = constraint->getProtocol();
-        return protocol->isSpecificProtocol(
+      CanBeNil(llvm::any_of(bindings.Literals, [](const auto &literal) {
+        return literal.first->isSpecificProtocol(
             KnownProtocolKind::ExpressibleByNilLiteral);
       })) {
   if (bindings.isDirectHole()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5330,11 +5330,7 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
 TypeVarBindingProducer::TypeVarBindingProducer(
     ConstraintSystem::PotentialBindings &bindings)
     : BindingProducer(bindings.CS, bindings.TypeVar->getImpl().getLocator()),
-      TypeVar(bindings.TypeVar),
-      CanBeNil(llvm::any_of(bindings.Literals, [](const auto &literal) {
-        return literal.first->isSpecificProtocol(
-            KnownProtocolKind::ExpressibleByNilLiteral);
-      })) {
+      TypeVar(bindings.TypeVar), CanBeNil(bindings.canBeNil()) {
   if (bindings.isDirectHole()) {
     auto *locator = getLocator();
     // If this type variable is associated with a code completion token

--- a/test/Constraints/sr10757.swift
+++ b/test/Constraints/sr10757.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-10757
+
+struct Parser<A> {
+  let run: (inout Substring) -> A?
+
+  func map<B>(_ f: @escaping (A) -> B) -> Parser<B> {
+    return Parser<B> { input in
+      self.run(&input).map(f)
+    }
+  }
+}
+
+let char = Parser<Character> { str in
+  guard let match = str.first else { return nil }
+  str.removeFirst()
+  return match
+}
+
+let northSouth = char.map {
+  $0 == "N"
+      ? 1.0
+      : $0 == "S" ? -1 : nil // Ok
+}

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -36,14 +36,19 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
           ->getDeclaredInterfaceType(),
       cs.getConstraintLocator(intLiteral));
 
-  auto bindings = cs.inferBindingsFor(literalTy);
+  auto intTy = getStdlibType("Int");
 
-  ASSERT_EQ(bindings.Bindings.size(), (unsigned)1);
+  {
+    auto bindings = cs.inferBindingsFor(literalTy);
 
-  const auto &binding = bindings.Bindings.front();
+    ASSERT_EQ(bindings.Literals.size(), (unsigned)1);
 
-  ASSERT_TRUE(binding.BindingType->isEqual(getStdlibType("Int")));
-  ASSERT_TRUE(binding.hasDefaultedLiteralProtocol());
+    const auto &literal = bindings.Literals.front().second;
+
+    ASSERT_TRUE(literal.hasDefaultType());
+    ASSERT_TRUE(literal.getDefaultType()->isEqual(intTy));
+    ASSERT_FALSE(literal.isCovered());
+  }
 }
 
 // Given a set of inferred protocol requirements, make sure that

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -13,6 +13,7 @@
 #include "SemaFixture.h"
 #include "swift/AST/Expr.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 using namespace swift;
@@ -48,6 +49,97 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
     ASSERT_TRUE(literal.hasDefaultType());
     ASSERT_TRUE(literal.getDefaultType()->isEqual(intTy));
     ASSERT_FALSE(literal.isCovered());
+  }
+
+  // Make sure that coverage by direct bindings works as expected.
+
+  // First, let's attempt a binding which would match default type
+  // of the literal.
+
+  cs.addConstraint(ConstraintKind::Conversion, literalTy, intTy,
+                   cs.getConstraintLocator(intLiteral));
+
+  {
+    auto bindings = cs.inferBindingsFor(literalTy);
+
+    ASSERT_EQ(bindings.Bindings.size(), (unsigned)1);
+    ASSERT_EQ(bindings.Literals.size(), (unsigned)1);
+
+    ASSERT_TRUE(bindings.Bindings[0].BindingType->isEqual(intTy));
+
+    const auto &literal = bindings.Literals.front().second;
+    ASSERT_TRUE(literal.isCovered());
+    ASSERT_TRUE(literal.isDirectRequirement());
+    ASSERT_TRUE(literal.getDefaultType()->isEqual(intTy));
+  }
+
+  // Now let's use non-default type that conforms to
+  // `ExpressibleByIntegerLiteral` protocol.
+
+  auto *floatLiteralTy =
+      cs.createTypeVariable(cs.getConstraintLocator(intLiteral),
+                            /*options=*/0);
+
+  auto floatTy = getStdlibType("Float");
+
+  // $T_float <conforms to> ExpressibleByIntegerLiteral
+  cs.addConstraint(
+      ConstraintKind::LiteralConformsTo, floatLiteralTy,
+      Context.getProtocol(KnownProtocolKind::ExpressibleByIntegerLiteral)
+          ->getDeclaredInterfaceType(),
+      cs.getConstraintLocator(intLiteral));
+
+  // Float <covertible> $T_float
+  cs.addConstraint(ConstraintKind::Conversion, floatTy, floatLiteralTy,
+                   cs.getConstraintLocator(intLiteral));
+
+  {
+    auto bindings = cs.inferBindingsFor(floatLiteralTy);
+
+    ASSERT_EQ(bindings.Bindings.size(), (unsigned)1);
+    ASSERT_EQ(bindings.Literals.size(), (unsigned)1);
+
+    ASSERT_TRUE(bindings.Bindings[0].BindingType->isEqual(floatTy));
+
+    const auto &literal = bindings.Literals.front().second;
+    ASSERT_TRUE(literal.isCovered());
+    ASSERT_TRUE(literal.isDirectRequirement());
+    ASSERT_FALSE(literal.getDefaultType()->isEqual(floatTy));
+  }
+
+  // Let's test transitive literal requirement coverage,
+  // literal requirements are prepagated up the subtype chain.
+
+  auto *otherTy = cs.createTypeVariable(cs.getConstraintLocator({}),
+                                        /*options=*/0);
+
+  cs.addConstraint(ConstraintKind::Subtype, floatLiteralTy, otherTy,
+                   cs.getConstraintLocator({}));
+
+  {
+    auto bindings = cs.inferBindingsFor(otherTy, /*finalize=*/false);
+
+    // Make sure that there are no direct bindings or protocol requirements.
+
+    ASSERT_EQ(bindings.Bindings.size(), (unsigned)0);
+    ASSERT_EQ(bindings.Literals.size(), (unsigned)0);
+
+    llvm::SmallDenseMap<TypeVariableType *, ConstraintSystem::PotentialBindings>
+        env;
+    env.insert({floatLiteralTy, cs.inferBindingsFor(floatLiteralTy)});
+
+    bindings.finalize(cs, env);
+
+    // Inferred a single transitive binding through `$T_float`.
+    ASSERT_EQ(bindings.Bindings.size(), (unsigned)1);
+    // Inferred literal requirement through `$T_float` as well.
+    ASSERT_EQ(bindings.Literals.size(), (unsigned)1);
+
+    const auto &literal = bindings.Literals.front().second;
+
+    ASSERT_TRUE(literal.isCovered());
+    ASSERT_FALSE(literal.isDirectRequirement());
+    ASSERT_FALSE(literal.getDefaultType()->isEqual(floatTy));
   }
 }
 


### PR DESCRIPTION
These changes refactor literal protocol requirement handling in `PotentialBindings`
to be more incremental. Each literal requirement would now record meta-information
about itself (whether it's a direct or transitive requirement, is it covered by an existing binding,
what is its "source" constraint).

Also instead of checking coverage post-factum, during finalization step, that information
is inferred once new bindings and literal requirements are added to the set.

Uncovered defaultable requirements are transformed into bindings only when type variable
is picked for attempting.

Resolves: SR-10757
Resolves: rdar://problem/72770327

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
