### PR TITLE
[build] Make home directory portable

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1167,7 +1167,7 @@ def main_preset():
                 "build-presets.ini")
         ]
 
-        user_presets_file = os.path.join(os.getenv("HOME", "/"),
+        user_presets_file = os.path.join(os.path.expanduser("~"),
                                          '.swift-build-presets')
         if os.path.isfile(user_presets_file):
             args.preset_file_names.append(user_presets_file)


### PR DESCRIPTION
Using `os.path.expanduser('~')` is more portable (in case we want to use
this script on Windows some day in the future).