### PR TITLE
build: improve _InternalSwiftSyntaxParser installation

### DIFF
--- a/tools/libSwiftSyntaxParser/CMakeLists.txt
+++ b/tools/libSwiftSyntaxParser/CMakeLists.txt
@@ -51,9 +51,10 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif()
 
 add_dependencies(parser-lib libSwiftSyntaxParser)
-swift_install_in_component(PROGRAMS "${SWIFT_LIBRARY_OUTPUT_INTDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${SYNTAX_PARSER_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}"
-                           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}"
-                           COMPONENT parser-lib)
+swift_install_in_component(TARGETS libSwiftSyntaxParser
+  ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" COMPONENT parser-lib
+  LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" COMPONENT parser-lib
+  RUNTIME DESTINATION "bin" COMPONENT parser-lib)
 swift_install_in_component(DIRECTORY "${SWIFT_MAIN_INCLUDE_DIR}/swift-c/SyntaxParser/"
                            DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SYNTAX_PARSER_LIB_NAME}"
                            COMPONENT parser-lib)


### PR DESCRIPTION
Use the `TARGETS` form of `install` to avoid having to spell out the
location and file name to install.  Additionally, setup the installation
rules to work better for Windows by listing install locations for the
archive (static library) form (which includes the import library on
Windows), library form (which is the Unix library), and the runtime
component (the .dll on Windows).

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
