### PR TITLE
WinSDK: use computed properties more aggressively

### DIFF
--- a/stdlib/public/Windows/WinSDK.swift
+++ b/stdlib/public/Windows/WinSDK.swift
@@ -13,47 +13,80 @@
 @_exported import WinSDK // Clang module
 
 // WinBase.h
-public let HANDLE_FLAG_INHERIT: DWORD = 0x00000001
+public var HANDLE_FLAG_INHERIT: DWORD {
+  0x00000001
+}
 
 // WinBase.h
-public let STARTF_USESTDHANDLES: DWORD = 0x00000100
+public var STARTF_USESTDHANDLES: DWORD {
+  0x00000100
+}
 
 // WinBase.h
-public let INFINITE: DWORD = DWORD(bitPattern: -1)
+public var INFINITE: DWORD {
+  DWORD(bitPattern: -1)
+}
 
 // WinBase.h
-public let WAIT_OBJECT_0: DWORD = 0
+public var WAIT_OBJECT_0: DWORD {
+  0
+}
 
 // WinBase.h
-public let STD_INPUT_HANDLE: DWORD = DWORD(bitPattern: -10)
-public let STD_OUTPUT_HANDLE: DWORD = DWORD(bitPattern: -11)
-public let STD_ERROR_HANDLE: DWORD = DWORD(bitPattern: -12)
+public var STD_INPUT_HANDLE: DWORD {
+  DWORD(bitPattern: -10)
+}
+public var STD_OUTPUT_HANDLE: DWORD {
+  DWORD(bitPattern: -11)
+}
+public var STD_ERROR_HANDLE: DWORD {
+  DWORD(bitPattern: -12)
+}
 
 // handleapi.h
-public let INVALID_HANDLE_VALUE: HANDLE = HANDLE(bitPattern: -1)!
+public var INVALID_HANDLE_VALUE: HANDLE {
+  HANDLE(bitPattern: -1)!
+}
 
 // shellapi.h
-public let FOF_NO_UI: FILEOP_FLAGS =
-    FILEOP_FLAGS(FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_NOCONFIRMMKDIR)
+public var FOF_NO_UI: FILEOP_FLAGS {
+  FILEOP_FLAGS(FOF_SILENT | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_NOCONFIRMMKDIR)
+}
 
 // winioctl.h
-public let FSCTL_SET_REPARSE_POINT: DWORD = 0x900a4
-public let FSCTL_GET_REPARSE_POINT: DWORD = 0x900a8
-public let FSCTL_DELETE_REPARSE_POINT: DWORD = 0x900ac
+public var FSCTL_SET_REPARSE_POINT: DWORD {
+  0x900a4
+}
+public var FSCTL_GET_REPARSE_POINT: DWORD {
+  0x900a8
+}
+public var FSCTL_DELETE_REPARSE_POINT: DWORD {
+  0x900ac
+}
 
 // WinSock2.h
-public let INVALID_SOCKET: SOCKET = SOCKET(bitPattern: -1)
-public let FIONBIO: Int32 = Int32(bitPattern: 0x8004667e)
+public var INVALID_SOCKET: SOCKET {
+  SOCKET(bitPattern: -1)
+}
+public var FIONBIO: Int32 {
+  Int32(bitPattern: 0x8004667e)
+}
 
 // WinUser.h
-public let CW_USEDEFAULT: Int32 = Int32(bitPattern: 2147483648)
-public let WS_OVERLAPPEDWINDOW: UINT =
-    UINT(WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
-public let WS_POPUPWINDOW: UINT =
-    UINT(numericCast(WS_POPUP) | WS_BORDER | WS_SYSMENU)
+public var CW_USEDEFAULT: Int32 {
+  Int32(bitPattern: 2147483648)
+}
+public var WS_OVERLAPPEDWINDOW: UINT {
+  UINT(WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
+}
+public var WS_POPUPWINDOW: UINT {
+  UINT(numericCast(WS_POPUP) | WS_BORDER | WS_SYSMENU)
+}
 
 // fileapi.h
-public let INVALID_FILE_ATTRIBUTES: DWORD = DWORD(bitPattern: -1)
+public var INVALID_FILE_ATTRIBUTES: DWORD {
+  DWORD(bitPattern: -1)
+}
 
 // CommCtrl.h
 public let WC_BUTTONW: [WCHAR] = Array<WCHAR>("Button".utf16)
@@ -76,32 +109,58 @@ public let TRACKBAR_CLASSW: [WCHAR] = Array<WCHAR>("msctls_trackbar32".utf16)
 public let UPDOWN_CLASSW: [WCHAR] = Array<WCHAR>("msctls_updown32".utf16)
 
 // consoleapi.h
-public let PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: DWORD_PTR = 0x00020016
+public var PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: DWORD_PTR {
+  0x00020016
+}
 
 // windef.h
-public let DPI_AWARENESS_CONTEXT_UNAWARE: DPI_AWARENESS_CONTEXT =
-    DPI_AWARENESS_CONTEXT(bitPattern: -1)!
-public let DPI_AWARENESS_CONTEXT_SYSTEM_AWARE: DPI_AWARENESS_CONTEXT =
-    DPI_AWARENESS_CONTEXT(bitPattern: -2)!
-public let DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE: DPI_AWARENESS_CONTEXT =
-    DPI_AWARENESS_CONTEXT(bitPattern: -3)!
-public let DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT =
-    DPI_AWARENESS_CONTEXT(bitPattern: -4)!
-public let DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT =
-    DPI_AWARENESS_CONTEXT(bitPattern: -5)!
+public var DPI_AWARENESS_CONTEXT_UNAWARE: DPI_AWARENESS_CONTEXT {
+  DPI_AWARENESS_CONTEXT(bitPattern: -1)!
+}
+public var DPI_AWARENESS_CONTEXT_SYSTEM_AWARE: DPI_AWARENESS_CONTEXT {
+  DPI_AWARENESS_CONTEXT(bitPattern: -2)!
+}
+public var DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE: DPI_AWARENESS_CONTEXT {
+  DPI_AWARENESS_CONTEXT(bitPattern: -3)!
+}
+public var DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT {
+  DPI_AWARENESS_CONTEXT(bitPattern: -4)!
+}
+public var DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT {
+  DPI_AWARENESS_CONTEXT(bitPattern: -5)!
+}
 
 // winreg.h
-public let HKEY_CLASSES_ROOT: HKEY = HKEY(bitPattern: UInt(0x80000000))!
-public let HKEY_CURRENT_USER: HKEY = HKEY(bitPattern: UInt(0x80000001))!
-public let HKEY_LOCAL_MACHINE: HKEY = HKEY(bitPattern: UInt(0x80000002))!
-public let HKEY_USERS: HKEY = HKEY(bitPattern: UInt(0x80000003))!
-public let HKEY_PERFORMANCE_DATA: HKEY = HKEY(bitPattern: UInt(0x80000004))!
-public let HKEY_PERFORMANCE_TEXT: HKEY = HKEY(bitPattern: UInt(0x80000050))!
-public let HKEY_PERFORMANCE_NLSTEXT: HKEY = HKEY(bitPattern: UInt(0x80000060))!
-public let HKEY_CURRENT_CONFIG: HKEY = HKEY(bitPattern: UInt(0x80000005))!
-public let HKEY_DYN_DATA: HKEY = HKEY(bitPattern: UInt(0x80000006))!
-public let HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY =
-    HKEY(bitPattern: UInt(0x80000007))!
+public var HKEY_CLASSES_ROOT: HKEY {
+  HKEY(bitPattern: UInt(0x80000000))!
+}
+public var HKEY_CURRENT_USER: HKEY {
+  HKEY(bitPattern: UInt(0x80000001))!
+}
+public var HKEY_LOCAL_MACHINE: HKEY {
+  HKEY(bitPattern: UInt(0x80000002))!
+}
+public var HKEY_USERS: HKEY {
+  HKEY(bitPattern: UInt(0x80000003))!
+}
+public var HKEY_PERFORMANCE_DATA: HKEY {
+  HKEY(bitPattern: UInt(0x80000004))!
+}
+public var HKEY_PERFORMANCE_TEXT: HKEY {
+  HKEY(bitPattern: UInt(0x80000050))!
+}
+public var HKEY_PERFORMANCE_NLSTEXT: HKEY {
+  HKEY(bitPattern: UInt(0x80000060))!
+}
+public var HKEY_CURRENT_CONFIG: HKEY {
+  HKEY(bitPattern: UInt(0x80000005))!
+}
+public var HKEY_DYN_DATA: HKEY {
+  HKEY(bitPattern: UInt(0x80000006))!
+}
+public var HKEY_CURRENT_USER_LOCAL_SETTINGS: HKEY {
+  HKEY(bitPattern: UInt(0x80000007))!
+}
 
 // Richedit.h
 public let MSFTEDIT_CLASS: [WCHAR] = Array<WCHAR>("RICHEDIT50W".utf16)


### PR DESCRIPTION
Rather than stored properties for constants that are not imported via
the clang importer, use computed properties.  Although this breaks ABI,
there is no guarantee of ABI stability on Windows.  The remaining
strings are left as stored properties as they may be interned by the
system.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
