### PR TITLE
[NFC] Replace uses of find(x) != end() idiom with contains(x) for StringRef and Set-like types

### DIFF
--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -162,8 +162,7 @@ public:
 
   bool rightCommentUnderscored() const {
     DeclNameViewer Viewer(RightComment);
-    auto HasUnderScore =
-      [](StringRef S) { return S.find('_') != StringRef::npos; };
+    auto HasUnderScore = [](StringRef S) { return S.contains('_'); };
     auto Args = Viewer.args();
     return HasUnderScore(Viewer.base()) ||
         std::any_of(Args.begin(), Args.end(), HasUnderScore);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1059,7 +1059,7 @@ public:
   /// Returns \c true if the lookup table has a complete accounting of the
   /// given name.
   bool isLazilyComplete(DeclBaseName name) const {
-    return LazilyCompleteNames.find(name) != LazilyCompleteNames.end();
+    return LazilyCompleteNames.contains(name);
   }
 
   /// Mark a given lazily-loaded name as being complete.

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -85,7 +85,7 @@ static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
         Impl.getClangPreprocessor().getSpelling(tok, SpellingBuffer, &Invalid);
     if (Invalid)
       return nullptr;
-    if (TokSpelling.find('_') != StringRef::npos)
+    if (TokSpelling.contains('_'))
       return nullptr;
   }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -660,7 +660,7 @@ static SmallVector<StringRef, 8> findRemovedInputs(
   SmallVector<StringRef, 8> missingInputs;
   for (auto &previousInput : previousInputs) {
     auto previousInputArg = previousInput.getKey();
-    if (inputArgs.find(previousInputArg) == inputArgs.end()) {
+    if (!inputArgs.contains(previousInputArg)) {
       missingInputs.push_back(previousInputArg);
     }
   }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -224,7 +224,7 @@ static void validateCompilationConditionArgs(DiagnosticEngine &diags,
                                              const ArgList &args) {
   for (const Arg *A : args.filtered(options::OPT_D)) {
     StringRef name = A->getValue();
-    if (name.find('=') != StringRef::npos) {
+    if (name.contains('=')) {
       diags.diagnose(SourceLoc(),
                      diag::cannot_assign_value_to_conditional_compilation_flag,
                      name);

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -128,7 +128,7 @@ findDiagnostic(std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics,
 
     // Verify the classification and string.
     if (I->Classification != Expected.Classification ||
-        !I->Message.contains(Expected.MessageStr))
+        I->Message.find(Expected.MessageStr) == StringRef::npos)
       continue;
 
     // Okay, we found a match, hurray!

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -128,7 +128,7 @@ findDiagnostic(std::vector<CapturedDiagnosticInfo> &CapturedDiagnostics,
 
     // Verify the classification and string.
     if (I->Classification != Expected.Classification ||
-        I->Message.find(Expected.MessageStr) == StringRef::npos)
+        !I->Message.contains(Expected.MessageStr))
       continue;
 
     // Okay, we found a match, hurray!

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -911,7 +911,7 @@ static void annotateSnippetWithInfo(SourceManager &SM,
     for (auto fixIt : Info.FixIts) {
       // Don't print multi-line fix-its inline, only include them at the end of
       // the message.
-      if (fixIt.getText().find("\n") == std::string::npos)
+      if (!fixIt.getText().contains("\n"))
         Snippet.addFixIt(fixIt.getRange(), fixIt.getText());
     }
   }

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -93,7 +93,7 @@ static bool validateSymbols(DiagnosticEngine &diags,
           irNotTBD.push_back(unmangledName);
       }
     } else {
-      assert(symbolSet.find(name) == symbolSet.end() &&
+      assert(!symbolSet.contains(name) &&
              "non-global value in value symbol table");
     }
   }

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -424,7 +424,7 @@ getDeclsFromCrossImportOverlay(ModuleDecl *Overlay, ModuleDecl *Declaring,
         return false;
 
       // Ignore an imports of modules also imported by the underlying module.
-      if (PrevImported.find(Imported) != PrevImported.end())
+      if (PrevImported.contains(Imported))
         return false;
     }
     if (auto *VD = dyn_cast<ValueDecl>(D)) {

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1620,8 +1620,7 @@ class DocFieldParser {
 
 public:
   DocFieldParser(StringRef text) : ptr(text.begin()), end(text.end()) {
-    assert(text.rtrim().find('\n') == StringRef::npos &&
-           "expected single line");
+    assert(!text.rtrim().contains('\n') && "expected single line");
   }
 
   // Case-insensitively match one of the following patterns:

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -921,8 +921,8 @@ void ide::collectModuleNames(StringRef SDKPath,
                                std::vector<std::string> &Modules) {
   std::string SDKName = getSDKName(SDKPath);
   std::string lowerSDKName = StringRef(SDKName).lower();
-  bool isOSXSDK = StringRef(lowerSDKName).find("macosx") != StringRef::npos;
-  bool isDeviceOnly = StringRef(lowerSDKName).find("iphoneos") != StringRef::npos;
+  bool isOSXSDK = StringRef(lowerSDKName).contains("macosx");
+  bool isDeviceOnly = StringRef(lowerSDKName).contains("iphoneos");
   auto Mods = isOSXSDK ? getOSXModuleList() : getiOSModuleList();
   Modules.insert(Modules.end(), Mods.begin(), Mods.end());
   if (isDeviceOnly) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1163,7 +1163,7 @@ llvm::SmallString<32> getTargetDependentLibraryOption(const llvm::Triple &T,
   llvm::SmallString<32> buffer;
 
   if (T.isWindowsMSVCEnvironment() || T.isWindowsItaniumEnvironment()) {
-    bool quote = library.find(' ') != StringRef::npos;
+    bool quote = library.contains(' ');
 
     buffer += "/DEFAULTLIB:";
     if (quote)
@@ -1174,7 +1174,7 @@ llvm::SmallString<32> getTargetDependentLibraryOption(const llvm::Triple &T,
     if (quote)
       buffer += '"';
   } else if (T.isPS4()) {
-    bool quote = library.find(' ') != StringRef::npos;
+    bool quote = library.contains(' ');
 
     buffer += "\01";
     if (quote)

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -193,8 +193,7 @@ public:
     // intrinsics are atomic today.
     if (I->getIntrinsicID() != llvm::Intrinsic::not_intrinsic)
       return false;
-    return (I->getCalledFunction()->getName().find("nonatomic") !=
-            llvm::StringRef::npos);
+    return (I->getCalledFunction()->getName().contains("nonatomic"));
   }
 
   bool isAtomic(CallInst *I) {

--- a/lib/LLVMPasses/LLVMARCOpts.cpp
+++ b/lib/LLVMPasses/LLVMARCOpts.cpp
@@ -142,8 +142,8 @@ static bool canonicalizeInputFunction(Function &F, ARCEntryPointBuilder &B,
         // Have not encountered a strong retain/release. keep it in the
         // unknown retain/release list for now. It might get replaced
         // later.
-        if (NativeRefs.find(ArgVal) == NativeRefs.end()) {
-           UnknownObjectRetains[ArgVal].push_back(&CI);
+        if (!NativeRefs.contains(ArgVal)) {
+          UnknownObjectRetains[ArgVal].push_back(&CI);
         } else {
           B.setInsertPoint(&CI);
           B.createRetain(ArgVal, &CI);
@@ -189,7 +189,7 @@ static bool canonicalizeInputFunction(Function &F, ARCEntryPointBuilder &B,
         // Have not encountered a strong retain/release. keep it in the
         // unknown retain/release list for now. It might get replaced
         // later.
-        if (NativeRefs.find(ArgVal) == NativeRefs.end()) {
+        if (!NativeRefs.contains(ArgVal)) {
           UnknownObjectReleases[ArgVal].push_back(&CI);
         } else {
           B.setInsertPoint(&CI);

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1358,8 +1358,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     llvm::raw_svector_ostream OS(Buffer);
     if (swift::ide::printValueDeclUSR(OD, OS))
       return SourceLoc();
-    return OverridingRemoveNames.find(OS.str()) == OverridingRemoveNames.end() ?
-      SourceLoc() : OverrideLoc;
+    return OverridingRemoveNames.contains(OS.str()) ? OverrideLoc : SourceLoc();
   }
 
   struct SuperRemoval: public ASTWalker {
@@ -1380,7 +1379,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
           auto *RD = DSC->getFn()->getReferencedDecl().getDecl();
           if (swift::ide::printValueDeclUSR(RD, OS))
             return false;
-          return USRs.find(OS.str()) != USRs.end();
+          return USRs.contains(OS.str());
         }
       }
       // We should handle try super.foo() too.

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -71,7 +71,7 @@ static bool isClangKeyword(Identifier name) {
 
   if (name.empty())
     return false;
-  return keywords.find(name.str()) != keywords.end();
+  return keywords.contains(name.str());
 }
 
 

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -697,7 +697,7 @@ findMatchingRetains(SILBasicBlock *BB) {
         SA = nullptr;
 
       for (auto X : R.first->getPredecessorBlocks()) {
-        if (HandledBBs.find(X) != HandledBBs.end())
+        if (HandledBBs.contains(X))
           continue;
         // Try to use the predecessor edge-value.
         if (SA && SA->getIncomingPhiValue(X)) {

--- a/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EpilogueARCAnalysis.cpp
@@ -40,8 +40,8 @@ void EpilogueARCContext::initializeDataflow() {
     SILValue CArg = ToProcess.pop_back_val();
     if (!CArg)
       continue;
-    if (Processed.find(CArg) != Processed.end())
-       continue;
+    if (Processed.contains(CArg))
+      continue;
     Processed.insert(CArg);
     if (auto *A = dyn_cast<SILPhiArgument>(CArg)) {
       // Find predecessor and break the SILArgument to predecessors.

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -236,7 +236,7 @@ static void removeToken(SILValue Op) {
     if (!(GAI->use_empty() || GAI->hasOneUse()))
       return;
     // If it is not a *_token global variable, bail.
-    if (!Global || Global->getName().find("_token") == StringRef::npos)
+    if (!Global || !Global->getName().contains("_token"))
       return;
     GAI->getModule().eraseGlobalVariable(Global);
     GAI->replaceAllUsesWithUndef();

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -163,12 +163,11 @@ static bool doPrintBefore(SILTransform *T, SILFunction *F) {
     return false;
 
   if (!SILPrintOnlyFuns.empty() && F &&
-      F->getName().find(SILPrintOnlyFuns, 0) == StringRef::npos)
+      !F->getName().contains(SILPrintOnlyFuns))
     return false;
 
   auto MatchFun = [&](const std::string &Str) -> bool {
-    return T->getTag().find(Str) != StringRef::npos
-      || T->getID().find(Str) != StringRef::npos;
+    return T->getTag().contains(Str) || T->getID().contains(Str);
   };
 
   if (SILPrintBefore.end() !=
@@ -188,12 +187,11 @@ static bool doPrintAfter(SILTransform *T, SILFunction *F, bool Default) {
     return false;
 
   if (!SILPrintOnlyFuns.empty() && F &&
-      F->getName().find(SILPrintOnlyFuns, 0) == StringRef::npos)
+      !F->getName().contains(SILPrintOnlyFuns))
     return false;
 
   auto MatchFun = [&](const std::string &Str) -> bool {
-    return T->getTag().find(Str) != StringRef::npos
-      || T->getID().find(Str) != StringRef::npos;
+    return T->getTag().contains(Str) || T->getID().contains(Str);
   };
 
   if (SILPrintAfter.end() !=
@@ -215,8 +213,7 @@ static bool isDisabled(SILTransform *T, SILFunction *F = nullptr) {
     return false;
 
   for (const std::string &NamePattern : SILDisablePass) {
-    if (T->getTag().find(NamePattern) != StringRef::npos
-        || T->getID().find(NamePattern) != StringRef::npos) {
+    if (T->getTag().contains(NamePattern) || T->getID().contains(NamePattern)) {
       return true;
     }
   }
@@ -233,8 +230,7 @@ static void printModule(SILModule *Mod, bool EmitVerboseSIL) {
         std::find(SILPrintOnlyFun.begin(), SILPrintOnlyFun.end(), F.getName()))
       F.dump(EmitVerboseSIL);
 
-    if (!SILPrintOnlyFuns.empty() &&
-        F.getName().find(SILPrintOnlyFuns, 0) != StringRef::npos)
+    if (!SILPrintOnlyFuns.empty() && F.getName().contains(SILPrintOnlyFuns))
       F.dump(EmitVerboseSIL);
   }
 }
@@ -429,8 +425,7 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
   CurrentPassHasInvalidated = false;
 
   auto MatchFun = [&](const std::string &Str) -> bool {
-    return SFT->getTag().find(Str) != StringRef::npos ||
-           SFT->getID().find(Str) != StringRef::npos;
+    return SFT->getTag().contains(Str) || SFT->getID().contains(Str);
   };
   if ((SILVerifyBeforePass.end() != std::find_if(SILVerifyBeforePass.begin(),
                                                  SILVerifyBeforePass.end(),
@@ -597,8 +592,7 @@ void SILPassManager::runModulePass(unsigned TransIdx) {
   }
 
   auto MatchFun = [&](const std::string &Str) -> bool {
-    return SMT->getTag().find(Str) != StringRef::npos ||
-           SMT->getID().find(Str) != StringRef::npos;
+    return SMT->getTag().contains(Str) || SMT->getID().contains(Str);
   };
   if ((SILVerifyBeforePass.end() != std::find_if(SILVerifyBeforePass.begin(),
                                                  SILVerifyBeforePass.end(),

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -1290,7 +1290,7 @@ public:
 
     // Dump function if requested.
     if (DumpFuncsBeforeOutliner.size() &&
-        Fun->getName().find(DumpFuncsBeforeOutliner, 0) != StringRef::npos) {
+        Fun->getName().contains(DumpFuncsBeforeOutliner)) {
       Fun->dump();
     }
 

--- a/lib/SILOptimizer/UtilityPasses/CFGPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/CFGPrinter.cpp
@@ -53,7 +53,7 @@ class SILCFGPrinter : public SILFunctionTransform {
     if (!SILViewCFGOnlyFun.empty() && F && F->getName() != SILViewCFGOnlyFun)
       return;
     if (!SILViewCFGOnlyFuns.empty() && F &&
-        F->getName().find(SILViewCFGOnlyFuns, 0) == StringRef::npos)
+        !F->getName().contains(SILViewCFGOnlyFuns))
       return;
 
     F->viewCFG();

--- a/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
+++ b/lib/SILOptimizer/UtilityPasses/LoopRegionPrinter.cpp
@@ -50,7 +50,7 @@ class LoopRegionViewText : public SILModuleTransform {
       if (!SILViewCFGOnlyFun.empty() && fn.getName() != SILViewCFGOnlyFun)
         continue;
       if (!SILViewCFGOnlyFuns.empty() &&
-          fn.getName().find(SILViewCFGOnlyFuns, 0) == StringRef::npos)
+          !fn.getName().contains(SILViewCFGOnlyFuns))
         continue;
 
       // Ok, we are going to analyze this function. Invalidate all state
@@ -74,7 +74,7 @@ class LoopRegionViewCFG : public SILModuleTransform {
       if (!SILViewCFGOnlyFun.empty() && fn.getName() != SILViewCFGOnlyFun)
         continue;
       if (!SILViewCFGOnlyFuns.empty() &&
-          fn.getName().find(SILViewCFGOnlyFuns, 0) == StringRef::npos)
+          !fn.getName().contains(SILViewCFGOnlyFuns))
         continue;
 
       // Ok, we are going to analyze this function. Invalidate all state

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -790,8 +790,8 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
     return nullptr;
   }
 
-  if (!SILInlineNeverFuns.empty()
-      && Callee->getName().find(SILInlineNeverFuns, 0) != StringRef::npos)
+  if (!SILInlineNeverFuns.empty() &&
+      Callee->getName().contains(SILInlineNeverFuns))
     return nullptr;
 
   if (!SILInlineNeverFun.empty() &&

--- a/tools/SourceKit/lib/Support/UIDRegistry.cpp
+++ b/tools/SourceKit/lib/Support/UIDRegistry.cpp
@@ -85,7 +85,7 @@ void UIdent::print(llvm::raw_ostream &OS) const {
 
 void *UIDRegistryImpl::get(StringRef Str) {
   assert(!Str.empty());
-  assert(Str.find(' ') == StringRef::npos);
+  assert(!Str.contains(' '));
   EntryTy *Ptr = 0;
   Queue.dispatchSync([&]{
     HashTableTy::iterator It = HashTable.find(Str);

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-Common.cpp
@@ -721,7 +721,7 @@ sourcekitd_object_t YAMLRequestParser::createObjFromNode(
     if (!Raw.getAsInteger(10, val))
       return sourcekitd_request_int64_create(val);
 
-    if (Raw.find(' ') != StringRef::npos)
+    if (Raw.contains(' '))
       return withError("Found space in non-string value", Value, Error);
 
     return sourcekitd_request_uid_create(

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -104,8 +104,8 @@ static bool shouldRunAsSubcommand(StringRef ExecName,
   // Otherwise, we have a program argument. If it looks like an option or a
   // path, then invoke in interactive mode with the arguments as given.
   StringRef FirstArg(Args[1]);
-  if (FirstArg.startswith("-") || FirstArg.find('.') != StringRef::npos ||
-      FirstArg.find('/') != StringRef::npos)
+  if (FirstArg.startswith("-") || FirstArg.contains('.') ||
+      FirstArg.contains('/'))
     return false;
 
   // Otherwise, we should have some sort of subcommand. Get the subcommand name

--- a/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
+++ b/tools/swift-api-digester/ModuleAnalyzerNodes.cpp
@@ -2291,8 +2291,7 @@ int swift::ide::api::findDeclUsr(StringRef dumpPath, CheckerOptions Opts) {
     FinderByLocation(StringRef Location): Location(Location) {}
     void visit(SDKNode* Node) override {
       if (auto *D = dyn_cast<SDKNodeDecl>(Node)) {
-        if (D->getLocation().find(Location) != StringRef::npos &&
-            !D->getUsr().empty()) {
+        if (D->getLocation().contains(Location) && !D->getUsr().empty()) {
           llvm::outs() << D->getFullyQualifiedName() << ": " << D->getUsr() << "\n";
         }
       }

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -2508,11 +2508,13 @@ static int generateMigrationScript(StringRef LeftPath, StringRef RightPath,
   TypeAliasDiffFinder(RightModule, LeftModule, RevertAliasMap).search();
   populateAliasChanges(RevertAliasMap, AllItems, /*IsRevert*/true);
 
-  AllItems.erase(std::remove_if(AllItems.begin(), AllItems.end(),
-                                [&](CommonDiffItem &Item) {
-    return Item.DiffKind == NodeAnnotation::RemovedDecl &&
-      IgnoredRemoveUsrs.find(Item.LeftUsr) != IgnoredRemoveUsrs.end();
-  }), AllItems.end());
+  AllItems.erase(
+      std::remove_if(AllItems.begin(), AllItems.end(),
+                     [&](CommonDiffItem &Item) {
+                       return Item.DiffKind == NodeAnnotation::RemovedDecl &&
+                              IgnoredRemoveUsrs.contains(Item.LeftUsr);
+                     }),
+      AllItems.end());
 
   NoEscapeFuncParamVector AllNoEscapingFuncs;
   NoEscapingFuncEmitter::collectDiffItems(RightModule, AllNoEscapingFuncs);


### PR DESCRIPTION
<!-- What's in this pull request? -->
> A little while back, LLVM Set-like data types got contains(t) methods which make code more readable. Many places in the compiler use the find(a) != .end() idiom to check for membership (and in some places find(a) == .end() to check if the item is not present).
>
> It would be nice to update the code to use contains(a) to improve the readability.

This PR replaces usages of `.find(Key) != .end()` idiom with `.contains(Key)`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13950.](https://bugs.swift.org/browse/SR-13950)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

@varungandhi-apple Could you please review this? :) 🙏 
