### PR TITLE
[Diagnostics] Improve diagnostic for defaulted accessor in a protocol property.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -248,6 +248,8 @@ ERROR(computed_property_no_accessors, none,
       "%select{computed property|subscript}0 must have accessors specified", (bool))
 ERROR(expected_getset_in_protocol,none,
       "expected get or set in a protocol property", ())
+ERROR(unexpected_getset_implementation_in_protocol,none,
+      "protocol property %0 cannot have a default implementation specified here; use extension instead", (StringRef))
 ERROR(computed_property_missing_type,none,
       "computed property must have an explicit type", ())
 ERROR(getset_nontrivial_pattern,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5817,9 +5817,15 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
                                  existingAccessor);
     }
 
-    // There's no body in the limited syntax.
-    if (parsingLimitedSyntax)
+    // There's should be no body in the limited syntax.
+    if (parsingLimitedSyntax) {
+      // If there ~is~ a body in the limited syntax, alert that accessors can not
+      // be implemented.
+      if (Tok.is(tok::l_brace))
+        diagnose(Tok, diag::unexpected_getset_implementation_in_protocol,
+                 getAccessorNameForDiagnostic(Kind, /*article*/ false));
       continue;
+    }
 
     // It's okay not to have a body if there's an external asm name.
     if (!Tok.is(tok::l_brace)) {

--- a/test/decl/protocol/invalid_accessors_implementation.swift
+++ b/test/decl/protocol/invalid_accessors_implementation.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift
+
+
+//===---
+// SR-13963
+//===---
+
+protocol Protocol1 {
+  var a: Int { get { 0 } } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol2 {
+  var a: Int { set { a = 0 } } // expected-error {{protocol property setter cannot have a default implementation specified here; use extension instead}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol3 {
+  var a: Int { get { 0 } set } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol4 {
+  var a: Int { get { 0 } set { a = 0 } } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol5 {
+  var a: Int { get set willSet { print("HI")} } // expected-error {{expected get or set in a protocol property}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol6 {
+  var a: Int { get { 0 } set willSet { print("HI")} } // expected-error {{protocol property getter cannot have a default implementation specified here; use extension instead}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol7 {
+  var a: Int { set { print("HI") } willSet { print("HI") } } // expected-error {{protocol property setter cannot have a default implementation specified here; use extension instead}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol8 {
+  var a: Int { set willSet { print("HI") } } // expected-error {{expected get or set in a protocol property}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol9 {
+  var a: Int { return 0 } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected get or set in a protocol property}}
+}
+
+protocol Protocol10 {
+}
+// No error in extension
+extension Protocol10 {
+  var a: Int { return 0 }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Code example:
```
protocol P {
    var x : Int {
        get { 0 }
        //  ^ error: expected get or set in a protocol property
    }
}
```
> we should provide a clearer diagnostic saying that you cannot provide a default implementation for a getter in a protocol, or something along those lines.

This PR adds a diagnostics that says `protocol property cannot have a default implementation of {ACCESSOR_TYPE}` when a body is provided to a computed property in protocol.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13963.](https://bugs.swift.org/browse/SR-13963)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
