### PR TITLE
Use SWIFT_HOST_VARIANT_ARCH for SWIFT_PRIMARY_VARIANT_ARCH_default instead of x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,7 +776,7 @@ elseif("${SWIFT_HOST_VARIANT_SDK}" MATCHES "(OSX|IOS*|TVOS*|WATCHOS*)")
   #
   # Primary variant is always OSX; even on iOS hosts.
   set(SWIFT_PRIMARY_VARIANT_SDK_default "OSX")
-  set(SWIFT_PRIMARY_VARIANT_ARCH_default "x86_64")
+  set(SWIFT_PRIMARY_VARIANT_ARCH_default "${SWIFT_HOST_VARIANT_ARCH}")
 
 endif()
 


### PR DESCRIPTION
Building Swift failed on my m1 MBP:
```
./swift/utils/build-script --release --no-assertions --skip-build-benchmarks --swift-darwin-supported-archs arm64
```
The following was created in `build/Ninja-DebugAssert/swift-macosx-arm64/build.ninja`
```
# Phony custom command for stdlib/CMakeFiles/swift-test-stdlib

build stdlib/CMakeFiles/swift-test-stdlib: phony stdlib/swift-test-stdlib-macosx-x86_64
```
This change fixes it.