### PR TITLE
SILOptimizer: treat a `destroy_addr` as modification

### DIFF
--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -321,6 +321,10 @@ SILInstruction *TempRValueOptPass::getLastUseWhileSourceIsNotModified(
     if (useInsts.count(inst))
       ++numLoadsFound;
 
+    if (auto *DAI = dyn_cast<DestroyAddrInst>(inst))
+      if (DAI->getOperand() == copySrc)
+        return nullptr;
+
     // If this is the last use of the temp we are ok. After this point,
     // modifications to the source don't matter anymore.
     // Note that we are assuming here that if an instruction loads and writes


### PR DESCRIPTION
When performing the r-value elimination pass repeatedly, we may have
inserted a `destroy_addr` of the source value.  In such a case, it is
important to treat the `destroy_addr` as a modification (as you may not
use the value any longer).  This seems to match the behaviour observed
on macOS (and theoretically Windows).  Although this appears to extra
copy, it does not misuse memory.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
