### PR TITLE
[SR-13753][Diagnostics] Downgrade l-value unused diagnostics to warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3786,8 +3786,8 @@ ERROR(expression_unused_closure,none,
       "closure expression is unused", ())
 ERROR(expression_unused_function,none,
       "expression resolves to an unused function", ())
-ERROR(expression_unused_lvalue,none,
-      "expression resolves to an unused %select{variable|property|subscript}0", (unsigned))
+WARNING(expression_unused_lvalue,none,
+        "expression resolves to an unused %select{variable|property|subscript}0", (unsigned))
 WARNING(expression_unused_result_call,none,
         "result of call to %0 is unused", (DeclName))
 WARNING(expression_unused_result_operator,none,

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -63,7 +63,7 @@ static void diagnoseMissingReturn(const UnreachableInst *UI,
   if (!BS->empty()) {
     auto element = BS->getLastElement();
     if (auto expr = element.dyn_cast<Expr *>()) {
-      if (expr->getType()->isEqual(ResTy)) {
+      if (expr->getType()->getRValueType()->isEqual(ResTy)) {
         Context.Diags.diagnose(
           expr->getStartLoc(),
           diag::missing_return_last_expr, ResTy,

--- a/test/Parse/consecutive_statements.swift
+++ b/test/Parse/consecutive_statements.swift
@@ -6,13 +6,13 @@ func statement_starts() {
 
   f(0)
   f (0)
-  f // expected-error{{expression resolves to an unused variable}}
+  f // expected-warning{{expression resolves to an unused variable}}
   (0) // expected-warning {{integer literal is unused}}
 
   var a = [1,2,3]
   a[0] = 1
   a [0] = 1
-  a // expected-error{{expression resolves to an unused variable}}
+  a // expected-warning{{expression resolves to an unused variable}}
   [0, 1, 2] // expected-warning {{expression of type '[Int]' is unused}}
 }
 

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -34,7 +34,7 @@ class D : B {
   }
 
   func super_calls() {
-    super.foo        // expected-error {{expression resolves to an unused property}}
+    super.foo        // expected-warning {{expression resolves to an unused property}}
     super.foo.bar    // expected-error {{value of type 'Int' has no member 'bar'}}
     super.bar        // expected-error {{expression resolves to an unused function}}
     super.bar()
@@ -42,7 +42,7 @@ class D : B {
     super.init // expected-error{{no exact matches in reference to initializer}}
     super.init() // expected-error{{'super.init' cannot be called outside of an initializer}}
     super.init(0) // expected-error{{'super.init' cannot be called outside of an initializer}} // expected-error {{missing argument label 'x:' in call}}
-    super[0]        // expected-error {{expression resolves to an unused subscript}}
+    super[0]        // expected-warning {{expression resolves to an unused subscript}}
     super
       .bar()
   }

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -159,3 +159,57 @@ struct StructWithIUOinit : InitProtocol {
   init!(_ x: Int) {  } // no missing-return error
 }
 
+func testSR13753() {
+  // SR-13753
+  let _ : () -> Int = {
+    var x : Int {
+      get { 0 }
+      set { }
+    }
+    x // expected-error {{missing return in a closure expected to return 'Int'; did you mean to return the last expression?}} {{5-5=return }}
+    // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
+    // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
+    // expected-warning@-3 {{expression resolves to an unused variable}} 
+  }
+
+  func f() -> Int {
+    var x : Int {
+        get { 0 }
+        set { }
+    }
+    x // expected-error {{missing return in a function expected to return 'Int'; did you mean to return the last expression?}} {{5-5=return }}
+    // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
+    // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
+    // expected-warning@-3 {{expression resolves to an unused variable}} 
+  } 
+
+  let _ : () -> Int = {
+    var x : UInt {
+      get { 0 }
+      set { }
+    }
+    x 
+    // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
+    // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
+    // expected-warning@-3 {{expression resolves to an unused variable}} 
+  } // expected-error {{missing return in a closure expected to return 'Int'}}
+
+  func f1() -> Int {
+    var x : UInt {
+        get { 0 }
+        set { }
+    }
+    x 
+    // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
+    // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
+    // expected-warning@-3 {{expression resolves to an unused variable}} 
+  } // expected-error {{missing return in a function expected to return 'Int'}}
+
+  let _ : () -> Int = {
+    var x : Int = 0 // expected-warning {{variable 'x' was never mutated; consider changing to 'let' constant}}
+    var _ : Int = 0
+    
+    x // expected-error{{missing return in a closure expected to return 'Int'; did you mean to return the last expression?}} {{5-5=return }}
+    //expected-warning@-1{{expression resolves to an unused variable}}
+  }
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -21,9 +21,9 @@ func1()
 _ = 4+7
 
 var bind_test1 : () -> () = func1
-var bind_test2 : Int = 4; func1 // expected-error {{expression resolves to an unused variable}}
+var bind_test2 : Int = 4; func1 // expected-warning {{expression resolves to an unused variable}}
 
-(func1, func2) // expected-error {{expression resolves to an unused variable}}
+(func1, func2) // expected-warning {{expression resolves to an unused variable}}
 
 func basictest() {
   // Simple integer variables.


### PR DESCRIPTION
<!-- What's in this pull request? -->
When expression type checks to a `l-value` no is produced `missing return` because lvalue unused is currently being diagnosed as an error and failing early on type checking, therefore not even getting into SIL dataflow diagnostics where missing return diagnostic would be produced. 
We can see this exactly on those two cases:
```swift

let _ : () -> Int = {
  let x : Int = 0 // x is a let so x would be an r-value, unused would be just a warning and correct SIL dataflow diagnostics would be produced. 
  var a : Int = 0
  
  x // error: missing return
}


let _ : () -> Int = {
  var x : Int = 0 // x is a var x result will typecheck as an l-value therefore fail early on typechecking 
  var a : Int = 0
  
  x // error: expression resolves to an unused variable
}
```
This just downgrades `l-value` to a warning and defer the proper diagnose errors in SIL. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13753.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
