### PR TITLE
[AST] #SR-13906 (Improvement) Error Messages

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2633,9 +2633,9 @@ WARNING(anyobject_class_inheritance_deprecated,none,
 ERROR(multiple_inheritance,none,
   "multiple inheritance from classes %0 and %1", (Type, Type))
 ERROR(inheritance_from_non_protocol_or_class,none,
-  "inheritance from non-protocol, non-class type %0", (Type))
+  "%0 type cannot inherit from non-protocol, non-class type %1", (DescriptiveDeclKind, Type))
 ERROR(inheritance_from_non_protocol,none,
-  "inheritance from non-protocol type %0", (Type))
+  "%0 type cannot inherit from non-protocol type %1", (DescriptiveDeclKind, Type))
 ERROR(superclass_not_first,none,
   "superclass %0 must appear first in the inheritance clause", (Type))
 ERROR(superclass_not_open,none,
@@ -2662,6 +2662,11 @@ ERROR(inheritance_from_cf_class,none,
 ERROR(inheritance_from_objc_runtime_visible_class,none,
       "cannot inherit from class %0 because it is only visible via the "
       "Objective-C runtime", (Identifier))
+ERROR(composition_of_protocol_and_anyobject,none,
+      "non-protocol type %0 cannot conform to composition type %1; "
+      "%0 must be a protocol type", 
+      (Identifier, Type))
+      
 
 // Enums
 ERROR(enum_case_access,none,

--- a/test/Generics/inheritance.swift
+++ b/test/Generics/inheritance.swift
@@ -55,7 +55,7 @@ func testGenericInherit() {
 }
 
 
-struct SS<T> : T { } // expected-error{{inheritance from non-protocol type 'T'}}
+struct SS<T> : T { } // expected-error{{generic struct type cannot inherit from non-protocol type 'T'giy }}
 enum SE<T> : T { case X } // expected-error{{raw type 'T' is not expressible by a string, integer, or floating-point literal}} // expected-error {{SE<T>' declares raw type 'T', but does not conform to RawRepresentable and conformance could not be synthesized}} expected-error{{RawRepresentable conformance cannot be synthesized because raw type 'T' is not Equatable}} 
 
 // Also need Equatable for init?(RawValue)

--- a/test/Parse/diagnostic_missing_func_keyword.swift
+++ b/test/Parse/diagnostic_missing_func_keyword.swift
@@ -57,7 +57,7 @@ class C1 {
 }
 
 class C2 {
-  class classProperty: Int { 0 } // expected-error {{inheritance from non-protocol, non-class type 'Int'}}
+  class classProperty: Int { 0 } // expected-error {{class type cannot inherit from non-protocol, non-class type 'Int'}}
                                  // expected-note @-1 {{in declaration of 'classProperty'}}
                                  // expected-error @-2 {{expected declaration}}
 }

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -30,13 +30,13 @@ class D3 : Any, A { } // expected-error{{superclass 'A' must appear first in the
 class D4 : P & P1, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{18-21=}}{{12-12=A, }}
 
 // Struct inheriting a class
-struct S : A { } // expected-error{{inheritance from non-protocol type 'A'}}
+struct S : A { } // expected-error{{struct type cannot inherit from non-protocol type 'A'}}
 
 // Protocol inheriting a class
 protocol Q : A { }
 
 // Extension inheriting a class
-extension C : A { } // expected-error{{inheritance from non-protocol type 'A'}}
+extension C : A { } // expected-error{{extension type cannot inherit from non-protocol type 'A'}}
 
 // Keywords in inheritance clauses
 struct S2 : struct { } // expected-error{{expected type}}
@@ -56,7 +56,7 @@ class GenericBase<T> {}
 
 class GenericSub<T> : GenericBase<T> {} // okay
 
-class InheritGenericParam<T> : T {} // expected-error {{inheritance from non-protocol, non-class type 'T'}}
+class InheritGenericParam<T> : T {} // expected-error {{generic class type cannot inherit from non-protocol, non-class type 'T'}}
 class InheritBody : T { // expected-error {{cannot find type 'T' in scope}}
   typealias T = A
 }

--- a/test/decl/protocol/conforms/placement.swift
+++ b/test/decl/protocol/conforms/placement.swift
@@ -105,20 +105,20 @@ extension ExplicitSub1 : P1 { } // expected-error{{redundant conformance of 'Exp
 // ---------------------------------------------------------------------------
 // Suppression of synthesized conformances
 // ---------------------------------------------------------------------------
-class SynthesizedClass1 : AnyObject { } // expected-error{{inheritance from non-protocol, non-class type 'AnyObject'}}
+class SynthesizedClass1 : AnyObject { } // expected-error{{class type cannot inherit from non-protocol, non-class type 'AnyObject'}}
 
 class SynthesizedClass2 { }
-extension SynthesizedClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension SynthesizedClass2 : AnyObject { } // expected-error{{extension type cannot inherit from non-protocol type 'AnyObject'}}
 
 class SynthesizedClass3 : AnyObjectRefinement { }
 
 class SynthesizedClass4 { }
 extension SynthesizedClass4 : AnyObjectRefinement { }
 
-class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { } // expected-error{{inheritance from non-protocol, non-class type 'AnyObject'}}
+class SynthesizedSubClass1 : SynthesizedClass1, AnyObject { } // expected-error{{class type cannot inherit from non-protocol, non-class type 'AnyObject'}}
 
 class SynthesizedSubClass2 : SynthesizedClass2 { }
-extension SynthesizedSubClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension SynthesizedSubClass2 : AnyObject { } // expected-error{{extension type cannot inherit from non-protocol type 'AnyObject'}}
 
 class SynthesizedSubClass3 : SynthesizedClass1, AnyObjectRefinement { }
 
@@ -169,12 +169,12 @@ extension MFExplicitSub1 : P1 { } // expected-error{{redundant conformance of 'M
 // ---------------------------------------------------------------------------
 class MFSynthesizedClass1 { }
 
-extension MFSynthesizedClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MFSynthesizedClass2 : AnyObject { } // expected-error{{extension type cannot inherit from non-protocol type 'AnyObject'}}
 
 class MFSynthesizedClass4 { }
 extension MFSynthesizedClass4 : AnyObjectRefinement { }
 
-extension MFSynthesizedSubClass2 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MFSynthesizedSubClass2 : AnyObject { } // expected-error{{extension type cannot inherit from non-protocol type 'AnyObject'}}
 
 extension MFSynthesizedSubClass3 : AnyObjectRefinement { }
 
@@ -198,7 +198,7 @@ extension MMSuper1 : MMP1 { } // expected-warning{{conformance of 'MMSuper1' to 
 extension MMSuper1 : MMP2a { } // expected-warning{{conformance of 'MMSuper1' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
 extension MMSuper1 : MMP3b { } // okay
 
-extension MMSub1 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MMSub1 : AnyObject { } // expected-error{{extension type cannot inherit from non-protocol type 'AnyObject'}}
 
 extension MMSub2 : MMP1 { } // expected-warning{{conformance of 'MMSub2' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
 extension MMSub2 : MMP2a { } // expected-warning{{conformance of 'MMSub2' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
@@ -209,7 +209,7 @@ extension MMSub2 : MMAnyObjectRefinement { } // okay
 extension MMSub3 : MMP1 { } // expected-warning{{conformance of 'MMSub3' to protocol 'MMP1' was already stated in the type's module 'placement_module_A'}}
 extension MMSub3 : MMP2a { } // expected-warning{{conformance of 'MMSub3' to protocol 'MMP2a' was already stated in the type's module 'placement_module_A'}}
 extension MMSub3 : MMP3b { } // okay
-extension MMSub3 : AnyObject { } // expected-error{{inheritance from non-protocol type 'AnyObject'}}
+extension MMSub3 : AnyObject { } // expected-error{{extension type cannot inherit from non-protocol type 'AnyObject'}}
 
 extension MMSub4 : MMP1 { } // expected-warning{{conformance of 'MMSub4' to protocol 'MMP1' was already stated in the type's module 'placement_module_B'}}
 extension MMSub4 : MMP2a { } // expected-warning{{conformance of 'MMSub4' to protocol 'MMP2a' was already stated in the type's module 'placement_module_B'}}

--- a/test/decl/protocol/protocol_with_superclass_objc.swift
+++ b/test/decl/protocol/protocol_with_superclass_objc.swift
@@ -3,7 +3,7 @@
 class Base {}
 
 @objc protocol Protocol1 : Base {}
-// expected-error@-1 {{inheritance from non-protocol type 'Base'}}
+// expected-error@-1 {{protocol type cannot inherit from non-protocol type 'Base'}}
 
 @objc protocol OtherProtocol {}
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -42,7 +42,7 @@ func test1() {
 }
 
 protocol Bogus : Int {}
-// expected-error@-1{{inheritance from non-protocol, non-class type 'Int'}}
+// expected-error@-1{{protocol type cannot inherit from non-protocol, non-class type 'Int'}}
 // expected-error@-2{{type 'Self' constrained to non-protocol, non-class type 'Int'}}
 
 // Explicit conformance checks (successful).


### PR DESCRIPTION
Resolves SR-13906
https://bugs.swift.org/browse/SR-13906

Updated Error message for types trying to conform to AnyObject or its Composition for better user understandability.

For instance:

```
protocol P {}
typealias Q = P & AnyObject
struct S: Q {}
enum T: P & AnyObject {}
struct U: P, AnyObject {}
```

Before :
```
error: inheritance from non-protocol type 'Q' (aka 'P & AnyObject')
struct S: Q {}
       ^
error: inheritance from non-protocol type 'P & AnyObject'
enum T: P & AnyObject {}
     ^
error: inheritance from non-protocol, non-class type 'AnyObject'
class U: P, AnyObject {}
       ^
```

After : 
```
error: Non-protocol 'S' cannot conform to composition 'Q' (aka 'P & AnyObject'). Composition 'Q' (aka 'P & AnyObject') involves 'AnyObject'
struct S: Q {}
       ^
error: Non-protocol 'T' cannot conform to composition 'P & AnyObject'. Composition 'P & AnyObject' involves 'AnyObject'
enum T: P & AnyObject {}
     ^
error: inheritance from non-protocol type 'AnyObject'
struct U: P, AnyObject {}
       ^
```