### PR TITLE
[NFC] Fix incorrectly handled if else in readWriteLockCacheExampleThreaded

### DIFF
--- a/unittests/runtime/Mutex.cpp
+++ b/unittests/runtime/Mutex.cpp
@@ -856,11 +856,12 @@ template <typename RW> void readWriteLockCacheExampleThreaded(RW &lock) {
             if (trace)
               printf("Worker[%d] miss for key = %d.\n", i, key);
             found = false; // cache miss, need to grab write lock
+          } else {
+            if (trace)
+              printf("Worker[%d] HIT for key = %d, value = %d.\n", i, key,
+                     value->second);
+            found = true; // cache hit, no need to grab write lock
           }
-          if (trace)
-            printf("Worker[%d] HIT for key = %d, value = %d.\n", i, key,
-                   value->second);
-          found = true; // cache hit, no need to grab write lock
         };
 
         lock.withReadLock(cacheLookupSection);


### PR DESCRIPTION
<!-- What's in this pull request? -->
While working on other issue, I noticed that this code was missing `else { }`  which could lead to weird results. This PR adds the missing `else` to `readWriteLockCacheExampleThreaded` with NFC. :) 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
