### PR TITLE
Enable the CopyPropagation pass.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -304,6 +304,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
 
   // We earlier eliminated ownership if we are not compiling the stdlib. Now
   // handle the stdlib functions, re-simplifying, eliminating ARC as we do.
+  P.addCopyPropagation();
   P.addSemanticARCOpts();
   P.addNonTransparentFunctionOwnershipModelEliminator();
 
@@ -447,6 +448,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   // Cleanup after SILGen: remove trivial copies to temporaries.
   P.addTempRValueOpt();
   // Cleanup after SILGen: remove unneeded borrows/copies.
+  P.addCopyPropagation();
   P.addSemanticARCOpts();
 
   // Devirtualizes differentiability witnesses into functions that reference them.

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -1,7 +1,5 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift -parse-stdlib %s -o %t/a.out
-// RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run-simple-swift(-Onone -parse-stdlib) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
+// RUN: %target-run-simple-swift(-O -parse-stdlib) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -66,6 +64,7 @@ if true {
   print(x === x1)
   // CHECK-NEXT: true
   print(x === x2)
+  // CHECK-OPT-NEXT: deallocated
 
   print(nonPointerBits(bo) == 0)
   // CHECK-NEXT: true
@@ -79,7 +78,7 @@ if true {
   _fixLifetime(bo3)
   _fixLifetime(bo4)
 }
-// CHECK-NEXT: deallocated
+// CHECK-DBG-NEXT: deallocated
 // CHECK-NEXT: deallocated
 
 // Try with all spare bits set.
@@ -94,6 +93,7 @@ if true {
   print(x === x1)
   // CHECK-NEXT: true
   print(x === x2)
+  // CHECK-OPT-NEXT: deallocated
   
   print(nonPointerBits(bo) == NATIVE_SPARE_BITS)
   // CHECK-NEXT: true
@@ -107,7 +107,7 @@ if true {
   _fixLifetime(bo3)
   _fixLifetime(bo4)
 }
-// CHECK-NEXT: deallocated
+// CHECK-DBG-NEXT: deallocated
 // CHECK-NEXT: deallocated
 
 

--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -140,6 +140,7 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK: [[NOT_ENABLED]]:
     // CHECK-NEXT: tail call void @swift_release
     // CHECK-NEXT: tail call void @llvm.objc.release
+    // CHECK-NEXT: tail call void @llvm.objc.release
     // CHECK-NEXT: br label %[[EXIT:[0-9]+]]
 
     // CHECK: [[ENABLED]]:
@@ -170,7 +171,7 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK-NEXT: [[BITCASTED_SRC2:%.+]] = bitcast i8* [[NSARRAY_ARG]] to %TSo7NSArrayC*
     // CHECK-64-NEXT: store %TSo7NSArrayC* [[BITCASTED_SRC2]], %TSo7NSArrayC** [[BITCASTED_DEST2]], align 8
     // CHECK-32-NEXT: store %TSo7NSArrayC* [[BITCASTED_SRC2]], %TSo7NSArrayC** [[BITCASTED_DEST2]], align 4
-
+    // CHECK-NEXT: tail call void @llvm.objc.release
     // CHECK-64-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
     // CHECK-32-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
     // CHECK-NEXT: [[BITCASTED_OBJ_STORAGE:%.+]] = bitcast i8* [[OBJ_STORAGE]] to %swift.opaque*
@@ -181,7 +182,6 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK-NEXT: br label %[[EXIT]]
   
     // CHECK: [[EXIT]]:
-    // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
     // CHECK-NEXT: ret void
 }
 
@@ -349,7 +349,6 @@ func testMetatypeInterpolation<T>(of type: T.Type) {
 
     // CHECK: [[NOT_ENABLED]]:
     // CHECK-NEXT: call void @swift_release
-    // CHECK-NEXT: br label %[[EXIT:[0-9]+]]
 
     // CHECK: [[ENABLED]]:
     //

--- a/test/SILOptimizer/opt-remark-generator-yaml.swift
+++ b/test/SILOptimizer/opt-remark-generator-yaml.swift
@@ -48,7 +48,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator-yaml.swift',
-// CHECK-NEXT:                    Line: [[# @LINE + 51]], Column: 11 }
+// CHECK-NEXT:                    Line: [[# @LINE + 23]], Column: 11 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'heap allocated ref of type '''
@@ -59,40 +59,12 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Pass:            sil-opt-remark-gen
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator-yaml.swift',
-// CHECK-NEXT:                    Line: [[# @LINE + 40]], Column: 5 }
-// CHECK-NEXT: Function:        'useGlobal()'
-// CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'retain of type '''
-// CHECK-NEXT:   - ValueType:       Klass
-// CHECK-NEXT:   - String:          ''''
-// CHECK-NEXT:   - InferredValue:   'of ''x'''
-// CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator-yaml.swift',
-// CHECK-NEXT:                        Line: [[# @LINE + 29]], Column: 9 }
-// CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
-// CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory
-// CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator-yaml.swift',
-// CHECK-NEXT:                    Line: [[# @LINE + 26]], Column: 12 }
+// CHECK-NEXT:                    Line: [[# @LINE + 12]], Column: 12 }
 // CHECK-NEXT: Function:        'useGlobal()'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'release of type '''
 // CHECK-NEXT:   - ValueType:
 // CHECK-NEXT:   - String:          ''''
-// CHECK-NEXT: ...
-// CHECK-NEXT: --- !Missed
-// CHECK-NEXT: Pass:            sil-opt-remark-gen
-// CHECK-NEXT: Name:            sil.memory
-// CHECK-NEXT: DebugLoc:        { File: '{{.*}}opt-remark-generator-yaml.swift',
-// CHECK-NEXT:                    Line: [[# @LINE + 15]], Column: 12 }
-// CHECK-NEXT: Function:        'useGlobal()'
-// CHECK-NEXT: Args:
-// CHECK-NEXT:   - String:          'release of type '''
-// CHECK-NEXT:   - ValueType:       Klass
-// CHECK-NEXT:   - String:          ''''
-// CHECK-NEXT:   - InferredValue:   'of ''x'''
-// CHECK-NEXT:     DebugLoc:        { File: '{{.*}}opt-remark-generator-yaml.swift',
-// CHECK-NEXT:                        Line: [[# @LINE + 4]], Column: 9 }
 // CHECK-NEXT: ...
 
 public func useGlobal() {
@@ -100,10 +72,6 @@ public func useGlobal() {
     // Make sure that the retain msg is at the beginning of the print and the
     // releases are the end of the print.
     print(x) // expected-remark @:11 {{heap allocated ref of type}}
-             // expected-remark @-1:5 {{retain of type 'Klass'}}
-             // expected-note @-5:9 {{of 'x'}}
              // We test the type emission above since FileCheck can handle regex.
-             // expected-remark @-4:12 {{release of type}}
-             // expected-remark @-5:12 {{release of type 'Klass'}}
-             // expected-note @-9:9 {{of 'x'}}
+             // expected-remark @-2:12 {{release of type}}
 }

--- a/test/SILOptimizer/opt-remark-generator.swift
+++ b/test/SILOptimizer/opt-remark-generator.swift
@@ -22,11 +22,7 @@ public func getGlobal() -> Klass {
 public func useGlobal() {
     let x = getGlobal()
     print(x) // expected-remark @:11 {{heap allocated ref of type}}
-             // expected-remark @-1:5 {{retain of type 'Klass'}}
-             // expected-note @-3:9 {{of 'x'}}
-             // expected-remark @-3:12 {{release of type}}
-             // expected-remark @-4:12 {{release of type 'Klass'}}
-             // expected-note @-6:9 {{of 'x'}}
+             // expected-remark @-1:12 {{release of type}}
 }
 
 public enum TrivialState {
@@ -188,21 +184,13 @@ func castAsQuestionDiamondGEP2(x: KlassPair) {
                                                       // expected-note @-4 {{of 'x.rhs'}}
     case let (.some(x1), .some(x2)):
         print(x1, x2) // expected-remark @:15 {{heap allocated ref of type}}
-                      // expected-remark @-1 {{retain of type 'Optional<SubKlass>'}}
-                      // expected-remark @-2 {{retain of type 'Optional<SubKlass>'}}
-                      // expected-remark @-3 {{release of type}}
-                      // expected-remark @-4 {{release of type 'Optional<SubKlass>'}}
-                      // expected-remark @-5 {{release of type 'Optional<SubKlass>'}}
+                      // expected-remark @-1 {{release of type}}
     case let (.some(x1), nil):
         print(x1) // expected-remark @:15 {{heap allocated ref of type}}
-                  // expected-remark @-1 {{retain of type 'SubKlass'}}
-                  // expected-remark @-2 {{release of type}}
-                  // expected-remark @-3 {{release of type 'Optional<SubKlass>'}}
+                  // expected-remark @-1 {{release of type}}
     case let (nil, .some(x2)):
         print(x2) // expected-remark @:15 {{heap allocated ref of type}}
-                  // expected-remark @-1 {{retain of type 'SubKlass'}}
-                  // expected-remark @-2 {{release of type}}
-                  // expected-remark @-3 {{release of type 'Optional<SubKlass>'}}
+                  // expected-remark @-1 {{release of type}}
     case (nil, nil):
         break
     }
@@ -278,9 +266,5 @@ func allocateValue() {
     let k = Klass() // expected-remark @:13 {{heap allocated ref of type 'Klass'}}
                     // expected-note @-1:9 {{of 'k'}}
     print(k)        // expected-remark @:11 {{heap allocated ref of type}}
-                    // expected-remark @-1:5 {{retain of type 'Klass'}}
-                    // expected-note @-4:9 {{of 'k'}}
-                    // expected-remark @-3:12 {{release of type}}
-                    // expected-remark @-4:12 {{release of type 'Klass'}}
-                    // expected-note @-7:9 {{of 'k'}}
+                    // expected-remark @-1:12 {{release of type}}
 }

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -40,7 +40,8 @@ public class MyGizmo {
 // CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned String, Int, Optional<AnyObject>, Gizmo) -> @owned Optional<String>
 // CHECK:  [[FUN:%.*]] = function_ref @$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_
 // CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@guaranteed Array<String>, Gizmo) -> @owned Optional<AnyObject>
-// CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@guaranteed Array<String>, Gizmo) -> @owned Optional<AnyObject>
+// CHECK:  [[FUN:%.*]] = function_ref @$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembnn_
+// CHECK:  apply [[FUN]]({{.*}}) : $@convention(thin) (@owned Array<String>, Gizmo) -> @owned Optional<AnyObject>
 // CHECK: return
 // CHECK: } // end sil function '$s8outliner13testOutliningyyF'
 public func testOutlining() {


### PR DESCRIPTION
For now simply run the pass before SemanticARCOpts. This will probably
be called as a utility from within SemanticARCOpts so it can be
iteratively applied after other ARC-related transformations.

This is rebased on top of the CanonicalOSSA utility:
https://github.com/apple/swift/pull/35241

And depends on a _StringObject.init fix:
https://github.com/apple/swift/pull/35243