### PR TITLE
Fix _StringObject.init(object:...)

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -207,6 +207,7 @@ extension _StringObject {
   internal init(
     object: AnyObject, discriminator: UInt64, countAndFlags: CountAndFlags
   ) {
+    defer { _fixLifetime(object) }
     let builtinRawObject: Builtin.Int64 = Builtin.reinterpretCast(object)
     let builtinDiscrim: Builtin.Int64 = discriminator._value
     self.init(


### PR DESCRIPTION
Add a missing fix_lifetime. This miscompiles with OSSA because
`object` is destroyed before `bridgeObject` is retained.

Reinterpreting a reference to a trivial type always requires a
fix_lifetime.
