### PR TITLE
[ownership] Fix a few small semantic changes introduced by OperandOwnership bringup.

### DIFF
--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -188,7 +188,6 @@ OPERAND_OWNERSHIP(InstantaneousUse, ValueMetatype)
 OPERAND_OWNERSHIP(InstantaneousUse, IsEscapingClosure)
 OPERAND_OWNERSHIP(InstantaneousUse, ClassMethod)
 OPERAND_OWNERSHIP(InstantaneousUse, SuperMethod)
-OPERAND_OWNERSHIP(InstantaneousUse, BridgeObjectToWord)
 OPERAND_OWNERSHIP(InstantaneousUse, ClassifyBridgeObject)
 OPERAND_OWNERSHIP(InstantaneousUse, SetDeallocating)
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
@@ -228,6 +227,7 @@ OPERAND_OWNERSHIP(BitwiseEscape, UncheckedBitwiseCast)
 OPERAND_OWNERSHIP(BitwiseEscape, ValueToBridgeObject)
 OPERAND_OWNERSHIP(BitwiseEscape, RefToRawPointer)
 OPERAND_OWNERSHIP(BitwiseEscape, UncheckedTrivialBitCast)
+OPERAND_OWNERSHIP(BitwiseEscape, BridgeObjectToWord)
 // FIXME: verify that no-escape results are always trivial
 OPERAND_OWNERSHIP(BitwiseEscape, ConvertEscapeToNoEscape)
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -192,11 +192,8 @@ OPERAND_OWNERSHIP(InstantaneousUse, BridgeObjectToWord)
 OPERAND_OWNERSHIP(InstantaneousUse, ClassifyBridgeObject)
 OPERAND_OWNERSHIP(InstantaneousUse, SetDeallocating)
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
-  OPERAND_OWNERSHIP(InstantaneousUse, RefTo##Name)                             \
-  OPERAND_OWNERSHIP(InstantaneousUse, Name##ToRef)                             \
   OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
 #define UNCHECKED_REF_STORAGE(Name, ...)                                       \
-  OPERAND_OWNERSHIP(InstantaneousUse, RefTo##Name)                             \
   OPERAND_OWNERSHIP(InstantaneousUse, StrongCopy##Name##Value)
 #include "swift/AST/ReferenceStorage.def"
 
@@ -209,6 +206,15 @@ OPERAND_OWNERSHIP(UnownedInstantaneousUse, ObjCSuperMethod)
 OPERAND_OWNERSHIP(UnownedInstantaneousUse, UnmanagedRetainValue)
 OPERAND_OWNERSHIP(UnownedInstantaneousUse, UnmanagedReleaseValue)
 OPERAND_OWNERSHIP(UnownedInstantaneousUse, UnmanagedAutoreleaseValue)
+
+// These always produce a value with unowned ownership so are unowned
+// instantaneous uses.
+#define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)     \
+  OPERAND_OWNERSHIP(UnownedInstantaneousUse, RefTo##Name)               \
+  OPERAND_OWNERSHIP(UnownedInstantaneousUse, Name##ToRef)
+#define UNCHECKED_REF_STORAGE(Name, ...)                        \
+  OPERAND_OWNERSHIP(UnownedInstantaneousUse, RefTo##Name)
+#include "swift/AST/ReferenceStorage.def"
 
 // Instructions that currently violate structural ownership requirements,
 // and therefore completely defeat canonicalization and optimization of any

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -1417,3 +1417,17 @@ bb3(%fUnknown : @owned $@callee_owned () -> ()):
   %9999 = tuple()
   return %9999 : $()
 }
+
+sil [ossa] @unowned_to_ref_is_unowned_instant_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> Builtin.NativeObject {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = ref_to_unowned %0 : $Builtin.NativeObject to $@sil_unowned Builtin.NativeObject
+  %2 = unowned_to_ref %1 : $@sil_unowned Builtin.NativeObject to $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
+}
+
+sil [ossa] @unmanaged_to_ref_is_unowned_instant_use : $@convention(thin) (@guaranteed Builtin.NativeObject) -> Builtin.NativeObject {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = ref_to_unmanaged %0 : $Builtin.NativeObject to $@sil_unmanaged Builtin.NativeObject
+  %2 = unmanaged_to_ref %1 : $@sil_unmanaged Builtin.NativeObject to $Builtin.NativeObject
+  return %2 : $Builtin.NativeObject
+}

--- a/test/SIL/ownership-verifier/use_verifier.sil
+++ b/test/SIL/ownership-verifier/use_verifier.sil
@@ -113,6 +113,10 @@ class ClassProtConformingRef {}
 protocol ClassProt : AnyObject {}
 extension ClassProtConformingRef : ClassProt {}
 
+struct UInt64 {
+   var _value: Builtin.Int64
+}
+
 ////////////////
 // Test Cases //
 ////////////////
@@ -1430,4 +1434,13 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = ref_to_unmanaged %0 : $Builtin.NativeObject to $@sil_unmanaged Builtin.NativeObject
   %2 = unmanaged_to_ref %1 : $@sil_unmanaged Builtin.NativeObject to $Builtin.NativeObject
   return %2 : $Builtin.NativeObject
+}
+
+sil [ossa] @conversion_to_and_from_bridge_object : $@convention(thin) (Builtin.Int64) -> (Builtin.Int64) {
+bb0(%0 : $Builtin.Int64):
+  %1 = struct $UInt64 (%0 : $Builtin.Int64)
+  %2 = value_to_bridge_object %1 : $UInt64
+  %3 = bridge_object_to_word %2 : $Builtin.BridgeObject to $Builtin.Word
+  %4 = builtin "zextOrBitCast_Word_Int64"(%3 : $Builtin.Word) : $Builtin.Int64
+  return %4 : $Builtin.Int64
 }


### PR DESCRIPTION
This PR contains two different commits that fix two mistakes that I found while working with some other code. I included the necessary changes and added a SIL/ownership-verifier test to make sure we have test coverage of these test cases!

----

[ownership] ref_to_* and *_to_ref produce values with OwnershipKind::Unowned so should be treated as UnownedInstantaneousUse.

The reason why these values produce a value with unowned ownership is that they
perform a conversion without taking ownership of the underlying
value. Semantically we do this to ensure that before anyone tries to use one of
these in an owned or gauranteed position they will need to perform some sort of
transform on the value semantically showing that it has ownership of the
value via a copy or some other operation.

----

[ownership] bridge_object_to_word is a bitwise escape not an instantaneous use.

----