### PR TITLE
WinSDK: add XAML hosting submodule

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -343,6 +343,15 @@ module WinSDK [system] {
     link "sensorsapi.lib"
   }
 
+  module UI {
+    module XAML {
+      module Hosting {
+        header "windows.ui.xaml.hosting.desktopwindowxamlsource.h"
+        export *
+      }
+    }
+  }
+
   module User {
     header "WinUser.h"
     export *


### PR DESCRIPTION
This exposes `IDesktopWindowXamlSourceNative` interface, which is used for embedding WinUI XAML controls into Win32 apps.

Relevant MSDN page: https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/using-the-xaml-hosting-api