### PR TITLE
[sil-inst-opt] Improve performance of InstModCallbacks by eliminating indirect call along default callback path.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
+++ b/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
@@ -25,6 +25,7 @@
 namespace swift {
 
 class SILInstruction;
+class InstModCallbacks;
 
 /// Try to simplify the specified instruction, performing local
 /// analysis of the operands of the instruction, without looking at its uses
@@ -46,11 +47,17 @@ SILValue simplifyInstruction(SILInstruction *I);
 ///
 /// NOTE: When OSSA is enabled this API assumes OSSA is properly formed and will
 /// insert compensating instructions.
-SILBasicBlock::iterator replaceAllSimplifiedUsesAndErase(
-    SILInstruction *I, SILValue result,
-    std::function<void(SILInstruction *)> eraseNotify = nullptr,
-    std::function<void(SILInstruction *)> newInstNotify = nullptr,
-    DeadEndBlocks *deadEndBlocks = nullptr);
+SILBasicBlock::iterator
+replaceAllSimplifiedUsesAndErase(SILInstruction *I, SILValue result,
+                                 InstModCallbacks &callbacks,
+                                 DeadEndBlocks *deadEndBlocks = nullptr);
+
+/// This is a low level routine that makes all uses of \p svi uses of \p
+/// newValue (ignoring end scope markers) and then deletes \p svi and all end
+/// scope markers. Then returns the next inst to process.
+SILBasicBlock::iterator replaceAllUsesAndErase(SingleValueInstruction *svi,
+                                               SILValue newValue,
+                                               InstModCallbacks &callbacks);
 
 /// Simplify invocations of builtin operations that may overflow.
 /// All such operations return a tuple (result, overflow_flag).

--- a/include/swift/SILOptimizer/Utils/CFGOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/CFGOptUtils.h
@@ -36,7 +36,7 @@ namespace swift {
 class DominanceInfo;
 class SILLoop;
 class SILLoopInfo;
-struct InstModCallbacks;
+class InstModCallbacks;
 
 /// Adds a new argument to an edge between a branch and a destination
 /// block. Allows for user injected callbacks via \p callbacks.
@@ -47,8 +47,7 @@ struct InstModCallbacks;
 /// \return The created branch. The old branch is deleted.
 /// The argument is appended at the end of the argument tuple.
 TermInst *addNewEdgeValueToBranch(TermInst *branch, SILBasicBlock *dest,
-                                  SILValue val,
-                                  const InstModCallbacks &callbacks);
+                                  SILValue val, InstModCallbacks &callbacks);
 
 /// Adds a new argument to an edge between a branch and a destination
 /// block.
@@ -60,7 +59,8 @@ TermInst *addNewEdgeValueToBranch(TermInst *branch, SILBasicBlock *dest,
 /// The argument is appended at the end of the argument tuple.
 inline TermInst *addNewEdgeValueToBranch(TermInst *branch, SILBasicBlock *dest,
                                          SILValue val) {
-  return addNewEdgeValueToBranch(branch, dest, val, InstModCallbacks());
+  InstModCallbacks callbacks;
+  return addNewEdgeValueToBranch(branch, dest, val, callbacks);
 }
 
 /// Changes the edge value between a branch and destination basic block

--- a/include/swift/SILOptimizer/Utils/CanonicalizeInstruction.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeInstruction.h
@@ -29,6 +29,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/Support/Debug.h"
 
 namespace swift {
@@ -40,10 +41,18 @@ struct CanonicalizeInstruction {
   static constexpr const char *defaultDebugType = "sil-canonicalize";
   const char *debugType = defaultDebugType;
   DeadEndBlocks &deadEndBlocks;
+  InstModCallbacks callbacks;
 
   CanonicalizeInstruction(const char *passDebugType,
                           DeadEndBlocks &deadEndBlocks)
-      : deadEndBlocks(deadEndBlocks) {
+      : deadEndBlocks(deadEndBlocks),
+        callbacks(
+            [&](SILInstruction *toDelete) { killInstruction(toDelete); },
+            [&](SILInstruction *newInst) { notifyNewInstruction(newInst); },
+            [&](SILValue oldValue, SILValue newValue) {
+              oldValue->replaceAllUsesWith(newValue);
+              notifyHasNewUsers(newValue);
+            }) {
 #ifndef NDEBUG
     if (llvm::DebugFlag && !llvm::isCurrentDebugType(debugType))
       debugType = passDebugType;

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -310,44 +310,97 @@ bool tryCheckedCastBrJumpThreading(
 
 /// A structure containing callbacks that are called when an instruction is
 /// removed or added.
-struct InstModCallbacks {
-  static const std::function<void(SILInstruction *)> defaultDeleteInst;
-  static const std::function<void(SILInstruction *)> defaultCreatedNewInst;
-  static const std::function<void(SILValue, SILValue)> defaultReplaceValueUsesWith;
-  static const std::function<void(SingleValueInstruction *, SILValue)>
-      defaultEraseAndRAUWSingleValueInst;
+///
+/// PERFORMANCE NOTES: This code can be used in loops, so we want to make sure
+/// to not have overhead when the user does not specify a callback. To do that
+/// instead of defining a "default" std::function, we represent the "default"
+/// functions as nullptr. Then, in the helper function trampoline that actually
+/// gets called, we check if we have a nullptr and if we do, we perform the
+/// default operation inline. What is nice about this from a perf perspective is
+/// that in a loop this property should predict well since you have a single
+/// branch that is going to go the same way everytime.
+class InstModCallbacks {
+  /// A function that takes in an instruction and deletes the inst.
+  ///
+  /// Default implementation is instToDelete->eraseFromParent();
+  std::function<void(SILInstruction *instToDelete)> deleteInstFunc;
 
-  std::function<void(SILInstruction *)> deleteInst =
-      InstModCallbacks::defaultDeleteInst;
-  std::function<void(SILInstruction *)> createdNewInst =
-      InstModCallbacks::defaultCreatedNewInst;
-  std::function<void(SILValue, SILValue)>
-      replaceValueUsesWith =
-          InstModCallbacks::defaultReplaceValueUsesWith;
-  std::function<void(SingleValueInstruction *, SILValue)>
-      eraseAndRAUWSingleValueInst =
-          InstModCallbacks::defaultEraseAndRAUWSingleValueInst;
+  /// A function that is called to notify that a new function was created.
+  ///
+  /// Default implementation is a no-op, but we still mark madeChange.
+  std::function<void(SILInstruction *newlyCreatedInst)> createdNewInstFunc;
 
-  InstModCallbacks(decltype(deleteInst) deleteInst,
-                   decltype(createdNewInst) createdNewInst,
-                   decltype(replaceValueUsesWith) replaceValueUsesWith)
-      : deleteInst(deleteInst), createdNewInst(createdNewInst),
-        replaceValueUsesWith(replaceValueUsesWith),
-        eraseAndRAUWSingleValueInst(
-            InstModCallbacks::defaultEraseAndRAUWSingleValueInst) {}
+  /// A function that first replaces all uses of oldValue with uses of newValue.
+  ///
+  /// Default implementation just calls oldValue->replaceAllUsesWith(newValue);
+  std::function<void(SILValue oldValue, SILValue newValue)>
+      replaceValueUsesWithFunc;
+
+  /// A function that first replaces all uses of oldValue with uses of newValue
+  /// and then erases oldValue.
+  ///
+  /// Default implementation just calls replaceValueUsesWithFunc and then
+  /// deleteInstFunc.
+  std::function<void(SingleValueInstruction *oldValue, SILValue newValue)>
+      eraseAndRAUWSingleValueInstFunc;
+
+  /// A boolean that tracks if any of our callbacks were ever called.
+  bool madeChange = false;
+
+public:
+  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc)
+      : deleteInstFunc(deleteInstFunc) {}
+
+  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
+                   decltype(createdNewInstFunc) createdNewInstFunc,
+                   decltype(replaceValueUsesWithFunc) replaceValueUsesWithFunc)
+      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc),
+        replaceValueUsesWithFunc(replaceValueUsesWithFunc) {}
 
   InstModCallbacks(
-      decltype(deleteInst) deleteInst, decltype(createdNewInst) createdNewInst,
-      decltype(replaceValueUsesWith) replaceValueUsesWith,
-      decltype(eraseAndRAUWSingleValueInst) eraseAndRAUWSingleValueInst)
-      : deleteInst(deleteInst), createdNewInst(createdNewInst),
-        replaceValueUsesWith(replaceValueUsesWith),
-        eraseAndRAUWSingleValueInst(eraseAndRAUWSingleValueInst) {}
+      decltype(deleteInstFunc) deleteInstFunc,
+      decltype(createdNewInstFunc) createdNewInstFunc,
+      decltype(replaceValueUsesWithFunc) replaceValueUsesWithFunc,
+      decltype(eraseAndRAUWSingleValueInstFunc) eraseAndRAUWSingleValueInstFunc)
+      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc),
+        replaceValueUsesWithFunc(replaceValueUsesWithFunc),
+        eraseAndRAUWSingleValueInstFunc(eraseAndRAUWSingleValueInstFunc) {}
 
   InstModCallbacks() = default;
   ~InstModCallbacks() = default;
   InstModCallbacks(const InstModCallbacks &) = default;
   InstModCallbacks(InstModCallbacks &&) = default;
+
+  void deleteInst(SILInstruction *instToDelete) {
+    madeChange = true;
+    if (deleteInstFunc)
+      return deleteInstFunc(instToDelete);
+    instToDelete->eraseFromParent();
+  }
+
+  void createdNewInst(SILInstruction *newlyCreatedInst) {
+    madeChange = true;
+    if (createdNewInstFunc)
+      createdNewInstFunc(newlyCreatedInst);
+  }
+
+  void replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
+    madeChange = true;
+    if (replaceValueUsesWithFunc)
+      return replaceValueUsesWithFunc(oldValue, newValue);
+    oldValue->replaceAllUsesWith(newValue);
+  }
+
+  void eraseAndRAUWSingleValueInst(SingleValueInstruction *oldInst,
+                                   SILValue newValue) {
+    madeChange = true;
+    if (eraseAndRAUWSingleValueInstFunc)
+      return eraseAndRAUWSingleValueInstFunc(oldInst, newValue);
+    replaceValueUsesWith(oldInst, newValue);
+    deleteInst(oldInst);
+  }
+
+  bool getMadeChange() const { return madeChange; }
 };
 
 /// Get all consumed arguments of a partial_apply.

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -21,6 +21,7 @@
 
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
 
 namespace swift {
 
@@ -28,8 +29,7 @@ namespace swift {
 struct JointPostDominanceSetComputer;
 
 struct OwnershipFixupContext {
-  std::function<void(SILInstruction *)> eraseNotify;
-  std::function<void(SILInstruction *)> newInstNotify;
+  InstModCallbacks callbacks;
   DeadEndBlocks &deBlocks;
   JointPostDominanceSetComputer &jointPostDomSetComputer;
 

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -735,9 +735,9 @@ case BuiltinValueKind::id:
 //                           Top Level Entrypoints
 //===----------------------------------------------------------------------===//
 
-static SILBasicBlock::iterator
-replaceAllUsesAndEraseInner(SingleValueInstruction *svi, SILValue newValue,
-                            std::function<void(SILInstruction *)> eraseNotify) {
+SILBasicBlock::iterator
+swift::replaceAllUsesAndErase(SingleValueInstruction *svi, SILValue newValue,
+                              InstModCallbacks &callbacks) {
   assert(svi != newValue && "Cannot RAUW a value with itself");
   SILBasicBlock::iterator nextii = std::next(svi->getIterator());
 
@@ -749,18 +749,13 @@ replaceAllUsesAndEraseInner(SingleValueInstruction *svi, SILValue newValue,
     if (isEndOfScopeMarker(user)) {
       if (&*nextii == user)
         ++nextii;
-      if (eraseNotify)
-        eraseNotify(user);
-      else
-        user->eraseFromParent();
+      callbacks.deleteInst(user);
       continue;
     }
     use->set(newValue);
   }
-  if (eraseNotify)
-    eraseNotify(svi);
-  else
-    svi->eraseFromParent();
+
+  callbacks.deleteInst(svi);
 
   return nextii;
 }
@@ -775,21 +770,19 @@ replaceAllUsesAndEraseInner(SingleValueInstruction *svi, SILValue newValue,
 /// before this is called. It will perform fixups as necessary to preserve OSSA.
 ///
 /// Return an iterator to the next (nondeleted) instruction.
-SILBasicBlock::iterator swift::replaceAllSimplifiedUsesAndErase(
-    SILInstruction *i, SILValue result,
-    std::function<void(SILInstruction *)> eraseNotify,
-    std::function<void(SILInstruction *)> newInstNotify,
-    DeadEndBlocks *deadEndBlocks) {
+SILBasicBlock::iterator
+swift::replaceAllSimplifiedUsesAndErase(SILInstruction *i, SILValue result,
+                                        InstModCallbacks &callbacks,
+                                        DeadEndBlocks *deadEndBlocks) {
   auto *svi = cast<SingleValueInstruction>(i);
   assert(svi != result && "Cannot RAUW a value with itself");
 
   if (svi->getFunction()->hasOwnership()) {
     JointPostDominanceSetComputer computer(*deadEndBlocks);
-    OwnershipFixupContext ctx{eraseNotify, newInstNotify, *deadEndBlocks,
-                              computer};
+    OwnershipFixupContext ctx{callbacks, *deadEndBlocks, computer};
     return ctx.replaceAllUsesAndEraseFixingOwnership(svi, result);
   }
-  return replaceAllUsesAndEraseInner(svi, result, eraseNotify);
+  return replaceAllUsesAndErase(svi, result, callbacks);
 }
 
 /// Simplify invocations of builtin operations that may overflow.

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -866,7 +866,8 @@ static void replaceValueMetatypeInstWithMetatypeArgument(
         valueMetatype->getLoc(), metatypeArgument,
         valueMetatype->getType());
   }
-  replaceAllSimplifiedUsesAndErase(valueMetatype, metatypeArgument);
+  InstModCallbacks callbacks;
+  replaceAllSimplifiedUsesAndErase(valueMetatype, metatypeArgument, callbacks);
 }
 
 void LifetimeChecker::handleLoadForTypeOfSelfUse(DIMemoryUse &Use) {

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -435,10 +435,10 @@ static bool stripOwnership(SILFunction &func) {
     if (!value.hasValue())
       continue;
     if (SILValue newValue = simplifyInstruction(*value)) {
-      replaceAllSimplifiedUsesAndErase(*value, newValue,
-                                       [&](SILInstruction *instToErase) {
-                                         visitor.eraseInstruction(instToErase);
-                                       });
+      InstModCallbacks callbacks([&](SILInstruction *instToErase) {
+        visitor.eraseInstruction(instToErase);
+      });
+      replaceAllSimplifiedUsesAndErase(*value, newValue, callbacks);
       madeChange = true;
     }
   }

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1139,6 +1139,7 @@ bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
 /// result in exposing opportunities for CFG simplification.
 bool SimplifyCFG::simplifyBranchOperands(OperandValueArrayRef Operands) {
   bool Simplified = false;
+  InstModCallbacks callbacks;
   for (auto O = Operands.begin(), E = Operands.end(); O != E; ++O) {
     // All of our interesting simplifications are on single-value instructions
     // for now.
@@ -1149,7 +1150,7 @@ bool SimplifyCFG::simplifyBranchOperands(OperandValueArrayRef Operands) {
       // unreachable block. In this case it can reference itself as operand.
       if (Result && Result != I) {
         LLVM_DEBUG(llvm::dbgs() << "simplify branch operand " << *I);
-        replaceAllSimplifiedUsesAndErase(I, Result);
+        replaceAllSimplifiedUsesAndErase(I, Result, callbacks);
         Simplified = true;
       }
     }

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -736,6 +736,19 @@ void TempRValueOptPass::run() {
   // Delete the copies and any unused address operands.
   // The same copy may have been added multiple times.
   sortUnique(deadCopies);
+  InstModCallbacks callbacks(
+#ifndef NDEBUG
+      // With asserts, we include this assert. Otherwise, we use the default
+      // impl for perf.
+      [](SILInstruction *instToKill) {
+        // SimplifyInstruction is not in the business of removing
+        // copy_addr. If it were, then we would need to update deadCopies.
+        assert(!isa<CopyAddrInst>(instToKill));
+        instToKill->eraseFromParent();
+      }
+#endif
+  );
+
   for (auto *deadCopy : deadCopies) {
     assert(changed);
     auto *srcInst = deadCopy->getSrc()->getDefiningInstruction();
@@ -744,13 +757,7 @@ void TempRValueOptPass::run() {
     // copy_addr and other potentially unused addresses.
     if (srcInst) {
       if (SILValue result = simplifyInstruction(srcInst)) {
-        replaceAllSimplifiedUsesAndErase(
-            srcInst, result, [](SILInstruction *instToKill) {
-              // SimplifyInstruction is not in the business of removing
-              // copy_addr. If it were, then we would need to update deadCopies.
-              assert(!isa<CopyAddrInst>(instToKill));
-              instToKill->eraseFromParent();
-            });
+        replaceAllSimplifiedUsesAndErase(srcInst, result, callbacks);
       }
     }
   }

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -25,7 +25,7 @@ using namespace swift;
 
 TermInst *swift::addNewEdgeValueToBranch(TermInst *branch, SILBasicBlock *dest,
                                          SILValue val,
-                                         const InstModCallbacks &callbacks) {
+                                         InstModCallbacks &callbacks) {
   SILBuilderWithScope builder(branch);
   TermInst *newBr = nullptr;
 

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -93,11 +93,8 @@ simplifyAndReplace(SILInstruction *inst, CanonicalizeInstruction &pass) {
   // Erase the simplified instruction and any instructions that end its
   // scope. Nothing needs to be added to the worklist except for Result,
   // because the instruction and all non-replaced users will be deleted.
-  auto nextII = replaceAllSimplifiedUsesAndErase(
-      inst, result,
-      [&pass](SILInstruction *deleted) { pass.killInstruction(deleted); },
-      [&pass](SILInstruction *newInst) { pass.notifyNewInstruction(newInst); },
-      &pass.deadEndBlocks);
+  auto nextII = replaceAllSimplifiedUsesAndErase(inst, result, pass.callbacks,
+                                                 &pass.deadEndBlocks);
 
   // Push the new instruction and any users onto the worklist.
   pass.notifyHasNewUsers(result);

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -33,40 +33,6 @@
 using namespace swift;
 
 //===----------------------------------------------------------------------===//
-//                           Low Level RAUW Utility
-//===----------------------------------------------------------------------===//
-
-static SILBasicBlock::iterator
-replaceAllUsesAndEraseInner(SingleValueInstruction *svi, SILValue newValue,
-                            std::function<void(SILInstruction *)> eraseNotify) {
-  assert(svi != newValue && "Cannot RAUW a value with itself");
-  SILBasicBlock::iterator nextii = std::next(svi->getIterator());
-
-  // Only SingleValueInstructions are currently simplified.
-  while (!svi->use_empty()) {
-    Operand *use = *svi->use_begin();
-    SILInstruction *user = use->getUser();
-    // Erase the end of scope marker.
-    if (isEndOfScopeMarker(user)) {
-      if (&*nextii == user)
-        ++nextii;
-      if (eraseNotify)
-        eraseNotify(user);
-      else
-        user->eraseFromParent();
-      continue;
-    }
-    use->set(newValue);
-  }
-  if (eraseNotify)
-    eraseNotify(svi);
-  else
-    svi->eraseFromParent();
-
-  return nextii;
-}
-
-//===----------------------------------------------------------------------===//
 //                        Ownership Lifetime Extender
 //===----------------------------------------------------------------------===//
 
@@ -119,8 +85,9 @@ CopyValueInst *OwnershipLifetimeExtender::copyAndExtendForLifetimeEndingRAUW(
     SILBuilderWithScope builder(newValInsertPt);
     copy = builder.createCopyValue(newValInsertPt->getLoc(), value);
   }
-  if (ctx.newInstNotify)
-    ctx.newInstNotify(copy);
+
+  auto &callbacks = ctx.callbacks;
+  callbacks.createdNewInst(copy);
 
   auto *result = copy;
   ctx.jointPostDomSetComputer.findJointPostDominatingSet(
@@ -135,8 +102,7 @@ CopyValueInst *OwnershipLifetimeExtender::copyAndExtendForLifetimeEndingRAUW(
         auto front = loopBlock->begin();
         SILBuilderWithScope newBuilder(front);
         result = newBuilder.createCopyValue(front->getLoc(), copy);
-        if (ctx.newInstNotify)
-          ctx.newInstNotify(result);
+        callbacks.createdNewInst(result);
 
         llvm_unreachable("Should never visit this!");
       },
@@ -145,8 +111,7 @@ CopyValueInst *OwnershipLifetimeExtender::copyAndExtendForLifetimeEndingRAUW(
         auto front = postDomBlock->begin();
         SILBuilderWithScope newBuilder(front);
         auto *dvi = newBuilder.createDestroyValue(front->getLoc(), copy);
-        if (ctx.newInstNotify)
-          ctx.newInstNotify(dvi);
+        callbacks.createdNewInst(dvi);
       });
   return result;
 }
@@ -167,8 +132,9 @@ CopyValueInst *OwnershipLifetimeExtender::copyAndExtendForNonLifetimeEndingRAUW(
     SILBuilderWithScope builder(newValInsertPt);
     copy = builder.createCopyValue(newValInsertPt->getLoc(), value);
   }
-  if (ctx.newInstNotify)
-    ctx.newInstNotify(copy);
+
+  auto &callbacks = ctx.callbacks;
+  callbacks.createdNewInst(copy);
 
   auto opRange = makeUserRange(range);
   ValueLifetimeAnalysis lifetimeAnalysis(copy, opRange);
@@ -181,8 +147,7 @@ CopyValueInst *OwnershipLifetimeExtender::copyAndExtendForNonLifetimeEndingRAUW(
     auto *insertPt = frontier.pop_back_val();
     SILBuilderWithScope frontierBuilder(insertPt);
     auto *dvi = frontierBuilder.createDestroyValue(insertPt->getLoc(), copy);
-    if (ctx.newInstNotify)
-      ctx.newInstNotify(dvi);
+    callbacks.createdNewInst(dvi);
   }
 
   return copy;
@@ -218,6 +183,7 @@ OwnershipLifetimeExtender::copyBorrowAndExtendForRAUW(SILValue newValue,
       frontier, ValueLifetimeAnalysis::DontModifyCFG, &ctx.deBlocks);
   assert(result);
 
+  auto &callbacks = ctx.callbacks;
   while (!frontier.empty()) {
     auto *insertPt = frontier.pop_back_val();
     SILBuilderWithScope frontierBuilder(insertPt);
@@ -227,10 +193,8 @@ OwnershipLifetimeExtender::copyBorrowAndExtendForRAUW(SILValue newValue,
         insertPt->getLoc().getSourceLoc());
     auto *ebi = frontierBuilder.createEndBorrow(loc, borrow);
     auto *dvi = frontierBuilder.createDestroyValue(loc, copy);
-    if (ctx.newInstNotify) {
-      ctx.newInstNotify(ebi);
-      ctx.newInstNotify(dvi);
-    }
+    callbacks.createdNewInst(ebi);
+    callbacks.createdNewInst(dvi);
   }
 
   return borrow;
@@ -262,9 +226,9 @@ OwnershipLifetimeExtender::copyBorrowAndExtendForLifetimeEndingRAUW(
   assert(oldValInsertPt);
   auto *borrow = SILBuilderWithScope(oldValInsertPt)
                      .createBeginBorrow(oldValInsertPt->getLoc(), copy);
-  if (ctx.newInstNotify) {
-    ctx.newInstNotify(borrow);
-  }
+
+  auto &callbacks = ctx.callbacks;
+  callbacks.createdNewInst(borrow);
 
   ValueLifetimeAnalysis lifetimeAnalysis(copy, oldValue->getUses());
   decltype(lifetimeAnalysis)::Frontier frontier;
@@ -276,9 +240,7 @@ OwnershipLifetimeExtender::copyBorrowAndExtendForLifetimeEndingRAUW(
     auto *insertPt = frontier.pop_back_val();
     SILBuilderWithScope frontierBuilder(insertPt);
     auto *dvi = frontierBuilder.createDestroyValue(insertPt->getLoc(), copy);
-    if (ctx.newInstNotify) {
-      ctx.newInstNotify(dvi);
-    }
+    callbacks.createdNewInst(dvi);
   }
 
   return borrow;
@@ -315,21 +277,13 @@ struct OwnershipRAUWUtility {
 
   OwnershipLifetimeExtender getLifetimeExtender() { return {ctx}; }
 
-  InstModCallbacks getCallbacks() const {
-    return InstModCallbacks(
-        ctx.eraseNotify, ctx.newInstNotify,
-        [](SILValue, SILValue) { llvm_unreachable("unhandled"); },
-        [](SingleValueInstruction *, SILValue) {
-          llvm_unreachable("unhandled");
-        });
-  }
+  const InstModCallbacks &getCallbacks() const { return ctx.callbacks; }
 };
 
 } // anonymous namespace
 
-static void cleanupOperandsBeforeDeletion(
-    SILInstruction *oldValue,
-    std::function<void(SILInstruction *)> newNotifyInst) {
+static void cleanupOperandsBeforeDeletion(SILInstruction *oldValue,
+                                          InstModCallbacks &callbacks) {
   SILBuilderWithScope builder(oldValue);
   for (auto &op : oldValue->getAllOperands()) {
     if (!op.isLifetimeEnding()) {
@@ -341,15 +295,13 @@ static void cleanupOperandsBeforeDeletion(
       llvm_unreachable("Invalid ownership for value");
     case OwnershipKind::Owned: {
       auto *dvi = builder.createDestroyValue(oldValue->getLoc(), op.get());
-      if (newNotifyInst)
-        newNotifyInst(dvi);
+      callbacks.createdNewInst(dvi);
       continue;
     }
     case OwnershipKind::Guaranteed: {
       // Should only happen once we model destructures as true reborrows.
       auto *ebi = builder.createEndBorrow(oldValue->getLoc(), op.get());
-      if (newNotifyInst)
-        newNotifyInst(ebi);
+      callbacks.createdNewInst(ebi);
       continue;
     }
     case OwnershipKind::None:
@@ -363,7 +315,7 @@ static void cleanupOperandsBeforeDeletion(
 
 static SILPhiArgument *
 insertOwnedBaseValueAlongBranchEdge(BranchInst *bi, SILValue innerCopy,
-                                    const InstModCallbacks &callbacks) {
+                                    InstModCallbacks &callbacks) {
   auto *destBB = bi->getDestBB();
   // We need to create the phi argument before calling addNewEdgeValueToBranch
   // since it checks that the destination block has enough arguments for the
@@ -457,6 +409,7 @@ void OwnershipRAUWUtility::eliminateReborrowsOfRecursiveBorrows(
     SmallVectorImpl<Operand *> &usePoints) {
   SmallVector<std::pair<SILPhiArgument *, SILPhiArgument *>, 8>
       baseBorrowedValuePair;
+  auto &callbacks = ctx.callbacks;
 
   // Ok, we have transitive reborrows.
   for (auto borrowingOperand : transitiveReborrows) {
@@ -474,11 +427,10 @@ void OwnershipRAUWUtility::eliminateReborrowsOfRecursiveBorrows(
     auto *innerCopy = reborrowBuilder.createCopyValue(loc, value);
     auto *innerBorrow = reborrowBuilder.createBeginBorrow(loc, innerCopy);
     auto *outerEndBorrow = reborrowBuilder.createEndBorrow(loc, value);
-    if (ctx.newInstNotify) {
-      ctx.newInstNotify(innerCopy);
-      ctx.newInstNotify(innerBorrow);
-      ctx.newInstNotify(outerEndBorrow);
-    }
+
+    callbacks.createdNewInst(innerCopy);
+    callbacks.createdNewInst(innerBorrow);
+    callbacks.createdNewInst(outerEndBorrow);
 
     // Then set our borrowing operand to take our innerBorrow instead of value
     // (whose lifetime we just ended).
@@ -492,7 +444,7 @@ void OwnershipRAUWUtility::eliminateReborrowsOfRecursiveBorrows(
     auto *borrowedArg =
         const_cast<SILPhiArgument *>(bi->getArgForOperand(borrowingOperand));
     auto *baseArg =
-        insertOwnedBaseValueAlongBranchEdge(bi, innerCopy, getCallbacks());
+        insertOwnedBaseValueAlongBranchEdge(bi, innerCopy, callbacks);
     baseBorrowedValuePair.emplace_back(baseArg, borrowedArg);
   }
 
@@ -508,8 +460,7 @@ void OwnershipRAUWUtility::eliminateReborrowsOfRecursiveBorrows(
       if (isEndOfScopeMarker(use->getUser())) {
         SILBuilderWithScope::insertAfter(use->getUser(), [&](SILBuilder &b) {
           auto *dvi = b.createDestroyValue(b.getInsertionPointLoc(), baseArg);
-          if (ctx.newInstNotify)
-            ctx.newInstNotify(dvi);
+          callbacks.createdNewInst(dvi);
         });
         continue;
       }
@@ -521,7 +472,7 @@ void OwnershipRAUWUtility::eliminateReborrowsOfRecursiveBorrows(
       auto *brInst = cast<BranchInst>(borrowingOp.op->getUser());
       auto *newBorrowedPhi = brInst->getArgForOperand(borrowingOp);
       auto *newBasePhi =
-          insertOwnedBaseValueAlongBranchEdge(brInst, baseArg, getCallbacks());
+          insertOwnedBaseValueAlongBranchEdge(brInst, baseArg, callbacks);
       baseBorrowedValuePair.emplace_back(newBasePhi, newBorrowedPhi);
     }
   }
@@ -533,6 +484,7 @@ void OwnershipRAUWUtility::rewriteReborrows(
   // that copy should be valid at the reborrow.
   SmallVector<std::pair<SILPhiArgument *, SILPhiArgument *>, 8>
       baseBorrowedValuePair;
+  auto &callbacks = ctx.callbacks;
   for (auto reborrow : foundReborrows) {
     auto *bi = cast<BranchInst>(reborrow.op->getUser());
     SILBuilderWithScope reborrowBuilder(bi);
@@ -544,18 +496,16 @@ void OwnershipRAUWUtility::rewriteReborrows(
     auto *innerBorrow = reborrowBuilder.createBeginBorrow(loc, innerCopy);
     auto *outerEndBorrow =
         reborrowBuilder.createEndBorrow(loc, reborrow.op->get());
-    if (ctx.newInstNotify) {
-      ctx.newInstNotify(innerCopy);
-      ctx.newInstNotify(innerBorrow);
-      ctx.newInstNotify(outerEndBorrow);
-    }
+    callbacks.createdNewInst(innerCopy);
+    callbacks.createdNewInst(innerBorrow);
+    callbacks.createdNewInst(outerEndBorrow);
 
     reborrow->set(innerBorrow);
 
     auto *borrowedArg =
         const_cast<SILPhiArgument *>(bi->getArgForOperand(reborrow.op));
     auto *baseArg =
-        insertOwnedBaseValueAlongBranchEdge(bi, innerCopy, getCallbacks());
+        insertOwnedBaseValueAlongBranchEdge(bi, innerCopy, callbacks);
     baseBorrowedValuePair.emplace_back(baseArg, borrowedArg);
   }
 
@@ -571,8 +521,7 @@ void OwnershipRAUWUtility::rewriteReborrows(
       if (isEndOfScopeMarker(use->getUser())) {
         SILBuilderWithScope::insertAfter(use->getUser(), [&](SILBuilder &b) {
           auto *dvi = b.createDestroyValue(b.getInsertionPointLoc(), baseArg);
-          if (ctx.newInstNotify)
-            ctx.newInstNotify(dvi);
+          callbacks.createdNewInst(dvi);
         });
         continue;
       }
@@ -584,13 +533,14 @@ void OwnershipRAUWUtility::rewriteReborrows(
       auto *brInst = cast<BranchInst>(borrowingOp.op->getUser());
       auto *newBorrowedPhi = brInst->getArgForOperand(borrowingOp);
       auto *newBasePhi =
-          insertOwnedBaseValueAlongBranchEdge(brInst, baseArg, getCallbacks());
+          insertOwnedBaseValueAlongBranchEdge(brInst, baseArg, callbacks);
       baseBorrowedValuePair.emplace_back(newBasePhi, newBorrowedPhi);
     }
   }
 }
 
 SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
+  auto &callbacks = ctx.callbacks;
   switch (newValue.getOwnershipKind()) {
   case OwnershipKind::None:
     llvm_unreachable("Should have been handled elsewhere");
@@ -598,7 +548,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
     llvm_unreachable("Invalid for values");
   case OwnershipKind::Unowned:
     // An unowned value can always be RAUWed with another unowned value.
-    return replaceAllUsesAndEraseInner(oldValue, newValue, ctx.eraseNotify);
+    return replaceAllUsesAndErase(oldValue, newValue, callbacks);
   case OwnershipKind::Guaranteed: {
     // If we have an unowned value that we want to replace with a guaranteed
     // value, we need to ensure that the guaranteed value is live at all use
@@ -619,8 +569,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
           SILBuilderWithScope builder(ti);
           auto *newInst = builder.createUncheckedOwnershipConversion(
               ti->getLoc(), use->get(), OwnershipKind::Unowned);
-          if (ctx.newInstNotify)
-            ctx.newInstNotify(newInst);
+          callbacks.createdNewInst(newInst);
           use->set(newInst);
         }
       }
@@ -631,9 +580,8 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
     SILBuilderWithScope builder(oldValue);
     auto *newInst = builder.createUncheckedOwnershipConversion(
         oldValue->getLoc(), borrow, OwnershipKind::Unowned);
-    if (ctx.newInstNotify)
-      ctx.newInstNotify(newInst);
-    return replaceAllUsesAndEraseInner(oldValue, newInst, ctx.eraseNotify);
+    callbacks.createdNewInst(newInst);
+    return replaceAllUsesAndErase(oldValue, newInst, callbacks);
   }
   case OwnershipKind::Owned: {
     // If we have an unowned value that we want to replace with an owned value,
@@ -653,8 +601,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
           // lifetime to before the function end point.
           auto *newInst = builder.createUncheckedOwnershipConversion(
               ti->getLoc(), use->get(), OwnershipKind::Unowned);
-          if (ctx.newInstNotify)
-            ctx.newInstNotify(newInst);
+          callbacks.createdNewInst(newInst);
           use->set(newInst);
         }
       }
@@ -665,10 +612,8 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
     SILBuilderWithScope builder(oldValue);
     auto *newInst = builder.createUncheckedOwnershipConversion(
         oldValue->getLoc(), copy, OwnershipKind::Unowned);
-    if (ctx.newInstNotify)
-      ctx.newInstNotify(newInst);
-    auto result =
-        replaceAllUsesAndEraseInner(oldValue, newInst, ctx.eraseNotify);
+    callbacks.createdNewInst(newInst);
+    auto result = replaceAllUsesAndErase(oldValue, newInst, callbacks);
     return result;
   }
   }
@@ -727,8 +672,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleGuaranteed() {
   // Ok, we now have eliminated any reborrows if we had any. That means that
   // the uses of oldValue should be completely within the lifetime of our new
   // borrow.
-  return replaceAllUsesAndEraseInner(oldValue, newBorrowedValue,
-                                     ctx.eraseNotify);
+  return replaceAllUsesAndErase(oldValue, newBorrowedValue, ctx.callbacks);
 }
 
 SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
@@ -741,7 +685,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
   //
   // NOTE: This handles RAUWing with undef.
   if (newValue.getOwnershipKind() == OwnershipKind::None)
-    return replaceAllUsesAndEraseInner(oldValue, newValue, ctx.eraseNotify);
+    return replaceAllUsesAndErase(oldValue, newValue, ctx.callbacks);
   assert(SILValue(oldValue).getOwnershipKind() != OwnershipKind::None);
 
   switch (SILValue(oldValue).getOwnershipKind()) {
@@ -763,8 +707,8 @@ SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
     auto extender = getLifetimeExtender();
     SILValue copy =
         extender.copyAndExtendForLifetimeEndingRAUW(newValue, oldValue);
-    cleanupOperandsBeforeDeletion(oldValue, ctx.newInstNotify);
-    auto result = replaceAllUsesAndEraseInner(oldValue, copy, ctx.eraseNotify);
+    cleanupOperandsBeforeDeletion(oldValue, ctx.callbacks);
+    auto result = replaceAllUsesAndErase(oldValue, copy, ctx.callbacks);
     return result;
   }
   case OwnershipKind::Unowned: {


### PR DESCRIPTION
Specifically before this PR, if a caller did not customize a specific callback
of InstModCallbacks, we would store a static default std::function into
InstModCallbacks. This means that we always would have an indirect jump. That is
unfortunate since this code is often called in loops.

In this PR, I eliminate this problem by:

1. I made all of the actual callback std::function in InstModCallback private
   and gave them a "Func" postfix (e.x.: deleteInst -> deleteInstFunc).

2. I created public methods with the old callback names to actually call the
   callbacks. This ensured that as long as we are not escaping callbacks from
   InstModCallback, this PR would not result in the need for any source changes
   since we are changing a call of a std::function field to a call to a method.

3. I changed all of the places that were escaping inst mod's callbacks to take
   an InstModCallback. We shouldn't be doing that anyway.

4. I changed the default value of each callback in InstModCallbacks to be a
   nullptr and changed the public helper methods to check if a callback is
   null. If the callback is not null, it is called, otherwise the getter falls
   back to an inline default implementation of the operation.

All together this means that the cost of a plain InstModCallback is reduced and
one pays an indirect function cost price as one customizes it further which is
better scalability.

P.S. as a little extra thing, I added a madeChange field onto the
InstModCallback. Now that we have the helpers calling the callbacks, I can
easily insert instrumentation like this, allowing for users to pass in
InstModCallback and see if anything was RAUWed without needing to specify a
callback.
