### PR TITLE
[SR-12383][Diagnostics] Do not use canonical type for aka diagnostics instead walk the type recursivelly desugaring 

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -455,18 +455,17 @@ static bool typeSpellingIsAmbiguous(Type type,
   return false;
 }
 
-/// Walks the type recursivelly desugaring  types to display, but skiping
-/// `GenericTypeParamType` because we would lose association with it's original
+/// Walks the type recursivelly desugaring  types to display, but skipping
+/// `GenericTypeParamType` because we would lose association with its original
 /// declaration and end up presenting the parameter in τ_0_0 format on
 /// diagnostic.
 static Type getAkaTypeForDisplay(Type type) {
-  auto Func = [](Type visitTy) -> Type {
+  return type.transform([](Type visitTy) -> Type {
     if (isa<SugarType>(visitTy.getPointer()) &&
         !isa<GenericTypeParamType>(visitTy.getPointer()))
       return getAkaTypeForDisplay(visitTy->getDesugaredType());
     return visitTy;
-  };
-  return type.transform(Func).getPointer();
+  });
 }
 
 /// Format a single diagnostic argument and write it to the given

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -392,7 +392,7 @@ struct TF_521<T: FloatingPoint> {
 }
 // expected-error @+1 {{type 'TF_521<T>' does not conform to protocol 'Differentiable'}}
 extension TF_521: Differentiable where T: Differentiable {
-  // expected-note @+1 {{possibly intended match 'TF_521<T>.TangentVector' does not conform to 'AdditiveArithmetic'}}
+  // expected-note @+1 {{possibly intended match 'TF_521<T>.TangentVector' (aka 'TF_521<T>') does not conform to 'AdditiveArithmetic'}}
   typealias TangentVector = TF_521
 }
 // expected-error @+1 {{result type 'TF_521<Float>' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}

--- a/test/ClangImporter/objc_generics_conformance.swift
+++ b/test/ClangImporter/objc_generics_conformance.swift
@@ -21,7 +21,7 @@ protocol WithAssocOther {
 }
 
 extension GenericClass : WithAssocOther {
-  typealias Other = [T] // expected-error{{type 'GenericClass<T>.Other' involving Objective-C type parameter 'T' cannot be used for associated type 'Other' of protocol 'WithAssocOther'}}
+  typealias Other = [T] // expected-error{{type 'GenericClass<T>.Other' (aka 'Array<T>') involving Objective-C type parameter 'T' cannot be used for associated type 'Other' of protocol 'WithAssocOther'}}
 }
 
 protocol WithAssocSeparate {
@@ -31,7 +31,7 @@ protocol WithAssocSeparate {
 extension GenericClass {
   typealias Separate = T // expected-note {{'Separate' declared here}}
 }
-extension GenericClass : WithAssocSeparate { // expected-error {{type 'GenericClass<T>.Separate' involving Objective-C type parameter 'T' cannot be used for associated type 'Separate' of protocol 'WithAssocSeparate'}}
+extension GenericClass : WithAssocSeparate { // expected-error {{type 'GenericClass<T>.Separate' (aka 'T') involving Objective-C type parameter 'T' cannot be used for associated type 'Separate' of protocol 'WithAssocSeparate'}}
 }
 
 protocol WithAssocElement {

--- a/test/Constraints/conditionally_defined_types.swift
+++ b/test/Constraints/conditionally_defined_types.swift
@@ -36,7 +36,7 @@ let _ = SameType<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.self
 let _ = SameType<X>.Decl5<X>.self
 
-let _ = SameType<Y>.TypeAlias1.self // expected-error {{'SameType<T>.TypeAlias1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<Y>.TypeAlias1.self // expected-error {{'SameType<T>.TypeAlias1' (aka 'T') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.TypeAlias2.self // expected-error {{'SameType<T>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.TypeAlias3<X>.self // expected-error {{'SameType<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<Y>.Decl1.self // expected-error {{'SameType<T>.Decl1' requires the types 'Y' and 'X' be equivalent}}
@@ -144,7 +144,7 @@ let _ = SameType<X>.Decl4<X>.Decl3.self
 let _ = SameType<X>.Decl4<X>.Decl4<X>.self
 let _ = SameType<X>.Decl4<X>.Decl5<X>.self
 
-let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{'SameType<T>.Decl4<U>.TypeAlias1' requires the types 'Y' and 'X' be equivalent}}
+let _ = SameType<X>.Decl4<Y>.TypeAlias1.self // expected-error {{'SameType<T>.Decl4<U>.TypeAlias1' (aka 'T') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.TypeAlias2.self // expected-error {{'SameType<T>.Decl4<U>.TypeAlias2' (aka 'Y') requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.TypeAlias3<X>.self // expected-error {{'SameType<X>.Decl4<Y>.TypeAlias3' requires the types 'Y' and 'X' be equivalent}}
 let _ = SameType<X>.Decl4<Y>.Decl1.self // expected-error {{'SameType<T>.Decl4<U>.Decl1' requires the types 'Y' and 'X' be equivalent}}

--- a/test/Constraints/sr12383.swift
+++ b/test/Constraints/sr12383.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Protocol {
+  associatedtype Index: Comparable
+  subscript(bounds: Range<Index>) -> Int { get }
+  // expected-note@+1 {{protocol requires subscript with type '(Wrapper<Base>.Index) -> Int' (aka '(Base.Index) -> Int'); do you want to add a stub?}}
+  subscript(position: Index) -> Int { get } 
+}
+
+struct Wrapper<Base: Protocol>: Protocol { // expected-error {{type 'Wrapper<Base>' does not conform to protocol 'Protocol'}}
+  typealias Index = Base.Index
+  subscript(bounds: Range<Index>) -> Int { // expected-note {{candidate has non-matching type '<Base> (Range<Wrapper<Base>.Index>) -> Int' (aka '<Base> (Range<Base.Index>) -> Int')}}
+    get { 1 }
+  }
+}

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -35,7 +35,7 @@ func requirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, T.C == T.B.X {}
 // CHECK-LABEL: .concreteRequirementOnConcreteNestedTypeAlias@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0.C == τ_0_0.B.A>
 func concreteRequirementOnConcreteNestedTypeAlias<T>(_: T) where T: Q2, S<T.C> == T.B.X {}
-// expected-warning@-1 {{neither type in same-type constraint ('S<T.C>' or 'T.B.X') refers to a generic parameter or associated type}}
+// expected-warning@-1 {{neither type in same-type constraint ('S<T.C>' or 'T.B.X' (aka 'S<T.B.A>')) refers to a generic parameter or associated type}}
 
 
 // Incompatible concrete typealias types are flagged as such

--- a/test/ImportResolution/import-specific-fixits.swift
+++ b/test/ImportResolution/import-specific-fixits.swift
@@ -36,7 +36,7 @@ import struct DeclsUsedWrongly.Choice // expected-error {{'Choice' was imported 
 import struct DeclsUsedWrongly.Callback // expected-error {{type alias 'Callback' (aka '() -> ()') cannot be imported as 'struct'}} {{8-14=typealias}}
 import var DeclsUsedWrongly.Callback // expected-error {{'Callback' was imported as 'var', but is a type}} {{8-11=typealias}}
 
-import struct DeclsUsedWrongly.Pair // expected-error {{type alias 'Pair' cannot be imported as 'struct'}} {{8-14=typealias}}
+import struct DeclsUsedWrongly.Pair // expected-error {{type alias 'Pair' (aka '(T, T)') cannot be imported as 'struct'}} {{8-14=typealias}}
 import var DeclsUsedWrongly.Pair // expected-error {{'Pair' was imported as 'var', but is a type}} {{8-11=typealias}}
 
 import struct Swift.print // expected-error {{'print' was imported as 'struct', but is a function}} {{8-14=func}}

--- a/validation-test/compiler_crashers_2_fixed/sr12990.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12990.swift
@@ -5,7 +5,7 @@ class ContainerTransition {
   func completeTransition() {
     viewControllers?[Int//.max
     // expected-error@-1 {{no exact matches in call to subscript}}
-    // expected-note@-2 {{found candidate with type '((Int).Type) -> Dictionary<Int, String>.SubSequence' (aka '(Int.Type) -> Slice<Dictionary<Int, String>>')}}
+    // expected-note@-2 {{found candidate with type '((Int).Type) -> Dictionary<Int, String>.SubSequence' (aka '((Int).Type) -> Slice<Dictionary<Int, String>>')}}
     // expected-note@-3 {{to match this opening '['}}
   } // expected-error {{expected ']' in expression list}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Instead of using `getCanonicalType()` to show aka diagnostics, we instead walk the type recursivelly desugaring  types to display, but skipping`GenericTypeParamType` because we would lose association with it's original declaration and end up presenting the parameter in τ_0_0 format on diagnostic.

cc @dan-zheng 
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12383.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
