### PR TITLE
[sil-inst-opt] Change InstModCallbacks to specify a setUseValue callback instead of RAUW callbacks.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeInstruction.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeInstruction.h
@@ -49,8 +49,8 @@ struct CanonicalizeInstruction {
         callbacks(
             [&](SILInstruction *toDelete) { killInstruction(toDelete); },
             [&](SILInstruction *newInst) { notifyNewInstruction(newInst); },
-            [&](SILValue oldValue, SILValue newValue) {
-              oldValue->replaceAllUsesWith(newValue);
+            [&](Operand *use, SILValue newValue) {
+              use->set(newValue);
               notifyHasNewUsers(newValue);
             }) {
 #ifndef NDEBUG

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -336,7 +336,7 @@ class InstModCallbacks {
   std::function<void(Operand *use, SILValue newValue)> setUseValueFunc;
 
   /// A boolean that tracks if any of our callbacks were ever called.
-  bool madeChange = false;
+  bool wereAnyCallbacksInvoked = false;
 
 public:
   InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc)
@@ -363,27 +363,27 @@ public:
   InstModCallbacks(InstModCallbacks &&) = default;
 
   void deleteInst(SILInstruction *instToDelete) {
-    madeChange = true;
+    wereAnyCallbacksInvoked = true;
     if (deleteInstFunc)
       return deleteInstFunc(instToDelete);
     instToDelete->eraseFromParent();
   }
 
   void createdNewInst(SILInstruction *newlyCreatedInst) {
-    madeChange = true;
+    wereAnyCallbacksInvoked = true;
     if (createdNewInstFunc)
       createdNewInstFunc(newlyCreatedInst);
   }
 
   void setUseValue(Operand *use, SILValue newValue) {
-    madeChange = true;
+    wereAnyCallbacksInvoked = true;
     if (setUseValueFunc)
       return setUseValueFunc(use, newValue);
     use->set(newValue);
   }
 
   void replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
-    madeChange = true;
+    wereAnyCallbacksInvoked = true;
 
     while (!oldValue->use_empty()) {
       auto *use = *oldValue->use_begin();
@@ -393,12 +393,12 @@ public:
 
   void eraseAndRAUWSingleValueInst(SingleValueInstruction *oldInst,
                                    SILValue newValue) {
-    madeChange = true;
+    wereAnyCallbacksInvoked = true;
     replaceValueUsesWith(oldInst, newValue);
     deleteInst(oldInst);
   }
 
-  bool getMadeChange() const { return madeChange; }
+  bool hadCallbackInvocation() const { return wereAnyCallbacksInvoked; }
 };
 
 /// Get all consumed arguments of a partial_apply.

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -752,7 +752,7 @@ swift::replaceAllUsesAndErase(SingleValueInstruction *svi, SILValue newValue,
       callbacks.deleteInst(user);
       continue;
     }
-    use->set(newValue);
+    callbacks.setUseValue(use, newValue);
   }
 
   callbacks.deleteInst(svi);

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -148,8 +148,9 @@ public:
               instructionsPendingDeletion.push_back(instruction);
             },
             [&](SILInstruction *instruction) { worklist.add(instruction); },
-            [this](SILValue oldValue, SILValue newValue) {
-              worklist.replaceValueUsesWith(oldValue, newValue);
+            [this](Operand *use, SILValue newValue) {
+              use->set(newValue);
+              worklist.add(use->getUser());
             }),
         createdInstructions(createdInstructions),
         deadEndBlocks(deadEndBlocks){};

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -84,6 +84,9 @@ class SILCombiner :
   /// Cast optimizer
   CastOptimizer CastOpt;
 
+  /// Centralized InstModCallback that we use for certain utility methods.
+  InstModCallbacks instModCallbacks;
+
 public:
   SILCombiner(SILOptFunctionBuilder &FuncBuilder, SILBuilder &B,
               AliasAnalysis *AA, DominanceAnalysis *DA,
@@ -103,7 +106,18 @@ public:
               replaceInstUsesWith(*I, V);
             },
             /* EraseAction */
-            [&](SILInstruction *I) { eraseInstFromFunction(*I); }) {}
+            [&](SILInstruction *I) { eraseInstFromFunction(*I); }),
+        instModCallbacks(
+            [&](SILInstruction *instToDelete) {
+              eraseInstFromFunction(*instToDelete);
+            },
+            [&](SILInstruction *newlyCreatedInst) {
+              Worklist.add(newlyCreatedInst);
+            },
+            [&](Operand *use, SILValue newValue) {
+              use->set(newValue);
+              Worklist.add(use->getUser());
+            }) {}
 
   bool runOnFunction(SILFunction &F);
 
@@ -307,14 +321,7 @@ public:
                                        StringRef FInverseName, StringRef FName);
 
 private:
-  InstModCallbacks getInstModCallbacks() {
-    return InstModCallbacks(
-        [this](SILInstruction *DeadInst) { eraseInstFromFunction(*DeadInst); },
-        [this](SILInstruction *NewInst) { Worklist.add(NewInst); },
-        [this](SILValue oldValue, SILValue newValue) {
-          replaceValueUsesWith(oldValue, newValue);
-        });
-  }
+  InstModCallbacks &getInstModCallbacks() { return instModCallbacks; }
 
   // Build concrete existential information using findInitExistential.
   Optional<ConcreteOpenedExistentialInfo>

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -434,7 +434,7 @@ void OwnershipRAUWUtility::eliminateReborrowsOfRecursiveBorrows(
 
     // Then set our borrowing operand to take our innerBorrow instead of value
     // (whose lifetime we just ended).
-    borrowingOperand->set(innerBorrow);
+    callbacks.setUseValue(*borrowingOperand, innerBorrow);
     // Add our outer end borrow as a use point to make sure that we extend our
     // base value to this point.
     usePoints.push_back(&outerEndBorrow->getAllOperands()[0]);
@@ -500,7 +500,7 @@ void OwnershipRAUWUtility::rewriteReborrows(
     callbacks.createdNewInst(innerBorrow);
     callbacks.createdNewInst(outerEndBorrow);
 
-    reborrow->set(innerBorrow);
+    callbacks.setUseValue(*reborrow, innerBorrow);
 
     auto *borrowedArg =
         const_cast<SILPhiArgument *>(bi->getArgForOperand(reborrow.op));
@@ -570,7 +570,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
           auto *newInst = builder.createUncheckedOwnershipConversion(
               ti->getLoc(), use->get(), OwnershipKind::Unowned);
           callbacks.createdNewInst(newInst);
-          use->set(newInst);
+          callbacks.setUseValue(use, newInst);
         }
       }
     }
@@ -602,7 +602,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleUnowned() {
           auto *newInst = builder.createUncheckedOwnershipConversion(
               ti->getLoc(), use->get(), OwnershipKind::Unowned);
           callbacks.createdNewInst(newInst);
-          use->set(newInst);
+          callbacks.setUseValue(use, newInst);
         }
       }
     }


### PR DESCRIPTION
NOTE: This PR contains two changes. The first commit (4600aa7) is the meat and I included the commit message below. The other commit is just follow up changes to #35253 the predecessor PR of this PR. 

----
[sil-inst-opt] Change InstModCallbacks to specify a setUseValue callback instead of RAUW callbacks.

This allows for me to do a couple of things improving quality/correctness/ease of use:

1. I reimplemented InstMod's RAUW and RAUW/erase helpers on top of
   setUseValue/deleteInst. Beyond allowing the caller to specify less things, we
   gain an orthogonality preventing bugs like overriding erase/RAUW but not
   overriding erase or having the erase used in erase/RAUW act differently than
   the erase for deleteInst.

2. There were a bunch of places using InstModCallback that also were setting
   uses without having the ability for InstModCallbacks perform it (since it
   only supported RAUW). This is an anti-pattern and could cause subtle bugs to
   be introduced by appropriate state in the caller not being updated.
