### PR TITLE
Comment mayWriteToMemory.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -620,7 +620,8 @@ public:
   /// that are not visible by merely examining their uses.
   bool mayHaveSideEffects() const;
 
-  /// Returns true if the instruction may write to memory.
+  /// Returns true if the instruction may write to memory, deinitialize memory,
+  /// or have other unknown side effects.
   bool mayWriteToMemory() const {
     MemoryBehavior B = getMemoryBehavior();
     return B == MemoryBehavior::MayWrite ||
@@ -636,7 +637,8 @@ public:
       B == MemoryBehavior::MayHaveSideEffects;
   }
 
-  /// Returns true if the instruction may read from or write to memory.
+  /// Returns true if the instruction may read from memory, write to memory,
+  /// deinitialize memory, or have other unknown side effects.
   bool mayReadOrWriteMemory() const {
     return getMemoryBehavior() != MemoryBehavior::None;
   }

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -224,8 +224,8 @@ public:
            B == MemoryBehavior::MayHaveSideEffects;
   }
 
-  /// Returns true if \p Inst may write to memory in a manner that
-  /// affects V.
+  /// Returns true if \p Inst may write to memory, deinitialize memory, or have
+  /// other side effects that may affect V.
   bool mayWriteToMemory(SILInstruction *Inst, SILValue V) {
     auto B = computeMemoryBehavior(Inst, V);
     return B == MemoryBehavior::MayWrite ||
@@ -233,8 +233,8 @@ public:
            B == MemoryBehavior::MayHaveSideEffects;
   }
 
-  /// Returns true if \p Inst may read or write to memory in a manner that
-  /// affects V.
+  /// Returns true if \p Inst may read to memory, write to memory, deinitialize
+  /// memory, or have other side effects that may affect V.
   bool mayReadOrWriteMemory(SILInstruction *Inst, SILValue V) {
     auto B = computeMemoryBehavior(Inst, V);
     return MemoryBehavior::None != B;


### PR DESCRIPTION
It's very important that fundamental APIs don't lie to their users.

Make it clear that this API always returns true for deinitialization, even if we could for example analyze the destructor and determine that there aren't any actual writes!