### PR TITLE
[Concurrency] Introduce "ConcurrentValue" protocol and checking.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4315,6 +4315,10 @@ WARNING(non_concurrent_property_type,none,
         "cannot use %0 %1 with a non-concurrent-value type %2 "
         "%select{across actors|from concurrently-executed code}3",
         (DescriptiveDeclKind, DeclName, Type, bool))
+WARNING(non_concurrent_function_type,none,
+        "`@concurrent` %select{function type|closure}0 has "
+        "non-concurrent-value %select{parameter|result}1 type %2",
+        (bool, bool, Type))
 
 ERROR(actorindependent_let,none,
       "'@actorIndependent' is meaningless on 'let' declarations because "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4319,6 +4319,17 @@ WARNING(non_concurrent_function_type,none,
         "`@concurrent` %select{function type|closure}0 has "
         "non-concurrent-value %select{parameter|result}1 type %2",
         (bool, bool, Type))
+ERROR(non_concurrent_type_member,none,
+      "%select{stored property %1|associated value %1}0 of "
+      "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",
+      (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
+ERROR(concurrent_value_class_mutable_property,none,
+      "stored property %0 of 'ConcurrentValue'-conforming %1 %2 is mutable",
+      (DeclName, DescriptiveDeclKind, DeclName))
+ERROR(concurrent_value_outside_source_file,none,
+      "conformance 'ConcurrentValue' must occur in the same source file as "
+      "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
+      (DescriptiveDeclKind, DeclName))
 
 ERROR(actorindependent_let,none,
       "'@actorIndependent' is meaningless on 'let' declarations because "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4305,6 +4305,17 @@ ERROR(global_actor_isolated_requirement_witness_conflict,none,
       "requirement from protocol %3 isolated to global actor %4",
       (DescriptiveDeclKind, DeclName, Type, Identifier, Type))
 
+WARNING(non_concurrent_param_type,none,
+        "cannot pass argument of non-concurrent-value type %0 across actors",
+        (Type))
+WARNING(non_concurrent_result_type,none,
+        "cannot call function returning non-concurrent-value type %0 across "
+        "actors", (Type))
+WARNING(non_concurrent_property_type,none,
+        "cannot use %0 %1 with a non-concurrent-value type %2 "
+        "%select{across actors|from concurrently-executed code}3",
+        (DescriptiveDeclKind, DeclName, Type, bool))
+
 ERROR(actorindependent_let,none,
       "'@actorIndependent' is meaningless on 'let' declarations because "
       "they are immutable",

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -80,6 +80,8 @@ PROTOCOL(CodingKey)
 PROTOCOL(Encodable)
 PROTOCOL(Decodable)
 
+PROTOCOL(ConcurrentValue)
+
 PROTOCOL_(ObjectiveCBridgeable)
 PROTOCOL_(DestructorSafeContainer)
 

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -81,6 +81,7 @@ PROTOCOL(Encodable)
 PROTOCOL(Decodable)
 
 PROTOCOL(ConcurrentValue)
+PROTOCOL(UnsafeConcurrentValue)
 
 PROTOCOL_(ObjectiveCBridgeable)
 PROTOCOL_(DestructorSafeContainer)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -244,6 +244,9 @@ namespace swift {
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 
+    /// Enable experimental ConcurrentValue checking.
+    bool EnableExperimentalConcurrentValueChecking = false;
+
     /// Disable the implicit import of the _Concurrency module.
     bool DisableImplicitConcurrencyModuleImport = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -221,7 +221,12 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOption] 
 def enable_experimental_concurrency :
   Flag<["-"], "enable-experimental-concurrency">,
   HelpText<"Enable experimental concurrency model">;
-  def enable_resilience : Flag<["-"], "enable-resilience">,
+
+def enable_experimental_concurrent_value_checking :
+  Flag<["-"], "enable-experimental-concurrent-value-checking">,
+  HelpText<"Enable ConcurrentValue checking">;
+
+def enable_resilience : Flag<["-"], "enable-resilience">,
      HelpText<"Deprecated, use -enable-library-evolution instead">;
 }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -971,6 +971,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
     M = getLoadedModule(Id_Differentiation);
     break;
   case KnownProtocolKind::Actor:
+  case KnownProtocolKind::ConcurrentValue:
   case KnownProtocolKind::AsyncSequence:
   case KnownProtocolKind::AsyncIteratorProtocol:
     M = getLoadedModule(Id_Concurrency);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -971,7 +971,6 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
     M = getLoadedModule(Id_Differentiation);
     break;
   case KnownProtocolKind::Actor:
-  case KnownProtocolKind::ConcurrentValue:
   case KnownProtocolKind::AsyncSequence:
   case KnownProtocolKind::AsyncIteratorProtocol:
     M = getLoadedModule(Id_Concurrency);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -385,6 +385,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
+  Opts.EnableExperimentalConcurrentValueChecking |=
+    Args.hasArg(OPT_enable_experimental_concurrent_value_checking);
 
   Opts.DisableImplicitConcurrencyModuleImport |=
     Args.hasArg(OPT_disable_implicit_concurrency_module_import);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5139,6 +5139,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::FloatingPoint:
   case KnownProtocolKind::Actor:
   case KnownProtocolKind::ConcurrentValue:
+  case KnownProtocolKind::UnsafeConcurrentValue:
     return SpecialProtocol::None;
   }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5138,6 +5138,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::Differentiable:
   case KnownProtocolKind::FloatingPoint:
   case KnownProtocolKind::Actor:
+  case KnownProtocolKind::ConcurrentValue:
     return SpecialProtocol::None;
   }
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -25,6 +25,7 @@ namespace swift {
 
 class AbstractFunctionDecl;
 class ActorIsolation;
+class AnyFunctionType;
 class ASTContext;
 class ClassDecl;
 class ConcreteDeclRef;
@@ -60,6 +61,8 @@ enum class ConcurrentReferenceKind {
   CrossActor,
   /// A local capture referenced from concurrent code.
   LocalCapture,
+  /// Concurrent function
+  ConcurrentFunction,
 };
 
 /// Describes why or where a particular entity has a non-concurrent-value type.
@@ -232,6 +235,12 @@ void checkOverrideActorIsolation(ValueDecl *value);
 bool diagnoseNonConcurrentTypesInReference(
     ConcreteDeclRef declRef, const DeclContext *dc, SourceLoc loc,
     ConcurrentReferenceKind refKind);
+
+/// Diagnose the presence of any non-concurrent types within the given
+/// function type.
+bool diagnoseNonConcurrentTypesInFunctionType(
+    const AnyFunctionType *fnType, const DeclContext *dc, SourceLoc loc,
+    bool isClosure);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -36,6 +36,7 @@ class Expr;
 class FuncDecl;
 class Initializer;
 class PatternBindingDecl;
+class ProtocolConformance;
 class TopLevelCodeDecl;
 class TypeBase;
 class ValueDecl;
@@ -241,6 +242,9 @@ bool diagnoseNonConcurrentTypesInReference(
 bool diagnoseNonConcurrentTypesInFunctionType(
     const AnyFunctionType *fnType, const DeclContext *dc, SourceLoc loc,
     bool isClosure);
+
+/// Check the correctness of the given ConcurrentValue conformance.
+void checkConcurrentValueConformance(ProtocolConformance *conformance);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SEMA_TYPECHECKCONCURRENCY_H
 #define SWIFT_SEMA_TYPECHECKCONCURRENCY_H
 
+#include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/Type.h"
 #include <cassert>
 
@@ -50,13 +51,53 @@ void checkEnumElementActorIsolation(EnumElementDecl *element, Expr *expr);
 void checkPropertyWrapperActorIsolation(
     PatternBindingDecl *binding, Expr *expr);
 
+/// Describes the kind of operation that introduced the concurrent refernece.
+enum class ConcurrentReferenceKind {
+  /// A synchronous operation that was "promoted" to an asynchronous call
+  /// because it was out of the actor's domain.
+  SynchronousAsAsyncCall,
+  /// A cross-actor reference.
+  CrossActor,
+  /// A local capture referenced from concurrent code.
+  LocalCapture,
+};
+
+/// Describes why or where a particular entity has a non-concurrent-value type.
+struct NonConcurrentType {
+  enum Kind {
+    /// A function parameter is a non-concurrent-value type.
+    Parameter,
+    /// The result of a function is a non-concurrent-value type.
+    Result,
+    /// The type of a property is a non-concurrent-value type.
+    Property,
+  } kind;
+
+  /// The declaration reference.
+  ConcreteDeclRef declRef;
+
+  /// The non-concurrent-value type being diagnosed.
+  Type type;
+
+  /// Determine whether a reference to the given declaration involves a
+  /// non-concurrent-value type. If it does, return the reason. Otherwise,
+  /// return \c None.
+  ///
+  /// \param dc The declaration context from which the reference occurs.
+  /// \param declRef The reference to the declaration.
+  static Optional<NonConcurrentType> get(
+      const DeclContext *dc, ConcreteDeclRef declRef);
+
+  /// Diagnose the non-concurrent-value type at the given source location.
+  void diagnose(SourceLoc loc);
+};
+
 /// The isolation restriction in effect for a given declaration that is
 /// referenced from source.
 class ActorIsolationRestriction {
 public:
   enum Kind {
-    /// There is no restriction on references to the given declaration,
-    /// e.g., because it's immutable.
+    /// There is no restriction on references to the given declaration.
     Unrestricted,
 
     /// Access to the declaration is unsafe in a concurrent context.
@@ -66,16 +107,24 @@ public:
     /// data races. The context in which the local was defined is provided.
     LocalCapture,
 
+    /// References to this entity are allowed from anywhere, but doing so
+    /// may cross an actor boundary if it is not on \c self.
+    CrossActorSelf,
+
     /// References to this member of an actor are only permitted on 'self'.
     ActorSelf,
 
     /// References to a declaration that is part of a global actor are only
     /// permitted from other declarations with that same global actor.
     GlobalActor,
+
+    /// Referneces to this entity are allowed from anywhere, but doing so may
+    /// cross an actor bounder if it is not from the same global actor.
+    CrossGlobalActor,
   };
 
 private:
-  /// The kind of restriction
+  /// The kind of restriction.
   Kind kind;
 
   union {
@@ -102,13 +151,13 @@ public:
 
   /// Retrieve the actor class that the declaration is within.
   ClassDecl *getActorClass() const {
-    assert(kind == ActorSelf);
+    assert(kind == ActorSelf || kind == CrossActorSelf);
     return data.actorClass;
   }
 
   /// Retrieve the actor class that the declaration is within.
   Type getGlobalActor() const {
-    assert(kind == GlobalActor);
+    assert(kind == GlobalActor || kind == CrossGlobalActor);
     return Type(data.globalActor);
   }
 
@@ -123,9 +172,10 @@ public:
   }
 
   /// Accesses to the given declaration can only be made via the 'self' of
-  /// the current actor.
-  static ActorIsolationRestriction forActorSelf(ClassDecl *actorClass) {
-    ActorIsolationRestriction result(ActorSelf);
+  /// the current actor or is a cross-actor access.
+  static ActorIsolationRestriction forActorSelf(
+      ClassDecl *actorClass, bool isCrossActor) {
+    ActorIsolationRestriction result(isCrossActor? CrossActorSelf : ActorSelf);
     result.data.actorClass = actorClass;
     return result;
   }
@@ -138,9 +188,11 @@ public:
   }
 
   /// Accesses to the given declaration can only be made via this particular
-  /// global actor.
-  static ActorIsolationRestriction forGlobalActor(Type globalActor) {
-    ActorIsolationRestriction result(GlobalActor);
+  /// global actor or is a cross-actor access.
+  static ActorIsolationRestriction forGlobalActor(
+      Type globalActor, bool isCrossActor) {
+    ActorIsolationRestriction result(
+        isCrossActor ? CrossGlobalActor : GlobalActor);
     result.data.globalActor = globalActor.getPointer();
     return result;
   }
@@ -154,6 +206,32 @@ public:
 /// Check that the actor isolation of an override matches that of its
 /// overridden declaration.
 void checkOverrideActorIsolation(ValueDecl *value);
+
+/// Diagnose the presence of any non-concurrent types when referencing a
+/// given declaration from a particular declaration context.
+///
+/// This function should be invoked any time that the given declaration
+/// reference is will move values of the declaration's types across a
+/// concurrency domain, whether in/out of an actor or in/or of a concurrent
+/// function or closure.
+///
+/// \param declRef The declaration being referenced from another concurrency
+/// domain, including the substitutions so that (e.g.) we can consider the
+/// specific types at the use site.
+///
+/// \param dc The declaration context from which the reference occurs. This is
+/// used to perform lookup of conformances to the \c ConcurrentValue protocol.
+///
+/// \param loc The location at which the reference occurs, which will be
+/// used when emitting diagnostics.
+///
+/// \param refKind Describes what kind of reference is being made, which is
+/// used to tailor the diagnostic.
+///
+/// \returns true if an problem was detected, false otherwise.
+bool diagnoseNonConcurrentTypesInReference(
+    ConcreteDeclRef declRef, const DeclContext *dc, SourceLoc loc,
+    ConcurrentReferenceKind refKind);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -377,6 +377,14 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
 
   switch (auto restriction = ActorIsolationRestriction::forDeclaration(
               const_cast<ValueDecl *>(VD))) {
+  case ActorIsolationRestriction::CrossActorSelf:
+    if (Diagnose) {
+      // FIXME: Substitution map?
+      diagnoseNonConcurrentTypesInReference(
+          const_cast<ValueDecl *>(VD), VD->getDeclContext(), VD->getLoc(),
+          ConcurrentReferenceKind::CrossActor);
+    }
+    return false;
   case ActorIsolationRestriction::ActorSelf:
     // Actor-isolated functions cannot be @objc.
     if (Diagnose) {
@@ -389,6 +397,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
     }
     return true;
 
+  case ActorIsolationRestriction::CrossGlobalActor:
   case ActorIsolationRestriction::GlobalActor:
     // FIXME: Consider whether to limit @objc on global-actor-qualified
     // declarations.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1906,6 +1906,8 @@ public:
     (void) TAD->getGenericSignature();
     (void) TAD->getUnderlyingType();
 
+    // Make sure to check the underlying type.
+    
     TypeChecker::checkDeclAttributes(TAD);
     checkAccessControl(TAD);
     checkGenericParams(TAD);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -17,6 +17,7 @@
 
 #include "TypeChecker.h"
 #include "TypeCheckAvailability.h"
+#include "TypeCheckConcurrency.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
 #include "TypoCorrection.h"
@@ -2823,6 +2824,14 @@ NeverNullType TypeResolver::resolveASTFunctionType(
   
   if (fnTy->hasError())
     return fnTy;
+
+  // Concurrent function types must be composed of concurrent-safe parameter
+  // and result types.
+  if (concurrent && resolution.getStage() > TypeResolutionStage::Structural) {
+    (void)diagnoseNonConcurrentTypesInFunctionType(
+         fnTy, resolution.getDeclContext(), repr->getLoc(),
+         /*isClosure=*/false);
+  }
 
   // If the type is a block or C function pointer, it must be representable in
   // ObjC.

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -19,7 +19,7 @@ import Swift
 /// which involves enqueuing new partial tasks to be executed at some
 /// point. Actor classes implicitly conform to this protocol as part of their
 /// primary class definition.
-public protocol Actor: AnyObject {
+public protocol Actor: AnyObject, ConcurrentValue {
   /// Enqueue a new partial task that will be executed in the actor's context.
   func enqueue(partialTask: PartialAsyncTask)
 }

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -37,6 +37,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   Actor.cpp
   Actor.swift
   CheckedContinuation.swift
+  ConcurrentValue.swift
   GlobalExecutor.cpp
   AsyncIteratorProtocol.swift
   AsyncSequence.swift

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -37,7 +37,6 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   Actor.cpp
   Actor.swift
   CheckedContinuation.swift
-  ConcurrentValue.swift
   GlobalExecutor.cpp
   AsyncIteratorProtocol.swift
   AsyncSequence.swift

--- a/stdlib/public/Concurrency/ConcurrentValue.swift
+++ b/stdlib/public/Concurrency/ConcurrentValue.swift
@@ -1,0 +1,161 @@
+////===----------------------------------------------------------------------===//
+////
+//// This source file is part of the Swift.org open source project
+////
+//// Copyright (c) 2020 Apple Inc. and the Swift project authors
+//// Licensed under Apache License v2.0 with Runtime Library Exception
+////
+//// See https://swift.org/LICENSE.txt for license information
+//// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+////
+////===----------------------------------------------------------------------===//
+
+import Swift
+
+/// The ConcurrentValue protocol indicates that value of the given type can
+/// be safely used in concurrent code.
+public protocol ConcurrentValue { }
+
+extension Array: ConcurrentValue where Element: ConcurrentValue { }
+extension ArraySlice: ConcurrentValue where Element: ConcurrentValue { }
+extension Bool: ConcurrentValue { }
+extension AutoreleasingUnsafeMutablePointer: ConcurrentValue { }
+extension Character: ConcurrentValue { }
+extension KeyedEncodingContainer: ConcurrentValue { }
+extension KeyedDecodingContainer: ConcurrentValue { }
+extension CodingUserInfoKey: ConcurrentValue { }
+extension EncodingError: ConcurrentValue { }
+extension DecodingError: ConcurrentValue { }
+extension IndexingIterator: ConcurrentValue { }
+extension ContiguousArray: ConcurrentValue { }
+extension ClosedRange: ConcurrentValue where Bound: ConcurrentValue { }
+extension ClosedRange.Index: ConcurrentValue where Bound: ConcurrentValue { }
+extension OpaquePointer: ConcurrentValue { }
+extension CVaListPointer: ConcurrentValue { }
+extension Dictionary: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Keys: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Values: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Keys.Iterator: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Values.Iterator: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Index: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Iterator: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension EmptyCollection: ConcurrentValue { }
+extension EmptyCollection.Iterator: ConcurrentValue { }
+extension Hasher: ConcurrentValue { }
+extension DefaultIndices: ConcurrentValue where Elements: ConcurrentValue { }
+extension KeyValuePairs: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension ManagedBufferPointer: ConcurrentValue where Header: ConcurrentValue, Element: ConcurrentValue { }
+extension Unicode.Scalar: ConcurrentValue { }
+extension Unicode.Scalar.UTF16View: ConcurrentValue { }
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension Unicode.Scalar.UTF8View: ConcurrentValue { }
+
+extension ObjectIdentifier: ConcurrentValue { }
+extension SystemRandomNumberGenerator: ConcurrentValue { }
+extension Range: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeUpTo: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeThrough: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeFrom: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeFrom.Iterator: ConcurrentValue where Bound: ConcurrentValue { }
+extension Repeated: ConcurrentValue where Element: ConcurrentValue { }
+extension IteratorSequence: ConcurrentValue where Base: ConcurrentValue { }
+extension Set: ConcurrentValue where Element: ConcurrentValue { }
+extension Set.Index: ConcurrentValue where Element: ConcurrentValue { }
+extension Set.Iterator: ConcurrentValue where Element: ConcurrentValue { }
+extension Slice: ConcurrentValue where Base: ConcurrentValue { }
+extension StaticString: ConcurrentValue { }
+extension StrideToIterator: ConcurrentValue where Element: ConcurrentValue { }
+extension StrideTo: ConcurrentValue where Element: ConcurrentValue { }
+extension StrideThroughIterator: ConcurrentValue where Element: ConcurrentValue { }
+extension StrideThrough: ConcurrentValue where Element: Strideable { }
+extension String: ConcurrentValue { }
+extension String.Iterator: ConcurrentValue { }
+extension String.Index: ConcurrentValue { }
+extension DefaultStringInterpolation: ConcurrentValue { }
+extension String.UnicodeScalarView: ConcurrentValue { }
+extension String.UnicodeScalarView.Iterator: ConcurrentValue { }
+extension String.UTF16View: ConcurrentValue { }
+extension String.UTF16View.Iterator: ConcurrentValue { }
+extension String.UTF8View: ConcurrentValue { }
+extension Substring: ConcurrentValue { }
+extension Substring.UnicodeScalarView: ConcurrentValue { }
+extension Substring.UTF16View: ConcurrentValue { }
+extension Substring.UTF8View: ConcurrentValue { }
+extension Unicode.Scalar.Properties: ConcurrentValue { }
+extension Unicode.CanonicalCombiningClass: ConcurrentValue { }
+extension Unmanaged: ConcurrentValue { }
+extension UnsafePointer: ConcurrentValue { }
+extension UnsafeMutablePointer: ConcurrentValue { }
+extension UnsafeRawPointer: ConcurrentValue { }
+extension UnsafeMutableRawPointer: ConcurrentValue { }
+extension Unicode.UTF8.ForwardParser: ConcurrentValue { }
+extension Unicode.UTF8.ReverseParser: ConcurrentValue { }
+extension Unicode.UTF16.ForwardParser: ConcurrentValue { }
+extension Unicode.UTF16.ReverseParser: ConcurrentValue { }
+extension Unicode.UTF32.Parser: ConcurrentValue { }
+extension Unicode.ParseResult: ConcurrentValue where T: ConcurrentValue { }
+extension Unicode.GeneralCategory: ConcurrentValue { }
+extension Unicode.NumericType: ConcurrentValue { }
+extension Unicode.UTF8: ConcurrentValue { }
+extension Unicode.UTF16: ConcurrentValue { }
+extension Unicode.UTF32: ConcurrentValue { }
+extension UnicodeDecodingResult: ConcurrentValue { }
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension CollectionDifference: ConcurrentValue where ChangeElement: ConcurrentValue { }
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension CollectionDifference.Change: ConcurrentValue where ChangeElement: ConcurrentValue { }
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension CollectionDifference.Index: ConcurrentValue where ChangeElement: ConcurrentValue { }
+
+extension CollectionOfOne: ConcurrentValue where Element: ConcurrentValue { }
+extension CollectionOfOne.Iterator: ConcurrentValue where Element: ConcurrentValue { }
+extension Mirror: ConcurrentValue { }
+extension Mirror.AncestorRepresentation: ConcurrentValue { }
+extension Mirror.DisplayStyle: ConcurrentValue { }
+
+// FIXME: Float16 when available
+extension Float: ConcurrentValue { }
+extension Double: ConcurrentValue { }
+// FIXME: Float80 when available
+
+// FIXME: hacks to enumerate integer types, and ".Words", and "SIMDnStorage"
+extension UInt8: ConcurrentValue { }
+extension Int8: ConcurrentValue { }
+extension UInt16: ConcurrentValue { }
+extension Int16: ConcurrentValue { }
+extension UInt32: ConcurrentValue { }
+extension Int32: ConcurrentValue { }
+extension UInt64: ConcurrentValue { }
+extension Int64: ConcurrentValue { }
+extension UInt: ConcurrentValue { }
+extension Int: ConcurrentValue { }
+
+extension UnsafeMutableBufferPointer: ConcurrentValue { }
+extension UnsafeBufferPointer: ConcurrentValue { }
+extension UnsafeBufferPointer.Iterator: ConcurrentValue { }
+extension UnsafeMutableRawBufferPointer: ConcurrentValue { }
+extension UnsafeRawBufferPointer: ConcurrentValue { }
+extension UnsafeRawBufferPointer.Iterator: ConcurrentValue { }
+
+extension SIMDMask: ConcurrentValue where Storage: ConcurrentValue { }
+// FIXME: enumerate SIMD types
+extension SIMD2: ConcurrentValue where Scalar: ConcurrentValue { }
+extension SIMD3: ConcurrentValue where Scalar: ConcurrentValue { }
+extension SIMD4: ConcurrentValue where Scalar: ConcurrentValue { }
+extension SIMD8: ConcurrentValue where Scalar: ConcurrentValue { }
+extension SIMD16: ConcurrentValue where Scalar: ConcurrentValue { }
+extension SIMD32: ConcurrentValue where Scalar: ConcurrentValue { }
+extension SIMD64: ConcurrentValue where Scalar: ConcurrentValue { }
+
+extension PartialKeyPath: ConcurrentValue where Root: ConcurrentValue { }
+
+extension FloatingPointSign: ConcurrentValue { }
+extension FloatingPointClassification: ConcurrentValue { }
+extension FloatingPointRoundingRule: ConcurrentValue { }
+
+extension Optional: ConcurrentValue where Wrapped: ConcurrentValue { }
+extension Never: ConcurrentValue { }
+extension Result: ConcurrentValue where Success: ConcurrentValue, Failure: ConcurrentValue { }
+

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1985,4 +1985,4 @@ internal struct _ArrayAnyHashableBox<Element: Hashable>
   }
 }
 
-extension Array: ConcurrentValue where Element: ConcurrentValue { }
+extension Array: ConcurrentValue, UnsafeConcurrentValue where Element: ConcurrentValue { }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1984,3 +1984,5 @@ internal struct _ArrayAnyHashableBox<Element: Hashable>
     return true
   }
 }
+
+extension Array: ConcurrentValue where Element: ConcurrentValue { }

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -673,3 +673,6 @@ extension _ArrayBuffer {
   }
 }
 #endif
+
+extension _ArrayBuffer: ConcurrentValue, UnsafeConcurrentValue
+  where Element: ConcurrentValue { }

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -672,7 +672,7 @@ extension _ArrayBuffer {
     }
   }
 }
-#endif
 
 extension _ArrayBuffer: ConcurrentValue, UnsafeConcurrentValue
   where Element: ConcurrentValue { }
+#endif

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1516,3 +1516,6 @@ extension ArraySlice {
         shiftedToStartIndex: _startIndex))
   }
 }
+
+extension ArraySlice: ConcurrentValue, UnsafeConcurrentValue
+  where Element: ConcurrentValue { }

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -61,7 +61,7 @@
 /// that functions, methods, and properties imported from C and Objective-C
 /// have a consistent type interface.
 @frozen
-public struct Bool {
+public struct Bool: ConcurrentValue {
   @usableFromInline
   internal var _value: Builtin.Int1
 

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -826,3 +826,4 @@ public func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject {
 
 #endif // !_runtime(_ObjC)
 
+extension AutoreleasingUnsafeMutablePointer: ConcurrentValue { }

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -589,6 +589,8 @@ extension UnsafeRawPointer {
   }
 }
 
+extension AutoreleasingUnsafeMutablePointer: ConcurrentValue { }
+
 internal struct _CocoaFastEnumerationStackBuf {
   // Clang uses 16 pointers.  So do we.
   internal var _item0: UnsafeRawPointer?
@@ -825,5 +827,3 @@ public func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject {
 }
 
 #endif // !_runtime(_ObjC)
-
-extension AutoreleasingUnsafeMutablePointer: ConcurrentValue { }

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SWIFTLIB_ESSENTIAL
   CollectionAlgorithms.swift
   Comparable.swift
   CompilerProtocols.swift
+  ConcurrentValue.swift
   ContiguousArray.swift
   ContiguouslyStored.swift
   ClosedRange.swift

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -124,7 +124,7 @@ public typealias CBool = Bool
 /// Opaque pointers are used to represent C pointers to types that
 /// cannot be represented in Swift, such as incomplete struct types.
 @frozen
-public struct OpaquePointer {
+public struct OpaquePointer: ConcurrentValue {
   @usableFromInline
   internal var _rawValue: Builtin.RawPointer
 
@@ -235,7 +235,7 @@ extension UInt {
 /// A wrapper around a C `va_list` pointer.
 #if arch(arm64) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(Windows))
 @frozen
-public struct CVaListPointer {
+public struct CVaListPointer: ConcurrentValue {
   @usableFromInline // unsafe-performance
   internal var _value: (__stack: UnsafeMutablePointer<Int>?,
                         __gr_top: UnsafeMutablePointer<Int>?,

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -62,7 +62,7 @@
 /// [clusters]: http://www.unicode.org/glossary/#extended_grapheme_cluster
 /// [scalars]: http://www.unicode.org/glossary/#unicode_scalar_value
 @frozen
-public struct Character {
+public struct Character: ConcurrentValue {
   @usableFromInline
   internal var _str: String
 

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -497,3 +497,6 @@ extension ClosedRange: Encodable where Bound: Encodable {
     try container.encode(self.upperBound)
   }
 }
+
+extension ClosedRange: ConcurrentValue where Bound: ConcurrentValue { }
+extension ClosedRange.Index: ConcurrentValue where Bound: ConcurrentValue { }

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3133,7 +3133,7 @@ public protocol SingleValueDecodingContainer {
 //===----------------------------------------------------------------------===//
 
 /// A user-defined key for providing context during encoding and decoding.
-public struct CodingUserInfoKey: RawRepresentable, Equatable, Hashable {
+public struct CodingUserInfoKey: RawRepresentable, Equatable, Hashable, ConcurrentValue {
   public typealias RawValue = String
 
   /// The key's string value.
@@ -3367,7 +3367,7 @@ public enum DecodingError: Error {
 
 // The following extensions allow for easier error construction.
 
-internal struct _GenericIndexKey: CodingKey {
+internal struct _GenericIndexKey: CodingKey, ConcurrentValue {
     internal var stringValue: String
     internal var intValue: Int?
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -130,6 +130,9 @@ extension IndexingIterator: IteratorProtocol, Sequence {
   }
 }
 
+extension IndexingIterator: ConcurrentValue
+  where Elements: ConcurrentValue, Elements.Index: ConcurrentValue { }
+
 /// A sequence whose elements can be traversed multiple times,
 /// nondestructively, and accessed by an indexed subscript.
 ///

--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -419,3 +419,10 @@ extension CollectionDifference.Change: Codable where ChangeElement: Codable {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CollectionDifference: Codable where ChangeElement: Codable {}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension CollectionDifference: ConcurrentValue where ChangeElement: ConcurrentValue { }
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension CollectionDifference.Change: ConcurrentValue where ChangeElement: ConcurrentValue { }
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension CollectionDifference.Index: ConcurrentValue where ChangeElement: ConcurrentValue { }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -170,3 +170,6 @@ extension CollectionOfOne: CustomReflectable {
     return Mirror(self, children: ["element": _element])
   }
 }
+
+extension CollectionOfOne: ConcurrentValue where Element: ConcurrentValue { }
+extension CollectionOfOne.Iterator: ConcurrentValue where Element: ConcurrentValue { }

--- a/stdlib/public/core/ConcurrentValue.swift
+++ b/stdlib/public/core/ConcurrentValue.swift
@@ -14,7 +14,7 @@ import Swift
 
 /// The ConcurrentValue protocol indicates that value of the given type can
 /// be safely used in concurrent code.
-public protocol ConcurrentValue { }
+@_marker public protocol ConcurrentValue { }
 
 extension Array: ConcurrentValue where Element: ConcurrentValue { }
 extension ArraySlice: ConcurrentValue where Element: ConcurrentValue { }
@@ -115,39 +115,12 @@ extension Mirror: ConcurrentValue { }
 extension Mirror.AncestorRepresentation: ConcurrentValue { }
 extension Mirror.DisplayStyle: ConcurrentValue { }
 
-// FIXME: Float16 when available
-extension Float: ConcurrentValue { }
-extension Double: ConcurrentValue { }
-// FIXME: Float80 when available
-
-// FIXME: hacks to enumerate integer types, and ".Words", and "SIMDnStorage"
-extension UInt8: ConcurrentValue { }
-extension Int8: ConcurrentValue { }
-extension UInt16: ConcurrentValue { }
-extension Int16: ConcurrentValue { }
-extension UInt32: ConcurrentValue { }
-extension Int32: ConcurrentValue { }
-extension UInt64: ConcurrentValue { }
-extension Int64: ConcurrentValue { }
-extension UInt: ConcurrentValue { }
-extension Int: ConcurrentValue { }
-
 extension UnsafeMutableBufferPointer: ConcurrentValue { }
 extension UnsafeBufferPointer: ConcurrentValue { }
 extension UnsafeBufferPointer.Iterator: ConcurrentValue { }
 extension UnsafeMutableRawBufferPointer: ConcurrentValue { }
 extension UnsafeRawBufferPointer: ConcurrentValue { }
 extension UnsafeRawBufferPointer.Iterator: ConcurrentValue { }
-
-extension SIMDMask: ConcurrentValue where Storage: ConcurrentValue { }
-// FIXME: enumerate SIMD types
-extension SIMD2: ConcurrentValue where Scalar: ConcurrentValue { }
-extension SIMD3: ConcurrentValue where Scalar: ConcurrentValue { }
-extension SIMD4: ConcurrentValue where Scalar: ConcurrentValue { }
-extension SIMD8: ConcurrentValue where Scalar: ConcurrentValue { }
-extension SIMD16: ConcurrentValue where Scalar: ConcurrentValue { }
-extension SIMD32: ConcurrentValue where Scalar: ConcurrentValue { }
-extension SIMD64: ConcurrentValue where Scalar: ConcurrentValue { }
 
 extension PartialKeyPath: ConcurrentValue where Root: ConcurrentValue { }
 
@@ -158,4 +131,3 @@ extension FloatingPointRoundingRule: ConcurrentValue { }
 extension Optional: ConcurrentValue where Wrapped: ConcurrentValue { }
 extension Never: ConcurrentValue { }
 extension Result: ConcurrentValue where Success: ConcurrentValue, Failure: ConcurrentValue { }
-

--- a/stdlib/public/core/ConcurrentValue.swift
+++ b/stdlib/public/core/ConcurrentValue.swift
@@ -2,7 +2,7 @@
 ////
 //// This source file is part of the Swift.org open source project
 ////
-//// Copyright (c) 2020 Apple Inc. and the Swift project authors
+//// Copyright (c) 2021 Apple Inc. and the Swift project authors
 //// Licensed under Apache License v2.0 with Runtime Library Exception
 ////
 //// See https://swift.org/LICENSE.txt for license information
@@ -14,118 +14,7 @@
 /// be safely used in concurrent code.
 @_marker public protocol ConcurrentValue { }
 
-extension Array: ConcurrentValue where Element: ConcurrentValue { }
-extension ArraySlice: ConcurrentValue where Element: ConcurrentValue { }
-extension Bool: ConcurrentValue { }
-extension AutoreleasingUnsafeMutablePointer: ConcurrentValue { }
-extension Character: ConcurrentValue { }
-extension KeyedEncodingContainer: ConcurrentValue { }
-extension KeyedDecodingContainer: ConcurrentValue { }
-extension CodingUserInfoKey: ConcurrentValue { }
-extension EncodingError: ConcurrentValue { }
-extension DecodingError: ConcurrentValue { }
-extension IndexingIterator: ConcurrentValue { }
-extension ContiguousArray: ConcurrentValue { }
-extension ClosedRange: ConcurrentValue where Bound: ConcurrentValue { }
-extension ClosedRange.Index: ConcurrentValue where Bound: ConcurrentValue { }
-extension OpaquePointer: ConcurrentValue { }
-extension CVaListPointer: ConcurrentValue { }
-extension Dictionary: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension Dictionary.Keys: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension Dictionary.Values: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension Dictionary.Keys.Iterator: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension Dictionary.Values.Iterator: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension Dictionary.Index: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension Dictionary.Iterator: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension EmptyCollection: ConcurrentValue { }
-extension EmptyCollection.Iterator: ConcurrentValue { }
-extension Hasher: ConcurrentValue { }
-extension DefaultIndices: ConcurrentValue where Elements: ConcurrentValue { }
-extension KeyValuePairs: ConcurrentValue where Key: ConcurrentValue, Value: ConcurrentValue { }
-extension ManagedBufferPointer: ConcurrentValue where Header: ConcurrentValue, Element: ConcurrentValue { }
-extension Unicode.Scalar: ConcurrentValue { }
-extension Unicode.Scalar.UTF16View: ConcurrentValue { }
-
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension Unicode.Scalar.UTF8View: ConcurrentValue { }
-
-extension ObjectIdentifier: ConcurrentValue { }
-extension SystemRandomNumberGenerator: ConcurrentValue { }
-extension Range: ConcurrentValue where Bound: ConcurrentValue { }
-extension PartialRangeUpTo: ConcurrentValue where Bound: ConcurrentValue { }
-extension PartialRangeThrough: ConcurrentValue where Bound: ConcurrentValue { }
-extension PartialRangeFrom: ConcurrentValue where Bound: ConcurrentValue { }
-extension PartialRangeFrom.Iterator: ConcurrentValue where Bound: ConcurrentValue { }
-extension Repeated: ConcurrentValue where Element: ConcurrentValue { }
-extension IteratorSequence: ConcurrentValue where Base: ConcurrentValue { }
-extension Set: ConcurrentValue where Element: ConcurrentValue { }
-extension Set.Index: ConcurrentValue where Element: ConcurrentValue { }
-extension Set.Iterator: ConcurrentValue where Element: ConcurrentValue { }
-extension Slice: ConcurrentValue where Base: ConcurrentValue { }
-extension StaticString: ConcurrentValue { }
-extension StrideToIterator: ConcurrentValue where Element: ConcurrentValue { }
-extension StrideTo: ConcurrentValue where Element: ConcurrentValue { }
-extension StrideThroughIterator: ConcurrentValue where Element: ConcurrentValue { }
-extension StrideThrough: ConcurrentValue where Element: Strideable { }
-extension String: ConcurrentValue { }
-extension String.Iterator: ConcurrentValue { }
-extension String.Index: ConcurrentValue { }
-extension DefaultStringInterpolation: ConcurrentValue { }
-extension String.UnicodeScalarView: ConcurrentValue { }
-extension String.UnicodeScalarView.Iterator: ConcurrentValue { }
-extension String.UTF16View: ConcurrentValue { }
-extension String.UTF16View.Iterator: ConcurrentValue { }
-extension String.UTF8View: ConcurrentValue { }
-extension Substring: ConcurrentValue { }
-extension Substring.UnicodeScalarView: ConcurrentValue { }
-extension Substring.UTF16View: ConcurrentValue { }
-extension Substring.UTF8View: ConcurrentValue { }
-extension Unicode.Scalar.Properties: ConcurrentValue { }
-extension Unicode.CanonicalCombiningClass: ConcurrentValue { }
-extension Unmanaged: ConcurrentValue { }
-extension UnsafePointer: ConcurrentValue { }
-extension UnsafeMutablePointer: ConcurrentValue { }
-extension UnsafeRawPointer: ConcurrentValue { }
-extension UnsafeMutableRawPointer: ConcurrentValue { }
-extension Unicode.UTF8.ForwardParser: ConcurrentValue { }
-extension Unicode.UTF8.ReverseParser: ConcurrentValue { }
-extension Unicode.UTF16.ForwardParser: ConcurrentValue { }
-extension Unicode.UTF16.ReverseParser: ConcurrentValue { }
-extension Unicode.UTF32.Parser: ConcurrentValue { }
-extension Unicode.ParseResult: ConcurrentValue where T: ConcurrentValue { }
-extension Unicode.GeneralCategory: ConcurrentValue { }
-extension Unicode.NumericType: ConcurrentValue { }
-extension Unicode.UTF8: ConcurrentValue { }
-extension Unicode.UTF16: ConcurrentValue { }
-extension Unicode.UTF32: ConcurrentValue { }
-extension UnicodeDecodingResult: ConcurrentValue { }
-
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension CollectionDifference: ConcurrentValue where ChangeElement: ConcurrentValue { }
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension CollectionDifference.Change: ConcurrentValue where ChangeElement: ConcurrentValue { }
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension CollectionDifference.Index: ConcurrentValue where ChangeElement: ConcurrentValue { }
-
-extension CollectionOfOne: ConcurrentValue where Element: ConcurrentValue { }
-extension CollectionOfOne.Iterator: ConcurrentValue where Element: ConcurrentValue { }
-extension Mirror: ConcurrentValue { }
-extension Mirror.AncestorRepresentation: ConcurrentValue { }
-extension Mirror.DisplayStyle: ConcurrentValue { }
-
-extension UnsafeMutableBufferPointer: ConcurrentValue { }
-extension UnsafeBufferPointer: ConcurrentValue { }
-extension UnsafeBufferPointer.Iterator: ConcurrentValue { }
-extension UnsafeMutableRawBufferPointer: ConcurrentValue { }
-extension UnsafeRawBufferPointer: ConcurrentValue { }
-extension UnsafeRawBufferPointer.Iterator: ConcurrentValue { }
-
-extension PartialKeyPath: ConcurrentValue where Root: ConcurrentValue { }
-
-extension FloatingPointSign: ConcurrentValue { }
-extension FloatingPointClassification: ConcurrentValue { }
-extension FloatingPointRoundingRule: ConcurrentValue { }
-
-extension Optional: ConcurrentValue where Wrapped: ConcurrentValue { }
-extension Never: ConcurrentValue { }
-extension Result: ConcurrentValue where Success: ConcurrentValue, Failure: ConcurrentValue { }
+/// The UnsafeConcurrentValue protocol indicates that value of the given type
+/// can be safely used in concurrent code, but disables some safety checking
+/// at the conformance site.
+@_marker public protocol UnsafeConcurrentValue: ConcurrentValue { }

--- a/stdlib/public/core/ConcurrentValue.swift
+++ b/stdlib/public/core/ConcurrentValue.swift
@@ -10,8 +10,6 @@
 ////
 ////===----------------------------------------------------------------------===//
 
-import Swift
-
 /// The ConcurrentValue protocol indicates that value of the given type can
 /// be safely used in concurrent code.
 @_marker public protocol ConcurrentValue { }

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1436,3 +1436,6 @@ extension ContiguousArray {
     }
   }
 }
+
+extension ContiguousArray: ConcurrentValue, UnsafeConcurrentValue
+  where Element: ConcurrentValue { }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2099,3 +2099,18 @@ public typealias DictionaryIndex<Key: Hashable, Value> =
   Dictionary<Key, Value>.Index
 public typealias DictionaryIterator<Key: Hashable, Value> =
   Dictionary<Key, Value>.Iterator
+
+extension Dictionary: ConcurrentValue, UnsafeConcurrentValue
+  where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Keys: ConcurrentValue, UnsafeConcurrentValue
+  where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Values: ConcurrentValue, UnsafeConcurrentValue
+  where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Keys.Iterator: ConcurrentValue, UnsafeConcurrentValue
+  where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Values.Iterator: ConcurrentValue, UnsafeConcurrentValue
+  where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Index: ConcurrentValue, UnsafeConcurrentValue
+  where Key: ConcurrentValue, Value: ConcurrentValue { }
+extension Dictionary.Iterator: ConcurrentValue, UnsafeConcurrentValue
+  where Key: ConcurrentValue, Value: ConcurrentValue { }

--- a/stdlib/public/core/EitherSequence.swift
+++ b/stdlib/public/core/EitherSequence.swift
@@ -43,6 +43,9 @@ extension _Either: Comparable where Left: Comparable, Right: Comparable {
   }
 }
 
+extension _Either: ConcurrentValue
+  where Left: ConcurrentValue, Right: ConcurrentValue { }
+
 /// A sequence that type erases two sequences. A lighter-weight alternative to
 /// AnySequence when more can be statically known, and which is more easily
 /// specialized.

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -172,3 +172,6 @@ extension EmptyCollection: Equatable {
     return true
   }
 }
+
+extension EmptyCollection: ConcurrentValue { }
+extension EmptyCollection.Iterator: ConcurrentValue { }

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1229,7 +1229,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable
 
 /// The sign of a floating-point value.
 @frozen
-public enum FloatingPointSign: Int {
+public enum FloatingPointSign: Int, ConcurrentValue {
   /// The sign for a positive value.
   case plus
 
@@ -1278,7 +1278,7 @@ public enum FloatingPointSign: Int {
 
 /// The IEEE 754 floating-point classes.
 @frozen
-public enum FloatingPointClassification {
+public enum FloatingPointClassification: ConcurrentValue {
   /// A signaling NaN ("not a number").
   ///
   /// A signaling NaN sets the floating-point exception status when used in
@@ -1316,7 +1316,7 @@ public enum FloatingPointClassification {
 }
 
 /// A rule for rounding a floating-point number.
-public enum FloatingPointRoundingRule {
+public enum FloatingPointRoundingRule: ConcurrentValue {
   /// Round to the closest allowed value; if two values are equally close, the
   /// one with greater magnitude is chosen.
   ///

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1343,6 +1343,9 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
 }
 % end
 
+${Availability(bits)}
+extension ${Self} : ConcurrentValue { }
+
 //===----------------------------------------------------------------------===//
 // Deprecated operators
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -199,6 +199,7 @@
   ],
   "Misc": [
     "AtomicInt.swift",
+    "ConcurrentValue.swift",
     "ErrorType.swift",
     "Identifiable.swift",
     "InputStream.swift",

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -144,3 +144,6 @@ extension Collection where Indices == DefaultIndices<Self> {
       endIndex: self.endIndex)
   }
 }
+
+extension DefaultIndices: ConcurrentValue
+  where Elements: ConcurrentValue, Elements.Index: ConcurrentValue { }

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1399,7 +1399,7 @@ ${assignmentOperatorComment(x.operator, True)}
 
   /// A type that represents the words of this integer.
   @frozen
-  public struct Words: RandomAccessCollection {
+  public struct Words: RandomAccessCollection, ConcurrentValue {
     public typealias Indices = Range<Int>
     public typealias SubSequence = Slice<${Self}.Words>
 
@@ -1708,6 +1708,8 @@ ${operatorComment(x.operator, True)}
   }
 }
 
+
+extension ${Self}: ConcurrentValue { }
 
 % if signed:
 // TODO: Consider removing the underscore.

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3677,3 +3677,4 @@ internal func _instantiateKeyPathBuffer(
       as: RawKeyPathComponent.Header.self)
   }
 }
+

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -139,3 +139,7 @@ extension KeyValuePairs: CustomDebugStringConvertible {
     return _makeKeyValuePairDescription()
   }
 }
+
+// TODO: Remove UnsafeConcurrentValue when we have tuples conforming
+extension KeyValuePairs: ConcurrentValue, UnsafeConcurrentValue
+    where Key: ConcurrentValue, Value: ConcurrentValue { }

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -155,7 +155,7 @@ public struct Mirror {
   /// Playgrounds and the debugger will show a representation similar
   /// to the one used for instances of the kind indicated by the
   /// `DisplayStyle` case name when the mirror is used for display.
-  public enum DisplayStyle {
+  public enum DisplayStyle: ConcurrentValue {
     case `struct`, `class`, `enum`, tuple, optional, collection
     case dictionary, `set`
   }

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -18,7 +18,7 @@
 /// In Swift, only class instances and metatypes have unique identities. There
 /// is no notion of identity for structs, enums, functions, or tuples.
 @frozen // trivial-implementation
-public struct ObjectIdentifier {
+public struct ObjectIdentifier: ConcurrentValue {
   @usableFromInline // trivial-implementation
   internal let _value: Builtin.RawPointer
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -748,3 +748,5 @@ extension Optional: _ObjectiveCBridgeable {
   }
 }
 #endif
+
+extension Optional: ConcurrentValue where Wrapped: ConcurrentValue { }

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -28,6 +28,8 @@
 @frozen
 public enum Never {}
 
+extension Never: ConcurrentValue { }
+
 extension Never: Error {}
 
 extension Never: Equatable, Comparable, Hashable {}

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -146,7 +146,7 @@ extension RandomNumberGenerator {
 ///   from `/dev/urandom`.
 /// - Windows uses `BCryptGenRandom`.
 @frozen
-public struct SystemRandomNumberGenerator: RandomNumberGenerator {
+public struct SystemRandomNumberGenerator: RandomNumberGenerator, ConcurrentValue {
   /// Creates a new instance of the system's default random number generator.
   @inlinable
   public init() { }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -1017,3 +1017,9 @@ public typealias CountableRange<Bound: Strideable> = Range<Bound>
 // shorthand. TODO: Add documentation
 public typealias CountablePartialRangeFrom<Bound: Strideable> = PartialRangeFrom<Bound>
   where Bound.Stride: SignedInteger
+
+extension Range: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeUpTo: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeThrough: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeFrom: ConcurrentValue where Bound: ConcurrentValue { }
+extension PartialRangeFrom.Iterator: ConcurrentValue where Bound: ConcurrentValue { }

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -107,3 +107,5 @@ extension Repeated: RandomAccessCollection {
 public func repeatElement<T>(_ element: T, count n: Int) -> Repeated<T> {
   return Repeated(_repeating: element, count: n)
 }
+
+extension Repeated: ConcurrentValue where Element: ConcurrentValue { }

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -190,3 +190,5 @@ extension Result where Failure == Swift.Error {
 extension Result: Equatable where Success: Equatable, Failure: Equatable { }
 
 extension Result: Hashable where Success: Hashable, Failure: Hashable { }
+
+extension Result: ConcurrentValue where Success: ConcurrentValue, Failure: ConcurrentValue { }

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -186,6 +186,8 @@ extension SIMD${n} where Scalar: BinaryFloatingPoint {
   }
 }
 
+extension SIMD${n}: ConcurrentValue where Scalar: ConcurrentValue { }
+
 %end
 
 extension SIMD3 {
@@ -217,7 +219,7 @@ extension ${Self}: SIMDScalar {
   /// Storage for a vector of ${spelledNumbers[n]} integers.
   @frozen
   @_alignment(${bytes if bytes <= 16 else 16})
-  public struct SIMD${n}Storage: SIMDStorage {
+  public struct SIMD${n}Storage: SIMDStorage, ConcurrentValue {
 
     public var _value: Builtin.Vec${n}x${BuiltinName}
 
@@ -266,7 +268,7 @@ extension ${Self} : SIMDScalar {
   /// Storage for a vector of ${spelledNumbers[n]} floating-point values.
   @frozen
   @_alignment(${bytes if bytes <= 16 else 16})
-  public struct SIMD${n}Storage: SIMDStorage {
+  public struct SIMD${n}Storage: SIMDStorage, ConcurrentValue {
 
     public var _value: Builtin.Vec${n}xFPIEEE${bits}
 

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -186,7 +186,9 @@ extension SIMD${n} where Scalar: BinaryFloatingPoint {
   }
 }
 
-extension SIMD${n}: ConcurrentValue where Scalar: ConcurrentValue { }
+extension SIMD${n}: ConcurrentValue
+  where Scalar: ConcurrentValue,
+        Scalar.SIMD${storageN}Storage: ConcurrentValue { }
 
 %end
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1159,6 +1159,8 @@ extension IteratorSequence: IteratorProtocol, Sequence {
   }
 }
 
+extension IteratorSequence: ConcurrentValue where Base: ConcurrentValue { }
+
 /* FIXME: ideally for compatibility we would declare
 extension Sequence {
   @available(swift, deprecated: 5, message: "")

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1629,3 +1629,10 @@ extension Set {
 
 public typealias SetIndex<Element: Hashable> = Set<Element>.Index
 public typealias SetIterator<Element: Hashable> = Set<Element>.Iterator
+
+extension Set: ConcurrentValue, UnsafeConcurrentValue
+  where Element: ConcurrentValue { }
+extension Set.Index: ConcurrentValue, UnsafeConcurrentValue
+  where Element: ConcurrentValue { }
+extension Set.Iterator: ConcurrentValue, UnsafeConcurrentValue
+  where Element: ConcurrentValue { }

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -507,3 +507,6 @@ extension Slice
     }
   }
 }
+
+extension Slice: ConcurrentValue
+where Base: ConcurrentValue, Base.Index: ConcurrentValue { }

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -69,7 +69,7 @@
 ///         utf8[4]     //-> Fatal error!
 ///     }
 @frozen
-public struct StaticString {
+public struct StaticString: ConcurrentValue {
 
   /// Either a pointer to the start of UTF-8 data, represented as an integer,
   /// or an integer representation of a single Unicode scalar.

--- a/stdlib/public/core/Stride.swift
+++ b/stdlib/public/core/Stride.swift
@@ -640,3 +640,12 @@ public func stride<T>(
 ) -> StrideThrough<T> {
   return StrideThrough(_start: start, end: end, stride: stride)
 }
+
+extension StrideToIterator: ConcurrentValue
+  where Element: ConcurrentValue, Element.Stride: ConcurrentValue { }
+extension StrideTo: ConcurrentValue
+  where Element: ConcurrentValue, Element.Stride: ConcurrentValue { }
+extension StrideThroughIterator: ConcurrentValue
+  where Element: ConcurrentValue, Element.Stride: ConcurrentValue { }
+extension StrideThrough: ConcurrentValue
+  where Element: ConcurrentValue, Element.Stride: ConcurrentValue { }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -349,7 +349,7 @@ internal func unimplemented_utf8_32bit(
 /// [scalars]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [equivalence]: http://www.unicode.org/glossary/#canonical_equivalent
 @frozen
-public struct String {
+public struct String: ConcurrentValue {
   public // @SPI(Foundation)
   var _guts: _StringGuts
 

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -349,7 +349,7 @@ internal func unimplemented_utf8_32bit(
 /// [scalars]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [equivalence]: http://www.unicode.org/glossary/#canonical_equivalent
 @frozen
-public struct String: ConcurrentValue {
+public struct String {
   public // @SPI(Foundation)
   var _guts: _StringGuts
 
@@ -382,6 +382,8 @@ public struct String: ConcurrentValue {
   @_semantics("string.init_empty")
   public init() { self.init(_StringGuts()) }
 }
+
+extension String: ConcurrentValue { }
 
 extension String {
   #if !INTERNAL_CHECKS_ENABLED

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -223,7 +223,7 @@ extension String: BidirectionalCollection {
 
 extension String {
   @frozen
-  public struct Iterator: IteratorProtocol {
+  public struct Iterator: IteratorProtocol, ConcurrentValue {
     @usableFromInline
     internal var _guts: _StringGuts
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -18,7 +18,7 @@ import SwiftShims
 //
 @frozen
 public // SPI(corelibs-foundation)
-struct _StringGuts {
+struct _StringGuts: UnsafeConcurrentValue {
   @usableFromInline
   internal var _object: _StringObject
 

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -51,7 +51,7 @@ boundary.
 extension String {
   /// A position of a character or code unit in a string.
   @frozen
-  public struct Index {
+  public struct Index: ConcurrentValue {
     @usableFromInline
     internal var _rawBits: UInt64
 

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -60,7 +60,7 @@
 /// `DefaultStringInterpolation` extensions should add only `mutating` members
 /// and should not copy `self` or capture it in an escaping closure.
 @frozen
-public struct DefaultStringInterpolation: StringInterpolationProtocol {
+public struct DefaultStringInterpolation: StringInterpolationProtocol, ConcurrentValue {
   /// The string contents accumulated by this instance.
   @usableFromInline
   internal var _storage: String

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -99,7 +99,7 @@ extension String {
   ///     }
   ///     // Prints "Let it snow!"
   @frozen
-  public struct UTF16View {
+  public struct UTF16View: ConcurrentValue {
     @usableFromInline
     internal var _guts: _StringGuts
 
@@ -259,7 +259,7 @@ extension String.UTF16View: BidirectionalCollection {
 
 extension String.UTF16View {
   @frozen
-  public struct Iterator: IteratorProtocol {
+  public struct Iterator: IteratorProtocol, ConcurrentValue {
     @usableFromInline
     internal var _guts: _StringGuts
 

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -89,7 +89,7 @@ extension String {
   ///     print(String(s1.utf8.prefix(15))!)
   ///     // Prints "They call me 'B"
   @frozen
-  public struct UTF8View {
+  public struct UTF8View: ConcurrentValue {
     @usableFromInline
     internal var _guts: _StringGuts
 

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -61,7 +61,7 @@ extension String {
   ///     }
   ///     // Prints "My favorite emoji is "
   @frozen
-  public struct UnicodeScalarView {
+  public struct UnicodeScalarView: ConcurrentValue {
     @usableFromInline
     internal var _guts: _StringGuts
 
@@ -169,7 +169,7 @@ extension String.UnicodeScalarView: BidirectionalCollection {
 
 extension String.UnicodeScalarView {
   @frozen
-  public struct Iterator: IteratorProtocol {
+  public struct Iterator: IteratorProtocol, ConcurrentValue {
     @usableFromInline
     internal var _guts: _StringGuts
 

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -93,7 +93,7 @@ extension String {
 ///   substrings may, therefore, prolong the lifetime of string data that is
 ///   no longer otherwise accessible, which can appear to be memory leakage.
 @frozen
-public struct Substring {
+public struct Substring: ConcurrentValue {
   @usableFromInline
   internal var _slice: Slice<String>
 
@@ -329,7 +329,7 @@ extension Substring: LosslessStringConvertible {
 
 extension Substring {
   @frozen
-  public struct UTF8View {
+  public struct UTF8View: ConcurrentValue {
     @usableFromInline
     internal var _slice: Slice<String.UTF8View>
   }
@@ -466,7 +466,7 @@ extension String {
 }
 extension Substring {
   @frozen
-  public struct UTF16View {
+  public struct UTF16View: ConcurrentValue {
     @usableFromInline
     internal var _slice: Slice<String.UTF16View>
   }
@@ -592,7 +592,7 @@ extension String {
 }
 extension Substring {
   @frozen
-  public struct UnicodeScalarView {
+  public struct UnicodeScalarView: ConcurrentValue {
     @usableFromInline
     internal var _slice: Slice<String.UnicodeScalarView>
   }

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -230,3 +230,5 @@ extension _UIntBuffer: RangeReplaceableCollection {
       truncatingIfNeeded: Int(_bitCount) &+ growth &* w)
   }
 }
+
+extension _UIntBuffer: ConcurrentValue where Element: ConcurrentValue { }

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 extension Unicode {
   @frozen
-  public enum UTF16 {
+  public enum UTF16: ConcurrentValue {
   case _swift3Buffer(Unicode.UTF16.ForwardParser)
   }
 }
@@ -370,7 +370,7 @@ extension Unicode.UTF16: Unicode.Encoding {
   }
   
   @frozen
-  public struct ForwardParser {
+  public struct ForwardParser: ConcurrentValue {
     public typealias _Buffer = _UIntBuffer<UInt16>
     @inlinable
     public init() { _buffer = _Buffer() }
@@ -378,7 +378,7 @@ extension Unicode.UTF16: Unicode.Encoding {
   }
   
   @frozen
-  public struct ReverseParser {
+  public struct ReverseParser: ConcurrentValue {
     public typealias _Buffer = _UIntBuffer<UInt16>
     @inlinable
     public init() { _buffer = _Buffer() }

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 extension Unicode {
   @frozen
-  public enum UTF32 {
+  public enum UTF32: ConcurrentValue {
   case _swift3Codec
   }
 }
@@ -57,7 +57,7 @@ extension Unicode.UTF32: Unicode.Encoding {
   }
   
   @frozen
-  public struct Parser {
+  public struct Parser: ConcurrentValue {
     @inlinable
     public init() { }
   }

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 extension Unicode {
   @frozen
-  public enum UTF8 {
+  public enum UTF8: ConcurrentValue {
   case _swift3Buffer(Unicode.UTF8.ForwardParser)
   }
 }
@@ -162,7 +162,7 @@ extension Unicode.UTF8: _UnicodeEncoding {
   }
 
   @frozen
-  public struct ForwardParser {
+  public struct ForwardParser: ConcurrentValue {
     public typealias _Buffer = _UIntBuffer<UInt8>
     @inline(__always)
     @inlinable
@@ -171,7 +171,7 @@ extension Unicode.UTF8: _UnicodeEncoding {
   }
 
   @frozen
-  public struct ReverseParser {
+  public struct ReverseParser: ConcurrentValue {
     public typealias _Buffer = _UIntBuffer<UInt8>
     @inline(__always)
     @inlinable

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -21,7 +21,7 @@ import SwiftShims
 /// an indication that no more Unicode scalars are available, or an indication
 /// of a decoding error.
 @frozen
-public enum UnicodeDecodingResult: Equatable {
+public enum UnicodeDecodingResult: Equatable, ConcurrentValue {
   /// A decoded Unicode scalar value.
   case scalarValue(Unicode.Scalar)
   

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -59,3 +59,5 @@ public protocol _UnicodeParser {
 extension Unicode {
   public typealias Parser = _UnicodeParser
 }
+
+extension Unicode.ParseResult: ConcurrentValue where T: ConcurrentValue { }

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -33,7 +33,7 @@ extension Unicode {
   ///     print(airplane)
   ///     // Prints "✈︎"
   @frozen
-  public struct Scalar {
+  public struct Scalar: ConcurrentValue {
     @inlinable
     internal init(_value: UInt32) {
       self._value = _value
@@ -387,7 +387,7 @@ extension Unicode.Scalar: Comparable {
 
 extension Unicode.Scalar {
   @frozen
-  public struct UTF16View {
+  public struct UTF16View: ConcurrentValue {
     @inlinable
     internal init(value: Unicode.Scalar) {
       self.value = value
@@ -437,7 +437,7 @@ extension Unicode.Scalar.UTF16View: RandomAccessCollection {
 extension Unicode.Scalar {
   @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
   @frozen
-  public struct UTF8View {
+  public struct UTF8View: ConcurrentValue {
     @inlinable
     internal init(value: Unicode.Scalar) {
       self.value = value

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -19,7 +19,7 @@ extension Unicode.Scalar {
 
   /// A value that provides access to properties of a Unicode scalar that are
   /// defined by the Unicode standard.
-  public struct Properties {
+  public struct Properties: ConcurrentValue {
     @usableFromInline
     internal var _scalar: Unicode.Scalar
 
@@ -821,7 +821,7 @@ extension Unicode {
   /// The general category of a scalar is its "first-order, most usual
   /// categorization". It does not attempt to cover multiple uses of some
   /// scalars, such as the use of letters to represent Roman numerals.
-  public enum GeneralCategory {
+  public enum GeneralCategory: ConcurrentValue {
 
     /// An uppercase letter.
     ///
@@ -1208,7 +1208,7 @@ extension Unicode {
   ///     let overlayClassIsOverlay = overlayClass == .overlay
   ///     // overlayClassIsOverlay == true
   public struct CanonicalCombiningClass:
-    Comparable, Hashable, RawRepresentable
+    Comparable, Hashable, RawRepresentable, ConcurrentValue
   {
     /// Base glyphs that occupy their own space and do not combine with others.
     public static let notReordered = CanonicalCombiningClass(rawValue: 0)
@@ -1332,7 +1332,7 @@ extension Unicode {
   /// Some letterlike scalars used in numeric systems, such as Greek or Latin
   /// letters, do not have a non-nil numeric type, in order to prevent programs
   /// from incorrectly interpreting them as numbers in non-numeric contexts.
-  public enum NumericType {
+  public enum NumericType: ConcurrentValue {
 
     /// A digit that is commonly understood to form base-10 numbers.
     ///

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -240,3 +240,6 @@ public struct Unmanaged<Instance: AnyObject> {
   }
 #endif
 }
+
+extension Unmanaged: ConcurrentValue where Instance: ConcurrentValue { }
+

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -764,6 +764,10 @@ extension UnsafeMutableBufferPointer {
   }
 }
 
+extension UnsafeBufferPointer: ConcurrentValue { }
+extension UnsafeBufferPointer.Iterator: ConcurrentValue { }
+extension UnsafeMutableBufferPointer: ConcurrentValue { }
+
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -205,7 +205,7 @@
 ///       let numberPointer = UnsafePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
-public struct UnsafePointer<Pointee>: _Pointer {
+public struct UnsafePointer<Pointee>: _Pointer, ConcurrentValue {
 
   /// A type that represents the distance between two pointers.
   public typealias Distance = Int
@@ -511,7 +511,7 @@ public struct UnsafePointer<Pointee>: _Pointer {
 ///       let numberPointer = UnsafeMutablePointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen // unsafe-performance
-public struct UnsafeMutablePointer<Pointee>: _Pointer {
+public struct UnsafeMutablePointer<Pointee>: _Pointer, ConcurrentValue {
 
   /// A type that represents the distance between two pointers.
   public typealias Distance = Int

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -820,6 +820,11 @@ public func withUnsafeBytes<T, Result>(
   return try body(buffer)
 }
 
+extension UnsafeRawBufferPointer: ConcurrentValue { }
+extension UnsafeRawBufferPointer.Iterator: ConcurrentValue { }
+extension UnsafeMutableRawBufferPointer: ConcurrentValue { }
+
+
 // ${'Local Variables'}:
 // eval: (read-only-mode 1)
 // End:

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -169,7 +169,7 @@
 ///       let numberPointer = UnsafeRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen
-public struct UnsafeRawPointer: _Pointer {
+public struct UnsafeRawPointer: _Pointer, ConcurrentValue {
   
   public typealias Pointee = UInt8
   
@@ -521,7 +521,7 @@ extension UnsafeRawPointer: Strideable {
 ///       let numberPointer = UnsafeMutableRawPointer(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
 @frozen
-public struct UnsafeMutableRawPointer: _Pointer {
+public struct UnsafeMutableRawPointer: _Pointer, ConcurrentValue {
   
   public typealias Pointee = UInt8
   

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -145,3 +145,74 @@ func concurrentClosures<T>(_: T) {
     x
   }
 }
+
+// ----------------------------------------------------------------------
+// ConcurrentValue checking
+// ----------------------------------------------------------------------
+struct S1: ConcurrentValue {
+  var nc: NotConcurrent // expected-error{{stored property 'nc' of 'ConcurrentValue'-conforming struct 'S1' has non-concurrent-value type 'NotConcurrent'}}
+}
+
+struct S2<T>: ConcurrentValue {
+  var nc: T // expected-error{{stored property 'nc' of 'ConcurrentValue'-conforming generic struct 'S2' has non-concurrent-value type 'T'}}
+}
+
+struct S3<T> {
+  var c: T
+  var array: [T]
+}
+
+extension S3: ConcurrentValue where T: ConcurrentValue { }
+
+enum E1: ConcurrentValue {
+  case payload(NotConcurrent) // expected-error{{associated value 'payload' of 'ConcurrentValue'-conforming enum 'E1' has non-concurrent-value type 'NotConcurrent'}}
+}
+
+enum E2<T> {
+  case payload(T)
+}
+
+extension E2: ConcurrentValue where T: ConcurrentValue { }
+
+class C1: ConcurrentValue {
+  let nc: NotConcurrent? = nil // expected-error{{stored property 'nc' of 'ConcurrentValue'-conforming class 'C1' has non-concurrent-value type 'NotConcurrent?'}}
+  var x: Int = 0 // expected-error{{stored property 'x' of 'ConcurrentValue'-conforming class 'C1' is mutable}}
+  let i: Int = 0
+}
+
+class C2: ConcurrentValue {
+  let x: Int = 0
+}
+
+class C3: C2 {
+  var y: Int = 0 // expected-error{{stored property 'y' of 'ConcurrentValue'-conforming class 'C3' is mutable}}
+}
+
+class C4: C2, UnsafeConcurrentValue {
+  var y: Int = 0 // okay
+}
+
+class C5: UnsafeConcurrentValue {
+  var x: Int = 0 // okay
+}
+
+class C6: C5 {
+  var y: Int = 0 // still okay
+}
+
+
+// ----------------------------------------------------------------------
+// UnsafeConcurrentValue disabling checking
+// ----------------------------------------------------------------------
+struct S11: UnsafeConcurrentValue {
+  var nc: NotConcurrent // okay
+}
+
+struct S12<T>: UnsafeConcurrentValue {
+  var nc: T // okay
+}
+
+enum E11<T>: UnsafeConcurrentValue {
+  case payload(NotConcurrent) // okay
+  case other(T) // okay
+}

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,0 +1,120 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -enable-experimental-concurrent-value-checking
+// REQUIRES: concurrency
+
+class NotConcurrent { }
+
+// ----------------------------------------------------------------------
+// ConcurrentValue restriction on actor operations
+// ----------------------------------------------------------------------
+
+actor class A1 {
+  let localLet: NotConcurrent = NotConcurrent()
+  func synchronous() -> NotConcurrent? { nil }
+  func asynchronous(_: NotConcurrent?) async { }
+}
+
+extension A1 {
+  func testIsolation(other: A1) async {
+    // All within the same actor domain, so the ConcurrentValue restriction
+    // does not apply.
+    _ = localLet
+    _ = synchronous()
+    _ = await asynchronous(nil)
+    _ = self.localLet
+    _ = self.synchronous()
+    _ = await self.asynchronous(nil)
+
+    // Across to a different actor, so ConcurrentValue restriction is enforced.
+    _ = other.localLet // expected-warning{{cannot use property 'localLet' with a non-concurrent-value type 'NotConcurrent' across actors}}
+    _ = await other.synchronous() // expected-warning{{cannot call function returning non-concurrent-value type 'NotConcurrent?' across actors}}
+    _ = await other.asynchronous(nil) // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent?' across actors}}
+  }
+}
+
+// ----------------------------------------------------------------------
+// ConcurrentValue restriction on global actor operations
+// ----------------------------------------------------------------------
+actor class TestActor {}
+
+@globalActor
+struct SomeGlobalActor {
+  static var shared: TestActor { TestActor() }
+}
+
+@SomeGlobalActor
+let globalValue: NotConcurrent? = nil
+
+@SomeGlobalActor
+func globalSync(_: NotConcurrent?) {
+}
+
+@SomeGlobalActor
+func globalAsync(_: NotConcurrent?) async {
+  await globalAsync(globalValue) // both okay because we're in the actor
+  globalSync(nil)
+}
+
+func globalTest() async {
+  let a = globalValue // expected-warning{{cannot use let 'globalValue' with a non-concurrent-value type 'NotConcurrent?' across actors}}
+  await globalAsync(a) // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent?' across actors}}
+  await globalSync(a)  // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent?' across actors}}
+}
+
+struct HasSubscript {
+  @SomeGlobalActor
+  subscript (i: Int) -> NotConcurrent? { nil }
+}
+
+@MainActor
+func globalTestMain() async {
+  let a = globalValue // expected-warning{{cannot use let 'globalValue' with a non-concurrent-value type 'NotConcurrent?' across actors}}
+  await globalAsync(a) // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent?' across actors}}
+  await globalSync(a)  // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent?' across actors}}
+}
+
+@SomeGlobalActor
+func someGlobalTest() {
+  let hs = HasSubscript()
+  let _ = hs[0] // okay
+}
+
+// ----------------------------------------------------------------------
+// ConcurrentValue restriction on captures.
+// ----------------------------------------------------------------------
+func acceptNonConcurrent(_: () -> Void) { }
+func acceptConcurrent(_: @concurrent () -> Void) { }
+
+func testConcurrency() {
+  let x = NotConcurrent()
+  var y = NotConcurrent()
+  y = NotConcurrent()
+  acceptNonConcurrent {
+    print(x) // okay
+    print(y) // okay
+  }
+  acceptConcurrent {
+    print(x) // expected-warning{{cannot use let 'x' with a non-concurrent-value type 'NotConcurrent' from concurrently-executed code}}
+    print(y) // expected-warning{{cannot use var 'y' with a non-concurrent-value type 'NotConcurrent' from concurrently-executed code}}
+  }
+}
+
+// ----------------------------------------------------------------------
+// ConcurrentValue restriction on conformances.
+// ----------------------------------------------------------------------
+protocol AsyncProto {
+  func asyncMethod(_: NotConcurrent) async
+}
+
+extension A1: AsyncProto {
+  // FIXME: Poor diagnostic.
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent' across actors}}
+}
+
+protocol MainActorProto {
+  func asyncMainMethod(_: NotConcurrent) async
+}
+
+class SomeClass: MainActorProto {
+  @SomeGlobalActor
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent' across actors}}
+}

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -118,3 +118,30 @@ class SomeClass: MainActorProto {
   @SomeGlobalActor
   func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{cannot pass argument of non-concurrent-value type 'NotConcurrent' across actors}}
 }
+
+// ----------------------------------------------------------------------
+// ConcurrentValue restriction on concurrent functions.
+// ----------------------------------------------------------------------
+
+// FIXME: poor diagnostic
+@concurrent func concurrentFunc() -> NotConcurrent? { nil } // expected-warning{{cannot call function returning non-concurrent-value type 'NotConcurrent?' across actors}}
+
+// ----------------------------------------------------------------------
+// ConcurrentValue restriction on @concurrent types.
+// ----------------------------------------------------------------------
+typealias CF = @concurrent () -> NotConcurrent? // expected-warning{{`@concurrent` function type has non-concurrent-value result type 'NotConcurrent?'}}
+typealias BadGenericCF<T> = @concurrent () -> T? // expected-warning{{`@concurrent` function type has non-concurrent-value result type 'T?'}}
+typealias GoodGenericCF<T: ConcurrentValue> = @concurrent () -> T? // okay
+
+var concurrentFuncVar: (@concurrent (NotConcurrent) -> Void)? = nil // expected-warning{{`@concurrent` function type has non-concurrent-value parameter type 'NotConcurrent'}}
+
+// ----------------------------------------------------------------------
+// ConcurrentValue restriction on @concurrent closures.
+// ----------------------------------------------------------------------
+func acceptConcurrentUnary<T>(_: @concurrent (T) -> T) { }
+
+func concurrentClosures<T>(_: T) {
+  acceptConcurrentUnary { (x: T) in // expected-warning{{`@concurrent` closure has non-concurrent-value parameter type 'T'}}
+    x
+  }
+}

--- a/test/Incremental/Verifier/single-file-private/AnyObject.swift
+++ b/test/Incremental/Verifier/single-file-private/AnyObject.swift
@@ -79,3 +79,4 @@ func lookupOnAnyObject(object: AnyObject) { // expected-provides {{lookupOnAnyOb
 // expected-member{{Swift.CustomDebugStringConvertible.someMember}}
 // expected-member{{Swift.CustomStringConvertible.someMember}}
 // expected-member{{Swift.Hashable.someMember}}
+// expected-member{{Swift.ConcurrentValue.callAsFunction}}

--- a/test/SourceKit/DocSupport/.#doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/.#doc_clang_module.swift
@@ -1,0 +1,1 @@
+dgregor@Trinsic.local.724

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -5591,6 +5591,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.ref.protocol,
         key.name: "_Pointer",
         key.usr: "s:s8_PointerP"
+      },
+      {
+        key.kind: source.lang.swift.ref.protocol,
+        key.name: "ConcurrentValue",
+        key.usr: "s:s15ConcurrentValueP"
       }
     ]
   },

--- a/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
+++ b/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
@@ -1214,14 +1214,7 @@ protocol Other1 {
         key.usr: "s:16UnderscoredProto1BC4Elema",
         key.offset: 548,
         key.length: 23,
-        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem</decl.name> = <ref.struct usr=\"s:SS\">String</ref.struct></decl.typealias>",
-        key.conforms: [
-          {
-            key.kind: source.lang.swift.ref.protocol,
-            key.name: "ConcurrentValue",
-            key.usr: "s:s15ConcurrentValueP"
-          }
-        ]
+        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem</decl.name> = <ref.struct usr=\"s:SS\">String</ref.struct></decl.typealias>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,

--- a/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
+++ b/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
@@ -1214,7 +1214,14 @@ protocol Other1 {
         key.usr: "s:16UnderscoredProto1BC4Elema",
         key.offset: 548,
         key.length: 23,
-        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem</decl.name> = <ref.struct usr=\"s:SS\">String</ref.struct></decl.typealias>"
+        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem</decl.name> = <ref.struct usr=\"s:SS\">String</ref.struct></decl.typealias>",
+        key.conforms: [
+          {
+            key.kind: source.lang.swift.ref.protocol,
+            key.name: "ConcurrentValue",
+            key.usr: "s:s15ConcurrentValueP"
+          }
+        ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1733,6 +1733,12 @@
         },
         {
           "kind": "Conformance",
+          "name": "ConcurrentValue",
+          "printedName": "ConcurrentValue",
+          "usr": "s:s15ConcurrentValueP"
+        },
+        {
+          "kind": "Conformance",
           "name": "SIMDScalar",
           "printedName": "SIMDScalar",
           "children": [

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1595,6 +1595,12 @@
         },
         {
           "kind": "Conformance",
+          "name": "ConcurrentValue",
+          "printedName": "ConcurrentValue",
+          "usr": "s:s15ConcurrentValueP"
+        },
+        {
+          "kind": "Conformance",
           "name": "SIMDScalar",
           "printedName": "SIMDScalar",
           "children": [

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -1168,7 +1168,8 @@ public:
         DeclAttribute::canAttributeAppearOnDeclKind(DeclAttrKind::DAK_Available,
                                                     D->getDeclKind()) &&
         !D->getIntroducingVersion().hasOSAvailability() &&
-        !D->hasDeclAttribute(DeclAttrKind::DAK_AlwaysEmitIntoClient)) {
+        !D->hasDeclAttribute(DeclAttrKind::DAK_AlwaysEmitIntoClient) &&
+        !D->hasDeclAttribute(DeclAttrKind::DAK_Marker)) {
       D->emitDiag(D->getLoc(), diag::new_decl_without_intro);
     }
   }


### PR DESCRIPTION
This pull request introduces the `ConcurrentValue` protocol, which 
describes types for which it is safe to use different copies of a value
concurrently. Value-semantic types, immutable types, and types that
have internal synchronization can all conform to `ConcurrentValue`.

A value of a non-`ConcurrentValue` type cannot be transferred 
into a separate isolation domain. For example, they cannot be used
in a call to an actor-isolated function on a different actor. Similarly,
a local variable of non-`ConcurrentValue` type cannot be captured
in a closure that executes concurrently with the function in which
the local variable was declared. The actor-isolation and capture
checking rules have been adjusted accordingly.

Structural types are treated as conforming to `ConcurrentValue` in
certain cases, although we don't form proper conformances just yet:
* Metatypes always conform to `ConcurrentValue`.
* `@concurrent` function types conform to `ConcurrentValue`; 
  their parameter and result types must also conform to `ConcurrentValue`
* Tuples conform to `ConcurrentValue` if all element types conform to
  `ConcurrentValue`.

Nominal types can declare conformance to `ConcurrentValue` explicitly.
That conformance is checked to ensure that none of the state of the
type lacks a conformance to `ConcurrentValue`:
- For structs, check that each stored property conforms to `ConcurrentValue`
- For enums, check that each associated value conforms to `ConcurrentValue`
- For classes, check that each stored property is immutable and conforms
  to `ConcurrentValue`

Because all of the stored properties / associated values need to be
visible for this check to work, limit `ConcurrentValue` conformances to
be in the same source file as the type definition.

This checking can be disabled by conforming to a new marker protocol,
`UnsafeConcurrentValue`, that inherits `ConcurrentValue`.
`UnsafeConcurrentValue` otherwise his no specific meaning. This allows
both "I know what I'm doing" for types that manage concurrent access
themselves as well as enabling retroactive conformance, both of which
are fundamentally unsafe but also quite necessary.

Roll out `ConcurrentValue` conformances throughout the standard library,
which both makes a lot of code "just work" and also provides out the
effectiveness of the checking and the model.

The checking for `ConcurrentValue` conformances is always enabled, since
there is no code using this protocol. However, all of the other diagnostics
related to `ConcurrentValue` checking are staged in as warnings behind a
flag `-Xfrontend -enable-experimental-concurrent-value-checking`.