### PR TITLE
Platform: add a `cplusplus` requirement to XAudio

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -168,6 +168,8 @@ module WinSDK [system] {
       export *
 
       link "xaudio2.lib"
+
+      requires cplusplus
     }
 
     // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was


### PR DESCRIPTION
In some cases when building the `XAudio` module, we would end up going
down C++ paths:

```
C:\Program Files (x86)\Windows Kits\10\/Include/10.0.17763.0/um/xaudio2.h:61:26: error: 'uuid' attribute is not supported in C
    interface __declspec(uuid("2B02E3CF-2E0B-4ec3-BE45-1B2A3FE7210D")) IXAudio2;
                             ^
<module-includes>:29:10: note: in file included from <module-includes>:29:
         ^
```

Although this works with newer SDKs, it does not work with older SDKs.
Filter out the module for the time being with a requirement on `C++`.
This should be possible to use with `-enable-cxx-interop`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
