### PR TITLE
Concurrency override actor isolation fixes

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1807,16 +1807,15 @@ ActorIsolation ActorIsolationRequest::evaluate(
   // If the declaration overrides another declaration, it must have the same
   // actor isolation.
   if (auto overriddenValue = value->getOverriddenDecl()) {
-    if (auto isolation = getActorIsolation(overriddenValue)) {
-      SubstitutionMap subs;
-      if (auto env = value->getInnermostDeclContext()
-              ->getGenericEnvironmentOfContext()) {
-        subs = SubstitutionMap::getOverrideSubstitutions(
-            overriddenValue, value, subs);
-      }
-
-      return inferredIsolation(isolation.subst(subs));
+    auto isolation = getActorIsolation(overriddenValue);
+    SubstitutionMap subs;
+    if (auto env = value->getInnermostDeclContext()
+            ->getGenericEnvironmentOfContext()) {
+      subs = SubstitutionMap::getOverrideSubstitutions(
+        overriddenValue, value, subs);
     }
+
+    return inferredIsolation(isolation.subst(subs));
   }
 
   // If this is an accessor, use the actor isolation of its storage

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -177,6 +177,21 @@ struct OtherContainer<U> {
   }
 }
 
+class SuperclassWithGlobalActors {
+  @GenericGlobalActor<Int> func f() { }
+  @GenericGlobalActor<Int> func g() { } // expected-note{{overridden declaration is here}}
+  func h() { }
+}
+
+@GenericGlobalActor<String>
+class SubclassWithGlobalActors : SuperclassWithGlobalActors {
+  override func f() { } // okay: inferred to @GenericGlobalActor<Int>
+
+  @GenericGlobalActor<String> override func g() { } // expected-error{{global actor 'GenericGlobalActor<String>'-isolated instance method 'g()' has different actor isolation from global actor 'GenericGlobalActor<Int>'-isolated overridden declaration}}
+
+  override func h() { } // okay: inferred to unspecified
+}
+
 // ----------------------------------------------------------------------
 // Global actor inference for unspecified contexts
 // ----------------------------------------------------------------------

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -181,6 +181,8 @@ class SuperclassWithGlobalActors {
   @GenericGlobalActor<Int> func f() { }
   @GenericGlobalActor<Int> func g() { } // expected-note{{overridden declaration is here}}
   func h() { }
+  func i() { }
+  func j() { }
 }
 
 @GenericGlobalActor<String>
@@ -190,6 +192,20 @@ class SubclassWithGlobalActors : SuperclassWithGlobalActors {
   @GenericGlobalActor<String> override func g() { } // expected-error{{global actor 'GenericGlobalActor<String>'-isolated instance method 'g()' has different actor isolation from global actor 'GenericGlobalActor<Int>'-isolated overridden declaration}}
 
   override func h() { } // okay: inferred to unspecified
+
+  func onGenericGlobalActorString() { }
+  @GenericGlobalActor<Int> func onGenericGlobalActorInt() { }
+
+  @asyncHandler @GenericGlobalActor<String>
+  override func i() { // okay to differ from superclass because it's an asyncHandler.
+    onGenericGlobalActorString()
+  }
+
+  @asyncHandler
+  override func j() { // okay, isolated to GenericGlobalActor<String>
+    onGenericGlobalActorString() // okay
+    onGenericGlobalActorInt() // expected-error{{call is 'async' but is not marked with 'await'}}
+  }
 }
 
 // ----------------------------------------------------------------------

--- a/test/Incremental/Verifier/single-file-private/AnyObject.swift
+++ b/test/Incremental/Verifier/single-file-private/AnyObject.swift
@@ -73,16 +73,9 @@ func lookupOnAnyObject(object: AnyObject) { // expected-provides {{lookupOnAnyOb
 // expected-member {{Swift.CustomStringConvertible.someMethod}}
 // expected-member {{Swift.CustomDebugStringConvertible.someMethod}}
 // expected-member {{Swift.Equatable.someMember}}
-// expected-member{{Swift.CustomDebugStringConvertible.init}}
 // expected-member{{Swift.CVarArg.someMember}}
 // expected-member{{Foundation._KeyValueCodingAndObservingPublishing.someMember}}
-// expected-member{{Swift.Equatable.init}}
-// expected-member{{Swift.Hashable.init}}
-// expected-member{{Swift.CVarArg.init}}
 // expected-member{{Foundation._KeyValueCodingAndObserving.someMember}}
-// expected-member{{Foundation._KeyValueCodingAndObservingPublishing.init}}
 // expected-member{{Swift.CustomDebugStringConvertible.someMember}}
 // expected-member{{Swift.CustomStringConvertible.someMember}}
-// expected-member{{Swift.CustomStringConvertible.init}}
 // expected-member{{Swift.Hashable.someMember}}
-// expected-member{{Foundation._KeyValueCodingAndObserving.init}}


### PR DESCRIPTION
Fix a few issues with actor-isolation checking for overrides:
* Treat the actor isolation of an overridding method as that of its overridden method even if when the overridden method is not isolation, and
* Allow `@asyncHandler` overriding declarations to arbitrarily change the actor, because they'll be running the code somewhere else anyway