### PR TITLE
Remove no-longer-needed external declaration of swift_dynamicCast_OLD

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -2185,17 +2185,6 @@ tryCast(
 /****************************** Main Entrypoint *******************************/
 /******************************************************************************/
 
-// XXX REMOVE ME XXX TODO XXX
-// Declare the old entrypoint
-SWIFT_RUNTIME_EXPORT
-bool
-swift_dynamicCast_OLD(OpaqueValue *destLocation,
-                      OpaqueValue *srcValue,
-                      const Metadata *srcType,
-                      const Metadata *destType,
-                      DynamicCastFlags flags);
-// XXX REMOVE ME XXX TODO XXX
-
 /// ABI: Perform a dynamic cast to an arbitrary type.
 static bool
 swift_dynamicCastImpl(OpaqueValue *destLocation,


### PR DESCRIPTION
Remove a stray declaration that was left behind when I cleaned out the old dynamic cast implementation.