### PR TITLE
[Concurrency] Loosen constraints on @actorIndependent placement.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -572,9 +572,10 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
   102)
 
 DECL_ATTR(actorIndependent, ActorIndependent,
-  OnFunc | OnVar | OnSubscript | ConcurrencyOnly |
+  OnClass | OnStruct | OnEnum | OnExtension | OnFunc | OnConstructor |
+  OnVar | OnSubscript | ConcurrencyOnly |
   ABIStableToAdd | ABIStableToRemove |
-  APIStableToAdd | APIBreakingToRemove,
+  APIBreakingToAdd | APIBreakingToRemove,
   103)
 
 SIMPLE_DECL_ATTR(globalActor, GlobalActor,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4281,13 +4281,6 @@ ERROR(actorindependent_mutable_storage,none,
 ERROR(actorindependent_local_var,none,
       "'@actorIndependent' can not be applied to local variables",
       ())
-ERROR(actorindependent_not_actor_member,none,
-      "'@actorIndependent' can only be applied to actor members and "
-      "global/static variables",
-      ())
-ERROR(actorindependent_not_actor_instance_member,none,
-      "'@actorIndependent' can only be applied to instance members of actors",
-      ())
 
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -298,7 +298,7 @@ public:
           case ActorIndependentKind::Safe:
             diagnoseAndRemoveAttr(attr, diag::actorindependent_mutable_storage);
             return;
-            
+
           case ActorIndependentKind::Unsafe:
             break;
         }
@@ -315,26 +315,11 @@ public:
           (dc->isTypeContext() && var->isStatic())) {
         return;
       }
-
-      // Otherwise, fall through to make sure we're in an appropriate
-      // context.
     }
 
-    // @actorIndependent only makes sense on an actor instance member.
-    if (!dc->getSelfClassDecl() ||
-        !dc->getSelfClassDecl()->isActor()) {
-      diagnoseAndRemoveAttr(attr, diag::actorindependent_not_actor_member);
-      return;
+    if (auto VD = dyn_cast<ValueDecl>(D)) {
+      (void)getActorIsolation(VD);
     }
-
-    auto VD = cast<ValueDecl>(D);
-    if (!VD->isInstanceMember()) {
-      diagnoseAndRemoveAttr(
-          attr, diag::actorindependent_not_actor_instance_member);
-      return;
-    }
-
-    (void)getActorIsolation(VD);
   }
 
   void visitGlobalActorAttr(GlobalActorAttr *attr) {

--- a/test/attr/actorindependent.swift
+++ b/test/attr/actorindependent.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: concurrency
 
-// expected-error@+1{{'@actorIndependent' can only be applied to actor members and global/static variables}}
 @actorIndependent func globalFunction() { }
 
 @actorIndependent var globalComputedProperty1: Int { 17 }
@@ -33,9 +32,11 @@ struct X {
 }
 
 class C {
-  // expected-error@+1{{'@actorIndependent' can only be applied to actor members and global/static variables}}
   @actorIndependent
   var property3: Int { 5 }
+
+  @actorIndependent
+  func f() { }
 }
 
 actor class A {
@@ -65,6 +66,8 @@ actor class A {
     set { }
   }
 
+  @actorIndependent init() { }
+
   @actorIndependent
   func synchronousFunc() { }
 
@@ -74,7 +77,6 @@ actor class A {
   @actorIndependent
   subscript(index: Int) -> String { "\(index)" }
 
-  // expected-error@+1{{'@actorIndependent' can only be applied to instance members of actors}}
   @actorIndependent static func staticFunc() { }
 }
 
@@ -96,3 +98,5 @@ actor class FromProperty {
     set { counter = newValue }
   }
 }
+
+@actorIndependent extension FromProperty { }


### PR DESCRIPTION
`@actorIndependent` is needed on declarations outside of actors to
(e.g.) disable inference of a global actor. It is also effectively the
default, so allow it to be specified explicitly.
