### PR TITLE
[Experiment] [Concurrency] Loosen isolation checking for overrides/witnesses to ObjC.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1907,6 +1907,12 @@ void swift::checkOverrideActorIsolation(ValueDecl *value) {
   if (isolation == overriddenIsolation)
     return;
 
+  // If the overridden declaration is from Objective-C with no actor annotation,
+  // and the overriding declaration has been placed in a global actor, allow it.
+  if (overridden->hasClangNode() && !overriddenIsolation &&
+      isolation.getKind() == ActorIsolation::GlobalActor)
+    return;
+
   // Isolation mismatch. Diagnose it.
   value->diagnose(
       diag::actor_isolation_override_mismatch, isolation,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2726,7 +2726,11 @@ bool ConformanceChecker::checkActorIsolation(
 
   // If the witness has a global actor but the requirement does not, we have
   // an isolation error.
-  if (witnessGlobalActor && !requirementGlobalActor) {
+  //
+  // However, we allow this case when the requirement was imported, because
+  // it might not have been annotated.
+  if (witnessGlobalActor && !requirementGlobalActor &&
+      !requirement->hasClangNode()) {
     witness->diagnose(
         diag::global_actor_isolated_witness, witness->getDescriptiveKind(),
         witness->getName(), witnessGlobalActor, Proto->getName());

--- a/test/decl/protocol/conforms/objc_async.swift
+++ b/test/decl/protocol/conforms/objc_async.swift
@@ -3,6 +3,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
 import Foundation
+import ObjectiveC
 import ObjCConcurrency
 
 // Conform via async method
@@ -50,4 +51,23 @@ extension C5: ConcurrentProtocol {
   func askUser(toJumpThroughHoop hoop: String, completionHandler: ((String) -> Void)?) {
     completionHandler?("hello")
   }
+}
+
+// Global actors.
+actor class SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+class C6: ConcurrentProtocol {
+  @SomeGlobalActor
+  func askUser(toSolvePuzzle puzzle: String) async throws -> String { "" }
+
+  func askUser(toJumpThroughHoop hoop: String) async -> String { "hello" }
+}
+
+class C7: NSObject {
+  @SomeGlobalActor override var description: String { "on an actor" }
 }


### PR DESCRIPTION
When overriding a method or witnessing a requirement that comes from
Objective-C and has no actor annotation, allow the overriding method
or witness to specify a global actor (any global actor, but probably
almost always the main actor) without triggering the actor-isolation
errors one would normally get if both entities were written in Swift.

This opens up a hole in actor-isolation checking, because nothing
guarantees that code won't call these methods through the superclass
or protocol from the wrong actor. On the other hand, it's a very
convenient hole, because it allows us to state when we "know" that an
Objective-C framework will only call a method on (e.g.) the main
actor, and make that known to Swift to be enforced everywhere else in
Swift. If this is a good idea, it's plausible to introduce runtime
assertions of some form to tell the user when such an annotation is
wrong.
