### PR TITLE
DefiniteInitialization: correctly handle implicit closures.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -98,11 +98,8 @@ public:
   /// instruction. For alloc_box though it returns the project_box associated
   /// with the memory info.
   SingleValueInstruction *getUninitializedValue() const {
-    if (auto *mui = dyn_cast<MarkUninitializedInst>(MemoryInst)) {
-      if (auto *pbi = mui->getSingleUserOfType<ProjectBoxInst>()) {
-        return pbi;
-      }
-    }
+    if (auto *pbi = MemoryInst->getSingleUserOfType<ProjectBoxInst>())
+      return pbi;
     return MemoryInst;
   }
 

--- a/test/SILOptimizer/definite_init_closures.sil
+++ b/test/SILOptimizer/definite_init_closures.sil
@@ -1,0 +1,80 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -definite-init
+
+// Test that implicit closures don't count as use of the whole self and only
+// actual uses inside the closures are taken into account.
+
+// Check that no errors are generated. No FileCheck needed.
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct SimpleStruct {
+  @_hasStorage let x: Bool
+  @_hasStorage let y: Bool
+  init()
+}
+
+class SimpleClass {
+  @_hasStorage final let x: Bool
+  @_hasStorage final let y: Bool
+  init()
+}
+
+sil [ossa] @$s4test1SVACycfC : $@convention(method) (Bool) -> SimpleStruct {
+bb0(%0 : $Bool):
+  %1 = alloc_stack $SimpleStruct, var, name "self"
+  %2 = mark_uninitialized [rootself] %1 : $*SimpleStruct
+  %7 = begin_access [modify] [static] %2 : $*SimpleStruct
+  %8 = struct_element_addr %7 : $*SimpleStruct, #SimpleStruct.x
+  assign %0 to %8 : $*Bool
+  end_access %7 : $*SimpleStruct
+  %16 = function_ref @implicit_closure_struct : $@convention(thin) (@inout_aliasable SimpleStruct) -> (Bool, @error Error)
+  %17 = partial_apply [callee_guaranteed] %16(%2) : $@convention(thin) (@inout_aliasable SimpleStruct) -> (Bool, @error Error)
+  destroy_value %17 : $@callee_guaranteed () -> (Bool, @error Error)
+  %23 = begin_access [modify] [static] %2 : $*SimpleStruct
+  %24 = struct_element_addr %23 : $*SimpleStruct, #SimpleStruct.y
+  assign %0 to %24 : $*Bool
+  end_access %23 : $*SimpleStruct
+  %27 = load [trivial] %2 : $*SimpleStruct
+  dealloc_stack %1 : $*SimpleStruct
+  return %27 : $SimpleStruct
+}
+
+sil private [transparent] [ossa] @implicit_closure_struct : $@convention(thin) (@inout_aliasable SimpleStruct) -> (Bool, @error Error) {
+bb0(%0 : $*SimpleStruct):
+  debug_value_addr %0 : $*SimpleStruct, var, name "self", argno 2
+  %3 = begin_access [read] [static] %0 : $*SimpleStruct
+  %4 = struct_element_addr %3 : $*SimpleStruct, #SimpleStruct.x
+  %5 = load [trivial] %4 : $*Bool
+  end_access %3 : $*SimpleStruct
+  return %5 : $Bool
+}
+
+sil [ossa] @$s4test11SimpleClassC1bACSb_tcfc : $@convention(method) (Bool, @owned SimpleClass) -> @owned SimpleClass {
+bb0(%0 : $Bool, %1 : @owned $SimpleClass):
+  %4 = mark_uninitialized [rootself] %1 : $SimpleClass
+  %5 = begin_borrow %4 : $SimpleClass
+  %6 = ref_element_addr %5 : $SimpleClass, #SimpleClass.x
+  assign %0 to %6 : $*Bool
+  end_borrow %5 : $SimpleClass
+  %9 = begin_borrow %4 : $SimpleClass
+  %11 = function_ref @implicit_closure_class : $@convention(thin) (@guaranteed SimpleClass) -> (Bool, @error Error)
+  %12 = copy_value %4 : $SimpleClass
+  %13 = partial_apply [callee_guaranteed] %11(%12) : $@convention(thin) (@guaranteed SimpleClass) -> (Bool, @error Error)
+  destroy_value %13 : $@callee_guaranteed () -> (Bool, @error Error)
+  %19 = ref_element_addr %9 : $SimpleClass, #SimpleClass.y
+  assign %0 to %19 : $*Bool
+  end_borrow %9 : $SimpleClass
+  return %4 : $SimpleClass
+}
+
+sil private [transparent] [ossa] @implicit_closure_class : $@convention(thin) (@guaranteed SimpleClass) -> (Bool, @error Error) {
+bb0(%0 : @guaranteed $SimpleClass):
+  debug_value %0 : $SimpleClass, let, name "self", argno 2
+  %3 = ref_element_addr %0 : $SimpleClass, #SimpleClass.x
+  %4 = load [trivial] %3 : $*Bool
+  return %4 : $Bool
+}

--- a/test/SILOptimizer/definite_init_closures.swift
+++ b/test/SILOptimizer/definite_init_closures.swift
@@ -1,0 +1,72 @@
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null
+
+// Test boolean operators with implicit closures
+
+struct Simple {
+  let x: Bool
+  let y: Bool
+
+  init() {
+    x = false
+    y = false || x
+  }
+}
+
+struct NestedClosures {
+  let x: Bool
+  let y: Bool
+  let z: Bool
+
+  init(a: Bool) {
+    x = false
+    y = false
+    z = false || (y || (x || a))
+  }
+
+  init(b: Bool) {
+    x = false
+    y = false
+    // With explicit self
+    z = false || (self.y || (self.x || b))
+  }
+}
+
+class SimpleClass {
+  let x: Bool
+  let y: Bool
+
+  init() {
+    x = false
+    y = false || x
+  }
+}
+
+func forward(_ b: inout Bool) -> Bool {
+  return b
+}
+
+struct InoutUse {
+  var x: Bool
+  var y: Bool
+
+  init() {
+    x = false
+    y = false || forward(&x)
+  }
+}
+
+protocol P {
+  var b: Bool { get }
+}
+
+struct Generic<T : P> {
+  let x: T
+  let y: Bool
+
+  init(_ t: T) {
+    x = t
+    y = false || x.b
+  }
+}
+
+

--- a/test/SILOptimizer/definite_init_closures_fail.swift
+++ b/test/SILOptimizer/definite_init_closures_fail.swift
@@ -1,0 +1,67 @@
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+
+// Test boolean operators with implicit closures
+
+struct Simple {
+  let x: Bool // expected-note {{'self.x' not initialized}}
+              // expected-note @-1 {{'self.x' not initialized}}
+  let y: Bool
+
+  init() {
+    y = false || x // expected-error {{constant 'self.x' used before being initialized}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+
+  init(b: Bool) {
+    if b {
+      x = false
+    }
+    y = false || x // expected-error {{constant 'self.x' used before being initialized}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+}
+
+struct NestedClosures {
+  let x: Bool // expected-note {{'self.x' not initialized}}
+  let y: Bool
+  let z: Bool
+
+  init(_ a: Bool) {
+    y = false
+    z = false || (y || (x || a)) // expected-error {{constant 'self.x' used before being initialized}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+}
+
+class SimpleClass {
+  let x: Bool // expected-note {{'self.x' not initialized}}
+  let y: Bool
+
+  init() {
+    y = false || x // expected-error {{constant 'self.x' used before being initialized}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+}
+
+func forward(_ b: inout Bool) -> Bool {
+  return b
+}
+
+struct InoutUse {
+  var x: Bool
+  var y: Bool
+
+  init() {
+    y = false || forward(&x) // expected-error {{variable 'self.x' passed by reference before being initialized}}
+  }
+}
+
+protocol P {
+  var b: Bool { get }
+}
+
+struct Generic<T : P> {
+  let x: T // expected-note {{'self.x' not initialized}}
+  let y: Bool
+
+  init(_ t: T) {
+    y = false || x.b // expected-error {{constant 'self.x' used before being initialized}}
+  } // expected-error {{return from initializer without initializing all stored properties}}
+}
+


### PR DESCRIPTION
Correctly handle implicit closures in initializers, e.g. with boolean operators:

```
init() {
  bool_member1 = false
  bool_member2 = false || bool_member1 // implicit closure
}
```

The implicit closure ('bool_member1' at the RHS of the || operator) captures the whole self, but only uses 'bool_member1'.
If the whole captured 'self' is considered as use, we would get a "'self.bool_member2' not initialized" error at the partial_apply.
Therefore look into the body of the closure and only add the actually used members.

rdar://66420045