### PR TITLE
Force unwrap auditing opt-in warning.

### DIFF
--- a/include/swift/AST/DefineDiagnosticMacros.h
+++ b/include/swift/AST/DefineDiagnosticMacros.h
@@ -37,6 +37,11 @@
   DIAG(NOTE, ID, Options, Text, Signature)
 #endif
 
+#ifndef LINT
+#define LINT(ID, Options, Text, Signature)                                     \
+  DIAG(LINT, ID, Options, Text, Signature)
+#endif
+
 #ifndef REMARK
 #define REMARK(ID, Options, Text, Signature)                                   \
   DIAG(REMARK, ID, Options, Text, Signature)
@@ -60,6 +65,7 @@
 
 #undef REMARK
 #undef NOTE
+#undef LINT
 #undef WARNING
 #undef ERROR
 #undef FIXIT

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -984,8 +984,8 @@ ERROR(tuple_types_not_convertible,none,
 
 ERROR(invalid_force_unwrap,none,
       "cannot force unwrap value of non-optional type %0", (Type))
-WARNING(force_unwrap_warning,none,
-      "Consider using an alternative to a forced unwrap", ())
+WARNING(warn_force_unwrap,none,
+      "consider using an alternative to a forced unwrap", ())
 ERROR(invalid_optional_chain,none,
       "cannot use optional chaining on non-optional value of type %0",
       (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -984,7 +984,7 @@ ERROR(tuple_types_not_convertible,none,
 
 ERROR(invalid_force_unwrap,none,
       "cannot force unwrap value of non-optional type %0", (Type))
-WARNING(warn_force_unwrap,none,
+LINT(force_unwrap_usage,none,
       "consider using an alternative to a forced unwrap", ())
 ERROR(invalid_optional_chain,none,
       "cannot use optional chaining on non-optional value of type %0",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -984,10 +984,8 @@ ERROR(tuple_types_not_convertible,none,
 
 ERROR(invalid_force_unwrap,none,
       "cannot force unwrap value of non-optional type %0", (Type))
-ERROR(force_unwrap_error,none,
-      "-force-unwrap-error flag prohibits use of force unwrap", ())
 WARNING(force_unwrap_warning,none,
-      "Consider using an alternative to force unwraping", ())
+      "Consider using an alternative to a forced unwrap", ())
 ERROR(invalid_optional_chain,none,
       "cannot use optional chaining on non-optional value of type %0",
       (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -984,6 +984,10 @@ ERROR(tuple_types_not_convertible,none,
 
 ERROR(invalid_force_unwrap,none,
       "cannot force unwrap value of non-optional type %0", (Type))
+ERROR(force_unwrap_error,none,
+      "-force-unwrap-error flag prohibits use of force unwrap", ())
+WARNING(force_unwrap_warning,none,
+      "Consider using an alternative to force unwraping", ())
 ERROR(invalid_optional_chain,none,
       "cannot use optional chaining on non-optional value of type %0",
       (Type))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -135,9 +135,6 @@ namespace swift {
     /// Warn on usage of force unwrap operator
     bool ForceUnwrapWarning = false;
 
-    /// Prohibit use of force unwrap operator
-    bool ForceUnwrapError = false;
-
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -132,9 +132,6 @@ namespace swift {
     /// Emit a remark after loading a module.
     bool EnableModuleLoadingRemarks = false;
 
-    /// Warn on usage of force unwrap operator
-    bool WarnForceUnwrap = false;
-
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -133,7 +133,7 @@ namespace swift {
     bool EnableModuleLoadingRemarks = false;
 
     /// Warn on usage of force unwrap operator
-    bool ForceUnwrapWarning = false;
+    bool WarnForceUnwrap = false;
 
     ///
     /// Support for alternate usage modes

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -132,6 +132,12 @@ namespace swift {
     /// Emit a remark after loading a module.
     bool EnableModuleLoadingRemarks = false;
 
+    /// Warn on usage of force unwrap operator
+    bool ForceUnwrapWarning = false;
+
+    /// Prohibit use of force unwrap operator
+    bool ForceUnwrapError = false;
+
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -575,11 +575,6 @@ def force_unwrap_warning : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Audit code for force-unwrap usage">;
 
-def force_unwrap_error : Flag<["-"],
-    "force-unwrap-error">,
-  Flags<[FrontendOption, ModuleInterfaceOption]>,
-  HelpText<"Prohibit usage of force unwrap in code">;
-
 def disable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
     "disable-fuzzy-forward-scan-trailing-closure-matching">,
   Flags<[FrontendOption]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -243,7 +243,7 @@ def tools_directory : Separate<["-"], "tools-directory">,
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
 
-def W : JoinedOrSeparate<["-"], "W">, Flags<[FrontendOption]>,
+def lint : JoinedOrSeparate<["-"], "lint">, Flags<[FrontendOption]>,
   HelpText<"Opt into linting warning">;
 
 def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption, ArgumentIsPath]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -570,8 +570,8 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
-def force_unwrap_warning : Flag<["-"],
-    "force-unwrap-warning">,
+def warn_force_unwrap : Flag<["-"],
+    "warn-force-unwrap">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Audit code for force-unwrap usage">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -570,6 +570,16 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
+def force_unwrap_warning : Flag<["-"],
+    "force-unwrap-warning">,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
+  HelpText<"Audit code for force-unwrap usage">;
+
+def force_unwrap_error : Flag<["-"],
+    "force-unwrap-error">,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
+  HelpText<"Prohibit usage of force unwrap in code">;
+
 def disable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
     "disable-fuzzy-forward-scan-trailing-closure-matching">,
   Flags<[FrontendOption]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -243,6 +243,9 @@ def tools_directory : Separate<["-"], "tools-directory">,
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
 
+def W : JoinedOrSeparate<["-"], "W">, Flags<[FrontendOption]>,
+  HelpText<"Opt into linting warning">;
+
 def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Add directory to framework search path">;
 def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption, ArgumentIsPath]>,
@@ -569,11 +572,6 @@ def enable_experimental_concise_pound_file : Flag<["-"],
     "enable-experimental-concise-pound-file">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
-
-def warn_force_unwrap : Flag<["-"],
-    "warn-force-unwrap">,
-  Flags<[FrontendOption, ModuleInterfaceOption]>,
-  HelpText<"Audit code for force-unwrap usage">;
 
 def disable_fuzzy_forward_scan_trailing_closure_matching : Flag<["-"],
     "disable-fuzzy-forward-scan-trailing-closure-matching">,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -82,6 +82,8 @@ static const constexpr StoredDiagnosticInfo storedDiagnosticInfos[] = {
   StoredDiagnosticInfo(DiagnosticKind::Error, DiagnosticOptions::Options),
 #define WARNING(ID, Options, Text, Signature)                                  \
   StoredDiagnosticInfo(DiagnosticKind::Warning, DiagnosticOptions::Options),
+#define LINT(ID, Options, Text, Signature)                                     \
+  StoredDiagnosticInfo(DiagnosticKind::Warning, DiagnosticOptions::Options),
 #define NOTE(ID, Options, Text, Signature)                                     \
   StoredDiagnosticInfo(DiagnosticKind::Note, DiagnosticOptions::Options),
 #define REMARK(ID, Options, Text, Signature)                                   \

--- a/lib/AST/DiagnosticList.cpp
+++ b/lib/AST/DiagnosticList.cpp
@@ -40,4 +40,16 @@ namespace swift {
     detail::StructuredFixItWithArguments<void Signature>::type ID = {FixItID::ID};
 #include "swift/AST/DiagnosticsAll.def"
   } // end namespace diag
+
+  const char *lintArgument(swift::DiagID ID) {
+    switch (ID) {
+  #define DIAG(KIND,ID,Options,Text,Signature)
+  #define LINT(ID,Options,Text,Signature) \
+      case DiagID::ID: \
+        return #ID;
+  #include "swift/AST/DiagnosticsAll.def"
+      default:
+        return nullptr;
+    }
+  }
 } // end namespace swift

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -590,7 +590,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
 
   Opts.ForceUnwrapWarning = Args.hasArg(OPT_force_unwrap_warning);
-  Opts.ForceUnwrapError = Args.hasArg(OPT_force_unwrap_error);
 
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -589,8 +589,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
 
-  Opts.WarnForceUnwrap = Args.hasArg(OPT_warn_force_unwrap);
-
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
   std::string TargetArgScratch;
@@ -699,6 +697,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (FrontendOpts.AllowModuleWithCompilerErrors) {
     Opts.AllowModuleWithCompilerErrors = true;
+  }
+
+  for (const Arg *A : Args.filtered(OPT_W)) {
+    Diags.ActiveLints[A->getValue()] = true;
+    A->claim();
   }
 
   return HadError || UnsupportedOS || UnsupportedArch;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -589,6 +589,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
 
+  Opts.ForceUnwrapWarning = Args.hasArg(OPT_force_unwrap_warning);
+  Opts.ForceUnwrapError = Args.hasArg(OPT_force_unwrap_error);
+
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
   std::string TargetArgScratch;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -699,7 +699,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.AllowModuleWithCompilerErrors = true;
   }
 
-  for (const Arg *A : Args.filtered(OPT_W)) {
+  for (const Arg *A : Args.filtered(OPT_lint)) {
     Diags.ActiveLints[A->getValue()] = true;
     A->claim();
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -589,7 +589,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
 
-  Opts.ForceUnwrapWarning = Args.hasArg(OPT_force_unwrap_warning);
+  Opts.WarnForceUnwrap = Args.hasArg(OPT_warn_force_unwrap);
 
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3001,8 +3001,6 @@ namespace {
       }
 
       auto &ctx = CS.getASTContext();
-      if (ctx.LangOpts.ForceUnwrapError)
-        ctx.Diags.diagnose(expr->getLoc(), diag::force_unwrap_error);
       if (ctx.LangOpts.ForceUnwrapWarning)
         ctx.Diags.diagnose(expr->getLoc(), diag::force_unwrap_warning);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3000,6 +3000,12 @@ namespace {
             CS, CS.getConstraintLocator(nilLiteral)));
       }
 
+      auto &ctx = CS.getASTContext();
+      if (ctx.LangOpts.ForceUnwrapError)
+        ctx.Diags.diagnose(expr->getLoc(), diag::force_unwrap_error);
+      if (ctx.LangOpts.ForceUnwrapWarning)
+        ctx.Diags.diagnose(expr->getLoc(), diag::force_unwrap_warning);
+
       // The result is the object type of the optional subexpression.
       CS.addConstraint(ConstraintKind::OptionalObject, CS.getType(valueExpr),
                        objectTy, locator);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3001,8 +3001,8 @@ namespace {
       }
 
       auto &ctx = CS.getASTContext();
-      if (ctx.LangOpts.ForceUnwrapWarning)
-        ctx.Diags.diagnose(expr->getLoc(), diag::force_unwrap_warning);
+      if (ctx.LangOpts.WarnForceUnwrap)
+        ctx.Diags.diagnose(expr->getLoc(), diag::warn_force_unwrap);
 
       // The result is the object type of the optional subexpression.
       CS.addConstraint(ConstraintKind::OptionalObject, CS.getType(valueExpr),

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3000,9 +3000,8 @@ namespace {
             CS, CS.getConstraintLocator(nilLiteral)));
       }
 
-      auto &ctx = CS.getASTContext();
-      if (ctx.LangOpts.WarnForceUnwrap)
-        ctx.Diags.diagnose(expr->getLoc(), diag::warn_force_unwrap);
+      CS.getASTContext().Diags.diagnose(expr->getLoc(),
+                                        diag::force_unwrap_usage);
 
       // The result is the object type of the optional subexpression.
       CS.addConstraint(ConstraintKind::OptionalObject, CS.getType(valueExpr),

--- a/test/Misc/warn_force_unwrap.swift
+++ b/test/Misc/warn_force_unwrap.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -Wforce_unwrap_usage -typecheck -verify -c %s
+// RUN: %target-swift-frontend -lint force_unwrap_usage -typecheck -verify -c %s
 
 var a: String?
 

--- a/test/Misc/warn_force_unwrap.swift
+++ b/test/Misc/warn_force_unwrap.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -warn-force-unwrap -typecheck -verify -c %s
+// RUN: %target-swift-frontend -Wforce_unwrap_usage -typecheck -verify -c %s
 
 var a: String?
 

--- a/test/Misc/warn_force_unwrap.swift
+++ b/test/Misc/warn_force_unwrap.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -warn-force-unwrap -typecheck -verify -c %s
+
+var a: String?
+
+print(a!) // expected-warning {{consider using an alternative to a forced unwrap}}
+


### PR DESCRIPTION
Hi Apple,

Another speculative PR for 2021 - very minor this time. It adds an opt-in warning for when the force unwrap operator is used as a means of auditing code more easily. My motivation for suggesting this change has been discussed at length on the swift-evolution forum post: https://forums.swift.org/t/moving-toward-deprecating-force-unwrap-from-swift/43455.

Please note this doesn't create a "dialect" as the warning is opt-in and will not appear unless the user elects to enable it. This could be performed by a linter but it is such a minor change to the compiler I hope you consider merging it.

Thanks again,

@johnno1962