### PR TITLE
[Test] Don't run protocol_conformance_collision.swift against older runtimes.

### DIFF
--- a/test/Runtime/protocol_conformance_collision.swift
+++ b/test/Runtime/protocol_conformance_collision.swift
@@ -14,6 +14,8 @@
 // UNSUPPORTED: DARWIN_SIMULATOR=tvos
 // UNSUPPORTED: DARWIN_SIMULATOR=watchos
 
+// UNSUPPORTED: use_os_stdlib
+
 import Accelerate
 import Foundation
 import StdlibUnittest


### PR DESCRIPTION
rdar://72856188