### PR TITLE
[Diagnostics] Special case requirement failures related to `return` statement/expression

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -762,6 +762,20 @@ public:
   }
 };
 
+class LocatorPathElt::ConformanceRequirement final
+    : public StoredPointerElement<ProtocolDecl> {
+public:
+  ConformanceRequirement(ProtocolDecl *protocol)
+      : StoredPointerElement(PathElementKind::ConformanceRequirement,
+                             protocol) {}
+
+  ProtocolDecl *getRequirement() const { return getStoredPointer(); }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::ConformanceRequirement;
+  }
+};
+
 namespace details {
   template <typename CustomPathElement>
   class PathElement {

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -195,6 +195,9 @@ CUSTOM_LOCATOR_PATH_ELT(ArgumentAttribute)
 /// The result of a chain of member accesses off an UnresolvedMemberExpr
 SIMPLE_LOCATOR_PATH_ELT(UnresolvedMemberChainResult)
 
+/// The conformance requirement associated with a type.
+CUSTOM_LOCATOR_PATH_ELT(ConformanceRequirement)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -211,12 +211,12 @@ ProtocolConformance *RequirementFailure::getConformanceForConditionalReq(
     return nullptr;
 
   auto path = locator->getPath();
-  auto *typeReqLoc = getConstraintLocator(getRawAnchor(), path.drop_back());
+  auto *conformanceLoc = getConstraintLocator(getRawAnchor(), path.drop_back());
 
   auto result = llvm::find_if(
       solution.Conformances,
       [&](const std::pair<ConstraintLocator *, ProtocolConformanceRef>
-              &conformance) { return conformance.first == typeReqLoc; });
+              &conformance) { return conformance.first == conformanceLoc; });
   assert(result != solution.Conformances.end());
 
   auto conformance = result->second;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -249,8 +249,28 @@ ValueDecl *RequirementFailure::getDeclRef() const {
     return getAffectedDeclFromType(func->getResultInterfaceType());
   }
 
-  if (isFromContextualType())
-    return getAffectedDeclFromType(getContextualType(getRawAnchor()));
+  if (isFromContextualType()) {
+    auto anchor = getRawAnchor();
+    auto contextualPurpose = getContextualTypePurpose(anchor);
+    auto contextualTy = getContextualType(anchor);
+
+    // If the issue is a mismatch between `return` statement/expression
+    // and its contextual requirements, it means that affected declaration
+    // is a declarer of a contextual "result" type e.g. member of a
+    // type, local function etc.
+    if (contextualPurpose == CTP_ReturnStmt ||
+        contextualPurpose == CTP_ReturnSingleExpr) {
+      // In case of opaque result type, let's point to the declaration
+      // associated with the type itself (since it has one) instead of
+      // declarer.
+      if (auto *opaque = contextualTy->getAs<OpaqueTypeArchetypeType>())
+        return opaque->getDecl();
+
+      return cast<ValueDecl>(getDC()->getAsDecl());
+    }
+
+    return getAffectedDeclFromType(contextualTy);
+  }
 
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     // If there is a declaration associated with this

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5710,10 +5710,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   /// Record the given conformance as the result, adding any conditional
   /// requirements if necessary.
   auto recordConformance = [&](ProtocolConformanceRef conformance) {
+    auto *conformanceLoc = getConstraintLocator(
+        loc, LocatorPathElt::ConformanceRequirement(protocol));
     // Record the conformance.
-    CheckedConformances.push_back({loc, conformance});
+    CheckedConformances.push_back({conformanceLoc, conformance});
 
-    if (isConformanceUnavailable(conformance, loc))
+    if (isConformanceUnavailable(conformance, conformanceLoc))
       increaseScore(SK_Unavailable);
 
     // This conformance may be conditional, in which case we need to consider
@@ -5721,10 +5723,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     if (conformance.isConcrete()) {
       unsigned index = 0;
       for (const auto &req : conformance.getConditionalRequirements()) {
-        addConstraint(req,
-                      locator.withPathElement(
-                          LocatorPathElt::ConditionalRequirement(
-                              index++, req.getKind())));
+        addConstraint(
+            req, getConstraintLocator(conformanceLoc,
+                                      LocatorPathElt::ConditionalRequirement(
+                                          index++, req.getKind())));
       }
     }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -66,6 +66,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::KeyPathComponent:
   case ConstraintLocator::ConditionalRequirement:
   case ConstraintLocator::TypeParameterRequirement:
+  case ConstraintLocator::ConformanceRequirement:
   case ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice:
   case ConstraintLocator::DynamicLookupResult:
   case ConstraintLocator::ContextualType:
@@ -394,6 +395,14 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
       auto reqElt = elt.castTo<LocatorPathElt::TypeParameterRequirement>();
       out << "type parameter requirement #" << llvm::utostr(reqElt.getIndex());
       dumpReqKind(reqElt.getRequirementKind());
+      break;
+    }
+
+    case ConformanceRequirement: {
+      auto reqElt = elt.castTo<LocatorPathElt::ConformanceRequirement>();
+      out << "conformance requirement (";
+      reqElt.getRequirement()->dumpRef(out);
+      out << ")";
       break;
     }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5180,15 +5180,15 @@ static Optional<Requirement> getRequirement(ConstraintSystem &cs,
 
   if (reqLoc->isConditionalRequirement()) {
     auto path = reqLocator->getPath();
-    auto *typeReqLoc =
+    auto *conformanceLoc =
         cs.getConstraintLocator(reqLocator->getAnchor(), path.drop_back());
 
     auto conformances = cs.getCheckedConformances();
     auto result = llvm::find_if(
         conformances,
-        [&typeReqLoc](
+        [&conformanceLoc](
             const std::pair<ConstraintLocator *, ProtocolConformanceRef>
-                &conformance) { return conformance.first == typeReqLoc; });
+                &conformance) { return conformance.first == conformanceLoc; });
     assert(result != conformances.end());
 
     auto conformance = result->second;

--- a/test/Constraints/sr13992.swift
+++ b/test/Constraints/sr13992.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-13992
+
+protocol V {}
+
+protocol P1 {}
+protocol P2 {
+  func bar() -> V
+}
+protocol P3 {}
+
+struct S<T> {
+  var foo: T
+}
+
+extension S : P1 {}
+extension S : P2 where T: P3 { // expected-note {{requirement from conditional conformance of 'S<V>' to 'P2'}}
+  func bar() -> V { fatalError() }
+}
+
+struct Q {
+  var foo: V
+
+  func test() -> P1 & P2 {
+    S(foo: foo) // expected-error {{protocol 'V' as a type cannot conform to 'P3'}}
+    // expected-note@-1 {{only concrete types such as structs, enums and classes can conform to protocols}}
+  }
+}


### PR DESCRIPTION
- Add a new locator path element to track conformance requirements
  to avoid loosing track of source of the conditional requirements introduced
  into the constraint system. Especially important for protocol composition types
  since all of the conformance requirements are anchored at the same locator base.

- Make sure that "affected" declaration is recognized as the one
to which result type is attached to if the requirement failure
is originated in contextual type of `return` statement/expression.

Resolves: SR-13992
Resolves: rdar://72819046
Resolves: rdar://57789606

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
