### PR TITLE
AST: Fix actor isolation checking for lazy property initializers

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -152,6 +152,9 @@ public:
 /// Determine how the given value declaration is isolated.
 ActorIsolation getActorIsolation(ValueDecl *value);
 
+/// Determine how the given declaration context is isolated.
+ActorIsolation getActorIsolationOfContext(DeclContext *dc);
+
 void simple_display(llvm::raw_ostream &out, const ActorIsolation &state);
 
 } // end namespace swift

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7976,6 +7976,25 @@ void ClassDecl::setSuperclass(Type superclass) {
     true);
 }
 
+ActorIsolation swift::getActorIsolation(ValueDecl *value) {
+  auto &ctx = value->getASTContext();
+  return evaluateOrDefault(
+      ctx.evaluator, ActorIsolationRequest{value},
+      ActorIsolation::forUnspecified());
+}
+
+ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
+  if (auto *vd = dyn_cast_or_null<ValueDecl>(dc->getAsDecl()))
+    return getActorIsolation(vd);
+
+  if (auto *init = dyn_cast<PatternBindingInitializer>(dc)) {
+    if (auto *var = init->getBinding()->getSingleVar())
+      return getActorIsolation(var);
+  }
+
+  return ActorIsolation::forUnspecified();
+}
+
 ClangNode Decl::getClangNodeImpl() const {
   assert(Bits.Decl.FromClang);
   void * const *ptr = nullptr;

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -367,3 +367,43 @@ func checkLocalFunctions() async {
 
   print(k)
 }
+
+// ----------------------------------------------------------------------
+// Lazy properties with initializers referencing 'self'
+// ----------------------------------------------------------------------
+
+actor class LazyActor {
+    var v: Int = 0
+    // expected-note@-1 5 {{mutable state is only available within the actor instance}}
+
+    let l: Int = 0
+
+    lazy var l11: Int = { v }()
+    lazy var l12: Int = v
+    lazy var l13: Int = { self.v }()
+    lazy var l14: Int = self.v
+    lazy var l15: Int = { [unowned self] in self.v }()
+
+    lazy var l21: Int = { l }()
+    lazy var l22: Int = l
+    lazy var l23: Int = { self.l }()
+    lazy var l24: Int = self.l
+    lazy var l25: Int = { [unowned self] in self.l }()
+
+    @actorIndependent lazy var l31: Int = { v }()
+    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from an '@actorIndependent' context}}
+    @actorIndependent lazy var l32: Int = v
+    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from an '@actorIndependent' context}}
+    @actorIndependent lazy var l33: Int = { self.v }()
+    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from an '@actorIndependent' context}}
+    @actorIndependent lazy var l34: Int = self.v
+    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from an '@actorIndependent' context}}
+    @actorIndependent lazy var l35: Int = { [unowned self] in self.v }()
+    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from an '@actorIndependent' context}}
+
+    @actorIndependent lazy var l41: Int = { l }()
+    @actorIndependent lazy var l42: Int = l
+    @actorIndependent lazy var l43: Int = { self.l }()
+    @actorIndependent lazy var l44: Int = self.l
+    @actorIndependent lazy var l45: Int = { [unowned self] in self.l }()
+}


### PR DESCRIPTION
The initializer DeclContext is not a ValueDecl; instead, fish out the
associated VarDecl using other means.

Fixes <rdar://problem/72727986>.