### PR TITLE
[test] Disable tests for newly introduced Range behavior on earlier OSes

### DIFF
--- a/test/stdlib/RangeTraps.swift
+++ b/test/stdlib/RangeTraps.swift
@@ -116,23 +116,26 @@ RangeTraps.test("throughNaN")
   _ = ...Double.nan
 }
 
-RangeTraps.test("UncheckedHalfOpen")
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  // Debug check was introduced in https://github.com/apple/swift/pull/34961
+  RangeTraps.test("UncheckedHalfOpen")
   .xfail(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "assertions are disabled in Release and Unchecked mode"))
+      { !_isDebugAssertConfiguration() },
+      reason: "assertions are disabled in Release and Unchecked mode"))
   .code {
     expectCrashLater()
     var range = Range(uncheckedBounds: (lower: 1, upper: 0))
   }
 
-RangeTraps.test("UncheckedClosed")
+  RangeTraps.test("UncheckedClosed")
   .xfail(.custom(
-    { !_isDebugAssertConfiguration() },
-    reason: "assertions are disabled in Release and Unchecked mode"))
+      { !_isDebugAssertConfiguration() },
+      reason: "assertions are disabled in Release and Unchecked mode"))
   .code {
     expectCrashLater()
     var range = ClosedRange(uncheckedBounds: (lower: 1, upper: 0))
   }
+}
 
 runAllTests()
 

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -344,20 +344,23 @@ ${TestSuite}.test("init(uncheckedBounds:)")
   expectEqual(upperInt, r.upperBound.value)
 }
 
-${TestSuite}.test("init(uncheckedBounds:) with invalid values")
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  // Debug check was introduced in https://github.com/apple/swift/pull/34961
+  ${TestSuite}.test("init(uncheckedBounds:) with invalid values")
   .xfail(
     .custom(
       { _isDebugAssertConfiguration() },
       reason: "unchecked initializer still checks its input in Debug mode"))
   .code {
-  let low = 2
-  let up = 1
-  // Check that 'init(uncheckedBounds:)' does not perform precondition checks,
-  // allowing to create ranges that break invariants.
-  let r = ${Self}(
-    uncheckedBounds: (lower: ${Bound}(low), upper: ${Bound}(up)))
-  expectEqual(low, r.lowerBound.value)
-  expectEqual(up, r.upperBound.value)
+    let low = 2
+    let up = 1
+    // Check that 'init(uncheckedBounds:)' does not perform precondition checks,
+    // allowing to create ranges that break invariants.
+    let r = ${Self}(
+      uncheckedBounds: (lower: ${Bound}(low), upper: ${Bound}(up)))
+    expectEqual(low, r.lowerBound.value)
+    expectEqual(up, r.upperBound.value)
+  }
 }
 
 %   for (DestinationSelf, _, _, _) in all_range_types:


### PR DESCRIPTION
This resolves CI failures in back deployment configurations.

rdar://72856139