### PR TITLE
Stop creating swift-project/swift/swift

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -60,8 +60,8 @@ toolchain as a one-off, there are a couple of differences:
 
 1. Create a directory for the whole project:
    ```sh
-   mkdir -p swift-project/swift
-   cd swift-project/swift
+   mkdir swift-project
+   cd swift-project
    ```
 2. Clone the sources:
    - Via SSH (recommended):


### PR DESCRIPTION
The instructions as written will create an unnecessary swift/swift directory, it looks like.
