### PR TITLE
Interop/Cxx: explicitly require `C++` for modules

### DIFF
--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -1,47 +1,59 @@
 module AccessSpecifiers {
   header "access-specifiers.h"
+  requires cplusplus
 }
 
 module TypeClassification {
   header "type-classification.h"
+  requires cplusplus
 }
 
 module Constructors {
   header "constructors.h"
+  requires cplusplus
 }
 
 module ConstructorsObjC {
   header "constructors-objc.h"
+  requires cplusplus
 }
 
 module LoadableTypes {
   header "loadable-types.h"
+  requires cplusplus
 }
 
 module MemberwiseInitializer {
   header "memberwise-initializer.h"
+  requires cplusplus
 }
 
 module MemoryLayout {
   header "memory-layout.h"
+  requires cplusplus
 }
 
 module MemberVariables {
   header "member-variables.h"
+  requires cplusplus
 }
 
 module ProtocolConformance {
   header "protocol-conformance.h"
+  requires cplusplus
 }
 
 module SynthesizedInitializers {
   header "synthesized-initializers.h"
+  requires cplusplus
 }
 
 module DebugInfo {
   header "debug-info.h"
+  requires cplusplus
 }
 
 module NestedRecords {
   header "nested-records.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -1,7 +1,9 @@
 module BoolEnums {
   header "bool-enums.h"
+  requires cplusplus
 }
 
 module ScopedEnums {
   header "scoped-enums.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/extern-var/Inputs/module.modulemap
+++ b/test/Interop/Cxx/extern-var/Inputs/module.modulemap
@@ -1,3 +1,4 @@
 module ExternVar {
   header "extern-var.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/implementation-only-imports/Inputs/module.modulemap
+++ b/test/Interop/Cxx/implementation-only-imports/Inputs/module.modulemap
@@ -1,24 +1,29 @@
 module UserA {
     header "user-a.h"
     export *
+    requires cplusplus
 }
 
 module UserB {
     header "user-b.h"
     export *
+    requires cplusplus
 }
 
 module UserC {
     header "user-c.h"
     export *
+    requires cplusplus
 }
 
 module DeclA {
     header "decl-a.h"
     export *
+    requires cplusplus
 }
 
 module DeclB {
     header "decl-b.h"
     export *
+    requires cplusplus
 }

--- a/test/Interop/Cxx/operators/Inputs/module.modulemap
+++ b/test/Interop/Cxx/operators/Inputs/module.modulemap
@@ -1,15 +1,19 @@
 module MemberInline {
   header "member-inline.h"
+  requires cplusplus
 }
 
 module MemberOutOfLine {
   header "member-out-of-line.h"
+  requires cplusplus
 }
 
 module NonMemberInline {
   header "non-member-inline.h"
+  requires cplusplus
 }
 
 module NonMemberOutOfLine {
   header "non-member-out-of-line.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/reference/Inputs/module.modulemap
@@ -1,3 +1,4 @@
 module Reference {
   header "reference.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/static/Inputs/module.modulemap
+++ b/test/Interop/Cxx/static/Inputs/module.modulemap
@@ -1,19 +1,24 @@
 module StaticVar {
   header "static-var.h"
+  requires cplusplus
 }
 
 module StaticLocalVar {
   header "static-local-var.h"
+  requires cplusplus
 }
 
 module StaticMemberVar {
   header "static-member-var.h"
+  requires cplusplus
 }
 
 module InlineStaticMemberVar {
   header "inline-static-member-var.h"
+  requires cplusplus
 }
 
 module StaticMemberFunc {
   header "static-member-func.h"
+  requires cplusplus
 }

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -1,67 +1,84 @@
 module ClassTemplateWithPrimitiveArgument {
   header "class-template-with-primitive-argument.h"
+  requires cplusplus
 }
 
 module NotPreDefinedClassTemplate {
   header "not-pre-defined-class-template.h"
+  requires cplusplus
 }
 
 module PartiallyPreDefinedClassTemplate {
   header "partially-pre-defined-class-template.h"
+  requires cplusplus
 }
 
 module FullyPreDefinedClassTemplate {
   header "fully-pre-defined-class-template.h"
+  requires cplusplus
 }
 
 module CanonicalTypes {
   header "canonical-types.h"
+  requires cplusplus
 }
 
 module ExplicitClassSpecialization {
   header "explicit-class-specialization.h"
+  requires cplusplus
 }
 
 module FunctionTemplates {
   header "function-templates.h"
+  requires cplusplus
 }
 
 module UsingDirective {
   header "using-directive.h"
+  requires cplusplus
 }
 
 module ClassTemplateEagerInstantiationProblems {
   header "class-template-eager-instantiation-problems.h"
+  requires cplusplus
 }
 
 module Mangling {
   header "mangling.h"
+  requires cplusplus
 }
 
 module LinkageOfSwiftSymbolsForImportedTypes {
   header "linkage-of-swift-symbols-for-imported-types.h"
+  requires cplusplus
 }
 
 module ClassTemplateVariadic {
   header "class-template-variadic.h"
+  requires cplusplus
 }
 
 module ClassTemplateNonTypeParameter {
   header "class-template-non-type-parameter.h"
+  requires cplusplus
 }
 
 module ClassTemplateTemplateParameter {
   header "class-template-template-parameter.h"
+  requires cplusplus
 }
 
 module ClassTemplateWithTypedef {
   header "class-template-with-typedef.h"
+  requires cplusplus
 }
 
 module ClassTemplateInNamespace {
   header "class-template-in-namespace.h"
+  requires cplusplus
 }
 
 module MemberTemplates {
   header "member-templates.h"
+  requires cplusplus
 }


### PR DESCRIPTION
The C++ interop modules require C++ support.  Explicitly require C++ as
a feature when building these modules.  This has no impact on the
changes as all the tests enable C++ already.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
