### PR TITLE
Revert "[build] Use Xcode toolchain Python executables"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -483,10 +483,6 @@ function set_build_options_for_host() {
               -DPython2_EXECUTABLE="$(xcrun -f python2.7)"
               -DPython3_EXECUTABLE="$(xcrun -f python3)"
             )
-            lldb_cmake_options+=(
-              -DPython2_EXECUTABLE="$(xcrun -f python2.7)"
-              -DPython3_EXECUTABLE="$(xcrun -f python3)"
-            )
             case ${host} in
                 macosx-x86_64)
                     SWIFT_HOST_TRIPLE="x86_64-apple-macosx${DARWIN_DEPLOYMENT_VERSION_OSX}"


### PR DESCRIPTION
Reverts apple/swift#35199 as it might be the root cause of some issues downstream. 