### PR TITLE
DefiniteInitialization: remove the limit of 64k aggregate elements.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -298,12 +298,10 @@ struct DIMemoryUse {
 
   /// For memory objects of (potentially recursive) tuple type, this keeps
   /// track of which tuple elements are affected.
-  unsigned short FirstElement, NumElements;
+  unsigned FirstElement, NumElements;
 
   DIMemoryUse(SILInstruction *Inst, DIUseKind Kind, unsigned FE, unsigned NE)
       : Inst(Inst), Kind(Kind), FirstElement(FE), NumElements(NE) {
-    assert(FE == FirstElement && NumElements == NE &&
-           "more than 64K elements not supported yet");
   }
 
   DIMemoryUse() : Inst(nullptr) {}


### PR DESCRIPTION
I didn't add a test, because there is a performance problem in PredictableMemoryAccessOptimizations.
Until this is fixed, the test would take too long.

rdar://71040556
