### PR TITLE
ClangImporter: synchronize clang and Swift

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -538,9 +538,28 @@ importer::getNormalInvocationArguments(
     });
   }
 
-  invocationArgStrs.insert(invocationArgStrs.end(), {
-    EnableCXXInterop ? "-std=gnu++17" : "-std=gnu11",
-  });
+  {
+    const clang::LangStandard &stdcxx =
+#if defined(CLANG_DEFAULT_STD_CXX)
+        *clang::LangStandard::getLangStandardForName(CLANG_DEFAULT_STD_CXX);
+#else
+        clang::LangStandard::getLangStandardForKind(
+            clang::LangStandard::lang_gnucxx14);
+#endif
+
+    const clang::LangStandard &stdc =
+#if defined(CLANG_DEFAULT_STD_C)
+        *clang::LangStandard::getLangStandardForName(CLANG_DEFAULT_STD_C);
+#else
+        clang::LangStandard::getLangStandardForKind(
+            clang::LangStandard::lang_gnu11);
+#endif
+
+    invocationArgStrs.insert(invocationArgStrs.end(), {
+      (Twine("-std=") + StringRef(EnableCXXInterop ? stdcxx.getName()
+                                                   : stdc.getName())).str()
+    });
+  }
 
   // Set C language options.
   if (triple.isOSDarwin()) {

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o -std=c++17
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
+// NOTE: we must use `-O` here to ensure that the constexpr value is inlined and no undefined reference remains.
+// RUN: %target-build-swift -O %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/static/static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-irgen.swift
@@ -14,7 +14,10 @@
 //to depend on external definitions. However, our code generation pattern loads
 //the value dynamically. Instead, we should inline known constants. That would
 //allow Swift code to even read the value of WithIncompleteStaticMember::notDefined.
-// CHECK: @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} = linkonce_odr {{(dso_local )?}}constant i32 139, {{(comdat, )?}}align 4
+// NOTE: we allow both available_externally and linkonce_odr as there are
+// differences in between MSVC and itanium model semantics where the constexpr
+// value is emitted into COMDAT.
+// CHECK: @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} = {{available_externally|linkonce_odr}} {{(dso_local )?}}constant i32 139, {{(comdat, )?}}align 4
 
 import StaticMemberVar
 

--- a/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
@@ -1,7 +1,11 @@
 #ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_NON_TYPE_PARAMETER_H
 #define TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_NON_TYPE_PARAMETER_H
 
-template<class T, auto Size>
+#if defined(__clang__)
+using size_t = __SIZE_TYPE__;
+#endif
+
+template<class T, size_t Size>
 struct MagicArray {
     T t[Size];
 };


### PR DESCRIPTION
This synchronizes the C/C++ standard that Swift uses for the clang
importer with the defaults of the clang compiler.

The default for the C standard remains the same at `gnu11`.  However, if
clang was built with a different default C standard, that will be
preferred.

The default for the C++ standard is moved to C++14.  Although this is a
reduced version, it matches what the current clang compiler defaults to.
Additionally, if the user built clang with a different C++ standard,
that standard would be preferred.

Although the C++ support is a bit more conservative, the idea is that we
can be certain that the clang version fully supports this standard as it
it the default version for clang.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
