### PR TITLE
Unblock newbies, suggesting --skip-test-cmark

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -241,7 +241,8 @@ Phew, that's a lot to digest! Now let's proceed to the actual build itself!
    There is also a third option, which is somewhat more involved:
    [using both Ninja and Xcode](#using-both-ninja-and-xcode).
 3. Build the toolchain with optimizations, debuginfo, and assertions and run
-   the tests.
+   the tests.  **Note:** until https://bugs.swift.org/browse/SR-13635 is fixed you
+   may need to add `--skip-test-cmark` to these commands.
    - Via Ninja:
      ```sh
      utils/build-script --skip-build-benchmarks \


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-13635 seems to affect lots of people and nobody knows why.  I know this isn't the right fix but it should prevent people from getting blocked.  Also https://forums.swift.org/t/failing-tests-while-compiling-swift-on-xcode-12-with-macos-big-sur-beta/40749

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apple/swift/35294)
<!-- Reviewable:end -->
