### PR TITLE
[Sema] Fix storage of availability macros definition for SourceKit

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -116,7 +116,7 @@ namespace swift {
     std::string RequireExplicitAvailabilityTarget;
 
     // Availability macros definitions to be expanded at parsing.
-    SmallVector<StringRef, 4> AvailabilityMacros;
+    SmallVector<std::string, 4> AvailabilityMacros;
 
     /// If false, '#file' evaluates to the full path rather than a
     /// human-readable string.

--- a/test/SourceKit/Sema/availability_define.swift
+++ b/test/SourceKit/Sema/availability_define.swift
@@ -1,0 +1,15 @@
+// RUN: %sourcekitd-test -req=sema %s -- %s \
+// RUN:  -Xfrontend -define-availability \
+// RUN:  -Xfrontend "_iOS8Aligned:macOS 10.10, iOS 8.0" | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+@available(_iOS8Aligned, *)
+public func onMacOS10_10() {}
+// CHECK-NOT: key.line: 7,
+
+@available(_iOS9Aligned, *)
+public func onMacOS10_11() {}
+// CHECK: key.line: 11,
+// CHECK: key.column: 26,
+// CHECK: key.description: "expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'",

--- a/test/SourceKit/Sema/availability_define.swift
+++ b/test/SourceKit/Sema/availability_define.swift
@@ -4,12 +4,15 @@
 
 // REQUIRES: OS=macosx
 
-@available(_iOS8Aligned, *)
-public func onMacOS10_10() {}
-// CHECK-NOT: key.line: 7,
-
+// Should fail.
 @available(_iOS9Aligned, *)
 public func onMacOS10_11() {}
-// CHECK: key.line: 11,
-// CHECK: key.column: 26,
-// CHECK: key.description: "expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'",
+// CHECK: key.line: 8
+// CHECK: key.description: "expected 'available' option such as 'unavailable', 'introduced', 'deprecated', 'obsoleted', 'message', or 'renamed'"
+// CHECK: key.line: 8
+// CHECK: key.description: "expected declaration"
+
+// Should be OK.
+@available(_iOS8Aligned, *)
+public func onMacOS10_10() {}
+// CHECK-NOT: key.line


### PR DESCRIPTION
Copy the availability macros definition from the program command line arguments into LangOptions. This should fix non-deterministic failures at parsing them in SourceKit.

rdar://72356584