### PR TITLE
SILGen: Copy values fed from completion handler invocation to balance retains.

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -233,7 +233,7 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
                                            IsNotDynamic);
   
   if (F->empty()) {
-    // TODO: Emit the implementation.
+    // Emit the implementation.
     SILGenFunction SGF(*this, *F, SwiftModule);
     {
       Scope scope(SGF, loc);
@@ -310,7 +310,7 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
           // Convert the ObjC argument to the bridged Swift representation we
           // want.
           ManagedValue bridgedArg = SGF.emitBridgedToNativeValue(loc,
-                                       arg,
+                                       arg.copy(SGF, loc),
                                        arg.getType().getASTType(),
                                        // FIXME: pass down formal type
                                        destBuf->getType().getASTType(),

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -47,6 +47,10 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)doSomethingSlowNullably:(NSString *)operation completionHandler:(void (^ _Nullable)(NSInteger))handler;
 -(void)findAnswerNullably:(NSString *)operation completionHandler:(void (^ _Nullable)(NSString *))handler;
 -(void)doSomethingDangerousNullably:(NSString *)operation completionHandler:(void (^ _Nullable)(NSString *_Nullable, NSError *_Nullable))handler;
+
+// rdar://72604599
+- (void)stopRecordingWithHandler:(nullable void (^)(NSObject *_Nullable_result x, NSError *_Nullable error))handler __attribute__((swift_async_name("stopRecording()"))) __attribute__((swift_async(not_swift_private, 1)));
+
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -58,6 +58,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
   let _: String = await slowServer.findAnswerNullably("foo")
   let _: String = try await slowServer.doSomethingDangerousNullably("foo")
+
+  let _: NSObject? = try await slowServer.stopRecording()
 }
 
 // CHECK: sil{{.*}}@[[INT_COMPLETION_BLOCK]]
@@ -77,8 +79,9 @@ func testSlowServer(slowServer: SlowServer) async throws {
 // CHECK:   switch_enum [[ERROR_IN_B]] : {{.*}}, case #Optional.some!enumelt: [[ERROR_BB:bb[0-9]+]], case #Optional.none!enumelt: [[RESUME_BB:bb[0-9]+]]
 // CHECK: [[RESUME_BB]]:
 // CHECK:   [[RESULT_BUF:%.*]] = alloc_stack $String
+// CHECK:   [[RESUME_CP:%.*]] = copy_value [[RESUME_IN]]
 // CHECK:   [[BRIDGE:%.*]] = function_ref @{{.*}}unconditionallyBridgeFromObjectiveC
-// CHECK:   [[BRIDGED_RESULT:%.*]] = apply [[BRIDGE]]([[RESUME_IN]]
+// CHECK:   [[BRIDGED_RESULT:%.*]] = apply [[BRIDGE]]([[RESUME_CP]]
 // CHECK:   store [[BRIDGED_RESULT]] to [init] [[RESULT_BUF]]
 // CHECK:   [[RESUME:%.*]] = function_ref @{{.*}}resumeUnsafeThrowingContinuation
 // CHECK:   apply [[RESUME]]<String>([[CONT]], [[RESULT_BUF]])


### PR DESCRIPTION
If a completion handler takes an error argument, then the non-error arguments are bridged and forwarded to
the continuation only on the happy path. Make sure we forward a copy so the retain level of the success values
remains balanced across both branches. Fixes rdar://72604599.