### PR TITLE
[5.4][Diagnostics] Attempt `.rawValue` fix only if both types are equally …

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4263,11 +4263,16 @@ bool ConstraintSystem::repairFailures(
       break;
     }
 
-    if (repairByUsingRawValueOfRawRepresentableType(lhs, rhs))
-      break;
-
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))
+      break;
+
+    // Let's wait until both sides are of the same optionality before
+    // attempting `.rawValue` fix.
+    if (hasConversionOrRestriction(ConversionRestrictionKind::ValueToOptional))
+      break;
+
+    if (repairByUsingRawValueOfRawRepresentableType(lhs, rhs))
       break;
 
     // If there are any restrictions here we need to wait and let

--- a/test/Constraints/sr13951.swift
+++ b/test/Constraints/sr13951.swift
@@ -29,8 +29,16 @@ func aTransformer(input: Int) -> TheEnum {
 func theProblem(input: Int?) {
   var enumValue: TheEnum?
 
+  func test_arg_position(_: TheEnum?) {}
+
   if let input = input {
     enumValue = aTransformer(input: input) // Ok
+    let _: TheEnum? = enumValue // Ok
+    let _: TheEnum? = aTransformer(input: input)  // Ok
+    let _: TheEnum?? = enumValue // Ok
+    let _: TheEnum?? = aTransformer(input: input)  // Ok
+    test_arg_position(aTransformer(input: input)) // Ok
+    test_arg_position(enumValue) // Ok
   }
 
   _ = enumValue // To silence the warning


### PR DESCRIPTION
…optional

This is a follow-up to https://github.com/apple/swift/pull/35072.

Let's wait until both sides are equally optional before attempting
`.rawValue` fix, otherwise there is a risk that a valid code would
get diagnosed.

Extend test coverage of possible `.rawValue` situations to
contextual and argument positions to make sure that valid
code is accepted.

Resolves: SR-13951
(cherry picked from commit 26415547e011ede07956e6dce9a2a3a984b4b8ce)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
