### PR TITLE
[Sema] Diagnose type error on Clang type mismatch.

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -504,7 +504,8 @@ struct PrintOptions {
   }
 
   /// Retrieve the set of options suitable for diagnostics printing.
-  static PrintOptions printForDiagnostics(AccessLevel accessFilter) {
+  static PrintOptions printForDiagnostics(AccessLevel accessFilter,
+                                          bool printFullConvention) {
     PrintOptions result = printVerbose();
     result.PrintAccess = true;
     result.Indent = 4;
@@ -523,12 +524,16 @@ struct PrintOptions {
         QualifyNestedDeclarations::TypesOnly;
     result.PrintDocumentationComments = false;
     result.PrintCurrentMembersOnly = true;
+    if (printFullConvention)
+      result.PrintFunctionRepresentationAttrs =
+          PrintOptions::FunctionRepresentationMode::Full;
     return result;
   }
 
   /// Retrieve the set of options suitable for interface generation.
-  static PrintOptions printInterface() {
-    PrintOptions result = printForDiagnostics(AccessLevel::Public);
+  static PrintOptions printInterface(bool printFullConvention) {
+    PrintOptions result =
+        printForDiagnostics(AccessLevel::Public, printFullConvention);
     result.SkipUnavailable = true;
     result.SkipImplicit = true;
     result.SkipSwiftPrivateClangDecls = true;
@@ -565,8 +570,8 @@ struct PrintOptions {
   /// Retrieve the set of options suitable for "Generated Interfaces", which
   /// are a prettified representation of the public API of a module, to be
   /// displayed to users in an editor.
-  static PrintOptions printModuleInterface();
-  static PrintOptions printTypeInterface(Type T);
+  static PrintOptions printModuleInterface(bool printFullConvention);
+  static PrintOptions printTypeInterface(Type T, bool printFullConvention);
 
   void setBaseType(Type T);
 
@@ -582,16 +587,16 @@ struct PrintOptions {
   }
 
   /// Retrieve the print options that are suitable to print the testable interface.
-  static PrintOptions printTestableInterface() {
-    PrintOptions result = printInterface();
+  static PrintOptions printTestableInterface(bool printFullConvention) {
+    PrintOptions result = printInterface(printFullConvention);
     result.AccessFilter = AccessLevel::Internal;
     return result;
   }
 
   /// Retrieve the print options that are suitable to print interface for a
   /// swift file.
-  static PrintOptions printSwiftFileInterface() {
-    PrintOptions result = printInterface();
+  static PrintOptions printSwiftFileInterface(bool printFullConvention) {
+    PrintOptions result = printInterface(printFullConvention);
     result.AccessFilter = AccessLevel::Internal;
     result.EmptyLineBetweenMembers = true;
     return result;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -547,6 +547,9 @@ namespace swift {
     /// Enable experimental support for one-way constraints for the
     /// parameters of closures.
     bool EnableOneWayClosureParameters = false;
+
+    /// See \ref FrontendOptions.PrintFullConvention
+    bool PrintFullConvention = false;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1375,6 +1375,17 @@ enum class ConstraintSystemFlags {
   /// CodeCompletionExpr, and should continue in the presence of errors wherever
   /// possible.
   ForCodeCompletion = 0x40,
+
+  /// Include Clang function types when checking equality for function types.
+  ///
+  /// When LangOptions.UseClangFunctionTypes is set, we can synthesize
+  /// different @convention(c) function types with the same parameter and result
+  /// types (similarly for blocks). This difference is reflected in the `cType:`
+  /// field (@convention(c, cType: ...)). When the cType is different, the types
+  /// should be treated as semantically different, as they may have different
+  /// calling conventions, say due to Clang attributes such as
+  /// `__attribute__((ns_consumed))`.
+  UseClangFunctionTypes = 0x80,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -770,6 +770,9 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.EnableOneWayClosureParameters |=
       Args.hasArg(OPT_experimental_one_way_closure_params);
 
+  Opts.PrintFullConvention |=
+      Args.hasArg(OPT_experimental_print_full_convention);
+
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -900,7 +900,8 @@ static void dumpAPIIfNeeded(const CompilerInstance &Instance) {
     SmallString<512> TempBuf;
     llvm::raw_svector_ostream TempOS(TempBuf);
 
-    PrintOptions PO = PrintOptions::printInterface();
+    PrintOptions PO = PrintOptions::printInterface(
+        Invocation.getFrontendOptions().PrintFullConvention);
     PO.PrintOriginalSourceText = true;
     PO.Indent = 2;
     PO.PrintAccess = false;

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -359,7 +359,8 @@ visitDocComment(const DocComment *DC, TypeOrExtensionDecl SynthesizedTarget) {
   }
 
   {
-    PrintOptions PO = PrintOptions::printInterface();
+    PrintOptions PO = PrintOptions::printInterface(
+        D->getASTContext().TypeCheckerOpts.PrintFullConvention);
     PO.PrintAccess = false;
     PO.AccessFilter = AccessLevel::Private;
     PO.PrintDocumentationComments = false;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -58,14 +58,15 @@ class ModulePrinterPrintableChecker: public ShouldPrintChecker {
   }
 };
 
-PrintOptions PrintOptions::printModuleInterface() {
-  PrintOptions result = printInterface();
+PrintOptions PrintOptions::printModuleInterface(bool printFullConvention) {
+  PrintOptions result = printInterface(printFullConvention);
   result.CurrentPrintabilityChecker.reset(new ModulePrinterPrintableChecker());
   return result;
 }
 
-PrintOptions PrintOptions::printTypeInterface(Type T) {
-  PrintOptions result = printModuleInterface();
+PrintOptions PrintOptions::printTypeInterface(Type T,
+                                              bool printFullConvention) {
+  PrintOptions result = printModuleInterface(printFullConvention);
   result.PrintExtensionFromConformingProtocols = true;
   result.TransformContext = TypeTransformContext(T);
   result.printExtensionContentAsMembers = [T](const ExtensionDecl *ED) {
@@ -77,7 +78,8 @@ PrintOptions PrintOptions::printTypeInterface(Type T) {
 }
 
 PrintOptions PrintOptions::printDocInterface() {
-  PrintOptions result = PrintOptions::printModuleInterface();
+  PrintOptions result =
+      PrintOptions::printModuleInterface(/*printFullConvention*/ false);
   result.PrintAccess = false;
   result.SkipUnavailable = false;
   result.ExcludeAttrList.push_back(DAK_Available);

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -172,7 +172,9 @@ printTypeInterface(ModuleDecl *M, Type Ty, ASTPrinter &Printer,
   }
   Ty = Ty->getRValueType();
   if (auto ND = Ty->getNominalOrBoundGenericNominal()) {
-    PrintOptions Options = PrintOptions::printTypeInterface(Ty.getPointer());
+    PrintOptions Options = PrintOptions::printTypeInterface(
+        Ty.getPointer(),
+        Ty->getASTContext().TypeCheckerOpts.PrintFullConvention);
     ND->print(Printer, Options);
     printTypeNameToString(Ty, TypeName);
     return false;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -86,6 +86,8 @@ ConstraintSystem::ConstraintSystem(DeclContext *dc,
       DC->getParentModule()->isMainModule()) {
     Options |= ConstraintSystemFlags::DebugConstraints;
   }
+  if (Context.LangOpts.UseClangFunctionTypes)
+    Options |= ConstraintSystemFlags::UseClangFunctionTypes;
 }
 
 ConstraintSystem::~ConstraintSystem() {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3085,8 +3085,8 @@ printRequirementStub(ValueDecl *Requirement, DeclContext *Adopter,
       }
     }
 
-    PrintOptions Options =
-        PrintOptions::printForDiagnostics(AccessLevel::Private);
+    PrintOptions Options = PrintOptions::printForDiagnostics(
+        AccessLevel::Private, Ctx.TypeCheckerOpts.PrintFullConvention);
     Options.PrintDocumentationComments = false;
     Options.PrintAccess = false;
     Options.SkipAttributes = true;

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -339,9 +339,10 @@ void SymbolGraph::recordConformanceSynthesizedMemberRelationships(Symbol S) {
     return;
   }
 
-  SynthesizedExtensionAnalyzer
-  ExtensionAnalyzer(const_cast<NominalTypeDecl*>(OwningNominal),
-      PrintOptions::printModuleInterface());
+  SynthesizedExtensionAnalyzer ExtensionAnalyzer(
+      const_cast<NominalTypeDecl *>(OwningNominal),
+      PrintOptions::printModuleInterface(
+          OwningNominal->getASTContext().TypeCheckerOpts.PrintFullConvention));
   auto MergeGroupKind = SynthesizedExtensionAnalyzer::MergeGroupKind::All;
   ExtensionAnalyzer.forEachExtensionMergeGroup(MergeGroupKind,
       [&](ArrayRef<ExtensionInfo> ExtensionInfos){

--- a/test/Sema/clang_fn_type_mismatch.swift
+++ b/test/Sema/clang_fn_type_mismatch.swift
@@ -1,5 +1,50 @@
-// RUN: not --crash %target-typecheck-verify-swift -sdk %clang-importer-sdk -experimental-print-full-convention -use-clang-function-types
+// RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -experimental-print-full-convention -use-clang-function-types
 
 import ctypes
 
-let _error : (@convention(c, cType: "(void *) (*)(void *)") (Int) -> Int)? = getFunctionPointer_()
+// Setting a C function type with the correct cType works.
+let f1 : (@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)? = getFunctionPointer_()
+
+// However, trying to convert between @convention(c) functions
+// with differing cTypes doesn't work.
+
+let _ : @convention(c) (Int) -> Int = f1!
+// expected-error@-1{{cannot convert value of type '@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int' to specified type '@convention(c) (Int) -> Int'}}
+
+let _ : (@convention(c) (Int) -> Int)? = f1
+// expected-error@-1{{cannot convert value of type '(@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to specified type '(@convention(c) (Int) -> Int)?'}}
+
+let _ : (@convention(c, cType: "void *(*)(void *)") (Int) -> Int)? = f1
+// expected-error@-1{{cannot convert value of type '(@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to specified type '(@convention(c, cType: "void *(*)(void *)") (Int) -> Int)?'}}
+
+
+// Converting from @convention(c) -> @convention(swift) works
+
+let _ : (Int) -> Int = ({ x in x } as @convention(c) (Int) -> Int)
+let _ : (Int) -> Int = ({ x in x } as @convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)
+
+
+// Converting from @convention(swift) -> @convention(c) doesn't work.
+
+let fs : (Int) -> Int = { x in x }
+
+let _ : @convention(c) (Int) -> Int = fs
+// expected-error@-1{{a C function pointer can only be formed from a reference to a 'func' or a literal closure}}
+
+let _ : @convention(c, cType: "size_t (*)(size_t)") (Int) -> Int = fs
+// expected-error@-1{{a C function pointer can only be formed from a reference to a 'func' or a literal closure}}
+
+
+// More complex examples.
+
+let f2 : (@convention(c) ((@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?)? = getHigherOrderFunctionPointer()!
+
+let _ : (@convention(c) ((@convention(c) (Swift.Int) -> Swift.Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Swift.Int) -> Swift.Int)?)? = f2!
+// expected-error@-1{{cannot convert value of type '@convention(c) ((@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to specified type '(@convention(c) ((@convention(c) (Int) -> Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?)?'}}
+
+let _ : (@convention(c) ((@convention(c) (Swift.Int) -> Swift.Int)?) -> (@convention(c) (Swift.Int) -> Swift.Int)?)? = f2!
+// expected-error@-1{{cannot convert value of type '@convention(c) ((@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?) -> (@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to specified type '(@convention(c) ((@convention(c) (Int) -> Int)?) -> (@convention(c) (Int) -> Int)?)?'}}
+
+let f3 = getFunctionPointer3
+
+let _ : @convention(c) (UnsafeMutablePointer<ctypes.Dummy>?) -> UnsafeMutablePointer<ctypes.Dummy>? = f3()!

--- a/test/Sema/clang_fn_type_mismatch.swift
+++ b/test/Sema/clang_fn_type_mismatch.swift
@@ -1,0 +1,5 @@
+// RUN: not --crash %target-typecheck-verify-swift -sdk %clang-importer-sdk -experimental-print-full-convention -use-clang-function-types
+
+import ctypes
+
+let _error : (@convention(c, cType: "(void *) (*)(void *)") (Int) -> Int)? = getFunctionPointer_()

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -286,7 +286,8 @@ static bool getModuleInterfaceInfo(ASTContext &Ctx,
     return true;
   }
 
-  PrintOptions Options = PrintOptions::printModuleInterface();
+  PrintOptions Options = PrintOptions::printModuleInterface(
+      Ctx.TypeCheckerOpts.PrintFullConvention);
   ModuleTraversalOptions TraversalOptions = None; // Don't print submodules.
   SmallString<128> Text;
   llvm::raw_svector_ostream OS(Text);
@@ -313,7 +314,8 @@ static bool getHeaderInterfaceInfo(ASTContext &Ctx,
     return true;
   }
 
-  PrintOptions Options = PrintOptions::printModuleInterface();
+  PrintOptions Options = PrintOptions::printModuleInterface(
+      Ctx.TypeCheckerOpts.PrintFullConvention);
 
   SmallString<128> Text;
   llvm::raw_svector_ostream OS(Text);
@@ -336,7 +338,8 @@ SwiftInterfaceGenContext::createForSwiftSource(StringRef DocumentName,
   IFaceGenCtx->Impl.ModuleOrHeaderName = SourceFileName.str();
   IFaceGenCtx->Impl.AstUnit = AstUnit;
 
-  PrintOptions Options = PrintOptions::printSwiftFileInterface();
+  PrintOptions Options = PrintOptions::printSwiftFileInterface(
+      Invocation.getFrontendOptions().PrintFullConvention);
   SmallString<128> Text;
   llvm::raw_svector_ostream OS(Text);
   AnnotatingPrinter Printer(IFaceGenCtx->Impl.Info, OS);

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -760,8 +760,9 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   bool InSynthesizedExtension = false;
   if (BaseType) {
     if (auto Target = BaseType->getAnyNominal()) {
-      SynthesizedExtensionAnalyzer Analyzer(Target,
-                                          PrintOptions::printModuleInterface());
+      SynthesizedExtensionAnalyzer Analyzer(
+          Target, PrintOptions::printModuleInterface(
+                      Invoc.getFrontendOptions().PrintFullConvention));
       InSynthesizedExtension = Analyzer.isInSynthesizedExtension(VD);
     }
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2733,7 +2733,8 @@ static int doPrintSwiftFileInterface(const CompilerInvocation &InitInvok,
   else
     Printer.reset(new StreamPrinter(llvm::outs()));
 
-  PrintOptions Options = PrintOptions::printSwiftFileInterface();
+  PrintOptions Options = PrintOptions::printSwiftFileInterface(
+      InitInvok.getFrontendOptions().PrintFullConvention);
   if (options::PrintOriginalSourceText)
     Options.PrintOriginalSourceText = true;
   printSwiftSourceInterface(*CI.getPrimarySourceFile(), *Printer, Options);
@@ -3946,7 +3947,8 @@ int main(int argc, char *argv[]) {
 
   PrintOptions PrintOpts;
   if (options::PrintInterface) {
-    PrintOpts = PrintOptions::printModuleInterface();
+    PrintOpts = PrintOptions::printModuleInterface(
+        InitInvok.getFrontendOptions().PrintFullConvention);
   } else if (options::PrintInterfaceForDoc) {
     PrintOpts = PrintOptions::printDocInterface();
   } else {


### PR DESCRIPTION
First commit has a crash test, third commit fixes the crash. I will investigate adding an implicit conversion later; for now, we just disallow any mismatch.

Fixes rdar://71904525.