### PR TITLE
[WIP][Concurrency] Port the classic "ring" benchmark to swift actors

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -27,6 +27,7 @@ include(AddSwiftBenchmarkSuite)
 
 set(SWIFT_BENCH_MODULES
     single-source/Ackermann
+    single-source/ActorRing
     single-source/AngryPhonebook
     single-source/AnyHashableWithAClass
     single-source/Array2D

--- a/benchmark/single-source/ActorRing.swift
+++ b/benchmark/single-source/ActorRing.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-//import TestsUtils
+import TestsUtils
 
 // Based on Joe Armstrong's task from the Programming Erlang book:
 // > Write a ring benchmark.
@@ -21,15 +21,16 @@
 // This benchmark measures how much time it takes to send messages around such "ring",
 // it involves waking up multiple actors and as such also shows the efficiency of the scheduling.
 
-//public let RingTests = [
+public let ActorRing: [BenchmarkInfo] = [
 //  BenchmarkInfo(
-//    name: "RingBenchmarks.bench_ring_m100_n10",
-//    runFunction: { bench_ring() },
+//    name: "ActorRing.bench_ring_m100_n10",
+//    runFunction: bench_ring,
 //    tags: [.actor],
 //    setUpFunction: { spawnRingActors(m: 100, n: 10) },
 //    tearDownFunction: { loopInit = nil }
 //  ),
-//]
+  // TODO: bigger rings too
+]
 
 // === -------------------------------------------------------------------------
 //private let q = LinkedBlockingQueue<Int>()
@@ -51,7 +52,6 @@ struct Token {
 }
 
 protocol LoopMember {
-  // var id: Int { get }
   func tell(_ token: Token) async
 }
 
@@ -64,11 +64,6 @@ actor class TokenLoopActor: LoopMember {
     self.id = id
     self.next = next
     self.token = token
-
-//    if id == 1 {
-//      // I am the leader and shall create the ring
-//      self.spawnActorRing()
-//    }
   }
 
   func tell(_ token: Token) async {
@@ -105,7 +100,7 @@ actor class LoopInitActor: LoopMember {
     // print("START RING SEND... \(Timer().getTime())")
 
     // print("Send \(m) \(context.myself.path.name) >>> \(loopRef.path.name)")
-    await next?.tell(token)
+    await next!.tell(token)
 
     // self.token = token
     // return loopMember(id: 1, next: loopRef, token: token)
@@ -114,23 +109,25 @@ actor class LoopInitActor: LoopMember {
 
 //private let mutex = _Mutex()
 
-var loopInit: LoopInitActor! = nil
+var loopInit: LoopInitActor? = nil
 
 func spawnRingActors(m messages: Int, n actors: Int) {
   loopInit = LoopInitActor()
   runAsyncAndBlock {
-    await loopInit.spawnRingActors(m: messages, n: actors)
+    await loopInit!.spawnRingActors(m: messages, n: actors)
   }
 }
 
 // === -----------------------------------------------------------------------------------------------------------------
 
-//@inline(never)
-//func bench_ring() {
-//  //  ringStart.store(Timer().getTimeAsInt())
-//  loopInit.tell(Token(100_000))
+@inline(never)
+func bench_ring(i: Int) {
+//  runAsyncAndBlock {
+//    //  ringStart.store(Timer().getTimeAsInt())
+//    await loopInit!.tell(Token(100_000))
 //
-//  //  _ = q.poll(.seconds(20))
-//  //  print("    Spawning           : \((spawnStop.load() - spawnStart.load()).milliseconds) ms")
-//  //  print("    Sending around Ring: \((ringStop.load() - ringStart.load()).milliseconds) ms")
-//}
+//    //  _ = q.poll(.seconds(20))
+//    //  print("    Spawning           : \((spawnStop.load() - spawnStart.load()).milliseconds) ms")
+//    //  print("    Sending around Ring: \((ringStop.load() - ringStart.load()).milliseconds) ms")
+//  }
+}

--- a/benchmark/single-source/ActorRing.swift
+++ b/benchmark/single-source/ActorRing.swift
@@ -1,0 +1,136 @@
+//===--- ActorRing.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//import TestsUtils
+
+// Based on Joe Armstrong's task from the Programming Erlang book:
+// > Write a ring benchmark.
+// > Create N processes in a ring.
+// > Send a message round the ring M times so that a total of N * M messages get sent.
+// > Time how long this takes for different values of N and M.
+//
+// This benchmark measures how much time it takes to send messages around such "ring",
+// it involves waking up multiple actors and as such also shows the efficiency of the scheduling.
+
+//public let RingTests = [
+//  BenchmarkInfo(
+//    name: "RingBenchmarks.bench_ring_m100_n10",
+//    runFunction: { bench_ring() },
+//    tags: [.actor],
+//    setUpFunction: { spawnRingActors(m: 100, n: 10) },
+//    tearDownFunction: { loopInit = nil }
+//  ),
+//]
+
+// === -------------------------------------------------------------------------
+//private let q = LinkedBlockingQueue<Int>()
+//
+//private let spawnStart = Atomic<UInt64>(value: 0)
+//private let spawnStop = Atomic<UInt64>(value: 0)
+//
+//private let ringStart = Atomic<UInt64>(value: 0)
+//private let ringStop = Atomic<UInt64>(value: 0)
+
+// === -------------------------------------------------------------------------
+
+struct Token {
+  let payload: Int
+
+  init(_ payload: Int) {
+    self.payload = payload
+  }
+}
+
+protocol LoopMember {
+  // var id: Int { get }
+  func tell(_ token: Token) async
+}
+
+actor class TokenLoopActor: LoopMember {
+  let id: Int
+  let next: LoopMember
+  let token: Token
+
+  init(id: Int, next: LoopMember, token: Token) {
+    self.id = id
+    self.next = next
+    self.token = token
+
+//    if id == 1 {
+//      // I am the leader and shall create the ring
+//      self.spawnActorRing()
+//    }
+  }
+
+  func tell(_ token: Token) async {
+    switch token.payload {
+    case 1:
+      //      ringStop.store(Timer().getTimeAsInt())
+      // stop. this actor could "stop" now
+      // q.enqueue(0) // done
+      break;
+
+    default:
+      await next.tell(Token(token.payload - 1))
+    }
+  }
+}
+
+actor class LoopInitActor: LoopMember {
+  let id = 0
+  var next: LoopMember?
+
+  func spawnRingActors(m messages: Int, n actors: Int) {
+    // TIME spawning
+    //  spawnStart.store(Timer().getTimeAsInt())
+
+    var next: LoopMember = self
+    for i in (1 ..< actors).reversed() {
+      next = TokenLoopActor(id: i, next: next, token: Token(messages))
+    }
+    //  spawnStop.store(Timer().getTimeAsInt())
+  }
+
+
+  func tell(_ token: Token) async {
+    // print("START RING SEND... \(Timer().getTime())")
+
+    // print("Send \(m) \(context.myself.path.name) >>> \(loopRef.path.name)")
+    await next?.tell(token)
+
+    // self.token = token
+    // return loopMember(id: 1, next: loopRef, token: token)
+  }
+}
+
+//private let mutex = _Mutex()
+
+var loopInit: LoopInitActor! = nil
+
+func spawnRingActors(m messages: Int, n actors: Int) {
+  loopInit = LoopInitActor()
+  runAsyncAndBlock {
+    await loopInit.spawnRingActors(m: messages, n: actors)
+  }
+}
+
+// === -----------------------------------------------------------------------------------------------------------------
+
+//@inline(never)
+//func bench_ring() {
+//  //  ringStart.store(Timer().getTimeAsInt())
+//  loopInit.tell(Token(100_000))
+//
+//  //  _ = q.poll(.seconds(20))
+//  //  print("    Spawning           : \((spawnStop.load() - spawnStart.load()).milliseconds) ms")
+//  //  print("    Sending around Ring: \((ringStop.load() - ringStart.load()).milliseconds) ms")
+//}

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -33,6 +33,9 @@ public enum BenchmarkCategory : String {
   // Algorithms are "micro" that test some well-known algorithm in isolation:
   // sorting, searching, hashing, fibonaci, crypto, etc.
   case algorithm
+  
+  /// Actor runtime benchmark
+  case actor
 
   // Miniapplications are contrived to mimic some subset of application behavior
   // in a way that can be easily measured. They are larger than micro-benchmarks,

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -15,6 +15,7 @@
 import TestsUtils
 import DriverUtils
 import Ackermann
+import ActorRing
 import AngryPhonebook
 import AnyHashableWithAClass
 import Array2D
@@ -206,6 +207,7 @@ private func registerBenchmark<
 }
 
 registerBenchmark(Ackermann)
+registerBenchmark(ActorRing)
 registerBenchmark(AngryPhonebook)
 registerBenchmark(AnyHashableWithAClass)
 registerBenchmark(Array2D)


### PR DESCRIPTION
This implements the classic "ring" benchmark from Joe Armstrong's work:

>  // Based on Joe Armstrong's task from the Programming Erlang book:
>  // > Write a ring benchmark.
>  // > Create N processes in a ring.
>  // > Send a message round the ring M times so that a total of N * M messages get sent.
>  // > Time how long this takes for different values of N and M.
>  //
>  // This benchmark measures how much time it takes to send messages around such "ring",
>  // it involves waking up multiple actors and as such also shows the efficiency of the scheduling.

It is actually quite weird since we await on the calls... but they go in full circle, so really we'd like to detach all the time I guess.

Once I have it running I'll build some variations of it and will be able to post comparisons with erlang, akka etc.

Refs rdar://70832308

---

Been mostly battling how to get it to actually build and run with concurrency...

I've initially been trying to get it built through 1) the build script, then 2) cmake and ninja, but could not figure out a properly passing the parameters -,-'' It should be simple but seems not to be... 



--- notes to self so I can get back to debugging this --- 

It is _not_ just passing as `SWIFT_BENCHMARK_EXTRA_FLAGS`.

```
ktoso@mikazuki-5plusplus [17:36:37] [~/code/swift-project/swift/benchmark/build] [wip-actor-ring *]
-> % cmake /Users/ktoso/code/swift-project/swift/benchmark -G Ninja -DSWIFT_EXEC=/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/bin/swift  -DSWIFT_BENCHMARK_EXTRA_FLAGS="-Xfrontend -enable-experimental-concurrency"

...
--   SWIFT_BENCHMARK_EXTRA_FLAGS = -Xfrontend -enable-experimental-concurrency

-> % ninja swift-benchmark-macosx-x86_64
[1/516] Generating Osize-x86_64-apple-macosx10.9/TestsUtils.o
FAILED: Osize-x86_64-apple-macosx10.9/TestsUtils.o
cd /Users/ktoso/code/swift-project/swift/benchmark/build && /Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/bin/swift -c -target x86_64-apple-macosx10.9 -Osize -Xllvm -align-module-to-page-size -g -I /Users/ktoso/code/swift-project/swift/benchmark/utils/ObjectiveCTests -I /Users/ktoso/code/swift-project/swift/benchmark/utils/LibProc -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/../../../Developer/Library/Frameworks -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk -no-link-objc-runtime -save-optimization-record=bitstream -swift-version 4 -whole-module-optimization -parse-as-library -module-name TestsUtils -emit-module -emit-module-path /Users/ktoso/code/swift-project/swift/benchmark/build/Osize-x86_64-apple-macosx10.9/TestsUtils.swiftmodule -I /Users/ktoso/code/swift-project/swift/benchmark/build/Osize-x86_64-apple-macosx10.9 -o /Users/ktoso/code/swift-project/swift/benchmark/build/Osize-x86_64-apple-macosx10.9/TestsUtils.o /Users/ktoso/code/swift-project/swift/benchmark/utils/TestsUtils.swift
<unknown>:0: error: option '-c' is not supported by 'swift'; did you mean to use 'swiftc'?
<unknown>:0: error: option '-whole-module-optimization' is not supported by 'swift'; did you mean to use 'swiftc'?
<unknown>:0: error: option '-parse-as-library' is not supported by 'swift'; did you mean to use 'swiftc'?
<unknown>:0: error: option '-emit-module' is not supported by 'swift'; did you mean to use 'swiftc'?
<unknown>:0: error: option '-emit-module-path' is not supported by 'swift'; did you mean to use 'swiftc'?
<unknown>:0: error: option '-o' is not supported by 'swift'; did you mean to use 'swiftc'?
[2/516] Generating Onone-x86_64-apple-macosx10.9/TestsUtils.o
FAILED: Onone-x86_64-apple-macosx10.9/TestsUtils.o
```

The swiftpm build is more promising but I need to get a newer toolchain or something... the DYLD_LIBRARY_PATH is not working as it should here somehow 🤔 

```
ktoso@mikazuki-5plusplus [17:29:40] [~/code/swift-project/swift/benchmark] [wip-actor-ring *]
-> % /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-12-23-a.xctoolchain/usr/bin/swift build -c release -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency && \
DYLD_LIBRARY_PATH=/Users/ktoso/code/swift-project/build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64/lib/swift/macosx /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-12-23-a.xctoolchain/usr/bin/swift run -c release -Xswiftc -Xfrontend -Xswiftc -enable-experimental-concurrency SwiftBench --list
dyld: Library not loaded: /usr/lib/swift/libswift_Concurrency.dylib
  Referenced from: /Users/ktoso/code/swift-project/swift/benchmark/.build/x86_64-apple-macosx/release/SwiftBench
  Reason: image not found
[1]    66670 abort      DYLD_LIBRARY_PATH=  run -c release -Xswiftc -Xfrontend -Xswiftc  SwiftBench
```