### PR TITLE
[cxx-interop] Inline constexpr vars.

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -209,8 +209,8 @@ void ASTScope::
 }
 
 void ASTScope::expandFunctionBody(AbstractFunctionDecl *AFD) {
-  auto *const SF = AFD->getParentSourceFile();
-  SF->getScope().expandFunctionBodyImpl(AFD);
+  if (auto *const SF = AFD->getParentSourceFile())
+    SF->getScope().expandFunctionBodyImpl(AFD);
 }
 
 void ASTScope::expandFunctionBodyImpl(AbstractFunctionDecl *AFD) {

--- a/test/Interop/Cxx/static/Inputs/static-member-var.h
+++ b/test/Interop/Cxx/static/Inputs/static-member-var.h
@@ -26,9 +26,15 @@ public:
   const static int definedOutOfLine;
 };
 
+constexpr float getFloatValue() { return 42; }
+constexpr float getIntValue(int arg) { return 40 + arg; }
+
 class WithConstexprStaticMember {
 public:
   constexpr static int definedInline = 139;
+  constexpr static int definedInlineWithArg = getIntValue(2);
+  constexpr static float definedInlineFloat = 139;
+  constexpr static float definedInlineFromMethod = getFloatValue();
 };
 
 class ClassA {

--- a/test/Interop/Cxx/static/static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-irgen.swift
@@ -10,14 +10,12 @@
 // CHECK: @{{_ZN21WithConstStaticMember7definedE|"\?defined@WithConstStaticMember@@2HB"}} = {{available_externally|linkonce_odr}} {{(dso_local )?}}constant i32 48, {{(comdat, )?}}align 4
 // CHECK: @{{_ZN21WithConstStaticMember16definedOutOfLineE|"\?definedOutOfLine@WithConstStaticMember@@2HB"}} = external {{(dso_local )?}}constant i32, align 4
 
-//TODO: This test uses only values of static const members, so it does not need
-//to depend on external definitions. However, our code generation pattern loads
-//the value dynamically. Instead, we should inline known constants. That would
-//allow Swift code to even read the value of WithIncompleteStaticMember::notDefined.
-// NOTE: we allow both available_externally and linkonce_odr as there are
-// differences in between MSVC and itanium model semantics where the constexpr
-// value is emitted into COMDAT.
-// CHECK: @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} = {{available_externally|linkonce_odr}} {{(dso_local )?}}constant i32 139, {{(comdat, )?}}align 4
+// Make sure we remove constexpr globals after all uses have been inlined.
+// CHECK-NOT: _ZN25WithConstexprStaticMember13definedInlineE
+// CHECK-NOT: ?definedInline@WithConstexprStaticMember@@2HB
+// CHECK-NOT: @_ZN25WithConstexprStaticMember20definedInlineWithArgE
+// CHECK-NOT: @_ZN25WithConstexprStaticMember18definedInlineFloatE
+// CHECK-NOT: @_ZN25WithConstexprStaticMember23definedInlineFromMethodE
 
 import StaticMemberVar
 
@@ -73,10 +71,38 @@ public func readDefinedOutOfLineConstMember() -> CInt {
 // CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN21WithConstStaticMember16definedOutOfLineE|"\?definedOutOfLine@WithConstStaticMember@@2HB"}} to %Ts5Int32V*), i32 0, i32 0), align 4
 // CHECK: ret i32 [[VALUE]]
 
-public func readConstexprStaticMember() -> CInt {
-  return WithConstexprStaticMember.definedInline
+public func readConstexprStaticIntMembers() {
+  let x = WithConstexprStaticMember.definedInline
+  let y = WithConstexprStaticMember.definedInlineWithArg
 }
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main25readConstexprStaticMembers5Int32VyF"() #0
-// CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZN25WithConstexprStaticMember13definedInlineE|"\?definedInline@WithConstexprStaticMember@@2HB"}} to %Ts5Int32V*), i32 0, i32 0), align 4
-// CHECK: ret i32 [[VALUE]]
+// CHECK-LABEL: define {{(protected |dllexport )?}}swiftcc void @"$s4main29readConstexprStaticIntMembersyyF"()
+// CHECK: call swiftcc i32 @"$sSo25WithConstexprStaticMemberV13definedInlines5Int32VvgZ"()
+// CHECK: call swiftcc i32 @"$sSo25WithConstexprStaticMemberV013definedInlineA3Args5Int32VvgZ"()
+// CHECK: ret void
+
+// CHECK-LABEL: define linkonce_odr {{.*}}swiftcc i32 @"$sSo25WithConstexprStaticMemberV13definedInlines5Int32VvgZ"()
+// CHECK-NEXT: entry
+// CHECK-NEXT: ret i32 139
+
+// CHECK-LABEL: define linkonce_odr {{.*}}swiftcc i32 @"$sSo25WithConstexprStaticMemberV013definedInlineA3Args5Int32VvgZ"()
+// CHECK-NEXT: entry
+// CHECK-NEXT: ret i32 42
+
+public func readConstexprStaticFloatMembers() {
+  let x = WithConstexprStaticMember.definedInlineFloat
+  let y = WithConstexprStaticMember.definedInlineFromMethod
+}
+
+// CHECK-LABEL: define {{(protected |dllexport )?}}swiftcc void @"$s4main31readConstexprStaticFloatMembersyyF"()
+// CHECK: call swiftcc float @"$sSo25WithConstexprStaticMemberV18definedInlineFloatSfvgZ"()
+// CHECK: call swiftcc float @"$sSo25WithConstexprStaticMemberV23definedInlineFromMethodSfvgZ"()
+// CHECK: ret void
+
+// CHECK-LABEL: define linkonce_odr {{.*}}swiftcc float @"$sSo25WithConstexprStaticMemberV18definedInlineFloatSfvgZ"()
+// CHECK-NEXT: entry
+// CHECK-NEXT: ret float 1.390000e+02
+
+// CHECK-LABEL: define linkonce_odr {{.*}}swiftcc float @"$sSo25WithConstexprStaticMemberV23definedInlineFromMethodSfvgZ"()
+// CHECK-NEXT: entry
+// CHECK-NEXT: ret float 4.200000e+01

--- a/test/Interop/Cxx/static/static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-silgen.swift
@@ -8,8 +8,6 @@
 // CHECK: sil_global public_external [let] @{{_ZN21WithConstStaticMember7definedE|\?defined@WithConstStaticMember@@2HB}} : $Int32
 // CHECK: // clang name: WithConstStaticMember::definedOutOfLine
 // CHECK: sil_global public_external [let] @{{_ZN21WithConstStaticMember16definedOutOfLineE|\?definedOutOfLine@WithConstStaticMember@@2HB}} : $Int32
-// CHECK: // clang name: WithConstexprStaticMember::definedInline
-// CHECK: sil_global public_external [let] @{{_ZN25WithConstexprStaticMember13definedInlineE|\?definedInline@WithConstexprStaticMember@@2HB}} : $Int32
 
 import StaticMemberVar
 
@@ -70,16 +68,20 @@ func readDefinedOutOfLineConstMember() -> CInt {
   return WithConstStaticMember.definedOutOfLine
 }
 
-// CHECK: sil hidden @$s4main31readDefinedOutOfLineConstMembers5Int32VyF : $@convention(thin) () -> Int32
-// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN21WithConstStaticMember16definedOutOfLineE|\?definedOutOfLine@WithConstStaticMember@@2HB}} : $*Int32
-// CHECK: [[VALUE:%.*]] = load [[ADDR]] : $*Int32
-// CHECK: return [[VALUE]] : $Int32
+// CHECK: sil hidden @$s4main25readConstexprStaticMembers5Int32VyF : $@convention(thin) () -> Int32
+// CHECK: [[META:%.*]] = metatype $@thin WithConstexprStaticMember.Type
+// CHECK: [[ACC:%.*]] = function_ref @$sSo25WithConstexprStaticMemberV13definedInlines5Int32VvgZ : $@convention(method) (@thin WithConstexprStaticMember.Type) -> Int32
+// CHECK: [[OUT:%.*]] = apply [[ACC]]([[META]]) : $@convention(method) (@thin WithConstexprStaticMember.Type) -> Int32
+// CHECK: return [[OUT]] : $Int32
+// CHECK-LABEL: end sil function '$s4main25readConstexprStaticMembers5Int32VyF'
+
+// Make sure we also generate the accessor with a numeric literal.
+// CHECK-LABEL: sil shared [serializable] @$sSo25WithConstexprStaticMemberV13definedInlines5Int32VvgZ : $@convention(method) (@thin WithConstexprStaticMember.Type) -> Int32
+// CHECK: [[IL:%.*]] = integer_literal $Builtin.Int32, 139
+// CHECK: [[OUT:%.*]] = struct $Int32 ([[IL]] : $Builtin.Int32)
+// CHECK: return [[OUT]] : $Int32
+// CHECK-LABEL: end sil function '$sSo25WithConstexprStaticMemberV13definedInlines5Int32VvgZ'
 
 func readConstexprStaticMember() -> CInt {
   return WithConstexprStaticMember.definedInline
 }
-
-// CHECK: sil hidden @$s4main25readConstexprStaticMembers5Int32VyF : $@convention(thin) () -> Int32
-// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN25WithConstexprStaticMember13definedInlineE|\?definedInline@WithConstexprStaticMember@@2HB}} : $*Int32
-// CHECK: [[VALUE:%.*]] = load [[ADDR]] : $*Int32
-// CHECK: return [[VALUE]] : $Int32

--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -8,13 +8,16 @@ public func initStaticVars() -> CInt {
     + staticConstexprNonTrivial.val
 }
 
+// Constexpr vars should be inlined and removed.
+// CHECK-NOT: ?staticConstexpr
+// CHECK-NOT: _ZL15staticConstexpr
+
 // CHECK: @{{_ZL9staticVar|staticVar}} = internal global i32 2, align 4
 // CHECK: @{{_ZL13staticVarInit|staticVarInit}} = internal global i32 0, align 4
 // CHECK: @{{_ZL19staticVarInlineInit|staticVarInlineInit}} = internal global i32 0, align 4
 // CHECK: @{{_ZL11staticConst|staticConst}} = internal constant i32 4, align 4
 // CHECK: @{{_ZL15staticConstInit|staticConstInit}} = internal global i32 0, align 4
 // CHECK: @{{_ZL21staticConstInlineInit|staticConstInlineInit}} = internal global i32 0, align 4
-// CHECK: @{{_ZL15staticConstexpr|staticConstexpr}} = internal constant i32 32, align 4
 // CHECK: @{{_ZL16staticNonTrivial|staticNonTrivial}} = internal global %class.NonTrivial zeroinitializer, align 4
 // CHECK: @{{_ZL21staticConstNonTrivial|staticConstNonTrivial}} = internal global %class.NonTrivial zeroinitializer, align 4
 // CHECK: @{{_ZL25staticConstexprNonTrivial|staticConstexprNonTrivial}} = internal constant %class.NonTrivial { i32 8192 }, align 4

--- a/test/Interop/Cxx/static/static-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-var-silgen.swift
@@ -8,6 +8,9 @@ func initStaticVars() -> CInt {
     + staticConstexprNonTrivial.val
 }
 
+// Constexpr globals should be inlined and removed.
+// CHECK-NOT: sil_global public_external [let] @staticConstexpr : $Int32
+
 // CHECK: // clang name: staticVar
 // CHECK: sil_global public_external @staticVar : $Int32
 // CHECK: // clang name: staticVarInit
@@ -20,8 +23,6 @@ func initStaticVars() -> CInt {
 // CHECK: sil_global public_external [let] @staticConstInit : $Int32
 // CHECK: // clang name: staticConstInlineInit
 // CHECK: sil_global public_external [let] @staticConstInlineInit : $Int32
-// CHECK: // clang name: staticConstexpr
-// CHECK: sil_global public_external [let] @staticConstexpr : $Int32
 // CHECK: // clang name: staticNonTrivial
 // CHECK: sil_global public_external @staticNonTrivial : $NonTrivial
 // CHECK: // clang name: staticConstNonTrivial


### PR DESCRIPTION
If a static variable can be evaluated at compile-time, create an accessor using that value. This means static variables will always be inlined and removed.

Note: currently this only works with numeric types.

Resolves SR-14023.
