### PR TITLE
Add a _fixLifetime to stdlib/Set.swift test.

### DIFF
--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -3242,6 +3242,11 @@ SetTestSuite.test("formSymmetricDifference")
 
   // Removing all elements should cause an identity change
   expectNotEqual(identity1, s1._rawIdentifier())
+
+  // Without a fixLifetime here, the (non-ObjC) optimizer destroys
+  // 's1' after its last uses and recycles the storage so the identity
+  // check above fails.
+  _fixLifetime(s1_copy)
 }
 
 SetTestSuite.test("removeFirst") {


### PR DESCRIPTION
On Linux with -O:

[ RUN      ] Set.formSymmetricDifference
stdout>>> check failed at /Users/docker_user/src/build/buildbot_linux/swift-linux-x86_64/main.swift, line 3245
stdout>>> unexpected value: "94788628116752" (of type Swift.Int)
[     FAIL ] Set.formSymmetricDifference

The test is roughly:

  var s1 = Set(...)
  let s1_copy = s1

  let identity1 = s1._rawIdentifier()
  s1.someMutatingMethod1()

  check(s1)
  check(s1_copy)

  s1.someMutatingMethod2()

  // Mutating the set should cause an identity change
  releaseAssert(identity1 != s1._rawIdentifier())

On Linux, the optimizer is able to destroy s1_copy before the call to
s1.someMutatingMethod2(), which generates new Set storage. This new
storage uses the same address as the destroyed s1_copy.

Fixes rdar://72933150 ([CanonicalOSSA] Fix Set.swift unit test that assumes object lifetime)
