### PR TITLE
Add a _fixLifetime call to stdlib/WeakMirror.swift test.

### DIFF
--- a/test/stdlib/WeakMirror.swift
+++ b/test/stdlib/WeakMirror.swift
@@ -113,6 +113,8 @@ mirrors.test("class/NativeSwiftClassHasNativeWeakReferenceNoLeak") {
     let mirror = Mirror(reflecting: parent)
     let children = Array(mirror.children)
     let extractedChild = children[0].1 as! NativeSwiftClass
+    // If child is destroyed, the above cast will fail.
+    _fixLifetime(child)
     expectNotNil(extractedChild)
     expectNotNil(verifier)
   }


### PR DESCRIPTION
On Linux with -O:

Could not cast value of type 'Swift.Optional<Swift.AnyObject>'
(0x7fa5f4285b60) to 'weaktest.NativeSwiftClass' (0x563acd3f30d8).

  weak var verifier: AnyObject?
  do {
    let parent = NativeSwiftClassHasWeak(x: 1010)
    let child = NativeSwiftClass(x: 2020)
    verifier = child
    parent.weakProperty = child
    let mirror = Mirror(reflecting: parent)
    let children = Array(mirror.children)
    let extractedChild = children[0].1 as! NativeSwiftClass
    expectNotNil(extractedChild)
    expectNotNil(verifier)
  }
  expectNil(verifier)

Here the expression children[-1].1 is a weak reference refering back
to 'child'. There's nothing keeping that 'child' object alive. On
Linux, the optimizer is able to destroy child before the dynamic type
cast. The cast attempts to cast a nil weak reference and fails.

Fixes rdar://72933297 ([CanonicalOSSA] Fix WeakMirror.swift test that
assumes object lifetime)

