### PR TITLE
[nfc] [benchmark] [cxx-interop] Add "GlobalVars" benchmark to test static variables.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -192,6 +192,7 @@ set(SWIFT_BENCH_MODULES
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects
+    cxx-source/GlobalVars
 )
 
 set(SWIFT_MULTISOURCE_SWIFT_BENCHES

--- a/benchmark/cxx-source/GlobalVars.swift
+++ b/benchmark/cxx-source/GlobalVars.swift
@@ -1,0 +1,40 @@
+//===--- GlobalVars.swift -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This is a simple test that creates thousands of C++ objects and does nothing
+// with them.
+
+import TestsUtils
+import CxxGlobalVars
+
+public let GlobalVars = BenchmarkInfo(
+  name: "GlobalVars",
+  runFunction: run_GlobalVars,
+  tags: [.validation, .bridging])
+
+@inline(never)
+public func run_GlobalVars(_ N: Int) {
+  for i in 0...(N * 10_000) {
+    let localVar1 = globalInt
+    let localVar2 = globalConstexprInt
+    let localVar3 = globalFloat
+    let localVar4 = globalConstexprFloat
+    let localVar5 = globalBigObject
+    let localVar6 = globalConstexprBigObject
+    blackHole(localVar1)
+    blackHole(localVar2)
+    blackHole(localVar3)
+    blackHole(localVar4)
+    blackHole(localVar5)
+    blackHole(localVar6)
+  }
+}

--- a/benchmark/utils/CxxTests/GlobalVars.h
+++ b/benchmark/utils/CxxTests/GlobalVars.h
@@ -1,0 +1,15 @@
+#ifndef BENCHMARK_GLOBAL_VARS_H
+#define BENCHMARK_GLOBAL_VARS_H
+
+static int globalInt = 42;
+static constexpr int globalConstexprInt = 42;
+static float globalFloat = 42;
+static constexpr float globalConstexprFloat = 42;
+
+struct BigObject {
+  char buff[512];
+};
+static BigObject globalBigObject = BigObject();
+static constexpr BigObject globalConstexprBigObject = BigObject();
+
+#endif // BENCHMARK_GLOBAL_VARS_H

--- a/benchmark/utils/CxxTests/module.modulemap
+++ b/benchmark/utils/CxxTests/module.modulemap
@@ -1,3 +1,8 @@
 module CxxCreateObjects {
   header "CreateObjects.h"
 }
+
+module CxxGlobalVars {
+  header "GlobalVars.h"
+  requires cplusplus
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -86,6 +86,7 @@ import FlattenList
 import FloatingPointConversion
 import FloatingPointParsing
 import FloatingPointPrinting
+import GlobalVars
 import Hanoi
 import Hash
 import Histogram
@@ -280,6 +281,7 @@ registerBenchmark(FlattenListFlatMap)
 registerBenchmark(FloatingPointConversion)
 registerBenchmark(FloatingPointParsing)
 registerBenchmark(FloatingPointPrinting)
+registerBenchmark(GlobalVars)
 registerBenchmark(Hanoi)
 registerBenchmark(HashTest)
 registerBenchmark(Histogram)


### PR DESCRIPTION
Tests performance of loading static C++ variables from Swift. Tests both constexpr and non-constexpr statics.

Refs #35311.