### PR TITLE
[ConstraintSystem] Remove used/checked conformances cache

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -39,6 +39,7 @@ class TypeLoc;
 class VarDecl;
 class Pattern;
 class SourceManager;
+class ProtocolConformance;
 
 namespace constraints {
 
@@ -763,13 +764,13 @@ public:
 };
 
 class LocatorPathElt::ConformanceRequirement final
-    : public StoredPointerElement<ProtocolDecl> {
+    : public StoredPointerElement<ProtocolConformance> {
 public:
-  ConformanceRequirement(ProtocolDecl *protocol)
+  ConformanceRequirement(ProtocolConformance *conformance)
       : StoredPointerElement(PathElementKind::ConformanceRequirement,
-                             protocol) {}
+                             conformance) {}
 
-  ProtocolDecl *getRequirement() const { return getStoredPointer(); }
+  ProtocolConformance *getConformance() const { return getStoredPointer(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::ConformanceRequirement;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1177,9 +1177,6 @@ public:
   llvm::SmallMapVector<const CaseLabelItem *, CaseLabelItemInfo, 4>
       caseLabelItems;
 
-  std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
-      Conformances;
-
   /// The set of functions that have been transformed by a result builder.
   llvm::MapVector<AnyFunctionRef, AppliedBuilderTransform>
       resultBuilderTransformed;
@@ -1254,11 +1251,6 @@ public:
       return known->second;
     return None;
   }
-
-  /// Retrieve a fully-resolved protocol conformance at the given locator
-  /// and with the given protocol.
-  ProtocolConformanceRef resolveConformance(ConstraintLocator *locator,
-                                            ProtocolDecl *proto);
 
   ConstraintLocator *getCalleeLocator(ConstraintLocator *locator,
                                       bool lookThroughApply = true) const;
@@ -2209,9 +2201,6 @@ private:
   /// each node had before introducing this type.
   llvm::SmallVector<std::pair<ASTNode, Type>, 8> addedNodeTypes;
 
-  std::vector<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
-      CheckedConformances;
-
   /// The set of functions that have been transformed by a result builder.
   std::vector<std::pair<AnyFunctionRef, AppliedBuilderTransform>>
       resultBuilderTransformed;
@@ -2674,8 +2663,6 @@ public:
     unsigned numDefaultedConstraints;
 
     unsigned numAddedNodeTypes;
-
-    unsigned numCheckedConformances;
 
     unsigned numDisabledConstraints;
 
@@ -3884,12 +3871,6 @@ public:
                           ConstraintLocatorBuilder locator,
                           const DeclRefExpr *base = nullptr,
                           OpenedTypeMap *replacements = nullptr);
-
-  /// Retrieve a list of conformances established along the current solver path.
-  ArrayRef<std::pair<ConstraintLocator *, ProtocolConformanceRef>>
-  getCheckedConformances() const {
-    return CheckedConformances;
-  }
 
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
   /// with a type variable) along the current path.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7972,12 +7972,8 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
   auto stmt = forEachStmtInfo.stmt;
   auto sequenceProto = TypeChecker::getProtocol(
       cs.getASTContext(), stmt->getForLoc(), KnownProtocolKind::Sequence);
-  auto contextualLocator = solution.getConstraintLocator(
-      target.getAsExpr(),
-      {LocatorPathElt::ContextualType(),
-       LocatorPathElt::ConformanceRequirement(sequenceProto)});
-  auto sequenceConformance =
-      solution.resolveConformance(contextualLocator, sequenceProto);
+  auto sequenceConformance = TypeChecker::conformsToProtocol(
+      forEachStmtInfo.sequenceType, sequenceProto, cs.DC);
   assert(!sequenceConformance.isInvalid() &&
          "Couldn't find sequence conformance");
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8382,34 +8382,6 @@ Expr *Solution::coerceToType(Expr *expr, Type toType,
   return result;
 }
 
-ProtocolConformanceRef Solution::resolveConformance(
-    ConstraintLocator *locator, ProtocolDecl *proto) {
-  auto conformance = llvm::find_if(Conformances, [&locator](const auto &elt) {
-    return elt.first == locator;
-  });
-
-  if (conformance == Conformances.end())
-    return ProtocolConformanceRef::forInvalid();
-
-  // If the conformance doesn't require substitution, return it immediately.
-  auto conformanceRef = conformance->second;
-  if (conformanceRef.isAbstract())
-    return conformanceRef;
-
-  auto concrete = conformanceRef.getConcrete();
-  auto conformingType = concrete->getType();
-  if (!conformingType->hasTypeVariable())
-    return conformanceRef;
-
-  // Substitute into the conformance type, then look for a conformance
-  // again.
-  // FIXME: Should be able to perform the substitution using the Solution
-  // itself rather than another conforms-to-protocol check.
-  Type substConformingType = simplifyType(conformingType);
-  return TypeChecker::conformsToProtocol(substConformingType, proto,
-                                         constraintSystem->DC);
-}
-
 bool Solution::hasType(ASTNode node) const {
   auto result = nodeTypes.find(node);
   if (result != nodeTypes.end())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -205,23 +205,14 @@ const Requirement &RequirementFailure::getRequirement() const {
 
 ProtocolConformance *RequirementFailure::getConformanceForConditionalReq(
     ConstraintLocator *locator) {
-  auto &solution = getSolution();
   auto reqElt = locator->castLastElementTo<LocatorPathElt::AnyRequirement>();
   if (!reqElt.isConditionalRequirement())
     return nullptr;
 
-  auto path = locator->getPath();
-  auto *conformanceLoc = getConstraintLocator(getRawAnchor(), path.drop_back());
-
-  auto result = llvm::find_if(
-      solution.Conformances,
-      [&](const std::pair<ConstraintLocator *, ProtocolConformanceRef>
-              &conformance) { return conformance.first == conformanceLoc; });
-  assert(result != solution.Conformances.end());
-
-  auto conformance = result->second;
-  assert(conformance.isConcrete());
-  return conformance.getConcrete();
+  auto conformanceRef =
+    locator->findLast<LocatorPathElt::ConformanceRequirement>();
+  assert(conformanceRef && "Invalid locator for a conditional requirement");
+  return conformanceRef->getConformance();
 }
 
 ValueDecl *RequirementFailure::getDeclRef() const {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5721,18 +5721,17 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   /// Record the given conformance as the result, adding any conditional
   /// requirements if necessary.
   auto recordConformance = [&](ProtocolConformanceRef conformance) {
-    auto *conformanceLoc = getConstraintLocator(
-        loc, LocatorPathElt::ConformanceRequirement(protocol));
-    // Record the conformance.
-    CheckedConformances.push_back({conformanceLoc, conformance});
-
-    if (isConformanceUnavailable(conformance, conformanceLoc))
+    if (isConformanceUnavailable(conformance, loc))
       increaseScore(SK_Unavailable);
 
     // This conformance may be conditional, in which case we need to consider
     // those requirements as constraints too.
     if (conformance.isConcrete()) {
       unsigned index = 0;
+      auto *conformanceLoc = getConstraintLocator(
+          loc,
+          LocatorPathElt::ConformanceRequirement(conformance.getConcrete()));
+
       for (const auto &req : conformance.getConditionalRequirements()) {
         addConstraint(
             req, getConstraintLocator(conformanceLoc,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -185,9 +185,6 @@ Solution ConstraintSystem::finalize() {
   solution.solutionApplicationTargets = solutionApplicationTargets;
   solution.caseLabelItems = caseLabelItems;
 
-  for (auto &e : CheckedConformances)
-    solution.Conformances.push_back({e.first, e.second});
-
   for (const auto &transformed : resultBuilderTransformed) {
     solution.resultBuilderTransformed.insert(transformed);
   }
@@ -272,10 +269,6 @@ void ConstraintSystem::applySolution(const Solution &solution) {
     if (!getCaseLabelItemInfo(info.first))
       setCaseLabelItemInfo(info.first, info.second);
   }
-
-  // Register the conformances checked along the way to arrive to solution.
-  for (auto &conformance : solution.Conformances)
-    CheckedConformances.push_back(conformance);
 
   for (const auto &transformed : solution.resultBuilderTransformed) {
     resultBuilderTransformed.push_back(transformed);
@@ -477,7 +470,6 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numOpenedExistentialTypes = cs.OpenedExistentialTypes.size();
   numDefaultedConstraints = cs.DefaultedConstraints.size();
   numAddedNodeTypes = cs.addedNodeTypes.size();
-  numCheckedConformances = cs.CheckedConformances.size();
   numDisabledConstraints = cs.solverState->getNumDisabledConstraints();
   numFavoredConstraints = cs.solverState->getNumFavoredConstraints();
   numResultBuilderTransformed = cs.resultBuilderTransformed.size();
@@ -554,9 +546,6 @@ ConstraintSystem::SolverScope::~SolverScope() {
       cs.NodeTypes.erase(node);
   }
   truncate(cs.addedNodeTypes, numAddedNodeTypes);
-
-  // Remove any conformances checked along the current path.
-  truncate(cs.CheckedConformances, numCheckedConformances);
 
   /// Remove any builder transformed closures.
   truncate(cs.resultBuilderTransformed, numResultBuilderTransformed);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -18,6 +18,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/Sema/ConstraintLocator.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "llvm/ADT/StringExtras.h"
@@ -399,9 +400,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
     }
 
     case ConformanceRequirement: {
-      auto reqElt = elt.castTo<LocatorPathElt::ConformanceRequirement>();
+      auto *conformance =
+          elt.castTo<LocatorPathElt::ConformanceRequirement>().getConformance();
       out << "conformance requirement (";
-      reqElt.getRequirement()->dumpRef(out);
+      conformance->getProtocol()->dumpRef(out);
       out << ")";
       break;
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2903,8 +2903,7 @@ size_t Solution::getTotalMemory() const {
          ConstraintRestrictions.getMemorySize() +
          llvm::capacity_in_bytes(Fixes) + DisjunctionChoices.getMemorySize() +
          OpenedTypes.getMemorySize() + OpenedExistentialTypes.getMemorySize() +
-         (DefaultedConstraints.size() * sizeof(void *)) +
-         Conformances.size() * sizeof(std::pair<ConstraintLocator *, ProtocolConformanceRef>);
+         (DefaultedConstraints.size() * sizeof(void *));
 }
 
 DeclContext *Solution::getDC() const { return constraintSystem->DC; }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5181,22 +5181,12 @@ static Optional<Requirement> getRequirement(ConstraintSystem &cs,
     return None;
 
   if (reqLoc->isConditionalRequirement()) {
-    auto path = reqLocator->getPath();
-    auto *conformanceLoc =
-        cs.getConstraintLocator(reqLocator->getAnchor(), path.drop_back());
+    auto conformanceRef =
+        reqLocator->findLast<LocatorPathElt::ConformanceRequirement>();
+    assert(conformanceRef && "Invalid locator for a conditional requirement");
 
-    auto conformances = cs.getCheckedConformances();
-    auto result = llvm::find_if(
-        conformances,
-        [&conformanceLoc](
-            const std::pair<ConstraintLocator *, ProtocolConformanceRef>
-                &conformance) { return conformance.first == conformanceLoc; });
-    assert(result != conformances.end());
-
-    auto conformance = result->second;
-    assert(conformance.isConcrete());
-
-    return conformance.getConditionalRequirements()[reqLoc->getIndex()];
+    auto conformance = conformanceRef->getConformance();
+    return conformance->getConditionalRequirements()[reqLoc->getIndex()];
   }
 
   if (auto openedGeneric =


### PR DESCRIPTION
-  Adjust `ConformanceRequirement` locator to carry `ProtocolConformance`
- Stop using `CheckedConformances` cache
  - Change `applySolutionToForEachStmt` to double-check conformance;
  -  Adjust requirement failures to retrieve conformance information from locator
- Remove obsolete used/checked conformances cache from `ConstraintSystem` and `Solution`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
