### PR TITLE
Sema: Fix preservation of DiagnoseErrorOnTry flag

### DIFF
--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -53,7 +53,7 @@ func test_unsafeContinuations() async {
   }
 }
 
-func test_unsafeThrowingContinuations() async {
+func test_unsafeThrowingContinuations() async throws {
   let _: String = try await withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
   }

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -264,3 +264,10 @@ func sr_13654_valid_interpolation() throws {
   _ = try "\(sr_13654_func())"
   _ = "\(try sr_13654_func())"
 }
+
+// rdar://problem/72748150
+func takesClosure(_: (() -> ())) throws -> Int {}
+
+func passesClosure() {
+    _ = try takesClosure { } // expected-error {{errors thrown from here are not handled}}
+}

--- a/test/stmt/errors_async.swift
+++ b/test/stmt/errors_async.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
+
+// REQUIRES: concurrency
+
+enum MyError : Error {
+  case bad
+}
+
+func shouldThrow() async {
+  // expected-error@+1 {{errors thrown from here are not handled}}
+  let _: Int = try await withUnsafeThrowingContinuation { continuation in
+    continuation.resume(throwing: MyError.bad)
+  }
+}


### PR DESCRIPTION
This fixes a regression from some over-eager logic introduced by my commit
5d6cf5cd96deab6f78263a09a5dd9e94cb63fe0b.

We need to be careful to preserve this flag only in cases where the
throwing-ness bubbles up from the nested ContextScope, namely AwaitExpr
and InterpolatedStringLiteralExpr.

Fixes <rdar://problem/72748150>.