### PR TITLE
Sema: Fix preservation of DiagnoseErrorOnTry flag [5.4]

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1579,10 +1579,22 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       OldMaxThrowingKind = std::max(OldMaxThrowingKind, Self.MaxThrowingKind);
     }
 
+    void preserveDiagnoseErrorOnTryFlag() {
+      // The "DiagnoseErrorOnTry" flag is a bit of mutable state
+      // in the Context itself, used to postpone diagnostic emission
+      // to a parent "try" expression. If something was diagnosed
+      // during this ContextScope, the flag may have been set, and
+      // we need to preseve its value when restoring the old Context.
+      bool DiagnoseErrorOnTry = Self.CurContext.shouldDiagnoseErrorOnTry();
+      OldContext.setDiagnoseErrorOnTry(DiagnoseErrorOnTry);
+    }
+
     void preserveCoverageFromAwaitOperand() {
       OldFlags.mergeFrom(ContextFlags::HasAnyAwait, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::throwFlags(), Self.Flags);
       OldMaxThrowingKind = std::max(OldMaxThrowingKind, Self.MaxThrowingKind);
+
+      preserveDiagnoseErrorOnTryFlag();
     }
 
     void preserveCoverageFromTryOperand() {
@@ -1601,6 +1613,8 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       OldFlags.mergeFrom(ContextFlags::HasAnyAsyncSite, Self.Flags);
       OldFlags.mergeFrom(ContextFlags::HasAnyAwait, Self.Flags);
       OldMaxThrowingKind = std::max(OldMaxThrowingKind, Self.MaxThrowingKind);
+
+      preserveDiagnoseErrorOnTryFlag();
     }
     
     bool wasTopLevelDebuggerFunction() const {
@@ -1608,15 +1622,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     }
 
     ~ContextScope() {
-      // The "DiagnoseErrorOnTry" flag is a bit of mutable state
-      // in the Context itself, used to postpone diagnostic emission
-      // to a parent "try" expression. If something was diagnosed
-      // during this ContextScope, the flag may have been set, and
-      // we need to preseve its value when restoring the old Context.
-      bool DiagnoseErrorOnTry = Self.CurContext.shouldDiagnoseErrorOnTry();
       Self.CurContext = OldContext;
-      Self.CurContext.setDiagnoseErrorOnTry(DiagnoseErrorOnTry);
-
       Self.RethrowsDC = OldRethrowsDC;
       Self.Flags = OldFlags;
       Self.MaxThrowingKind = OldMaxThrowingKind;

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -53,7 +53,7 @@ func test_unsafeContinuations() async {
   }
 }
 
-func test_unsafeThrowingContinuations() async {
+func test_unsafeThrowingContinuations() async throws {
   let _: String = await try withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
   }

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -264,3 +264,10 @@ func sr_13654_valid_interpolation() throws {
   _ = try "\(sr_13654_func())"
   _ = "\(try sr_13654_func())"
 }
+
+// rdar://problem/72748150
+func takesClosure(_: (() -> ())) throws -> Int {}
+
+func passesClosure() {
+    _ = try takesClosure { } // expected-error {{errors thrown from here are not handled}}
+}

--- a/test/stmt/errors_async.swift
+++ b/test/stmt/errors_async.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
+
+// REQUIRES: concurrency
+
+enum MyError : Error {
+  case bad
+}
+
+func shouldThrow() async {
+  // expected-error@+1 {{errors thrown from here are not handled}}
+  let _: Int = await try withUnsafeThrowingContinuation { continuation in
+    continuation.resume(throwing: MyError.bad)
+  }
+}


### PR DESCRIPTION
This fixes a regression from some over-eager logic introduced by my commit
5d6cf5cd96deab6f78263a09a5dd9e94cb63fe0b.

We need to be careful to preserve this flag only in cases where the
throwing-ness bubbles up from the nested ContextScope, namely AwaitExpr
and InterpolatedStringLiteralExpr.

Fixes <rdar://problem/72748150>.