### PR TITLE
[Concurrency] Handle more expr types for inout checking

### DIFF
--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -110,8 +110,8 @@ extension TestActor {
 
   func callMutatingFunctionOnStruct() async {
     // expected-error@+3:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}
-    // expected-error@+2:38{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
-    // expected-error@+1:58{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
+    // expected-error@+2:51{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
+    // expected-error@+1:71{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
     await position.setComponents(x: &nextPosition.x, y: &nextPosition.y)
 
     // expected-error@+3:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -14,6 +14,7 @@
 struct Point {
   var x: Int
   var y: Int
+  var z: Int? = nil
 
   mutating func setComponents(x: inout Int, y: inout Int) async {
     defer { (x, y) = (self.x, self.y) }
@@ -22,10 +23,12 @@ struct Point {
 }
 
 actor class TestActor {
+  // expected-note@+1{{mutable state is only available within the actor instance}}
   var position = Point(x: 0, y: 0)
   var nextPosition = Point(x: 0, y: 1)
   var value1: Int = 0
   var value2: Int = 1
+  var points: [Point] = []
 }
 
 func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }
@@ -56,6 +59,15 @@ extension TestActor {
     // expected-error@+1{{actor-isolated property 'position' cannot be passed 'inout' to 'async' function call}}
     await modifyAsynchronously(&position.x)
   }
+
+  func nestedExprs() async {
+    // expected-error@+1{{actor-isolated property 'position' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&position.z!)
+
+    // expected-error@+1{{actor-isolated property 'points' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&points[0].z!)
+  }
+
 }
 
 // internal method call
@@ -98,8 +110,8 @@ extension TestActor {
 
   func callMutatingFunctionOnStruct() async {
     // expected-error@+3:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}
-    // expected-error@+2:51{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
-    // expected-error@+1:71{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
+    // expected-error@+2:38{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
+    // expected-error@+1:58{{actor-isolated property 'nextPosition' cannot be passed 'inout' to 'async' function call}}
     await position.setComponents(x: &nextPosition.x, y: &nextPosition.y)
 
     // expected-error@+3:20{{cannot call mutating async function 'setComponents(x:y:)' on actor-isolated property 'position'}}
@@ -132,6 +144,40 @@ extension TestActor {
   }
 }
 
+actor class MyActor {
+  var points: [Point] = []
+  var int: Int = 0
+  var maybeInt: Int?
+  var maybePoint: Point?
+  var myActor: TestActor = TestActor()
+
+  // Checking that various ways of unwrapping emit the right error messages at
+  // the right times and that illegal operations are caught
+  func modifyStuff() async {
+    // expected-error@+1{{actor-isolated property 'points' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&points[0].x)
+    // expected-error@+1{{actor-isolated property 'points' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&points[0].z!)
+    // expected-error@+1{{actor-isolated property 'int' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&int)
+    // expected-error@+1{{actor-isolated property 'maybeInt' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&maybeInt!)
+    // expected-error@+1{{actor-isolated property 'maybePoint' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&maybePoint!.z!)
+    // expected-error@+1{{actor-isolated property 'int' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&(int))
+
+    // This warning is emitted because this fails to typecheck before the
+    // async-ness is attached.
+    // expected-warning@+2{{no calls to 'async' functions occur within 'await' expression}}
+    // expected-error@+1{{cannot pass immutable value of type 'Int' as inout argument}}
+    await modifyAsynchronously(&(maybePoint?.z)!)
+    // expected-error@+2{{actor-isolated property 'position' can only be referenced inside the actor}}
+    // expected-error@+1{{actor-isolated property 'myActor' cannot be passed 'inout' to 'async' function call}}
+    await modifyAsynchronously(&myActor.position.x)
+  }
+}
+
 // Verify global actor protection
 
 @globalActor
@@ -159,3 +205,17 @@ func globalSyncFunction(_ foo: inout Int) { }
 @MyGlobalActor func globalActorAsyncOkay() async { globalActorSyncFunction(&number) }
 @MyGlobalActor func globalActorAsyncOkay2() async { globalSyncFunction(&number) }
 @MyGlobalActor func globalActorSyncOkay() { globalSyncFunction(&number) }
+
+// Gently unwrap things that are fine
+struct Cat {
+  mutating func meow() async { }
+}
+
+struct Dog {
+  var cat: Cat?
+
+  mutating func woof() async {
+    // This used to cause the compiler to crash, but should be fine
+    await cat?.meow()
+  }
+}


### PR DESCRIPTION
This patch fixes a compiler crash when optional values were being unwrapped and passed to a function. The crash was caused because `diagnoseInOutArg` could only handle `LookupExpr` and `DeclRefExpr`. This patch adds code to unwrap more kinds of expressions.

I've introduced a new static function, `getInoutTopExpr `, which walks through the expression types it knows about down to what is hopefully either a `LookupExpr` or a `DeclRefExpr`, from which we can pull the correct `ValueDecl`.
If we hit an `InOutExpr` sub-expression while traversing, we just return a nullptr and jump out of the diagnostic. If we don't do this, we will get duplicate error messages emitted since it appears to get re-checked. The duplicate error messages show up on `await modifyAsynchronously(&points[0].x)` and `await modifyAsynchronously(&points[0].z!)`.

Fixes: rdar://72906215