### PR TITLE
WinSDK: use `xinput` instead of `xinputuap`

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -153,7 +153,7 @@ module WinSDK [system] {
     }
   }
 
-  module DirectX {
+  explicit module DirectX {
     module Direct3D12 {
       header "d3d12.h"
       export *
@@ -178,7 +178,7 @@ module WinSDK [system] {
       header "Xinput.h"
       export *
 
-      link "xinputuap.lib"
+      link "xinput.lib"
     }
 
     link "dxguid.lib"


### PR DESCRIPTION
The UAP variant is included into the WinSDK module which then fails to
run.  Adjust the linkage.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
