### PR TITLE
[Clang importer] Import Clang swift_attr attribute. 

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -75,6 +75,9 @@ NOTE(unresolvable_clang_decl_is_a_framework_bug,none,
      "please report this issue to the owners of '%0'",
      (StringRef))
 
+WARNING(clang_swift_attr_without_at,none,
+        "Swift attribute '%0' does not start with '@'", (StringRef))
+
 WARNING(implicit_bridging_header_imported_from_module,none,
         "implicit import of bridging header '%0' via module %1 "
         "is deprecated and will be removed in a later version of Swift",

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1038,10 +1038,12 @@ public:
                                                       SourceLoc Loc);
 
   /// Parse a specific attribute.
-  ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc);
+  ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
+                                  bool isFromClangAttribute = false);
 
   bool parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
-                             DeclAttrKind DK);
+                             DeclAttrKind DK,
+                             bool isFromClangAttribute = false);
 
   /// Parse a version tuple of the form x[.y[.z]]. Returns true if there was
   /// an error parsing.

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -273,12 +273,12 @@ void UnqualifiedLookupFactory::performUnqualifiedLookup() {
                                   "performUnqualifedLookup",
                                   DC->getParentSourceFile());
 
-  if (Loc.isValid()) {
+  if (Loc.isValid() && DC->getParentSourceFile()) {
     // Operator lookup is always global, for the time being.
     if (!Name.isOperator())
       lookInASTScopes();
   } else {
-    assert(DC->isModuleScopeContext() &&
+    assert((DC->isModuleScopeContext() || !DC->getParentSourceFile()) &&
            "Unqualified lookup without a source location must start from "
            "a module-scope context");
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -41,6 +41,7 @@
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Path.h"
 #include <set>
@@ -399,6 +400,15 @@ private:
 
   /// Clang arguments used to create the Clang invocation.
   std::vector<std::string> ClangArgs;
+
+  /// Mapping from Clang swift_attr attribute text to the Swift source buffer
+  /// IDs that contain that attribute text. These are re-used when parsing the
+  /// Swift attributes on import.
+  llvm::StringMap<unsigned> ClangSwiftAttrSourceBuffers;
+
+  /// Mapping from modules in which a Clang swift_attr attribute occurs, to be
+  /// used when parsing the attribute text.
+  llvm::SmallDenseMap<ModuleDecl *, SourceFile *> ClangSwiftAttrSourceFiles;
 
 public:
   /// Mapping of already-imported declarations.
@@ -767,6 +777,14 @@ public:
 
   /// Map a Clang identifier name to its imported Swift equivalent.
   StringRef getSwiftNameFromClangName(StringRef name);
+
+  /// Retrieve the Swift source buffer ID that corresponds to the given
+  /// swift_attr attribute text, creating one if necessary.
+  unsigned getClangSwiftAttrSourceBuffer(StringRef attributeText);
+
+  /// Retrieve the placeholder source file for use in parsing Swift attributes
+  /// in the given module.
+  SourceFile &getClangSwiftAttrSourceFile(ModuleDecl &module);
 
   /// Import attributes from the given Clang declaration to its Swift
   /// equivalent.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -401,6 +401,9 @@ private:
   /// Clang arguments used to create the Clang invocation.
   std::vector<std::string> ClangArgs;
 
+  /// The main actor type, populated the first time we look for it.
+  Optional<Type> MainActorType;
+
   /// Mapping from Clang swift_attr attribute text to the Swift source buffer
   /// IDs that contain that attribute text. These are re-used when parsing the
   /// Swift attributes on import.
@@ -777,6 +780,9 @@ public:
 
   /// Map a Clang identifier name to its imported Swift equivalent.
   StringRef getSwiftNameFromClangName(StringRef name);
+
+  /// Look for the MainActor type in the _Concurrency library.
+  Type getMainActorType();
 
   /// Retrieve the Swift source buffer ID that corresponds to the given
   /// swift_attr attribute text, creating one if necessary.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1536,7 +1536,7 @@ void Parser::parseAllAvailabilityMacroArguments() {
 }
 
 bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
-                                   DeclAttrKind DK) {
+                                   DeclAttrKind DK, bool isFromClangAttribute) {
   // Ok, it is a valid attribute, eat it, and then process it.
   StringRef AttrName = Tok.getText();
   SourceLoc Loc = consumeToken();
@@ -1550,7 +1550,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       // Delay issuing the diagnostic until we parse the attribute.
       DiscardAttribute = true;
     }
- 
+
   // If this is a SIL-only attribute, reject it.
   if ((DeclAttribute::getOptions(DK) & DeclAttribute::SILOnly) != 0 &&
       !isInSILMode()) {
@@ -1561,9 +1561,13 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   // If this attribute is only permitted when concurrency is enabled, reject it.
   if (DeclAttribute::isConcurrencyOnly(DK) &&
       !shouldParseExperimentalConcurrency()) {
-    diagnose(
-        Loc, diag::attr_requires_concurrency, AttrName,
-        DeclAttribute::isDeclModifier(DK));
+    // Ignore concurrency-only attributes that come from Clang.
+    if (!isFromClangAttribute) {
+      diagnose(
+          Loc, diag::attr_requires_concurrency, AttrName,
+          DeclAttribute::isDeclModifier(DK));
+    }
+
     DiscardAttribute = true;
   }
 
@@ -2682,7 +2686,8 @@ static PatternBindingInitializer *findAttributeInitContent(
 /// Note that various attributes (like mutating, weak, and unowned) are parsed
 /// but rejected since they have context-sensitive keywords.
 ///
-ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc) {
+ParserStatus Parser::parseDeclAttribute(
+  DeclAttributes &Attributes, SourceLoc AtLoc, bool isFromClangAttribute) {
   // If this not an identifier, the attribute is malformed.
   if (Tok.isNot(tok::identifier) &&
       Tok.isNot(tok::kw_in) &&
@@ -2789,7 +2794,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc At
   }
 
   if (DK != DAK_Count && !DeclAttribute::shouldBeRejectedByParser(DK)) {
-    parseNewDeclAttribute(Attributes, AtLoc, DK);
+    parseNewDeclAttribute(Attributes, AtLoc, DK, isFromClangAttribute);
     return makeParserSuccess();
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -64,3 +64,18 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
 
   _ = slowServer.allOperations
 }
+
+// Check import of attributes
+func globalAsync() async { }
+
+actor class MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
+  func syncMethod() { } // expected-note{{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
+
+  func independentMethod() {
+    syncMethod() // expected-error{{ctor-isolated instance method 'syncMethod()' can not be referenced from an '@actorIndependent' context}}
+  }
+
+  func asyncHandlerMethod() {
+    await globalAsync() // okay because we infer @asyncHandler from the protocol
+  }
+}

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -69,7 +69,7 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
 func globalAsync() async { }
 
 actor class MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
-  func syncMethod() { } // expected-note{{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
+  func syncMethod() { } // expected-note 2{{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
 
   func independentMethod() {
     syncMethod() // expected-error{{ctor-isolated instance method 'syncMethod()' can not be referenced from an '@actorIndependent' context}}
@@ -77,5 +77,9 @@ actor class MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
 
   func asyncHandlerMethod() {
     await globalAsync() // okay because we infer @asyncHandler from the protocol
+  }
+
+  func mainActorMethod() {
+    syncMethod() // expected-error{{actor-isolated instance method 'syncMethod()' can not be referenced from context of global actor 'MainActor'}}
   }
 }

--- a/test/ClangImporter/objc_async_attrs_noconcurrency.swift
+++ b/test/ClangImporter/objc_async_attrs_noconcurrency.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify
+
+// REQUIRES: objc_interop
+import Foundation
+import ObjCConcurrency
+
+func testSlowServerSynchronous(slowServer: SlowServer) {
+  // synchronous version
+  let _: Int = slowServer.doSomethingConflicted("thinking")
+  slowServer.poorlyNamed("hello") { (i: Int) in print(i) }
+  slowServer.customize(with: "hello") { (i: Int) in print(i) }
+
+  slowServer.dance("jig") { s in print(s + "") }
+  slowServer.leap(17) { s in print(s + "") }
+  slowServer.repeatTrick("jump") { i in print(i + 1) }
+}
+
+func testSlowServerOldSchool(slowServer: SlowServer) {
+  slowServer.doSomethingSlow("mail") { i in
+    _ = i
+  }
+
+  _ = slowServer.allOperations
+}

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -34,3 +34,9 @@
 // CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, willAddItem item: Any)
 // CHECK-NEXT: {{^}}  func refrigerator(_ fridge: Any, didRemoveItem item: Any) -> Bool
 // CHECK-NEXT: {{^[}]$}}
+
+// CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
+// CHECK-NEXT: @actorIndependent func independentMethod()
+// CHECK-NEXT: @asyncHandler func asyncHandlerMethod()
+// CHECK-NEXT: {{^}}  optional func missingAtAttributeMethod()
+// CHECK-NEXT: {{^[}]$}}

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
+import _Concurrency
 
 // CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {
 // CHECK-DAG:     func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
@@ -38,5 +39,6 @@
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: @actorIndependent func independentMethod()
 // CHECK-NEXT: @asyncHandler func asyncHandlerMethod()
+// CHECK-NEXT: @MainActor func mainActorMethod()
 // CHECK-NEXT: {{^}}  optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -64,4 +64,12 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)askUserToJumpThroughHoop:(NSString *)hoop completionHandler:(void (^ _Nullable)(NSString *))completionHandler;
 @end
 
+@protocol ProtocolWithSwiftAttributes
+-(void)independentMethod __attribute__((__swift_attr__("@actorIndependent")));
+-(void)asyncHandlerMethod __attribute__((__swift_attr__("@asyncHandler")));
+
+@optional
+-(void)missingAtAttributeMethod __attribute__((__swift_attr__("asyncHandler")));
+@end
+
 #pragma clang assume_nonnull end

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -67,6 +67,7 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 @protocol ProtocolWithSwiftAttributes
 -(void)independentMethod __attribute__((__swift_attr__("@actorIndependent")));
 -(void)asyncHandlerMethod __attribute__((__swift_attr__("@asyncHandler")));
+-(void)mainActorMethod __attribute__((__swift_attr__("@MainActor")));
 
 @optional
 -(void)missingAtAttributeMethod __attribute__((__swift_attr__("asyncHandler")));

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2613,6 +2613,14 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
     return 1;
   }
 
+  // If needed, load _Concurrency library so that the Clang importer can use it.
+  if (Context.LangOpts.EnableExperimentalConcurrency) {
+    if (!getModuleByFullName(Context, Context.Id_Concurrency)) {
+      llvm::errs() << "Failed loading _Concurrency library\n";
+      return 1;
+    }
+  }
+
   int ExitCode = 0;
 
   std::unique_ptr<ASTPrinter> Printer;


### PR DESCRIPTION
The Clang swift_attr attribute allows C code to describe, via a Clang
attribute, the Swift attributes that should be applied to the given
declaration. When an

    __attribute__((__swift_attr__("@tribute")))

occurs on a Clang declaration, parse the attribute within the string
literal as a Swift attribute, then attach that to the imported Swift
declaration.

Fixes rdar://70146633.