### PR TITLE
[5.4] [AutoDiff] generated linear maps should be "convention(thin)"

### DIFF
--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -1699,7 +1699,7 @@ void JVPCloner::Implementation::prepareForDifferentialGeneration() {
   auto *diffGenericEnv =
       diffGenericSig ? diffGenericSig->getGenericEnvironment() : nullptr;
   auto diffType = SILFunctionType::get(
-      diffGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
+      diffGenericSig, SILExtInfo::getThin(), origTy->getCoroutineKind(),
       origTy->getCalleeConvention(), dfParams, {}, dfResults, None,
       origTy->getPatternSubstitutions(), origTy->getInvocationSubstitutions(),
       original->getASTContext());

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -980,7 +980,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
   auto *pbGenericEnv =
       pbGenericSig ? pbGenericSig->getGenericEnvironment() : nullptr;
   auto pbType = SILFunctionType::get(
-      pbGenericSig, origTy->getExtInfo(), origTy->getCoroutineKind(),
+      pbGenericSig, SILExtInfo::getThin(), origTy->getCoroutineKind(),
       origTy->getCalleeConvention(), pbParams, {}, adjResults, None,
       origTy->getPatternSubstitutions(), origTy->getInvocationSubstitutions(),
       original->getASTContext());

--- a/test/AutoDiff/SILOptimizer/derivative_sil.swift
+++ b/test/AutoDiff/SILOptimizer/derivative_sil.swift
@@ -86,3 +86,25 @@ func foo(_ x: Float) -> Float {
 // CHECK-SIL:   dealloc_stack [[TMP_BUF_RES]] : $*Float
 // CHECK-SIL:   return [[DX]] : $Float
 // CHECK-SIL: }
+
+// Check the conventions of the generated functions for a method (SR-13945).
+struct ExampleStruct {
+  @_silgen_name("fooMethod")
+  @differentiable
+  func fooMethod(_ x: Float) -> Float {
+    let y = Float.add(x, x)
+    return y
+  }
+}
+
+// CHECK-SIL-LABEL: sil hidden [ossa] @AD__fooMethod__jvp_src_0_wrt_0 : $@convention(method) (Float, ExampleStruct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK-SIL: }  // end sil function 'AD__fooMethod__jvp_src_0_wrt_0'
+
+// CHECK-SIL-LABEL: sil hidden [ossa] @AD__fooMethod__differential_src_0_wrt_0 : $@convention(thin) (Float, @owned _AD__fooMethod_bb0__DF__src_0_wrt_0) -> Float {
+// CHECK-SIL: }  // end sil function 'AD__fooMethod__differential_src_0_wrt_0'
+
+// CHECK-SIL-LABEL: sil hidden [ossa] @AD__fooMethod__vjp_src_0_wrt_0 : $@convention(method) (Float, ExampleStruct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK-SIL: }  // end sil function 'AD__fooMethod__vjp_src_0_wrt_0'
+
+// CHECK-SIL-LABEL: sil private [ossa] @AD__fooMethod__pullback_src_0_wrt_0 : $@convention(thin) (Float, @owned _AD__fooMethod_bb0__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL: }  // end sil function 'AD__fooMethod__pullback_src_0_wrt_0'

--- a/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
+++ b/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
@@ -44,7 +44,7 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK-LABEL: // differentiability witness for Struct.x.getter
 // CHECK-NEXT: sil_differentiability_witness private [parameters 0] [results 0] @$s4null6StructV1xSfvg : $@convention(method) (Struct) -> Float {
 
-// CHECK-LABEL: sil private [ossa] @AD__$s4null7GenericV1xxvs__pullback_src_0_wrt_0_1_{{16_Differentiation|s}}14DifferentiableRzl : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@inout Generic<τ_0_0>.TangentVector, @owned {{.*}}) -> @out τ_0_0.TangentVector {
+// CHECK-LABEL: sil private [ossa] @AD__$s4null7GenericV1xxvs__pullback_src_0_wrt_0_1_{{16_Differentiation|s}}14DifferentiableRzl : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@inout Generic<τ_0_0>.TangentVector, @owned {{.*}}) -> @out τ_0_0.TangentVector {
 // CHECK: bb0([[ADJ_X_RESULT:%.*]] : $*τ_0_0.TangentVector, [[ADJ_SELF:%.*]] : $*Generic<τ_0_0>.TangentVector, {{.*}} : {{.*}}):
 // CHECK:   [[ADJ_X_TMP:%.*]] = alloc_stack $τ_0_0.TangentVector
 // CHECK:   [[ZERO_FN:%.*]] = witness_method $τ_0_0.TangentVector, #AdditiveArithmetic.zero!getter
@@ -60,7 +60,7 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK:   return {{.*}} : $()
 // CHECK: }
 
-// CHECK-LABEL: sil private [ossa] @AD__$s4null7GenericV1xxvg__pullback_src_0_wrt_0_{{16_Differentiation|s}}14DifferentiableRzl : $@convention(method) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0.TangentVector, @owned {{.*}}) -> @out Generic<τ_0_0>.TangentVector {
+// CHECK-LABEL: sil private [ossa] @AD__$s4null7GenericV1xxvg__pullback_src_0_wrt_0_{{16_Differentiation|s}}14DifferentiableRzl : $@convention(thin) <τ_0_0 where τ_0_0 : Differentiable> (@in_guaranteed τ_0_0.TangentVector, @owned {{.*}}) -> @out Generic<τ_0_0>.TangentVector {
 // CHECK: bb0([[ADJ_SELF_RESULT:%.*]] : $*Generic<τ_0_0>.TangentVector, [[SEED:%.*]] : $*τ_0_0.TangentVector, {{.*}} : ${{.*}}):
 // CHECK:   [[ADJ_SELF_TMP:%.*]] = alloc_stack $Generic<τ_0_0>.TangentVector
 // CHECK:   [[SEED_COPY:%.*]] = alloc_stack $τ_0_0.TangentVector
@@ -76,7 +76,7 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK:   return {{.*}} : $()
 // CHECK: }
 
-// CHECK-LABEL: sil private [ossa] @AD__$s4null6StructV1xSfvs__pullback_src_0_wrt_0_1 : $@convention(method) (@inout Struct.TangentVector, @owned _AD__$s4null6StructV1xSfvs_bb0__PB__src_0_wrt_0_1) -> Float {
+// CHECK-LABEL: sil private [ossa] @AD__$s4null6StructV1xSfvs__pullback_src_0_wrt_0_1 : $@convention(thin) (@inout Struct.TangentVector, @owned _AD__$s4null6StructV1xSfvs_bb0__PB__src_0_wrt_0_1) -> Float {
 // CHECK: bb0([[ADJ_SELF:%.*]] : $*Struct.TangentVector, {{.*}} : $_AD__$s4null6StructV1xSfvs_bb0__PB__src_0_wrt_0_1):
 // CHECK:   [[ADJ_X_ADDR:%.*]] = struct_element_addr [[ADJ_SELF]] : $*Struct.TangentVector, #Struct.TangentVector.x
 // CHECK:   [[ADJ_X:%.*]] = load [trivial] [[ADJ_X_ADDR]] : $*Float
@@ -85,7 +85,7 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK:   return [[ADJ_X]] : $Float
 // CHECK: }
 
-// CHECK-LABEL: sil private [ossa] @AD__$s4null6StructV1xSfvg__pullback_src_0_wrt_0 : $@convention(method) (Float, @owned _AD__$s4null6StructV1xSfvg_bb0__PB__src_0_wrt_0) -> Struct.TangentVector {
+// CHECK-LABEL: sil private [ossa] @AD__$s4null6StructV1xSfvg__pullback_src_0_wrt_0 : $@convention(thin) (Float, @owned _AD__$s4null6StructV1xSfvg_bb0__PB__src_0_wrt_0) -> Struct.TangentVector {
 // CHECK: bb0([[ADJ_X:%.*]] : $Float, {{.*}} : $_AD__$s4null6StructV1xSfvg_bb0__PB__src_0_wrt_0):
 // CHECK:   [[ADJ_Y_ADDR:%.*]] = alloc_stack $Float
 // CHECK:   [[ZERO_FN:%.*]] = witness_method $Float, #AdditiveArithmetic.zero!getter

--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -716,6 +716,19 @@ ControlFlowTests.test("Loops") {
   expectEqual((20, 22), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
   expectEqual((52, 80), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
   expectEqual((24, 28), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
+
+  // SR13945: Loops in methods caused a runtime segfault.
+  struct SR13945 {
+    func loopInMethod(_ x: Float) -> Float {
+      var result = x
+      for _ in 0..<2 {
+        result *= result
+      }
+      return result
+    }
+  }
+  expectEqual((0, 0), valueWithGradient(at: 0, in: { SR13945().loopInMethod($0) }))
+  expectEqual((1, 4), valueWithGradient(at: 1, in: { SR13945().loopInMethod($0) }))
 }
 
 ControlFlowTests.test("BranchingCastInstructions") {


### PR DESCRIPTION
Cherry-pick #35236 onto 5.4.  This is to fix regression SR-13945 that broke all differentiable methods using loops.