### PR TITLE
[concurrency] quick-and-dirty implementation of MainActor in the runtime system

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -299,6 +299,14 @@ void swift_task_enqueue(Job *job, ExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobal(Job *job);
 
+/// FIXME: only exists for the quick-and-dirty MainActor implementation.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_enqueueMainExecutor(Job *job);
+
+/// FIXME: only exists for the quick-and-dirty MainActor implementation.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_MainActor_register(HeapObject *actor);
+
 /// A hook to take over global enqueuing.
 /// TODO: figure out a better abstraction plan than this.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -39,16 +39,16 @@ public func _defaultActorDestroy(_ actor: AnyObject)
 public func _defaultActorEnqueue(partialTask: PartialAsyncTask,
                                  actor: AnyObject)
 
+/// FIXME: only exists for the quick-and-dirty MainActor implementation.
+@_silgen_name("swift_MainActor_register")
+fileprivate func _registerMainActor(actor: AnyObject)
+
 /// A singleton actor whose executor is equivalent to 
 /// \c DispatchQueue.main, which is the main dispatch queue.
 @globalActor public final class MainActor {
   public static let shared = _Impl()
   
   public actor class _Impl {
-    @actorIndependent
-    public func enqueue(partialTask: PartialAsyncTask) {
-      // TODO: implement this.
-      _ = (nil as String?)! + "MainActor is not implemented yet."
-    }
+    init() { _registerMainActor(actor: self) }
   }
 }

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -1,38 +1,110 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: libdispatch
 
+// REQUIRES: OS=macosx || OS=ios
+// FIXME: should not require Darwin to run this test once we have async main!
+
+// for exit(:Int)
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #endif
 
-import Foundation
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  import Dispatch
+#endif
 
-// CHECK: starting
-// CHECK-NOT: ERROR
-// CHECK: launched
-// CHECK-NOT: ERROR
-// CHECK: hello from main actor!
+/// @returns true iff the expected answer is actually the case, i.e., correct.
+/// If the current queue does not match expectations, this function may return
+/// false or just crash the program with non-zero exit code, depending on SDK.
+func checkIfMainQueue(expectedAnswer expected: Bool) -> Bool {
+  // FIXME: until we start using dispatch on Linux, we only check
+  // which queue we're on with Darwin platforms.
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *) {
+    dispatchPrecondition(condition: expected ? .onQueue(DispatchQueue.main) 
+                                             : .notOnQueue(DispatchQueue.main))
+    
+  }
+#endif
+  return true
+}
 
-@MainActor func helloMainActor() -> Never {
-  if Thread.isMainThread {
-    print("hello from main actor!")
-    exit(EXIT_SUCCESS)
-  } else {
-    print("ERROR: not on correct thread!")
-    exit(EXIT_FAILURE)
+actor class A {
+  func onCorrectQueue() -> Bool {
+    if checkIfMainQueue(expectedAnswer: false) {
+      print("on actor instance's queue")
+      return true
+    }
+    print("ERROR: not on actor instance's queue")
+    return false
   }
 }
 
-func someFunc() async {
-  await helloMainActor()
+@MainActor func exitTest(success: Bool) -> Never {
+  if !success {
+    exit(EXIT_FAILURE)
+  }
+
+  if checkIfMainQueue(expectedAnswer: true) {
+    print("on main queue again!")
+  } else {
+    print("ERROR: left the main queue?")
+  }
+
+  exit(EXIT_SUCCESS)
 }
 
+@MainActor func enterMainActor() async -> Never {
+  var ok = checkIfMainQueue(expectedAnswer: true)
+  if ok {
+    print("hello from main actor!")
+  } else {
+    print("ERROR: not on correct queue!")
+  }
+
+  // try calling a function on another actor.
+  let someActor = A()
+  let successfulActorSwitch = await someActor.onCorrectQueue()
+  ok = ok && successfulActorSwitch
+
+  exitTest(success: ok)
+}
+
+func someFunc() async {
+  guard checkIfMainQueue(expectedAnswer: false) else {
+    print("ERROR: did not expect detatched task to run on main queue!")
+    exit(EXIT_FAILURE)
+  }
+  await enterMainActor()
+}
+
+
+// CHECK: starting
+// CHECK-NOT: ERROR
+// CHECK: hello from main actor!
+// CHECK-NOT: ERROR
+// CHECK: on actor instance's queue
+// CHECK-NOT: ERROR
+// CHECK: on main queue again!
+
+import CoreFoundation
+
 print("starting")
-let _ = Task.runDetached(operation: someFunc)
-print("launched")
-dispatchMain() // give up the main queue.
+Task.runDetached(operation: someFunc)
+CFRunLoopRun()
+
+// FIXME: remove the use of CFRunLoopRun and the CoreFoundation import
+// in favor of the below once we have async main support.
+// don't forget to add -parse-as-library to the RUN line
+/*
+@main struct RunIt {
+  static func main() async {
+    print("starting")
+    await someFunc()
+  }
+}
+*/


### PR DESCRIPTION
To help unblock work that depends on the `@MainActor`, here's a hacky implementation of MainActor. This implementation should be replaced once we have better support for custom executors in the runtime system.

TODOs:
- [x] Have code marked with `@MainActor` actually run on the main thread.
- [x] Fix deadlock in `test/Concurrency/Runtime/mainactor.swift`. That test blocks the main thread while waiting on a task that needs the main thread.
- [x] ~Create working regression test for Linux.~ Defer support on Linux until PR #35215 is merged