### PR TITLE
SILGen: Introduce a new debug scope for GuardStmts

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -724,11 +724,14 @@ void StmtEmitter::visitGuardStmt(GuardStmt *S) {
       SGF.B.createUnreachable(S);
   }
 
-  // Emit the condition bindings, branching to the bodyBB if they fail.  Since
-  // we didn't push a scope, the bound variables are live after this statement.
+  // Emit the condition bindings, branching to the bodyBB if they fail.
   auto NumFalseTaken = SGF.loadProfilerCount(S->getBody());
   auto NumNonTaken = SGF.loadProfilerCount(S);
   SGF.emitStmtCondition(S->getCond(), bodyBB, S, NumNonTaken, NumFalseTaken);
+
+  // Begin a new 'guard' scope, which is popped when the next innermost debug
+  // scope ends.
+  SGF.enterDebugScope(S, /*isGuardScope=*/true);
 }
 
 void StmtEmitter::visitWhileStmt(WhileStmt *S) {

--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -28,14 +28,16 @@ public class M {
 
 // Make sure the expanded sequence gets the right scope.
 
-// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 2
-// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 2
-// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 2
-// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 2
-// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:23:20, scope 2
+// CHECK-LABEL: sil [ossa] @$s3del1MC4fromAcA12WithDelegate_p_tKcfc : $@convention(method) (@in WithDelegate, @owned M) -> (@owned M, @error Error)
+
+// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 4
+// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 4
+// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 4
+// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 4
+// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:23:20, scope 4
 
 // Make sure the dealloc_stack gets the same scope of the instructions surrounding it.
 
-// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 2
-// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 2
-// CHECK:   throw %{{.*}} : $Error, loc {{.*}}:20:12, scope 2
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 4
+// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 4
+// CHECK:   throw %{{.*}} : $Error, loc {{.*}}:20:12, scope 4


### PR DESCRIPTION
A GuardStmt can shadow bindings from outer scopes, so make sure
we actually create a new debug scope here.

Note that we push the scope, but pop it when the next innermost
debug scope ends. To keep track of this I added a new bit of state
to the debug scope stack, indicating that this scope originated
from a GuardStmt.

Ideally, debug info would rely on ASTScope which is the canonical
source of truth for this information. For now, this is a spot fix.

I filed <rdar://problem/72954242> to track implementing the longer
term solution.

Fixes <rdar://problem/72900354>.