### PR TITLE
[Concurrency] Don't perform actor isolation checking within #selector.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -834,6 +834,13 @@ namespace {
         }
       }
 
+      // The children of #selector expressions are not evaluation, so we do not
+      // need to do isolation checking there. This is convenient because such
+      // expressions tend to violate restrictions on the use of instance
+      // methods.
+      if (isa<ObjCSelectorExpr>(expr))
+        return { false, expr };
+
       return { true, expr };
     }
 

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+import Foundation
+
+func g(_ selector: Selector) -> Int { }
+
+actor class A {
+  func selectors() {
+    _ = #selector(type(of: self).f) // expected-error{{argument of '#selector' refers to instance method 'f()' that is not exposed to Objective-C}}
+    _ = #selector(type(of: self).g) // expected-error{{argument of '#selector' refers to instance method 'g()' that is not exposed to Objective-C}}
+    _ = #selector(type(of: self).h)
+  }
+
+  func keypaths() {
+    _ = #keyPath(A.x) // expected-error{{argument of '#keyPath' refers to non-'@objc' property 'x'}}
+    _ = #keyPath(A.y) // expected-error{{argument of '#keyPath' refers to non-'@objc' property 'y'}}
+    _ = #keyPath(A.z)
+  }
+
+  var x: Int = 0 // expected-note{{add '@objc' to expose this property to Objective-C}}
+  @objc var y: Int = 0 // expected-note{{add '@objc' to expose this property to Objective-C}}
+  // expected-error@-1{{actor-isolated property 'y' cannot be @objc}}
+  @objc @actorIndependent(unsafe) var z: Int = 0
+
+  func f() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}
+  func g() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}
+  @objc func h() async { }
+}
+
+
+


### PR DESCRIPTION
The code in #selector doesn't execute, so don't perform actor-isolation
checking in there. It also happens to have subexpressions that don't
really follow the rules for references to instance methods, so
avoiding this checking eliminates both compiler crashes and
been spurious errors.

Fixes rdar://72945343.
