### PR TITLE
Add a _fixLifetime to stdlib/BridgeStorage.swift test.

### DIFF
--- a/test/stdlib/BridgeStorage.swift
+++ b/test/stdlib/BridgeStorage.swift
@@ -145,6 +145,8 @@ allTests.test("_BridgeStorage") {
         expectTrue(b.unflaggedNativeInstance === c)
         expectFalse(b.isUniquelyReferencedUnflaggedNative())
       }
+      // Keep 'c' alive for the isUniquelyReferenced check above.
+      _fixLifetime(c)
     }
 
   }


### PR DESCRIPTION
Otherwise, this uniqueness check will unexpectedly succeed when tests
run in optimize mode and 'c' is destroyed early:

      let c = C()
      var b = B(native: c, isFlagged: flag)
      //...
      expectFalse(b.isUniquelyReferencedUnflaggedNative())
      // Keep 'c' alive for the isUniquelyReferenced check above.
      _fixLifetime(c)

Fixes rdar://72957398 ([CanonicalOSSA] Add a _fixLifetime to
stdlib/BridgeStorage.swift test.)
