### PR TITLE
Platform: add ActiveX module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -139,6 +139,11 @@ module WinSDK [system] {
     }
   }
 
+  module ActiveX {
+    header "OCIdl.h"
+    export *
+  }
+
   module Controls {
     module CommCtrl {
       header "CommCtrl.h"


### PR DESCRIPTION
Add the ActiveX module to the Windows SDK.  This is needed for the
IPropBag2 interface.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
