### PR TITLE
[Concurrency] Only infer extension/nominal actor for instance members.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1886,20 +1886,23 @@ ActorIsolation ActorIsolationRequest::evaluate(
     }
   }
 
-  // If the declaration is in an extension that has one of the isolation
-  // attributes, use that.
-  if (auto ext = dyn_cast<ExtensionDecl>(value->getDeclContext())) {
-    if (auto isolationFromAttr = getIsolationFromAttributes(ext)) {
-      return inferredIsolation(*isolationFromAttr);
+  // Instance members can infer isolation from their context.
+  if (value->isInstanceMember()) {
+    // If the declaration is in an extension that has one of the isolation
+    // attributes, use that.
+    if (auto ext = dyn_cast<ExtensionDecl>(value->getDeclContext())) {
+      if (auto isolationFromAttr = getIsolationFromAttributes(ext)) {
+        return inferredIsolation(*isolationFromAttr);
+      }
     }
-  }
 
-  // If the declaration is in a nominal type (or extension thereof) that
-  // has isolation, use that.
-  if (auto selfTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl()) {
-    auto selfTypeIsolation = getActorIsolation(selfTypeDecl);
-    if (!selfTypeIsolation.isUnspecified()) {
-      return inferredIsolation(selfTypeIsolation);
+    // If the declaration is in a nominal type (or extension thereof) that
+    // has isolation, use that.
+    if (auto selfTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl()) {
+      auto selfTypeIsolation = getActorIsolation(selfTypeDecl);
+      if (!selfTypeIsolation.isUnspecified()) {
+        return inferredIsolation(selfTypeIsolation);
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -834,7 +834,7 @@ namespace {
         }
       }
 
-      // The children of #selector expressions are not evaluation, so we do not
+      // The children of #selector expressions are not evaluated, so we do not
       // need to do isolation checking there. This is convenient because such
       // expressions tend to violate restrictions on the use of instance
       // methods.

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -407,3 +407,19 @@ actor class LazyActor {
     @actorIndependent lazy var l44: Int = self.l
     @actorIndependent lazy var l45: Int = { [unowned self] in self.l }()
 }
+
+// Infer global actors from context only for instance members.
+@MainActor
+class SomeClassInActor {
+  enum ID: String { case best }
+
+  func inActor() { } // expected-note{{calls to instance method 'inActor()' from outside of its actor context are implicitly asynchronous}}
+}
+
+extension SomeClassInActor.ID {
+  func f(_ object: SomeClassInActor) { // expected-note{{add '@MainActor' to make instance method 'f' part of global actor 'MainActor'}}
+    // expected-note@-1{{add 'async' to function 'f' to make it asynchronous}}
+    // expected-note@-2{{add '@asyncHandler' to function 'f' to create an implicit asynchronous context}}
+    object.inActor() // expected-error{{'async' in a function that does not support concurrency}}
+  }
+}

--- a/test/decl/class/circular_inheritance.swift
+++ b/test/decl/class/circular_inheritance.swift
@@ -4,14 +4,14 @@
 // RUN: not %target-swift-frontend -typecheck -debug-cycles %s -build-request-dependency-graph -output-request-graphviz %t.dot -stats-output-dir %t/stats-dir 2> %t.cycles
 // RUN: %FileCheck -check-prefix CHECK-DOT %s < %t.dot
 
-class Left // expected-error {{'Left' inherits from itself}} expected-note 2{{through reference here}}
+class Left // expected-error {{'Left' inherits from itself}} expected-note {{through reference here}}
     : Right.Hand { // expected-note {{through reference here}}
-  class Hand {}  // expected-note {{through reference here}}
+  class Hand {}
 }
 
-class Right // expected-note 2 {{through reference here}} expected-note{{class 'Right' declared here}}
+class Right // expected-note {{through reference here}} expected-note{{class 'Right' declared here}}
   : Left.Hand { // expected-note {{through reference here}}
-  class Hand {}  // expected-error {{circular reference}}
+  class Hand {}
 }
 
 class C : B { } // expected-error{{'C' inherits from itself}}
@@ -30,15 +30,15 @@ class Outer {
   class Inner : Outer {}
 }
 
-class Outer2 // expected-error {{'Outer2' inherits from itself}} expected-note 2 {{through reference here}}
+class Outer2 // expected-error {{'Outer2' inherits from itself}} expected-note  {{through reference here}}
     : Outer2.Inner { // expected-note {{through reference here}}
 
-  class Inner {} // expected-error{{circular reference}}
+  class Inner {}
 }
 
-class Outer3 // expected-error {{'Outer3' inherits from itself}} expected-note 2 {{through reference here}}
+class Outer3 // expected-error {{'Outer3' inherits from itself}} expected-note  {{through reference here}}
     : Outer3.Inner<Int> { // expected-note {{through reference here}}
-  class Inner<T> {} // expected-error{{circular reference}}
+  class Inner<T> {}
 }
 
 // CHECK-DOT: digraph Dependencies


### PR DESCRIPTION
Fixes rdar://72966018.
