### PR TITLE
[Runtime] Fix premature snapshot destruction in StableAddressConcurrentReadableHashMap::find.

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -488,9 +488,13 @@ public:
     ~Snapshot() {
       Array->decrementReaders();
     }
-    
-    const ElemTy *begin() { return Start; }
-    const ElemTy *end() { return Start + Count; }
+
+    // These are marked as ref-qualified (the &) to make sure they can't be
+    // called on temporaries, since the temporary would be destroyed before the
+    // return value can be used, making it invalid.
+    const ElemTy *begin() & { return Start; }
+    const ElemTy *end() & { return Start + Count; }
+
     size_t count() { return Count; }
   };
 
@@ -974,7 +978,11 @@ public:
 
     /// Search for an element matching the given key. Returns a pointer to the
     /// found element, or nullptr if no matching element exists.
-    template <class KeyTy> const ElemTy *find(const KeyTy &key) {
+    //
+    // This is marked as ref-qualified (the &) to make sure it can't be called
+    // on temporaries, since the temporary would be destroyed before the return
+    // value can be used, making it invalid.
+    template <class KeyTy> const ElemTy *find(const KeyTy &key) & {
       if (!Indices.Value || !ElementCount || !Elements)
         return nullptr;
       return ConcurrentReadableHashMap::find(key, Indices, ElementCount,
@@ -1181,7 +1189,8 @@ struct StableAddressConcurrentReadableHashMap
   }
 
   template <class KeyTy> ElemTy *find(const KeyTy &key) {
-    auto result = this->snapshot().find(key);
+    auto snapshot = this->snapshot();
+    auto result = snapshot.find(key);
     if (!result)
       return nullptr;
     return result->Ptr;


### PR DESCRIPTION
Mark the relevant snapshot methods as ref-qualified (adding a `&` after the parameter list) so the compiler will enforce this for us and forbid calling them on temporaries.

rdar://72997638