### PR TITLE
[rebranch] Update reference to initializeDwarfEHPreparePass

### DIFF
--- a/tools/swift-llvm-opt/LLVMOpt.cpp
+++ b/tools/swift-llvm-opt/LLVMOpt.cpp
@@ -237,7 +237,7 @@ int main(int argc, char **argv) {
   initializeAtomicExpandPass(Registry);
   initializeRewriteSymbolsLegacyPassPass(Registry);
   initializeWinEHPreparePass(Registry);
-  initializeDwarfEHPreparePass(Registry);
+  initializeDwarfEHPrepareLegacyPassPass(Registry);
   initializeSjLjEHPreparePass(Registry);
 
   // Register Swift Only Passes.


### PR DESCRIPTION
Update to reflect LLVM changes from:

```
[NFC][CodeGen] Split DwarfEHPrepare pass into an actual transform and an legacy-PM wrapper
e6b1a27fb9c71a9a81439917368a25ddc7d371a9
```

Fix rdar://73006157

Cherry-pick of #35349.