### PR TITLE
[next] Pass clang::ASTContext for serialization.

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4492,7 +4492,8 @@ class ClangToSwiftBasicWriter :
 
 public:
   ClangToSwiftBasicWriter(Serializer &S, SmallVectorImpl<uint64_t> &record)
-    : swift::DataStreamBasicWriter<ClangToSwiftBasicWriter>(S.getASTContext()),
+    : swift::DataStreamBasicWriter<ClangToSwiftBasicWriter>(
+        S.getASTContext().getClangModuleLoader()->getClangASTContext()),
       S(S), Record(record), Types(*this) {}
 
   void writeUInt64(uint64_t value) {


### PR DESCRIPTION
Instead of Swift's ASTContext. Goofed this up earlier in #35295.

Corresponding rebranch commit: https://github.com/apple/swift/pull/35351