### PR TITLE
[ConstraintSystem] Refactor storage of potential bindings

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4623,10 +4623,7 @@ public: // binding inference logic is public for unit testing.
   /// bindings, e.g., the supertypes of a given type.
   struct PotentialBinding {
     /// The type to which the type variable can be bound.
-    ///
-    /// Note that the type is mutable since it could be
-    /// adjusted as a result of type-join operation.
-    mutable Type BindingType;
+    Type BindingType;
 
     /// The kind of bindings permitted.
     AllowedBindingKind Kind;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5040,12 +5040,9 @@ private:
     ///
     /// Which gives us a new (superclass A) binding for T2 as well as T1.
     ///
-    /// \param cs The constraint system this type variable is associated with.
-    ///
     /// \param inferredBindings The set of all bindings inferred for type
     /// variables in the workset.
     void inferTransitiveBindings(
-        ConstraintSystem &cs,
         const llvm::SmallDenseMap<TypeVariableType *,
                                   ConstraintSystem::PotentialBindings>
             &inferredBindings);
@@ -5054,18 +5051,16 @@ private:
     /// between two type variables and attempt to propagate protocol
     /// requirements down the subtype or equivalence chain.
     void inferTransitiveProtocolRequirements(
-        const ConstraintSystem &cs,
         llvm::SmallDenseMap<TypeVariableType *,
                             ConstraintSystem::PotentialBindings>
             &inferredBindings);
 
 public:
-    bool infer(ConstraintSystem &cs, Constraint *constraint);
+    bool infer(Constraint *constraint);
 
     /// Finalize binding computation for this type variable by
     /// inferring bindings from context e.g. transitive bindings.
-    void finalize(ConstraintSystem &cs,
-                  llvm::SmallDenseMap<TypeVariableType *,
+    void finalize(llvm::SmallDenseMap<TypeVariableType *,
                                       ConstraintSystem::PotentialBindings>
                       &inferredBindings);
 

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -128,7 +128,7 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
         env;
     env.insert({floatLiteralTy, cs.inferBindingsFor(floatLiteralTy)});
 
-    bindings.finalize(cs, env);
+    bindings.finalize(env);
 
     // Inferred a single transitive binding through `$T_float`.
     ASSERT_EQ(bindings.Bindings.size(), (unsigned)1);

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -136,7 +136,7 @@ SemaTest::inferBindings(ConstraintSystem &cs, TypeVariableType *typeVar) {
       continue;
 
     auto &bindings = cachedBindings->getSecond();
-    bindings.finalize(cs, cache);
+    bindings.finalize(cache);
   }
 
   auto result = cache.find(typeVar);


### PR DESCRIPTION
- Make it possible for `PotentialBinding` to be stored in set/map

- Switch from using `SmallVector` to `SetVector` for potential binding storage in `PotentialBindings`
   This is one more step towards incremental binding computation that also simplifies the logic around
   binding storage. It's no longer necessary to pass type cache to the inference/finalization methods.

- Since constraint system is associated with potential bindings there is no need to pass it an argument
  to inference methods anymore.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
