### PR TITLE
Interop: use new `target-clangxx` for building C++ code

### DIFF
--- a/test/Interop/Cxx/extern-var/extern-var.swift
+++ b/test/Interop/Cxx/extern-var/extern-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/extern-var.cpp -I %S/Inputs -o %t/extern-var.o
+// RUN: %target-clangxx -c %S/Inputs/extern-var.cpp -I %S/Inputs -o %t/extern-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/extern-var %t/extern-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/extern-var
 // RUN: %target-run %t/extern-var

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
+// RUN: %target-clangxx -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
+// RUN: %target-clangxx -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/non-member-out-of-line
 // RUN: %target-run %t/non-member-out-of-line

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
+// RUN: %target-clangxx -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/reference
 // RUN: %target-run %t/reference

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/inline-static-member-var.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/inline-static-member-var.cpp -I %S/Inputs -o %t/inline-static-member-var.o
+// RUN: %target-clangxx -c %S/Inputs/inline-static-member-var.cpp -I %S/Inputs -o %t/inline-static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/inline-static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics 2&>1

--- a/test/Interop/Cxx/static/static-local-var.swift
+++ b/test/Interop/Cxx/static/static-local-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-local-var.cpp -I %S/Inputs -o %t/static-local-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-local-var.cpp -I %S/Inputs -o %t/static-local-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-local-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-member-func.swift
+++ b/test/Interop/Cxx/static/static-member-func.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o
+// RUN: %target-clangxx -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-func.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -std=c++11 -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/Interop/Cxx/static/static-var.swift
+++ b/test/Interop/Cxx/static/static-var.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang -c %S/Inputs/static-var.cpp -I %S/Inputs -o %t/static-var.o
+// RUN: %target-clangxx -c %S/Inputs/static-var.cpp -I %S/Inputs -o %t/static-var.o
 // RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1942,6 +1942,7 @@ config.substitutions.append(('%target-jit-run', subst_target_jit_run))
 config.substitutions.append(('%target-build-swift-dylib\(([^)]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
+config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
 config.substitutions.append(('%target-clang', config.target_clang))
 config.substitutions.append(('%target-ld', config.target_ld))
 if hasattr(config, 'target_cc_options'):


### PR DESCRIPTION
This enables control over the C++ flags used during testing for the C++
interop from a single location rather than having to alter all the
tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
