### PR TITLE
[Dependency Scanning] Optionally, resolve direct dependencies of a module using only the `ModuleDependenciesCache`.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -795,7 +795,8 @@ public:
       StringRef moduleName,
       bool isUnderlyingClangModule,
       ModuleDependenciesCache &cache,
-      InterfaceSubContextDelegate &delegate);
+      InterfaceSubContextDelegate &delegate,
+      bool cacheOnly = false);
 
   /// Retrieve the module dependencies for the Swift module with the given name.
   Optional<ModuleDependencies> getSwiftModuleDependencies(

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -153,7 +153,8 @@ static void findAllImportedClangModules(ASTContext &ctx, StringRef moduleName,
 static std::vector<ModuleDependencyID>
 resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
                           ModuleDependenciesCache &cache,
-                          InterfaceSubContextDelegate &ASTDelegate) {
+                          InterfaceSubContextDelegate &ASTDelegate,
+                          bool cacheOnly = false) {
   auto &ctx = instance.getASTContext();
   auto knownDependencies = *cache.findDependencies(module.first, module.second);
   auto isSwift = knownDependencies.isSwiftTextualModule();
@@ -163,10 +164,8 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
   for (auto dependsOn : knownDependencies.getModuleDependencies()) {
     // Figure out what kind of module we need.
     bool onlyClangModule = !isSwift || module.first == dependsOn;
-
-    // Retrieve the dependencies for this module.
     if (auto found = ctx.getModuleDependencies(dependsOn, onlyClangModule,
-                                               cache, ASTDelegate)) {
+                                               cache, ASTDelegate, cacheOnly)) {
       result.insert({dependsOn, found->getKind()});
     }
   }
@@ -209,7 +208,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
     // directly depends on these.
     for (const auto &clangDep : allClangModules) {
       if (auto found = ctx.getModuleDependencies(
-              clangDep, /*onlyClangModule=*/false, cache, ASTDelegate)) {
+              clangDep, /*onlyClangModule=*/false, cache, ASTDelegate, cacheOnly)) {
         // ASTContext::getModuleDependencies returns dependencies for a module
         // with a given name. This Clang module may have the same name as the
         // Swift module we are resolving, so we need to make sure we don't add a
@@ -761,7 +760,7 @@ generateFullDependencyGraph(CompilerInstance &instance,
     // DirectDependencies
     auto directDependencies = resolveDirectDependencies(
         instance, ModuleDependencyID(module.first, module.second), cache,
-        ASTDelegate);
+        ASTDelegate, /*cacheOnly*/ true);
 
     // Generate a swiftscan_clang_details_t object based on the dependency kind
     auto getModuleDetails = [&]() -> swiftscan_module_details_t {
@@ -871,7 +870,7 @@ static bool diagnoseCycle(CompilerInstance &instance,
     auto &lastOpen = openSet.back();
     auto beforeSize = openSet.size();
     for (auto dep :
-         resolveDirectDependencies(instance, lastOpen, cache, astDelegate)) {
+         resolveDirectDependencies(instance, lastOpen, cache, astDelegate, /*cacheOnly*/ true)) {
       if (closeSet.count(dep))
         continue;
       if (openSet.insert(dep)) {


### PR DESCRIPTION
This speeds up contexts where we need to resolve dependencies after the main scanning action is complete.
For example: libSwiftScan binary graph generation and cycle detection.

This is necessary because ordinarily, ModuleDependenciesCache must be queried on a per-loader basis.
For example: 
1. We first search for Swift modules with the `SerializedModuleLoaderBase`, at which point we check the cache for previously-found Swift modules. If cache is not hit, we search the filesystem.
2. We search for Clang modules with the `ClangImporter`, at which point we check the cache for previously-found Clang modules. If cache is not hit, we search the filesystem.

This change allows to eliminate a bunch of filesystem searching in step (1) when a Clang modules is in the cache and we know we have completed the scan and no longer need to be concerned with the possibility that we will discover a new Swift module that will have a higher precedence in the cache query order. 
