### PR TITLE
[build] Reenable lldb tests for macOS toolchain package

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1389,8 +1389,6 @@ mixin-preset=
     mixin_osx_package_test
     mixin_lightweight_assertions,no-stdlib-asserts
 
-# SKIP LLDB TESTS (67923799)
-skip-test-lldb
 skip-test-playgroundsupport
 
 [preset: buildbot_osx_package,use_os_runtime]


### PR DESCRIPTION
Reenable lldb tests for package builds. The cause of the test failures have been fixed in the recent releases of lldb.

rdar://67820344
