### PR TITLE
Interop: remove `-O` in test

### DIFF
--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -std=c++11 -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
-// NOTE: we must use `-O` here to ensure that the constexpr value is inlined and no undefined reference remains.
-// RUN: %target-build-swift -O %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //


### PR DESCRIPTION
Now that the integral constants are being materialized when importing
`constexpr` from C++, we can avoid the need for the optimizer to inline
the value.  Remove this workaround.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
