### PR TITLE
Add checks to unit tests for ArrayPropertyOpt

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/ArrayOpt.h
+++ b/lib/SILOptimizer/LoopTransforms/ArrayOpt.h
@@ -31,7 +31,7 @@ namespace swift {
 /// Projections over the aggregate that do not access the struct are ignored.
 ///
 /// StructLoads records loads of the struct value.
-/// StructAddressUsers records other uses of the struct address.
+/// StructAddressUsers records all uses of the struct address.
 /// StructValueUsers records direct uses of the loaded struct.
 ///
 /// Projections of the struct over its elements are all similarly recorded in

--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -254,12 +254,15 @@ private:
   /// new array onto it.
   bool checkSafeArrayAddressUses(UserList &AddressUsers) {
     for (auto *UseInst : AddressUsers) {
-
       if (UseInst->isDebugInstruction())
         continue;
 
       if (isa<DeallocStackInst>(UseInst)) {
         // Handle destruction of a local array.
+        continue;
+      }
+
+      if (isa<LoadInst>(UseInst)) {
         continue;
       }
 

--- a/test/SILOptimizer/array_specialize.sil
+++ b/test/SILOptimizer/array_specialize.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -array-property-opt
+// RUN: %target-sil-opt -enable-sil-verify-all %s -array-property-opt | %FileCheck %s
 
 sil_stage canonical
 
@@ -20,6 +20,18 @@ enum MyBool{
 
 class MyClass {
 }
+
+// CHECK-LABEL: sil @clone_switch_enum_exit : 
+// CHECK: bb1:
+// CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC1]]
+// CHECK: cond_br {{.*}}, bb11, bb2
+// CHECK: bb2:
+// CHECK:   br bb3
+// CHECK: bb3:
+// CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC2]]
+// CHECK_LABEL: } // end sil function 'clone_switch_enum_exit'
 
 /// We need to split the loop exit edge from bb1 to bb3 before updating ssa form
 /// after cloning.
@@ -55,6 +67,13 @@ bb6:
 protocol AProtocol : class {
 }
 
+// CHECK-LABEL: sil @cant_handle_open_existential_use_outside_loop : 
+// CHECK: bb1:
+// CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC1]]
+// CHECK-NOT: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK-NOT: apply [[FUNC2]]
+// CHECK-LABEL: } // end sil function 'cant_handle_open_existential_use_outside_loop'
 sil @cant_handle_open_existential_use_outside_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool, @owned AProtocol) -> MyBool {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool, %10 : $AProtocol):
   %3 = load %0 : $*MyArray<MyClass>
@@ -95,6 +114,17 @@ bb0(%0: $MyArray<MyClass>):
 
 sil @throwing_fun : $@convention(thin) () -> (MyBool, @error Error)
 
+// CHECK-LABEL: sil @clone_try_apply_exit : 
+// CHECK: bb1:
+// CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC1]]
+// CHECK: cond_br {{.*}}, bb10, bb2
+// CHECK: bb2:
+// CHECK:   br bb3
+// CHECK: bb3:
+// CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC2]]
+// CHECK_LABEL: } // end sil function 'clone_try_apply_exit'
 sil @clone_try_apply_exit : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> (MyBool, @error Error) {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load %0 : $*MyArray<MyClass>
@@ -122,6 +152,17 @@ bb6(%9 : $Error):
   throw %9 : $Error
 }
 
+// CHECK-LABEL: sil @dominator_update_outside_non_exit_block : 
+// CHECK: bb1:
+// CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC1]]
+// CHECK: cond_br {{.*}}, bb16, bb2
+// CHECK: bb2:
+// CHECK:   br bb3
+// CHECK: bb3:
+// CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC2]]
+// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block'
 sil @dominator_update_outside_non_exit_block : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load %0 : $*MyArray<MyClass>
@@ -163,6 +204,17 @@ bb10:
   return %4 : $Builtin.Int1
 }
 
+// CHECK-LABEL: sil @dominator_update_outside_non_exit_block_2 : 
+// CHECK: bb1:
+// CHECK: [[FUNC1:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC1]]
+// CHECK: cond_br {{.*}}, bb17, bb2
+// CHECK: bb2:
+// CHECK:   br bb3
+// CHECK: bb3:
+// CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
+// CHECK: apply [[FUNC2]]
+// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block_2'
 sil @dominator_update_outside_non_exit_block_2 : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load %0 : $*MyArray<MyClass>


### PR DESCRIPTION
There were no checks for the unit tests for ArrayPropertyOpt. Added them. Also allow load instructions in ArrayPropertyOpt's checkSafeArrayAddressUses.
LoadInsts were added as StructAddressUsers in #35312