### PR TITLE
[rebranch][ClangImporter] Update tests for conflicting swift_name attributes 

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -41,6 +41,10 @@ public:
   /// Indicates whether diagnostic passes should be skipped.
   bool SkipDiagnosticPasses = false;
 
+  /// Additional non-source files which will have diagnostics emitted in them,
+  /// and which should be scanned for expectations by the diagnostic verifier.
+  std::vector<std::string> AdditionalVerifierFiles;
+
   /// Keep emitting subsequent diagnostics after a fatal error.
   bool ShowDiagnosticsAfterFatalError = false;
 
@@ -54,22 +58,23 @@ public:
   /// Treat all warnings as errors
   bool WarningsAsErrors = false;
 
-  // When printing diagnostics, include the diagnostic name at the end
+  /// When printing diagnostics, include the diagnostic name (diag::whatever) at
+  /// the end.
   bool PrintDiagnosticNames = false;
 
   /// If set to true, include educational notes in printed output if available.
   /// Educational notes are documentation which supplement diagnostics.
   bool PrintEducationalNotes = false;
 
-  // If set to true, use the more descriptive experimental formatting style for
-  // diagnostics.
+  /// Whether to emit diagnostics in the terse LLVM style or in a more
+  /// descriptive style that's specific to Swift (currently experimental).
   FormattingStyle PrintedFormattingStyle = FormattingStyle::LLVM;
 
   std::string DiagnosticDocumentationPath = "";
 
   std::string LocalizationCode = "";
 
-  // Diagnostic messages directory path.
+  /// Path to a directory of diagnostic localization tables.
   std::string LocalizationPath = "";
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -65,6 +65,7 @@ class DiagnosticVerifier : public DiagnosticConsumer {
   SourceManager &SM;
   std::vector<CapturedDiagnosticInfo> CapturedDiagnostics;
   ArrayRef<unsigned> BufferIDs;
+  SmallVector<unsigned, 4> AdditionalBufferIDs;
   bool AutoApplyFixes;
   bool IgnoreUnknown;
 
@@ -73,6 +74,10 @@ public:
                               bool AutoApplyFixes, bool IgnoreUnknown)
       : SM(SM), BufferIDs(BufferIDs), AutoApplyFixes(AutoApplyFixes),
         IgnoreUnknown(IgnoreUnknown) {}
+
+  void appendAdditionalBufferID(unsigned bufferID) {
+    AdditionalBufferIDs.push_back(bufferID);
+  }
 
   virtual void handleDiagnostic(SourceManager &SM,
                                 const DiagnosticInfo &Info) override;

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -560,8 +560,11 @@ private:
   bool setUpInputs();
   bool setUpASTContextIfNeeded();
   void setupStatsReporter();
-  void setupDiagnosticVerifierIfNeeded();
   void setupDependencyTrackerIfNeeded();
+
+  /// \return false if successsful, true on error.
+  bool setupDiagnosticVerifierIfNeeded();
+
   Optional<unsigned> setUpCodeCompletionBuffer();
 
   /// Find a buffer for a given input file and ensure it is recorded in

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -114,6 +114,8 @@ def tbd_is_installapi: Flag<["-"], "tbd-is-installapi">,
 def verify : Flag<["-"], "verify">,
   HelpText<"Verify diagnostics against expected-{error|warning|note} "
            "annotations">;
+def verify_additional_file : Separate<["-"], "verify-additional-file">,
+  HelpText<"Verify diagnostics in this file in addition to source files">;
 def verify_apply_fixes : Flag<["-"], "verify-apply-fixes">,
   HelpText<"Like -verify, but updates the original source file">;
 def verify_ignore_unknown: Flag<["-"], "verify-ignore-unknown">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -957,6 +957,9 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
   Opts.ShowDiagnosticsAfterFatalError |=
     Args.hasArg(OPT_show_diagnostics_after_fatal);
 
+  for (Arg *A : Args.filtered(OPT_verify_additional_file))
+    Opts.AdditionalVerifierFiles.push_back(A->getValue());
+
   Opts.UseColor |=
       Args.hasFlag(OPT_color_diagnostics,
                    OPT_no_color_diagnostics,

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -978,11 +978,13 @@ void DiagnosticVerifier::handleDiagnostic(SourceManager &SM,
 bool DiagnosticVerifier::finishProcessing() {
   DiagnosticVerifier::Result Result = {false, false};
 
-  for (auto &BufferID : BufferIDs) {
-    DiagnosticVerifier::Result FileResult = verifyFile(BufferID);
-    Result.HadError |= FileResult.HadError;
-    Result.HadUnexpectedDiag |= FileResult.HadUnexpectedDiag;
-  }
+  ArrayRef<unsigned> BufferIDLists[2] = { BufferIDs, AdditionalBufferIDs };
+  for (ArrayRef<unsigned> BufferIDList : BufferIDLists)
+    for (auto &BufferID : BufferIDList) {
+      DiagnosticVerifier::Result FileResult = verifyFile(BufferID);
+      Result.HadError |= FileResult.HadError;
+      Result.HadUnexpectedDiag |= FileResult.HadUnexpectedDiag;
+    }
   if (!IgnoreUnknown) {
     bool HadError = verifyUnknown(SM, CapturedDiagnostics);
     Result.HadError |= HadError;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -290,15 +290,31 @@ void CompilerInstance::setupStatsReporter() {
   Stats = std::move(Reporter);
 }
 
-void CompilerInstance::setupDiagnosticVerifierIfNeeded() {
+bool CompilerInstance::setupDiagnosticVerifierIfNeeded() {
   auto &diagOpts = Invocation.getDiagnosticOptions();
+  bool hadError = false;
+
   if (diagOpts.VerifyMode != DiagnosticOptions::NoVerify) {
     DiagVerifier = std::make_unique<DiagnosticVerifier>(
         SourceMgr, InputSourceCodeBufferIDs,
         diagOpts.VerifyMode == DiagnosticOptions::VerifyAndApplyFixes,
         diagOpts.VerifyIgnoreUnknown);
+    for (const auto &filename : diagOpts.AdditionalVerifierFiles) {
+      auto result = getFileSystem().getBufferForFile(filename);
+      if (!result) {
+        Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
+                             filename, result.getError().message());
+        hadError |= true;
+      }
+
+      auto bufferID = SourceMgr.addNewSourceBuffer(std::move(result.get()));
+      DiagVerifier->appendAdditionalBufferID(bufferID);
+    }
+
     addDiagnosticConsumer(DiagVerifier.get());
   }
+
+  return hadError;
 }
 
 void CompilerInstance::setupDependencyTrackerIfNeeded() {
@@ -347,7 +363,9 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     return true;
 
   setupStatsReporter();
-  setupDiagnosticVerifierIfNeeded();
+
+  if (setupDiagnosticVerifierIfNeeded())
+    return true;
 
   return false;
 }

--- a/test/ClangImporter/Inputs/custom-modules/ConflictingNames.h
+++ b/test/ClangImporter/Inputs/custom-modules/ConflictingNames.h
@@ -1,0 +1,16 @@
+@import Foundation;
+
+@protocol OMWWiggle
+-(void)conflicting1 __attribute__((swift_name("wiggle1()"))); // expected-error {{'swift_name' and 'swift_name' attributes are not compatible}}
+@end
+
+@protocol OMWWaggle
+-(void)conflicting1 __attribute__((swift_name("waggle1()"))); // expected-note {{conflicting attribute is here}}
+@end
+
+@interface OMWSuper : NSObject <OMWWiggle>
+@end
+
+@interface OMWSub : OMWSuper <OMWWaggle>
+-(void)conflicting1;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -26,6 +26,11 @@ module ClangModuleWithOverlay {
   link "UnderlyingClangLibrary"
 }
 
+module ConflictingNames {
+  header "ConflictingNames.h"
+  export *
+}
+
 module CoreData {
   header "NSManagedObject.h"
   export *

--- a/test/ClangImporter/attr-swift_name-errors.swift
+++ b/test/ClangImporter/attr-swift_name-errors.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -typecheck %s -disable-named-lazy-member-loading \
+// RUN:     -verify -verify-additional-file %S/Inputs/custom-modules/ConflictingNames.h -verify-ignore-unknown
+
+// REQUIRES: objc_interop
+
+import ConflictingNames // expected-error {{could not build Objective-C module 'ConflictingNames'}}

--- a/test/IDE/Inputs/custom-modules/OmitNeedlessWords.h
+++ b/test/IDE/Inputs/custom-modules/OmitNeedlessWords.h
@@ -59,12 +59,10 @@ typedef NS_OPTIONS(NSUInteger, OMWWobbleOptions) {
 
 @protocol OMWWiggle
 -(void)joinSub;
--(void)conflicting1 NS_SWIFT_NAME(wiggle1());
 @property (readonly) NSInteger conflictingProp1 NS_SWIFT_NAME(wiggleProp1);
 @end
 
 @protocol OMWWaggle
--(void)conflicting1 NS_SWIFT_NAME(waggle1());
 @property (readonly) NSInteger conflictingProp1 NS_SWIFT_NAME(waggleProp1);
 @end
 
@@ -76,7 +74,6 @@ typedef NS_OPTIONS(NSUInteger, OMWWobbleOptions) {
 @interface OMWSub : OMWSuper <OMWWaggle>
 -(void)jumpSuper;
 -(void)joinSub;
--(void)conflicting1;
 @property (readonly) NSInteger conflictingProp1;
 @end
 

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -273,17 +273,11 @@
 // Verify that we get the Swift name from the original declaration.
 // CHECK-OMIT-NEEDLESS-WORDS-LABEL: protocol OMWWiggle
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func joinSub()
-// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func wiggle1()
-// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "wiggle1()")
-// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func conflicting1()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: var wiggleProp1: Int { get }
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "wiggleProp1")
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: var conflictingProp1: Int { get }
 
 // CHECK-OMIT-NEEDLESS-WORDS-LABEL: protocol OMWWaggle
-// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func waggle1()
-// CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "waggle1()")
-// CHECK-OMIT-NEEDLESS-WORDS-NEXT: func conflicting1()
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: var waggleProp1: Int { get }
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "waggleProp1")
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: var conflictingProp1: Int { get }
@@ -319,7 +313,6 @@
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: @available(swift, obsoleted: 3, renamed: "veryCarefullyBurn()")
 // CHECK-OMIT-NEEDLESS-WORDS-NEXT: func veryCarefullyBurnGarbage4DTypeRefMask_t()
 
-// CHECK-OMIT-NEEDLESS-WORDS-DIAGS: inconsistent Swift name for Objective-C method 'conflicting1' in 'OMWSub' ('waggle1()' in 'OMWWaggle' vs. 'wiggle1()' in 'OMWWiggle')
 // CHECK-OMIT-NEEDLESS-WORDS-DIAGS: inconsistent Swift name for Objective-C property 'conflictingProp1' in 'OMWSub' ('waggleProp1' in 'OMWWaggle' vs. 'wiggleProp1' in 'OMWSuper')
 
 // Don't drop the 'error'.


### PR DESCRIPTION
The upstreaming of `attribute((__swift_name__))` in LLVM makes the compiler raise errors on conflicting attributes. This PR updates the tests to reflect that change with the help of a new compiler flag `-verify-additional-file` implemented by @brentdax.

rdar://72473419