### PR TITLE
[nfc] Add comment describing when there may not be a parent source file.

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -209,6 +209,8 @@ void ASTScope::
 }
 
 void ASTScope::expandFunctionBody(AbstractFunctionDecl *AFD) {
+  // There is no source file associated with C++ decl contexts, so there will
+  // be no parent source file if AFD is a C++ function.
   if (auto *const SF = AFD->getParentSourceFile())
     SF->getScope().expandFunctionBodyImpl(AFD);
 }


### PR DESCRIPTION
Add a comment explaining that C++ functions won't have an attached parent source file. Refs #35311.
