### PR TITLE
[Diagnostics] Simplify unused lvalue warning wording

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3785,9 +3785,14 @@ WARNING(guard_always_succeeds,none,
 ERROR(expression_unused_closure,none,
       "closure expression is unused", ())
 ERROR(expression_unused_function,none,
-      "expression resolves to an unused function", ())
+      "function is unused", ())
 WARNING(expression_unused_lvalue,none,
-        "expression resolves to an unused %select{variable|property|subscript}0", (unsigned))
+      "%select{"
+        "variable|"
+        "property is accessed but result|"
+        "subscript is accessed but result"
+      "}0 is unused",
+      (unsigned))
 WARNING(expression_unused_result_call,none,
         "result of call to %0 is unused", (DeclName))
 WARNING(expression_unused_result_operator,none,

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -168,7 +168,7 @@ func SR3671() {
   ;
 
   // Also a valid call (!!)
-  { $0 { $0 } } { $0 { 1 } }  // expected-error {{expression resolves to an unused function}}
+  { $0 { $0 } } { $0 { 1 } }  // expected-error {{function is unused}}
   consume(111)
 }
 
@@ -907,7 +907,7 @@ do {
 // The funny error is because we infer the type of badResult as () -> ()
 // via the 'T -> U => T -> ()' implicit conversion.
 let badResult = { (fn: () -> ()) in fn }
-// expected-error@-1 {{expression resolves to an unused function}}
+// expected-error@-1 {{function is unused}}
 
 // rdar://problem/55102498 - closure's result type can't be inferred if the last parameter has a default value
 func test_trailing_closure_with_defaulted_last() {

--- a/test/Parse/consecutive_statements.swift
+++ b/test/Parse/consecutive_statements.swift
@@ -6,13 +6,13 @@ func statement_starts() {
 
   f(0)
   f (0)
-  f // expected-warning{{expression resolves to an unused variable}}
+  f // expected-warning{{variable is unused}}
   (0) // expected-warning {{integer literal is unused}}
 
   var a = [1,2,3]
   a[0] = 1
   a [0] = 1
-  a // expected-warning{{expression resolves to an unused variable}}
+  a // expected-warning{{variable is unused}}
   [0, 1, 2] // expected-warning {{expression of type '[Int]' is unused}}
 }
 

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -34,15 +34,15 @@ class D : B {
   }
 
   func super_calls() {
-    super.foo        // expected-warning {{expression resolves to an unused property}}
+    super.foo        // expected-warning {{property is accessed but result is unused}}
     super.foo.bar    // expected-error {{value of type 'Int' has no member 'bar'}}
-    super.bar        // expected-error {{expression resolves to an unused function}}
+    super.bar        // expected-error {{function is unused}}
     super.bar()
     // FIXME: should also say "'super.init' cannot be referenced outside of an initializer"
     super.init // expected-error{{no exact matches in reference to initializer}}
     super.init() // expected-error{{'super.init' cannot be called outside of an initializer}}
     super.init(0) // expected-error{{'super.init' cannot be called outside of an initializer}} // expected-error {{missing argument label 'x:' in call}}
-    super[0]        // expected-warning {{expression resolves to an unused subscript}}
+    super[0]        // expected-warning {{subscript is accessed but result is unused}}
     super
       .bar()
   }

--- a/test/Parse/toplevel_library_invalid.swift
+++ b/test/Parse/toplevel_library_invalid.swift
@@ -4,7 +4,7 @@ let x = 42
 x + x; // expected-error {{expressions are not allowed at the top level}} expected-warning {{result of operator '+' is unused}}
 x + x; // expected-error {{expressions are not allowed at the top level}} expected-warning {{result of operator '+' is unused}}
 // Make sure we don't crash on closures at the top level
-({ }) // expected-error {{expressions are not allowed at the top level}} expected-error{{expression resolves to an unused function}}
+({ }) // expected-error {{expressions are not allowed at the top level}} expected-error{{function is unused}}
 ({ 5 }()) // expected-error {{expressions are not allowed at the top level}}
 // expected-warning @-1 {{result of call to closure returning 'Int' is unused}}
 

--- a/test/SILOptimizer/return.swift
+++ b/test/SILOptimizer/return.swift
@@ -169,7 +169,7 @@ func testSR13753() {
     x // expected-error {{missing return in a closure expected to return 'Int'; did you mean to return the last expression?}} {{5-5=return }}
     // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
     // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
-    // expected-warning@-3 {{expression resolves to an unused variable}} 
+    // expected-warning@-3 {{variable is unused}}
   }
 
   func f() -> Int {
@@ -180,7 +180,7 @@ func testSR13753() {
     x // expected-error {{missing return in a function expected to return 'Int'; did you mean to return the last expression?}} {{5-5=return }}
     // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
     // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
-    // expected-warning@-3 {{expression resolves to an unused variable}} 
+    // expected-warning@-3 {{variable is unused}}
   } 
 
   let _ : () -> Int = {
@@ -191,7 +191,7 @@ func testSR13753() {
     x 
     // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
     // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
-    // expected-warning@-3 {{expression resolves to an unused variable}} 
+    // expected-warning@-3 {{variable is unused}}
   } // expected-error {{missing return in a closure expected to return 'Int'}}
 
   func f1() -> Int {
@@ -202,7 +202,7 @@ func testSR13753() {
     x 
     // expected-warning@-1 {{setter argument 'newValue' was never used, but the property was accessed}}
     // expected-note@-2 {{did you mean to use 'newValue' instead of accessing the property's current value?}}
-    // expected-warning@-3 {{expression resolves to an unused variable}} 
+    // expected-warning@-3 {{variable is unused}}
   } // expected-error {{missing return in a function expected to return 'Int'}}
 
   let _ : () -> Int = {
@@ -210,6 +210,6 @@ func testSR13753() {
     var _ : Int = 0
     
     x // expected-error{{missing return in a closure expected to return 'Int'; did you mean to return the last expression?}} {{5-5=return }}
-    //expected-warning@-1{{expression resolves to an unused variable}}
+    //expected-warning@-1{{variable is unused}}
   }
 }

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -218,8 +218,8 @@ class Discard {
   }
 
   func baz() {
-    self.bar // expected-error {{expression resolves to an unused function}}
-    bar // expected-error {{expression resolves to an unused function}}
+    self.bar // expected-error {{function is unused}}
+    bar // expected-error {{function is unused}}
   }
 }
 
@@ -240,5 +240,5 @@ struct SR_12271_S {
 SR_12271_S().bar1() // Okay
 SR_12271_S.bar2() // Okay
 
-SR_12271_S().bar1 // expected-error {{expression resolves to an unused function}}
-SR_12271_S.bar2 // expected-error {{expression resolves to an unused function}}
+SR_12271_S().bar1 // expected-error {{function is unused}}
+SR_12271_S.bar2 // expected-error {{function is unused}}

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -76,10 +76,10 @@ func test3(_ a: ZeroOneTwoThree) {
      ZeroOneTwoThree.Zero // expected-error {{cannot convert value of type 'ZeroOneTwoThree' to specified type 'Int'}}
 
   // expected-warning @+1 {{unused}}
-  test3 ZeroOneTwoThree.Zero // expected-error {{expression resolves to an unused function}} expected-error{{consecutive statements}} {{8-8=;}}
+  test3 ZeroOneTwoThree.Zero // expected-error {{function is unused}} expected-error{{consecutive statements}} {{8-8=;}}
   test3 (ZeroOneTwoThree.Zero)
   test3(ZeroOneTwoThree.Zero)
-  test3 // expected-error {{expression resolves to an unused function}}
+  test3 // expected-error {{function is unused}}
   // expected-warning @+1 {{unused}}
   (ZeroOneTwoThree.Zero)
   
@@ -101,9 +101,9 @@ func test3a(_ a: ZeroOneTwoThree) {
   
   var i = 0 > 3 ? .none : .some(3) // expected-error {{cannot infer contextual base in reference to member 'none'}}
 
-  test3a;  // expected-error {{unused function}}
+  test3a;  // expected-error {{function is unused}}
   .Zero   // expected-error {{reference to member 'Zero' cannot be resolved without a contextual type}}
-  test3a   // expected-error {{unused function}}
+  test3a   // expected-error {{function is unused}}
   (.Zero) // expected-error {{reference to member 'Zero' cannot be resolved without a contextual type}}
   test3a(.Zero)
 }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -21,9 +21,9 @@ func1()
 _ = 4+7
 
 var bind_test1 : () -> () = func1
-var bind_test2 : Int = 4; func1 // expected-warning {{expression resolves to an unused variable}}
+var bind_test2 : Int = 4; func1 // expected-warning {{variable is unused}}
 
-(func1, func2) // expected-warning {{expression resolves to an unused variable}}
+(func1, func2) // expected-warning {{variable is unused}}
 
 func basictest() {
   // Simple integer variables.
@@ -714,7 +714,7 @@ func unusedExpressionResults() {
   // <rdar://problem/20749592> Conditional Optional binding hides compiler error
   let optionalc:C? = nil
   optionalc?.method()  // ok
-  optionalc?.method  // expected-error {{expression resolves to an unused function}}
+  optionalc?.method  // expected-error {{function is unused}}
 }
 
 

--- a/test/stmt/yield.swift
+++ b/test/stmt/yield.swift
@@ -85,7 +85,7 @@ struct YieldInDefer {
       defer { // expected-warning {{'defer' statement at end of scope always executes immediately}}{{7-12=do}}
         // FIXME: this recovery is terrible
         yield ""
-        // expected-error@-1 {{expression resolves to an unused function}}
+        // expected-error@-1 {{function is unused}}
         // expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
         // expected-warning@-3 {{string literal is unused}}
       }

--- a/validation-test/compiler_crashers_2_fixed/sr12994.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr12994.swift
@@ -7,6 +7,6 @@ protocol MyProto {
 
 func compile(x: MyProto) throws {
   try x.compile 
-  // expected-error@-1 {{expression resolves to an unused function}}
+  // expected-error@-1 {{function is unused}}
   // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Cases like
```
func f() {
  var a: Int = 1
  a // warning: expression resolves to an unused variable
}
```
currently (on main) it produces a "expression resolves to an unused variable" diagnostic which as discussed [here](https://github.com/apple/swift/pull/35237#issuecomment-754909836) is a bit jargon-heavy.
So the idea is to improve the wording for this diagnostic `expression_unused_lvalue`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-14022.](https://bugs.swift.org/browse/SR-14022)

I changed it to:
`function is unused`,
`result of variable/property/subscript is unused` to match other diagnostics. 

Please let me know if you think there are more suitable alternatives to this one 😄 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
