### PR TITLE
Improve diagnoses of infinite recursions

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -277,8 +277,8 @@ WARNING(unreachable_case,none,
 WARNING(switch_on_a_constant,none,
         "switch condition evaluates to a constant", ())
 NOTE(unreachable_code_note,none, "will never be executed", ())
-WARNING(warn_infinite_recursive_function,none,
-        "all paths through this function will call itself", ())
+WARNING(warn_infinite_recursive_call,none,
+        "function call causes an infinite recursion", ())
 
 // 'transparent' diagnostics
 ERROR(circular_transparent,none,

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -314,6 +314,10 @@ public:
   const_succblock_iterator succblock_end() const {
     return getTerminator()->succblock_end();
   }
+  
+  unsigned getNumSuccessors() const {
+    return getTerminator()->getNumSuccessors();
+  }
 
   SILBasicBlock *getSingleSuccessorBlock() {
     return getTerminator()->getSingleSuccessorBlock();

--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,45 +10,57 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implements a diagnostic pass that detects deleterious forms of
-// recursive functions.
+// This file implements a diagnostic pass that detects infinite recursive
+// function calls.
+//
+// It detects simple forms of infinite recursions, like
+//
+//   func f() {
+//     f()
+//   }
+//
+// and can also deal with invariant conditions, like availability checks
+//
+//   func f() {
+//     if #available(macOS 10.4.4, *) {
+//       f()
+//     }
+//   }
+//
+// or invariant conditions due to forwarded arguments:
+//
+//   func f(_ x: Int) {
+//     if x > 0 {
+//       f(x)
+//     }
+//   }
 //
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "infinite-recursion"
 #include "swift/AST/DiagnosticsSIL.h"
-#include "swift/AST/Expr.h"
-#include "swift/Parse/Lexer.h"
-#include "swift/SIL/CFG.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
-#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
-#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/MemAccessUtils.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
-#include "llvm/ADT/PostOrderIterator.h"
-#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Debug.h"
 
 using namespace swift;
 
-template<typename...T, typename...U>
-static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
-                     U &&...args) {
-  Context.Diags.diagnose(loc,
-                         diag, std::forward<U>(args)...);
-}
+namespace {
 
-static bool isRecursiveCall(SILInstruction *inst, SILFunction *target) {
-  FullApplySite FAI = FullApplySite::isa(inst);
-  if (!FAI)
-    return false;
-
-  if (SILFunction *calledFn = FAI.getReferencedFunctionOrNull())
-    return calledFn == target;
+/// Returns true if \p inst is a full-apply site which calls the containing
+/// function.
+static bool isRecursiveCall(FullApplySite applySite) {
+  SILFunction *parentFunc = applySite.getFunction();
+  if (SILFunction *calledFn = applySite.getReferencedFunctionOrNull())
+    return calledFn == parentFunc;
 
   // Don't touch dynamic dispatch.
-  const auto callee = FAI.getCallee();
+  const auto callee = applySite.getCallee();
   if (isa<SuperMethodInst>(callee) ||
       isa<ObjCSuperMethodInst>(callee) ||
       isa<ObjCMethodInst>(callee)) {
@@ -64,7 +76,7 @@ static bool isRecursiveCall(SILInstruction *inst, SILFunction *target) {
     // Though, this has the added bonus of not looking into vtables
     // outside the current module.  Because we're not doing IPA, let
     // alone cross-module IPA, this is all well and good.
-    SILModule &module = target->getModule();
+    SILModule &module = parentFunc->getModule();
     CanType classType = CMI->getOperand()->getType().getASTType();
     ClassDecl *classDecl = classType.getClassOrBoundGenericClass();
     if (classDecl && classDecl->getModuleContext() != module.getSwiftModule())
@@ -81,117 +93,484 @@ static bool isRecursiveCall(SILInstruction *inst, SILFunction *target) {
       return false;
 
     SILFunction *method = getTargetClassMethod(module, classDecl, CMI);
-    return method == target;
+    return method == parentFunc;
   }
 
   if (auto *WMI = dyn_cast<WitnessMethodInst>(callee)) {
-    auto funcAndTable = target->getModule().lookUpFunctionInWitnessTable(
+    auto funcAndTable = parentFunc->getModule().lookUpFunctionInWitnessTable(
         WMI->getConformance(), WMI->getMember());
-    return funcAndTable.first == target;
+    return funcAndTable.first == parentFunc;
   }
   return false;
 }
 
-static bool hasRecursiveCallInBlock(SILBasicBlock &block, SILFunction *target) {
-  // Process all instructions in the block to find applies that reference
-  // the parent function.  Also looks through vtables for statically
-  // dispatched (witness) methods.
-  for (auto &inst : block) {
-    if (isRecursiveCall(&inst, target))
-      return true;
-  }
-  return false;
-}
-
-/// Returns true if the block has a call to a function marked with
-/// @_semantics("programtermination_point").
-static bool isKnownProgramTerminationPoint(const SILBasicBlock *bb) {
-  // Skip checking anything if this block doesn't end in a program terminator.
-  if (!bb->getTerminator()->isProgramTerminating())
+/// For the purpose of this analysis we can exclude certain memory-writing
+/// instructions.
+static bool mayWriteToMemory(SILInstruction *inst) {
+  switch (inst->getKind()) {
+  case SILInstructionKind::LoadInst:
+    // A `load` is defined to write memory or have side effects in two cases:
+    // * We don't care about retain instructions of a `load [copy]`.
+    // * We don't care about a `load [take]` because it cannot occur in an
+    //   infinite recursion loop without another write (which re-initializes
+    //   the memory).
+  case SILInstructionKind::BeginAccessInst:
+  case SILInstructionKind::EndAccessInst:
     return false;
-
-  // Check each instruction for a call to something that's a known
-  // programtermination_point
-  for (auto it = bb->rbegin(); it != bb->rend(); ++it) {
-    auto applySite = FullApplySite::isa(const_cast<SILInstruction *>(&*it));
-    if (!applySite) continue;
-    if (applySite.isCalleeKnownProgramTerminationPoint())
-      return true;
+  default:
+    return inst->mayWriteToMemory();
   }
-  return false;
 }
 
-/// Perform a DFS through the target function to find any paths to an exit node
-/// that do not call into the target.
-static bool hasInfinitelyRecursiveApply(SILFunction *targetFn) {
-  SmallPtrSet<SILBasicBlock *, 32> visited = { targetFn->getEntryBlock() };
-  SmallVector<SILBasicBlock *, 32> workList = { targetFn->getEntryBlock() };
+/// Describes what is expected to be invariant in an infinite recursion loop.
+///
+/// * Memory: it's all or nothing. Either all memory is expected to be invariant
+///   (= never written) or not. We could use AliasAnalysis to do a more fine-
+///   grained analysis, but in mandatory optimizations we want to keep things
+///   simple.
+///
+/// * Arguments: an argument is invariant if a recursive call forwards the
+///   incoming argument. For example:
+///   \code
+///     func f(_ x: Int, _ y: Int) {
+///       f(x, y - 1) // The first argument is invariant, the second is not
+///     }
+///   \endcode
+class Invariants {
+  enum {
+    /// The first bit represents invariant memory.
+    invariantMemoryBit = 0,
+    /// The remaining bits are used for arguments.
+    firstArgBit = 1,
+    maxArgIndex = 16 // should be more than enough.
+  };
 
-  // Keep track of if we've found any recursive blocks at all.
-  // We return true if we found any recursion and did not find any
-  // non-recursive, function-exiting blocks.
-  bool foundRecursion = false;
+  static_assert((unsigned)(1 << (firstArgBit + maxArgIndex)) != 0,
+                "too many argument bits");
 
-  while (!workList.empty()) {
-    SILBasicBlock *curBlock = workList.pop_back_val();
+  unsigned bitMask;
 
-    // Before checking for infinite recursion, see if we're calling something
-    // that's @_semantics("programtermination_point"). We explicitly don't
-    // want this call to disqualify the warning for infinite recursion,
-    // because they're reserved for exceptional circumstances.
-    if (isKnownProgramTerminationPoint(curBlock))
-      continue;
+  explicit Invariants(unsigned bitMask) : bitMask(bitMask) { }
 
-    // We're looking for functions that are recursive on _all_ paths. If this
-    // block is recursive, mark that we found recursion and check the next
-    // block in the work list.
-    if (hasRecursiveCallInBlock(*curBlock, targetFn)) {
-      foundRecursion = true;
-      continue;
+  bool isBitSet(int bitNr) const { return (bitMask & (1 << bitNr)) != 0; }
+
+  /// Recursively walks the use-def chain starting at \p value and returns
+  /// true if all visited values are invariant.
+  bool isInvariantValue(SILValue value,
+                        SmallPtrSetImpl<SILNode *> &visited) const {
+    SILNode *node = value->getRepresentativeSILNodeInObject();
+
+    // Avoid exponential complexity in case a value is used by multiple
+    // operands.
+    if (!visited.insert(node).second)
+      return true;
+
+    if (auto *inst = dyn_cast<SILInstruction>(node)) {
+      if (!isMemoryInvariant() && inst->mayReadFromMemory())
+        return false;
+
+      for (Operand &op : inst->getAllOperands()) {
+        if (!isInvariantValue(op.get(), visited))
+          return false;
+      }
+      return true;
     }
 
-    // If this block doesn't have a recursive call, and it exits the function,
-    // then we know the function is not infinitely recursive.
-    auto term = curBlock->getTerminator();
-    if (term->isFunctionExiting() || term->isProgramTerminating())
-      return false;
+    if (auto *funcArg = dyn_cast<SILFunctionArgument>(value)) {
+      return isArgumentInvariant(funcArg->getIndex());
+    }
 
-    // Otherwise, push the successors onto the stack if we haven't visited them.
-    for (auto *succ : curBlock->getSuccessorBlocks()) {
-      if (visited.insert(succ).second)
-        workList.push_back(succ);
+    return false;
+  }
+
+  friend llvm::DenseMapInfo<Invariants>;
+
+public:
+
+  static Invariants noInvariants() { return Invariants(0); }
+
+  /// Constructs invariants which include all forwarding arguments of
+  /// \p recursiveApply.
+  static Invariants fromForwardingArguments(FullApplySite recursiveApply) {
+    unsigned bitMask = 0;
+    auto incomingArgs = recursiveApply.getFunction()->getArguments();
+    for (auto argAndIndex : llvm::enumerate(recursiveApply.getArguments())) {
+      unsigned argIdx = argAndIndex.index();
+      if (argIdx <= maxArgIndex &&
+          stripAccessMarkers(argAndIndex.value()) == incomingArgs[argIdx])
+        bitMask |= (1 << (argIdx + firstArgBit));
+    }
+    return Invariants(bitMask);
+  }
+
+  Invariants withInvariantMemory() const {
+    return Invariants(bitMask | (1 << invariantMemoryBit));
+  }
+
+  bool isMemoryInvariant() const { return isBitSet(invariantMemoryBit); }
+
+  bool isArgumentInvariant(unsigned argIdx) const {
+    return argIdx <= maxArgIndex && isBitSet(argIdx + firstArgBit);
+  }
+
+  /// Returns true if \p term is a conditional terminator and has an invariant
+  /// condition.
+  bool isInvariant(TermInst *term) const {
+    switch (term->getTermKind()) {
+    case TermKind::SwitchEnumAddrInst:
+    case TermKind::CheckedCastAddrBranchInst:
+      if (!isMemoryInvariant())
+        return false;
+      LLVM_FALLTHROUGH;
+    case TermKind::CondBranchInst:
+    case TermKind::SwitchValueInst:
+    case TermKind::SwitchEnumInst:
+    case TermKind::CheckedCastBranchInst:
+    case TermKind::CheckedCastValueBranchInst: {
+      SmallPtrSet<SILNode *, 16> visited;
+      return isInvariantValue(term->getOperand(0), visited);
+    }
+    default:
+      return false;
     }
   }
-  return foundRecursion;
+
+  /// Returns true if \p recursiveApply is forwarding all arguments which are
+  /// expected to be invariant.
+  bool hasInvariantArguments(FullApplySite recursiveApply) const {
+    auto incomingArgs = recursiveApply.getFunction()->getArguments();
+    for (auto argAndIndex : llvm::enumerate(recursiveApply.getArguments())) {
+      unsigned argIdx = argAndIndex.index();
+      if (isArgumentInvariant(argIdx) &&
+          stripAccessMarkers(argAndIndex.value()) != incomingArgs[argIdx]) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+} // end anonymous namespace
+
+namespace  llvm {
+  template<> struct DenseMapInfo<Invariants> {
+    static Invariants getEmptyKey() {
+      return Invariants(DenseMapInfo<unsigned>::getEmptyKey());
+    }
+    static Invariants getTombstoneKey() {
+      return Invariants(DenseMapInfo<unsigned>::getTombstoneKey());
+    }
+    static unsigned getHashValue(Invariants deps) {
+      return DenseMapInfo<unsigned>::getHashValue(deps.bitMask);
+    }
+    static bool isEqual(Invariants LHS, Invariants RHS) {
+      return LHS.bitMask == RHS.bitMask;
+    }
+  };
 }
 
 namespace {
-  class DiagnoseInfiniteRecursion : public SILFunctionTransform {
-  public:
-    DiagnoseInfiniteRecursion() {}
 
-  private:
-    void run() override {
-      SILFunction *Fn = getFunction();
-      // Don't rerun diagnostics on deserialized functions.
-      if (Fn->wasDeserializedCanonical())
+/// Contains block-specific info which is needed to do the analysis.
+struct BlockInfo {
+  /// non-null if this block contains a recursive call.
+  SILInstruction *recursiveCall;
+
+  /// The number of successors which reach a `return`.
+  unsigned numSuccsNotReachingReturn;
+
+  /// True if the block has a terminator with an invariant condition.
+  ///
+  /// Note: "invariant" means: invariant with respect to the expected invariants,
+  ///       which are passed to the constructor.
+  bool hasInvariantCondition;
+
+  /// Is there any path from the this block to a function return, without going
+  /// through a recursive call?
+  ///
+  /// This flag is propagated up the control flow, starting at returns.
+  ///
+  /// Note that if memory is expected to be invariant, all memory-writing
+  /// instructions are also considered as a "return".
+  bool reachesReturn;
+
+  /// Is there any path from the entry to this block without going through a
+  /// `reachesReturn` block.
+  ///
+  /// This flag is propagated down the control flow, starting at entry. If this
+  /// flag reaches a block with a recursiveCall, it means that it's an infinite
+  /// recursive call.
+  bool reachableFromEntry;
+
+  // Make DenseMap<...,BlockInfo> compilable.
+  BlockInfo() {
+    llvm_unreachable("DenseMap should not construct an empty BlockInfo");
+  }
+
+  /// Get block information with expected \p invariants.
+  BlockInfo(SILBasicBlock *block, Invariants invariants) :
+      recursiveCall(nullptr),
+      numSuccsNotReachingReturn(block->getNumSuccessors()),
+      hasInvariantCondition(invariants.isInvariant(block->getTerminator())),
+      reachesReturn(false), reachableFromEntry(false) {
+    for (SILInstruction &inst : *block) {
+      if (auto applySite = FullApplySite::isa(&inst)) {
+        // Ignore blocks which call a @_semantics("programtermination_point").
+        // This is an assert-like program termination and we explicitly don't
+        // want this call to disqualify the warning for infinite recursion,
+        // because they're reserved for exceptional circumstances.
+        if (applySite.isCalleeKnownProgramTerminationPoint())
+          return;
+
+        if (isRecursiveCall(applySite) &&
+            invariants.hasInvariantArguments(applySite)) {
+          recursiveCall = &inst;
+          return;
+        }
+      }
+      if (invariants.isMemoryInvariant() && mayWriteToMemory(&inst)) {
+        // If we are assuming that all memory is invariant, a memory-writing
+        // instruction potentially breaks the infinite recursion loop. For the
+        // sake of the anlaysis, it's like a function return.
+        reachesReturn = true;
         return;
-
-      // Ignore empty functions and straight-line thunks.
-      if (Fn->empty() || Fn->isThunk() != IsNotThunk)
-        return;
-
-      // If we can't diagnose it, there's no sense analyzing it.
-      if (!Fn->hasLocation() || Fn->getLocation().getSourceLoc().isInvalid())
-        return;
-
-      if (hasInfinitelyRecursiveApply(Fn)) {
-        diagnose(Fn->getModule().getASTContext(),
-                 Fn->getLocation().getSourceLoc(),
-                 diag::warn_infinite_recursive_function);
       }
     }
-  };
+    TermInst *term = block->getTerminator();
+    if (term->isFunctionExiting() ||
+        // Also treat non-assert-like unreachables as returns, like "exit()".
+        term->isProgramTerminating()) {
+      reachesReturn = true;
+    }
+  }
+};
+
+/// Performs the analysis to detect infinite recursion loops.
+///
+/// The basic idea is to see if there is a path from the entry block to a
+/// function return without going through an infinite recursive call.
+///
+/// The analysis is done with a given set of invariants (see Invariants). The
+/// correctness of the result (i.e. no false infinite recursion reported) does
+/// _not_ depend on the chosen invariants. But it's a trade-off:
+/// The more invariants we include, the more conditions might become invariant
+/// (which is good). On the other hand, we have to ignore recursive calls which
+/// don't forward all invariant arguments.
+///
+/// We don't know in advance which invariants will yield the best result, i.e.
+/// let us detect an infinite recursion.
+/// For example, in f() we can only detect the infinite recursion if we expect
+/// that the parameter `x` is invariant.
+///
+///   func f(_ x: Int) {
+///     if x > 0 {   // an invariant condition!
+///       f(x)       // the call is forwarding the argument
+///     }
+///   }
+///
+/// But in g() we can only detect the infinite recursion if we _don't_ expect
+/// that the parameter is invariant.
+///
+///   func g(_ x: Int) {
+///     if x > 0 {   // no invariant condition
+///       g(x - 1)   // argument is not forwarded
+///     } else {
+///       g(x - 2)   // argument is not forwarded
+///     }
+///   }
+///
+class InfiniteRecursionAnalysis {
+  SILFunction *function;
+  llvm::DenseMap<SILBasicBlock *, BlockInfo> blockInfos;
+
+  InfiniteRecursionAnalysis(SILFunction *function) :
+    function(function),
+    // Reserve enough space in the map. Though, SILFunction::size() iterates
+    // over all blocks. But this is still better than to risk multiple mallocs.
+    blockInfos(function->size()) { }
+
+  BlockInfo &info(SILBasicBlock *block) { return blockInfos[block]; }
+
+  /// Propagates the `reachesReturn` flags up the control flow and returns true
+  /// if the flag reaches the entry block.
+  bool isEntryReachableFromReturn(Invariants invariants) {
+    // Contains blocks for which the `reachesReturn` flag is set.
+    SmallVector<SILBasicBlock *, 32> workList;
+
+    // First, initialize the block infos.
+    for (SILBasicBlock &block : *function) {
+      BlockInfo blockInfo(&block, invariants);
+      blockInfos.insert({&block, blockInfo});
+      if (blockInfo.reachesReturn)
+        workList.push_back(&block);
+    }
+
+    while (!workList.empty()) {
+      SILBasicBlock *block = workList.pop_back_val();
+      for (auto *pred : block->getPredecessorBlocks()) {
+        BlockInfo &predInfo = info(pred);
+        if (predInfo.reachesReturn ||
+            // Recursive calls block the flag propagation.
+            predInfo.recursiveCall != nullptr)
+          continue;
+
+        assert(predInfo.numSuccsNotReachingReturn > 0);
+        predInfo.numSuccsNotReachingReturn -= 1;
+
+        // This is the trick for handling invariant conditions: usually the
+        // `reachesReturn` flag is propagated if _any_ of the successors has it
+        // set.
+        // For invariant conditions, it's only propagated if _all_ successors
+        // have it set. If at least one of the successors reaches a recursive
+        // call and this successor is taken once, it will be taken forever
+        // (because the condition is invariant).
+        if (predInfo.hasInvariantCondition &&
+            predInfo.numSuccsNotReachingReturn > 0)
+          continue;
+
+        predInfo.reachesReturn = true;
+        workList.push_back(pred);
+      }
+    }
+    return info(function->getEntryBlock()).reachesReturn;
+  }
+
+  /// Propagates the `reachableFromEntry` flags down the control flow and
+  /// issues a warning if it reaches a recursive call.
+  /// Returns true, if at least one recursive call is found.
+  bool findRecursiveCallsAndDiagnose() {
+    SmallVector<SILBasicBlock *, 32> workList;
+    SILBasicBlock *entryBlock = function->getEntryBlock();
+    info(entryBlock).reachableFromEntry = true;
+    workList.push_back(entryBlock);
+
+    bool foundInfiniteRecursion = false;
+    while (!workList.empty()) {
+      SILBasicBlock *block = workList.pop_back_val();
+      if (auto *recursiveCall = info(block).recursiveCall) {
+        function->getModule().getASTContext().Diags.diagnose(
+                 recursiveCall->getLoc().getSourceLoc(),
+                 diag::warn_infinite_recursive_call);
+        foundInfiniteRecursion = true;
+        continue;
+      }
+      for (auto *succ : block->getSuccessorBlocks()) {
+        BlockInfo &succInfo = info(succ);
+        if (!succInfo.reachesReturn && !succInfo.reachableFromEntry) {
+          succInfo.reachableFromEntry = true;
+          workList.push_back(succ);
+        }
+      }
+    }
+    return foundInfiniteRecursion;
+  }
+
+public:
+
+  LLVM_ATTRIBUTE_USED void dump() {
+    for (SILBasicBlock &block : *function) {
+      BlockInfo &blockInfo = info(&block);
+      llvm::dbgs() << "bb" << block.getDebugID()
+                   << ": numSuccs= " << blockInfo.numSuccsNotReachingReturn;
+      if (blockInfo.recursiveCall)
+        llvm::dbgs() << " hasRecursiveCall";
+      if (blockInfo.hasInvariantCondition)
+        llvm::dbgs() << " hasInvariantCondition";
+      if (blockInfo.reachesReturn)
+        llvm::dbgs() << " reachesReturn";
+      if (blockInfo.reachableFromEntry)
+        llvm::dbgs() << " reachesRecursiveCall";
+      llvm::dbgs() << '\n';
+    }
+  }
+
+  /// Performs the analysis and issues a warnings for recursive calls.
+  /// Returns true, if at least one recursive call is found.
+  static bool analyzeAndDiagnose(SILFunction *function, Invariants invariants) {
+    InfiniteRecursionAnalysis analysis(function);
+    if (analysis.isEntryReachableFromReturn(invariants))
+      return false;
+
+    // Now we know that the function never returns.
+    // There can be three cases:
+    // 1. All paths end up in an abnormal program termination, like fatalError().
+    //    We don't want to warn about this. It's probably intention.
+    // 2. There is an infinite loop.
+    //    We don't want to warn about this either. Maybe it's intention. Anyway,
+    //    this case is handled by the DiagnoseUnreachable pass.
+    // 3. There is an infinite recursion.
+    //    That's what we are interested in. We do a forward propagation to find
+    //    the actual infinite recursive call(s) - if any.
+    return analysis.findRecursiveCallsAndDiagnose();
+  }
+};
+
+typedef SmallSetVector<Invariants, 4> InvariantsSet;
+
+/// Collect invariants with which we should try the analysis and return true if
+/// there is at least one recursive call in the function.
+static bool collectInvariantsToTry(SILFunction *function,
+                                   InvariantsSet &invariantsToTry) {
+  // Try with no invariants.
+  invariantsToTry.insert(Invariants::noInvariants());
+
+  bool recursiveCallsFound = false;
+
+  // Scan the function for recursive calls.
+  for (SILBasicBlock &block : *function) {
+    for (auto &inst : block) {
+      auto applySite = FullApplySite::isa(&inst);
+      if (applySite && isRecursiveCall(applySite)) {
+        recursiveCallsFound = true;
+
+        // See what parameters the recursive call is forwarding and use that
+        // as invariants.
+        invariantsToTry.insert(Invariants::fromForwardingArguments(applySite));
+
+        // Limit the size of the set to avoid quadratic complexity in corner
+        // cases. Usually 4 invariants are more than enough.
+        if (invariantsToTry.size() >= 4)
+          return true;
+      }
+    }
+  }
+  return recursiveCallsFound;
+}
+
+class DiagnoseInfiniteRecursion : public SILFunctionTransform {
+public:
+  DiagnoseInfiniteRecursion() {}
+
+private:
+  void run() override {
+    SILFunction *function = getFunction();
+    // Don't rerun diagnostics on deserialized functions.
+    if (function->wasDeserializedCanonical())
+      return;
+
+    // Try with different sets of invariants. To catch all cases we would need
+    // to try all parameter/memory permutations.
+    // But in practice, it's good enough to collect a reasonable set by finding
+    // all recursive calls and see what arguments they are forwarding.
+    InvariantsSet invariantsToTry;
+    if (!collectInvariantsToTry(function, invariantsToTry)) {
+      // There are no recursive calls in the function at all. We don't need to
+      // ramp-up the analysis.
+      // This is the case for most functions.
+      return;
+    }
+
+    for (Invariants invariants : invariantsToTry) {
+      if (InfiniteRecursionAnalysis::analyzeAndDiagnose(function, invariants))
+        return;
+      // Try again, assuming that memory is invariant.
+      if (InfiniteRecursionAnalysis::analyzeAndDiagnose(
+                               function, invariants.withInvariantMemory()))
+        return;
+    }
+  }
+};
+
 } // end anonymous namespace
 
 SILTransform *swift::createDiagnoseInfiniteRecursion() {

--- a/test/SILOptimizer/diagnose_unreachable.swift
+++ b/test/SILOptimizer/diagnose_unreachable.swift
@@ -258,7 +258,7 @@ class r20097963MyClass {
   }
 }
 
-func die() -> Never { die() } // expected-warning {{all paths through this function will call itself}}
+func die() -> Never { die() } // expected-warning {{function call causes an infinite recursion}}
 
 func testGuard(_ a : Int) {
   guard case 4 = a else {  }  // expected-error {{'guard' body must not fall through, consider using a 'return' or 'throw'}}

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -5,6 +5,10 @@ func a() {  // expected-warning {{all paths through this function will call itse
   a()
 }
 
+func throwing_func() throws {  // expected-warning {{all paths through this function will call itself}}
+  try throwing_func()
+}
+
 func b(_ x : Int) {  // expected-warning {{all paths through this function will call itself}}
   if x != 0 {
     b(x)

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -1,19 +1,26 @@
 // RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
 
-func a() {  // expected-warning {{all paths through this function will call itself}}
-  a()
+func a() {
+  a()  // expected-warning {{function call causes an infinite recursion}}
 }
 
-func throwing_func() throws {  // expected-warning {{all paths through this function will call itself}}
-  try throwing_func()
+func throwing_func() throws {
+  try throwing_func()  // expected-warning {{function call causes an infinite recursion}}
 }
 
-func b(_ x : Int) {  // expected-warning {{all paths through this function will call itself}}
+func b(_ x : Int) {
   if x != 0 {
-    b(x)
+    b(x)  // expected-warning {{function call causes an infinite recursion}}
   } else {
-    b(x+1)
+    b(x+1)  // expected-warning {{function call causes an infinite recursion}}
+  }
+}
+
+func noInvariantArgs(_ x : Int) {
+  if x != 0 {
+    noInvariantArgs(x-1)  // expected-warning {{function call causes an infinite recursion}}
+  } else {
+    noInvariantArgs(x+1)  // expected-warning {{function call causes an infinite recursion}}
   }
 }
 
@@ -23,12 +30,108 @@ func c(_ x : Int) {
   }
 }
 
-func d(_ x : Int) {  // expected-warning {{all paths through this function will call itself}}
+func invariantArgCondition(_ x : Int) {
+  if x != 0 {
+    invariantArgCondition(x)  // expected-warning {{function call causes an infinite recursion}}
+  }
+}
+
+func invariantLoopCondition(_ x : Int) {
+  while x != 0 {
+    invariantLoopCondition(x)  // expected-warning {{function call causes an infinite recursion}}
+  }
+}
+
+final class ClassWithInt {
+  var i: Int = 0
+}
+
+func invariantMemCondition(_ c: ClassWithInt) {
+  if c.i > 0 {
+    invariantMemCondition(c)  // expected-warning {{function call causes an infinite recursion}}
+  }
+}
+
+func variantMemCondition(_ c: ClassWithInt) {
+  if c.i > 0 {
+    c.i -= 1
+    invariantMemCondition(c)  // no warning
+  }
+}
+
+func nestedInvariantCondition(_ x : Int, _ y: Int) {
+  if x > 0 {
+    if y != 0 {
+      if x == 0 {
+        nestedInvariantCondition(x, y)  // expected-warning {{function call causes an infinite recursion}}
+      }
+    }
+  }
+}
+
+func nestedVariantCondition(_ x : Int, _ y: Int) {
+  if x > 0 {
+    if y != 0 {
+      if x == 0 {
+        nestedVariantCondition(x, y - 1) // no warning
+      }
+    }
+  }
+}
+
+func multipleArgs1(_ x : Int, _ y : Int) {
+  if y > 0 {
+    multipleArgs1(x - 1, y)  // expected-warning {{function call causes an infinite recursion}}
+  } else if x > 10 {
+    multipleArgs1(x - 2, y)
+  }
+}
+
+func multipleArgs2(_ x : Int, _ y : Int) {
+  if y > 0 {
+    multipleArgs2(x, y - 1)  // expected-warning {{function call causes an infinite recursion}}
+  } else if x > 10 {
+    multipleArgs2(x, y - 2)  // expected-warning {{function call causes an infinite recursion}}
+  }
+}
+
+func multipleArgsNoWarning(_ x : Int, _ y : Int) {
+  if y > 0 {
+    multipleArgsNoWarning(x, y - 1)
+  } else if x > 10 {
+    multipleArgsNoWarning(x - 1, y)
+  }
+}
+
+struct Str {
+  var x = 27
+
+  mutating func writesMemory() {
+    if x > 0 {
+      x -= 1
+      writesMemory() // no warning
+    }
+  }
+
+  mutating func doesNotWriteMem() {
+    if x > 0 {
+      doesNotWriteMem()  // expected-warning {{function call causes an infinite recursion}}
+    }
+  }
+
+  func nonMutating() {
+    if x > 0 {
+      nonMutating()  // expected-warning {{function call causes an infinite recursion}}
+    }
+  }
+}
+
+func d(_ x : Int) {
   var x = x
   if x != 0 {
     x += 1
   }
-  return d(x)
+  return d(x)  // expected-warning {{function call causes an infinite recursion}}
 }
 
 // Doesn't warn on mutually recursive functions
@@ -36,9 +139,9 @@ func d(_ x : Int) {  // expected-warning {{all paths through this function will 
 func e() { f() }
 func f() { e() }
 
-func g() { // expected-warning {{all paths through this function will call itself}}
+func g() {
   while true { // expected-note {{condition always evaluates to true}}
-    g()
+    g() // expected-warning {{function call causes an infinite recursion}}
   }
 
   g() // expected-warning {{will never be executed}}
@@ -50,20 +153,20 @@ func h(_ x : Int) {
   }
 }
 
-func i(_ x : Int) {  // expected-warning {{all paths through this function will call itself}}
+func i(_ x : Int) {
   var x = x
   while (x < 5) {
     x -= 1
   }
-  i(0)
+  i(0)  // expected-warning {{function call causes an infinite recursion}}
 }
 
-func j() -> Int {  // expected-warning {{all paths through this function will call itself}}
-  return 5 + j()
+func j() -> Int {
+  return 5 + j()  // expected-warning {{function call causes an infinite recursion}}
 }
 
-func k() -> Any {  // expected-warning {{all paths through this function will call itself}}
-  return type(of: k())
+func k() -> Any {
+  return type(of: k())  // expected-warning {{function call causes an infinite recursion}}
 }
 
 @_silgen_name("exit") func exit(_: Int32) -> Never
@@ -75,17 +178,17 @@ func l() {
   l()
 }
 
-func m() { // expected-warning {{all paths through this function will call itself}}
+func m() {
   guard Bool.random() else {
     fatalError() // we _do_ warn here, because fatalError is a programtermination_point
   }
-  m()
+  m() // expected-warning {{function call causes an infinite recursion}}
 }
 
 enum MyNever {}
 
-func blackHole() -> MyNever { // expected-warning {{all paths through this function will call itself}}
-  blackHole()
+func blackHole() -> MyNever {
+  blackHole() // expected-warning {{function call causes an infinite recursion}}
 }
 
 @_semantics("programtermination_point")
@@ -109,22 +212,22 @@ func o() -> MyNever {
 
 func mayHaveSideEffects() {}
 
-func p() { // expected-warning {{all paths through this function will call itself}}
+func p() {
   if Bool.random() {
     mayHaveSideEffects() // presence of side-effects doesn't alter the check for the programtermination_point apply
     fatalError()
   }
-  p()
+  p() // expected-warning {{function call causes an infinite recursion}}
 }
 
 class S {
-  convenience init(a: Int) { // expected-warning {{all paths through this function will call itself}}
-    self.init(a: a)
+  convenience init(a: Int) {
+    self.init(a: a) // expected-warning {{function call causes an infinite recursion}}
   }
   init(a: Int?) {}
 
-  static func a() { // expected-warning {{all paths through this function will call itself}}
-    return a()
+  static func a() {
+    return a() // expected-warning {{function call causes an infinite recursion}}
   }
 
   func b() { // No warning - has a known override.
@@ -152,28 +255,31 @@ class T: S {
     get {
       return super.bar
     }
-    set { // expected-warning {{all paths through this function will call itself}}
-      self.bar = newValue
+    set {
+      self.bar = newValue // expected-warning {{function call causes an infinite recursion}}
     }
   }
 }
 
-func == (l: S?, r: S?) -> Bool { // expected-warning {{all paths through this function will call itself}}
-  if l == nil && r == nil { return true }
+func == (l: S?, r: S?) -> Bool {
+  if l == nil && r == nil { return true } // expected-warning {{function call causes an infinite recursion}}
   guard let l = l, let r = r else { return false }
   return l === r
 }
 
-public func == <Element>(lhs: Array<Element>, rhs: Array<Element>) -> Bool { // expected-warning {{all paths through this function will call itself}}
-  return lhs == rhs
+public func == <Element>(lhs: Array<Element>, rhs: Array<Element>) -> Bool {
+  return lhs == rhs // expected-warning {{function call causes an infinite recursion}}
 }
 
-func factorial(_ n : UInt) -> UInt { // expected-warning {{all paths through this function will call itself}}
-  return (n != 0) ? factorial(n - 1) * n : factorial(1)
+func factorial(_ n : UInt) -> UInt {
+  return (n != 0) ? factorial(n - 1) * n : factorial(1) // expected-warning {{function call causes an infinite recursion}}
+                                                        // expected-warning @-1 {{function call causes an infinite recursion}}
+
 }
 
-func tr(_ key: String) -> String { // expected-warning {{all paths through this function will call itself}}
+func tr(_ key: String) -> String {
   return tr(key) ?? key // expected-warning {{left side of nil coalescing operator '??' has non-optional type}}
+                        // expected-warning @-1 {{function call causes an infinite recursion}}
 }
 
 class Node {

--- a/test/SILOptimizer/infinite_recursion_objc.swift
+++ b/test/SILOptimizer/infinite_recursion_objc.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 
 // REQUIRES: objc_interop
+// REQUIRES: OS=macosx
 
 // A negative test that the infinite recursion pass doesn't diagnose dynamic
 // dispatch.
@@ -15,6 +16,12 @@ class MyRecursiveClass {
 
   @objc dynamic func foo2() {
     return self.foo()
+  }
+}
+
+func insideAvailability() {
+  if #available(macOS 10.4.4, *) {
+    insideAvailability()  // expected-warning {{function call causes an infinite recursion}}
   }
 }
 


### PR DESCRIPTION
This PR contains 3 changes:

* handle throwing functions

https://bugs.swift.org/browse/SR-13568
rdar://69235604

* detect infinite recursive calls under invariant conditions. For example:
```
  func f() {
    if #available(macOS 10.4.4, *) {
      f()
    }
  }
```
or invariant conditions due to forwarded arguments:
```
  func f(_ x: Int) {
    if x > 0 {
      f(x)
    }
  }
```

https://bugs.swift.org/browse/SR-11842
rdar://57460599

* improve the warning message. Instead of giving a warning at the function location
```
  warning: all paths through this function will call itself
```
give a warning at the call location:
```
  warning: function call causes an infinite recursion
```
Especially in case of multiple recursive calls, it makes it easier to locate the problem.
