### PR TITLE
[5.4][Runtime] Fix incorrect memory ordering in ConcurrentReadableArray/HashMap

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -527,13 +527,18 @@ public:
       
       storage = newStorage;
       Capacity = newCapacity;
-      Elements.store(storage, std::memory_order_release);
+
+      // Use seq_cst here to ensure that the subsequent load of ReaderCount is
+      // ordered after this store. If ReaderCount is loaded first, then a new
+      // reader could come in between that load and this store, and then we
+      // could end up freeing the old storage pointer while it's still in use.
+      Elements.store(storage, std::memory_order_seq_cst);
     }
     
     new(&storage->data()[count]) ElemTy(elem);
     storage->Count.store(count + 1, std::memory_order_release);
     
-    if (ReaderCount.load(std::memory_order_acquire) == 0)
+    if (ReaderCount.load(std::memory_order_seq_cst) == 0)
       deallocateFreeList();
   }
 
@@ -848,7 +853,7 @@ private:
   /// Free all the arrays in the free lists if there are no active readers. If
   /// there are active readers, do nothing.
   void deallocateFreeListIfSafe() {
-    if (ReaderCount.load(std::memory_order_acquire) == 0)
+    if (ReaderCount.load(std::memory_order_seq_cst) == 0)
       FreeListNode::freeAll(&FreeList);
   }
 
@@ -866,7 +871,11 @@ private:
       FreeListNode::add(&FreeList, elements);
     }
 
-    Elements.store(newElements, std::memory_order_release);
+    // Use seq_cst here to ensure that the subsequent load of ReaderCount is
+    // ordered after this store. If ReaderCount is loaded first, then a new
+    // reader could come in between that load and this store, and then we
+    // could end up freeing the old elements pointer while it's still in use.
+    Elements.store(newElements, std::memory_order_seq_cst);
     return newElements;
   }
 
@@ -900,7 +909,11 @@ private:
       newIndices.storeIndexAt(nullptr, index, newI, std::memory_order_relaxed);
     }
 
-    Indices.store(newIndices.Value, std::memory_order_release);
+    // Use seq_cst here to ensure that the subsequent load of ReaderCount is
+    // ordered after this store. If ReaderCount is loaded first, then a new
+    // reader could come in between that load and this store, and then we
+    // could end up freeing the old indices pointer while it's still in use.
+    Indices.store(newIndices.Value, std::memory_order_seq_cst);
 
     if (auto *ptr = indices.pointer())
       FreeListNode::add(&FreeList, ptr);


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/35348 and https://github.com/apple/swift/pull/35383 to 5.4.

When reallocating storage, the storing the pointer to the new storage had insufficiently strong ordering. This could cause writers to check the reader count before storing the new storage pointer. If a reader then came in between that load and store, it would end up using the old storage pointer, while the writer could end up freeing it.

Also adjust the Concurrent.cpp tests to test with a variety of reader and writer counts. Counterintuitively, when freeing garbage is gated on there being zero readers, having a single reader will shake out problems that having lots of readers will not. We were testing with lots of readers in order to stress the code as much as possible, but this resulted in it being extremely rare for writers to ever see zero active readers.

rdar://69798617