### PR TITLE
test: introduce new `target-swiftxx-frontend` for C++ interop

### DIFF
--- a/test/ClangImporter/cxx_interop.swift
+++ b/test/ClangImporter/cxx_interop.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -typecheck %s -I %S/Inputs/custom-modules
 
 import CXXInterop
 

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s | %FileCheck %s
 
 import CXXInterop
 

--- a/test/ClangImporter/enum-cxx.swift
+++ b/test/ClangImporter/enum-cxx.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s -I %S/Inputs/custom-modules -module-cache-path %t -enable-cxx-interop -o - | %FileCheck %s
+// RUN: %target-swiftxx-frontend -emit-ir -primary-file %s -I %S/Inputs/custom-modules -o - | %FileCheck %s
 
 import CXXInterop
 

--- a/test/Interop/C/function/emit-called-inline-function-irgen.swift
+++ b/test/Interop/C/function/emit-called-inline-function-irgen.swift
@@ -6,7 +6,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -I %S/Inputs -Xcc -std=c99 -emit-ir -o - | %FileCheck %s -check-prefix C99 --implicit-check-not notCalled
-// RUN: %target-swift-frontend %s -I %S/Inputs -enable-cxx-interop -emit-ir -o - | %FileCheck %s -check-prefix CXX --implicit-check-not notCalled
+// RUN: %target-swiftxx-frontend %s -I %S/Inputs -emit-ir -o - | %FileCheck %s -check-prefix CXX --implicit-check-not notCalled
 
 import EmitCalledInlineFunction
 

--- a/test/Interop/Cxx/class/constructors-silgen.swift
+++ b/test/Interop/Cxx/class/constructors-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-silgen %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-silgen %s | %FileCheck %s
 
 import Constructors
 

--- a/test/Interop/Cxx/class/debug-info-irgen.swift
+++ b/test/Interop/Cxx/class/debug-info-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir -g | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir -g | %FileCheck %s
 
 // Validate that we don't crash when trying to deserialize C++ type debug info.
 // Note, however, that the actual debug info is not generated, see SR-13223.

--- a/test/Interop/Cxx/class/memory-layout-silgen.swift
+++ b/test/Interop/Cxx/class/memory-layout-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-ir -o - %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-ir -o - %s | %FileCheck %s
 
 import MemoryLayout
 

--- a/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 // Verify that non-trival/address-only C++ classes are constructed and accessed
 // correctly. Make sure that we correctly IRGen functions that construct

--- a/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -I %S/Inputs -enable-cxx-interop -emit-silgen %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs -emit-silgen %s | %FileCheck %s
 
 import TypeClassification
 

--- a/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility-inversed.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-constructor-visibility.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-decls-are-identical.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-decls-are-identical.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s 2>&1 | %FileCheck %s
+// RUN: not %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s 2>&1 | %FileCheck %s
 
 // This test checks that Swift recognizes that the DeclA and DeclB provide
 // different implementations for `getFortySomething()`

--- a/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility-inversed.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/use_module_a %t/use_module_b
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs -enable-cxx-interop
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs
 
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-transitive-visibility.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/use_module_a %t/use_module_b
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs -enable-cxx-interop
-// RUN: %target-swift-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_a/UseModuleA.swiftmodule %S/Inputs/use-module-a.swift -I %S/Inputs
+// RUN: %target-swiftxx-frontend -enable-library-evolution -swift-version 5 -emit-module -o %t/use_module_b/UseModuleB.swiftmodule %S/Inputs/use-module-b.swift -I %S/Inputs
 
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -typecheck -swift-version 5 -I %t/use_module_a -I %t/use_module_b -I %S/Inputs %s
 
 
 // Swift should consider all sources for a decl and recognize that the

--- a/test/Interop/Cxx/implementation-only-imports/check-function-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-visibility-inversed.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-function-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-function-visibility.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility-inversed.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
+++ b/test/Interop/Cxx/implementation-only-imports/check-operator-visibility.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s -enable-cxx-interop
+// RUN: %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s
 
 // Swift should consider all sources for a decl and recognize that the
 // decl is not hidden behind @_implementationOnly in all modules.

--- a/test/Interop/Cxx/implementation-only-imports/skip-forward-declarations.swift
+++ b/test/Interop/Cxx/implementation-only-imports/skip-forward-declarations.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs -enable-cxx-interop %s 2>&1 | %FileCheck %s
+// RUN: not %target-swiftxx-frontend -emit-module -o %t/FortyTwo.swiftmodule -I %S/Inputs %s 2>&1 | %FileCheck %s
 
 // This test checks that forward declarations are not considered
 // when determining the visibility of the decl.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1908,6 +1908,9 @@ if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_impli
 # When changing substitutions, update docs/Testing.md.
 #
 
+config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
+config.substitutions.append(('%target-swiftxx-frontend', '%s -enable-cxx-interop' % config.target_swift_frontend))
+
 config.substitutions.append(('%target-runtime', config.target_runtime))
 
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
@@ -1942,7 +1945,6 @@ config.substitutions.append(('%target-jit-run', subst_target_jit_run))
 config.substitutions.append(('%target-build-swift-dylib\(([^)]+)\)', config.target_build_swift_dylib))
 config.substitutions.append(('%target-codesign', config.target_codesign))
 config.substitutions.append(('%target-build-swift', config.target_build_swift))
-config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
 config.substitutions.append(('%target-clang', config.target_clang))
 config.substitutions.append(('%target-ld', config.target_ld))
 if hasattr(config, 'target_cc_options'):


### PR DESCRIPTION
Add an convert to the new `target-swiftxx-frontend` substitution in lit
to control the C++ interop enabling in Swift.  This allows for a single
site which will enable control of both an overridden standard (for
testing multiple C++ standards) and simplify writing tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
