### PR TITLE
[5.4][ConstraintSystem] Increase score only if members found on `Optional`…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2798,8 +2798,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     increaseScore(SK_DisfavoredOverload);
   }
 
-  if (choice.getKind() == OverloadChoiceKind::DeclViaUnwrappedOptional &&
-      locator->isLastElement<LocatorPathElt::UnresolvedMember>()) {
+  if (choice.isFallbackMemberOnUnwrappedBase()) {
     increaseScore(SK_UnresolvedMemberViaOptional);
   }
 }

--- a/test/Constraints/sr13815.swift
+++ b/test/Constraints/sr13815.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+// SR-13815
+
+enum E {
+case foo(String)
+}
+
+struct Test {
+  var bar: E?
+}
+
+struct S {
+  func evaluate(_: Test) -> [Test] {
+    return []
+  }
+
+  func test(set: Set<String>)  {
+    let flattened = set.flatMap { element in
+      evaluate(Test(bar: .foo(element)))
+    }
+
+    let _: [Test] = flattened // Ok (find .`bar` after unwrap)
+  }
+}


### PR DESCRIPTION
… and its unwrapped type

Unresolved member lookup is allowed to perform implicit optional
unwrap of a base type to find members. Previously if there were
any members directly on `Optional`, lookup would stop there. But
since SR-13815 it became possible for solver to attempt members
found on unwrapped type even if there are viable ones on
`Optional` as well.

New score kind has been introduced to guard against possible ambiguities
with new scheme - `SK_UnresolvedMemberViaOptional`. It's used very
time member found via base type unwrap is attempted. Unfortunately,
doing so can lead to behavior changes in existing code because it's
possible that base was wrapped into optional implicitly based on
context e.g. unresolved member passed in as an argument to a parameter
of optional type.

To fix situations like that, `SK_UnresolvedMemberViaOptional` should
only be increased if there is a mix of members to attempt - both directly
on `Optional` and on unwrapped type, in all other cases score should stay
the same because there could be no ambiguity.

Resolves: rdar://73027153
(cherry picked from commit 51dc7fdefab230d76518b97f9074a3f98e1fd0c3)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
