### PR TITLE
[Dependency Scanning] Distinguish Swift Textual and Swift Binary modules when resolving direct dependencies

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -156,7 +156,8 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
                           InterfaceSubContextDelegate &ASTDelegate) {
   auto &ctx = instance.getASTContext();
   auto knownDependencies = *cache.findDependencies(module.first, module.second);
-  auto isSwift = knownDependencies.isSwiftTextualModule();
+  auto isSwiftInterface = knownDependencies.isSwiftTextualModule();
+  auto isSwift = isSwiftInterface || knownDependencies.isSwiftBinaryModule();
 
   // Find the dependencies of every module this module directly depends on.
   std::set<ModuleDependencyID> result;
@@ -171,7 +172,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
     }
   }
 
-  if (isSwift) {
+  if (isSwiftInterface) {
     // A record of all of the Clang modules referenced from this Swift module.
     std::vector<std::string> allClangModules;
     llvm::StringSet<> knownModules;

--- a/test/ScanDependencies/bin_mod_import.swift
+++ b/test/ScanDependencies/bin_mod_import.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+import EWrapper
+
+// Step 1: Put the textual interface for E in the right place
+// RUN: cp %S/Inputs/Swift/E.swiftinterface %t/E.swiftinterface
+// Step 1: Build a swift interface into a binary module
+// RUN: %target-swift-frontend -compile-module-from-interface %S/Inputs/Swift/EWrapper.swiftinterface -o %t/EWrapper.swiftmodule -I %t
+// Step 3: scan dependency should give us the binary module and a textual swift dependency from it
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I %t
+// Step 4: Verify
+// RUN: %FileCheck %s < %t/deps.json
+
+// CHECK: "modulePath": "{{.*}}EWrapper.swiftmodule"
+// CHECK-NEXT: "directDependencies": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "E"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "Swift"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],


### PR DESCRIPTION
The intent is two-fold:
1. This fixes a bug where we would only attempt to resolve direct dependencies as Clang modules for Swift Binary modules.
2. Ensures that we only query the presence of a Bridging Header for textual Swift modules.

Resolves rdar://73015075