### PR TITLE
[DNM] [rebranch] Correct nullability of free() redeclaration

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -490,14 +490,6 @@ static void addIndirectResultAttributes(IRGenModule &IGM,
                               b);
 }
 
-void IRGenModule::addSwiftAsyncContextAttributes(llvm::AttributeList &attrs,
-                                                 unsigned argIndex) {
-  llvm::AttrBuilder b;
-  b.addAttribute(llvm::Attribute::SwiftAsync);
-  attrs = attrs.addAttributes(this->getLLVMContext(),
-                              argIndex + llvm::AttributeList::FirstArgIndex, b);
-}
-
 void IRGenModule::addSwiftSelfAttributes(llvm::AttributeList &attrs,
                                          unsigned argIndex) {
   llvm::AttrBuilder b;
@@ -1534,9 +1526,6 @@ void SignatureExpansion::expandExternalSignatureTypes() {
     case clang::CodeGen::ABIArgInfo::Direct: {
       switch (FI.getExtParameterInfo(i).getABI()) {
       case clang::ParameterABI::Ordinary:
-        break;
-      case clang::ParameterABI::SwiftAsyncContext:
-        IGM.addSwiftAsyncContextAttributes(Attrs, getCurParamIndex());
         break;
       case clang::ParameterABI::SwiftContext:
         IGM.addSwiftSelfAttributes(Attrs, getCurParamIndex());

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1620,9 +1620,6 @@ public:
   /// Add the swiftself attribute.
   void addSwiftSelfAttributes(llvm::AttributeList &attrs, unsigned argIndex);
 
-  void addSwiftAsyncContextAttributes(llvm::AttributeList &attrs,
-                                      unsigned argIndex);
-
   /// Add the swifterror attribute.
   void addSwiftErrorAttributes(llvm::AttributeList &attrs, unsigned argIndex);
 

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -43,7 +43,7 @@ __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
 // General utilities <stdlib.h>
 // Memory management functions
 static inline void _swift_stdlib_free(void *_Nullable ptr) {
-  extern void free(void *);
+  extern void free(void *_Nullable);
   free(ptr);
 }
 


### PR DESCRIPTION
In the new clang, this declaration ends up influencing the redeclaration chain, altering the nullability of the `free(_:)` function imported into Swift.

Fixes rdar://71269128. Note that tests may fail unless a clean build is performed.

I'm not yet certain whether I will merge this to rebranch or to main, but I know that I want a PR test against rebranch.