### PR TITLE
[Serialization] Serialize source file information to '.swiftsourceinfo' file

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -402,6 +402,9 @@ public:
     return false;
   }
 
+  virtual void
+  collectSourceFileNames(llvm::function_ref<void(StringRef)> callback) const {}
+
   static bool classof(const FileUnit *file) {
     return file->getKind() == FileUnitKind::SerializedAST ||
            file->getKind() == FileUnitKind::ClangModule ||

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -402,8 +402,8 @@ public:
     return false;
   }
 
-  virtual void
-  collectSourceFileNames(llvm::function_ref<void(StringRef)> callback) const {}
+  virtual void collectBasicSourceFileInfo(
+      llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const {}
 
   static bool classof(const FileUnit *file) {
     return file->getKind() == FileUnitKind::SerializedAST ||

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -728,6 +728,7 @@ public:
     return ReverseFullNameIterator(this);
   }
 
+  /// Calls \p callback for each source file of the module.
   void collectBasicSourceFileInfo(
       llvm::function_ref<void(const BasicSourceFileInfo &)> callback);
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -728,7 +728,8 @@ public:
     return ReverseFullNameIterator(this);
   }
 
-  void collectSourceFileNames(llvm::function_ref<void(StringRef)> callback);
+  void collectBasicSourceFileInfo(
+      llvm::function_ref<void(const BasicSourceFileInfo &)> callback);
 
   SourceRange getSourceRange() const { return SourceRange(); }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -728,6 +728,8 @@ public:
     return ReverseFullNameIterator(this);
   }
 
+  void collectSourceFileNames(llvm::function_ref<void(StringRef)> callback);
+
   SourceRange getSourceRange() const { return SourceRange(); }
 
   static bool classof(const DeclContext *DC) {

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -13,11 +13,15 @@
 #ifndef SWIFT_AST_RAW_COMMENT_H
 #define SWIFT_AST_RAW_COMMENT_H
 
+#include "swift/Basic/Fingerprint.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Basic/SourceManager.h"
 
 namespace swift {
+
+class SourceFile;
+
 struct SingleRawComment {
   enum class CommentKind {
     OrdinaryLine,  ///< Any normal // comments
@@ -90,6 +94,17 @@ struct BasicDeclLocs {
   LineColumn Loc;
   LineColumn StartLoc;
   LineColumn EndLoc;
+};
+
+struct BasicSourceFileInfo {
+  StringRef FilePath;
+  Fingerprint InterfaceHash = Fingerprint::ZERO();
+  llvm::sys::TimePoint<> LastModified = {};
+  uint64_t FileSize = 0;
+
+  BasicSourceFileInfo() {}
+
+  bool populate(SourceFile *SF);
 };
 
 } // namespace swift

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -531,6 +531,9 @@ public:
     out << getInterfaceHash() << '\n';
   }
 
+  /// Get this file's interface hash including the type members in the file.
+  Fingerprint getInterfaceHashIncludingTypeMembers() const;
+
   /// If this source file has been told to collect its parsed tokens, retrieve
   /// those tokens.
   ArrayRef<Token> getAllTokens() const;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -446,8 +446,8 @@ public:
 
   StringRef getTargetTriple() const;
 
-  virtual void collectSourceFileNames(
-      llvm::function_ref<void(StringRef)>) const override;
+  virtual void collectBasicSourceFileInfo(
+      llvm::function_ref<void(const BasicSourceFileInfo &)>) const override;
 
   static bool classof(const FileUnit *file) {
     return file->getKind() == FileUnitKind::SerializedAST;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -446,6 +446,9 @@ public:
 
   StringRef getTargetTriple() const;
 
+  virtual void collectSourceFileNames(
+      llvm::function_ref<void(StringRef)>) const override;
+
   static bool classof(const FileUnit *file) {
     return file->getKind() == FileUnitKind::SerializedAST;
   }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1514,6 +1514,17 @@ const clang::Module *ModuleDecl::findUnderlyingClangModule() const {
   return nullptr;
 }
 
+void ModuleDecl::collectSourceFileNames(
+    llvm::function_ref<void(StringRef)> callback) {
+  for (FileUnit *fileUnit : getFiles()) {
+    if (SourceFile *SF = dyn_cast<SourceFile>(fileUnit)) {
+      callback(SF->getFilename());
+    } else if (auto *serialized = dyn_cast<LoadedFile>(fileUnit)) {
+      serialized->collectSourceFileNames(callback);
+    }
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Cross-Import Overlays
 //===----------------------------------------------------------------------===//

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1538,13 +1538,16 @@ const clang::Module *ModuleDecl::findUnderlyingClangModule() const {
   return nullptr;
 }
 
-void ModuleDecl::collectSourceFileNames(
-    llvm::function_ref<void(StringRef)> callback) {
+void ModuleDecl::collectBasicSourceFileInfo(
+    llvm::function_ref<void(const BasicSourceFileInfo &)> callback) {
   for (FileUnit *fileUnit : getFiles()) {
     if (SourceFile *SF = dyn_cast<SourceFile>(fileUnit)) {
-      callback(SF->getFilename());
+      BasicSourceFileInfo info;
+      if (info.populate(SF))
+        continue;
+      callback(info);
     } else if (auto *serialized = dyn_cast<LoadedFile>(fileUnit)) {
-      serialized->collectSourceFileNames(callback);
+      serialized->collectBasicSourceFileInfo(callback);
     }
   }
 }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -968,11 +968,15 @@ void ModuleFile::collectBasicSourceFileInfo(
   auto *Cursor = Core->SourceFileListData.bytes_begin();
   auto *End = Core->SourceFileListData.bytes_end();
   while (Cursor < End) {
+    // FilePath (byte offset in 'SourceLocsTextData').
     auto fileID = endian::readNext<uint32_t, little, unaligned>(Cursor);
+    // InterfaceHash (fixed length string).
     auto fpStr = StringRef{reinterpret_cast<const char *>(Cursor),
                            Fingerprint::DIGEST_LENGTH};
     Cursor += Fingerprint::DIGEST_LENGTH;
+    // LastModified (seconds since epoch).
     auto timestamp = endian::readNext<uint64_t, little, unaligned>(Cursor);
+    // FileSize (num of bytes).
     auto fileSize = endian::readNext<uint64_t, little, unaligned>(Cursor);
 
     assert(fileID < Core->SourceLocsTextData.size());

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -974,7 +974,7 @@ void ModuleFile::collectBasicSourceFileInfo(
     auto fpStr = StringRef{reinterpret_cast<const char *>(Cursor),
                            Fingerprint::DIGEST_LENGTH};
     Cursor += Fingerprint::DIGEST_LENGTH;
-    // LastModified (seconds since epoch).
+    // LastModified (nanoseconds since epoch).
     auto timestamp = endian::readNext<uint64_t, little, unaligned>(Cursor);
     // FileSize (num of bytes).
     auto fileSize = endian::readNext<uint64_t, little, unaligned>(Cursor);
@@ -987,7 +987,8 @@ void ModuleFile::collectBasicSourceFileInfo(
     BasicSourceFileInfo info;
     info.FilePath = filePath;
     info.InterfaceHash = Fingerprint::fromString(fpStr);
-    info.LastModified = llvm::sys::TimePoint<>(std::chrono::seconds(timestamp));
+    info.LastModified =
+        llvm::sys::TimePoint<>(std::chrono::nanoseconds(timestamp));
     info.FileSize = fileSize;
     callback(info);
   }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -694,7 +694,8 @@ public:
   Optional<BasicDeclLocs> getBasicDeclLocsForDecl(const Decl *D) const;
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D);
   Optional<Fingerprint> loadFingerprint(const IterableDeclContext *IDC) const;
-  void collectSourceFileNames(llvm::function_ref<void(StringRef)> callback) const;
+  void collectBasicSourceFileInfo(
+      llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const;
 
 
   // MARK: Deserialization interface

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -694,6 +694,7 @@ public:
   Optional<BasicDeclLocs> getBasicDeclLocsForDecl(const Decl *D) const;
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D);
   Optional<Fingerprint> loadFingerprint(const IterableDeclContext *IDC) const;
+  void collectSourceFileNames(llvm::function_ref<void(StringRef)> callback) const;
 
 
   // MARK: Deserialization interface

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -974,6 +974,9 @@ bool ModuleFileSharedCore::readDeclLocsBlock(llvm::BitstreamCursor &cursor) {
         return false;
       }
       switch (*kind) {
+      case decl_locs_block::SOURCE_FILE_LIST:
+        SourceFileListData = blobData;
+        break;
       case decl_locs_block::BASIC_DECL_LOCS:
         BasicDeclLocsData = blobData;
         break;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -289,6 +289,9 @@ private:
   /// A blob of 0 terminated string segments referenced in \c SourceLocsTextData
   StringRef SourceLocsTextData;
 
+  /// A blob of source file list.
+  StringRef SourceFileListData;
+
   /// An array of fixed size source location data for each USR appearing in
   /// \c DeclUSRsTable.
   StringRef BasicDeclLocsData;

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -804,7 +804,7 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
 
       auto fileID = FWriter.getTextOffset(absolutePath);
       auto fingerprintStr = info.InterfaceHash.getRawValue();
-      auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+      auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
                            info.LastModified.time_since_epoch())
                            .count();
 
@@ -815,9 +815,9 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
       // InterfaceHash (fixed length string).
       assert(fingerprintStr.size() == Fingerprint::DIGEST_LENGTH);
       out << fingerprintStr;
-      // LastModified.
+      // LastModified (nanoseconds since epoch).
       writer.write<uint64_t>(timestamp);
-      // FileSize.
+      // FileSize (num of bytes).
       writer.write<uint64_t>(info.FileSize);
     }
 

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -793,29 +793,39 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
     llvm::SmallString<1024> Buffer;
     llvm::StringSet<> seenFilenames;
 
-    void emitFilename(StringRef filename) {
-      if (filename.empty())
-        return;
-      llvm::SmallString<128> absolutePath = filename;
+    void emitSourceFileInfo(const BasicSourceFileInfo &info) {
+      // Make 'FilePath' absolute for serialization;
+      SmallString<128> absolutePath = info.FilePath;
       llvm::sys::fs::make_absolute(absolutePath);
-      if (!seenFilenames.insert(absolutePath).second)
+
+      // Don't emit duplicated files.
+      if (!seenFilenames.insert(info.FilePath).second)
         return;
 
       auto fileID = FWriter.getTextOffset(absolutePath);
+      auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(info.LastModified.time_since_epoch()).count();
+
       llvm::raw_svector_ostream out(Buffer);
       endian::Writer writer(out, little);
       writer.write<uint32_t>(fileID);
+      out << info.InterfaceHash.getRawValue();
+      writer.write<uint64_t>(timestamp);
+      writer.write<uint64_t>(info.FileSize);
     }
 
     SourceFileListWriter(StringWriter &FWriter) : FWriter(FWriter) {}
   } writer(FWriter);
 
   if (SourceFile *SF = MSF.dyn_cast<SourceFile *>()) {
-    writer.emitFilename(SF->getFilename());
+    BasicSourceFileInfo info;
+    SmallString<128> stash;
+    if (info.populate(SF))
+      return;
+    writer.emitSourceFileInfo(info);
   } else {
     auto *M = MSF.get<ModuleDecl *>();
-    M->collectSourceFileNames(
-        [&](StringRef filename) { writer.emitFilename(filename); });
+    M->collectBasicSourceFileInfo(
+        [&](const BasicSourceFileInfo &info) { writer.emitSourceFileInfo(info); });
   }
 
   const decl_locs_block::SourceFileListLayout FileList(Out);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1327,3 +1327,8 @@ SerializedASTFile::getDiscriminatorForPrivateValue(const ValueDecl *D) const {
   assert(!discriminator.empty() && "no discriminator found for value");
   return discriminator;
 }
+
+void SerializedASTFile::collectSourceFileNames(
+    llvm::function_ref<void(StringRef)> callback) const {
+  File.collectSourceFileNames(callback);
+}

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1328,7 +1328,7 @@ SerializedASTFile::getDiscriminatorForPrivateValue(const ValueDecl *D) const {
   return discriminator;
 }
 
-void SerializedASTFile::collectSourceFileNames(
-    llvm::function_ref<void(StringRef)> callback) const {
-  File.collectSourceFileNames(callback);
+void SerializedASTFile::collectBasicSourceFileInfo(
+    llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const {
+  File.collectBasicSourceFileInfo(callback);
 }

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -49,7 +49,7 @@ const uint16_t SWIFTSOURCEINFO_VERSION_MAJOR = 2;
 /// interesting to test for. A backwards-compatible change is one where an \e
 /// old compiler can read the new format without any problems (usually by
 /// ignoring new information).
-const uint16_t SWIFTSOURCEINFO_VERSION_MINOR = 0; // Last change: add doc comment ranges
+const uint16_t SWIFTSOURCEINFO_VERSION_MINOR = 1; // Last change: add source file list
 
 /// The hash seed used for the string hashes(llvm::djbHash) in a .swiftsourceinfo file.
 const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;
@@ -72,11 +72,17 @@ namespace decl_locs_block {
     DECL_USRS,
     TEXT_DATA,
     DOC_RANGES,
+    SOURCE_FILE_LIST,
   };
 
   using BasicDeclLocsLayout = BCRecordLayout<
     BASIC_DECL_LOCS, // record ID
     BCBlob           // an array of fixed size location data
+  >;
+
+  using SourceFileListLayout = BCRecordLayout<
+    SOURCE_FILE_LIST, // record ID
+    BCBlob            // An array of string offsets in TextDataLayout
   >;
 
   using DeclUSRSLayout = BCRecordLayout<

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -75,14 +75,14 @@ namespace decl_locs_block {
     SOURCE_FILE_LIST,
   };
 
+  using SourceFileListLayout = BCRecordLayout<
+    SOURCE_FILE_LIST, // record ID
+    BCBlob            // An array of fixed size 'BasicSourceFileInfo' data.
+  >;
+
   using BasicDeclLocsLayout = BCRecordLayout<
     BASIC_DECL_LOCS, // record ID
     BCBlob           // an array of fixed size location data
-  >;
-
-  using SourceFileListLayout = BCRecordLayout<
-    SOURCE_FILE_LIST, // record ID
-    BCBlob            // An array of string offsets in TextDataLayout
   >;
 
   using DeclUSRSLayout = BCRecordLayout<

--- a/test/Serialization/Inputs/SourceInfo/File1.swift
+++ b/test/Serialization/Inputs/SourceInfo/File1.swift
@@ -1,0 +1,2 @@
+public func foo(val: MyStruct) {
+}

--- a/test/Serialization/Inputs/SourceInfo/File2.swift
+++ b/test/Serialization/Inputs/SourceInfo/File2.swift
@@ -1,0 +1,4 @@
+public struct MyStruct {
+    var x: Int
+    var y: Int
+}

--- a/test/Serialization/sourceinfo.swift
+++ b/test/Serialization/sourceinfo.swift
@@ -1,0 +1,22 @@
+// BEGIN File1.swift
+public func foo(val: MyStruct) {
+}
+
+// BEGIN File2.swift
+public struct MyStruct {
+    var x: Int
+    var y: Int
+}
+
+// BEGIN DUMMY.swift
+import MyModule
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swiftc_driver -emit-module -module-name MyModule -o %t/Modules/MyModule.swiftmodule %t/File1.swift %t/File2.swift
+// RUN: %swift-ide-test -print-module-metadata -module-to-print MyModule -enable-swiftsourceinfo -I %t/Modules -source-filename %t/DUMMY.swift | %FileCheck %s
+
+// CHECK: filepath=BUILD_DIR/{{.*}}/File1.swift; hash=b44bab617797a7239a9fa948f11eb90b; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=36
+// CHECK: filepath=BUILD_DIR/{{.*}}/File2.swift; hash=c989d6b98d505a1f52749d43ea0569a1; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=58

--- a/test/Serialization/sourceinfo.swift
+++ b/test/Serialization/sourceinfo.swift
@@ -1,22 +1,10 @@
-// BEGIN File1.swift
-public func foo(val: MyStruct) {
-}
-
-// BEGIN File2.swift
-public struct MyStruct {
-    var x: Int
-    var y: Int
-}
-
-// BEGIN DUMMY.swift
 import MyModule
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Modules)
-// RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swiftc_driver -emit-module -module-name MyModule -o %t/Modules/MyModule.swiftmodule %t/File1.swift %t/File2.swift
-// RUN: %swift-ide-test -print-module-metadata -module-to-print MyModule -enable-swiftsourceinfo -I %t/Modules -source-filename %t/DUMMY.swift | %FileCheck %s
+// RUN: %target-swiftc_driver -emit-module -module-name MyModule -o %t/Modules/MyModule.swiftmodule %S/Inputs/SourceInfo/File1.swift %S/Inputs/SourceInfo/File2.swift
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print MyModule -enable-swiftsourceinfo -I %t/Modules -source-filename %s | %FileCheck %s
 
-// CHECK: filepath=BUILD_DIR/{{.*}}/File1.swift; hash=b44bab617797a7239a9fa948f11eb90b; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=36
-// CHECK: filepath=BUILD_DIR/{{.*}}/File2.swift; hash=c989d6b98d505a1f52749d43ea0569a1; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=58
+// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File1.swift; hash=b44bab617797a7239a9fa948f11eb90b; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=35
+// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File2.swift; hash=c989d6b98d505a1f52749d43ea0569a1; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=57

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2519,6 +2519,9 @@ static void printModuleMetadata(ModuleDecl *MD) {
     OS << "link library: " << lib.getName()
        << ", force load: " << (lib.shouldForceLoad() ? "true" : "false") << "\n";
   });
+  MD->collectSourceFileNames([&](StringRef filename) {
+    OS << filename << "\n";
+  });
 }
 
 static int doPrintModuleMetaData(const CompilerInvocation &InitInvok,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2519,8 +2519,12 @@ static void printModuleMetadata(ModuleDecl *MD) {
     OS << "link library: " << lib.getName()
        << ", force load: " << (lib.shouldForceLoad() ? "true" : "false") << "\n";
   });
-  MD->collectSourceFileNames([&](StringRef filename) {
-    OS << filename << "\n";
+  MD->collectBasicSourceFileInfo([&](const BasicSourceFileInfo &info) {
+    OS << "filepath=" << info.FilePath << "; ";
+    OS << "hash=" << info.InterfaceHash.getRawValue() << "; ";
+    OS << "mtime=" << info.LastModified << "; ";
+    OS << "size=" << info.FileSize;
+    OS << "\n";
   });
 }
 


### PR DESCRIPTION
Serialize module source file informations to `.swiftsourceinfo` file.
* File path
* Interface hash (including type members)
* Modified time
* Size
