### PR TITLE
[NFC-ish] Correct nullability of free() redeclaration

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -43,7 +43,7 @@ __swift_size_t _swift_stdlib_fwrite_stdout(const void *ptr, __swift_size_t size,
 // General utilities <stdlib.h>
 // Memory management functions
 static inline void _swift_stdlib_free(void *_Nullable ptr) {
-  extern void free(void *);
+  extern void free(void *_Nullable);
   free(ptr);
 }
 


### PR DESCRIPTION
LibcShims.h redeclares `free()` inside an "assume_nonnull" section, so this redeclaration's parameter is treated as `_Nonnull`.

With the clang currently used by the "main" branch, this mistake is harmless. With the clang in "next" and "rebranch", however, this redeclaration changes the optionality of `free(_:)`'s parameter when imported into Swift, which causes source compatibility failures in both the Swift test suite and downstream projects like llbuildSwift.

This PR adds a `_Nonnull` annotation to the redeclaration so that it imports as intended.

Fixes rdar://71269128. Note that some tests may fail unless a clean build is performed; I'm hoping the PR test provides a little clarity about this.