### PR TITLE
GSB: Handle concrete ResolvedTypes in ArchetypeType::resolveNestedType() [5.4]

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/sr13519.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13519.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+// https://bugs.swift.org/browse/SR-13519
+
+class Class: P {
+  typealias A = Bool
+}
+
+protocol P {
+  associatedtype A
+}
+
+protocol Q : P {
+  func takesA(arg: A)
+}
+
+func test<T: Class & Q>(arg: T) {
+  arg.takesA(arg: true)
+}


### PR DESCRIPTION
A nested type of an archetype type might be concrete, for example, via a
same-type constraint:

```
extension SomeProtocol where SomeAssoc == Int {
  ... Self.SomeAssoc ...
}
```

This can happen in one of two ways; either the EquivalenceClass of the
nested type has a concrete type, or it is "fully concrete" because
there is no equivalence class and maybeResolveEquivalenceClass() returns
a ResolvedType storing the concrete type.

For some reason we didn't handle the second case here.

This is a slightly simplified version of PR https://github.com/apple/swift/pull/33859 by @AnthonyLatsis.

Fixes https://bugs.swift.org/browse/SR-13519 / rdar://problem/68531679