### PR TITLE
Trade Usages of -m${platform}-version-min For -target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,9 +655,10 @@ endif()
 #
 
 if(XCODE)
-  # FIXME: Cannot cross-compile the standard library using Xcode.  Xcode
-  # insists on passing -mmacosx-version-min to the compiler, and we need
-  # to pass -mios-version-min.  Clang sees both options and complains.
+  # FIXME: It used to be the case that Xcode would force
+  # -m${platform}-version-min flags that would conflict with those computed
+  # by build-script. version-min flags are deprecated in favor of -target since
+  # clang-11, so we might be able to undo this.
   set(SWIFT_SDKS "OSX")
 endif()
 

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -114,8 +114,7 @@ function(_add_host_variant_c_compile_link_flags name)
     # side effects are introduced should a new search path be added.
     target_compile_options(${name} PRIVATE
       -arch ${SWIFT_HOST_VARIANT_ARCH}
-      "-F${SWIFT_SDK_${SWIFT_HOST_VARIANT_ARCH}_PATH}/../../../Developer/Library/Frameworks"
-      "-m${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_VERSION_MIN_NAME}-version-min=${DEPLOYMENT_VERSION}")
+      "-F${SWIFT_SDK_${SWIFT_HOST_VARIANT_ARCH}_PATH}/../../../Developer/Library/Frameworks")
   endif()
 
   _compute_lto_flag("${SWIFT_TOOLS_ENABLE_LTO}" _lto_flag_out)

--- a/cmake/modules/DarwinSDKs.cmake
+++ b/cmake/modules/DarwinSDKs.cmake
@@ -20,7 +20,7 @@ is_sdk_requested(OSX swift_build_osx)
 if(swift_build_osx)
   configure_sdk_darwin(
       OSX "OS X" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}"
-      macosx macosx macosx macos "${SUPPORTED_OSX_ARCHS}")
+      macosx macosx macos "${SUPPORTED_OSX_ARCHS}")
   configure_target_variant(OSX-DA "OS X Debug+Asserts"   OSX DA "Debug+Asserts")
   configure_target_variant(OSX-RA "OS X Release+Asserts" OSX RA "Release+Asserts")
   configure_target_variant(OSX-R  "OS X Release"         OSX R  "Release")
@@ -38,7 +38,7 @@ if(swift_build_freestanding)
       "Which architectures to build when building the FREESTANDING stdlib")
   configure_sdk_darwin(
       FREESTANDING "FREESTANDING" ""
-      "${SWIFT_FREESTANDING_SDK}" freestanding
+      "${SWIFT_FREESTANDING_SDK}"
       "${SWIFT_FREESTANDING_TRIPLE_NAME}" "${SWIFT_FREESTANDING_MODULE_NAME}" "${SWIFT_FREESTANDING_ARCHS}")
   set(SWIFT_SDK_FREESTANDING_LIB_SUBDIR "freestanding")
   configure_target_variant(FREESTANDING-DA "FREESTANDING Debug+Asserts"   FREESTANDING DA "Debug+Asserts")
@@ -54,7 +54,7 @@ is_sdk_requested(IOS swift_build_ios)
 if(swift_build_ios)
   configure_sdk_darwin(
       IOS "iOS" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_IOS}"
-      iphoneos ios ios ios "${SUPPORTED_IOS_ARCHS}")
+      iphoneos ios ios "${SUPPORTED_IOS_ARCHS}")
   configure_target_variant(IOS-DA "iOS Debug+Asserts"   IOS DA "Debug+Asserts")
   configure_target_variant(IOS-RA "iOS Release+Asserts" IOS RA "Release+Asserts")
   configure_target_variant(IOS-R  "iOS Release"         IOS R "Release")
@@ -64,7 +64,7 @@ is_sdk_requested(IOS_SIMULATOR swift_build_ios_simulator)
 if(swift_build_ios_simulator)
   configure_sdk_darwin(
       IOS_SIMULATOR "iOS Simulator" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_IOS}"
-      iphonesimulator ios-simulator ios ios-simulator
+      iphonesimulator ios ios-simulator
       "${SUPPORTED_IOS_SIMULATOR_ARCHS}")
   configure_target_variant(
       IOS_SIMULATOR-DA "iOS Debug+Asserts"   IOS_SIMULATOR DA "Debug+Asserts")
@@ -78,7 +78,7 @@ is_sdk_requested(TVOS swift_build_tvos)
 if(swift_build_tvos)
   configure_sdk_darwin(
       TVOS "tvOS" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS}"
-      appletvos tvos tvos tvos "${SUPPORTED_TVOS_ARCHS}")
+      appletvos tvos tvos "${SUPPORTED_TVOS_ARCHS}")
   configure_target_variant(TVOS-DA "tvOS Debug+Asserts"   TVOS DA "Debug+Asserts")
   configure_target_variant(TVOS-RA "tvOS Release+Asserts" TVOS RA "Release+Asserts")
   configure_target_variant(TVOS-R  "tvOS Release"         TVOS R "Release")
@@ -88,7 +88,7 @@ is_sdk_requested(TVOS_SIMULATOR swift_build_tvos_simulator)
 if(swift_build_tvos_simulator)
   configure_sdk_darwin(
       TVOS_SIMULATOR "tvOS Simulator" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS}"
-      appletvsimulator tvos-simulator tvos tvos-simulator
+      appletvsimulator tvos tvos-simulator
       "${SUPPORTED_TVOS_SIMULATOR_ARCHS}")
   configure_target_variant(
     TVOS_SIMULATOR-DA "tvOS Debug+Asserts"   TVOS_SIMULATOR DA "Debug+Asserts")
@@ -102,7 +102,7 @@ is_sdk_requested(WATCHOS swift_build_watchos)
 if(swift_build_watchos)
   configure_sdk_darwin(
       WATCHOS "watchOS" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
-      watchos watchos watchos watchos "${SUPPORTED_WATCHOS_ARCHS}")
+      watchos watchos watchos "${SUPPORTED_WATCHOS_ARCHS}")
   configure_target_variant(WATCHOS-DA "watchOS Debug+Asserts"   WATCHOS DA "Debug+Asserts")
   configure_target_variant(WATCHOS-RA "watchOS Release+Asserts" WATCHOS RA "Release+Asserts")
   configure_target_variant(WATCHOS-R  "watchOS Release"         WATCHOS R "Release")
@@ -112,7 +112,7 @@ is_sdk_requested(WATCHOS_SIMULATOR swift_build_watchos_simulator)
 if(swift_build_watchos_simulator)
   configure_sdk_darwin(
       WATCHOS_SIMULATOR "watchOS Simulator" "${SWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
-      watchsimulator watchos-simulator watchos watchos-simulator
+      watchsimulator watchos watchos-simulator
       "${SUPPORTED_WATCHOS_SIMULATOR_ARCHS}")
   configure_target_variant(WATCHOS_SIMULATOR-DA "watchOS Debug+Asserts"   WATCHOS_SIMULATOR DA "Debug+Asserts")
   configure_target_variant(WATCHOS_SIMULATOR-RA "watchOS Release+Asserts" WATCHOS_SIMULATOR RA "Release+Asserts")

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -28,7 +28,6 @@ function(_report_sdk prefix)
     message(STATUS "  Version: ${SWIFT_SDK_${prefix}_VERSION}")
     message(STATUS "  Build number: ${SWIFT_SDK_${prefix}_BUILD_NUMBER}")
     message(STATUS "  Deployment version: ${SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION}")
-    message(STATUS "  Version min name: ${SWIFT_SDK_${prefix}_VERSION_MIN_NAME}")
     message(STATUS "  Triple name: ${SWIFT_SDK_${prefix}_TRIPLE_NAME}")
     message(STATUS "  Simulator: ${SWIFT_SDK_${prefix}_IS_SIMULATOR}")
   endif()
@@ -125,7 +124,6 @@ endfunction()
 #     name               # Display name for this SDK
 #     deployment_version # Deployment version
 #     xcrun_name         # SDK name to use with xcrun
-#     version_min_name   # The name used in the -mOS-version-min flag
 #     triple_name        # The name used in Swift's -triple
 #     architectures      # A list of architectures this SDK supports
 #   )
@@ -143,7 +141,6 @@ endfunction()
 #   SWIFT_SDK_${prefix}_BUILD_NUMBER        SDK build number (e.g., 14A389a)
 #   SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION  Deployment version (e.g., 10.9, 7.0)
 #   SWIFT_SDK_${prefix}_LIB_SUBDIR          Library subdir for this SDK
-#   SWIFT_SDK_${prefix}_VERSION_MIN_NAME    Version min name for this SDK
 #   SWIFT_SDK_${prefix}_TRIPLE_NAME         Triple name for this SDK
 #   SWIFT_SDK_${prefix}_OBJECT_FORMAT       The object file format (e.g. MACHO)
 #   SWIFT_SDK_${prefix}_USE_ISYSROOT        Whether to use -isysroot
@@ -153,7 +150,7 @@ endfunction()
 #   SWIFT_SDK_${prefix}_ARCH_${ARCH}_MODULE Module triple name for this SDK
 macro(configure_sdk_darwin
     prefix name deployment_version xcrun_name
-    version_min_name triple_name module_name architectures)
+    triple_name module_name architectures)
   # Note: this has to be implemented as a macro because it sets global
   # variables.
 
@@ -186,7 +183,6 @@ macro(configure_sdk_darwin
   set(SWIFT_SDK_${prefix}_NAME "${name}")
   set(SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION "${deployment_version}")
   set(SWIFT_SDK_${prefix}_LIB_SUBDIR "${xcrun_name}")
-  set(SWIFT_SDK_${prefix}_VERSION_MIN_NAME "${version_min_name}")
   set(SWIFT_SDK_${prefix}_TRIPLE_NAME "${triple_name}")
   set(SWIFT_SDK_${prefix}_OBJECT_FORMAT "MACHO")
   set(SWIFT_SDK_${prefix}_USE_ISYSROOT TRUE)
@@ -495,7 +491,6 @@ function(configure_target_variant prefix name sdk build_config lib_subdir)
   set(SWIFT_VARIANT_${prefix}_BUILD_NUMBER       ${SWIFT_SDK_${sdk}_BUILD_NUMBER})
   set(SWIFT_VARIANT_${prefix}_DEPLOYMENT_VERSION ${SWIFT_SDK_${sdk}_DEPLOYMENT_VERSION})
   set(SWIFT_VARIANT_${prefix}_LIB_SUBDIR         "${lib_subdir}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
-  set(SWIFT_VARIANT_${prefix}_VERSION_MIN_NAME   ${SWIFT_SDK_${sdk}_VERSION_MIN_NAME})
   set(SWIFT_VARIANT_${prefix}_TRIPLE_NAME        ${SWIFT_SDK_${sdk}_TRIPLE_NAME})
   set(SWIFT_VARIANT_${prefix}_ARCHITECTURES      ${SWIFT_SDK_${sdk}_ARCHITECTURES})
 endfunction()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -105,20 +105,6 @@ function(_add_target_variant_c_compile_link_flags)
     list(APPEND result
       "-arch" "${CFLAGS_ARCH}"
       "-F${SWIFT_SDK_${CFLAGS_SDK}_PATH}/../../../Developer/Library/Frameworks")
-
-    set(add_explicit_version TRUE)
-
-    # iOS-like and zippered libraries get their deployment version from the
-    # target triple
-    if(maccatalyst_build_flavor STREQUAL "ios-like" OR
-        maccatalyst_build_flavor STREQUAL "zippered")
-      set(add_explicit_version FALSE)
-    endif()
-
-    if(add_explicit_version)
-      list(APPEND result
-        "-m${SWIFT_SDK_${CFLAGS_SDK}_VERSION_MIN_NAME}-version-min=${DEPLOYMENT_VERSION}")
-     endif()
   endif()
 
   if(CFLAGS_ANALYZE_CODE_COVERAGE)

--- a/test/Interpreter/objc_class_properties_runtime.swift
+++ b/test/Interpreter/objc_class_properties_runtime.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %clang -arch %target-cpu -mmacosx-version-min=10.11 -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
+// RUN: %clang -arch %target-cpu -target %target-cpu-apple-macosx10.11 -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 
 // RUN: %swiftc_driver -target $(echo '%target-triple' | sed -E -e 's/macosx10.(9|10).*/macosx10.11/') -sdk %sdk -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out
 // RUN: %target-codesign %t/a.out

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -920,8 +920,8 @@ if run_vendor == 'apple':
            target_future_version = "9.99.0"
 
        config.target_cc_options = (
-           "-arch %s -m%s-version-min=%s %s" %
-           (run_cpu, run_os, run_vers, clang_mcp_opt))
+           "-arch %s %s" %
+           (run_cpu, clang_mcp_opt))
 
        config.target_build_swift = (
            ("%s %s %s -F %r -toolchain-stdlib-rpath " +
@@ -960,8 +960,8 @@ if run_vendor == 'apple':
         target_specific_module_triple += "-simulator"
 
         config.target_cc_options = (
-            "-arch %s -m%s-simulator-version-min=%s %s" %
-            (run_cpu, run_os, run_vers, clang_mcp_opt))
+            "-arch %s %s" %
+            (run_cpu, clang_mcp_opt))
 
         config.target_build_swift = (
             ("%s %s %s -F %r -toolchain-stdlib-rpath %s " +
@@ -1004,8 +1004,8 @@ if run_vendor == 'apple':
                 (config.variant_triple, clang_mcp_opt))
         else:
             config.target_cc_options = (
-                "-arch %s -m%s-version-min=%s %s" %
-                (run_cpu, run_os, run_vers, clang_mcp_opt))
+                "-arch %s %s" %
+                (run_cpu, clang_mcp_opt))
 
         maccatalyst_frameworks_component = ""
         if run_os == 'maccatalyst':

--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -63,7 +63,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
 
   # Sadly there are two OS naming conventions.
   # xcrun SDK name:   macosx iphoneos iphonesimulator (+ "internal" or version)
-  # -mOS-version-min: macosx ios      ios-simulator
+  # triple name:      macosx ios      ios-simulator
 
   if (SOURCEKIT_DEPLOYMENT_OS MATCHES "^iphoneos")
     set(version_min_os "ios")
@@ -89,10 +89,6 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     else()
       set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${SOURCEKIT_DEPLOYMENT_TARGET})
     endif()
-  else()
-    add_compile_options(-m${version_min_os}-version-min=${SOURCEKIT_DEPLOYMENT_TARGET})
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -m${version_min_os}-version-min=${SOURCEKIT_DEPLOYMENT_TARGET}")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -m${version_min_os}-version-min=${SOURCEKIT_DEPLOYMENT_TARGET}")
   endif()
 endif()
 

--- a/utils/build-parser-lib
+++ b/utils/build-parser-lib
@@ -105,7 +105,7 @@ class Builder(object):
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET=" + deployment_version,
                 "-DSWIFT_DARWIN_DEPLOYMENT_VERSION_IOS=" + deployment_version,
             ]
-            llvm_c_flags += " -mios-simulator-version-min=" + deployment_version
+            llvm_c_flags += " -target " + host_triple
 
         elif self.host == "iphoneos":
             deployment_version = "10.0"
@@ -115,7 +115,7 @@ class Builder(object):
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET=" + deployment_version,
                 "-DSWIFT_DARWIN_DEPLOYMENT_VERSION_IOS=" + deployment_version,
             ]
-            llvm_c_flags += " -miphoneos-version-min=" + deployment_version
+            llvm_c_flags += " -target " + host_triple
 
         elif self.host == "appletvsimulator":
             deployment_version = "10.0"
@@ -125,7 +125,7 @@ class Builder(object):
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET=" + deployment_version,
                 "-DSWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS=" + deployment_version,
             ]
-            llvm_c_flags += " -mtvos-simulator-version-min=" + deployment_version
+            llvm_c_flags += " -target " + host_triple
 
         elif self.host == "appletvos":
             deployment_version = "10.0"
@@ -135,7 +135,7 @@ class Builder(object):
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET=" + deployment_version,
                 "-DSWIFT_DARWIN_DEPLOYMENT_VERSION_TVOS=" + deployment_version,
             ]
-            llvm_c_flags += " -mtvos-version-min=" + deployment_version
+            llvm_c_flags += " -target " + host_triple
 
         elif self.host == "watchsimulator":
             deployment_version = "3.0"
@@ -148,7 +148,7 @@ class Builder(object):
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET=" + deployment_version,
                 "-DSWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS=" + deployment_version,
             ]
-            llvm_c_flags += " -mwatchos-simulator-version-min=" + deployment_version
+            llvm_c_flags += " -target " + host_triple
 
         elif self.host == "watchos":
             deployment_version = "3.0"
@@ -158,7 +158,7 @@ class Builder(object):
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET=" + deployment_version,
                 "-DSWIFT_DARWIN_DEPLOYMENT_VERSION_WATCHOS=" + deployment_version,
             ]
-            llvm_c_flags += " -mwatchos-version-min=" + deployment_version
+            llvm_c_flags += " -target " + host_triple
 
         assert host_triple
         assert host_sdk

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1289,25 +1289,25 @@ function common_cross_c_flags() {
 
     case $host in
         macosx-*)
-            echo -n " -arch ${arch} "
+            echo -n " -arch ${arch} -target ${arch}-apple-macosx${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}"
             ;;
         iphonesimulator-*)
-            echo -n " -arch ${arch}  -mios-simulator-version-min=${DARWIN_DEPLOYMENT_VERSION_IOS}"
+            echo -n " -arch ${arch} -target ${arch}-apple-ios-simulator${DARWIN_DEPLOYMENT_VERSION_IOS}"
             ;;
         iphoneos-*)
-            echo -n " -arch ${arch}  -miphoneos-version-min=${DARWIN_DEPLOYMENT_VERSION_IOS}"
+            echo -n " -arch ${arch} -target ${arch}-apple-iphoneos${DARWIN_DEPLOYMENT_VERSION_IOS}"
             ;;
         appletvsimulator-*)
-            echo -n " -arch ${arch}  -mtvos-simulator-version-min=${DARWIN_DEPLOYMENT_VERSION_TVOS}"
+            echo -n " -arch ${arch} -target ${arch}-apple-tvos-simulator${DARWIN_DEPLOYMENT_VERSION_TVOS}"
             ;;
         appletvos-*)
-            echo -n " -arch ${arch}  -mtvos-version-min=${DARWIN_DEPLOYMENT_VERSION_TVOS}"
+            echo -n " -arch ${arch} -target ${arch}-apple-tvos${DARWIN_DEPLOYMENT_VERSION_TVOS}"
             ;;
         watchsimulator-*)
-            echo -n " -arch ${arch}  -mwatchos-simulator-version-min=${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
+            echo -n " -arch ${arch} -target ${arch}-apple-watchos-simulator${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
             ;;
         watchos-*)
-            echo -n " -arch ${arch}  -mwatchos-version-min=${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
+            echo -n " -arch ${arch} -target ${arch}-apple-watchos${DARWIN_DEPLOYMENT_VERSION_WATCHOS}"
             ;;
     esac
 

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -55,18 +55,15 @@ class NinjaBuilder(product.ProductBuilder):
         env = None
         if platform.system() == "Darwin":
             sysroot = xcrun.sdk_path("macosx")
-            osx_version_min = self.args.darwin_deployment_version_osx
             assert sysroot is not None
             env = {
                 "CXX": shell._quote(self.toolchain.cxx),
                 "CFLAGS": (
-                    "-isysroot {sysroot} -mmacosx-version-min={osx_version}"
-                ).format(sysroot=shell._quote(sysroot),
-                         osx_version=osx_version_min),
+                    "-isysroot {sysroot}"
+                ).format(sysroot=shell._quote(sysroot)),
                 "LDFLAGS": (
-                    "-isysroot {sysroot} -mmacosx-version-min={osx_version}"
-                ).format(sysroot=shell._quote(sysroot),
-                         osx_version=osx_version_min),
+                    "-isysroot {sysroot}"
+                ).format(sysroot=shell._quote(sysroot)),
             }
         elif self.toolchain.cxx:
             env = {

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -99,9 +99,9 @@ class NinjaTestCase(unittest.TestCase):
         if platform.system() == "Darwin":
             expect_env = (
                 "env "
-                "'CFLAGS=-isysroot {sysroot} -mmacosx-version-min=10.9' "
+                "'CFLAGS=-isysroot {sysroot}' "
                 "CXX={cxx} "
-                "'LDFLAGS=-isysroot {sysroot} -mmacosx-version-min=10.9' "
+                "'LDFLAGS=-isysroot {sysroot}' "
             ).format(
                 cxx=self.toolchain.cxx,
                 sysroot=xcrun.sdk_path('macosx')


### PR DESCRIPTION
There's no reason to use `-m${platform}-version-min` as of clang-11/Xcode 11. Clang is now smart enough to parse `-target` and provide Apple's `ld` with the appropriate `-platform_version` argument string.