### PR TITLE
SILOptimizer: remove the unused DeadEndBlocks::empty() API

### DIFF
--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -81,15 +81,6 @@ public:
     return ReachableBlocks.count(block) == 0;
   }
 
-  bool empty() {
-    if (!isComputed) {
-      // Lazily compute the dataflow.
-      compute();
-      isComputed = true;
-    }
-    return ReachableBlocks.empty();
-  }
-
   const SILFunction *getFunction() const { return F; }
 };
 


### PR DESCRIPTION
NFC

Not only that this function _is_ not used anymore, it also _should_ not be used.
Optimizations should not make decisions based on if there are any dead-end blocks in a function.
This could lead to situations, e.g. where an optimization can be done before inlining, but not after inlining a (potentially small) function which has a dead-end block.
