### PR TITLE
[tests] Fix compilation errors in test/Interop/Cxx/static

### DIFF
--- a/test/Interop/Cxx/static/static-member-func.swift
+++ b/test/Interop/Cxx/static/static-member-func.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o -std=c++11
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-func.o -Xfrontend -enable-cxx-interop -Xcc -std=c++11
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-func.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clang -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o -std=c++11
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop -Xcc -std=c++11
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //


### PR DESCRIPTION
Fixes two test failures that must be happening now because of a compiler change.

These two tests fail with this error:

```
<unknown>:0: error: invalid argument '-std=c++11' not allowed with 'Objective-C'
```
