### PR TITLE
[Sema] Accept availability macros in @_originallyDefinedIn

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -534,7 +534,7 @@ SIMPLE_DECL_ATTR(IBSegueAction, IBSegueAction,
 
 DECL_ATTR(_originallyDefinedIn, OriginallyDefinedIn,
   OnNominalType | OnFunc | OnVar | OnExtension | UserInaccessible |
-  AllowMultipleAttributes |
+  AllowMultipleAttributes | LongAttribute |
   ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   96)
 

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -201,6 +201,8 @@ public:
       : AvailabilitySpec(AvailabilitySpecKind::OtherPlatform),
         StarLoc(StarLoc) {}
 
+  SourceLoc getStarLoc() const { return StarLoc; }
+
   SourceRange getSourceRange() const { return SourceRange(StarLoc, StarLoc); }
 
   void print(raw_ostream &OS, unsigned Indent) const;

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1489,6 +1489,14 @@ WARNING(originally_defined_in_major_minor_only,none,
 WARNING(originally_defined_in_missing_platform_name,none,
         "* as platform name has no effect", ())
 
+WARNING(originally_defined_in_swift_version, none,
+        "Swift language version checks has no effect "
+        "in @_originallyDefinedIn", ())
+
+WARNING(originally_defined_in_package_description, none,
+        "PackageDescription version checks has no effect "
+        "in @_originallyDefinedIn", ())
+
 // convention
 ERROR(convention_attribute_expected_lparen,none,
       "expected '(' after 'convention' attribute", ())

--- a/test/ModuleInterface/originally-defined-attr.swift
+++ b/test/ModuleInterface/originally-defined-attr.swift
@@ -1,7 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // Ensure the attribute is printed in swiftinterface files
-// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/Foo.swiftinterface %s -module-name Foo
+// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/Foo.swiftinterface %s -module-name Foo \
+// RUN:   -define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0" \
+// RUN:   -define-availability "_iOS9:iOS 9.0" \
+// RUN:   -define-availability "_macOS10_11:macOS 10.11" \
+// RUN:   -define-availability "_myProject 1.0:macOS 10.11"
 // RUN: %FileCheck %s < %t/Foo.swiftinterface
 
 // Ensure the attribute is in .swiftmodule files
@@ -21,3 +25,20 @@ public protocol SimpleProto { }
 @_originallyDefinedIn(module: "original", tvOS 1.0)
 @_originallyDefinedIn(module: "another_original", OSX 2.0, iOS 3.0, watchOS 4.0)
 public struct SimpleStruct {}
+
+// CHECK: @_originallyDefinedIn(module: "other0", macOS 10.10)
+// CHECK: @_originallyDefinedIn(module: "other0", iOS 8.0)
+@available(tvOS 0.7, OSX 1.1, iOS 2.1, watchOS 3.2, *)
+@_originallyDefinedIn(module: "other0", _iOS8Aligned)
+public struct SimpleThingInAlphabeticalOrderForMacros0 {}
+
+// CHECK: @_originallyDefinedIn(module: "other1", iOS 9.0)
+// CHECK: @_originallyDefinedIn(module: "other1", macOS 10.11)
+@available(tvOS 0.7, OSX 1.1, iOS 2.1, watchOS 3.2, *)
+@_originallyDefinedIn(module: "other1", _iOS9, _macOS10_11)
+public struct SimpleThingInAlphabeticalOrderForMacros1 {}
+
+// CHECK: @_originallyDefinedIn(module: "other2", macOS 10.11)
+@available(tvOS 0.7, OSX 1.1, iOS 2.1, watchOS 3.2, *)
+@_originallyDefinedIn(module: "other2", _myProject 1.0)
+public struct SimpleThingInAlphabeticalOrderForMacros2 {}

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -define-availability "_myProject 1.0:macOS 10.10"
 // REQUIRES: OS=macosx
 
 @_originallyDefinedIn(module: "original", OSX 10.13) // expected-error {{need @available attribute for @_originallyDefinedIn}}
@@ -10,3 +11,13 @@ public class C {
   @_originallyDefinedIn(module: "original", OSX 10.13) // expected-error {{@_originallyDefinedIn is only applicable to top-level decl}}
   public func foo() {}
 }
+
+@available(macOS 10.9, *)
+@_originallyDefinedIn(module: "original", _myProject 2.0) // expected-error {{expected at least one platform version in @_originallyDefinedIn}}
+// expected-error @-1 {{reference to undefined version '2.0' for availability macro '_myProject'}}
+public func macroVersionned() {}
+
+// Fallback to the default diagnostic when the macro is unknown.
+@available(macOS 10.9, *)
+@_originallyDefinedIn(module: "original", _unknownMacro) // expected-error {{expected at least one platform version in @_originallyDefinedIn}}
+public func macroUnknown() {}

--- a/test/attr/Inputs/SymbolMove/HighlevelOriginal.swift
+++ b/test/attr/Inputs/SymbolMove/HighlevelOriginal.swift
@@ -47,3 +47,5 @@ open class Vehicle {
     public init() {}
     public var currentSpeed = -40.0
 }
+
+public func funcMacro() { print("Macro from HighLevel") }

--- a/test/attr/Inputs/SymbolMove/LowLevel.swift
+++ b/test/attr/Inputs/SymbolMove/LowLevel.swift
@@ -51,3 +51,8 @@ open class Vehicle {
     public init() {}
     public var currentSpeed = 40.0
 }
+
+// =================== Move from macro ======================= //
+@available(OSX 10.7, iOS 7.0, *)
+@_originallyDefinedIn(module: "HighLevel", _iOS13Aligned)
+public func funcMacro () { print("Macro from LowLevel") }

--- a/test/attr/attr_originally_definedin_backward_compatibility.swift
+++ b/test/attr/attr_originally_definedin_backward_compatibility.swift
@@ -30,8 +30,9 @@
 // --- Build low level framework.
 // RUN: mkdir -p %t/SDK/Frameworks/LowLevel.framework/Modules/LowLevel.swiftmodule
 // RUN: %target-build-swift-dylib(%t/SDK/Frameworks/LowLevel.framework/LowLevel) -module-name LowLevel -emit-module \
-// RUN:		-emit-module-path %t/SDK/Frameworks/LowLevel.framework/Modules/LowLevel.swiftmodule/%module-target-triple.swiftmodule \
-// RUN:     %S/Inputs/SymbolMove/LowLevel.swift -Xlinker -install_name -Xlinker @rpath/LowLevel.framework/LowLevel -enable-library-evolution
+// RUN:     -emit-module-path %t/SDK/Frameworks/LowLevel.framework/Modules/LowLevel.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     %S/Inputs/SymbolMove/LowLevel.swift -Xlinker -install_name -Xlinker @rpath/LowLevel.framework/LowLevel -enable-library-evolution \
+// RUN:     -Xfrontend -define-availability -Xfrontend "_iOS13Aligned:macOS 10.10, iOS 8.0"
 
 // --- Build high level framework.
 // RUN: mkdir -p %t/SDK/Frameworks/HighLevel.framework/Modules/HighLevel.swiftmodule
@@ -81,3 +82,7 @@ print("\(bicycle.currentSpeed)")
 
 // BEFORE_MOVE: 15.0
 // AFTER_MOVE: 15.0
+
+funcMacro()
+// BEFORE_MOVE: Macro from HighLevel
+// AFTER_MOVE: Macro from LowLevel


### PR DESCRIPTION
Availability macros passed via the frontend flag `-define-availability` should be accepted by `@_originallyDefinedIn` where they behave as they do in `@available`.

rdar://72354787