### PR TITLE
Frontend: add an option -bad-file-descriptor-retry-count

### DIFF
--- a/include/swift/Basic/FileSystem.h
+++ b/include/swift/Basic/FileSystem.h
@@ -80,7 +80,8 @@ namespace swift {
     llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
     getFileOrSTDIN(llvm::vfs::FileSystem &FS,
                    const llvm::Twine &Name, int64_t FileSize = -1,
-                   bool RequiresNullTerminator = true, bool IsVolatile = false);
+                   bool RequiresNullTerminator = true, bool IsVolatile = false,
+                   unsigned BADFRetry = 0);
   } // end namespace vfs
 
 } // end namespace swift

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -86,6 +86,9 @@ public:
   /// The module for which we should verify all of the generic signatures.
   std::string VerifyGenericSignaturesInModule;
 
+  /// Number of retry opening an input file if the previous opening returns
+  /// bad file descriptor error.
+  unsigned BadFileDescriptorRetryCount = 0;
   enum class ActionType {
     NoneAction,        ///< No specific action
     Parse,             ///< Parse only

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -786,4 +786,8 @@ def experimental_allow_module_with_compiler_errors:
   Flags<[HelpHidden]>,
   HelpText<"Attempt to output .swiftmodule, regardless of compilation errors">;
 
+def bad_file_descriptor_retry_count:
+  Separate<["-"], "bad-file-descriptor-retry-count">,
+  HelpText<"Number of retrying opening a file if previous open returns a bad "
+           "file descriptor error.">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/ArgsToFrontendInputsConverter.h
+++ b/lib/Frontend/ArgsToFrontendInputsConverter.h
@@ -47,6 +47,7 @@ class ArgsToFrontendInputsConverter {
 
   llvm::opt::Arg const *const FilelistPathArg;
   llvm::opt::Arg const *const PrimaryFilelistPathArg;
+  llvm::opt::Arg const *const BadFileDescriptorRetryCountArg;
 
   /// A place to keep alive any buffers that are loaded as part of setting up
   /// the frontend inputs.

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -89,6 +89,16 @@ bool ArgsToFrontendOptionsConverter::convert(
         IntermoduleDepTrackingMode::IncludeSystem;
   }
 
+  if (const Arg *A = Args.getLastArg(OPT_bad_file_descriptor_retry_count)) {
+    unsigned limit;
+    if (StringRef(A->getValue()).getAsInteger(10, limit)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      return true;
+    }
+    Opts.BadFileDescriptorRetryCount = limit;
+  }
+
   Opts.DisableImplicitModules |= Args.hasArg(OPT_disable_implicit_swift_modules);
 
   Opts.ImportPrescan |= Args.hasArg(OPT_import_prescan);

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -588,8 +588,24 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
   }
   const StringRef supplementaryFileMapPath =
       Args.getLastArgValue(options::OPT_supplementary_output_file_map);
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer =
-      llvm::MemoryBuffer::getFile(supplementaryFileMapPath);
+
+  unsigned BadFileDescriptorRetryCount = 0;
+  if (const Arg *A = Args.getLastArg(options::OPT_bad_file_descriptor_retry_count)) {
+    if (StringRef(A->getValue()).getAsInteger(10, BadFileDescriptorRetryCount)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      return None;
+    }
+  }
+
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buffer = nullptr;
+  for (unsigned I = 0; I < BadFileDescriptorRetryCount + 1; ++I) {
+    buffer = llvm::MemoryBuffer::getFile(supplementaryFileMapPath);
+    if (buffer)
+      break;
+    if (buffer.getError().value() != EBADF)
+      break;
+  }
   if (!buffer) {
     Diags.diagnose(SourceLoc(), diag::cannot_open_file,
                    supplementaryFileMapPath, buffer.getError().message());

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -668,8 +668,13 @@ Optional<ModuleBuffers> CompilerInstance::getInputBuffersIfPresent(
   // FIXME: Working with filenames is fragile, maybe use the real path
   // or have some kind of FileManager.
   using FileOrError = llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>;
-  FileOrError inputFileOrErr = swift::vfs::getFileOrSTDIN(getFileSystem(),
-                                                          input.getFileName());
+  FileOrError inputFileOrErr =
+    swift::vfs::getFileOrSTDIN(getFileSystem(), input.getFileName(),
+                              /*FileSize*/-1,
+                              /*RequiresNullTerminator*/true,
+                              /*IsVolatile*/false,
+      /*Bad File Descriptor Retry*/getInvocation().getFrontendOptions()
+                               .BadFileDescriptorRetryCount);
   if (!inputFileOrErr) {
     Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
                          input.getFileName(),


### PR DESCRIPTION
This option allows the compiler to retry opening an input file if the previous opening returns an error of bad file descriptor. Swift-driver will set this argument in certain circumstances to walk-around such error.

rdar://73157185