### PR TITLE
test: explicitly reference SR (NFC)

### DIFF
--- a/test/AutoDiff/validation-test/derivative_registration.swift
+++ b/test/AutoDiff/validation-test/derivative_registration.swift
@@ -217,7 +217,7 @@ DerivativeRegistrationTests.testWithLeakChecking("DerivativeGenericSignature") {
   expectEqual(1000, dx)
 }
 
-#if REQUIRES_SRxxxx
+#if REQUIRES_SR14042
 // When non-canonicalized generic signatures are used to compare derivative configurations, the
 // `@differentiable` and `@derivative` attributes create separate derivatives, and we get a
 // duplicate symbol error in TBDGen.

--- a/test/AutoDiff/validation-test/reabstraction.swift
+++ b/test/AutoDiff/validation-test/reabstraction.swift
@@ -62,7 +62,7 @@ extension Float: HasFloat {
   init(float: Float) { self = float }
 }
 
-#if REQUIRES_SRxxxx
+#if REQUIRES_SR14042
 ReabstractionE2ETests.test("diff param generic => concrete") {
   func inner<T: HasFloat>(x: T) -> Float {
     7 * x.float * x.float
@@ -82,7 +82,7 @@ ReabstractionE2ETests.test("nondiff param generic => concrete") {
   expectEqual(Float(7 * 2 * 3), gradient(at: 3) { transformed($0, 10) })
 }
 
-#if REQUIRES_SRxxxx
+#if REQUIRES_SR14042
 ReabstractionE2ETests.test("diff param and nondiff param generic => concrete") {
   func inner<T: HasFloat>(x: T, y: T) -> Float {
     7 * x.float * x.float + y.float
@@ -93,7 +93,7 @@ ReabstractionE2ETests.test("diff param and nondiff param generic => concrete") {
 }
 #endif
 
-#if REQUIRES_SRxxxx
+#if REQUIRES_SR14042
 ReabstractionE2ETests.test("result generic => concrete") {
   func inner<T: HasFloat>(x: Float) -> T {
     T(float: 7 * x * x)


### PR DESCRIPTION
Adjust the disabled tests to explicitly reference the SR.  This cleans
up the previous change to enable the autodifferentiation CI tests on
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
