### PR TITLE
Sema: Allow re-declarations of typealiases in constrained extensions with different generic signatures

### DIFF
--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -132,7 +132,7 @@ extension CountSteps1 // expected-error {{type 'CountSteps1<T>' does not conform
      where T : Equatable
 {
   typealias Index = Int
-  // expected-error@-1 {{invalid redeclaration of synthesized implementation for protocol requirement 'Index'}}
+
   func index(_ i: Index, offsetBy d: Int) -> Index {
     return i + d
   }

--- a/test/decl/typealias/redeclaration.swift
+++ b/test/decl/typealias/redeclaration.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift
+
+struct NonGenericStruct {
+  typealias Horse = Int // expected-note {{'Horse' previously declared here}}
+  typealias Horse = String // expected-error {{invalid redeclaration of 'Horse'}}
+}
+
+struct NonGenericExtendedStruct {}
+
+extension NonGenericExtendedStruct {
+  typealias Horse = Int // expected-note {{'Horse' previously declared here}}
+}
+
+extension NonGenericExtendedStruct {
+  typealias Horse = String // expected-error {{invalid redeclaration of 'Horse'}}
+}
+
+struct GenericStruct<T> {
+  typealias Horse = Int // expected-note {{'Horse' previously declared here}}
+  typealias Horse = String // expected-error {{invalid redeclaration of 'Horse'}}
+}
+
+struct GenericExtendedStruct<T> {}
+
+extension GenericExtendedStruct {
+  typealias Horse = Int // expected-note {{'Horse' previously declared here}}
+}
+
+extension GenericExtendedStruct {
+  typealias Horse = String // expected-error {{invalid redeclaration of 'Horse'}}
+}
+
+struct GenericConstrainedExtendedStruct<T> {}
+
+protocol SomeProtocol {}
+
+extension GenericConstrainedExtendedStruct where T : SomeProtocol {
+  typealias Horse = Int
+}
+
+protocol OtherProtocol {}
+
+extension GenericConstrainedExtendedStruct where T : OtherProtocol {
+  typealias Horse = String // This is OK!
+}


### PR DESCRIPTION
Associated type inference will synthesize typealiases in
constrained extensions for conditional conformances, but
then we might later flag them as re-declarations.

Let's not do this, since name lookup does check if generic
requirements are satisfied, so such redeclarations are not
in fact erroneous.

Fixes <rdar://problem/68933045>.