### PR TITLE
[Serialization] Skip opaque types nested in skipped function bodies

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5273,6 +5273,11 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
     }
     
     for (auto OTD : opaqueReturnTypeDecls) {
+      // FIXME: We should delay parsing function bodies so these type decls
+      //        don't even get added to the file.
+      if (OTD->getDeclContext()->getInnermostSkippedFunctionContext())
+        continue;
+
       hasOpaqueReturnTypes = true;
       Mangle::ASTMangler Mangler;
       auto MangledName = Mangler.mangleOpaqueTypeDecl(OTD);

--- a/test/Serialization/opaque_nested.swift
+++ b/test/Serialization/opaque_nested.swift
@@ -1,0 +1,21 @@
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -emit-module -module-name A -Xfrontend -experimental-skip-all-function-bodies -Xfrontend -debug-forbid-typecheck-prefix -Xfrontend NEVERTYPECHECK %s
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -emit-module -module-name A -Xfrontend -experimental-skip-non-inlinable-function-bodies -Xfrontend -debug-forbid-typecheck-prefix -Xfrontend NEVERTYPECHECK %s
+
+protocol Base {
+  func anything()
+}
+
+func test() {
+  struct Nested : Base {
+    let NEVERTYPECHECK_property = 1
+
+    func anything() {
+      let NEVERTYPECHECK_local = 1
+    }
+
+    func opaqueReturnType() -> some Base {
+      let NEVERTYPECHECK_local = 1
+      return Nested()
+    }
+  }
+}


### PR DESCRIPTION
Opaque types are gathered and visited separately. As with local types,
only serialize them if they are not within a skipped function body.

Fixes a crash caused when compiling the primary file, where delayed
parsing is explictly disabled.

Resolves rdar://73167790