### PR TITLE
SourceKit: avoid self-imports in generated Swift interfaces

### DIFF
--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -609,6 +609,9 @@ void swift::ide::printModuleInterface(
     auto ShouldPrintImport = [&](ImportDecl *ImportD) -> bool {
       if (!TargetClangMod)
         return true;
+      if (ImportD->getModule() == TargetMod)
+        return false;
+
       auto ImportedMod = ImportD->getClangModule();
       if (!ImportedMod)
         return true;

--- a/test/IDE/print_ast_overlay.swift
+++ b/test/IDE/print_ast_overlay.swift
@@ -41,6 +41,6 @@ public class FooOverlayClassDerived : FooOverlayClassBase {
 
 // PASS_NO_INTERNAL-NOT: overlay_func_internal
 
-// PASS_ANNOTATED: <decl:Import>@_exported import <ref:module>Foo</ref></decl>
+// PASS_ANNOTATED-NOT: import Foo
 // PASS_ANNOTATED: <decl:Import>@_exported import <ref:module>Foo</ref>.<ref:module>FooSub</ref></decl>
 // PASS_ANNOTATED: <decl:Import>@_exported import <ref:module>FooHelper</ref></decl>

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,4 +1,3 @@
-import OverlaidClangFramework
 import SwiftOnoneSupport
 
 func fromOverlaidClangFramework()
@@ -21,61 +20,51 @@ func fromOverlaidClangFrameworkCrossImport()
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 7,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 30,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 37,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 56,
+    key.offset: 26,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 61,
+    key.offset: 31,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 90,
+    key.offset: 60,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 95,
+    key.offset: 65,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 133,
+    key.offset: 103,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 136,
+    key.offset: 106,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 174,
+    key.offset: 144,
     key.length: 76
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 250,
+    key.offset: 220,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 255,
+    key.offset: 225,
     key.length: 37
   }
 ]
@@ -84,7 +73,7 @@ func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOverlaidClangFramework()",
     key.usr: "c:@F@fromOverlaidClangFramework",
-    key.offset: 56,
+    key.offset: 26,
     key.length: 33,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFramework</decl.name>()</decl.function.free>"
   },
@@ -92,7 +81,7 @@ func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOverlaidClangFrameworkOverlay()",
     key.usr: "s:22OverlaidClangFramework04fromabC7OverlayyyF",
-    key.offset: 90,
+    key.offset: 60,
     key.length: 40,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFrameworkOverlay</decl.name>()</decl.function.free>"
   },
@@ -100,7 +89,7 @@ func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOverlaidClangFrameworkCrossImport()",
     key.usr: "s:41_OverlaidClangFramework_BystandingLibrary04fromabC11CrossImportyyF",
-    key.offset: 250,
+    key.offset: 220,
     key.length: 44,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFrameworkCrossImport</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -31,7 +31,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=205:67 | %FileCheck -check-prefix=CHECK1 %s
+// RUN:      == -req=cursor -pos=204:67 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooClassBase' inside the list of base classes, see 'gen_clang_module.swift.response'
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
@@ -47,7 +47,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=232:20 | %FileCheck -check-prefix=CHECK2 %s
+// RUN:      == -req=cursor -pos=231:20 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
 // CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:27)
@@ -61,7 +61,7 @@ var x: FooClassBase
 // RUN:      == -req=find-usr -usr "c:objc(cs)FooClassDerived(im)fooInstanceFunc0" | %FileCheck -check-prefix=CHECK-USR %s
 // The returned line:col points inside the interface, see 'gen_clang_module.swift.response'
 
-// CHECK-USR: (232:15-232:33)
+// CHECK-USR: (231:15-231:33)
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
@@ -73,14 +73,10 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=1:8 \
-// RUN:      == -req=cursor -pos=2:8 == -req=cursor -pos=2:12 \
-// RUN:      == -req=cursor -pos=3:8 | %FileCheck -check-prefix=CHECK-IMPORT %s
+// RUN:      == -req=cursor -pos=1:8 == -req=cursor -pos=1:12 \
+// RUN:      == -req=cursor -pos=2:8 | %FileCheck -check-prefix=CHECK-IMPORT %s
 // The cursors point to module names inside the imports, see 'gen_clang_module.swift.response'
 
-// CHECK-IMPORT: 	  source.lang.swift.ref.module ()
-// CHECK-IMPORT-NEXT: Foo{{$}}
-// CHECK-IMPORT-NEXT: Foo{{$}}
 // CHECK-IMPORT: 	  source.lang.swift.ref.module ()
 // CHECK-IMPORT-NEXT: Foo{{$}}
 // CHECK-IMPORT-NEXT: Foo{{$}}

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -1,4 +1,3 @@
-import Foo
 import Foo.FooSub
 import FooHelper
 import SwiftOnoneSupport
@@ -370,1593 +369,1588 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 11,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 18,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 22,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 29,
+    key.offset: 18,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 36,
+    key.offset: 25,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 46,
+    key.offset: 35,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 53,
+    key.offset: 42,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 72,
+    key.offset: 61,
     key.length: 75
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 149,
+    key.offset: 138,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 160,
+    key.offset: 149,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 174,
+    key.offset: 163,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 182,
+    key.offset: 171,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 208,
+    key.offset: 197,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 215,
+    key.offset: 204,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 222,
+    key.offset: 211,
     key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 222,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 233,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 244,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 268,
+    key.offset: 257,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 275,
+    key.offset: 264,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 280,
+    key.offset: 269,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 282,
+    key.offset: 271,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 292,
+    key.offset: 281,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 305,
+    key.offset: 294,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 312,
+    key.offset: 301,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 317,
+    key.offset: 306,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 327,
+    key.offset: 316,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 340,
+    key.offset: 329,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 347,
+    key.offset: 336,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 351,
+    key.offset: 340,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 361,
+    key.offset: 350,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 371,
+    key.offset: 360,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 398,
+    key.offset: 387,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 405,
+    key.offset: 394,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 409,
+    key.offset: 398,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 420,
+    key.offset: 409,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 431,
+    key.offset: 420,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 438,
+    key.offset: 427,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 445,
+    key.offset: 434,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 452,
+    key.offset: 441,
     key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 452,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 463,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 474,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 498,
+    key.offset: 487,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 505,
+    key.offset: 494,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 510,
+    key.offset: 499,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 512,
+    key.offset: 501,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 522,
+    key.offset: 511,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 535,
+    key.offset: 524,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 542,
+    key.offset: 531,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 547,
+    key.offset: 536,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 557,
+    key.offset: 546,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 559,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 566,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 570,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 577,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 581,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 591,
+    key.offset: 580,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 589,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 596,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 600,
-    key.length: 6
+    key.length: 9
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 607,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 611,
-    key.length: 9
+    key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 622,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 633,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 639,
+    key.offset: 628,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 646,
+    key.offset: 635,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 650,
+    key.offset: 639,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 661,
+    key.offset: 650,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 672,
+    key.offset: 661,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 678,
+    key.offset: 667,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 685,
+    key.offset: 674,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 692,
+    key.offset: 681,
     key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 692,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 703,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 714,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 738,
+    key.offset: 727,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 745,
+    key.offset: 734,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 750,
+    key.offset: 739,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 752,
+    key.offset: 741,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 762,
+    key.offset: 751,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 775,
+    key.offset: 764,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 782,
+    key.offset: 771,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 787,
+    key.offset: 776,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 797,
+    key.offset: 786,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 799,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 806,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 810,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 817,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 821,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 831,
+    key.offset: 820,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 829,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 836,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 840,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 847,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 851,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 862,
+    key.offset: 851,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 873,
+    key.offset: 862,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 879,
+    key.offset: 868,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 886,
+    key.offset: 875,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 890,
+    key.offset: 879,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 901,
+    key.offset: 890,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 912,
+    key.offset: 901,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 919,
+    key.offset: 908,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 956,
+    key.offset: 945,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 963,
+    key.offset: 952,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 968,
+    key.offset: 957,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 990,
+    key.offset: 979,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1006,
+    key.offset: 995,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1031,
+    key.offset: 1020,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1036,
+    key.offset: 1025,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1055,
+    key.offset: 1044,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1063,
+    key.offset: 1052,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1068,
+    key.offset: 1057,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1082,
+    key.offset: 1071,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1084,
+    key.offset: 1073,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1114,
+    key.offset: 1103,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1119,
+    key.offset: 1108,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1139,
+    key.offset: 1128,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1144,
+    key.offset: 1133,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1179,
+    key.offset: 1168,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1186,
+    key.offset: 1175,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1193,
+    key.offset: 1182,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1213,
+    key.offset: 1202,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1230,
+    key.offset: 1219,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1237,
+    key.offset: 1226,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1242,
+    key.offset: 1231,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1252,
+    key.offset: 1241,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1267,
+    key.offset: 1256,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1289,
+    key.offset: 1278,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1296,
+    key.offset: 1285,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1303,
+    key.offset: 1292,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1307,
+    key.offset: 1296,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1320,
+    key.offset: 1309,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1340,
+    key.offset: 1329,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1351,
+    key.offset: 1340,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1358,
+    key.offset: 1347,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1365,
+    key.offset: 1354,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1369,
+    key.offset: 1358,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1383,
+    key.offset: 1372,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1403,
+    key.offset: 1392,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1409,
+    key.offset: 1398,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1437,
+    key.offset: 1426,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1444,
+    key.offset: 1433,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1451,
+    key.offset: 1440,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1458,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1465,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1469,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1476,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1480,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1472,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 1483,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1494,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1501,
+    key.offset: 1490,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1505,
+    key.offset: 1494,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1508,
+    key.offset: 1497,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1520,
+    key.offset: 1509,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1527,
+    key.offset: 1516,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1539,
+    key.offset: 1528,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1546,
+    key.offset: 1535,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1551,
+    key.offset: 1540,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1554,
+    key.offset: 1543,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1561,
+    key.offset: 1550,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1564,
+    key.offset: 1553,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1574,
+    key.offset: 1563,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1581,
+    key.offset: 1570,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1591,
+    key.offset: 1580,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1611,
+    key.offset: 1600,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1632,
+    key.offset: 1621,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1645,
+    key.offset: 1634,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1652,
+    key.offset: 1641,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1659,
+    key.offset: 1648,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1666,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1673,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1677,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1684,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1688,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1680,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 1691,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1702,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1709,
+    key.offset: 1698,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1713,
+    key.offset: 1702,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1716,
+    key.offset: 1705,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1728,
+    key.offset: 1717,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1735,
+    key.offset: 1724,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1747,
+    key.offset: 1736,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1754,
+    key.offset: 1743,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1759,
+    key.offset: 1748,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1762,
+    key.offset: 1751,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1769,
+    key.offset: 1758,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1772,
+    key.offset: 1761,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1782,
+    key.offset: 1771,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1789,
+    key.offset: 1778,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1799,
+    key.offset: 1788,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1819,
+    key.offset: 1808,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1831,
+    key.offset: 1820,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1838,
+    key.offset: 1827,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1845,
+    key.offset: 1834,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1859,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1866,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1870,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1877,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1881,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1873,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 1884,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1895,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1902,
+    key.offset: 1891,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1906,
+    key.offset: 1895,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1909,
+    key.offset: 1898,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1921,
+    key.offset: 1910,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1928,
+    key.offset: 1917,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1940,
+    key.offset: 1929,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1947,
+    key.offset: 1936,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1952,
+    key.offset: 1941,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1955,
+    key.offset: 1944,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1962,
+    key.offset: 1951,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1965,
+    key.offset: 1954,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1976,
+    key.offset: 1965,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2005,
+    key.offset: 1994,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2012,
+    key.offset: 2001,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2022,
+    key.offset: 2011,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2036,
+    key.offset: 2025,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2043,
+    key.offset: 2032,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2070,
+    key.offset: 2059,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2077,
+    key.offset: 2066,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2081,
+    key.offset: 2070,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2092,
+    key.offset: 2081,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2099,
+    key.offset: 2088,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2125,
+    key.offset: 2114,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2132,
+    key.offset: 2121,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2126,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2135,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 2137,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2146,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2148,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2151,
+    key.offset: 2140,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2161,
+    key.offset: 2150,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2168,
+    key.offset: 2157,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2175,
+    key.offset: 2164,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2180,
+    key.offset: 2169,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2203,
+    key.offset: 2192,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2206,
+    key.offset: 2195,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2216,
+    key.offset: 2205,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2222,
+    key.offset: 2211,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2229,
+    key.offset: 2218,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2223,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2232,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 2234,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2243,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2245,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2248,
+    key.offset: 2237,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2255,
+    key.offset: 2244,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2257,
+    key.offset: 2246,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2260,
+    key.offset: 2249,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2267,
+    key.offset: 2256,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2258,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2261,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 2269,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2272,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2280,
-    key.length: 1
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2282,
+    key.offset: 2271,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2285,
+    key.offset: 2274,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2306,
+    key.offset: 2295,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2318,
+    key.offset: 2307,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2325,
+    key.offset: 2314,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2372,
+    key.offset: 2361,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2379,
+    key.offset: 2368,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2384,
+    key.offset: 2373,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2401,
+    key.offset: 2390,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2403,
+    key.offset: 2392,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2410,
+    key.offset: 2399,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2420,
+    key.offset: 2409,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2430,
+    key.offset: 2419,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2437,
+    key.offset: 2426,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2442,
+    key.offset: 2431,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2469,
+    key.offset: 2458,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2471,
+    key.offset: 2460,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2478,
+    key.offset: 2467,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2490,
+    key.offset: 2479,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2494,
+    key.offset: 2483,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2504,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2514,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2521,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2526,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2548,
+    key.offset: 2493,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2554,
+    key.offset: 2503,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2561,
+    key.offset: 2510,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2566,
+    key.offset: 2515,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2588,
+    key.offset: 2537,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2543,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2550,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2555,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2577,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2595,
+    key.offset: 2584,
     key.length: 62
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2658,
+    key.offset: 2647,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2665,
+    key.offset: 2654,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2670,
+    key.offset: 2659,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2693,
+    key.offset: 2682,
     key.length: 42
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2736,
+    key.offset: 2725,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2743,
+    key.offset: 2732,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2748,
+    key.offset: 2737,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2771,
+    key.offset: 2760,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2815,
+    key.offset: 2804,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2831,
+    key.offset: 2820,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2838,
+    key.offset: 2827,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2843,
+    key.offset: 2832,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2866,
+    key.offset: 2855,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2910,
+    key.offset: 2899,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2919,
+    key.offset: 2908,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2926,
+    key.offset: 2915,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2931,
+    key.offset: 2920,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2954,
+    key.offset: 2943,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2991,
+    key.offset: 2980,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3000,
+    key.offset: 2989,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3004,
+    key.offset: 2993,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3013,
+    key.offset: 3002,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3020,
+    key.offset: 3009,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3025,
+    key.offset: 3014,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3048,
+    key.offset: 3037,
     key.length: 50
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3098,
+    key.offset: 3087,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3105,
+    key.offset: 3094,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3110,
+    key.offset: 3099,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3143,
+    key.offset: 3132,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3145,
+    key.offset: 3134,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3148,
+    key.offset: 3137,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3158,
+    key.offset: 3147,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3165,
+    key.offset: 3154,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3198,
+    key.offset: 3187,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3205,
+    key.offset: 3194,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3214,
+    key.offset: 3203,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3242,
+    key.offset: 3231,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3276,
+    key.offset: 3265,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3289,
+    key.offset: 3278,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3294,
+    key.offset: 3283,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3319,
+    key.offset: 3308,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3374,
+    key.offset: 3363,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3387,
+    key.offset: 3376,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3392,
+    key.offset: 3381,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3438,
+    key.offset: 3427,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3520,
+    key.offset: 3509,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3525,
+    key.offset: 3514,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3571,
+    key.offset: 3560,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3578,
+    key.offset: 3567,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3583,
+    key.offset: 3572,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3613,
+    key.offset: 3602,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3617,
+    key.offset: 3606,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3631,
+    key.offset: 3620,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3639,
+    key.offset: 3628,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3632,
     key.length: 3
   },
   {
@@ -1965,23 +1959,23 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3654,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3658,
+    key.offset: 3647,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3672,
+    key.offset: 3661,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3680,
+    key.offset: 3669,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3673,
     key.length: 3
   },
   {
@@ -1990,1613 +1984,1608 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3695,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3699,
+    key.offset: 3688,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3713,
+    key.offset: 3702,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3721,
+    key.offset: 3710,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3730,
+    key.offset: 3719,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3737,
+    key.offset: 3726,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3746,
+    key.offset: 3735,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3767,
+    key.offset: 3756,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3788,
+    key.offset: 3777,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3793,
+    key.offset: 3782,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3799,
+    key.offset: 3788,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3819,
+    key.offset: 3808,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3824,
+    key.offset: 3813,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3829,
+    key.offset: 3818,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3857,
+    key.offset: 3846,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3862,
+    key.offset: 3851,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3867,
+    key.offset: 3856,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3888,
+    key.offset: 3877,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3890,
+    key.offset: 3879,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3900,
+    key.offset: 3889,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3909,
+    key.offset: 3898,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3928,
+    key.offset: 3917,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3935,
+    key.offset: 3924,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3948,
+    key.offset: 3937,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3955,
+    key.offset: 3944,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3967,
+    key.offset: 3956,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3973,
+    key.offset: 3962,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3979,
+    key.offset: 3968,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3982,
+    key.offset: 3971,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3994,
+    key.offset: 3983,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3999,
+    key.offset: 3988,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4004,
+    key.offset: 3993,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4035,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4040,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4046,
     key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4051,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4057,
-    key.length: 4
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4062,
+    key.offset: 4051,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 4085,
+    key.offset: 4074,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4118,
+    key.offset: 4107,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4123,
+    key.offset: 4112,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4129,
+    key.offset: 4118,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4147,
+    key.offset: 4136,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4161,
+    key.offset: 4150,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4192,
+    key.offset: 4181,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4197,
+    key.offset: 4186,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4201,
+    key.offset: 4190,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4204,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 4215,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4226,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4231,
+    key.offset: 4220,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4235,
+    key.offset: 4224,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4238,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 4249,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4260,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4265,
+    key.offset: 4254,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4269,
+    key.offset: 4258,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4283,
+    key.offset: 4272,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4291,
+    key.offset: 4280,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4307,
+    key.offset: 4296,
     key.length: 64
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4376,
+    key.offset: 4365,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4381,
+    key.offset: 4370,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4386,
+    key.offset: 4375,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4410,
+    key.offset: 4399,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4415,
+    key.offset: 4404,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4420,
+    key.offset: 4409,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4437,
+    key.offset: 4426,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4439,
+    key.offset: 4428,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4442,
+    key.offset: 4431,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4454,
+    key.offset: 4443,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4459,
+    key.offset: 4448,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4464,
+    key.offset: 4453,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4481,
+    key.offset: 4470,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4483,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4486,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4493,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4499,
+    key.offset: 4472,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4502,
+    key.offset: 4475,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4482,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4488,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4491,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4519,
+    key.offset: 4508,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4524,
+    key.offset: 4513,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4529,
+    key.offset: 4518,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4560,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4565,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4571,
     key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4576,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4582,
-    key.length: 4
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4587,
+    key.offset: 4576,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4606,
+    key.offset: 4595,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4613,
+    key.offset: 4602,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4623,
+    key.offset: 4612,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4639,
+    key.offset: 4628,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4646,
+    key.offset: 4635,
     key.length: 31
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4667,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4674,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4678,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4685,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4689,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4702,
+    key.offset: 4691,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4710,
+    key.offset: 4699,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4705,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4712,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4716,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4723,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4727,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4740,
+    key.offset: 4729,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4748,
+    key.offset: 4737,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4754,
+    key.offset: 4743,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4761,
+    key.offset: 4750,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4765,
+    key.offset: 4754,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4778,
+    key.offset: 4767,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4786,
+    key.offset: 4775,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4792,
+    key.offset: 4781,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4820,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4827,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4831,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4838,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4842,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4855,
+    key.offset: 4844,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4864,
+    key.offset: 4853,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4859,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4866,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4870,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4877,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4881,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4894,
+    key.offset: 4883,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4903,
+    key.offset: 4892,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4898,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4905,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4909,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4916,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4920,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4933,
+    key.offset: 4922,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4949,
+    key.offset: 4938,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4944,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4951,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4955,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4962,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4966,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4979,
+    key.offset: 4968,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4995,
+    key.offset: 4984,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4990,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4997,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5001,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5008,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5012,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5025,
+    key.offset: 5014,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5033,
+    key.offset: 5022,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5028,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5035,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5039,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5046,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5050,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5063,
+    key.offset: 5052,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5071,
+    key.offset: 5060,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5066,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5073,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5077,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5084,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5088,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5102,
+    key.offset: 5091,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5110,
+    key.offset: 5099,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5105,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5112,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5116,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5123,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5127,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5141,
+    key.offset: 5130,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5147,
+    key.offset: 5136,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5153,
+    key.offset: 5142,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5160,
+    key.offset: 5149,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5164,
+    key.offset: 5153,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5178,
+    key.offset: 5167,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5186,
+    key.offset: 5175,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5192,
+    key.offset: 5181,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5199,
+    key.offset: 5188,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5203,
+    key.offset: 5192,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5218,
+    key.offset: 5207,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5226,
+    key.offset: 5215,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5232,
+    key.offset: 5221,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5239,
+    key.offset: 5228,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5243,
+    key.offset: 5232,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5263,
+    key.offset: 5252,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5272,
+    key.offset: 5261,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5267,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5274,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5278,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5285,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5289,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5307,
+    key.offset: 5296,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5316,
+    key.offset: 5305,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5312,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5319,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5323,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5330,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5334,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5353,
+    key.offset: 5342,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5361,
+    key.offset: 5350,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5357,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5364,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5368,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5375,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5379,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5398,
+    key.offset: 5387,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5406,
+    key.offset: 5395,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5413,
+    key.offset: 5402,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5420,
+    key.offset: 5409,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5425,
+    key.offset: 5414,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5445,
+    key.offset: 5434,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5452,
+    key.offset: 5441,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5457,
+    key.offset: 5446,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5482,
+    key.offset: 5471,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5489,
+    key.offset: 5478,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5496,
+    key.offset: 5485,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5519,
+    key.offset: 5508,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5526,
+    key.offset: 5515,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5530,
+    key.offset: 5519,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5533,
+    key.offset: 5522,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5544,
+    key.offset: 5533,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5551,
+    key.offset: 5540,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5563,
+    key.offset: 5552,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5570,
+    key.offset: 5559,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5575,
+    key.offset: 5564,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5578,
+    key.offset: 5567,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5588,
+    key.offset: 5577,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5598,
+    key.offset: 5587,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5618,
+    key.offset: 5607,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5623,
+    key.offset: 5612,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5628,
+    key.offset: 5617,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5648,
+    key.offset: 5637,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 5656,
+    key.offset: 5645,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5701,
+    key.offset: 5690,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5711,
+    key.offset: 5700,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5731,
+    key.offset: 5720,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5736,
+    key.offset: 5725,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5741,
+    key.offset: 5730,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5761,
+    key.offset: 5750,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5771,
+    key.offset: 5760,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5776,
+    key.offset: 5765,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5781,
+    key.offset: 5770,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5802,
+    key.offset: 5791,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5810,
+    key.offset: 5799,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5820,
+    key.offset: 5809,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5840,
+    key.offset: 5829,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5845,
+    key.offset: 5834,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5850,
+    key.offset: 5839,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5870,
+    key.offset: 5859,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5878,
+    key.offset: 5867,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5885,
+    key.offset: 5874,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5894,
+    key.offset: 5883,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5913,
+    key.offset: 5902,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5918,
+    key.offset: 5907,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5924,
+    key.offset: 5913,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5948,
+    key.offset: 5937,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5967,
+    key.offset: 5956,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5972,
+    key.offset: 5961,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5978,
+    key.offset: 5967,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6006,
+    key.offset: 5995,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6026,
+    key.offset: 6015,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6042,
+    key.offset: 6031,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6047,
+    key.offset: 6036,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6051,
+    key.offset: 6040,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6063,
+    key.offset: 6052,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6079,
+    key.offset: 6068,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6095,
+    key.offset: 6084,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6100,
+    key.offset: 6089,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6104,
+    key.offset: 6093,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6122,
+    key.offset: 6111,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6138,
+    key.offset: 6127,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6143,
+    key.offset: 6132,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6147,
+    key.offset: 6136,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6159,
+    key.offset: 6148,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6169,
+    key.offset: 6158,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6174,
+    key.offset: 6163,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6178,
+    key.offset: 6167,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6189,
+    key.offset: 6178,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6199,
+    key.offset: 6188,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6204,
+    key.offset: 6193,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6208,
+    key.offset: 6197,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6218,
+    key.offset: 6207,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6228,
+    key.offset: 6217,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6233,
+    key.offset: 6222,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6238,
+    key.offset: 6227,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6242,
+    key.offset: 6231,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6251,
+    key.offset: 6240,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6267,
+    key.offset: 6256,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6272,
+    key.offset: 6261,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6276,
+    key.offset: 6265,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6284,
+    key.offset: 6273,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6293,
+    key.offset: 6282,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6298,
+    key.offset: 6287,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6304,
+    key.offset: 6293,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6328,
+    key.offset: 6317,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6348,
+    key.offset: 6337,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6355,
+    key.offset: 6344,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6367,
+    key.offset: 6356,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6373,
+    key.offset: 6362,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6377,
+    key.offset: 6366,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6380,
+    key.offset: 6369,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6397,
+    key.offset: 6386,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6411,
+    key.offset: 6400,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6423,
+    key.offset: 6412,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6432,
+    key.offset: 6421,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6441,
+    key.offset: 6430,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6446,
+    key.offset: 6435,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6451,
+    key.offset: 6440,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6474,
+    key.offset: 6463,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6485,
+    key.offset: 6474,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6491,
+    key.offset: 6480,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6504,
+    key.offset: 6493,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6509,
+    key.offset: 6498,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6514,
+    key.offset: 6503,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6549,
+    key.offset: 6538,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6560,
+    key.offset: 6549,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6567,
+    key.offset: 6556,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6579,
+    key.offset: 6568,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6585,
+    key.offset: 6574,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6594,
+    key.offset: 6583,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6603,
+    key.offset: 6592,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6608,
+    key.offset: 6597,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6613,
+    key.offset: 6602,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6644,
+    key.offset: 6633,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6651,
+    key.offset: 6640,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6657,
+    key.offset: 6646,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6672,
+    key.offset: 6661,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6686,
+    key.offset: 6675,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6698,
+    key.offset: 6687,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6707,
+    key.offset: 6696,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6736,
+    key.offset: 6725,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6743,
+    key.offset: 6732,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6748,
+    key.offset: 6737,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6772,
+    key.offset: 6761,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6788,
+    key.offset: 6777,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6793,
+    key.offset: 6782,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6809,
+    key.offset: 6798,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 6811,
+    key.offset: 6800,
     key.length: 54
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6870,
+    key.offset: 6859,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6875,
+    key.offset: 6864,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6888,
+    key.offset: 6877,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 6890,
+    key.offset: 6879,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6943,
+    key.offset: 6932,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6950,
+    key.offset: 6939,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6956,
+    key.offset: 6945,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6983,
+    key.offset: 6972,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6990,
+    key.offset: 6979,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6995,
+    key.offset: 6984,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7002,
+    key.offset: 6991,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7009,
+    key.offset: 6998,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7015,
+    key.offset: 7004,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7040,
+    key.offset: 7029,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7044,
+    key.offset: 7033,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7071,
+    key.offset: 7060,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7080,
+    key.offset: 7069,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7087,
+    key.offset: 7076,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7092,
+    key.offset: 7081,
     key.length: 1
   }
 ]
@@ -3608,630 +3597,625 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 18,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 22,
+    key.offset: 11,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 36,
+    key.offset: 25,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 53,
+    key.offset: 42,
     key.length: 17,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 233,
+    key.offset: 222,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 244,
+    key.offset: 233,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 292,
+    key.offset: 281,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 327,
+    key.offset: 316,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 361,
+    key.offset: 350,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 420,
+    key.offset: 409,
     key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.protocol,
+    key.offset: 452,
+    key.length: 9,
+    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.offset: 463,
-    key.length: 9,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.protocol,
-    key.offset: 474,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 522,
+    key.offset: 511,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 557,
+    key.offset: 546,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 591,
+    key.offset: 580,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 622,
+    key.offset: 611,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 661,
+    key.offset: 650,
     key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.protocol,
+    key.offset: 692,
+    key.length: 9,
+    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.offset: 703,
-    key.length: 9,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.protocol,
-    key.offset: 714,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 762,
+    key.offset: 751,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 797,
+    key.offset: 786,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 831,
+    key.offset: 820,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 862,
+    key.offset: 851,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 901,
+    key.offset: 890,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 990,
+    key.offset: 979,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 1213,
+    key.offset: 1202,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1252,
+    key.offset: 1241,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1320,
+    key.offset: 1309,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1383,
+    key.offset: 1372,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1483,
+    key.offset: 1472,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1508,
+    key.offset: 1497,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1554,
+    key.offset: 1543,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1564,
+    key.offset: 1553,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1611,
+    key.offset: 1600,
     key.length: 20,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1632,
+    key.offset: 1621,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1691,
+    key.offset: 1680,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1716,
+    key.offset: 1705,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1762,
+    key.offset: 1751,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1772,
+    key.offset: 1761,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1819,
+    key.offset: 1808,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1884,
+    key.offset: 1873,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1909,
+    key.offset: 1898,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1955,
+    key.offset: 1944,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1965,
+    key.offset: 1954,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2036,
+    key.offset: 2025,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2092,
+    key.offset: 2081,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2151,
+    key.offset: 2140,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2161,
+    key.offset: 2150,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2206,
+    key.offset: 2195,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2216,
+    key.offset: 2205,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2248,
+    key.offset: 2237,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2260,
+    key.offset: 2249,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2272,
+    key.offset: 2261,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2285,
+    key.offset: 2274,
     key.length: 20,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2306,
+    key.offset: 2295,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2318,
+    key.offset: 2307,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2410,
+    key.offset: 2399,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2420,
+    key.offset: 2409,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2494,
+    key.offset: 2483,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2504,
+    key.offset: 2493,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2548,
+    key.offset: 2537,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2588,
+    key.offset: 2577,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3148,
+    key.offset: 3137,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3158,
+    key.offset: 3147,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3631,
+    key.offset: 3620,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3672,
+    key.offset: 3661,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3713,
+    key.offset: 3702,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3767,
+    key.offset: 3756,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3909,
+    key.offset: 3898,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3982,
+    key.offset: 3971,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 4147,
+    key.offset: 4136,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 4161,
+    key.offset: 4150,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4215,
+    key.offset: 4204,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4249,
+    key.offset: 4238,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4283,
+    key.offset: 4272,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4442,
+    key.offset: 4431,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4486,
+    key.offset: 4475,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4502,
+    key.offset: 4491,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4639,
+    key.offset: 4628,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4702,
+    key.offset: 4691,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4740,
+    key.offset: 4729,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4778,
+    key.offset: 4767,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4855,
+    key.offset: 4844,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4894,
+    key.offset: 4883,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4933,
+    key.offset: 4922,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4979,
+    key.offset: 4968,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 5025,
+    key.offset: 5014,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5063,
+    key.offset: 5052,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5102,
+    key.offset: 5091,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5141,
+    key.offset: 5130,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5178,
+    key.offset: 5167,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5218,
+    key.offset: 5207,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5263,
+    key.offset: 5252,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5307,
+    key.offset: 5296,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5353,
+    key.offset: 5342,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5398,
+    key.offset: 5387,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5533,
+    key.offset: 5522,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5578,
+    key.offset: 5567,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5598,
+    key.offset: 5587,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5711,
+    key.offset: 5700,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5820,
+    key.offset: 5809,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5948,
+    key.offset: 5937,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6006,
+    key.offset: 5995,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6284,
+    key.offset: 6273,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6328,
+    key.offset: 6317,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6380,
+    key.offset: 6369,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6772,
+    key.offset: 6761,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 7040,
+    key.offset: 7029,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 7044,
+    key.offset: 7033,
     key.length: 19
   }
 ]
@@ -4240,13 +4224,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1",
-    key.offset: 215,
+    key.offset: 204,
     key.length: 154,
-    key.nameoffset: 222,
+    key.nameoffset: 211,
     key.namelength: 8,
-    key.bodyoffset: 262,
+    key.bodyoffset: 251,
     key.bodylength: 106,
-    key.docoffset: 182,
+    key.docoffset: 171,
     key.doclength: 26,
     key.inheritedtypes: [
       {
@@ -4258,7 +4242,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 208,
+        key.offset: 197,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4266,12 +4250,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 233,
+        key.offset: 222,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 244,
+        key.offset: 233,
         key.length: 16
       }
     ],
@@ -4280,13 +4264,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 275,
+        key.offset: 264,
         key.length: 24,
-        key.nameoffset: 275,
+        key.nameoffset: 264,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 268,
+            key.offset: 257,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4295,7 +4279,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 280,
+            key.offset: 269,
             key.length: 18,
             key.typename: "UInt32",
             key.nameoffset: 0,
@@ -4307,13 +4291,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 312,
+        key.offset: 301,
         key.length: 22,
-        key.nameoffset: 312,
+        key.nameoffset: 301,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 305,
+            key.offset: 294,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4322,10 +4306,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 317,
+            key.offset: 306,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 317,
+            key.nameoffset: 306,
             key.namelength: 8
           }
         ]
@@ -4335,14 +4319,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 347,
+        key.offset: 336,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 351,
+        key.nameoffset: 340,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 340,
+            key.offset: 329,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4354,18 +4338,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1X",
-    key.offset: 405,
+    key.offset: 394,
     key.length: 31,
     key.typename: "FooEnum1",
-    key.nameoffset: 409,
+    key.nameoffset: 398,
     key.namelength: 9,
-    key.bodyoffset: 430,
+    key.bodyoffset: 419,
     key.bodylength: 5,
-    key.docoffset: 371,
+    key.docoffset: 360,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 398,
+        key.offset: 387,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4375,11 +4359,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2",
-    key.offset: 445,
+    key.offset: 434,
     key.length: 154,
-    key.nameoffset: 452,
+    key.nameoffset: 441,
     key.namelength: 8,
-    key.bodyoffset: 492,
+    key.bodyoffset: 481,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4391,7 +4375,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 438,
+        key.offset: 427,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4399,12 +4383,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 463,
+        key.offset: 452,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 474,
+        key.offset: 463,
         key.length: 16
       }
     ],
@@ -4413,13 +4397,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 505,
+        key.offset: 494,
         key.length: 24,
-        key.nameoffset: 505,
+        key.nameoffset: 494,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 498,
+            key.offset: 487,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4428,7 +4412,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 510,
+            key.offset: 499,
             key.length: 18,
             key.typename: "UInt32",
             key.nameoffset: 0,
@@ -4440,13 +4424,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 542,
+        key.offset: 531,
         key.length: 22,
-        key.nameoffset: 542,
+        key.nameoffset: 531,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 535,
+            key.offset: 524,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4455,10 +4439,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 547,
+            key.offset: 536,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 547,
+            key.nameoffset: 536,
             key.namelength: 8
           }
         ]
@@ -4468,14 +4452,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 577,
+        key.offset: 566,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 581,
+        key.nameoffset: 570,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 570,
+            key.offset: 559,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4487,16 +4471,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2X",
-    key.offset: 607,
+    key.offset: 596,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 611,
+    key.nameoffset: 600,
     key.namelength: 9,
-    key.bodyoffset: 632,
+    key.bodyoffset: 621,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 600,
+        key.offset: 589,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4506,16 +4490,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2Y",
-    key.offset: 646,
+    key.offset: 635,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 650,
+    key.nameoffset: 639,
     key.namelength: 9,
-    key.bodyoffset: 671,
+    key.bodyoffset: 660,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 639,
+        key.offset: 628,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4525,11 +4509,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3",
-    key.offset: 685,
+    key.offset: 674,
     key.length: 154,
-    key.nameoffset: 692,
+    key.nameoffset: 681,
     key.namelength: 8,
-    key.bodyoffset: 732,
+    key.bodyoffset: 721,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4541,7 +4525,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 678,
+        key.offset: 667,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4549,12 +4533,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 703,
+        key.offset: 692,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 714,
+        key.offset: 703,
         key.length: 16
       }
     ],
@@ -4563,13 +4547,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 745,
+        key.offset: 734,
         key.length: 24,
-        key.nameoffset: 745,
+        key.nameoffset: 734,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 738,
+            key.offset: 727,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4578,7 +4562,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 750,
+            key.offset: 739,
             key.length: 18,
             key.typename: "UInt32",
             key.nameoffset: 0,
@@ -4590,13 +4574,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 782,
+        key.offset: 771,
         key.length: 22,
-        key.nameoffset: 782,
+        key.nameoffset: 771,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 775,
+            key.offset: 764,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4605,10 +4589,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 787,
+            key.offset: 776,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 787,
+            key.nameoffset: 776,
             key.namelength: 8
           }
         ]
@@ -4618,14 +4602,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 817,
+        key.offset: 806,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 821,
+        key.nameoffset: 810,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 810,
+            key.offset: 799,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4637,16 +4621,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3X",
-    key.offset: 847,
+    key.offset: 836,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 851,
+    key.nameoffset: 840,
     key.namelength: 9,
-    key.bodyoffset: 872,
+    key.bodyoffset: 861,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 840,
+        key.offset: 829,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4656,16 +4640,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3Y",
-    key.offset: 886,
+    key.offset: 875,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 890,
+    key.nameoffset: 879,
     key.namelength: 9,
-    key.bodyoffset: 911,
+    key.bodyoffset: 900,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 879,
+        key.offset: 868,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4675,13 +4659,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooComparisonResult",
-    key.offset: 963,
+    key.offset: 952,
     key.length: 179,
-    key.nameoffset: 968,
+    key.nameoffset: 957,
     key.namelength: 19,
-    key.bodyoffset: 995,
+    key.bodyoffset: 984,
     key.bodylength: 146,
-    key.docoffset: 919,
+    key.docoffset: 908,
     key.doclength: 37,
     key.inheritedtypes: [
       {
@@ -4690,7 +4674,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 956,
+        key.offset: 945,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4698,14 +4682,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 990,
+        key.offset: 979,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1031,
+        key.offset: 1020,
         key.length: 26,
         key.nameoffset: 0,
         key.namelength: 0,
@@ -4714,14 +4698,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedAscending",
-            key.offset: 1036,
+            key.offset: 1025,
             key.length: 21,
-            key.nameoffset: 1036,
+            key.nameoffset: 1025,
             key.namelength: 16,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1055,
+                key.offset: 1044,
                 key.length: 2
               }
             ]
@@ -4730,7 +4714,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1063,
+        key.offset: 1052,
         key.length: 20,
         key.nameoffset: 0,
         key.namelength: 0,
@@ -4739,14 +4723,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedSame",
-            key.offset: 1068,
+            key.offset: 1057,
             key.length: 15,
-            key.nameoffset: 1068,
+            key.nameoffset: 1057,
             key.namelength: 11,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1082,
+                key.offset: 1071,
                 key.length: 1
               }
             ]
@@ -4755,7 +4739,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1114,
+        key.offset: 1103,
         key.length: 26,
         key.nameoffset: 0,
         key.namelength: 0,
@@ -4764,14 +4748,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedDescending",
-            key.offset: 1119,
+            key.offset: 1108,
             key.length: 21,
-            key.nameoffset: 1119,
+            key.nameoffset: 1108,
             key.namelength: 17,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1139,
+                key.offset: 1128,
                 key.length: 1
               }
             ]
@@ -4784,13 +4768,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooRuncingOptions",
-    key.offset: 1186,
+    key.offset: 1175,
     key.length: 249,
-    key.nameoffset: 1193,
+    key.nameoffset: 1182,
     key.namelength: 17,
-    key.bodyoffset: 1224,
+    key.bodyoffset: 1213,
     key.bodylength: 210,
-    key.docoffset: 1144,
+    key.docoffset: 1133,
     key.doclength: 35,
     key.inheritedtypes: [
       {
@@ -4799,7 +4783,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 1179,
+        key.offset: 1168,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4807,7 +4791,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1213,
+        key.offset: 1202,
         key.length: 9
       }
     ],
@@ -4816,13 +4800,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 1237,
+        key.offset: 1226,
         key.length: 19,
-        key.nameoffset: 1237,
+        key.nameoffset: 1226,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 1230,
+            key.offset: 1219,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4831,10 +4815,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 1242,
+            key.offset: 1231,
             key.length: 13,
             key.typename: "Int",
-            key.nameoffset: 1242,
+            key.nameoffset: 1231,
             key.namelength: 8
           }
         ]
@@ -4843,16 +4827,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableMince",
-        key.offset: 1296,
+        key.offset: 1285,
         key.length: 49,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1307,
+        key.nameoffset: 1296,
         key.namelength: 11,
-        key.bodyoffset: 1339,
+        key.bodyoffset: 1328,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1289,
+            key.offset: 1278,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4862,16 +4846,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableQuince",
-        key.offset: 1358,
+        key.offset: 1347,
         key.length: 50,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1369,
+        key.nameoffset: 1358,
         key.namelength: 12,
-        key.bodyoffset: 1402,
+        key.bodyoffset: 1391,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1351,
+            key.offset: 1340,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4883,15 +4867,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1",
-    key.offset: 1444,
+    key.offset: 1433,
     key.length: 129,
-    key.nameoffset: 1451,
+    key.nameoffset: 1440,
     key.namelength: 10,
-    key.bodyoffset: 1463,
+    key.bodyoffset: 1452,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1437,
+        key.offset: 1426,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4902,14 +4886,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1476,
+        key.offset: 1465,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1480,
+        key.nameoffset: 1469,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1469,
+            key.offset: 1458,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4920,14 +4904,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1501,
+        key.offset: 1490,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1505,
+        key.nameoffset: 1494,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1494,
+            key.offset: 1483,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4937,13 +4921,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1527,
+        key.offset: 1516,
         key.length: 6,
-        key.nameoffset: 1527,
+        key.nameoffset: 1516,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1520,
+            key.offset: 1509,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4953,13 +4937,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1546,
+        key.offset: 1535,
         key.length: 25,
-        key.nameoffset: 1546,
+        key.nameoffset: 1535,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1539,
+            key.offset: 1528,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4968,19 +4952,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1551,
+            key.offset: 1540,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1551,
+            key.nameoffset: 1540,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1561,
+            key.offset: 1550,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1561,
+            key.nameoffset: 1550,
             key.namelength: 1
           }
         ]
@@ -4991,13 +4975,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1Pointer",
-    key.offset: 1581,
+    key.offset: 1570,
     key.length: 62,
-    key.nameoffset: 1591,
+    key.nameoffset: 1580,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1574,
+        key.offset: 1563,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5007,15 +4991,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct2",
-    key.offset: 1652,
+    key.offset: 1641,
     key.length: 129,
-    key.nameoffset: 1659,
+    key.nameoffset: 1648,
     key.namelength: 10,
-    key.bodyoffset: 1671,
+    key.bodyoffset: 1660,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1645,
+        key.offset: 1634,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5026,14 +5010,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1684,
+        key.offset: 1673,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1688,
+        key.nameoffset: 1677,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1677,
+            key.offset: 1666,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5044,14 +5028,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1709,
+        key.offset: 1698,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1713,
+        key.nameoffset: 1702,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1702,
+            key.offset: 1691,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5061,13 +5045,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1735,
+        key.offset: 1724,
         key.length: 6,
-        key.nameoffset: 1735,
+        key.nameoffset: 1724,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1728,
+            key.offset: 1717,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5077,13 +5061,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1754,
+        key.offset: 1743,
         key.length: 25,
-        key.nameoffset: 1754,
+        key.nameoffset: 1743,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1747,
+            key.offset: 1736,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5092,19 +5076,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1759,
+            key.offset: 1748,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1759,
+            key.nameoffset: 1748,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1769,
+            key.offset: 1758,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1769,
+            key.nameoffset: 1758,
             key.namelength: 1
           }
         ]
@@ -5115,13 +5099,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef1",
-    key.offset: 1789,
+    key.offset: 1778,
     key.length: 40,
-    key.nameoffset: 1799,
+    key.nameoffset: 1788,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1782,
+        key.offset: 1771,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5131,15 +5115,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef2",
-    key.offset: 1838,
+    key.offset: 1827,
     key.length: 136,
-    key.nameoffset: 1845,
+    key.nameoffset: 1834,
     key.namelength: 17,
-    key.bodyoffset: 1864,
+    key.bodyoffset: 1853,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1831,
+        key.offset: 1820,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5150,14 +5134,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1877,
+        key.offset: 1866,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1881,
+        key.nameoffset: 1870,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1870,
+            key.offset: 1859,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5168,14 +5152,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1902,
+        key.offset: 1891,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1906,
+        key.nameoffset: 1895,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1895,
+            key.offset: 1884,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5185,13 +5169,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1928,
+        key.offset: 1917,
         key.length: 6,
-        key.nameoffset: 1928,
+        key.nameoffset: 1917,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1921,
+            key.offset: 1910,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5201,13 +5185,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1947,
+        key.offset: 1936,
         key.length: 25,
-        key.nameoffset: 1947,
+        key.nameoffset: 1936,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1940,
+            key.offset: 1929,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5216,19 +5200,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1952,
+            key.offset: 1941,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1952,
+            key.nameoffset: 1941,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1962,
+            key.offset: 1951,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1962,
+            key.nameoffset: 1951,
             key.namelength: 1
           }
         ]
@@ -5239,15 +5223,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooTypedef1",
-    key.offset: 2012,
+    key.offset: 2001,
     key.length: 29,
-    key.nameoffset: 2022,
+    key.nameoffset: 2011,
     key.namelength: 11,
-    key.docoffset: 1976,
+    key.docoffset: 1965,
     key.doclength: 29,
     key.attributes: [
       {
-        key.offset: 2005,
+        key.offset: 1994,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5258,16 +5242,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "fooIntVar",
-    key.offset: 2077,
+    key.offset: 2066,
     key.length: 20,
     key.typename: "Int32",
-    key.nameoffset: 2081,
+    key.nameoffset: 2070,
     key.namelength: 9,
-    key.docoffset: 2043,
+    key.docoffset: 2032,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 2070,
+        key.offset: 2059,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5277,16 +5261,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1(_:)",
-    key.offset: 2132,
+    key.offset: 2121,
     key.length: 34,
     key.typename: "Int32",
-    key.nameoffset: 2137,
+    key.nameoffset: 2126,
     key.namelength: 20,
-    key.docoffset: 2099,
+    key.docoffset: 2088,
     key.doclength: 26,
     key.attributes: [
       {
-        key.offset: 2125,
+        key.offset: 2114,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5295,7 +5279,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2146,
+        key.offset: 2135,
         key.length: 10,
         key.typename: "Int32",
         key.nameoffset: 0,
@@ -5307,14 +5291,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1AnonymousParam(_:)",
-    key.offset: 2175,
+    key.offset: 2164,
     key.length: 46,
     key.typename: "Int32",
-    key.nameoffset: 2180,
+    key.nameoffset: 2169,
     key.namelength: 32,
     key.attributes: [
       {
-        key.offset: 2168,
+        key.offset: 2157,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5322,7 +5306,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
-        key.offset: 2203,
+        key.offset: 2192,
         key.length: 8,
         key.typename: "Int32",
         key.nameoffset: 0,
@@ -5334,14 +5318,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc3(_:_:_:_:)",
-    key.offset: 2229,
+    key.offset: 2218,
     key.length: 94,
     key.typename: "Int32",
-    key.nameoffset: 2234,
+    key.nameoffset: 2223,
     key.namelength: 80,
     key.attributes: [
       {
-        key.offset: 2222,
+        key.offset: 2211,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5350,7 +5334,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2243,
+        key.offset: 2232,
         key.length: 10,
         key.typename: "Int32",
         key.nameoffset: 0,
@@ -5359,7 +5343,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "b",
-        key.offset: 2255,
+        key.offset: 2244,
         key.length: 10,
         key.typename: "Float",
         key.nameoffset: 0,
@@ -5368,7 +5352,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "c",
-        key.offset: 2267,
+        key.offset: 2256,
         key.length: 11,
         key.typename: "Double",
         key.nameoffset: 0,
@@ -5377,7 +5361,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "d",
-        key.offset: 2280,
+        key.offset: 2269,
         key.length: 33,
         key.typename: "UnsafeMutablePointer<Int32>!",
         key.nameoffset: 0,
@@ -5389,13 +5373,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithBlock(_:)",
-    key.offset: 2379,
+    key.offset: 2368,
     key.length: 49,
-    key.nameoffset: 2384,
+    key.nameoffset: 2373,
     key.namelength: 44,
     key.attributes: [
       {
-        key.offset: 2372,
+        key.offset: 2361,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5404,7 +5388,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "blk",
-        key.offset: 2401,
+        key.offset: 2390,
         key.length: 26,
         key.typename: "((Float) -> Int32)!",
         key.nameoffset: 0,
@@ -5416,13 +5400,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithFunctionPointer(_:)",
-    key.offset: 2437,
+    key.offset: 2426,
     key.length: 75,
-    key.nameoffset: 2442,
+    key.nameoffset: 2431,
     key.namelength: 70,
     key.attributes: [
       {
-        key.offset: 2430,
+        key.offset: 2419,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5431,7 +5415,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "fptr",
-        key.offset: 2469,
+        key.offset: 2458,
         key.length: 42,
         key.typename: "(@convention(c) (Float) -> Int32)!",
         key.nameoffset: 0,
@@ -5443,14 +5427,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn1()",
-    key.offset: 2521,
+    key.offset: 2510,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2526,
+    key.nameoffset: 2515,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2514,
+        key.offset: 2503,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5460,14 +5444,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn2()",
-    key.offset: 2561,
+    key.offset: 2550,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2566,
+    key.nameoffset: 2555,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2554,
+        key.offset: 2543,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5477,15 +5461,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment1()",
-    key.offset: 2665,
+    key.offset: 2654,
     key.length: 26,
-    key.nameoffset: 2670,
+    key.nameoffset: 2659,
     key.namelength: 21,
-    key.docoffset: 2595,
+    key.docoffset: 2584,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 2658,
+        key.offset: 2647,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5495,15 +5479,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment2()",
-    key.offset: 2743,
+    key.offset: 2732,
     key.length: 26,
-    key.nameoffset: 2748,
+    key.nameoffset: 2737,
     key.namelength: 21,
-    key.docoffset: 2693,
+    key.docoffset: 2682,
     key.doclength: 42,
     key.attributes: [
       {
-        key.offset: 2736,
+        key.offset: 2725,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5513,15 +5497,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment3()",
-    key.offset: 2838,
+    key.offset: 2827,
     key.length: 26,
-    key.nameoffset: 2843,
+    key.nameoffset: 2832,
     key.namelength: 21,
-    key.docoffset: 2771,
+    key.docoffset: 2760,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 2831,
+        key.offset: 2820,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5531,15 +5515,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment4()",
-    key.offset: 2926,
+    key.offset: 2915,
     key.length: 26,
-    key.nameoffset: 2931,
+    key.nameoffset: 2920,
     key.namelength: 21,
-    key.docoffset: 2866,
+    key.docoffset: 2855,
     key.doclength: 53,
     key.attributes: [
       {
-        key.offset: 2919,
+        key.offset: 2908,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5549,15 +5533,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment5()",
-    key.offset: 3020,
+    key.offset: 3009,
     key.length: 26,
-    key.nameoffset: 3025,
+    key.nameoffset: 3014,
     key.namelength: 21,
-    key.docoffset: 2954,
+    key.docoffset: 2943,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 3013,
+        key.offset: 3002,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5567,16 +5551,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
-    key.offset: 3105,
+    key.offset: 3094,
     key.length: 58,
     key.typename: "Int32",
-    key.nameoffset: 3110,
+    key.nameoffset: 3099,
     key.namelength: 44,
-    key.docoffset: 3048,
+    key.docoffset: 3037,
     key.doclength: 50,
     key.attributes: [
       {
-        key.offset: 3098,
+        key.offset: 3087,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5585,7 +5569,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 3143,
+        key.offset: 3132,
         key.length: 10,
         key.typename: "Int32",
         key.nameoffset: 0,
@@ -5597,17 +5581,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolBase",
-    key.offset: 3205,
+    key.offset: 3194,
     key.length: 523,
-    key.nameoffset: 3214,
+    key.nameoffset: 3203,
     key.namelength: 15,
-    key.bodyoffset: 3231,
+    key.bodyoffset: 3220,
     key.bodylength: 496,
-    key.docoffset: 3165,
+    key.docoffset: 3154,
     key.doclength: 33,
     key.attributes: [
       {
-        key.offset: 3198,
+        key.offset: 3187,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5617,42 +5601,42 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFunc()",
-        key.offset: 3289,
+        key.offset: 3278,
         key.length: 19,
-        key.nameoffset: 3294,
+        key.nameoffset: 3283,
         key.namelength: 14,
-        key.docoffset: 3242,
+        key.docoffset: 3231,
         key.doclength: 43
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation1()",
-        key.offset: 3387,
+        key.offset: 3376,
         key.length: 40,
-        key.nameoffset: 3392,
+        key.nameoffset: 3381,
         key.namelength: 35,
-        key.docoffset: 3319,
+        key.docoffset: 3308,
         key.doclength: 64
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation2()",
-        key.offset: 3520,
+        key.offset: 3509,
         key.length: 40,
-        key.nameoffset: 3525,
+        key.nameoffset: 3514,
         key.namelength: 35,
-        key.docoffset: 3438,
+        key.docoffset: 3427,
         key.doclength: 77
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoClassFunc()",
-        key.offset: 3571,
+        key.offset: 3560,
         key.length: 31,
-        key.nameoffset: 3583,
+        key.nameoffset: 3572,
         key.namelength: 19
       },
       {
@@ -5660,12 +5644,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 3613,
+        key.offset: 3602,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3617,
+        key.nameoffset: 3606,
         key.namelength: 12,
-        key.bodyoffset: 3638,
+        key.bodyoffset: 3627,
         key.bodylength: 9
       },
       {
@@ -5673,24 +5657,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 3654,
+        key.offset: 3643,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3658,
+        key.nameoffset: 3647,
         key.namelength: 12,
-        key.bodyoffset: 3679,
+        key.bodyoffset: 3668,
         key.bodylength: 9
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 3695,
+        key.offset: 3684,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 3699,
+        key.nameoffset: 3688,
         key.namelength: 12,
-        key.bodyoffset: 3720,
+        key.bodyoffset: 3709,
         key.bodylength: 5
       }
     ]
@@ -5699,11 +5683,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolDerived",
-    key.offset: 3737,
+    key.offset: 3726,
     key.length: 49,
-    key.nameoffset: 3746,
+    key.nameoffset: 3735,
     key.namelength: 18,
-    key.bodyoffset: 3784,
+    key.bodyoffset: 3773,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -5712,7 +5696,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 3730,
+        key.offset: 3719,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5720,7 +5704,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3767,
+        key.offset: 3756,
         key.length: 15
       }
     ]
@@ -5729,15 +5713,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassBase",
-    key.offset: 3793,
+    key.offset: 3782,
     key.length: 290,
-    key.nameoffset: 3799,
+    key.nameoffset: 3788,
     key.namelength: 12,
-    key.bodyoffset: 3813,
+    key.bodyoffset: 3802,
     key.bodylength: 269,
     key.attributes: [
       {
-        key.offset: 3788,
+        key.offset: 3777,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5747,13 +5731,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc0()",
-        key.offset: 3824,
+        key.offset: 3813,
         key.length: 27,
-        key.nameoffset: 3829,
+        key.nameoffset: 3818,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 3819,
+            key.offset: 3808,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5763,14 +5747,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc1(_:)",
-        key.offset: 3862,
+        key.offset: 3851,
         key.length: 60,
         key.typename: "FooClassBase!",
-        key.nameoffset: 3867,
+        key.nameoffset: 3856,
         key.namelength: 38,
         key.attributes: [
           {
-            key.offset: 3857,
+            key.offset: 3846,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5779,7 +5763,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "anObject",
-            key.offset: 3888,
+            key.offset: 3877,
             key.length: 16,
             key.typename: "Any!",
             key.nameoffset: 0,
@@ -5791,13 +5775,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 3935,
+        key.offset: 3924,
         key.length: 7,
-        key.nameoffset: 3935,
+        key.nameoffset: 3924,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3928,
+            key.offset: 3917,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5807,18 +5791,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(float:)",
-        key.offset: 3967,
+        key.offset: 3956,
         key.length: 21,
-        key.nameoffset: 3967,
+        key.nameoffset: 3956,
         key.namelength: 21,
         key.attributes: [
           {
-            key.offset: 3955,
+            key.offset: 3944,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 3948,
+            key.offset: 3937,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5827,10 +5811,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "f",
-            key.offset: 3973,
+            key.offset: 3962,
             key.length: 14,
             key.typename: "Float",
-            key.nameoffset: 3973,
+            key.nameoffset: 3962,
             key.namelength: 5
           }
         ]
@@ -5839,13 +5823,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 3999,
+        key.offset: 3988,
         key.length: 36,
-        key.nameoffset: 4004,
+        key.nameoffset: 3993,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 3994,
+            key.offset: 3983,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5855,13 +5839,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseClassFunc0()",
-        key.offset: 4051,
+        key.offset: 4040,
         key.length: 30,
-        key.nameoffset: 4062,
+        key.nameoffset: 4051,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 4046,
+            key.offset: 4035,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5873,13 +5857,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassDerived",
-    key.offset: 4123,
+    key.offset: 4112,
     key.length: 481,
-    key.nameoffset: 4129,
+    key.nameoffset: 4118,
     key.namelength: 15,
-    key.bodyoffset: 4181,
+    key.bodyoffset: 4170,
     key.bodylength: 422,
-    key.docoffset: 4085,
+    key.docoffset: 4074,
     key.doclength: 33,
     key.inheritedtypes: [
       {
@@ -5891,7 +5875,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 4118,
+        key.offset: 4107,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5899,12 +5883,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4147,
+        key.offset: 4136,
         key.length: 12
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4161,
+        key.offset: 4150,
         key.length: 18
       }
     ],
@@ -5914,14 +5898,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty1",
-        key.offset: 4197,
+        key.offset: 4186,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4201,
+        key.nameoffset: 4190,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 4192,
+            key.offset: 4181,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5932,14 +5916,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty2",
-        key.offset: 4231,
+        key.offset: 4220,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4235,
+        key.nameoffset: 4224,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 4226,
+            key.offset: 4215,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5949,16 +5933,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty3",
-        key.offset: 4265,
+        key.offset: 4254,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 4269,
+        key.nameoffset: 4258,
         key.namelength: 12,
-        key.bodyoffset: 4290,
+        key.bodyoffset: 4279,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 4260,
+            key.offset: 4249,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5968,13 +5952,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc0()",
-        key.offset: 4381,
+        key.offset: 4370,
         key.length: 23,
-        key.nameoffset: 4386,
+        key.nameoffset: 4375,
         key.namelength: 18,
         key.attributes: [
           {
-            key.offset: 4376,
+            key.offset: 4365,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5984,13 +5968,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc1(_:)",
-        key.offset: 4415,
+        key.offset: 4404,
         key.length: 33,
-        key.nameoffset: 4420,
+        key.nameoffset: 4409,
         key.namelength: 28,
         key.attributes: [
           {
-            key.offset: 4410,
+            key.offset: 4399,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5999,7 +5983,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4437,
+            key.offset: 4426,
             key.length: 10,
             key.typename: "Int32",
             key.nameoffset: 0,
@@ -6011,13 +5995,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc2(_:withB:)",
-        key.offset: 4459,
+        key.offset: 4448,
         key.length: 49,
-        key.nameoffset: 4464,
+        key.nameoffset: 4453,
         key.namelength: 44,
         key.attributes: [
           {
-            key.offset: 4454,
+            key.offset: 4443,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6026,7 +6010,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4481,
+            key.offset: 4470,
             key.length: 10,
             key.typename: "Int32",
             key.nameoffset: 0,
@@ -6035,10 +6019,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "b",
-            key.offset: 4493,
+            key.offset: 4482,
             key.length: 14,
             key.typename: "Int32",
-            key.nameoffset: 4493,
+            key.nameoffset: 4482,
             key.namelength: 5
           }
         ]
@@ -6047,13 +6031,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 4524,
+        key.offset: 4513,
         key.length: 36,
-        key.nameoffset: 4529,
+        key.nameoffset: 4518,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 4519,
+            key.offset: 4508,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6063,13 +6047,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooClassFunc0()",
-        key.offset: 4576,
+        key.offset: 4565,
         key.length: 26,
-        key.nameoffset: 4587,
+        key.nameoffset: 4576,
         key.namelength: 15,
         key.attributes: [
           {
-            key.offset: 4571,
+            key.offset: 4560,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6081,13 +6065,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "typedef_int_t",
-    key.offset: 4613,
+    key.offset: 4602,
     key.length: 31,
-    key.nameoffset: 4623,
+    key.nameoffset: 4612,
     key.namelength: 13,
     key.attributes: [
       {
-        key.offset: 4606,
+        key.offset: 4595,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6097,16 +6081,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
-    key.offset: 4685,
+    key.offset: 4674,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4689,
+    key.nameoffset: 4678,
     key.namelength: 11,
-    key.bodyoffset: 4709,
+    key.bodyoffset: 4698,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4678,
+        key.offset: 4667,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6116,16 +6100,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
-    key.offset: 4723,
+    key.offset: 4712,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4727,
+    key.nameoffset: 4716,
     key.namelength: 11,
-    key.bodyoffset: 4747,
+    key.bodyoffset: 4736,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4716,
+        key.offset: 4705,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6135,16 +6119,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
-    key.offset: 4761,
+    key.offset: 4750,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4765,
+    key.nameoffset: 4754,
     key.namelength: 11,
-    key.bodyoffset: 4785,
+    key.bodyoffset: 4774,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4754,
+        key.offset: 4743,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6154,16 +6138,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
-    key.offset: 4838,
+    key.offset: 4827,
     key.length: 31,
     key.typename: "UInt32",
-    key.nameoffset: 4842,
+    key.nameoffset: 4831,
     key.namelength: 11,
-    key.bodyoffset: 4863,
+    key.bodyoffset: 4852,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4831,
+        key.offset: 4820,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6173,16 +6157,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
-    key.offset: 4877,
+    key.offset: 4866,
     key.length: 31,
     key.typename: "UInt64",
-    key.nameoffset: 4881,
+    key.nameoffset: 4870,
     key.namelength: 11,
-    key.bodyoffset: 4902,
+    key.bodyoffset: 4891,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4870,
+        key.offset: 4859,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6192,16 +6176,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_6",
-    key.offset: 4916,
+    key.offset: 4905,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4920,
+    key.nameoffset: 4909,
     key.namelength: 11,
-    key.bodyoffset: 4948,
+    key.bodyoffset: 4937,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4909,
+        key.offset: 4898,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6211,16 +6195,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_7",
-    key.offset: 4962,
+    key.offset: 4951,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4966,
+    key.nameoffset: 4955,
     key.namelength: 11,
-    key.bodyoffset: 4994,
+    key.bodyoffset: 4983,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4955,
+        key.offset: 4944,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6230,16 +6214,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_8",
-    key.offset: 5008,
+    key.offset: 4997,
     key.length: 30,
     key.typename: "CChar",
-    key.nameoffset: 5012,
+    key.nameoffset: 5001,
     key.namelength: 11,
-    key.bodyoffset: 5032,
+    key.bodyoffset: 5021,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5001,
+        key.offset: 4990,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6249,16 +6233,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_9",
-    key.offset: 5046,
+    key.offset: 5035,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 5050,
+    key.nameoffset: 5039,
     key.namelength: 11,
-    key.bodyoffset: 5070,
+    key.bodyoffset: 5059,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5039,
+        key.offset: 5028,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6268,16 +6252,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_10",
-    key.offset: 5084,
+    key.offset: 5073,
     key.length: 31,
     key.typename: "Int16",
-    key.nameoffset: 5088,
+    key.nameoffset: 5077,
     key.namelength: 12,
-    key.bodyoffset: 5109,
+    key.bodyoffset: 5098,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5077,
+        key.offset: 5066,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6287,16 +6271,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_11",
-    key.offset: 5123,
+    key.offset: 5112,
     key.length: 29,
     key.typename: "Int",
-    key.nameoffset: 5127,
+    key.nameoffset: 5116,
     key.namelength: 12,
-    key.bodyoffset: 5146,
+    key.bodyoffset: 5135,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5116,
+        key.offset: 5105,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6306,16 +6290,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_OR",
-    key.offset: 5160,
+    key.offset: 5149,
     key.length: 31,
     key.typename: "Int32",
-    key.nameoffset: 5164,
+    key.nameoffset: 5153,
     key.namelength: 12,
-    key.bodyoffset: 5185,
+    key.bodyoffset: 5174,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5153,
+        key.offset: 5142,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6325,16 +6309,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_AND",
-    key.offset: 5199,
+    key.offset: 5188,
     key.length: 32,
     key.typename: "Int32",
-    key.nameoffset: 5203,
+    key.nameoffset: 5192,
     key.namelength: 13,
-    key.bodyoffset: 5225,
+    key.bodyoffset: 5214,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5192,
+        key.offset: 5181,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6344,16 +6328,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_BITWIDTH",
-    key.offset: 5239,
+    key.offset: 5228,
     key.length: 38,
     key.typename: "UInt64",
-    key.nameoffset: 5243,
+    key.nameoffset: 5232,
     key.namelength: 18,
-    key.bodyoffset: 5271,
+    key.bodyoffset: 5260,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5232,
+        key.offset: 5221,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6363,16 +6347,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_SIGNED",
-    key.offset: 5285,
+    key.offset: 5274,
     key.length: 36,
     key.typename: "UInt32",
-    key.nameoffset: 5289,
+    key.nameoffset: 5278,
     key.namelength: 16,
-    key.bodyoffset: 5315,
+    key.bodyoffset: 5304,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5278,
+        key.offset: 5267,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6382,16 +6366,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
-    key.offset: 5330,
+    key.offset: 5319,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 5334,
+    key.nameoffset: 5323,
     key.namelength: 17,
-    key.bodyoffset: 5360,
+    key.bodyoffset: 5349,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5323,
+        key.offset: 5312,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6401,16 +6385,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
-    key.offset: 5375,
+    key.offset: 5364,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 5379,
+    key.nameoffset: 5368,
     key.namelength: 17,
-    key.bodyoffset: 5405,
+    key.bodyoffset: 5394,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5368,
+        key.offset: 5357,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6420,13 +6404,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "theLastDeclInFoo()",
-    key.offset: 5420,
+    key.offset: 5409,
     key.length: 23,
-    key.nameoffset: 5425,
+    key.nameoffset: 5414,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 5413,
+        key.offset: 5402,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6436,13 +6420,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_internalTopLevelFunc()",
-    key.offset: 5452,
+    key.offset: 5441,
     key.length: 28,
-    key.nameoffset: 5457,
+    key.nameoffset: 5446,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 5445,
+        key.offset: 5434,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6452,15 +6436,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalStruct",
-    key.offset: 5489,
+    key.offset: 5478,
     key.length: 97,
-    key.nameoffset: 5496,
+    key.nameoffset: 5485,
     key.namelength: 15,
-    key.bodyoffset: 5513,
+    key.bodyoffset: 5502,
     key.bodylength: 72,
     key.attributes: [
       {
-        key.offset: 5482,
+        key.offset: 5471,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6471,14 +6455,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 5526,
+        key.offset: 5515,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 5530,
+        key.nameoffset: 5519,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 5519,
+            key.offset: 5508,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6488,13 +6472,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 5551,
+        key.offset: 5540,
         key.length: 6,
-        key.nameoffset: 5551,
+        key.nameoffset: 5540,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 5544,
+            key.offset: 5533,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6504,13 +6488,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5570,
+        key.offset: 5559,
         key.length: 14,
-        key.nameoffset: 5570,
+        key.nameoffset: 5559,
         key.namelength: 14,
         key.attributes: [
           {
-            key.offset: 5563,
+            key.offset: 5552,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6519,10 +6503,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5575,
+            key.offset: 5564,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5575,
+            key.nameoffset: 5564,
             key.namelength: 1
           }
         ]
@@ -6532,25 +6516,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5588,
+    key.offset: 5577,
     key.length: 66,
-    key.nameoffset: 5598,
+    key.nameoffset: 5587,
     key.namelength: 12,
-    key.bodyoffset: 5612,
+    key.bodyoffset: 5601,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth1()",
-        key.offset: 5623,
+        key.offset: 5612,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5628,
+        key.nameoffset: 5617,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5618,
+            key.offset: 5607,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6561,25 +6545,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5701,
+    key.offset: 5690,
     key.length: 107,
-    key.nameoffset: 5711,
+    key.nameoffset: 5700,
     key.namelength: 12,
-    key.bodyoffset: 5725,
+    key.bodyoffset: 5714,
     key.bodylength: 82,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth2()",
-        key.offset: 5736,
+        key.offset: 5725,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5741,
+        key.nameoffset: 5730,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5731,
+            key.offset: 5720,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6589,14 +6573,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "nonInternalMeth()",
-        key.offset: 5776,
+        key.offset: 5765,
         key.length: 30,
         key.typename: "Any!",
-        key.nameoffset: 5781,
+        key.nameoffset: 5770,
         key.namelength: 17,
         key.attributes: [
           {
-            key.offset: 5771,
+            key.offset: 5760,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6607,25 +6591,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5810,
+    key.offset: 5799,
     key.length: 66,
-    key.nameoffset: 5820,
+    key.nameoffset: 5809,
     key.namelength: 12,
-    key.bodyoffset: 5834,
+    key.bodyoffset: 5823,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth3()",
-        key.offset: 5845,
+        key.offset: 5834,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5850,
+        key.nameoffset: 5839,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5840,
+            key.offset: 5829,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6637,15 +6621,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalProt",
-    key.offset: 5885,
+    key.offset: 5874,
     key.length: 26,
-    key.nameoffset: 5894,
+    key.nameoffset: 5883,
     key.namelength: 13,
-    key.bodyoffset: 5909,
+    key.bodyoffset: 5898,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 5878,
+        key.offset: 5867,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6655,11 +6639,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "ClassWithInternalProt",
-    key.offset: 5918,
+    key.offset: 5907,
     key.length: 47,
-    key.nameoffset: 5924,
+    key.nameoffset: 5913,
     key.namelength: 21,
-    key.bodyoffset: 5963,
+    key.bodyoffset: 5952,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -6668,7 +6652,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5913,
+        key.offset: 5902,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6676,7 +6660,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5948,
+        key.offset: 5937,
         key.length: 13
       }
     ]
@@ -6685,11 +6669,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassPropertyOwnership",
-    key.offset: 5972,
+    key.offset: 5961,
     key.length: 319,
-    key.nameoffset: 5978,
+    key.nameoffset: 5967,
     key.namelength: 25,
-    key.bodyoffset: 6020,
+    key.bodyoffset: 6009,
     key.bodylength: 270,
     key.inheritedtypes: [
       {
@@ -6698,7 +6682,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5967,
+        key.offset: 5956,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6706,7 +6690,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6006,
+        key.offset: 5995,
         key.length: 12
       }
     ],
@@ -6716,19 +6700,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "assignable",
-        key.offset: 6047,
+        key.offset: 6036,
         key.length: 26,
         key.typename: "AnyObject!",
-        key.nameoffset: 6051,
+        key.nameoffset: 6040,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 6042,
+            key.offset: 6031,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6026,
+            key.offset: 6015,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6739,19 +6723,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "unsafeAssignable",
-        key.offset: 6100,
+        key.offset: 6089,
         key.length: 32,
         key.typename: "AnyObject!",
-        key.nameoffset: 6104,
+        key.nameoffset: 6093,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 6095,
+            key.offset: 6084,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6079,
+            key.offset: 6068,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6762,14 +6746,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "retainable",
-        key.offset: 6143,
+        key.offset: 6132,
         key.length: 20,
         key.typename: "Any!",
-        key.nameoffset: 6147,
+        key.nameoffset: 6136,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 6138,
+            key.offset: 6127,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6780,14 +6764,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "strongRef",
-        key.offset: 6174,
+        key.offset: 6163,
         key.length: 19,
         key.typename: "Any!",
-        key.nameoffset: 6178,
+        key.nameoffset: 6167,
         key.namelength: 9,
         key.attributes: [
           {
-            key.offset: 6169,
+            key.offset: 6158,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6798,14 +6782,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "copyable",
-        key.offset: 6204,
+        key.offset: 6193,
         key.length: 18,
         key.typename: "Any!",
-        key.nameoffset: 6208,
+        key.nameoffset: 6197,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 6199,
+            key.offset: 6188,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6816,19 +6800,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "weakRef",
-        key.offset: 6238,
+        key.offset: 6227,
         key.length: 23,
         key.typename: "AnyObject!",
-        key.nameoffset: 6242,
+        key.nameoffset: 6231,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 6233,
+            key.offset: 6222,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6228,
+            key.offset: 6217,
             key.length: 4,
             key.attribute: source.decl.attribute.weak
           }
@@ -6839,14 +6823,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "scalar",
-        key.offset: 6272,
+        key.offset: 6261,
         key.length: 17,
         key.typename: "Int32",
-        key.nameoffset: 6276,
+        key.nameoffset: 6265,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 6267,
+            key.offset: 6256,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6858,11 +6842,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooUnavailableMembers",
-    key.offset: 6298,
+    key.offset: 6287,
     key.length: 344,
-    key.nameoffset: 6304,
+    key.nameoffset: 6293,
     key.namelength: 21,
-    key.bodyoffset: 6342,
+    key.bodyoffset: 6331,
     key.bodylength: 299,
     key.inheritedtypes: [
       {
@@ -6871,7 +6855,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6293,
+        key.offset: 6282,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6879,7 +6863,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6328,
+        key.offset: 6317,
         key.length: 12
       }
     ],
@@ -6888,18 +6872,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(int:)",
-        key.offset: 6367,
+        key.offset: 6356,
         key.length: 19,
-        key.nameoffset: 6367,
+        key.nameoffset: 6356,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 6355,
+            key.offset: 6344,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 6348,
+            key.offset: 6337,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6908,10 +6892,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "i",
-            key.offset: 6373,
+            key.offset: 6362,
             key.length: 12,
             key.typename: "Int32",
-            key.nameoffset: 6373,
+            key.nameoffset: 6362,
             key.namelength: 3
           }
         ]
@@ -6920,18 +6904,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "deprecated()",
-        key.offset: 6446,
+        key.offset: 6435,
         key.length: 17,
-        key.nameoffset: 6451,
+        key.nameoffset: 6440,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 6441,
+            key.offset: 6430,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6397,
+            key.offset: 6386,
             key.length: 39,
             key.attribute: source.decl.attribute.available
           }
@@ -6941,18 +6925,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroduced()",
-        key.offset: 6509,
+        key.offset: 6498,
         key.length: 29,
-        key.nameoffset: 6514,
+        key.nameoffset: 6503,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 6504,
+            key.offset: 6493,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6474,
+            key.offset: 6463,
             key.length: 25,
             key.attribute: source.decl.attribute.available
           }
@@ -6962,18 +6946,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6608,
+        key.offset: 6597,
         key.length: 32,
-        key.nameoffset: 6613,
+        key.nameoffset: 6602,
         key.namelength: 27,
         key.attributes: [
           {
-            key.offset: 6603,
+            key.offset: 6592,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6549,
+            key.offset: 6538,
             key.length: 49,
             key.attribute: source.decl.attribute.available
           }
@@ -6985,15 +6969,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFType",
-    key.offset: 6651,
+    key.offset: 6640,
     key.length: 19,
-    key.nameoffset: 6657,
+    key.nameoffset: 6646,
     key.namelength: 9,
-    key.bodyoffset: 6668,
+    key.bodyoffset: 6657,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 6644,
+        key.offset: 6633,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7003,11 +6987,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "ABAuthorizationStatus",
-    key.offset: 6743,
+    key.offset: 6732,
     key.length: 199,
-    key.nameoffset: 6748,
+    key.nameoffset: 6737,
     key.namelength: 21,
-    key.bodyoffset: 6777,
+    key.bodyoffset: 6766,
     key.bodylength: 164,
     key.inheritedtypes: [
       {
@@ -7016,12 +7000,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6736,
+        key.offset: 6725,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       },
       {
-        key.offset: 6672,
+        key.offset: 6661,
         key.length: 63,
         key.attribute: source.decl.attribute.available
       }
@@ -7029,14 +7013,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6772,
+        key.offset: 6761,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6788,
+        key.offset: 6777,
         key.length: 22,
         key.nameoffset: 0,
         key.namelength: 0,
@@ -7045,14 +7029,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "notDetermined",
-            key.offset: 6793,
+            key.offset: 6782,
             key.length: 17,
-            key.nameoffset: 6793,
+            key.nameoffset: 6782,
             key.namelength: 13,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6809,
+                key.offset: 6798,
                 key.length: 1
               }
             ]
@@ -7061,7 +7045,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6870,
+        key.offset: 6859,
         key.length: 19,
         key.nameoffset: 0,
         key.namelength: 0,
@@ -7070,14 +7054,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "restricted",
-            key.offset: 6875,
+            key.offset: 6864,
             key.length: 14,
-            key.nameoffset: 6875,
+            key.nameoffset: 6864,
             key.namelength: 10,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6888,
+                key.offset: 6877,
                 key.length: 1
               }
             ]
@@ -7090,15 +7074,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6950,
+    key.offset: 6939,
     key.length: 50,
-    key.nameoffset: 6956,
+    key.nameoffset: 6945,
     key.namelength: 19,
-    key.bodyoffset: 6977,
+    key.bodyoffset: 6966,
     key.bodylength: 22,
     key.attributes: [
       {
-        key.offset: 6943,
+        key.offset: 6932,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7108,13 +7092,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6990,
+        key.offset: 6979,
         key.length: 8,
-        key.nameoffset: 6995,
+        key.nameoffset: 6984,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 6983,
+            key.offset: 6972,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -7126,11 +7110,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 7009,
+    key.offset: 6998,
     key.length: 88,
-    key.nameoffset: 7015,
+    key.nameoffset: 7004,
     key.namelength: 22,
-    key.bodyoffset: 7065,
+    key.bodyoffset: 7054,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -7139,7 +7123,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 7002,
+        key.offset: 6991,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7147,7 +7131,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 7040,
+        key.offset: 7029,
         key.length: 23
       }
     ],
@@ -7156,18 +7140,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 7087,
+        key.offset: 7076,
         key.length: 8,
-        key.nameoffset: 7092,
+        key.nameoffset: 7081,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 7080,
+            key.offset: 7069,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           },
           {
-            key.offset: 7071,
+            key.offset: 7060,
             key.length: 8,
             key.attribute: source.decl.attribute.override
           }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
@@ -42,7 +42,7 @@
 // Make sure cursor info within the generated interface of OverlaidClangFramework on one of the
 // decls originally from a cross-import decls shows 'OverlaidClangFramework' as the parent module.
 //
-// RUN: %sourcekitd-test -req=interface-gen-open -module OverlaidClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=12:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %sourcekitd-test -req=interface-gen-open -module OverlaidClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=11:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
 // RUN: %FileCheck --input-file %t.response --check-prefix=CHECKOVERLAIDCLANG %s
 //
 // CHECKOVERLAIDCLANG: key.name: "fromOverlaidClangFrameworkCrossImport()"

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,4 +1,3 @@
-import OverlaidClangFramework
 import SwiftOnoneSupport
 
 public func fromOverlaidClangFramework()
@@ -21,76 +20,66 @@ public func fromOverlaidClangFrameworkCrossImport()
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 7,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 30,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 37,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 56,
+    key.offset: 26,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 63,
+    key.offset: 33,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 68,
+    key.offset: 38,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 97,
+    key.offset: 67,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 104,
+    key.offset: 74,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 109,
+    key.offset: 79,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 147,
+    key.offset: 117,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 150,
+    key.offset: 120,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 188,
+    key.offset: 158,
     key.length: 76
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 264,
+    key.offset: 234,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 271,
+    key.offset: 241,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 276,
+    key.offset: 246,
     key.length: 37
   }
 ]
@@ -98,11 +87,6 @@ public func fromOverlaidClangFrameworkCrossImport()
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 7,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 37,
     key.length: 17,
     key.is_system: 1
   }
@@ -112,13 +96,13 @@ public func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOverlaidClangFramework()",
-    key.offset: 63,
+    key.offset: 33,
     key.length: 33,
-    key.nameoffset: 68,
+    key.nameoffset: 38,
     key.namelength: 28,
     key.attributes: [
       {
-        key.offset: 56,
+        key.offset: 26,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -128,13 +112,13 @@ public func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOverlaidClangFrameworkOverlay()",
-    key.offset: 104,
+    key.offset: 74,
     key.length: 40,
-    key.nameoffset: 109,
+    key.nameoffset: 79,
     key.namelength: 35,
     key.attributes: [
       {
-        key.offset: 97,
+        key.offset: 67,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -144,13 +128,13 @@ public func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOverlaidClangFrameworkCrossImport()",
-    key.offset: 271,
+    key.offset: 241,
     key.length: 44,
-    key.nameoffset: 276,
+    key.nameoffset: 246,
     key.namelength: 39,
     key.attributes: [
       {
-        key.offset: 264,
+        key.offset: 234,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }


### PR DESCRIPTION
Generated Swift interfaces for modules with overlays, like Foundation or Dispatch, currently contain `import Foundation`/`import Dispatch` statements.

These imports are redundant, and this change removes them.