### PR TITLE
SIL: move all the block-list modifying APIs to SILFunction.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -56,7 +56,7 @@ private:
 
   void operator delete(void *Ptr, size_t) = delete;
 
-  SILBasicBlock(SILFunction *F, SILBasicBlock *relativeToBB, bool after);
+  SILBasicBlock(SILFunction *parent) : Parent(parent), PredList(nullptr) { }
 
 public:
   ~SILBasicBlock();
@@ -142,12 +142,6 @@ public:
   /// stay as part of the original basic block. The old basic block is left
   /// without a terminator.
   SILBasicBlock *split(iterator I);
-
-  /// Move the basic block to after the specified basic block in the IR.
-  ///
-  /// Assumes that the basic blocks must reside in the same function. In asserts
-  /// builds, an assert verifies that this is true.
-  void moveAfter(SILBasicBlock *After);
 
   /// Moves the instruction to the iterator in this basic block.
   void moveTo(SILBasicBlock::iterator To, SILInstruction *I);

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -354,25 +354,6 @@ public:
   // CFG Manipulation
   //===--------------------------------------------------------------------===//
 
-  /// moveBlockTo - Move a block to immediately before the given iterator.
-  void moveBlockTo(SILBasicBlock *BB, SILFunction::iterator IP) {
-    assert(SILFunction::iterator(BB) != IP && "moving block before itself?");
-    SILFunction *F = BB->getParent();
-    auto &Blocks = F->getBlocks();
-    Blocks.remove(BB);
-    Blocks.insert(IP, BB);
-  }
-
-  /// moveBlockTo - Move \p BB to immediately before \p Before.
-  void moveBlockTo(SILBasicBlock *BB, SILBasicBlock *Before) {
-    moveBlockTo(BB, Before->getIterator());
-  }
-
-  /// moveBlockToEnd - Reorder a block to the end of its containing function.
-  void moveBlockToEnd(SILBasicBlock *BB) {
-    moveBlockTo(BB, BB->getParent()->end());
-  }
-
   /// Move the insertion point to the end of the given block.
   ///
   /// Assumes that no insertion point is currently active.

--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -460,7 +460,7 @@ public:
       analyzeLoopsRecursively(Loop, 1);
     }
     // Compute the distances for the function itself.
-    solveDataFlow(F->getBlocks(), 0);
+    solveDataFlow(*F, 0);
   }
 
   /// Returns the length of the shortest path of the block \p BB in the loop

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -511,9 +511,8 @@ void SILModule::eraseFunction(SILFunction *F) {
 
   // This opens dead-function-removal opportunities for called functions.
   // (References are not needed anymore.)
-  F->dropAllReferences();
+  F->clear();
   F->dropDynamicallyReplacedFunction();
-  F->getBlocks().clear();
   // Drop references for any _specialize(target:) functions.
   F->clearSpecializeAttrs();
 }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -5714,8 +5714,7 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
   
   // Make sure the block is at the end of the function so that forward
   // references don't affect block layout.
-  F->getBlocks().remove(BB);
-  F->getBlocks().push_back(BB);
+  F->moveBlockBefore(BB, F->end());
 
   B.setInsertionPoint(BB);
   do {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5528,7 +5528,7 @@ public:
     }
 
     // Otherwise, verify the body of the function.
-    verifyEntryBlock(&*F->getBlocks().begin());
+    verifyEntryBlock(F->getEntryBlock());
     verifyEpilogBlocks(F);
     verifyFlowSensitiveRules(F);
     verifyBranches(F);

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -146,7 +146,7 @@ prepareForEpilogBlockEmission(SILGenFunction &SGF, SILLocation topLevel,
 
   // Move the epilog block to the end of the ordinary section.
   auto endOfOrdinarySection = SGF.StartOfPostmatter;
-  SGF.B.moveBlockTo(epilogBB, endOfOrdinarySection);
+  SGF.F.moveBlockBefore(epilogBB, endOfOrdinarySection);
 
   // Emit the epilog into the epilog bb. Its arguments are the
   // direct results.
@@ -282,7 +282,7 @@ static bool prepareExtraEpilog(SILGenFunction &SGF, JumpDest &dest,
   // Reposition the block to the end of the postmatter section
   // unless we're emitting into a single predecessor.
   if (reposition) {
-    SGF.B.moveBlockTo(epilogBB, SGF.F.end());
+    SGF.F.moveBlockBefore(epilogBB, SGF.F.end());
   }
 
   SGF.B.setInsertionPoint(epilogBB);

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2484,7 +2484,7 @@ void PatternMatchEmission::emitSharedCaseBlocks(
 
       // Otherwise, move the block to after the first predecessor.
       auto predBB = *caseBB->pred_begin();
-      caseBB->moveAfter(predBB);
+      SGF.F.moveBlockAfter(caseBB, predBB);
 
       // Then emit the case body into the caseBB.
       SGF.B.setInsertionPoint(caseBB);

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -158,7 +158,7 @@ void SILGenFunction::mergeCleanupBlocks() {
       // not already adjacent, then the first is typically the trampoline.)
       assert(beforeSucc != F.rend()
              && "entry block cannot have a predecessor.");
-      predBB->moveAfter(&*beforeSucc);
+      F.moveBlockAfter(predBB, &*beforeSucc);
     }
     // If after moving predBB there are no more blocks to process, then break.
     if (beforePred == F.rbegin())

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -535,7 +535,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   }
 
   // Then we transfer the body of F to NewF.
-  NewF->spliceBody(F);
+  NewF->moveAllBlocksFromOtherFunction(F);
 
   // Array semantic clients rely on the signature being as in the original
   // version.

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -406,7 +406,7 @@ bool swift::rotateLoop(SILLoop *loop, DominanceInfo *domInfo,
 
   // Beautify the IR. Move the old header to after the old latch as it is now
   // the latch.
-  header->moveAfter(latch);
+  header->getParent()->moveBlockAfter(header, latch);
 
   // Merge the old latch with the old header if possible.
   if (mergeBasicBlockWithSuccessor(latch, domInfo, loopInfo))

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -67,12 +67,12 @@ static void InsertCFGDiamond(SILValue Cond, SILLocation Loc, SILBuilder &B,
   ContBB = StartBB->split(B.getInsertionPoint());
 
   TrueBB = StartBB->getParent()->createBasicBlock();
-  B.moveBlockTo(TrueBB, ContBB);
+  TrueBB->getParent()->moveBlockBefore(TrueBB, ContBB->getIterator());
   B.setInsertionPoint(TrueBB);
   B.createBranch(Loc, ContBB);
 
   FalseBB = StartBB->getParent()->createBasicBlock();
-  B.moveBlockTo(FalseBB, ContBB);
+  FalseBB->getParent()->moveBlockBefore(FalseBB, ContBB->getIterator());
   B.setInsertionPoint(FalseBB);
   B.createBranch(Loc, ContBB);
 

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -993,12 +993,14 @@ static bool removeUnreachableBlocks(SILFunction &F, SILModule &M,
   NumInstructionsRemoved += ToBeDeleted.size();
 
   // Delete the dead blocks.
-  for (auto I = F.begin(), E = F.end(); I != E;)
-    if (!Reachable.count(&*I)) {
-      I = F.getBlocks().erase(I);
+  for (auto I = F.begin(), E = F.end(); I != E;) {
+    SILBasicBlock *BB = &*I;
+    ++I;
+    if (!Reachable.count(BB)) {
+      F.eraseBlock(BB);
       ++NumBlocksRemoved;
-    } else
-      ++I;
+    }
+  }
 
   return true;
 }

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -163,7 +163,7 @@ static bool diagnoseNoReturn(ADContext &context, SILFunction *original,
 static bool diagnoseUnsupportedControlFlow(ADContext &context,
                                            SILFunction *original,
                                            DifferentiationInvoker invoker) {
-  if (original->getBlocks().size() <= 1)
+  if (original->size() <= 1)
     return false;
   // Diagnose unsupported branching terminators.
   for (auto &bb : *original) {
@@ -926,7 +926,7 @@ bool DifferentiationTransformer::canonicalizeDifferentiabilityWitness(
         !witness->getVJP()) {
       // JVP and differential generation do not currently support functions with
       // multiple basic blocks.
-      if (witness->getOriginalFunction()->getBlocks().size() > 1) {
+      if (witness->getOriginalFunction()->size() > 1) {
         context.emitNondifferentiabilityError(
             witness->getOriginalFunction()->getLocation().getSourceLoc(),
             invoker, diag::autodiff_jvp_control_flow_not_supported);

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -743,7 +743,7 @@ calculateBBWeights(SILFunction *Caller, DominanceInfo *DT,
     return;
   }
   // Add all blocks to BBToWeightMap without count 0
-  for (auto &block : Caller->getBlocks()) {
+  for (auto &block : *Caller) {
     BBToWeightMap[&block] = 0;
   }
   BBToWeightMap[Caller->getEntryBlock()] = entryCount.getValue();

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -96,8 +96,7 @@ void MapOpaqueArchetypes::replace() {
   cloneFunctionBody(&fn, clonedEntryBlock, entryArgs,
                     true /*replaceOriginalFunctionInPlace*/);
   // Insert the new entry block at the beginning.
-  fn.getBlocks().splice(fn.getBlocks().begin(), fn.getBlocks(),
-                        clonedEntryBlock);
+  fn.moveBlockBefore(clonedEntryBlock, fn.begin());
   removeUnreachableBlocks(fn);
 }
 

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -123,7 +123,7 @@ convertObjectToLoadableBridgeableType(SILBuilderWithScope &builder,
   // insert the bridge call/switch there. We return the argument of the cast
   // success block as the value to be passed to the bridging function.
   if (load->getType() == silBridgedTy) {
-    castSuccessBB->moveAfter(dynamicCast.getInstruction()->getParent());
+    f->moveBlockAfter(castSuccessBB, dynamicCast.getInstruction()->getParent());
     builder.createBranch(loc, castSuccessBB, load);
     builder.setInsertionPoint(castSuccessBB);
     return {castSuccessBB->getArgument(0), nullptr};
@@ -138,7 +138,7 @@ convertObjectToLoadableBridgeableType(SILBuilderWithScope &builder,
 
   // Now that we have created the failure bb, move our cast success block right
   // after the checked_cast_br bb.
-  castSuccessBB->moveAfter(dynamicCast.getInstruction()->getParent());
+  f->moveBlockAfter(castSuccessBB, dynamicCast.getInstruction()->getParent());
 
   // Ok, we need to perform the full cast optimization. This means that we are
   // going to replace the cast terminator in inst_block with a checked_cast_br.

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -50,7 +50,7 @@ static bool canInlineBeginApply(BeginApplyInst *BA) {
   // potentially after the resumption site when there are un-mergeable
   // values alive across it.
   bool hasYield = false;
-  for (auto &B : BA->getReferencedFunctionOrNull()->getBlocks()) {
+  for (auto &B : *BA->getReferencedFunctionOrNull()) {
     if (isa<YieldInst>(B.getTerminator())) {
       if (hasYield) return false;
       hasYield = true;

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -320,7 +320,7 @@ SILBasicBlock *SILDeserializer::getBBForDefinition(SILFunction *Fn,
   (void)wasForwardReferenced;
 
   if (Prev)
-    BB->moveAfter(Prev);
+    Fn->moveBlockAfter(BB, Prev);
   return BB;
 }
 

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -206,7 +206,7 @@ void removeUnwantedFunctions(SILModule *M, ArrayRef<std::string> MangledNames,
   // Now mark all of these functions as public and remove their bodies.
   for (auto &F : DeadFunctions) {
     F->setLinkage(SILLinkage::PublicExternal);
-    F->getBlocks().clear();
+    F->clear();
   }
 
   // Remove dead functions.


### PR DESCRIPTION
... and remove SILFunction::getBlocks().

It's just a cleanup, NFC.
