### PR TITLE
Pass -target to lit Tests instead of -arch (+ -version-min)

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -920,8 +920,8 @@ if run_vendor == 'apple':
            target_future_version = "9.99.0"
 
        config.target_cc_options = (
-           "-arch %s %s" %
-           (run_cpu, clang_mcp_opt))
+           "-target %s %s" %
+           (config.variant_triple, clang_mcp_opt))
 
        config.target_build_swift = (
            ("%s %s %s -F %r -toolchain-stdlib-rpath " +
@@ -960,8 +960,8 @@ if run_vendor == 'apple':
         target_specific_module_triple += "-simulator"
 
         config.target_cc_options = (
-            "-arch %s %s" %
-            (run_cpu, clang_mcp_opt))
+            "-target %s %s" %
+            (config.variant_triple, clang_mcp_opt))
 
         config.target_build_swift = (
             ("%s %s %s -F %r -toolchain-stdlib-rpath %s " +
@@ -996,16 +996,9 @@ if run_vendor == 'apple':
 
         xcrun_sdk_name = "macosx"
 
-        if run_os == 'maccatalyst':
-            # For maccatalyst, pass the target triple to clang
-            # rather than arch and version separately.
-            config.target_cc_options = (
-                "-target %s %s" %
-                (config.variant_triple, clang_mcp_opt))
-        else:
-            config.target_cc_options = (
-                "-arch %s %s" %
-                (run_cpu, clang_mcp_opt))
+        config.target_cc_options = (
+            "-target %s %s" %
+            (config.variant_triple, clang_mcp_opt))
 
         maccatalyst_frameworks_component = ""
         if run_os == 'maccatalyst':

--- a/test/stdlib/Compatibility50Linking.c
+++ b/test/stdlib/Compatibility50Linking.c
@@ -4,7 +4,6 @@
 // RUN: %target-run %t/main
 // REQUIRES: objc_interop
 // REQUIRES: executable_test
-// REQUIRES: rdar73174820
 
 // The compatibility library needs to have no build-time dependencies on
 // libswiftCore so it can be linked into a program that doesn't link

--- a/validation-test/Runtime/class_update_callback_with_fixed_layout.m
+++ b/validation-test/Runtime/class_update_callback_with_fixed_layout.m
@@ -25,7 +25,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: rdar73174820
 
 #import <objc/runtime.h>
 #import <assert.h>


### PR DESCRIPTION
A follow-on to `b4368259480ed2c895e8c855bbfde20c1805acd1` where
-m${platform}-version-min was traded for -target. The lit substitution
for %target-clang was relying on -arch and -version-min to specify the
intended platform version to the linker. With the removal of
version-min, only arch was given, so a fallback platform was selected.
For the iPhone simulator, for example, this is iOS 10.99 despite there
being no such simulator for that deployment version. Provide the variant
triple everywhere instead. This has the added benefit of unifying the
special paths catalyst takes.

Fixes rdar://73174820