### PR TITLE
[TBDGen] Use effective linkage for class member async function pointers.

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -418,6 +418,20 @@ void TBDGenVisitor::addSymbol(SILDeclRef declRef) {
   addSymbol(declRef.mangle(), SymbolSource::forSILDeclRef(declRef));
 }
 
+void TBDGenVisitor::addAsyncFunctionPointerSymbol(AbstractFunctionDecl *AFD) {
+  auto declRef = SILDeclRef(AFD);
+  auto silLinkage = effectiveLinkageForClassMember(
+    declRef.getLinkage(ForDefinition),
+    declRef.getSubclassScope());
+  if (Opts.PublicSymbolsOnly && silLinkage != SILLinkage::Public)
+    return;
+
+  auto entity = LinkEntity::forAsyncFunctionPointer(AFD);
+  auto linkage =
+      LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
+  addSymbol(linkage.getName(), SymbolSource::forSILDeclRef(declRef));
+}
+
 void TBDGenVisitor::addSymbol(LinkEntity entity) {
   auto linkage =
       LinkInfo::get(UniversalLinkInfo, SwiftModule, entity, ForDefinition);
@@ -724,7 +738,7 @@ void TBDGenVisitor::visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
   visitDefaultArguments(AFD, AFD->getParameters());
 
   if (AFD->hasAsync()) {
-    addSymbol(LinkEntity::forAsyncFunctionPointer(AFD));
+    addAsyncFunctionPointerSymbol(AFD);
   }
 }
 

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -99,6 +99,7 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
                  SymbolKind kind = SymbolKind::GlobalSymbol);
 
   void addSymbol(SILDeclRef declRef);
+  void addAsyncFunctionPointerSymbol(AbstractFunctionDecl *AFD);
 
   void addSymbol(LinkEntity entity);
 

--- a/test/IRGen/async/Inputs/class_open-1instance-void_to_void.swift
+++ b/test/IRGen/async/Inputs/class_open-1instance-void_to_void.swift
@@ -1,0 +1,25 @@
+import _Concurrency
+
+func printGeneric<T>(_ t: T) {
+  print(t)
+}
+// CHECK-LL: @"$s4main6call_fyyAA1CCYFTu" = {{(dllexport )?}}{{(protected )?}}global %swift.async_func_pointer 
+// CHECK-LL: @"$s4main1CC1fyyYFTu" = {{(dllexport )?}}{{(protected )?}}global %swift.async_func_pointer 
+
+// CHECK-LL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s4main6call_fyyAA1CCYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
+// CHECK-LL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s4main1CC1fyyYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}}) {{#[0-9]*}} {
+public func call_f(_ c: C) async {
+  print("entering call_f")
+  await c.f()
+  print("exiting call_f")
+}
+open class C {
+  public init() {}
+  func f() async {
+    printGeneric("entering f")
+    printGeneric(Self.self)
+    printGeneric(self)
+    printGeneric("exiting f")
+  }
+}
+

--- a/test/IRGen/async/run-call-nonresilient-classinstance-void-to-void.swift
+++ b/test/IRGen/async/run-call-nonresilient-classinstance-void-to-void.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(NonresilientClass)) %S/Inputs/class_open-1instance-void_to_void.swift -Xfrontend -enable-experimental-concurrency -module-name NonresilientClass -emit-module -emit-module-path %t/NonresilientClass.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(NonresilientClass)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %S/Inputs/class_open-1instance-void_to_void.swift -emit-ir -I %t -L %t -lNonresilientClass | %FileCheck %S/Inputs/class_open-1instance-void_to_void.swift --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -module-name main -o %t/main -I %t -L %t -lNonresilientClass %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(NonresilientClass) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+// XFAIL: windows
+
+import _Concurrency
+import NonresilientClass
+
+class D : C {
+}
+
+// CHECK: entering call_f
+// CHECK: entering f
+// CHECK: D
+// CHECK: main.D
+// CHECK: exiting f
+// CHECK: exiting call_f
+runAsyncAndBlock {
+  let c = D()
+  await call_f(c)
+}

--- a/test/TBD/async-function-pointer.swift
+++ b/test/TBD/async-function-pointer.swift
@@ -5,3 +5,9 @@
 
 @asyncHandler
 public func testit() { }
+
+// CHECK: @"$s4test1CC1f33_295642D23064661A21CD592AD781409CLLyyYFTu" = global %swift.async_func_pointer 
+
+open class C {
+  private func f() async { }
+}


### PR DESCRIPTION
Previously, the "bare" linkage of a link entity was used to determine whether to put an async function pointer into the tbd.  That did not match the mechanism by which the linkage was determined in IRGen.  There, the linkage is the "_effective_" linkage (i.e. the value returned from SILFunction::getEffectiveSymbolLinkage).

Here, whether to put the async function pointer corresponding to a class method is determined on the basis of that effective linkage.

rdar://problem/73203508