### PR TITLE
[Parser] Keep delayed body parsing even with interface hash generation

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2348,8 +2348,6 @@ bool SourceFile::hasDelayedBodyParsing() const {
   // Not supported right now.
   if (Kind == SourceFileKind::SIL)
     return false;
-  if (hasInterfaceHash())
-    return false;
   if (shouldCollectTokens())
     return false;
   if (shouldBuildSyntaxTree())


### PR DESCRIPTION
The generated hash ignores tokens parsed in the body anyway, so there's
no reason to disable delayed body parsing in this case.