### PR TITLE
Add debug info support for boxed arguments in async functions.

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -66,6 +66,7 @@ public:
 
   Demangle::NodeFactory &getNodeFactory() { return Factory; }
 
+  Type decodeMangledType(NodePointer node);
   Type createBuiltinType(StringRef builtinName, StringRef mangledName);
 
   TypeDecl *createTypeDecl(NodePointer node);
@@ -126,6 +127,18 @@ public:
 #include "swift/AST/ReferenceStorage.def"
 
   Type createSILBoxType(Type base);
+  using BuiltSILBoxField = llvm::PointerIntPair<Type, 1>;
+  using BuiltSubstitution = std::pair<Type, Type>;
+  using BuiltRequirement = swift::Requirement;
+  using BuiltLayoutConstraint = swift::LayoutConstraint;
+  Type createSILBoxTypeWithLayout(ArrayRef<BuiltSILBoxField> Fields,
+                                  ArrayRef<BuiltSubstitution> Substitutions,
+                                  ArrayRef<BuiltRequirement> Requirements);
+
+  bool isExistential(Type type) {
+    return type->isExistentialType();
+  }
+
 
   Type createObjCClassType(StringRef name);
 
@@ -148,6 +161,11 @@ public:
   Type createDictionaryType(Type key, Type value);
 
   Type createParenType(Type base);
+
+  LayoutConstraint getLayoutConstraint(LayoutConstraintKind kind);
+  LayoutConstraint getLayoutConstraintWithSizeAlign(LayoutConstraintKind kind,
+                                                    unsigned size,
+                                                    unsigned alignment);
 
 private:
   bool validateParentType(TypeDecl *decl, Type parent);

--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_LAYOUT_CONSTRAINT_H
 #define SWIFT_LAYOUT_CONSTRAINT_H
 
+#include "swift/AST/LayoutConstraintKind.h"
+#include "swift/AST/PrintOptions.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/SourceLoc.h"
@@ -24,36 +26,12 @@
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
-#include "swift/AST/PrintOptions.h"
 
 namespace swift {
 
 enum class AllocationArena;
 class ASTContext;
 class ASTPrinter;
-
-/// Describes a layout constraint information.
-enum class LayoutConstraintKind : uint8_t {
-  // It is not a known layout constraint.
-  UnknownLayout,
-  // It is a layout constraint representing a trivial type of a known size.
-  TrivialOfExactSize,
-  // It is a layout constraint representing a trivial type of a size known to
-  // be no larger than a given size.
-  TrivialOfAtMostSize,
-  // It is a layout constraint representing a trivial type of an unknown size.
-  Trivial,
-  // It is a layout constraint representing a reference counted class instance.
-  Class,
-  // It is a layout constraint representing a reference counted native class
-  // instance.
-  NativeClass,
-  // It is a layout constraint representing a reference counted object.
-  RefCountedObject,
-  // It is a layout constraint representing a native reference counted object.
-  NativeRefCountedObject,
-  LastLayout = NativeRefCountedObject,
-};
 
 /// This is a class representing the layout constraint.
 class LayoutConstraintInfo : public llvm::FoldingSetNode {

--- a/include/swift/AST/LayoutConstraintKind.h
+++ b/include/swift/AST/LayoutConstraintKind.h
@@ -1,0 +1,43 @@
+//===-- LayoutConstraintKind.h - Layout constraints kinds -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines types and APIs for layout constraints.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_LAYOUT_CONSTRAINTKIND_H
+#define SWIFT_LAYOUT_CONSTRAINTKIND_H
+
+/// Describes a layout constraint information.
+enum class LayoutConstraintKind : uint8_t {
+  // It is not a known layout constraint.
+  UnknownLayout,
+  // It is a layout constraint representing a trivial type of a known size.
+  TrivialOfExactSize,
+  // It is a layout constraint representing a trivial type of a size known to
+  // be no larger than a given size.
+  TrivialOfAtMostSize,
+  // It is a layout constraint representing a trivial type of an unknown size.
+  Trivial,
+  // It is a layout constraint representing a reference counted class instance.
+  Class,
+  // It is a layout constraint representing a reference counted native class
+  // instance.
+  NativeClass,
+  // It is a layout constraint representing a reference counted object.
+  RefCountedObject,
+  // It is a layout constraint representing a native reference counted object.
+  NativeRefCountedObject,
+  LastLayout = NativeRefCountedObject,
+};
+
+#endif

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_AST_REQUIREMENT_H
 #define SWIFT_AST_REQUIREMENT_H
 
+#include "swift/AST/LayoutConstraint.h"
+#include "swift/AST/RequirementBase.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/Debug.h"
 #include "llvm/ADT/Hashing.h"
@@ -25,76 +27,33 @@
 
 namespace swift {
 
-/// Describes the kind of a requirement that occurs within a requirements
-/// clause.
-enum class RequirementKind : unsigned {
-  /// A conformance requirement T : P, where T is a type that depends
-  /// on a generic parameter and P is a protocol to which T must conform.
-  Conformance,
-  /// A superclass requirement T : C, where T is a type that depends
-  /// on a generic parameter and C is a concrete class type which T must
-  /// equal or be a subclass of.
-  Superclass,
-  /// A same-type requirement T == U, where T and U are types that shall be
-  /// equivalent.
-  SameType,
-  /// A layout bound T : L, where T is a type that depends on a generic
-  /// parameter and L is some layout specification that should bound T.
-  Layout,
-
-  // Note: there is code that packs this enum in a 2-bit bitfield.  Audit users
-  // when adding enumerators.
-};
-
 /// A single requirement placed on the type parameters (or associated
 /// types thereof) of a
-class Requirement {
-  llvm::PointerIntPair<Type, 3, RequirementKind> FirstTypeAndKind;
-  /// The second element of the requirement. Its content is dependent
-  /// on the requirement kind.
-  /// The payload of the following enum should always match the kind!
-  /// Any access to the fields of this enum should first check if the
-  /// requested access matches the kind of the requirement.
-  union {
-    Type SecondType;
-    LayoutConstraint SecondLayout;
-  };
-
+class Requirement
+    : public RequirementBase<Type,
+                             llvm::PointerIntPair<Type, 3, RequirementKind>,
+                             LayoutConstraint> {
 public:
   /// Create a conformance or same-type requirement.
   Requirement(RequirementKind kind, Type first, Type second)
-    : FirstTypeAndKind(first, kind), SecondType(second) {
-    assert(first);
-    assert(second);
-  }
+      : RequirementBase(kind, first, second) {}
 
   /// Create a layout constraint requirement.
   Requirement(RequirementKind kind, Type first, LayoutConstraint second)
-    : FirstTypeAndKind(first, kind), SecondLayout(second) {
-    assert(first);
-    assert(second);
-  }
+    : RequirementBase(kind, first, second) {}
 
-  /// Determine the kind of requirement.
-  RequirementKind getKind() const { return FirstTypeAndKind.getInt(); }
+  /// Whether this requirement is in its canonical form.
+  bool isCanonical() const;
 
-  /// Retrieve the first type.
-  Type getFirstType() const {
-    return FirstTypeAndKind.getPointer();
-  }
-
-  /// Retrieve the second type.
-  Type getSecondType() const {
-    assert(getKind() != RequirementKind::Layout);
-    return SecondType;
-  }
+  /// Get the canonical form of this requirement.
+  Requirement getCanonical() const;
 
   /// Subst the types involved in this requirement.
   ///
   /// The \c args arguments are passed through to Type::subst. This doesn't
   /// touch the superclasses, protocols or layout constraints.
-  template <typename... Args>
-  Optional<Requirement> subst(Args &&... args) const {
+  template <typename ...Args>
+  llvm::Optional<Requirement> subst(Args &&...args) const {
     auto newFirst = getFirstType().subst(std::forward<Args>(args)...);
     if (newFirst->hasError())
       return None;
@@ -115,61 +74,10 @@ public:
     llvm_unreachable("Unhandled RequirementKind in switch.");
   }
 
-  /// Retrieve the layout constraint.
-  LayoutConstraint getLayoutConstraint() const {
-    assert(getKind() == RequirementKind::Layout);
-    return SecondLayout;
-  }
-
-  /// Whether this requirement is in its canonical form.
-  bool isCanonical() const;
-
-  /// Get the canonical form of this requirement.
-  Requirement getCanonical() const;
-
   SWIFT_DEBUG_DUMP;
   void dump(raw_ostream &out) const;
   void print(raw_ostream &os, const PrintOptions &opts) const;
   void print(ASTPrinter &printer, const PrintOptions &opts) const;
-
-  friend llvm::hash_code hash_value(const Requirement &requirement) {
-    using llvm::hash_value;
-
-    llvm::hash_code first =
-        hash_value(requirement.FirstTypeAndKind.getOpaqueValue());
-    llvm::hash_code second;
-    switch (requirement.getKind()) {
-    case RequirementKind::Conformance:
-    case RequirementKind::Superclass:
-    case RequirementKind::SameType:
-      second = hash_value(requirement.getSecondType().getPointer());
-      break;
-
-    case RequirementKind::Layout:
-      second = hash_value(requirement.getLayoutConstraint());
-      break;
-    }
-
-    return llvm::hash_combine(first, second);
-  }
-
-  friend bool operator==(const Requirement &lhs, const Requirement &rhs) {
-    if (lhs.FirstTypeAndKind.getOpaqueValue()
-          != rhs.FirstTypeAndKind.getOpaqueValue())
-      return false;
-
-    switch (lhs.getKind()) {
-    case RequirementKind::Conformance:
-    case RequirementKind::Superclass:
-    case RequirementKind::SameType:
-      return lhs.getSecondType().getPointer() ==
-          rhs.getSecondType().getPointer();
-
-    case RequirementKind::Layout:
-      return lhs.getLayoutConstraint() == rhs.getLayoutConstraint();
-    }
-    llvm_unreachable("Unhandled RequirementKind in switch");
-  }
 };
 
 inline void simple_display(llvm::raw_ostream &out, const Requirement &req) {

--- a/include/swift/AST/RequirementBase.h
+++ b/include/swift/AST/RequirementBase.h
@@ -1,0 +1,137 @@
+//===--- RequirementBase.h - Swift Requirement ASTs -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the Requirement class and subclasses.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_REQUIREMENTBASE_H
+#define SWIFT_AST_REQUIREMENTBASE_H
+
+#include "llvm/ADT/Hashing.h"
+
+namespace swift {
+/// Describes the kind of a requirement that occurs within a requirements
+/// clause.
+enum class RequirementKind : unsigned {
+  /// A conformance requirement T : P, where T is a type that depends
+  /// on a generic parameter and P is a protocol to which T must conform.
+  Conformance,
+  /// A superclass requirement T : C, where T is a type that depends
+  /// on a generic parameter and C is a concrete class type which T must
+  /// equal or be a subclass of.
+  Superclass,
+  /// A same-type requirement T == U, where T and U are types that shall be
+  /// equivalent.
+  SameType,
+  /// A layout bound T : L, where T is a type that depends on a generic
+  /// parameter and L is some layout specification that should bound T.
+  Layout,
+
+  // Note: there is code that packs this enum in a 2-bit bitfield.  Audit users
+  // when adding enumerators.
+};
+
+/// Abstract base class for Requirement.
+template <typename TypeType, typename PointerIntPairType,
+          typename LayoutConstraintType>
+class RequirementBase {
+protected:
+  PointerIntPairType FirstTypeAndKind;
+  /// The second element of the requirement. Its content is dependent
+  /// on the requirement kind.
+  /// The payload of the following enum should always match the kind!
+  /// Any access to the fields of this enum should first check if the
+  /// requested access matches the kind of the requirement.
+  union {
+    TypeType SecondType;
+    LayoutConstraintType SecondLayout;
+  };
+
+public:
+  /// Create a conformance or same-type requirement.
+  RequirementBase(RequirementKind kind, TypeType first, TypeType second)
+      : FirstTypeAndKind(first, kind), SecondType(second) {
+    assert(first);
+    assert(second);
+  }
+
+  /// Create a layout constraint requirement.
+  RequirementBase(RequirementKind kind, TypeType first,
+                  LayoutConstraintType second)
+      : FirstTypeAndKind(first, kind), SecondLayout(second) {
+    assert(first);
+    assert(second);
+  }
+
+  /// Determine the kind of requirement.
+  RequirementKind getKind() const { return FirstTypeAndKind.getInt(); }
+
+  /// Retrieve the first type.
+  TypeType getFirstType() const {
+    return FirstTypeAndKind.getPointer();
+  }
+
+  /// Retrieve the second type.
+  TypeType getSecondType() const {
+    assert(getKind() != RequirementKind::Layout);
+    return SecondType;
+  }
+
+  /// Retrieve the layout constraint.
+  LayoutConstraintType getLayoutConstraint() const {
+    assert(getKind() == RequirementKind::Layout);
+    return SecondLayout;
+  }
+
+  friend llvm::hash_code hash_value(const RequirementBase &requirement) {
+    using llvm::hash_value;
+
+    llvm::hash_code first =
+        hash_value(requirement.FirstTypeAndKind.getOpaqueValue());
+    llvm::hash_code second;
+    switch (requirement.getKind()) {
+    case RequirementKind::Conformance:
+    case RequirementKind::Superclass:
+    case RequirementKind::SameType:
+      second = hash_value(requirement.getSecondType());
+      break;
+
+    case RequirementKind::Layout:
+      second = hash_value(requirement.getLayoutConstraint());
+      break;
+    }
+
+    return llvm::hash_combine(first, second);
+  }
+
+  friend bool operator==(const RequirementBase &lhs,
+                         const RequirementBase &rhs) {
+    if (lhs.FirstTypeAndKind.getOpaqueValue()
+          != rhs.FirstTypeAndKind.getOpaqueValue())
+      return false;
+
+    switch (lhs.getKind()) {
+    case RequirementKind::Conformance:
+    case RequirementKind::Superclass:
+    case RequirementKind::SameType:
+      return lhs.getSecondType().getPointer() ==
+          rhs.getSecondType().getPointer();
+
+    case RequirementKind::Layout:
+      return lhs.getLayoutConstraint() == rhs.getLayoutConstraint();
+    }
+    llvm_unreachable("Unhandled RequirementKind in switch");
+  }
+};
+} // namespace swift
+#endif

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -367,6 +367,10 @@ public:
   /// correct join but one better than Any may exist.
   static Optional<Type> join(Type first, Type second);
 
+  friend llvm::hash_code hash_value(Type T) {
+    return llvm::hash_value(T.getPointer());
+  }
+
 private:
   // Direct comparison is disabled for types, because they may not be canonical.
   void operator==(Type T) const = delete;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -287,6 +287,8 @@ public:
 
   Demangle::NodeFactory &getNodeFactory() { return Dem; }
 
+  BuiltType decodeMangledType(Node *node);
+  
   ///
   /// Factory methods for all TypeRef kinds
   ///
@@ -512,6 +514,34 @@ public:
 
   const SILBoxTypeRef *createSILBoxType(const TypeRef *base) {
     return SILBoxTypeRef::create(*this, base);
+  }
+
+  using BuiltSILBoxField = typename SILBoxTypeWithLayoutTypeRef::Field;
+  using BuiltSubstitution = std::pair<const TypeRef *, const TypeRef *>;
+  using BuiltRequirement = TypeRefRequirement;
+  using BuiltLayoutConstraint = TypeRefLayoutConstraint;
+  BuiltLayoutConstraint getLayoutConstraint(LayoutConstraintKind kind) {
+    // FIXME: Implement this.
+    return {};
+  }
+  BuiltLayoutConstraint
+  getLayoutConstraintWithSizeAlign(LayoutConstraintKind kind, unsigned size,
+                                   unsigned alignment) {
+    // FIXME: Implement this.
+    return {};
+  }
+
+  const SILBoxTypeWithLayoutTypeRef *createSILBoxTypeWithLayout(
+      const llvm::SmallVectorImpl<BuiltSILBoxField> &Fields,
+      const llvm::SmallVectorImpl<BuiltSubstitution> &Substitutions,
+      const llvm::SmallVectorImpl<BuiltRequirement> &Requirements) {
+    return SILBoxTypeWithLayoutTypeRef::create(*this, Fields, Substitutions,
+                                               Requirements);
+  }
+
+  bool isExistential(const TypeRef *) {
+    // FIXME: Implement this.
+    return true;
   }
 
   const TypeRef *createDynamicSelfType(const TypeRef *selfType) {

--- a/include/swift/Reflection/TypeRefs.def
+++ b/include/swift/Reflection/TypeRefs.def
@@ -35,5 +35,6 @@ TYPEREF(OpaqueArchetype, TypeRef)
   TYPEREF(Name##Storage, TypeRef)
 #include "swift/AST/ReferenceStorage.def"
 TYPEREF(SILBox, TypeRef)
+TYPEREF(SILBoxTypeWithLayout, TypeRef)
 
 #undef TYPEREF

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -164,6 +164,7 @@ public:
   using BuiltType = typename BuilderType::BuiltType;
   using BuiltTypeDecl = typename BuilderType::BuiltTypeDecl;
   using BuiltProtocolDecl = typename BuilderType::BuiltProtocolDecl;
+  using BuiltRequirement = typename BuilderType::BuiltRequirement;
   using StoredPointer = typename Runtime::StoredPointer;
   using StoredSignedPointer = typename Runtime::StoredSignedPointer;
   using StoredSize = typename Runtime::StoredSize;

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -150,6 +150,10 @@ public:
                         llvm::DILocalVariable *Var, llvm::DIExpression *Expr,
                         unsigned Line, unsigned Col, llvm::DILocalScope *Scope,
                         const SILDebugScope *DS, bool InCoroContext = false);
+#ifndef NDEBUG
+  /// Verify that Addr can be processed by llvm's CoroFrame/CoroSplit.
+  bool verifyCoroutineArgument(llvm::Value *Addr);
+#endif
 
   enum { NotHeapAllocated = false };
   

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -1565,6 +1565,10 @@ public:
     return true;
   }
 
+  bool visitSILBoxTypeWithLayoutTypeRef(const SILBoxTypeWithLayoutTypeRef *SB) {
+    return true;
+  }
+
   bool
   visitForeignClassTypeRef(const ForeignClassTypeRef *F) {
     return true;
@@ -1685,6 +1689,11 @@ public:
 
   MetatypeRepresentation
   visitSILBoxTypeRef(const SILBoxTypeRef *SB) {
+    return MetatypeRepresentation::Thin;
+  }
+
+  MetatypeRepresentation
+  visitSILBoxTypeWithLayoutTypeRef(const SILBoxTypeWithLayoutTypeRef *SB) {
     return MetatypeRepresentation::Thin;
   }
 
@@ -2184,6 +2193,12 @@ public:
 #include "swift/AST/ReferenceStorage.def"
 
   const TypeInfo *visitSILBoxTypeRef(const SILBoxTypeRef *SB) {
+    return TC.getReferenceTypeInfo(ReferenceKind::Strong,
+                                   ReferenceCounting::Native);
+  }
+
+  const TypeInfo *
+  visitSILBoxTypeWithLayoutTypeRef(const SILBoxTypeWithLayoutTypeRef *SB) {
     return TC.getReferenceTypeInfo(ReferenceKind::Strong,
                                    ReferenceCounting::Native);
   }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1284,6 +1284,10 @@ public:
   using BuiltTypeDecl = const ContextDescriptor *;
   using BuiltProtocolDecl = ProtocolDescriptorRef;
 
+  BuiltType decodeMangledType(NodePointer node) {
+    return Demangle::decodeMangledType(*this, node).getType();
+  }
+
   Demangle::NodeFactory &getNodeFactory() { return demangler; }
 
   TypeLookupErrorOr<BuiltType>
@@ -1463,7 +1467,7 @@ public:
     return BuiltType();
   }
 
-  TypeLookupErrorOr<BuiltType>
+  BuiltType
   createGenericTypeParameterType(unsigned depth, unsigned index) const {
     // Use the callback, when provided.
     if (substGenericParameter)
@@ -1560,6 +1564,67 @@ public:
   TypeLookupErrorOr<BuiltType> createSILBoxType(BuiltType base) const {
     // FIXME: Implement.
     return BuiltType();
+  }
+
+  using BuiltSILBoxField = llvm::PointerIntPair<BuiltType, 1>;
+  using BuiltSubstitution = std::pair<BuiltType, BuiltType>;
+  struct BuiltLayoutConstraint {
+    bool operator==(BuiltLayoutConstraint rhs) const { return true; }
+    operator bool() const { return true; }
+  };
+  using BuiltLayoutConstraint = BuiltLayoutConstraint;
+  BuiltLayoutConstraint getLayoutConstraint(LayoutConstraintKind kind) {
+    return {};
+  }
+  BuiltLayoutConstraint
+  getLayoutConstraintWithSizeAlign(LayoutConstraintKind kind, unsigned size,
+                                   unsigned alignment) {
+    return {};
+  }
+
+#if LLVM_PTR_SIZE == 4
+  /// Unfortunately the alignment of TypeRef is too large to squeeze in 3 extra
+  /// bits on (some?) 32-bit systems.
+  class BigBuiltTypeIntPair {
+    BuiltType Ptr;
+    RequirementKind Int;
+  public:
+    BigBuiltTypeIntPair(BuiltType ptr, RequirementKind i) : Ptr(ptr), Int(i) {}
+    RequirementKind getInt() const { return Int; }
+    BuiltType getPointer() const { return Ptr; }
+    uint64_t getOpaqueValue() const {
+      return (uint64_t)Ptr | ((uint64_t)Int << 32);
+    }
+  };
+#endif
+
+  struct Requirement : public RequirementBase<BuiltType,
+#if LLVM_PTR_SIZE == 4
+         BigBuiltTypeIntPair,
+#else
+         llvm::PointerIntPair<BuiltType, 3, RequirementKind>,
+
+#endif
+         BuiltLayoutConstraint> {
+    Requirement(RequirementKind kind, BuiltType first, BuiltType second)
+        : RequirementBase(kind, first, second) {}
+    Requirement(RequirementKind kind, BuiltType first,
+                BuiltLayoutConstraint second)
+        : RequirementBase(kind, first, second) {}
+  };
+  using BuiltRequirement = Requirement;
+
+  TypeLookupErrorOr<BuiltType> createSILBoxTypeWithLayout(
+      llvm::ArrayRef<BuiltSILBoxField> Fields,
+      llvm::ArrayRef<BuiltSubstitution> Substitutions,
+      llvm::ArrayRef<BuiltRequirement> Requirements) const {
+    // FIXME: Implement.
+    return BuiltType();
+  }
+
+  bool isExistential(BuiltType) {
+    // FIXME: Implement.
+    return true;
   }
 
   TypeReferenceOwnership getReferenceOwnership() const {

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - -parse-as-library \
+// RUN:    -module-name M -enable-experimental-concurrency | %FileCheck %s
+// REQUIRES: concurrency
+
+extension Collection {
+  public func f() async throws {
+    return await try Task.withGroup(resultType: Element.self) { group in
+      var i = self.startIndex
+      func doit() async throws {
+        await group.add { [i] in
+          return self[i]
+        }
+      }
+      await try doit()
+    }
+  }
+}
+
+// CHECK: ![[BOXTY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s5IndexSlQzz_x_SlRzlXXD"
+// CHECK: !DILocalVariable(name: "i", arg: 3, {{.*}}type: ![[BOXTY]]

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -46,7 +46,14 @@ bb0(%i : $Int, %p : $@thick P.Type):
 
 // CHECK:      - Capture types:
 // CHECK-NEXT: (struct Swift.Int)
-// CHECK-NEXT: (builtin Builtin.NativeObject)
+// CHECK-NEXT: (sil_box_with_layout
+// CHECK-NEXT:   (layout
+// CHECK-NEXT:     (var
+// CHECK-NEXT:       (generic_type_parameter depth=0 index=0)))
+// CHECK-NEXT:   (generic_signature
+// CHECK-NEXT:     (substitution
+// CHECK-NEXT:       (generic_type_parameter depth=0 index=0)
+// CHECK-NEXT:       (struct Swift.Int))))
 // CHECK-NEXT: (existential_metatype
 // CHECK-NEXT:   (protocol_composition
 // CHECK-NEXT:     (protocol capture_descriptors.P)))
@@ -82,7 +89,14 @@ bb0:
 
 // CHECK:      - Capture types:
 // CHECK-NEXT: (struct Swift.Int)
-// CHECK-NEXT: (builtin Builtin.NativeObject)
+// CHECK-NEXT: (sil_box_with_layout
+// CHECK-NEXT:   (layout
+// CHECK-NEXT:     (var
+// CHECK-NEXT:       (generic_type_parameter depth=0 index=0)))
+// CHECK-NEXT:   (generic_signature
+// CHECK-NEXT:     (substitution
+// CHECK-NEXT:       (generic_type_parameter depth=0 index=0)
+// CHECK-NEXT:       (struct Swift.String))))
 // CHECK-NEXT:   - Metadata sources:
 
 


### PR DESCRIPTION
Usually debug info only ever describes the result of a projectBox
call. To display a boxed parameter of an async continuation object,
however, the debug info can only describe the box itself and thus also
needs to emit a box type for it so the debugger knows to call into
Remote Mirrors to unbox the value.

Fixes https://bugs.swift.org/browse/SR-14059.