### PR TITLE
SIL: add a utility which can manage per-block data efficiently.

### DIFF
--- a/include/swift/SIL/BasicBlockData.h
+++ b/include/swift/SIL/BasicBlockData.h
@@ -1,0 +1,207 @@
+//===--- BasicBlockData.h - Defines the BasicBlockData utility --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the BasicBlockData utility
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_BASICBLOCKDATA_H
+#define SWIFT_SIL_BASICBLOCKDATA_H
+
+#include "swift/SIL/SILFunction.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace swift {
+
+/// Manage additional data for a function's basic blocks.
+///
+/// This can be used by transforms to store temporary data per basic block.
+/// It is very efficient: only a single memory allocation is needed and no maps
+/// are used to lookup data.
+///
+/// It is still permitted to use a BasicBlockData after the block list of a
+/// function has changed. With two exceptions:
+///  * If new blocks are added during the lifetime of a BasicBlockData, no data
+///    can be queried for a new block.
+///  * If a new BasicBlockData is created after the block list changed, then any
+///    older BasicBlockData (which was created before the change) cannot be
+///    used anymore.
+///
+/// This means, it's totally fine to store a BasicBlockData in an Analysis, as
+/// long as the invalidation mechanism ensures that the analysis data is not
+/// retrieved after the function's block list changed.
+///
+/// The Vector template argument specifies how the data is stored. By default
+/// it's a SmallVector with an inline-size of 4. This avoids memory allocation
+/// for about 70% of all functions.
+template <typename Data, typename Vector = llvm::SmallVector<Data, 4>>
+class BasicBlockData {
+  SILFunction *function;
+  Vector data;
+
+  /// The data is valid if validForBlockOrder matches the function's
+  /// BlockListChangeIdx.
+  unsigned validForBlockOrder = 0;
+
+  int getIndex(SILBasicBlock *block) const {
+    assert(block->index >= 0 && "Cannot get data for a new block");
+    assert(validForBlockOrder == function->BlockListChangeIdx &&
+           "BasicBlockData invalid because the function's block list changed");
+    return block->index;
+  }
+
+public:
+
+  /// For iterating over the function's blocks, yielding the block and its data.
+  template <typename BlockIterTy, bool IsConst> class IteratorTy {
+    using DataTy = typename std::conditional<IsConst, const Data, Data>::type;
+    using BasicBlockDataTy = typename std::conditional<IsConst,
+      const BasicBlockData<Data>, BasicBlockData<Data>>::type;
+
+    /// The underlying SILBasicBlock iterator.
+    BlockIterTy blockIter;
+
+    /// Reference to the constructing BasicBlockData. Used to retrieve the data.
+    BasicBlockDataTy &blockData;
+
+    friend class BasicBlockData<Data>;
+
+    IteratorTy(BlockIterTy blockIter, BasicBlockDataTy &blockData) :
+      blockIter(blockIter), blockData(blockData) {}
+
+  public:
+    /// Result of re-referencing the iterator.
+    struct BlockAndData {
+      SILBasicBlock &block;
+      DataTy &data;
+
+      BlockAndData(SILBasicBlock &block, DataTy &data) :
+        block(block), data(data) {}
+    };
+
+    IteratorTy & operator++() {  // Preincrement
+      blockIter++; return *this;
+    }
+    IteratorTy & operator++(int) {  // Postincrement
+      IteratorTy tmp = *this; ++*this; return tmp;
+    }
+
+    SILBasicBlock &block() const { return *blockIter; }
+    DataTy &data() const { return blockData[&block()]; }
+
+    BlockAndData operator*() const { return BlockAndData(block(), data()); }
+
+    bool operator==(const IteratorTy &rhs) const {
+      return blockIter == rhs.blockIter;
+    }
+    bool operator!=(const IteratorTy &rhs) const {
+      return blockIter != rhs.blockIter;
+    }
+  };
+
+  using iterator = IteratorTy<SILFunction::iterator, false>;
+  using const_iterator = IteratorTy<SILFunction::iterator, true>;
+  using reverse_iterator = IteratorTy<SILFunction::reverse_iterator, false>;
+  using const_reverse_iterator = IteratorTy<SILFunction::reverse_iterator, true>;
+
+  static Data constructDefaultData(SILBasicBlock *) { return Data(); }
+
+  /// Initialize Data for all basic blocks.
+  ///
+  /// The \p init function must return the initial data for a block. If not
+  /// provided, all data is constructed with the Data() default constructor.
+  BasicBlockData(SILFunction *function,
+                 llvm::function_ref<Data(SILBasicBlock *block)> init =
+                   // Would be nice to simply write constructDefaultData in
+                   // closure syntax, but I didn't get it compile under Windows.
+                   constructDefaultData) :
+      function(function) {
+    // Reserve enough space. Though SILFunction::size() iterates over all
+    // blocks it is still better than to risk multiple mallocs.
+    data.reserve(function->size());
+    bool blockListChanged = false;
+    for (auto blockAndIdx : llvm::enumerate(*function)) {
+      SILBasicBlock &block = blockAndIdx.value();
+      int idx = blockAndIdx.index();
+      if (block.index != idx) {
+        blockListChanged = true;
+        block.index = idx;
+      }
+      data.push_back(init(&block));
+    }
+    function->incrementRefCount();
+
+    // If we assigned new block indices, it invalidates all older BasicBlockData
+    // instances.
+    if (blockListChanged)
+      ++function->BlockListChangeIdx;
+    validForBlockOrder = function->BlockListChangeIdx;
+  }
+
+  ~BasicBlockData() {
+    function->decrementRefCount();
+  }
+
+  // For iterating over the function's basic blocks, yielding the block and its
+  // data. For example:
+  //
+  //    BasicBlockData<Mydata> blockData;
+  //    for (auto bd : blockData) {
+  //      SILBasicBlock &block = bd.block;
+  //      Mydata &dataForBlock = bd.data;
+  //    }
+
+  iterator begin() { return iterator(function->begin(), *this); }
+  iterator end() { return iterator(function->end(), *this); }
+  const_iterator begin() const {
+    return const_iterator(function->begin(), *this);
+  }
+  const_iterator end() const {
+    return const_iterator(function->end(), *this);
+  }
+  reverse_iterator rbegin() {
+    return reverse_iterator(function->rbegin(), *this);
+  }
+  reverse_iterator rend() {
+    return reverse_iterator(function->rend(), *this);
+  }
+  const_reverse_iterator rbegin() const {
+    return const_reverse_iterator(function->rbegin(), *this);
+  }
+  const_reverse_iterator rend() const {
+    return const_reverse_iterator(function->rend(), *this);
+  }
+
+  /// Returns the function's entry block and its data.
+  typename iterator::BlockAndData entry() { return *begin(); }
+
+  /// Returns the function's entry block and its data (const-version).
+  typename const_iterator::BlockAndData entry() const { return *begin(); }
+
+  /// Returns the underlying function.
+  SILFunction *getFunction() const { return function; }
+
+  /// Gets a mutable reference to a block's data.
+  Data &operator[] (SILBasicBlock *block) {
+    return data[getIndex(block)];
+  }
+
+  /// Gets a constant reference to a block's data.
+  const Data &operator[] (SILBasicBlock *block) const {
+    return data[getIndex(block)];
+  }
+};
+
+} // end swift namespace
+
+#endif

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -33,6 +33,8 @@ public llvm::ilist_node<SILBasicBlock>, public SILAllocated<SILBasicBlock> {
   friend class SILSuccessor;
   friend class SILFunction;
   friend class SILGlobalVariable;
+  template <typename Data, typename Vector> friend class BasicBlockData;
+
 public:
   using InstListType = llvm::iplist<SILInstruction>;
 private:
@@ -49,6 +51,11 @@ private:
 
   /// The ordered set of instructions in the SILBasicBlock.
   InstListType InstList;
+
+  /// Used by BasicBlockData to index the Data vector.
+  ///
+  /// A value of -1 means that the index is not initialized yet.
+  int index = -1;
 
   friend struct llvm::ilist_traits<SILBasicBlock>;
   SILBasicBlock() : Parent(nullptr) {}

--- a/include/swift/SILOptimizer/Utils/StackNesting.h
+++ b/include/swift/SILOptimizer/Utils/StackNesting.h
@@ -13,10 +13,9 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_STACKNESTING_H
 #define SWIFT_SILOPTIMIZER_UTILS_STACKNESTING_H
 
-#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/BasicBlockData.h"
 #include "llvm/ADT/SmallBitVector.h"
-
-#include <vector>
 
 namespace swift {
 
@@ -48,17 +47,25 @@ namespace swift {
 ///
 class StackNesting {
 
+public:
+
+  /// The possible return values of fixNesting().
+  enum class Changes {
+    /// No changes are made.
+    None,
+
+    /// Only instructions were inserted or deleted.
+    Instructions,
+
+    /// Instructions were inserted or deleted and new blocks were inserted.
+    CFG
+  };
+
+private:
   typedef SmallBitVector BitVector;
 
   /// Data stored for each block (actually for each block which is not dead).
   struct BlockInfo {
-
-    /// Back-link to the block.
-    SILBasicBlock *Block;
-
-    /// The cached list of successors.
-    llvm::SmallVector<BlockInfo *, 8> Successors;
-
     /// The list of stack allocating/deallocating instructions in the block.
     llvm::SmallVector<SILInstruction *, 8> StackInsts;
 
@@ -68,7 +75,8 @@ class StackNesting {
     /// The bit-set of alive stack locations at the block exit.
     BitVector AliveStackLocsAtExit;
 
-    BlockInfo(SILBasicBlock *Block) : Block(Block) { }
+    /// Used in the setup function to walk over the CFG.
+    bool visited = false;
   };
 
   /// Data stored for each stack location (= allocation).
@@ -93,45 +101,34 @@ class StackNesting {
   /// number in the bit-sets.
   llvm::SmallVector<StackLoc, 8> StackLocs;
 
-  /// Block data for all (non-dead) blocks.
-  std::vector<BlockInfo> BlockInfos;
+  BasicBlockData<BlockInfo> BlockInfos;
 
-public:
-
-  /// The possible return values of correctStackNesting().
-  enum class Changes {
-    /// No changes are made.
-    None,
-
-    /// Only instructions were inserted or deleted.
-    Instructions,
-
-    /// Instructions were inserted or deleted and new blocks were inserted.
-    CFG
-  };
-
-  StackNesting() { }
+  StackNesting(SILFunction *F) : BlockInfos(F) { }
 
   /// Performs correction of stack nesting by moving stack-deallocation
   /// instructions down the control flow.
   ///
   /// Returns the status of what changes were made.
-  Changes correctStackNesting(SILFunction *F);
+  Changes run();
   
   /// For debug dumping.
   void dump() const;
 
   static void dumpBits(const BitVector &Bits);
 
-private:
   /// Initializes the data structures.
-  void setup(SILFunction *F);
+  void setup();
 
   /// Solves the dataflow problem.
   ///
   /// Returns true if there is a nesting of locations in any way, which can
   /// potentially in the wrong order.
   bool solve();
+
+  bool analyze() {
+    setup();
+    return solve();
+  }
 
   /// Insert deallocation instructions for all locations which are alive before
   /// the InsertionPoint (AliveBefore) but not alive after the InsertionPoint
@@ -161,7 +158,15 @@ private:
   /// Modifies the SIL to end up with a correct stack nesting.
   ///
   /// Returns the status of what changes were made.
-  bool adaptDeallocs();
+  Changes adaptDeallocs();
+
+public:
+
+  /// Performs correction of stack nesting by moving stack-deallocation
+  /// instructions down the control flow.
+  ///
+  /// Returns the status of what changes were made.
+  static Changes fixNesting(SILFunction *F);
 };
 
 } // end namespace swift

--- a/lib/SIL/Verifier/MemoryLifetime.cpp
+++ b/lib/SIL/Verifier/MemoryLifetime.cpp
@@ -393,64 +393,50 @@ void MemoryLocations::initFieldsCounter(Location &loc) {
 //                     MemoryDataflow members
 //===----------------------------------------------------------------------===//
 
-MemoryDataflow::MemoryDataflow(SILFunction *function, unsigned numLocations) {
-  // Resizing is mandatory! Just adding states with push_back would potentially
-  // invalidate previous pointers to states, which are stored in block2State.
-  blockStates.resize(function->size());
-
-  unsigned idx = 0;
-  unsigned numBits = numLocations;
-  for (SILBasicBlock &BB : *function) {
-    BlockState *st = &blockStates[idx++];
-    st->block = &BB;
-    st->entrySet.resize(numBits);
-    st->genSet.resize(numBits);
-    st->killSet.resize(numBits);
-    st->exitSet.resize(numBits);
-    block2State[&BB] = st;
-  }
-}
+MemoryDataflow::MemoryDataflow(SILFunction *function, unsigned numLocations) :
+  blockStates(function, [numLocations](SILBasicBlock *block) {
+    return BlockState(numLocations);
+  }) {}
 
 void MemoryDataflow::entryReachabilityAnalysis() {
-  llvm::SmallVector<BlockState *, 16> workList;
-  BlockState *entryState = &blockStates[0];
-  assert(entryState ==
-         block2State[entryState->block->getParent()->getEntryBlock()]);
-  entryState->reachableFromEntry = true;
-  workList.push_back(entryState);
+  llvm::SmallVector<SILBasicBlock *, 16> workList;
+  auto entry = blockStates.entry();
+  entry.data.reachableFromEntry = true;
+  workList.push_back(&entry.block);
 
   while (!workList.empty()) {
-    BlockState *state = workList.pop_back_val();
-    for (SILBasicBlock *succ : state->block->getSuccessorBlocks()) {
-      BlockState *succState = block2State[succ];
-      if (!succState->reachableFromEntry) {
-        succState->reachableFromEntry = true;
-        workList.push_back(succState);
+    SILBasicBlock *block = workList.pop_back_val();
+    for (SILBasicBlock *succ : block->getSuccessorBlocks()) {
+      BlockState &succState = blockStates[succ];
+      if (!succState.reachableFromEntry) {
+        succState.reachableFromEntry = true;
+        workList.push_back(succ);
       }
     }
   }
 }
 
 void MemoryDataflow::exitReachableAnalysis() {
-  llvm::SmallVector<BlockState *, 16> workList;
-  for (BlockState &state : blockStates) {
-    if (state.block->getTerminator()->isFunctionExiting()) {
-      state.exitReachability = ExitReachability::ReachesExit;
-      workList.push_back(&state);
-    } else if (isa<UnreachableInst>(state.block->getTerminator())) {
-      state.exitReachability = ExitReachability::ReachesUnreachable;
-      workList.push_back(&state);
+  llvm::SmallVector<SILBasicBlock *, 16> workList;
+  for (auto bd : blockStates) {
+    if (bd.block.getTerminator()->isFunctionExiting()) {
+      bd.data.exitReachability = ExitReachability::ReachesExit;
+      workList.push_back(&bd.block);
+    } else if (isa<UnreachableInst>(bd.block.getTerminator())) {
+      bd.data.exitReachability = ExitReachability::ReachesUnreachable;
+      workList.push_back(&bd.block);
     }
   }
   while (!workList.empty()) {
-    BlockState *state = workList.pop_back_val();
-    for (SILBasicBlock *pred : state->block->getPredecessorBlocks()) {
-      BlockState *predState = block2State[pred];
-      if (predState->exitReachability < state->exitReachability) {
+    SILBasicBlock *block = workList.pop_back_val();
+    BlockState &state = blockStates[block];
+    for (SILBasicBlock *pred : block->getPredecessorBlocks()) {
+      BlockState &predState = blockStates[pred];
+      if (predState.exitReachability < state.exitReachability) {
         // As there are 3 states, each block can be put into the workList 2
         // times maximum.
-        predState->exitReachability = state->exitReachability;
-        workList.push_back(predState);
+        predState.exitReachability = state.exitReachability;
+        workList.push_back(pred);
       }
     }
   }
@@ -462,18 +448,18 @@ void MemoryDataflow::solveForward(JoinOperation join) {
   bool firstRound = true;
   do {
     changed = false;
-    for (BlockState &st : blockStates) {
-      Bits bits = st.entrySet;
+    for (auto bd : blockStates) {
+      Bits bits = bd.data.entrySet;
       assert(!bits.empty());
-      for (SILBasicBlock *pred : st.block->getPredecessorBlocks()) {
-        join(bits, block2State[pred]->exitSet);
+      for (SILBasicBlock *pred : bd.block.getPredecessorBlocks()) {
+        join(bits, blockStates[pred].exitSet);
       }
-      if (firstRound || bits != st.entrySet) {
+      if (firstRound || bits != bd.data.entrySet) {
         changed = true;
-        st.entrySet = bits;
-        bits |= st.genSet;
-        bits.reset(st.killSet);
-        st.exitSet = bits;
+        bd.data.entrySet = bits;
+        bits |= bd.data.genSet;
+        bits.reset(bd.data.killSet);
+        bd.data.exitSet = bits;
       }
     }
     firstRound = false;
@@ -498,18 +484,18 @@ void MemoryDataflow::solveBackward(JoinOperation join) {
   bool firstRound = true;
   do {
     changed = false;
-    for (BlockState &st : llvm::reverse(blockStates)) {
-      Bits bits = st.exitSet;
+    for (auto bd : llvm::reverse(blockStates)) {
+      Bits bits = bd.data.exitSet;
       assert(!bits.empty());
-      for (SILBasicBlock *succ : st.block->getSuccessorBlocks()) {
-        join(bits, block2State[succ]->entrySet);
+      for (SILBasicBlock *succ : bd.block.getSuccessorBlocks()) {
+        join(bits, blockStates[succ].entrySet);
       }
-      if (firstRound || bits != st.exitSet) {
+      if (firstRound || bits != bd.data.exitSet) {
         changed = true;
-        st.exitSet = bits;
-        bits |= st.genSet;
-        bits.reset(st.killSet);
-        st.entrySet = bits;
+        bd.data.exitSet = bits;
+        bits |= bd.data.genSet;
+        bits.reset(bd.data.killSet);
+        bd.data.entrySet = bits;
       }
     }
     firstRound = false;
@@ -529,12 +515,12 @@ void MemoryDataflow::solveBackwardWithUnion() {
 }
 
 void MemoryDataflow::dump() const {
-  for (const BlockState &st : blockStates) {
-    llvm::dbgs() << "bb" << st.block->getDebugID() << ":\n"
-                 << "    entry: " << st.entrySet << '\n'
-                 << "    gen:   " << st.genSet << '\n'
-                 << "    kill:  " << st.killSet << '\n'
-                 << "    exit:  " << st.exitSet << '\n';
+    for (auto bd : blockStates) {
+    llvm::dbgs() << "bb" << bd.block.getDebugID() << ":\n"
+                 << "    entry: " << bd.data.entrySet << '\n'
+                 << "    gen:   " << bd.data.genSet << '\n'
+                 << "    kill:  " << bd.data.killSet << '\n'
+                 << "    exit:  " << bd.data.exitSet << '\n';
   }
 }
 
@@ -585,7 +571,7 @@ class MemoryLifetimeVerifier {
   void initDataflow(MemoryDataflow &dataFlow);
 
   /// Initializes the data flow bits sets in the block state for a single block.
-  void initDataflowInBlock(BlockState &state);
+  void initDataflowInBlock(SILBasicBlock *block, BlockState &state);
 
   /// Helper function to set bits for function arguments and returns.
   void setFuncOperandBits(BlockState &state, Operand &op,
@@ -658,36 +644,37 @@ void MemoryLifetimeVerifier::requireBitsSet(const Bits &bits, SILValue addr,
 void MemoryLifetimeVerifier::initDataflow(MemoryDataflow &dataFlow) {
   // Initialize the entry and exit sets to all-bits-set. Except for the function
   // entry.
-  for (BlockState &st : dataFlow) {
-    if (st.block == function->getEntryBlock()) {
-      st.entrySet.reset();
+  for (auto bs : dataFlow) {
+      if (&bs.block == function->getEntryBlock()) {
+      bs.data.entrySet.reset();
       for (SILArgument *arg : function->getArguments()) {
         SILFunctionArgument *funcArg = cast<SILFunctionArgument>(arg);
         if (funcArg->getArgumentConvention() !=
               SILArgumentConvention::Indirect_Out) {
-          locations.setBits(st.entrySet, arg);
+          locations.setBits(bs.data.entrySet, arg);
         }
       }
     } else {
-      st.entrySet.set();
+      bs.data.entrySet.set();
     }
-    st.exitSet.set();
+    bs.data.exitSet.set();
 
     // Anything weired can happen in unreachable blocks. So just ignore them.
     // Note: while solving the dataflow, unreachable blocks are implicitly
     // ignored, because their entry/exit sets are all-ones and their gen/kill
     // sets are all-zeroes.
-    if (st.reachableFromEntry)
-      initDataflowInBlock(st);
+    if (bs.data.reachableFromEntry)
+      initDataflowInBlock(&bs.block, bs.data);
   }
 }
 
-void MemoryLifetimeVerifier::initDataflowInBlock(BlockState &state) {
+void MemoryLifetimeVerifier::initDataflowInBlock(SILBasicBlock *block,
+                                                 BlockState &state) {
   // Initialize the genSet with special cases, like the @out results of an
   // try_apply in the predecessor block.
-  setBitsOfPredecessor(state.genSet, state.block);
+  setBitsOfPredecessor(state.genSet, block);
 
-  for (SILInstruction &I : *state.block) {
+  for (SILInstruction &I : *block) {
     switch (I.getKind()) {
       case SILInstructionKind::LoadInst: {
         auto *LI = cast<LoadInst>(&I);
@@ -809,38 +796,38 @@ void MemoryLifetimeVerifier::checkFunction(MemoryDataflow &dataFlow) {
 
   const Bits &nonTrivialLocations = locations.getNonTrivialLocations();
   Bits bits(locations.getNumLocations());
-  for (BlockState &st : dataFlow) {
-    if (!st.reachableFromEntry || !st.exitReachable())
+  for (auto bs : dataFlow) {
+    if (!bs.data.reachableFromEntry || !bs.data.exitReachable())
       continue;
 
     // Check all instructions in the block.
-    bits = st.entrySet;
-    checkBlock(st.block, bits);
+    bits = bs.data.entrySet;
+    checkBlock(&bs.block, bits);
 
     // Check if there is a mismatch in location lifetime at the merge point.
-    for (SILBasicBlock *pred : st.block->getPredecessorBlocks()) {
-      BlockState *predState = dataFlow.getState(pred);
-      if (predState->reachableFromEntry) {
-        require((st.entrySet ^ predState->exitSet) & nonTrivialLocations,
-          "lifetime mismatch in predecessors", &*st.block->begin());
+    for (SILBasicBlock *pred : bs.block.getPredecessorBlocks()) {
+      BlockState &predState = dataFlow[pred];
+      if (predState.reachableFromEntry) {
+        require((bs.data.entrySet ^ predState.exitSet) & nonTrivialLocations,
+          "lifetime mismatch in predecessors", &*bs.block.begin());
       }
     }
 
     // Check the bits at function exit.
-    TermInst *term = st.block->getTerminator();
-    assert(bits == st.exitSet || isa<TryApplyInst>(term));
+    TermInst *term = bs.block.getTerminator();
+    assert(bits == bs.data.exitSet || isa<TryApplyInst>(term));
     switch (term->getKind()) {
       case SILInstructionKind::ReturnInst:
       case SILInstructionKind::UnwindInst:
-        require(expectedReturnBits & ~st.exitSet,
+        require(expectedReturnBits & ~bs.data.exitSet,
           "indirect argument is not alive at function return", term);
-        require(st.exitSet & ~expectedReturnBits & nonTrivialLocations,
+        require(bs.data.exitSet & ~expectedReturnBits & nonTrivialLocations,
           "memory is initialized at function return but shouldn't", term);
         break;
       case SILInstructionKind::ThrowInst:
-        require(expectedThrowBits & ~st.exitSet,
+        require(expectedThrowBits & ~bs.data.exitSet,
           "indirect argument is not alive at throw", term);
-        require(st.exitSet & ~expectedThrowBits & nonTrivialLocations,
+        require(bs.data.exitSet & ~expectedThrowBits & nonTrivialLocations,
           "memory is initialized at throw but shouldn't", term);
         break;
       default:

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -927,7 +927,7 @@ void ClosureSpecCloner::populateCloned() {
     }
   }
   if (invalidatedStackNesting) {
-    StackNesting().correctStackNesting(Cloned);
+    StackNesting::fixNesting(Cloned);
   }
 }
 
@@ -992,7 +992,7 @@ void SILClosureSpecializerTransform::run() {
     }
 
     if (invalidatedStackNesting) {
-      StackNesting().correctStackNesting(F);
+      StackNesting::fixNesting(F);
     }
   }
 

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -1003,9 +1003,8 @@ class ClosureLifetimeFixup : public SILFunctionTransform {
 
     if (fixupClosureLifetimes(*getFunction(), checkStackNesting, modifiedCFG)) {
       if (checkStackNesting){
-        StackNesting sn;
         modifiedCFG |=
-            sn.correctStackNesting(getFunction()) == StackNesting::Changes::CFG;
+          StackNesting::fixNesting(getFunction()) == StackNesting::Changes::CFG;
       }
       if (modifiedCFG)
         invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -180,7 +180,7 @@ public:
     }
 
     if (invalidatedStackNesting) {
-      StackNesting().correctStackNesting(&function);
+      StackNesting::fixNesting(&function);
     }
 
     return changed;

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -1000,7 +1000,7 @@ runOnFunctionRecursively(SILOptFunctionBuilder &FuncBuilder, SILFunction *F,
   }
 
   if (invalidatedStackNesting) {
-    StackNesting().correctStackNesting(F);
+    StackNesting::fixNesting(F);
     changedFunctions.insert(F);
   }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -322,7 +322,7 @@ bool SILCombiner::runOnFunction(SILFunction &F) {
   }
 
   if (invalidatedStackNesting) {
-    StackNesting().correctStackNesting(&F);
+    StackNesting::fixNesting(&F);
   }
 
   // Cleanup the builder and return whether or not we made any changes.

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -1095,8 +1095,7 @@ class AllocBoxToStack : public SILFunctionTransform {
       auto Count = rewritePromotedBoxes(pass);
       NumStackPromoted += Count;
       if (Count) {
-        StackNesting SN;
-        if (SN.correctStackNesting(getFunction()) == StackNesting::Changes::CFG)
+        if (StackNesting::fixNesting(getFunction()) == StackNesting::Changes::CFG)
           pass.CFGChanged = true;
       }
 

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -987,7 +987,7 @@ bool SILPerformanceInliner::inlineCallsIntoFunction(SILFunction *Caller) {
   mergeBasicBlocks(Caller);
 
   if (invalidatedStackNesting) {
-    StackNesting().correctStackNesting(Caller);
+    StackNesting::fixNesting(Caller);
   }
 
   // If we were asked to verify our caller after inlining all callees we could

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -73,8 +73,7 @@ void StackPromotion::run() {
     return;
 
   // Make sure that all stack allocating instructions are nested correctly.
-  StackNesting SN;
-  if (SN.correctStackNesting(F) == StackNesting::Changes::CFG) {
+  if (StackNesting::fixNesting(F) == StackNesting::Changes::CFG) {
     invalidateAnalysis(SILAnalysis::InvalidationKind::BranchesAndInstructions);
   } else {
     invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);

--- a/test/SILOptimizer/stack-nesting-wrong-scope.swift
+++ b/test/SILOptimizer/stack-nesting-wrong-scope.swift
@@ -3,9 +3,9 @@
 // RUN:   -sil-print-only-functions=$s3red19ThrowAddrOnlyStructV016throwsOptionalToG0ACyxGSgSi_tcfC \
 // RUN:   -Xllvm -sil-print-debuginfo -o %t -module-name red 2>&1 | %FileCheck %s
 
-// CHECK: bb5(%33 : @owned $Error):
-// CHECK:   dealloc_stack %6 : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:26:68, scope 2
-// CHECK:   br bb4(%33 : $Error), loc {{.*}}:26:15, scope 2
+// CHECK: bb{{[0-9]+}}(%{{[0-9]+}} : @owned $Error):
+// CHECK:   dealloc_stack %{{[0-9]+}} : $*ThrowAddrOnlyStruct<T>, loc {{.*}}:26:68, scope 2
+// CHECK:   br bb{{[0-9]+}}(%{{[0-9]+}} : $Error), loc {{.*}}:26:15, scope 2
 
 protocol Patatino {
   init()


### PR DESCRIPTION
It can be used by transforms to store temporary data per basic block.
It is very efficient: only a single memory allocation is needed and no maps are used to lookup data.

It uses an integer-index stored in SILBasicBlock to index a data vector.

This PR also contains three commits which change StackNesting, MemoryDataflow and InfiniteRecursionAnalysis to use the new utility.