### PR TITLE
Revert #35409

### DIFF
--- a/test/Runtime/protocol_conformance_collision.swift
+++ b/test/Runtime/protocol_conformance_collision.swift
@@ -16,8 +16,6 @@
 
 // UNSUPPORTED: use_os_stdlib
 
-// REQUIRES: rdar73049300
-
 import Accelerate
 import Foundation
 import StdlibUnittest


### PR DESCRIPTION
This test was preemptively disabled to avoid problems from some
forthcoming changes.  Those problems have been fixed elsewhere,
so we no longer need to disable this test.

Resolves rdar://73049300