### PR TITLE
[inst-simplify] Hide simplifyInstruction in favor of using simplifyAndReplaceAllSimplifiedUsesAndErase

### DIFF
--- a/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
+++ b/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
@@ -27,23 +27,9 @@ namespace swift {
 class SILInstruction;
 class InstModCallbacks;
 
-/// Try to simplify the specified instruction, performing local
-/// analysis of the operands of the instruction, without looking at its uses
-/// (e.g. constant folding).  If a simpler result can be found, it is
-/// returned, otherwise a null SILValue is returned.
-///
-/// This is assumed to implement read-none transformations.
-SILValue simplifyInstruction(SILInstruction *I);
-
 /// Replace an instruction with a simplified result and erase it. If the
 /// instruction initiates a scope, do not replace the end of its scope; it will
 /// be deleted along with its parent.
-///
-/// If it is nonnull, eraseNotify will be called before each instruction is
-/// deleted.
-///
-/// If it is nonnull and inst is in OSSA, newInstNotify will be called with each
-/// new instruction inserted to compensate for ownership.
 ///
 /// NOTE: When OSSA is enabled this API assumes OSSA is properly formed and will
 /// insert compensating instructions.
@@ -51,6 +37,17 @@ SILBasicBlock::iterator
 replaceAllSimplifiedUsesAndErase(SILInstruction *I, SILValue result,
                                  InstModCallbacks &callbacks,
                                  DeadEndBlocks *deadEndBlocks = nullptr);
+
+/// Attempt to map \p inst to a simplified result. Upon success, replace \p inst
+/// with this simplified result and erase \p inst. If the instruction initiates
+/// a scope, do not replace the end of its scope; it will be deleted along with
+/// its parent.
+///
+/// NOTE: When OSSA is enabled this API assumes OSSA is properly formed and will
+/// insert compensating instructions.
+SILBasicBlock::iterator simplifyAndReplaceAllSimplifiedUsesAndErase(
+    SILInstruction *I, InstModCallbacks &callbacks,
+    DeadEndBlocks *deadEndBlocks = nullptr);
 
 // Simplify invocations of builtin operations that may overflow.
 /// All such operations return a tuple (result, overflow_flag).

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -399,6 +399,10 @@ public:
   }
 
   bool hadCallbackInvocation() const { return wereAnyCallbacksInvoked; }
+
+  /// Set \p wereAnyCallbacksInvoked to false. Useful if one wants to reuse an
+  /// InstModCallback in between iterations.
+  void resetHadCallbackInvocation() { wereAnyCallbacksInvoked = false; }
 };
 
 /// Get all consumed arguments of a partial_apply.

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -38,18 +38,44 @@ struct OwnershipFixupContext {
   DeadEndBlocks &deBlocks;
   JointPostDominanceSetComputer &jointPostDomSetComputer;
 
-  OwnershipFixupContext(InstModCallbacks &callbacks, DeadEndBlocks &deBlocks,
-                        JointPostDominanceSetComputer &inputJPDComputer)
-      : inlineCallbacks(), callbacks(callbacks), deBlocks(deBlocks),
-        jointPostDomSetComputer(inputJPDComputer) {}
+  /// Extra state initialized by OwnershipRAUWFixupHelper::get() that we use
+  /// when RAUWing addresses. This ensures we do not need to recompute this
+  /// state when we perform the actual RAUW.
+  struct AddressFixupContext {
+    /// When determining if we need to perform an address pointer fixup, we
+    /// compute all transitive address uses of oldValue. If we find that we do
+    /// need this fixed up, then we will copy our interior pointer base value
+    /// and use this to seed that new lifetime.
+    SmallVector<Operand *, 8> allAddressUsesFromOldValue;
 
-  OwnershipFixupContext(DeadEndBlocks &deBlocks,
-                        JointPostDominanceSetComputer &inputJPDComputer)
-      : inlineCallbacks(InstModCallbacks()), callbacks(*inlineCallbacks),
-        deBlocks(deBlocks), jointPostDomSetComputer(inputJPDComputer) {}
+    /// This is the interior pointer operand that the new value we want to RAUW
+    /// is transitively derived from and enables us to know the underlying
+    /// borrowed base value that we need to lifetime extend.
+    InteriorPointerOperand intPtrOp;
+
+    void clear() {
+      allAddressUsesFromOldValue.clear();
+      intPtrOp = InteriorPointerOperand();
+    }
+  };
+  AddressFixupContext extraAddressFixupInfo;
+
+  OwnershipFixupContext(InstModCallbacks &callbacks, DeadEndBlocks &deBlocks,
+                        JointPostDominanceSetComputer &jointPostDomSetComputer)
+      : callbacks(callbacks), deBlocks(deBlocks),
+        jointPostDomSetComputer(jointPostDomSetComputer) {}
 
   void clear() {
     jointPostDomSetComputer.clear();
+    extraAddressFixupInfo.allAddressUsesFromOldValue.clear();
+    extraAddressFixupInfo.intPtrOp = InteriorPointerOperand();
+  }
+
+private:
+  /// Helper method called to determine if we discovered we needed interior
+  /// pointer fixups while simplifying.
+  bool needsInteriorPointerFixups() const {
+    return bool(extraAddressFixupInfo.intPtrOp);
   }
 };
 
@@ -57,20 +83,44 @@ struct OwnershipFixupContext {
 /// value or a single value instruction with a new value and then fixup
 /// ownership invariants afterwards.
 class OwnershipRAUWHelper {
-  OwnershipFixupContext &ctx;
+  OwnershipFixupContext *ctx;
+  SingleValueInstruction *oldValue;
+  SILValue newValue;
 
 public:
-  OwnershipRAUWHelper(OwnershipFixupContext &ctx) : ctx(ctx) {}
+  OwnershipRAUWHelper() : ctx(nullptr), oldValue(nullptr), newValue(nullptr) {}
 
-  SILBasicBlock::iterator
-  replaceAllUsesAndErase(SingleValueInstruction *oldValue, SILValue newValue);
-
-  /// We can not RAUW all old values with new values.
+  /// Return an instance of this class if we can perform the specific RAUW
+  /// operation ignoring if the types line up. Returns None otherwise.
   ///
-  /// Namely, we do not support RAUWing values with ValueOwnershipKind::None
-  /// that have uses that do not require ValueOwnershipKind::None or
-  /// ValueOwnershipKind::Any.
-  static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue);
+  /// DISCUSSION: We do not check that the types line up here so that we can
+  /// allow for our users to transform our new value in ways that preserve
+  /// ownership at \p oldValue before we perform the actual RAUW. If \p newValue
+  /// is an object, any instructions in the chain of transforming instructions
+  /// from \p newValue at \p oldValue's must be forwarding. If \p newValue is an
+  /// address, then these transforms can only transform the address into a
+  /// derived address.
+  OwnershipRAUWHelper(OwnershipFixupContext &ctx,
+                      SingleValueInstruction *oldValue, SILValue newValue);
+
+  /// Returns true if this helper was initialized into a valid state.
+  operator bool() const { return isValid(); }
+  bool isValid() const { return bool(ctx) && bool(oldValue) && bool(newValue); }
+
+  /// Perform the actual RAUW. We require that \p newValue and \p oldValue have
+  /// the same type at this point (in contrast to when calling
+  /// OwnershipRAUWFixupHelper::get()).
+  ///
+  /// This is so that we can avoid creating "forwarding" transformation
+  /// instructions before we know if we can perform the RAUW. Any such
+  /// "forwarding" transformation must be performed upon \p newValue at \p
+  /// oldValue's insertion point so that we can then here RAUW the transformed
+  /// \p newValue.
+  SILBasicBlock::iterator perform();
+
+private:
+  SILBasicBlock::iterator replaceAddressUses(SingleValueInstruction *oldValue,
+                                             SILValue newValue);
 };
 
 } // namespace swift

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -300,14 +300,6 @@ SILValue InstSimplifier::visitAddressToPointerInst(AddressToPointerInst *ATPI) {
 }
 
 SILValue InstSimplifier::visitPointerToAddressInst(PointerToAddressInst *PTAI) {
-  // (pointer_to_address strict (address_to_pointer x)) -> x
-  //
-  // NOTE: We can not perform this optimization in OSSA without dealing with
-  // interior pointers since we may be escaping an interior pointer address from
-  // a borrow scope.
-  if (PTAI->getFunction()->hasOwnership())
-    return SILValue();
-
   // If this address is not strict, then it cannot be replaced by an address
   // that may be strict.
   if (auto *ATPI = dyn_cast<AddressToPointerInst>(PTAI->getOperand()))

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -755,7 +755,8 @@ swift::replaceAllSimplifiedUsesAndErase(SILInstruction *i, SILValue result,
   if (svi->getFunction()->hasOwnership()) {
     JointPostDominanceSetComputer computer(*deadEndBlocks);
     OwnershipFixupContext ctx{callbacks, *deadEndBlocks, computer};
-    return ctx.replaceAllUsesAndErase(svi, result);
+    OwnershipRAUWHelper helper(ctx);
+    return helper.replaceAllUsesAndErase(svi, result);
   }
   return replaceAllUsesAndErase(svi, result, callbacks);
 }
@@ -790,7 +791,7 @@ static SILValue simplifyInstruction(SILInstruction *i) {
   // this code is not updated at this point in time.
   auto *svi = cast<SingleValueInstruction>(i);
   if (svi->getFunction()->hasOwnership())
-    if (!OwnershipFixupContext::canFixUpOwnershipForRAUW(svi, result))
+    if (!OwnershipRAUWHelper::canFixUpOwnershipForRAUW(svi, result))
       return SILValue();
 
   return result;
@@ -813,7 +814,8 @@ SILBasicBlock::iterator swift::simplifyAndReplaceAllSimplifiedUsesAndErase(
   if (svi->getFunction()->hasOwnership()) {
     JointPostDominanceSetComputer computer(*deadEndBlocks);
     OwnershipFixupContext ctx{callbacks, *deadEndBlocks, computer};
-    return ctx.replaceAllUsesAndErase(svi, result);
+    OwnershipRAUWHelper helper(ctx);
+    return helper.replaceAllUsesAndErase(svi, result);
   }
   return replaceAllUsesAndErase(svi, result, callbacks);
 }

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -479,13 +479,11 @@ static bool stripOwnership(SILFunction &func) {
     auto value = visitor.instructionsToSimplify.pop_back_val();
     if (!value.hasValue())
       continue;
-    if (SILValue newValue = simplifyInstruction(*value)) {
-      InstModCallbacks callbacks([&](SILInstruction *instToErase) {
-        visitor.eraseInstruction(instToErase);
-      });
-      replaceAllSimplifiedUsesAndErase(*value, newValue, callbacks);
-      madeChange = true;
-    }
+    InstModCallbacks callbacks([&](SILInstruction *instToErase) {
+      visitor.eraseInstruction(instToErase);
+    });
+    simplifyAndReplaceAllSimplifiedUsesAndErase(*value, callbacks);
+    madeChange |= callbacks.hadCallbackInvocation();
   }
 
   return madeChange;

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -96,11 +96,8 @@ class SILCombiner :
   /// post-dominating blocks to a full jointly post-dominating set.
   JointPostDominanceSetComputer jPostDomComputer;
 
-  /// A utility that we use to perform erase+RAUW that fixes up ownership for us
-  /// afterwards by lifetime extending/copy values as appropriate. We rely on
-  /// later optimizations to chew through this traffic. This ensures we can use
-  /// one code base for both OSSA and non-OSSA.
-  OwnershipFixupContext ownershipRAUWHelper;
+  /// External context struct used by \see ownershipRAUWHelper.
+  OwnershipFixupContext ownershipFixupContext;
 
 public:
   SILCombiner(SILOptFunctionBuilder &FuncBuilder, SILBuilder &B,
@@ -134,7 +131,7 @@ public:
               Worklist.add(use->getUser());
             }),
         deBlocks(&B.getFunction()), jPostDomComputer(deBlocks),
-        ownershipRAUWHelper(instModCallbacks, deBlocks, jPostDomComputer) {}
+        ownershipFixupContext(instModCallbacks, deBlocks, jPostDomComputer) {}
 
   bool runOnFunction(SILFunction &F);
 

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -756,9 +756,7 @@ void TempRValueOptPass::run() {
     // Simplify any access scope markers that were only used by the dead
     // copy_addr and other potentially unused addresses.
     if (srcInst) {
-      if (SILValue result = simplifyInstruction(srcInst)) {
-        replaceAllSimplifiedUsesAndErase(srcInst, result, callbacks);
-      }
+      simplifyAndReplaceAllSimplifiedUsesAndErase(srcInst, callbacks);
     }
   }
   if (changed) {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1458,12 +1458,9 @@ bool swift::simplifyUsers(SingleValueInstruction *inst) {
     if (!svi)
       continue;
 
-    SILValue S = simplifyInstruction(svi);
-    if (!S)
-      continue;
-
-    replaceAllSimplifiedUsesAndErase(svi, S, callbacks);
-    changed = true;
+    callbacks.resetHadCallbackInvocation();
+    simplifyAndReplaceAllSimplifiedUsesAndErase(svi, callbacks);
+    changed |= callbacks.hadCallbackInvocation();
   }
 
   return changed;

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -644,7 +644,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleGuaranteed() {
 SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
   assert(oldValue->getFunction()->hasOwnership());
   assert(
-      OwnershipFixupContext::canFixUpOwnershipForRAUW(oldValue, newValue) &&
+      OwnershipRAUWHelper::canFixUpOwnershipForRAUW(oldValue, newValue) &&
       "Should have checked if can perform this operation before calling it?!");
   // If our new value is just none, we can pass anything to do it so just RAUW
   // and return.
@@ -689,7 +689,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
 
 // All callers of our RAUW routines must ensure that their values return true
 // from this.
-bool OwnershipFixupContext::canFixUpOwnershipForRAUW(SILValue oldValue,
+bool OwnershipRAUWHelper::canFixUpOwnershipForRAUW(SILValue oldValue,
                                                      SILValue newValue) {
   auto newOwnershipKind = newValue.getOwnershipKind();
 
@@ -741,8 +741,8 @@ bool OwnershipFixupContext::canFixUpOwnershipForRAUW(SILValue oldValue,
 }
 
 SILBasicBlock::iterator
-OwnershipFixupContext::replaceAllUsesAndErase(SingleValueInstruction *oldValue,
+OwnershipRAUWHelper::replaceAllUsesAndErase(SingleValueInstruction *oldValue,
                                               SILValue newValue) {
-  OwnershipRAUWUtility utility{oldValue, newValue, *this};
+  OwnershipRAUWUtility utility{oldValue, newValue, ctx};
   return utility.perform();
 }

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -22,6 +22,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/LinearLifetimeChecker.h"
+#include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILArgument.h"
@@ -157,6 +158,58 @@ static void getAllNonTrivialUsePointsOfBorrowedValue(
       continue;
     }
   }
+}
+
+// All callers of our RAUW routines must ensure that their values return true
+// from this.
+static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue) {
+  auto newOwnershipKind = newValue.getOwnershipKind();
+
+  // If our new kind is ValueOwnershipKind::None, then we are fine. We
+  // trivially support that. This check also ensures that we can always
+  // replace any value with a ValueOwnershipKind::None value.
+  if (newOwnershipKind == OwnershipKind::None)
+    return true;
+
+  // First check if oldValue is SILUndef. If it is, then we know that:
+  //
+  // 1. SILUndef (and thus oldValue) must have OwnershipKind::None.
+  // 2. newValue is not OwnershipKind::None due to our check above.
+  //
+  // Thus we know that we would be replacing a value with OwnershipKind::None
+  // with a value with non-None ownership. This is a case we don't support, so
+  // we can bail now.
+  if (isa<SILUndef>(oldValue))
+    return false;
+
+  // Ok, we now know that we do not have SILUndef implying that we must be able
+  // to get a module from our value since we must have an argument or an
+  // instruction.
+  auto *m = oldValue->getModule();
+  assert(m);
+
+  // If we are in Raw SIL, just bail at this point. We do not support
+  // ownership fixups.
+  if (m->getStage() == SILStage::Raw)
+    return false;
+
+  // If our old ownership kind is ValueOwnershipKind::None and our new kind is
+  // not, we may need to do more work that has not been implemented yet. So
+  // bail.
+  //
+  // Due to our requirement that types line up, this can only occur given a
+  // non-trivial typed value with None ownership. This can only happen when
+  // oldValue is a trivial payloaded or no-payload non-trivially typed
+  // enum. That doesn't occur that often so we just bail on it today until we
+  // implement this functionality.
+  auto oldOwnershipKind = SILValue(oldValue).getOwnershipKind();
+  if (oldOwnershipKind != OwnershipKind::None)
+    return true;
+
+  // Ok, we have an old ownership kind that is OwnershipKind::None and a new
+  // ownership kind that is not OwnershipKind::None. In that case, for now, do
+  // not perform this transform.
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -477,7 +530,7 @@ static void rewriteReborrows(SILValue newBorrowedValue,
 }
 
 //===----------------------------------------------------------------------===//
-//                            Ownership Fixup RAUW
+//                OwnershipRAUWUtility - RAUW + fix ownership
 //===----------------------------------------------------------------------===//
 
 /// Given an old value and a new value, lifetime extend new value as appropriate
@@ -644,7 +697,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleGuaranteed() {
 SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
   assert(oldValue->getFunction()->hasOwnership());
   assert(
-      OwnershipRAUWHelper::canFixUpOwnershipForRAUW(oldValue, newValue) &&
+      canFixUpOwnershipForRAUW(oldValue, newValue) &&
       "Should have checked if can perform this operation before calling it?!");
   // If our new value is just none, we can pass anything to do it so just RAUW
   // and return.
@@ -684,65 +737,244 @@ SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
 }
 
 //===----------------------------------------------------------------------===//
-//                          Ownership Fixup Context
+//                     Interior Pointer Operand Rebasing
 //===----------------------------------------------------------------------===//
 
-// All callers of our RAUW routines must ensure that their values return true
-// from this.
-bool OwnershipRAUWHelper::canFixUpOwnershipForRAUW(SILValue oldValue,
-                                                     SILValue newValue) {
-  auto newOwnershipKind = newValue.getOwnershipKind();
+namespace {
 
-  // If our new kind is ValueOwnershipKind::None, then we are fine. We
-  // trivially support that. This check also ensures that we can always
-  // replace any value with a ValueOwnershipKind::None value.
-  if (newOwnershipKind == OwnershipKind::None)
-    return true;
+/// Clone all projections and casts on the access use-def chain until either the
+/// specified predicate is true or the access base is reached.
+///
+/// This will not clone ref_element_addr or ref_tail_addr because those aren't
+/// part of the access chain.
+class InteriorPointerAddressRebaseUseDefChainCloner
+    : public AccessUseDefChainVisitor<
+          InteriorPointerAddressRebaseUseDefChainCloner, SILValue> {
+  SILValue oldAddressValue;
+  SingleValueInstruction *oldIntPtr;
+  SingleValueInstruction *newIntPtr;
+  SILInstruction *insertPt;
 
-  // First check if oldValue is SILUndef. If it is, then we know that:
-  //
-  // 1. SILUndef (and thus oldValue) must have OwnershipKind::None.
-  // 2. newValue is not OwnershipKind::None due to our check above.
-  //
-  // Thus we know that we would be replacing a value with OwnershipKind::None
-  // with a value with non-None ownership. This is a case we don't support, so
-  // we can bail now.
-  if (isa<SILUndef>(oldValue))
-    return false;
+public:
+  InteriorPointerAddressRebaseUseDefChainCloner(
+      SILValue oldAddressValue, SingleValueInstruction *oldIntPtr,
+      SingleValueInstruction *newIntPtr, SILInstruction *insertPt)
+      : oldAddressValue(oldAddressValue), oldIntPtr(oldIntPtr),
+        newIntPtr(newIntPtr), insertPt(insertPt) {}
 
-  // Ok, we now know that we do not have SILUndef implying that we must be able
-  // to get a module from our value since we must have an argument or an
-  // instruction.
-  auto *m = oldValue->getModule();
-  assert(m);
+  // Recursive main entry point
+  SILValue cloneUseDefChain(SILValue currentOldAddr) {
+    // If we have finally hit oldIntPtr, we are done.
+    if (currentOldAddr == oldIntPtr)
+      return currentOldAddr;
+    return this->visit(currentOldAddr);
+  }
 
-  // If we are in Raw SIL, just bail at this point. We do not support
-  // ownership fixups.
-  if (m->getStage() == SILStage::Raw)
-    return false;
+  // Recursively clone an address on the use-def chain.
+  SingleValueInstruction *cloneProjection(SingleValueInstruction *projectedAddr,
+                                          Operand *sourceOper) {
+    SILValue sourceOperVal = sourceOper->get();
+    SILValue projectedSource = cloneUseDefChain(sourceOperVal);
+    // If we hit the end of our chain, then make newIntPtr the operand so that
+    // we have successfully rebased.
+    if (sourceOperVal == projectedSource)
+      projectedSource = newIntPtr;
+    SILInstruction *clone = projectedAddr->clone(insertPt);
+    clone->setOperand(sourceOper->getOperandNumber(), projectedSource);
+    return cast<SingleValueInstruction>(clone);
+  }
 
-  // If our old ownership kind is ValueOwnershipKind::None and our new kind is
-  // not, we may need to do more work that has not been implemented yet. So
-  // bail.
-  //
-  // Due to our requirement that types line up, this can only occur given a
-  // non-trivial typed value with None ownership. This can only happen when
-  // oldValue is a trivial payloaded or no-payload non-trivially typed
-  // enum. That doesn't occur that often so we just bail on it today until we
-  // implement this functionality.
-  auto oldOwnershipKind = SILValue(oldValue).getOwnershipKind();
-  if (oldOwnershipKind != OwnershipKind::None)
-    return true;
+  SILValue visitBase(SILValue base, AccessedStorage::Kind kind) {
+    assert(false && "access base cannot be cloned");
+    return SILValue();
+  }
 
-  // Ok, we have an old ownership kind that is OwnershipKind::None and a new
-  // ownership kind that is not OwnershipKind::None. In that case, for now, do
-  // not perform this transform.
-  return false;
+  SILValue visitNonAccess(SILValue base) {
+    assert(false && "unknown address root cannot be cloned");
+    return SILValue();
+  }
+
+  SILValue visitPhi(SILPhiArgument *phi) {
+    assert(false && "unexpected phi on access path");
+    return SILValue();
+  }
+
+  SILValue visitStorageCast(SingleValueInstruction *cast, Operand *sourceOper) {
+    assert(false && "unexpected storage cast on access path");
+    return SILValue();
+  }
+
+  SILValue visitAccessProjection(SingleValueInstruction *projectedAddr,
+                                 Operand *sourceOper) {
+    return cloneProjection(projectedAddr, sourceOper);
+  }
+};
+
+} // namespace
+
+/// \p oldAddressValue is an address rooted in \p oldIntPtr. Clone the use-def
+/// chain from \p oldAddressValue to \p oldIntPtr, but starting from \p
+/// newAddressValue.
+static SILValue cloneInteriorProjectionUseDefChain(
+    SILValue oldAddressValue, SingleValueInstruction *oldIntPtr,
+    SingleValueInstruction *newIntPtr, SILInstruction *insertPt) {
+  InteriorPointerAddressRebaseUseDefChainCloner cloner(
+      oldAddressValue, oldIntPtr, newIntPtr, insertPt);
+  return cloner.cloneUseDefChain(oldAddressValue);
 }
 
 SILBasicBlock::iterator
-OwnershipRAUWHelper::replaceAllUsesAndErase(SingleValueInstruction *oldValue,
-                                              SILValue newValue) {
-  OwnershipRAUWUtility utility{oldValue, newValue, ctx};
+OwnershipRAUWHelper::replaceAddressUses(SingleValueInstruction *oldValue,
+                                        SILValue newValue) {
+  assert(oldValue->getType().isAddress() &&
+         oldValue->getType() == newValue->getType());
+
+  // If we are replacing addresses, see if we need to handle interior pointer
+  // fixups. If we don't have any extra info, then we know that we can just RAUW
+  // without any further work.
+  if (!ctx->extraAddressFixupInfo.intPtrOp)
+    return replaceAllUsesAndErase(oldValue, newValue, ctx->callbacks);
+
+  // We are RAUWing two addresses and we found that:
+  //
+  // 1. newValue is an address associated with an interior pointer instruction.
+  // 2. oldValue has uses that are outside of newValue's borrow scope.
+  //
+  // So, we need to copy/borrow the base value of the interior pointer to
+  // lifetime extend the base value over the new uses. Then we clone the
+  // interior pointer instruction and change the clone to use our new borrowed
+  // value. Then we RAUW as appropriate.
+  OwnershipLifetimeExtender extender{*ctx};
+  auto &extraInfo = ctx->extraAddressFixupInfo;
+  auto intPtr = *extraInfo.intPtrOp;
+  BeginBorrowInst *bbi = extender.createPlusZeroBorrow(
+      intPtr->get(), llvm::makeArrayRef(extraInfo.allAddressUsesFromOldValue));
+  auto bbiNext = &*std::next(bbi->getIterator());
+  auto *newIntPtrUser =
+      cast<SingleValueInstruction>(intPtr->getUser()->clone(bbiNext));
+  ctx->callbacks.createdNewInst(newIntPtrUser);
+  newIntPtrUser->setOperand(0, bbi);
+
+  // Now that we have extended our lifetime as appropriate, we need to recreate
+  // the access path from newValue to intPtr but upon newIntPtr. Then we make it
+  // use newIntPtr.
+  auto *intPtrUser = cast<SingleValueInstruction>(intPtr->getUser());
+  SILValue initialAddr = cloneInteriorProjectionUseDefChain(
+      newValue /*address we originally wanted to replace*/,
+      intPtrUser /*the interior pointer of that value*/,
+      newIntPtrUser /*the interior pointer we need to recreate the chain upon*/,
+      oldValue /*insert point*/);
+
+  // If we got back newValue, then we need to set initialAddr to be int ptr
+  // user.
+  if (initialAddr == newValue)
+    initialAddr = newIntPtrUser;
+
+  // Now that we have an addr that is setup appropriately, RAUW!
+  return replaceAllUsesAndErase(oldValue, initialAddr, ctx->callbacks);
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoints
+//===----------------------------------------------------------------------===//
+
+OwnershipRAUWHelper::OwnershipRAUWHelper(OwnershipFixupContext &inputCtx,
+                                         SingleValueInstruction *inputOldValue,
+                                         SILValue inputNewValue)
+    : ctx(&inputCtx), oldValue(inputOldValue), newValue(inputNewValue) {
+  // If we are already not valid, just bail.
+  if (!isValid())
+    return;
+
+  // Otherwise, lets check if we can perform this RAUW operation. If we can't,
+  // set ctx to nullptr to invalidate the helper and return.
+  if (!canFixUpOwnershipForRAUW(oldValue, newValue)) {
+    ctx = nullptr;
+    return;
+  }
+
+  // If we have an object, at this point we are good to go so we can just
+  // return.
+  if (newValue->getType().isObject())
+    return;
+
+  // But if we have an address, we need to check if new value is from an
+  // interior pointer or not in a way that the pass understands. What we do is:
+  //
+  // 1. Compute the AccessPathWithBase of newValue. If we do not get back a
+  //    valid such object, invalidate and then bail.
+  //
+  // 2. Then we check if the base address is the result of an interior pointer
+  //    instruction. If we do not find one we bail.
+  //
+  // 3. Then grab the base value of the interior pointer operand. We only
+  //    support cases where we have a single BorrowedValue as our base. This is
+  //    a safe future proof assumption since one reborrows are on
+  //    structs/tuple/destructures, a guaranteed value will always be associated
+  //    with a single BorrowedValue, so this will never fail (and the code will
+  //    probably be DCEed).
+  //
+  // 4. Then we compute an AccessPathWithBase for oldValue and then find its
+  //    derived uses. If we fail, we bail.
+  //
+  // 5. At this point, we know that we can perform this RAUW. The only question
+  //    is if we need to when we RAUW copy the interior pointer base value. We
+  //    perform this check by making sure all of the old value's derived uses
+  //    are within our BorrowedValue's scope. If so, we clear the extra state we
+  //    were tracking (the interior pointer/oldValue's transitive uses), so we
+  //    perform just a normal RAUW (without inserting the copy) when we RAUW.
+  auto accessPathWithBase = AccessPathWithBase::compute(newValue);
+  if (!accessPathWithBase.base) {
+    // Invalidate!
+    ctx = nullptr;
+    return;
+  }
+
+  auto &intPtr = ctx->extraAddressFixupInfo.intPtrOp;
+  intPtr = InteriorPointerOperand::inferFromResult(accessPathWithBase.base);
+  if (!intPtr) {
+    // We can optimize! Do not invalidate!
+    return;
+  }
+
+  auto borrowedValue = intPtr.getSingleBaseValue();
+  if (!borrowedValue) {
+    // Invalidate!
+    ctx = nullptr;
+    return;
+  }
+
+  auto oldValueAccessPath = AccessPath::compute(oldValue);
+  auto &oldValueUses = ctx->extraAddressFixupInfo.allAddressUsesFromOldValue;
+  if (!oldValueAccessPath.collectUses(oldValueUses, AccessUseType::Inner,
+                                      intPtr->getParentFunction())) {
+    // Invalidate!
+    ctx = nullptr;
+    return;
+  }
+
+  // Ok, at this point we know that we can optimize. The only question is if we
+  // need to perform the copy or not when we actually RAUW. So perform the is
+  // within region check. If we succeed, clear our extra state so we perform a
+  // normal RAUW.
+  SmallVector<Operand *, 8> scratchSpace;
+  SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
+  if (borrowedValue.areUsesWithinScope(oldValueUses, scratchSpace,
+                                       visitedBlocks, ctx->deBlocks)) {
+    // We do not need to copy the base value! Clear the extra info we have.
+    ctx->extraAddressFixupInfo.clear();
+  }
+}
+
+SILBasicBlock::iterator OwnershipRAUWHelper::perform() {
+  assert(isValid() && "OwnershipRAUWHelper invalid?!");
+
+  // Make sure to always clear our context after we transform.
+  SWIFT_DEFER { ctx->clear(); };
+
+  if (oldValue->getType().isAddress())
+    return replaceAddressUses(oldValue, newValue);
+
+  OwnershipRAUWUtility utility{oldValue, newValue, *ctx};
   return utility.perform();
 }

--- a/test/SILOptimizer/ossa_rauw_tests.sil
+++ b/test/SILOptimizer/ossa_rauw_tests.sil
@@ -21,9 +21,18 @@ protocol Addable {
 
 // Class declarations
 
+struct NativeObjectWrapper {
+  var obj: Builtin.NativeObject
+}
+
+sil @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+
 class Klass {
   init()
   deinit
+
+  var field: Klass
+  var structField: NativeObjectWrapper
 }
 
 class SubKlass : Klass {}
@@ -666,4 +675,301 @@ bb3(%4 : @owned $FakeOptional<Klass>):
   destroy_value %4 : $FakeOptional<Klass>
   %9999 = tuple()
   return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_arg_not_int_ptr : $@convention(thin) (@in_guaranteed Klass) -> @owned Klass {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_arg_not_int_ptr'
+sil [ossa] @interior_pointer_lifetime_extension_arg_not_int_ptr : $@convention(thin) (@in_guaranteed Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = address_to_pointer %0 : $*Klass to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Klass
+  %3 = load [copy] %2 : $*Klass
+  return %3 : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_no_lifetime_ext_needed : $@convention(thin) (@owned Klass) -> @owned Klass {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_no_lifetime_ext_needed'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_no_lifetime_ext_needed : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  %0b = ref_element_addr %0a : $Klass, #Klass.field
+  %1 = address_to_pointer %0b : $*Klass to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Klass
+  %3 = load [copy] %2 : $*Klass
+  end_borrow %0a : $Klass
+  destroy_value %0 : $Klass
+  return %3 : $Klass
+}
+
+// In this case, we need to perform the interior pointer lifetime extension.
+//
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext : $@convention(thin) (@owned Klass) -> @owned Klass {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  %0b = ref_element_addr %0a : $Klass, #Klass.field
+  %1 = address_to_pointer %0b : $*Klass to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Klass
+  end_borrow %0a : $Klass
+  %3 = load [copy] %2 : $*Klass
+  destroy_value %0 : $Klass
+  return %3 : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  end_borrow %0a : $Klass
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// Make sure we inserted everything in the right places rather than using the
+// ownership verifier.
+//
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK: bb0([[ARG:%.*]] : @owned
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[NEW_INT_PTR:%.*]] = ref_element_addr [[BORROWED_ARG]]
+// CHECK-NEXT: br bb1
+//
+// CHECK: bb1:
+// CHECK-NEXT: br bb2
+//
+// CHECK: bb2:
+// CHECK-NEXT: [[NEW_GEP:%.*]] = struct_element_addr [[NEW_INT_PTR]]
+// CHECK-NEXT: br bb3
+//
+// CHECK: bb3:
+// CHECK-NEXT: br bb4
+//
+// CHECK: bb4:
+// CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[NEW_GEP]] :
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]]
+// CHECK-NEXT: destroy_value [[ARG]]
+// CHECK-NEXT: return [[RESULT]]
+// CHECK-NEXT: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_2'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bb3
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// Make sure we inserted everything in the right places rather than using the
+// ownership verifier given we can't eliminate the underlying RAUW.
+//
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK: bb0([[ARG:%.*]] : @owned
+// CHECK-NEXT: [[ORIGINAL_BORROW:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[COPIED_ARG:%.*]] = copy_value [[ORIGINAL_BORROW]]
+// CHECK-NEXT: [[BORROWED_COPIED_ARG:%.*]] = begin_borrow [[COPIED_ARG]]
+// CHECK-NEXT: [[NEW_INT_PTR:%.*]] = ref_element_addr [[BORROWED_COPIED_ARG]]
+// CHECK-NEXT: br bb1
+//
+// CHECK: bb1:
+// CHECK-NEXT: [[OLD_INT_PTR:%.*]] = ref_element_addr
+// CHECK-NEXT: [[OLD_GEP:%.*]] = struct_element_addr [[OLD_INT_PTR]]
+// CHECK-NEXT: br bb2
+//
+// CHECK: bb2:
+// CHECK-NEXT: // function_ref
+// CHECK-NEXT: [[USER:%.*]] = function_ref @
+// CHECK-NEXT: apply [[USER]]([[OLD_GEP]])
+// CHECK-NEXT: [[NEW_GEP:%.*]] = struct_element_addr [[NEW_INT_PTR]]
+// CHECK-NEXT: br bb3
+//
+// CHECK: bb3:
+// CHECK-NEXT: end_borrow [[ORIGINAL_BORROW]]
+// CHECK-NEXT: br bb4
+//
+// CHECK: bb4:
+// CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[NEW_GEP]]
+// CHECK-NEXT: end_borrow [[BORROWED_COPIED_ARG]]
+// CHECK-NEXT: destroy_value [[COPIED_ARG]]
+// CHECK-NEXT: destroy_value [[ARG]]
+// CHECK-NEXT: return [[RESULT]]
+// CHECK-NEXT: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_3'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bb3
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_1 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_1'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_1 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  br bbLoop
+
+bbLoop:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  cond_br undef, bbBackEdge, bb3
+
+bbBackEdge:
+  br bbLoop
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_2'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  br bbLoop
+
+bbLoop:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bbLoop2
+
+bbLoop2:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bbBackEdge, bb3
+
+bbBackEdge:
+  destroy_value %3 : $Builtin.NativeObject
+  br bbLoop
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_3'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  br bb2
+
+bb2:
+  br bbLoop(%0a : $Klass, undef : $Klass)
+
+bbLoop(%arg : @guaranteed $Klass, %base : @owned $Klass):
+  %0b = ref_element_addr %arg : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bbLoop2
+
+bbLoop2:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bbLoop3
+
+bbLoop3:
+  end_borrow %arg : $Klass
+  destroy_value %base : $Klass
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bbBackEdge, bb3
+
+bbBackEdge:
+  destroy_value %3 : $Builtin.NativeObject
+  br bbLoop(undef : $Klass, undef : $Klass)
+
+bb3:
+  br bb4
+
+bb4:
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
 }

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -semantic-arc-opts | %FileCheck %s
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
@@ -453,10 +453,10 @@ bb0(%0 : $Builtin.Int8, %1 : @guaranteed $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil [ossa] @a2p_p2a_test
-// XHECK: bb0([[ADR:%[0-9]+]] : $*Builtin.Word, [[RAWPTR:%[0-9]+]] : $Builtin.RawPointer):
-// XHECK-NEXT: load
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK: bb0([[ADR:%[0-9]+]] : $*Builtin.Word, [[RAWPTR:%[0-9]+]] : $Builtin.RawPointer):
+// CHECK-NEXT: load
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
 sil [ossa] @a2p_p2a_test : $@convention(thin) (@inout Builtin.Word, Builtin.RawPointer) -> (Builtin.Word, Builtin.RawPointer) {
 bb0(%0 : $*Builtin.Word, %1 : $Builtin.RawPointer):
   %2 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
@@ -1634,8 +1634,6 @@ bb0(%0 : $*E, %1 : @owned $E, %2 : $*B):
 
 // CHECK-LABEL: sil [ossa] @dont_form_upcast_when_casts_are_identity : $@convention(thin) (@inout E, @owned E, @inout E) -> @owned E {
 // CHECK: bb0
-// CHECK-NEXT: copy_value
-// CHECK-NEXT: destroy_value
 // CHECK-NEXT: load
 // CHECK-NEXT: store
 // CHECK-NEXT: return


### PR DESCRIPTION
Currently all of these places in the code base perform simplifyInstruction and
then a replaceAllSimplifiedUsesAndErase(...). This is a bad pattern since:

1. simplifyInstruction assumes its result will be passed to
   replaceAllSimplifiedUsesAndErase. So by leaving these as separate things, we
   allow for users to pointlessly make this mistake.

2. I am going to implement in a subsequent commit a utility that lifetime
   extends interior pointer bases when replacing an address with an interior
   pointer derived address. To do this efficiently, I want to reuse state I
   compute during simplifyInstruction during the actual RAUW meaning that if the
   two operations are split, that is difficult without extending the API. So by
   removing this, I can make the transform and eliminate mistakes at the same
   time.

IOW, this is just an NFC in preparation for other changes.