### PR TITLE
Use the Formal Access *Scope* of the Extended Nominal For Its Max Access

### DIFF
--- a/test/multifile/Inputs/conditional-conformance-catch22.swift
+++ b/test/multifile/Inputs/conditional-conformance-catch22.swift
@@ -1,0 +1,3 @@
+struct Catch22<Value>: Equatable where Value: Equatable {
+  var value: Value
+}

--- a/test/multifile/conditional-conformance.swift
+++ b/test/multifile/conditional-conformance.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/catch22.swiftmodule %S/Inputs/conditional-conformance-catch22.swift -module-name catch22 -enable-testing
+// RUN: %target-swift-frontend -typecheck %s -I %t
+
+@testable import catch22
+
+extension Catch22: Comparable where Value: Comparable {
+  public static func <(lhs: Catch22, rhs: Catch22) -> Bool { true }
+}


### PR DESCRIPTION
Formal access alone does not take into account @testable imports of
internal types. This prevented otherwise valid conditional conformances
of these types from compiling.

rdar://72875683