### PR TITLE
[docs] Tidy and document permissible conversions based on calling conventions

### DIFF
--- a/docs/DynamicCasting.md
+++ b/docs/DynamicCasting.md
@@ -299,6 +299,7 @@ Casting from a function type F1 to a function type F2 will succeed iff the follo
 * Corresponding arguments have identical types
 * The return types are identical
 * If F1 is a throwing function type, then F2 must be a throwing function type.  If F1 is not throwing, then F2 may be a throwing or non-throwing function type.
+* F1 and F2 have the same calling convention.
 
 Note that it is _not_ sufficient for argument and return types to be castable; they must actually be identical.
 

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -169,6 +169,45 @@ enum class SILFunctionTypeRepresentation : uint8_t {
   Closure,
 };
 
+/// Returns true if the function with this convention doesn't carry a context.
+constexpr bool
+isThinRepresentation(FunctionTypeRepresentation rep) {
+  switch (rep) {
+    case FunctionTypeRepresentation::Swift:
+    case FunctionTypeRepresentation::Block:
+      return false;
+    case FunctionTypeRepresentation::Thin:
+    case FunctionTypeRepresentation::CFunctionPointer:
+      return true;
+  }
+  llvm_unreachable("Unhandled FunctionTypeRepresentation in switch.");
+}
+
+/// Returns true if the function with this convention doesn't carry a context.
+constexpr bool
+isThinRepresentation(SILFunctionTypeRepresentation rep) {
+  switch (rep) {
+  case SILFunctionTypeRepresentation::Thick:
+  case SILFunctionTypeRepresentation::Block:
+    return false;
+  case SILFunctionTypeRepresentation::Thin:
+  case SILFunctionTypeRepresentation::Method:
+  case SILFunctionTypeRepresentation::ObjCMethod:
+  case SILFunctionTypeRepresentation::WitnessMethod:
+  case SILFunctionTypeRepresentation::CFunctionPointer:
+  case SILFunctionTypeRepresentation::Closure:
+    return true;
+  }
+  llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
+}
+
+/// Returns true if the function with this convention carries a context.
+template <typename Repr>
+constexpr bool
+isThickRepresentation(Repr repr) {
+  return !isThinRepresentation(repr);
+}
+
 constexpr SILFunctionTypeRepresentation
 convertRepresentation(FunctionTypeRepresentation rep) {
   switch (rep) {
@@ -350,19 +389,7 @@ public:
 
   /// True if the function representation carries context.
   constexpr bool hasContext() const {
-    switch (getSILRepresentation()) {
-    case SILFunctionTypeRepresentation::Thick:
-    case SILFunctionTypeRepresentation::Block:
-      return true;
-    case SILFunctionTypeRepresentation::Thin:
-    case SILFunctionTypeRepresentation::Method:
-    case SILFunctionTypeRepresentation::ObjCMethod:
-    case SILFunctionTypeRepresentation::WitnessMethod:
-    case SILFunctionTypeRepresentation::CFunctionPointer:
-    case SILFunctionTypeRepresentation::Closure:
-      return false;
-    }
-    llvm_unreachable("Unhandled SILFunctionTypeRepresentation in switch.");
+    return isThickRepresentation(getSILRepresentation());
   }
 
   // Note that we don't have setters. That is by design, use

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1590,6 +1590,10 @@ ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
   // C function pointers cannot capture anything from their context.
   auto captures = SGF.SGM.Types.getLoweredLocalCaptures(constant);
 
+  // Catch cases like:
+  //   func g(_ : @convention(c) () -> ()) {}
+  //   func q() { let z = 0; func r() { print(z) }; g(r); } // error
+  // (See also: [NOTE: diagnose-swift-to-c-convention-change])
   if (!captures.getCaptures().empty() ||
       captures.hasGenericParamCaptures() ||
       captures.hasDynamicSelfCapture() ||

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6013,6 +6013,11 @@ maybeDiagnoseUnsupportedFunctionConversion(ConstraintSystem &cs, Expr *expr,
     if (auto closure = dyn_cast<ClosureExpr>(semanticExpr))
       return;
 
+    // Diagnose cases like:
+    //   func f() { print(w) }; func g(_ : @convention(c) () -> ()) {}
+    //   let k = f; g(k) // error
+    //   func m() { let x = 0; g({ print(x) }) } // error
+    // (See also: [NOTE: diagnose-swift-to-c-convention-change])
     de.diagnose(expr->getLoc(),
                 diag::invalid_c_function_pointer_conversion_expr);
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1552,22 +1552,9 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
 static bool
 isSubtypeOf(FunctionTypeRepresentation potentialSubRepr,
             FunctionTypeRepresentation potentialSuperRepr) {
-  auto isThin = [](FunctionTypeRepresentation rep) {
-    return rep == FunctionTypeRepresentation::CFunctionPointer ||
-        rep == FunctionTypeRepresentation::Thin;
-  };
-  
-  // Allowing "thin" (c, thin) to "thin" conversions
-  if (isThin(potentialSubRepr) && isThin(potentialSuperRepr))
-    return true;
-  
-  // Allowing all to "thick" (swift, block) conversions
-  // "thin" (c, thin) to "thick" or "thick" to "thick"
-  if (potentialSuperRepr == FunctionTypeRepresentation::Swift ||
-      potentialSuperRepr == FunctionTypeRepresentation::Block)
-    return true;
-  
-  return potentialSubRepr == potentialSuperRepr;
+  return (potentialSubRepr == potentialSuperRepr)
+       || isThinRepresentation(potentialSubRepr)
+       || isThickRepresentation(potentialSuperRepr);
 }
 
 /// Returns true if `constraint rep1 rep2` is satisfied.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1558,8 +1558,7 @@ isConversionAllowedBetween(FunctionTypeRepresentation rep1,
   return rep1 == rep2;
 }
 
-// Returns 'false' (i.e. no error) if it is legal to match functions with the
-// corresponding function type representations and the given match kind.
+/// Returns true if `constraint rep1 rep2` is satisfied.
 static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
                                          FunctionTypeRepresentation rep2,
                                          ConstraintKind kind,
@@ -1569,16 +1568,14 @@ static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
   case ConstraintKind::BindParam:
   case ConstraintKind::BindToPointerType:
   case ConstraintKind::Equal:
-    return rep1 != rep2;
+    return rep1 == rep2;
       
   case ConstraintKind::Subtype: {
     auto last = locator.last();
     if (!(last && last->is<LocatorPathElt::FunctionArgument>()))
-      return false;
-    
-    // Inverting the result because matchFunctionRepresentations
-    // returns false in conversions are allowed.
-    return !isConversionAllowedBetween(rep1, rep2);
+      return true;
+
+    return isConversionAllowedBetween(rep1, rep2);
   }
 
   case ConstraintKind::OpaqueUnderlyingType:
@@ -1609,7 +1606,7 @@ static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
-    return false;
+    return true;
   }
 
   llvm_unreachable("Unhandled ConstraintKind in switch.");
@@ -1902,9 +1899,9 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       return getTypeMatchFailure(locator);
   }
 
-  if (matchFunctionRepresentations(func1->getExtInfo().getRepresentation(),
-                                   func2->getExtInfo().getRepresentation(),
-                                   kind, locator)) {
+  if (!matchFunctionRepresentations(func1->getExtInfo().getRepresentation(),
+                                    func2->getExtInfo().getRepresentation(),
+                                    kind, locator)) {
     return getTypeMatchFailure(locator);
   }
 


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-14051 and matching rdar://73250604.

Also, I filed https://bugs.swift.org/browse/SR-14058 recently for the difference between the compiler and the runtime, so I figured it is worth updating `DynamicCasting.md` to reflect this.