### PR TITLE
[ownership] Implement Interior Pointer handling API for RAUWing addresses

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -27,6 +27,10 @@ SILValue getUnderlyingObject(SILValue V);
 
 SILValue getUnderlyingObjectStopAtMarkDependence(SILValue V);
 
+/// Given an address look through address to address projections and indexing
+/// insts.
+SILValue getUnderlyingObjectStoppingAtObjectToAddrProjections(SILValue v);
+
 SILValue stripSinglePredecessorArgs(SILValue V);
 
 /// Return the underlying SILValue after stripping off all casts from the
@@ -55,7 +59,13 @@ SILValue stripClassCasts(SILValue V);
 
 /// Return the underlying SILValue after stripping off all address projection
 /// instructions.
+///
+/// FIXME: Today address projections are referring to the result of the
+/// projection and doesn't consider the operand. Should we change this?
 SILValue stripAddressProjections(SILValue V);
+
+/// Look through any projections that transform an address -> an address.
+SILValue lookThroughAddressToAddressProjections(SILValue v);
 
 /// Return the underlying SILValue after stripping off all aggregate projection
 /// instructions.

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -669,7 +669,17 @@ struct InteriorPointerOperand {
   /// requirements to ensure that the underlying class is alive at all use
   /// points.
   bool getImplicitUses(SmallVectorImpl<Operand *> &foundUses,
-                       std::function<void(Operand *)> *onError = nullptr);
+                       std::function<void(Operand *)> *onError = nullptr) {
+    return getImplicitUsesForAddress(getProjectedAddress(), foundUses, onError);
+  }
+
+  /// The algorithm that is used to determine what the verifier will consider to
+  /// be implicit uses of the given address. Used to implement \see
+  /// getImplicitUses.
+  static bool
+  getImplicitUsesForAddress(SILValue address,
+                            SmallVectorImpl<Operand *> &foundUses,
+                            std::function<void(Operand *)> *onError = nullptr);
 
   Operand *operator->() { return operand; }
   const Operand *operator->() const { return operand; }

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -391,6 +391,10 @@ public:
     }
   }
 
+  static bool isAddressToAddressProjection(SILValue v) {
+    return isAddressProjection(v) && !isObjectToAddressProjection(v);
+  }
+
   /// Returns true if this instruction projects from an object type into an
   /// address subtype.
   static bool isObjectToAddressProjection(SILValue V) {

--- a/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
+++ b/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
@@ -45,6 +45,8 @@ replaceAllSimplifiedUsesAndErase(SILInstruction *I, SILValue result,
 ///
 /// NOTE: When OSSA is enabled this API assumes OSSA is properly formed and will
 /// insert compensating instructions.
+/// NOTE: When \p I is in an OSSA function, this fails to optimize if \p
+/// deadEndBlocks is null.
 SILBasicBlock::iterator simplifyAndReplaceAllSimplifiedUsesAndErase(
     SILInstruction *I, InstModCallbacks &callbacks,
     DeadEndBlocks *deadEndBlocks = nullptr);

--- a/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
+++ b/include/swift/SILOptimizer/Analysis/SimplifyInstruction.h
@@ -27,23 +27,9 @@ namespace swift {
 class SILInstruction;
 class InstModCallbacks;
 
-/// Try to simplify the specified instruction, performing local
-/// analysis of the operands of the instruction, without looking at its uses
-/// (e.g. constant folding).  If a simpler result can be found, it is
-/// returned, otherwise a null SILValue is returned.
-///
-/// This is assumed to implement read-none transformations.
-SILValue simplifyInstruction(SILInstruction *I);
-
 /// Replace an instruction with a simplified result and erase it. If the
 /// instruction initiates a scope, do not replace the end of its scope; it will
 /// be deleted along with its parent.
-///
-/// If it is nonnull, eraseNotify will be called before each instruction is
-/// deleted.
-///
-/// If it is nonnull and inst is in OSSA, newInstNotify will be called with each
-/// new instruction inserted to compensate for ownership.
 ///
 /// NOTE: When OSSA is enabled this API assumes OSSA is properly formed and will
 /// insert compensating instructions.
@@ -51,6 +37,17 @@ SILBasicBlock::iterator
 replaceAllSimplifiedUsesAndErase(SILInstruction *I, SILValue result,
                                  InstModCallbacks &callbacks,
                                  DeadEndBlocks *deadEndBlocks = nullptr);
+
+/// Attempt to map \p inst to a simplified result. Upon success, replace \p inst
+/// with this simplified result and erase \p inst. If the instruction initiates
+/// a scope, do not replace the end of its scope; it will be deleted along with
+/// its parent.
+///
+/// NOTE: When OSSA is enabled this API assumes OSSA is properly formed and will
+/// insert compensating instructions.
+SILBasicBlock::iterator simplifyAndReplaceAllSimplifiedUsesAndErase(
+    SILInstruction *I, InstModCallbacks &callbacks,
+    DeadEndBlocks *deadEndBlocks = nullptr);
 
 // Simplify invocations of builtin operations that may overflow.
 /// All such operations return a tuple (result, overflow_flag).

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -399,6 +399,10 @@ public:
   }
 
   bool hadCallbackInvocation() const { return wereAnyCallbacksInvoked; }
+
+  /// Set \p wereAnyCallbacksInvoked to false. Useful if one wants to reuse an
+  /// InstModCallback in between iterations.
+  void resetHadCallbackInvocation() { wereAnyCallbacksInvoked = false; }
 };
 
 /// Get all consumed arguments of a partial_apply.

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -38,18 +38,44 @@ struct OwnershipFixupContext {
   DeadEndBlocks &deBlocks;
   JointPostDominanceSetComputer &jointPostDomSetComputer;
 
-  OwnershipFixupContext(InstModCallbacks &callbacks, DeadEndBlocks &deBlocks,
-                        JointPostDominanceSetComputer &inputJPDComputer)
-      : inlineCallbacks(), callbacks(callbacks), deBlocks(deBlocks),
-        jointPostDomSetComputer(inputJPDComputer) {}
+  /// Extra state initialized by OwnershipRAUWFixupHelper::get() that we use
+  /// when RAUWing addresses. This ensures we do not need to recompute this
+  /// state when we perform the actual RAUW.
+  struct AddressFixupContext {
+    /// When determining if we need to perform an address pointer fixup, we
+    /// compute all transitive address uses of oldValue. If we find that we do
+    /// need this fixed up, then we will copy our interior pointer base value
+    /// and use this to seed that new lifetime.
+    SmallVector<Operand *, 8> allAddressUsesFromOldValue;
 
-  OwnershipFixupContext(DeadEndBlocks &deBlocks,
-                        JointPostDominanceSetComputer &inputJPDComputer)
-      : inlineCallbacks(InstModCallbacks()), callbacks(*inlineCallbacks),
-        deBlocks(deBlocks), jointPostDomSetComputer(inputJPDComputer) {}
+    /// This is the interior pointer operand that the new value we want to RAUW
+    /// is transitively derived from and enables us to know the underlying
+    /// borrowed base value that we need to lifetime extend.
+    InteriorPointerOperand intPtrOp;
+
+    void clear() {
+      allAddressUsesFromOldValue.clear();
+      intPtrOp = InteriorPointerOperand();
+    }
+  };
+  AddressFixupContext extraAddressFixupInfo;
+
+  OwnershipFixupContext(InstModCallbacks &callbacks, DeadEndBlocks &deBlocks,
+                        JointPostDominanceSetComputer &jointPostDomSetComputer)
+      : callbacks(callbacks), deBlocks(deBlocks),
+        jointPostDomSetComputer(jointPostDomSetComputer) {}
 
   void clear() {
     jointPostDomSetComputer.clear();
+    extraAddressFixupInfo.allAddressUsesFromOldValue.clear();
+    extraAddressFixupInfo.intPtrOp = InteriorPointerOperand();
+  }
+
+private:
+  /// Helper method called to determine if we discovered we needed interior
+  /// pointer fixups while simplifying.
+  bool needsInteriorPointerFixups() const {
+    return bool(extraAddressFixupInfo.intPtrOp);
   }
 };
 
@@ -57,20 +83,44 @@ struct OwnershipFixupContext {
 /// value or a single value instruction with a new value and then fixup
 /// ownership invariants afterwards.
 class OwnershipRAUWHelper {
-  OwnershipFixupContext &ctx;
+  OwnershipFixupContext *ctx;
+  SingleValueInstruction *oldValue;
+  SILValue newValue;
 
 public:
-  OwnershipRAUWHelper(OwnershipFixupContext &ctx) : ctx(ctx) {}
+  OwnershipRAUWHelper() : ctx(nullptr), oldValue(nullptr), newValue(nullptr) {}
 
-  SILBasicBlock::iterator
-  replaceAllUsesAndErase(SingleValueInstruction *oldValue, SILValue newValue);
-
-  /// We can not RAUW all old values with new values.
+  /// Return an instance of this class if we can perform the specific RAUW
+  /// operation ignoring if the types line up. Returns None otherwise.
   ///
-  /// Namely, we do not support RAUWing values with ValueOwnershipKind::None
-  /// that have uses that do not require ValueOwnershipKind::None or
-  /// ValueOwnershipKind::Any.
-  static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue);
+  /// DISCUSSION: We do not check that the types line up here so that we can
+  /// allow for our users to transform our new value in ways that preserve
+  /// ownership at \p oldValue before we perform the actual RAUW. If \p newValue
+  /// is an object, any instructions in the chain of transforming instructions
+  /// from \p newValue at \p oldValue's must be forwarding. If \p newValue is an
+  /// address, then these transforms can only transform the address into a
+  /// derived address.
+  OwnershipRAUWHelper(OwnershipFixupContext &ctx,
+                      SingleValueInstruction *oldValue, SILValue newValue);
+
+  /// Returns true if this helper was initialized into a valid state.
+  operator bool() const { return isValid(); }
+  bool isValid() const { return bool(ctx) && bool(oldValue) && bool(newValue); }
+
+  /// Perform the actual RAUW. We require that \p newValue and \p oldValue have
+  /// the same type at this point (in contrast to when calling
+  /// OwnershipRAUWFixupHelper::get()).
+  ///
+  /// This is so that we can avoid creating "forwarding" transformation
+  /// instructions before we know if we can perform the RAUW. Any such
+  /// "forwarding" transformation must be performed upon \p newValue at \p
+  /// oldValue's insertion point so that we can then here RAUW the transformed
+  /// \p newValue.
+  SILBasicBlock::iterator perform();
+
+private:
+  SILBasicBlock::iterator replaceAddressUses(SingleValueInstruction *oldValue,
+                                             SILValue newValue);
 };
 
 } // namespace swift

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -520,10 +520,9 @@ bool BorrowedValue::visitInteriorPointerOperands(
 //                           InteriorPointerOperand
 //===----------------------------------------------------------------------===//
 
-bool InteriorPointerOperand::getImplicitUses(
-    SmallVectorImpl<Operand *> &foundUses,
+bool InteriorPointerOperand::getImplicitUsesForAddress(
+    SILValue projectedAddress, SmallVectorImpl<Operand *> &foundUses,
     std::function<void(Operand *)> *onError) {
-  SILValue projectedAddress = getProjectedAddress();
   SmallVector<Operand *, 8> worklist(projectedAddress->getUses());
 
   bool foundError = false;

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -300,14 +300,6 @@ SILValue InstSimplifier::visitAddressToPointerInst(AddressToPointerInst *ATPI) {
 }
 
 SILValue InstSimplifier::visitPointerToAddressInst(PointerToAddressInst *PTAI) {
-  // (pointer_to_address strict (address_to_pointer x)) -> x
-  //
-  // NOTE: We can not perform this optimization in OSSA without dealing with
-  // interior pointers since we may be escaping an interior pointer address from
-  // a borrow scope.
-  if (PTAI->getFunction()->hasOwnership())
-    return SILValue();
-
   // If this address is not strict, then it cannot be replaced by an address
   // that may be strict.
   if (auto *ATPI = dyn_cast<AddressToPointerInst>(PTAI->getOperand()))

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -793,6 +793,11 @@ SILBasicBlock::iterator swift::simplifyAndReplaceAllSimplifiedUsesAndErase(
   if (!svi->getFunction()->hasOwnership())
     return replaceAllUsesAndErase(svi, result, callbacks);
 
+  // If we weren't passed a dead end blocks, we can't optimize without ownership
+  // enabled.
+  if (!deadEndBlocks)
+    return next;
+
   JointPostDominanceSetComputer computer(*deadEndBlocks);
   OwnershipFixupContext ctx{callbacks, *deadEndBlocks, computer};
   OwnershipRAUWHelper helper(ctx, svi, result);

--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -755,7 +755,8 @@ swift::replaceAllSimplifiedUsesAndErase(SILInstruction *i, SILValue result,
   if (svi->getFunction()->hasOwnership()) {
     JointPostDominanceSetComputer computer(*deadEndBlocks);
     OwnershipFixupContext ctx{callbacks, *deadEndBlocks, computer};
-    return ctx.replaceAllUsesAndErase(svi, result);
+    OwnershipRAUWHelper helper(ctx);
+    return helper.replaceAllUsesAndErase(svi, result);
   }
   return replaceAllUsesAndErase(svi, result, callbacks);
 }
@@ -790,7 +791,7 @@ static SILValue simplifyInstruction(SILInstruction *i) {
   // this code is not updated at this point in time.
   auto *svi = cast<SingleValueInstruction>(i);
   if (svi->getFunction()->hasOwnership())
-    if (!OwnershipFixupContext::canFixUpOwnershipForRAUW(svi, result))
+    if (!OwnershipRAUWHelper::canFixUpOwnershipForRAUW(svi, result))
       return SILValue();
 
   return result;
@@ -813,7 +814,8 @@ SILBasicBlock::iterator swift::simplifyAndReplaceAllSimplifiedUsesAndErase(
   if (svi->getFunction()->hasOwnership()) {
     JointPostDominanceSetComputer computer(*deadEndBlocks);
     OwnershipFixupContext ctx{callbacks, *deadEndBlocks, computer};
-    return ctx.replaceAllUsesAndErase(svi, result);
+    OwnershipRAUWHelper helper(ctx);
+    return helper.replaceAllUsesAndErase(svi, result);
   }
   return replaceAllUsesAndErase(svi, result, callbacks);
 }

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -482,6 +482,7 @@ static bool stripOwnership(SILFunction &func) {
     InstModCallbacks callbacks([&](SILInstruction *instToErase) {
       visitor.eraseInstruction(instToErase);
     });
+    // We are no longer in OSSA, so we don't need to pass in a deBlocks.
     simplifyAndReplaceAllSimplifiedUsesAndErase(*value, callbacks);
     madeChange |= callbacks.hadCallbackInvocation();
   }

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -479,13 +479,11 @@ static bool stripOwnership(SILFunction &func) {
     auto value = visitor.instructionsToSimplify.pop_back_val();
     if (!value.hasValue())
       continue;
-    if (SILValue newValue = simplifyInstruction(*value)) {
-      InstModCallbacks callbacks([&](SILInstruction *instToErase) {
-        visitor.eraseInstruction(instToErase);
-      });
-      replaceAllSimplifiedUsesAndErase(*value, newValue, callbacks);
-      madeChange = true;
-    }
+    InstModCallbacks callbacks([&](SILInstruction *instToErase) {
+      visitor.eraseInstruction(instToErase);
+    });
+    simplifyAndReplaceAllSimplifiedUsesAndErase(*value, callbacks);
+    madeChange |= callbacks.hadCallbackInvocation();
   }
 
   return madeChange;

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -96,11 +96,8 @@ class SILCombiner :
   /// post-dominating blocks to a full jointly post-dominating set.
   JointPostDominanceSetComputer jPostDomComputer;
 
-  /// A utility that we use to perform erase+RAUW that fixes up ownership for us
-  /// afterwards by lifetime extending/copy values as appropriate. We rely on
-  /// later optimizations to chew through this traffic. This ensures we can use
-  /// one code base for both OSSA and non-OSSA.
-  OwnershipFixupContext ownershipRAUWHelper;
+  /// External context struct used by \see ownershipRAUWHelper.
+  OwnershipFixupContext ownershipFixupContext;
 
 public:
   SILCombiner(SILOptFunctionBuilder &FuncBuilder, SILBuilder &B,
@@ -134,7 +131,7 @@ public:
               Worklist.add(use->getUser());
             }),
         deBlocks(&B.getFunction()), jPostDomComputer(deBlocks),
-        ownershipRAUWHelper(instModCallbacks, deBlocks, jPostDomComputer) {}
+        ownershipFixupContext(instModCallbacks, deBlocks, jPostDomComputer) {}
 
   bool runOnFunction(SILFunction &F);
 

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -756,9 +756,7 @@ void TempRValueOptPass::run() {
     // Simplify any access scope markers that were only used by the dead
     // copy_addr and other potentially unused addresses.
     if (srcInst) {
-      if (SILValue result = simplifyInstruction(srcInst)) {
-        replaceAllSimplifiedUsesAndErase(srcInst, result, callbacks);
-      }
+      simplifyAndReplaceAllSimplifiedUsesAndErase(srcInst, callbacks);
     }
   }
   if (changed) {

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -17,7 +17,9 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-temp-rvalue-opt"
+
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
@@ -749,6 +751,7 @@ void TempRValueOptPass::run() {
 #endif
   };
 
+  DeadEndBlocks deBlocks(getFunction());
   for (auto *deadCopy : deadCopies) {
     assert(changed);
     auto *srcInst = deadCopy->getSrc()->getDefiningInstruction();
@@ -756,7 +759,7 @@ void TempRValueOptPass::run() {
     // Simplify any access scope markers that were only used by the dead
     // copy_addr and other potentially unused addresses.
     if (srcInst) {
-      simplifyAndReplaceAllSimplifiedUsesAndErase(srcInst, callbacks);
+      simplifyAndReplaceAllSimplifiedUsesAndErase(srcInst, callbacks, &deBlocks);
     }
   }
   if (changed) {

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1458,12 +1458,9 @@ bool swift::simplifyUsers(SingleValueInstruction *inst) {
     if (!svi)
       continue;
 
-    SILValue S = simplifyInstruction(svi);
-    if (!S)
-      continue;
-
-    replaceAllSimplifiedUsesAndErase(svi, S, callbacks);
-    changed = true;
+    callbacks.resetHadCallbackInvocation();
+    simplifyAndReplaceAllSimplifiedUsesAndErase(svi, callbacks);
+    changed |= callbacks.hadCallbackInvocation();
   }
 
   return changed;

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -644,7 +644,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleGuaranteed() {
 SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
   assert(oldValue->getFunction()->hasOwnership());
   assert(
-      OwnershipFixupContext::canFixUpOwnershipForRAUW(oldValue, newValue) &&
+      OwnershipRAUWHelper::canFixUpOwnershipForRAUW(oldValue, newValue) &&
       "Should have checked if can perform this operation before calling it?!");
   // If our new value is just none, we can pass anything to do it so just RAUW
   // and return.
@@ -689,7 +689,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::perform() {
 
 // All callers of our RAUW routines must ensure that their values return true
 // from this.
-bool OwnershipFixupContext::canFixUpOwnershipForRAUW(SILValue oldValue,
+bool OwnershipRAUWHelper::canFixUpOwnershipForRAUW(SILValue oldValue,
                                                      SILValue newValue) {
   auto newOwnershipKind = newValue.getOwnershipKind();
 
@@ -741,8 +741,8 @@ bool OwnershipFixupContext::canFixUpOwnershipForRAUW(SILValue oldValue,
 }
 
 SILBasicBlock::iterator
-OwnershipFixupContext::replaceAllUsesAndErase(SingleValueInstruction *oldValue,
+OwnershipRAUWHelper::replaceAllUsesAndErase(SingleValueInstruction *oldValue,
                                               SILValue newValue) {
-  OwnershipRAUWUtility utility{oldValue, newValue, *this};
+  OwnershipRAUWUtility utility{oldValue, newValue, ctx};
   return utility.perform();
 }

--- a/test/SILOptimizer/ossa_rauw_tests.sil
+++ b/test/SILOptimizer/ossa_rauw_tests.sil
@@ -21,9 +21,18 @@ protocol Addable {
 
 // Class declarations
 
+struct NativeObjectWrapper {
+  var obj: Builtin.NativeObject
+}
+
+sil @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+
 class Klass {
   init()
   deinit
+
+  var field: Klass
+  var structField: NativeObjectWrapper
 }
 
 class SubKlass : Klass {}
@@ -666,4 +675,301 @@ bb3(%4 : @owned $FakeOptional<Klass>):
   destroy_value %4 : $FakeOptional<Klass>
   %9999 = tuple()
   return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_arg_not_int_ptr : $@convention(thin) (@in_guaranteed Klass) -> @owned Klass {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_arg_not_int_ptr'
+sil [ossa] @interior_pointer_lifetime_extension_arg_not_int_ptr : $@convention(thin) (@in_guaranteed Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = address_to_pointer %0 : $*Klass to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Klass
+  %3 = load [copy] %2 : $*Klass
+  return %3 : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_no_lifetime_ext_needed : $@convention(thin) (@owned Klass) -> @owned Klass {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_no_lifetime_ext_needed'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_no_lifetime_ext_needed : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  %0b = ref_element_addr %0a : $Klass, #Klass.field
+  %1 = address_to_pointer %0b : $*Klass to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Klass
+  %3 = load [copy] %2 : $*Klass
+  end_borrow %0a : $Klass
+  destroy_value %0 : $Klass
+  return %3 : $Klass
+}
+
+// In this case, we need to perform the interior pointer lifetime extension.
+//
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext : $@convention(thin) (@owned Klass) -> @owned Klass {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  %0b = ref_element_addr %0a : $Klass, #Klass.field
+  %1 = address_to_pointer %0b : $*Klass to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Klass
+  end_borrow %0a : $Klass
+  %3 = load [copy] %2 : $*Klass
+  destroy_value %0 : $Klass
+  return %3 : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  end_borrow %0a : $Klass
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// Make sure we inserted everything in the right places rather than using the
+// ownership verifier.
+//
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK: bb0([[ARG:%.*]] : @owned
+// CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[NEW_INT_PTR:%.*]] = ref_element_addr [[BORROWED_ARG]]
+// CHECK-NEXT: br bb1
+//
+// CHECK: bb1:
+// CHECK-NEXT: br bb2
+//
+// CHECK: bb2:
+// CHECK-NEXT: [[NEW_GEP:%.*]] = struct_element_addr [[NEW_INT_PTR]]
+// CHECK-NEXT: br bb3
+//
+// CHECK: bb3:
+// CHECK-NEXT: br bb4
+//
+// CHECK: bb4:
+// CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[NEW_GEP]] :
+// CHECK-NEXT: end_borrow [[BORROWED_ARG]]
+// CHECK-NEXT: destroy_value [[ARG]]
+// CHECK-NEXT: return [[RESULT]]
+// CHECK-NEXT: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_2'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bb3
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// Make sure we inserted everything in the right places rather than using the
+// ownership verifier given we can't eliminate the underlying RAUW.
+//
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK: bb0([[ARG:%.*]] : @owned
+// CHECK-NEXT: [[ORIGINAL_BORROW:%.*]] = begin_borrow [[ARG]]
+// CHECK-NEXT: [[COPIED_ARG:%.*]] = copy_value [[ORIGINAL_BORROW]]
+// CHECK-NEXT: [[BORROWED_COPIED_ARG:%.*]] = begin_borrow [[COPIED_ARG]]
+// CHECK-NEXT: [[NEW_INT_PTR:%.*]] = ref_element_addr [[BORROWED_COPIED_ARG]]
+// CHECK-NEXT: br bb1
+//
+// CHECK: bb1:
+// CHECK-NEXT: [[OLD_INT_PTR:%.*]] = ref_element_addr
+// CHECK-NEXT: [[OLD_GEP:%.*]] = struct_element_addr [[OLD_INT_PTR]]
+// CHECK-NEXT: br bb2
+//
+// CHECK: bb2:
+// CHECK-NEXT: // function_ref
+// CHECK-NEXT: [[USER:%.*]] = function_ref @
+// CHECK-NEXT: apply [[USER]]([[OLD_GEP]])
+// CHECK-NEXT: [[NEW_GEP:%.*]] = struct_element_addr [[NEW_INT_PTR]]
+// CHECK-NEXT: br bb3
+//
+// CHECK: bb3:
+// CHECK-NEXT: end_borrow [[ORIGINAL_BORROW]]
+// CHECK-NEXT: br bb4
+//
+// CHECK: bb4:
+// CHECK-NEXT: [[RESULT:%.*]] = load [copy] [[NEW_GEP]]
+// CHECK-NEXT: end_borrow [[BORROWED_COPIED_ARG]]
+// CHECK-NEXT: destroy_value [[COPIED_ARG]]
+// CHECK-NEXT: destroy_value [[ARG]]
+// CHECK-NEXT: return [[RESULT]]
+// CHECK-NEXT: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_3'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_with_proj_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bb3
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_1 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_1'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_1 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  br bbLoop
+
+bbLoop:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  cond_br undef, bbBackEdge, bb3
+
+bbBackEdge:
+  br bbLoop
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_2'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  %0b = ref_element_addr %0a : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bb2
+
+bb2:
+  br bbLoop
+
+bbLoop:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bbLoop2
+
+bbLoop2:
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bbBackEdge, bb3
+
+bbBackEdge:
+  destroy_value %3 : $Builtin.NativeObject
+  br bbLoop
+
+bb3:
+  end_borrow %0a : $Klass
+  br bb4
+
+bb4:
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
+}
+
+// CHECK-LABEL: sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_3'
+sil [ossa] @interior_pointer_lifetime_extension_int_ptr_need_lifetime_ext_loop_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Klass):
+  %0a = begin_borrow %0 : $Klass
+  br bb1
+
+bb1:
+  br bb2
+
+bb2:
+  br bbLoop(%0a : $Klass, undef : $Klass)
+
+bbLoop(%arg : @guaranteed $Klass, %base : @owned $Klass):
+  %0b = ref_element_addr %arg : $Klass, #Klass.structField
+  %0c = struct_element_addr %0b : $*NativeObjectWrapper, #NativeObjectWrapper.obj
+  br bbLoop2
+
+bbLoop2:
+  %f = function_ref @inguaranteed_nativeobject_user : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%0c) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  %1 = address_to_pointer %0c : $*Builtin.NativeObject to $Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  br bbLoop3
+
+bbLoop3:
+  end_borrow %arg : $Klass
+  destroy_value %base : $Klass
+  %3 = load [copy] %2 : $*Builtin.NativeObject
+  cond_br undef, bbBackEdge, bb3
+
+bbBackEdge:
+  destroy_value %3 : $Builtin.NativeObject
+  br bbLoop(undef : $Klass, undef : $Klass)
+
+bb3:
+  br bb4
+
+bb4:
+  destroy_value %0 : $Klass
+  return %3 : $Builtin.NativeObject
 }

--- a/test/SILOptimizer/ossa_rauw_tests.sil
+++ b/test/SILOptimizer/ossa_rauw_tests.sil
@@ -973,3 +973,23 @@ bb4:
   destroy_value %0 : $Klass
   return %3 : $Builtin.NativeObject
 }
+
+// Make sure that we always RAUW if our new value address is from a
+// pointer_to_address since we don't track interior pointers that escape through
+// address_to_pointer.
+//
+// CHECK-LABEL: sil [ossa] @interior_pointer_no_base_new_value : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> @owned Builtin.NativeObject {
+// CHECK: pointer_to_address
+// CHECK-NOT: address_to_pointer
+// CHECK-NOT: pointer_to_address
+// CHECK: } // end sil function 'interior_pointer_no_base_new_value'
+sil [ossa] @interior_pointer_no_base_new_value : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> @owned Builtin.NativeObject {
+bb0(%0 : $Builtin.RawPointer, %count : $Builtin.Word):
+  %0a = index_raw_pointer %0 : $Builtin.RawPointer, %count : $Builtin.Word
+  %2 = pointer_to_address %0a : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  %3 = index_addr %2 : $*Builtin.NativeObject, %count : $Builtin.Word
+  %4 = address_to_pointer %3 : $*Builtin.NativeObject to $Builtin.RawPointer
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
+  %6 = load [copy] %5 : $*Builtin.NativeObject
+  return %6 : $Builtin.NativeObject
+}

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -453,10 +453,10 @@ bb0(%0 : $Builtin.Int8, %1 : @guaranteed $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil [ossa] @a2p_p2a_test
-// XHECK: bb0([[ADR:%[0-9]+]] : $*Builtin.Word, [[RAWPTR:%[0-9]+]] : $Builtin.RawPointer):
-// XHECK-NEXT: load
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK: bb0([[ADR:%[0-9]+]] : $*Builtin.Word, [[RAWPTR:%[0-9]+]] : $Builtin.RawPointer):
+// CHECK-NEXT: load
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
 sil [ossa] @a2p_p2a_test : $@convention(thin) (@inout Builtin.Word, Builtin.RawPointer) -> (Builtin.Word, Builtin.RawPointer) {
 bb0(%0 : $*Builtin.Word, %1 : $Builtin.RawPointer):
   %2 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer


### PR DESCRIPTION
This PR contains 4 commits all in service of one goal: allowing us to eliminate address_to_pointer, pointer_to_address round trips. This is an important problem to solve since the stdlib uses this pattern to reinterpret cast addresses that point into COW containers. Our emission strategy of small scopes generally makes it so that when we get the underlying address, we create a borrow scope, then address_to_pointer a pointer derived from a ref_element_addr. Later we then cast the pointer to the new address type and then use it for whatever purpose the author intended.

It is important that we be able to convert these to addresses for memory promotion/alias analysis/etc on the stdlib, so this PR introduces a new utility that if necessary will extend the lifetime of the base value that the interior pointer operand is derived from and produce a new access path into the base value that is valid over all uses of the new value. Later passes (CopyPropagation/SemanticARCOpts) will then clean up the ARC and intervening passes can now actually use these addresses without being stymied by the escaping nature of pointer_to_address.

----

Now in terms of the 4 commits themselves, lets go through each:

1. The first is hiding simplifyInstruction and changing all callers of it to use a simplifyAndReplace variant instead. Already there was a hidden assumption that simplifyInstruction's result would be passed to replaceAllUsesAndErase, this just eliminates that bug. It also prepares the 
2. OwnershipFixupContext has grown a bit and I want to convert it back to a more context struct that various utilities use. So, I extracted the RAUW methods onto a new helper class called OwnershipRAUWHelper that composes with OwnershipFixupContext.
3. In this PR,  I implemented the actual RAUW API and got everything in place.
4. In this final API, I let InstSimplify fold identity address_to_pointer/pointer_to_address using this new utility. I also added a bunch of tests that exercise the new API with various CFG patterns (diamonds, loops, etc). Once this lands, I am going to use this to implement other optimizations like this (e.x.: non-identity reinterpret casts).