### PR TITLE
[Diagnostics] Add specific warning for overriden `NSObject.hash(into:)`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5351,6 +5351,10 @@ ERROR(override_nsobject_hashvalue_error,none,
       "'NSObject.hashValue' is not overridable; "
       "did you mean to override 'NSObject.hash'?", ())
 
+ERROR(override_nsobject_hash_error,none,
+      "`NSObject.hash(into:)` is not overridable; "
+      "subclasses can customize hashing by overriding the `hash` property", ())
+
 WARNING(hashvalue_implementation,none,
         "'Hashable.hashValue' is deprecated as a protocol requirement; "
         "conform type %0 to 'Hashable' by implementing 'hash(into:)' instead",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2454,8 +2454,10 @@ NOTE(overridden_near_match_here,none,
      "potential overridden %0 %1 here",
       (DescriptiveDeclKind, DeclName))
 ERROR(override_decl_extension,none,
-      "overriding %select{|non-@objc }0declarations "
-      "%select{in extensions|from extensions}0 is not supported", (bool, bool))
+      "%select{|non-@objc}0 %2 %3 %select{"
+      "is declared in extension of %4 and cannot be overriden|"
+      "declared in %4 cannot be overriden from extension}1", 
+      (bool, bool, DescriptiveDeclKind, DeclName, DeclName))
 NOTE(overridden_here,none,
      "overridden declaration is here", ())
 NOTE(overridden_here_can_be_objc,none,

--- a/test/ClangImporter/objc-cross-module-override.swift
+++ b/test/ClangImporter/objc-cross-module-override.swift
@@ -11,7 +11,7 @@
 import ImageInitializers
 
 final class MyImage : Image {
-  // CHECK: overriding non-@objc declarations from extensions is not supported
+  // CHECK: non-@objc initializer 'init(imageLiteralResourceName:)' is declared in extension of 'Image' and cannot be overriden
   // Make sure we aren't emitting a fixit into the extant module...
   // CHECK-NOT: add '@objc' to make this declaration overridable
   // CHECK: ImageInitializers.Image:{{.*}}: note: overridden declaration is here

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -114,6 +114,10 @@ class MyHashableNSObject: NSObject {
     // expected-error@-1 {{'NSObject.hashValue' is not overridable; did you mean to override 'NSObject.hash'?}}
     return 0
   }
+
+  override func hash(into hasher: inout Hasher) {
+    // expected-error@-1 {{`NSObject.hash(into:)` is not overridable; subclasses can customize hashing by overriding the `hash` property}}
+  }
 }
 
 // rdar://problem/47557376

--- a/test/attr/attr_objc_override.swift
+++ b/test/attr/attr_objc_override.swift
@@ -29,11 +29,11 @@ class B : A {
     get { return self }  // expected-error{{subscript getter with Objective-C selector 'objectForKeyedSubscript:' conflicts with subscript getter from superclass 'A'}}
   }
 
-  override func foo() { } // expected-error{{overriding non-@objc declarations from extensions is not supported}}
+  override func foo() { } // expected-error{{non-@objc instance method 'foo()' is declared in extension of 'A' and cannot be overriden}}
 
-  override func wibble(_: SwiftStruct) { } // expected-error{{overriding declarations in extensions is not supported}}
+  override func wibble(_: SwiftStruct) { } // expected-error{{instance method 'wibble' is declared in extension of 'A' and cannot be overriden}}
 }
 
 extension B {
-  override func bar() { } // expected-error{{overriding non-@objc declarations from extensions is not supported}}
+  override func bar() { } // expected-error{{non-@objc instance method 'bar()' declared in 'A' cannot be overriden from extension}}
 }

--- a/test/decl/func/static_func.swift
+++ b/test/decl/func/static_func.swift
@@ -83,8 +83,8 @@ class C_Derived : C {
   override class func f2() {}
   class override func f3() {}
 
-  override class func ef2() {} // expected-error {{not supported}}
-  class override func ef3() {} // expected-error {{not supported}}
+  override class func ef2() {} // expected-error {{cannot be overriden}}
+  class override func ef3() {} // expected-error {{cannot be overriden}}
   override static func f7() {} // expected-error {{static method overrides a 'final' class method}}
 }
 
@@ -98,11 +98,11 @@ class C_Derived3 : C {
 }
 
 extension C_Derived {
-  override class func f4() {} // expected-error {{not supported}}
-  class override func f5() {} // expected-error {{not supported}}
+  override class func f4() {} // expected-error {{cannot be overriden}}
+  class override func f5() {} // expected-error {{cannot be overriden}}
 
-  override class func ef4() {} // expected-error {{not supported}}
-  class override func ef5() {} // expected-error {{not supported}}
+  override class func ef4() {} // expected-error {{cannot be overriden}}
+  class override func ef5() {} // expected-error {{cannot be overriden}}
 }
 
 protocol P { // expected-note{{extended type declared here}}

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -46,8 +46,8 @@ extension B {
   override func f3D() { }
   override func f4D() -> ObjCClassB { }
 
-  func f5() { }  // expected-error{{overridi}}
-  func f6() -> A { }  // expected-error{{overriding declarations in extensions is not supported}}
+  func f5() { }  // expected-error{{overri}}
+  func f6() -> A { }  // expected-error{{instance method 'f6()' is declared in extension of 'A' and cannot be overriden}}
 
   @objc override func f7() { }
   @objc override func f8() -> ObjCClassA { }

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -25,7 +25,7 @@ class InitSubclass: InitClass {}
 // expected-note@-1{{'init(baz:)' previously overridden here}}
 // expected-note@-2{{'init(bar:)' previously overridden here}}
 extension InitSubclass {
-  convenience init(arg: Bool) {} // expected-error{{overriding non-@objc declarations from extensions is not supported}}
+  convenience init(arg: Bool) {} // expected-error{{non-@objc initializer 'init(arg:)' declared in 'InitClass' cannot be overriden from extension}}
   convenience override init(baz: Int) {}
   // expected-error@-1 {{'init(baz:)' has already been overridden}}
   // expected-error@-2 {{cannot override a non-dynamic class declaration from an extension}}

--- a/test/stdlib/NSObject-hashing.swift
+++ b/test/stdlib/NSObject-hashing.swift
@@ -12,7 +12,6 @@ class Foo: NSObject {
   }
 
   override func hash(into hasher: inout Hasher) {
-    // expected-error@-1 {{overriding non-open instance method outside of its defining module}}
-    // expected-error@-2 {{overriding declarations in extensions is not supported}}
+    // expected-error@-1 {{`NSObject.hash(into:)` is not overridable; subclasses can customize hashing by overriding the `hash` property}}
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
```swift
import Foundation
class C: NSObject {
    override func hash(into hasher: inout Hasher) { }
}
```
The above code produces the following errors:
```
tmp.swift:3:19: error: overriding non-open instance method outside of its defining module
    override func hash(into hasher: inout Hasher) { }
                  ^
tmp.swift:3:19: error: overriding declarations in extensions is not supported
    override func hash(into hasher: inout Hasher) { }
                  ^
ObjectiveC.NSObject:4:17: note: overridden declaration is here
    public func hash(into hasher: inout Hasher)
```

which is possibly misleading as the code doesn't have any extensions. This case should be handled together with NSObject.hashValue as invalid overrided interfaces. 

I added more detailed information about the error: 
`'NSObject.hash(into:)' is not overridable; subclasses can customize hashing by overriding the 'hash' property`
which correctly guides the user to use `NSObject.hash` property instead. 

I also modified existing `override_decl_extension` error to produce better diagnostics like this:
`method 'foo()' is declared in extension of 'A' and cannot be overriden`
and 
`method 'foo()' declared in 'A' cannot be overriden from extension`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13593.](https://bugs.swift.org/browse/SR-13593)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
