### PR TITLE
SR-13976: Improve compiler error message: "partial application of ‘mutating’ method is not allowed"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3700,20 +3700,20 @@ NOTE(ambiguous_because_of_trailing_closure,none,
 // Cannot capture inout-ness of a parameter
 // Partial application of foreign functions not supported
 ERROR(partial_application_of_function_invalid,none,
-      "partial application of %select{"
+      "cannot reference %select{"
         "'mutating' method|"
         "'super.init' initializer chain|"
         "'self.init' initializer delegation|"
         "'super' instance method with metatype base"
-      "}0 is not allowed",
+      "}0 as function value",
       (unsigned))
 WARNING(partial_application_of_function_invalid_swift4,none,
-      "partial application of %select{"
+      "cannot reference %select{"
         "'mutating' method|"
         "'super.init' initializer chain|"
         "'self.init' initializer delegation|"
         "'super' instance method with metatype base"
-      "}0 is not allowed; calling the function has undefined behavior and will "
+      "}0 as function value; calling the function has undefined behavior and will "
       "be an error in future Swift versions",
       (unsigned))
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4189,6 +4189,9 @@ bool PartialApplicationFailure::diagnoseAsError() {
     kind = RefKind::SuperMethod;
   }
 
+  /* TODO(diagnostics): SR-15250, 
+  Add a "did you mean to call it?" note with a fix-it for inserting '()'
+  if function type has no params or all have a default value. */
   auto diagnostic = CompatibilityWarning
                         ? diag::partial_application_of_function_invalid_swift4
                         : diag::partial_application_of_function_invalid;

--- a/test/Constraints/construction.swift
+++ b/test/Constraints/construction.swift
@@ -241,7 +241,7 @@ func sr_10837() {
     convenience init(foo: Int = 42) {
       self.init(value:)(foo) // Ok
       self.init(value:)
-      // expected-error@-1 {{partial application of 'self.init' initializer delegation is not allowed}}
+      // expected-error@-1 {{cannot reference 'self.init' initializer delegation as function value}}
     }
   }
 
@@ -249,7 +249,7 @@ func sr_10837() {
     override init(bar: Int) {
       super.init(bar:)(bar) // Ok
       super.init(bar:)
-      // expected-error@-1 {{partial application of 'super.init' initializer chain is not allowed}}
+      // expected-error@-1 {{cannot reference 'super.init' initializer chain as function value}}
     }
   }
 }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -28,7 +28,7 @@ func g0(_: (inout X) -> (Float) -> ()) {}
 _ = x.f0(i)
 x.f0(i).f1(i)
 
-g0(X.f1) // expected-error{{partial application of 'mutating' method}}
+g0(X.f1) // expected-error{{cannot reference 'mutating' method as function value}}
 
 _ = x.f0(x.f2(1))
 _ = x.f0(1).f2(i)
@@ -74,7 +74,7 @@ struct GZ<T> {
 
 var z = Z(i: 0)
 var getI = z.getI
-var incI = z.incI // expected-error{{partial application of 'mutating'}}
+var incI = z.incI // expected-error{{cannot reference 'mutating' method as function value}}
 var zi = z.getI()
 var zcurried1 = z.curried
 var zcurried2 = z.curried(0)

--- a/test/Constraints/mutating_members.swift
+++ b/test/Constraints/mutating_members.swift
@@ -6,31 +6,31 @@ struct Foo {
   mutating func boom() {}
 }
 
-let x = Foo.boom // expected-error{{partial application of 'mutating' method}}
+let x = Foo.boom // expected-error{{cannot reference 'mutating' method as function value}}
 var y = Foo()
-let z0 = y.boom // expected-error{{partial application of 'mutating' method}}
-let z1 = Foo.boom(&y) // expected-error{{partial application of 'mutating' method}}
+let z0 = y.boom // expected-error{{cannot reference 'mutating' method as function value}}
+let z1 = Foo.boom(&y) // expected-error{{cannot reference 'mutating' method as function value}}
 
 func fromLocalContext() -> (inout Foo) -> () -> () {
-  return Foo.boom // expected-error{{partial application of 'mutating' method}}
+  return Foo.boom // expected-error{{cannot reference 'mutating' method as function value}}
 }
 func fromLocalContext2(x: inout Foo, y: Bool) -> () -> () {
   if y {
-    return x.boom // expected-error{{partial application of 'mutating' method}}
+    return x.boom // expected-error{{cannot reference 'mutating' method as function value}}
   } else {
-    return Foo.boom(&x) // expected-error{{partial application of 'mutating' method}}
+    return Foo.boom(&x) // expected-error{{cannot reference 'mutating' method as function value}}
   }
 }
 
 func bar() -> P.Type { fatalError() }
 func bar() -> Foo.Type { fatalError() }
 
-_ = bar().boom       // expected-error{{partial application of 'mutating' method}}
-_ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
-_ = bar().boom(&y)() // expected-error{{partial application of 'mutating' method}}
+_ = bar().boom       // expected-error{{cannot reference 'mutating' method as function value}}
+_ = bar().boom(&y)   // expected-error{{cannot reference 'mutating' method as function value}}
+_ = bar().boom(&y)() // expected-error{{cannot reference 'mutating' method as function value}}
 
 func foo(_ foo: Foo.Type) {
-  _ = foo.boom       // expected-error{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)() // expected-error{{partial application of 'mutating' method}}
+  _ = foo.boom       // expected-error{{cannot reference 'mutating' method as function value}}
+  _ = foo.boom(&y)   // expected-error{{cannot reference 'mutating' method as function value}}
+  _ = foo.boom(&y)() // expected-error{{cannot reference 'mutating' method as function value}}
 }

--- a/test/Constraints/mutating_members_compat.swift
+++ b/test/Constraints/mutating_members_compat.swift
@@ -6,31 +6,31 @@ struct Foo {
   mutating func boom() {}
 }
 
-let x = Foo.boom // expected-warning{{partial application of 'mutating' method}}
+let x = Foo.boom // expected-warning{{cannot reference 'mutating' method as function value; calling the function has undefined behavior and will be an error in future Swift versions}}
 var y = Foo()
-let z0 = y.boom // expected-error{{partial application of 'mutating' method}}
-let z1 = Foo.boom(&y) // expected-error{{partial application of 'mutating' method}}
+let z0 = y.boom // expected-error{{cannot reference 'mutating' method as function value}}
+let z1 = Foo.boom(&y) // expected-error{{cannot reference 'mutating' method as function value}}
 
 func fromLocalContext() -> (inout Foo) -> () -> () {
-  return Foo.boom // expected-warning{{partial application of 'mutating' method}}
+  return Foo.boom // expected-warning{{cannot reference 'mutating' method as function value; calling the function has undefined behavior and will be an error in future Swift versions}}
 }
 func fromLocalContext2(x: inout Foo, y: Bool) -> () -> () {
   if y {
-    return x.boom // expected-error{{partial application of 'mutating' method}}
+    return x.boom // expected-error{{cannot reference 'mutating' method as function value}}
   } else {
-    return Foo.boom(&x) // expected-error{{partial application of 'mutating' method}}
+    return Foo.boom(&x) // expected-error{{cannot reference 'mutating' method as function value}}
   }
 }
 
 func bar() -> P.Type { fatalError() }
 func bar() -> Foo.Type { fatalError() }
 
-_ = bar().boom       // expected-warning{{partial application of 'mutating' method}}
-_ = bar().boom(&y)   // expected-error{{partial application of 'mutating' method}}
-_ = bar().boom(&y)() // expected-error{{partial application of 'mutating' method}}
+_ = bar().boom       // expected-warning{{cannot reference 'mutating' method as function value; calling the function has undefined behavior and will be an error in future Swift versions}}
+_ = bar().boom(&y)   // expected-error{{cannot reference 'mutating' method as function value}}
+_ = bar().boom(&y)() // expected-error{{cannot reference 'mutating' method as function value}}
 
 func foo(_ foo: Foo.Type) {
-  _ = foo.boom       // expected-warning{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)   // expected-error{{partial application of 'mutating' method}}
-  _ = foo.boom(&y)() // expected-error{{partial application of 'mutating' method}}
+  _ = foo.boom       // expected-warning{{cannot reference 'mutating' method as function value; calling the function has undefined behavior and will be an error in future Swift versions}}
+  _ = foo.boom(&y)   // expected-error{{cannot reference 'mutating' method as function value}}
+  _ = foo.boom(&y)() // expected-error{{cannot reference 'mutating' method as function value}}
 }

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -136,7 +136,7 @@ func generic<T: P>(_ t: T) {
   let _: (T) -> (Int) -> () = id(T.bar)
   let _: (Int) -> () = id(T.bar(t))
 
-  _ = t.mut // expected-error{{partial application of 'mutating' method is not allowed}}
+  _ = t.mut // expected-error{{cannot reference 'mutating' method as function value}}
   _ = t.tum // expected-error{{static member 'tum' cannot be used on instance of type 'T'}}
 }
 
@@ -167,7 +167,7 @@ func existential(_ p: P) {
   var p = p
   // Fully applied mutating method
   p.mut(1)
-  _ = p.mut // expected-error{{partial application of 'mutating' method is not allowed}}
+  _ = p.mut // expected-error{{cannot reference 'mutating' method as function value}}
 
   // Instance member of existential)
   let _: (Int) -> () = id(p.bar)
@@ -212,7 +212,7 @@ func staticExistential(_ p: P.Type, pp: P.Protocol) {
   // Instance member of existential metatype -- not allowed
   _ = p.bar // expected-error{{instance member 'bar' cannot be used on type 'P'}}
   _ = p.mut // expected-error{{instance member 'mut' cannot be used on type 'P'}}
-  // expected-error@-1 {{partial application of 'mutating' method is not allowed}}
+  // expected-error@-1 {{cannot reference 'mutating' method as function value}}
 
   // Static member of metatype -- not allowed
   _ = pp.tum // expected-error{{static member 'tum' cannot be used on protocol metatype 'P.Protocol'}}

--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -288,15 +288,16 @@ class ThisDerived1 : ThisBase1 {
     self.Type // expected-error {{type 'ThisDerived1' has no member 'Type'}}
   }
 
+  // FIXME(SR-15250): Partial application diagnostic is applied incorrectly for some test cases.
   class func staticTestSuper1() {
     super.baseInstanceVar = 42 // expected-error {{member 'baseInstanceVar' cannot be used on type 'ThisBase1'}}
     super.baseProp = 42 // expected-error {{member 'baseProp' cannot be used on type 'ThisBase1'}}
     super.baseFunc0() // expected-error {{instance member 'baseFunc0' cannot be used on type 'ThisBase1'}}
-    // expected-error@-1 {{partial application of 'super' instance method with metatype base is not allowed}}
-    super.baseFunc0(ThisBase1())() // expected-error {{partial application of 'super' instance method with metatype base is not allowed}}
+    // expected-error@-1 {{cannot reference 'super' instance method with metatype base as function value}}
+    super.baseFunc0(ThisBase1())() // expected-error {{cannot reference 'super' instance method with metatype base as function value}}
     super.baseFunc1(42) // expected-error {{instance member 'baseFunc1' cannot be used on type 'ThisBase1'}}
-    // expected-error@-1 {{partial application of 'super' instance method with metatype base is not allowed}}
-    super.baseFunc1(ThisBase1())(42) // expected-error {{partial application of 'super' instance method with metatype base is not allowed}}
+    // expected-error@-1 {{cannot reference 'super' instance method with metatype base as function value}}
+    super.baseFunc1(ThisBase1())(42) // expected-error {{cannot reference 'super' instance method with metatype base as function value}}
     super[0] = 42.0 // expected-error {{instance member 'subscript' cannot be used on type 'ThisBase1'}}
     super.baseStaticVar = 42
     super.baseStaticProp = 42
@@ -304,7 +305,7 @@ class ThisDerived1 : ThisBase1 {
 
     super.baseExtProp = 42 // expected-error {{member 'baseExtProp' cannot be used on type 'ThisBase1'}}
     super.baseExtFunc0() // expected-error {{instance member 'baseExtFunc0' cannot be used on type 'ThisBase1'}}
-    // expected-error@-1 {{partial application of 'super' instance method with metatype base is not allowed}}
+    // expected-error@-1 {{cannot reference 'super' instance method with metatype base as function value}}
     super.baseExtStaticVar = 42 // expected-error {{instance member 'baseExtStaticVar' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticProp = 42 // expected-error {{member 'baseExtStaticProp' cannot be used on type 'ThisBase1'}}
     super.baseExtStaticFunc0()

--- a/test/Parse/super.swift
+++ b/test/Parse/super.swift
@@ -21,11 +21,11 @@ class D : B {
   }
 
   override init(x:Int) {
-    let _: () -> B = super.init // expected-error {{partial application of 'super.init' initializer chain is not allowed}}
+    let _: () -> B = super.init // expected-error {{cannot reference 'super.init' initializer chain as function value}}
   }
 
   convenience init(y:Int) {
-    let _: () -> D = self.init // expected-error {{partial application of 'self.init' initializer delegation is not allowed}}
+    let _: () -> D = self.init // expected-error {{cannot reference 'self.init' initializer delegation as function value}}
   }
 
   init(z: Int) {

--- a/test/expr/capture/inout.swift
+++ b/test/expr/capture/inout.swift
@@ -13,4 +13,4 @@ struct C {
 }
 
 var c = C()
-let x = c.f // expected-error{{partial application of 'mutating' method is not allowed}}
+let x = c.f // expected-error{{cannot reference 'mutating' method as function value}}

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -125,7 +125,7 @@ class Z5 : Z4 {
 // Ill-formed initialization: failure to call initializer.
 class Z6 {
   convenience init() {
-    var _ : () -> Z6 = self.init // expected-error{{partial application of 'self.init' initializer delegation is not allowed}}
+    var _ : () -> Z6 = self.init // expected-error{{cannot reference 'self.init' initializer delegation as function value}}
   }
 
   init(other: Z6) { }
@@ -171,7 +171,7 @@ struct S {
   init() {
     let _ = S.init()
     self.init()
-    let _ = self.init // expected-error{{partial application of 'self.init' initializer delegation is not allowed}}
+    let _ = self.init // expected-error{{cannot reference 'self.init' initializer delegation as function value}}
   }
 }
 
@@ -179,7 +179,7 @@ class C {
   convenience init() { // expected-note 11 {{selected non-required initializer 'init()'}}
     self.init()
     let _: C = self.init() // expected-error{{cannot convert value of type '()' to specified type 'C'}}
-    let _: () -> C = self.init // expected-error{{partial application of 'self.init' initializer delegation is not allowed}}
+    let _: () -> C = self.init // expected-error{{cannot reference 'self.init' initializer delegation as function value}}
   }
 
   init(x: Int) {} // expected-note 11 {{selected non-required initializer 'init(x:)'}}
@@ -191,7 +191,7 @@ class D: C {
   override init(x: Int) {
     super.init(x: x)
     let _: C = super.init() // expected-error{{cannot convert value of type '()' to specified type 'C'}}
-    let _: () -> C = super.init // expected-error{{partial application of 'super.init' initializer chain is not allowed}}
+    let _: () -> C = super.init // expected-error{{cannot reference 'super.init' initializer chain as function value}}
   }
 
   func foo() {

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -355,7 +355,7 @@ do {
       let _: Self = super.property // expected-error {{cannot convert value of type 'D' to specified type 'Self'}}
       let _: Self = super[] // expected-error {{cannot convert value of type 'D' to specified type 'Self'}}
       let _: () -> Self = super.method
-      // expected-error@-1 {{partial application of 'super' instance method with metatype base is not allowed}}
+      // expected-error@-1 {{cannot reference 'super' instance method with metatype base as function value}}
       // expected-error@-2 {{cannot convert value of type '(C) -> () -> D' to specified type '() -> Self'}}
     }
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
As mentioned on the Jira ticket, partial application is not a well-known term so I have reworded the error messages with a suggested phrase to help people diagnose the issue easier. 

Based on the diagnostics definition file there were 4 different combinations that I saw that used the error, below is the wording changes i made:

+ partial application of 'mutating' method is not allowed -> calling a 'mutating' method without an argument list is not allowed
+ partial application of 'super.init' initializer chain is not allowed -> calling a 'super.init' initializer chain without an argument list is not allowed
+ partial application of 'self.init' initializer delegation is not allowed -> calling a 'self.init' initializer delegation without an argument list is not allowed
+ partial application of 'super' instance method with metatype base is not allowed -> calling a 'super' instance method with metatype base without an argument list is not allowed

The first commit has the change, second commit has the test updates.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13976](https://bugs.swift.org/browse/SR-13976). cc @varungandhi-apple 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
