### PR TITLE
Remove unused frontend option

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -421,9 +421,6 @@ def disable_conformance_availability_errors : Flag<["-"],
   "disable-conformance-availability-errors">,
   HelpText<"Diagnose conformance availability violations as warnings">;
 
-def report_errors_to_debugger : Flag<["-"], "report-errors-to-debugger">,
-  HelpText<"Deprecated, will be removed in future versions.">;
-
 def enable_infer_import_as_member :
   Flag<["-"], "enable-infer-import-as-member">,
   HelpText<"Infer when a global could be imported as a member">;


### PR DESCRIPTION
Looks like 3 years ago this was still used in some places so it was
added back. I hope it's entirely unused by this point! 680d151963ff5e55f0aa80c8dcb51cd19e4871c8