### PR TITLE
Sema: Fix a couple of crash-on-invalid problems with class inheritance

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -151,12 +151,12 @@ namespace {
       auto conformance = DC->getParentModule()->lookupConformance(
           conformingType, foundProto);
       if (conformance.isInvalid()) {
-        // If there's no conformance, we have an existential
-        // and we found a member from one of the protocols, and
-        // not a class constraint if any.
-        assert(foundInType->isExistentialType() || foundInType->hasError());
-        if (foundInType->isExistentialType())
+        if (foundInType->isExistentialType()) {
+          // If there's no conformance, we have an existential
+          // and we found a member from one of the protocols, and
+          // not a class constraint if any.
           addResult(found);
+        }
         return;
       }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -717,10 +717,16 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
       // Adjust the self type of the access to refer to the relevant superclass.
       auto *baseClass = override->getDeclContext()->getSelfClassDecl();
       selfTypeForAccess = selfTypeForAccess->getSuperclassForDecl(baseClass);
-      subs =
-        selfTypeForAccess->getContextSubstitutionMap(
-          accessor->getParentModule(),
-          baseClass);
+
+      // Error recovery path. We get an ErrorType here if getSuperclassForDecl()
+      // fails (because, for instance, a generic parameter of a generic nominal
+      // type cannot be resolved).
+      if (!selfTypeForAccess->is<ErrorType>()) {
+        subs =
+          selfTypeForAccess->getContextSubstitutionMap(
+            accessor->getParentModule(),
+            baseClass);
+      }
 
       storage = override;
 

--- a/validation-test/compiler_crashers_2_fixed/rdar73169149.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar73169149.swift
@@ -1,0 +1,26 @@
+// RUN: not %target-swift-frontend -emit-ir %s
+
+public protocol Ungulate {
+  func eat()
+}
+
+public class Horse<T> : Ungulate {
+  public var saddle: AnyObject? = nil
+
+  public func eat() {}
+}
+
+public struct Hay {}
+
+// Here, ClassDecl::getSuperclassDecl() will find the 'Horse' class, but
+// ClassDecl::getSuperclass() will return ErrorType because the generic
+// argument 'DoesNotExist' cannot be resolved.
+public class Pony : Horse<DoesNotExist> {
+  public override var saddle: AnyObject? {
+    didSet {}
+  }
+
+  public func eat(_: Hay) {
+    eat()
+  }
+}


### PR DESCRIPTION
It is possible for ClassDecl::getSuperclassDecl() to succeed but for
ClassDecl::getSuperclass() to fail. This happens if the superclass is
a generic type and one of the generic arguments could not be resolved,
or does not satisfy the generic requirements, for example; in that
case, a BoundGenericType cannot be formed.

In a couple of places we were not prepared for this possibility.
Let's recover by making judicious use of ErrorType.

Fixes <rdar://problem/73169149>.