### PR TITLE
CopyPropagation: Temporarily disable borrow scope rewriting.

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -92,7 +92,7 @@ SILValue CanonicalizeOSSALifetime::getCanonicalCopiedDef(SILValue v) {
 //===----------------------------------------------------------------------===//
 
 llvm::cl::opt<bool>
-    EnableRewriteBorrows("canonical-ossa-rewrite-borrows", llvm::cl::init(true),
+    EnableRewriteBorrows("canonical-ossa-rewrite-borrows", llvm::cl::init(false),
                          llvm::cl::desc("Enable rewriting borrow scopes"));
 
 bool CanonicalizeOSSALifetime::computeBorrowLiveness() {


### PR DESCRIPTION
For the purpose of staging in functionality, this should be initially
disabled.

I'll reenable it on main with more complete unit tests, but it will be
useful to selectively apply/revert just this commit.
