### PR TITLE
Add a missing CHECK line to OSLogFullOptTest.swift

### DIFF
--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -349,6 +349,7 @@ func testMetatypeInterpolation<T>(of type: T.Type) {
 
     // CHECK: [[NOT_ENABLED]]:
     // CHECK-NEXT: call void @swift_release
+    // CHECK: br label %[[EXIT:[0-9]+]]
 
     // CHECK: [[ENABLED]]:
     //


### PR DESCRIPTION
This test was sensitive to arbitrary block ID's because it was missing
the CHECK line that sets a regex used by subsequent checks.

This is also an example of why it helps to use CHECK-LABEL at the end
of a function scope.
