### PR TITLE
Warn on member assignments capturing self

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3570,6 +3570,9 @@ ERROR(self_assignment_prop,none,
 ERROR(property_use_in_closure_without_explicit_self,none,
       "reference to property %0 in closure requires explicit use of 'self' to"
       " make capture semantics explicit", (Identifier))
+WARNING(member_assign_to_closure_without_explicit_self,none,
+      "assignment of member %0 to closure requires explicit use of 'self' to"
+      " make capture semantics explicit", (Identifier))
 ERROR(method_call_in_closure_without_explicit_self,none,
       "call to method %0 in closure requires explicit use of 'self' to make"
       " capture semantics explicit", (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3570,9 +3570,9 @@ ERROR(self_assignment_prop,none,
 ERROR(property_use_in_closure_without_explicit_self,none,
       "reference to property %0 in closure requires explicit use of 'self' to"
       " make capture semantics explicit", (Identifier))
-WARNING(member_assign_to_closure_without_explicit_self,none,
-      "assignment of member %0 to closure requires explicit use of 'self' to"
-      " make capture semantics explicit", (Identifier))
+WARNING(warn_method_call_in_autoclosure_without_explicit_self,none,
+      "call to method %0 in autoclosure requires explicit use of 'self' to make"
+      " capture semantics explicit", (Identifier))
 ERROR(method_call_in_closure_without_explicit_self,none,
       "call to method %0 in closure requires explicit use of 'self' to make"
       " capture semantics explicit", (Identifier))

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -528,3 +528,15 @@ class SR3186 {
     print("\(v)")
   }
 }
+
+var sr8536_closure: () -> () = {}
+
+class SR8536 {
+
+  func baz() {}
+
+  init() {
+     // expected-warning@+1{{assignment of member 'baz' to closure requires explicit use of 'self' to make capture semantics explicit}}
+    sr8536_closure = baz
+  }
+}

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -536,7 +536,8 @@ class SR8536 {
   func baz() {}
 
   init() {
-     // expected-warning@+1{{assignment of member 'baz' to closure requires explicit use of 'self' to make capture semantics explicit}}
+    // expected-warning@+2{{call to method 'baz' in autoclosure requires explicit use of 'self' to make capture semantics explicit}}
+    // expected-note@+1{{reference 'self.' explicitly}}
     sr8536_closure = baz
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Warn on member assignments capturing self. 

The approach has been to find a `AssignExpr` that has a `AutoClosureExpr` with `DoubleCurryThunk` as the r-value. 

I am not currently sure about the performance of this implementation & think that there will be a way for `ASTWalker` to avoid walking through the whole AST. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-8536](https://bugs.swift.org/browse/SR-8536).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
