### PR TITLE
LoadableByAddress: fix a crash related to single-element tuples containing a label and a closure.

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2765,7 +2765,8 @@ bool LoadableByAddress::recreateTupleInstr(
   for (auto elem : tupleInstr->getElements()) {
     elems.push_back(elem);
   }
-  auto *newTuple = tupleBuilder.createTuple(tupleInstr->getLoc(), elems);
+  auto *newTuple = tupleBuilder.createTuple(tupleInstr->getLoc(), newResultTy,
+                                            elems);
   tupleInstr->replaceAllUsesWith(newTuple);
   Delete.push_back(tupleInstr);
   return true;

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -276,6 +276,15 @@ bb0(%0 : $*BigStruct):
   return %12 : $()
 }
 
+sil @dontCrashWithLabeledSingleElementTupleOfClosure : $@convention(thin) () -> @callee_guaranteed () -> @owned BigStruct {
+bb0:
+  %f = function_ref @returnBigStruct : $@convention(thin) () -> @owned BigStruct
+  %thick = thin_to_thick_function %f : $@convention(thin) () -> @owned BigStruct to $@callee_guaranteed () -> @owned BigStruct
+  %38 = tuple $(closure: @callee_guaranteed () -> @owned BigStruct) (%thick)
+  %99 = tuple_extract %38 : $(closure: @callee_guaranteed () -> @owned BigStruct), 0
+  return %99 : $@callee_guaranteed () -> @owned BigStruct
+}
+
 sil_vtable SuperBase {
 }
 


### PR DESCRIPTION
The canonical type was wrong for such tuples.

The problem here was that re-constructing a tuple-type from its element types is not good enough, because it is not preserving the tuple labels (and this makes a difference in type canonicalization). Instead, explicitly provide the resulting tuple type to SILBuilder.

https://bugs.swift.org/browse/SR-14046
rdar://73245321
