### PR TITLE
[ownership] Add a DeadEndBlocksAnalysis that vends/saves DeadEndBlocks in between passes.

### DIFF
--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -62,26 +62,31 @@ void mergeBasicBlockWithSingleSuccessor(SILBasicBlock *BB,
 /// This utility is needed to determine if the a value definition can have a
 /// lack of users ignored along a specific path.
 class DeadEndBlocks {
-  llvm::SetVector<const SILBasicBlock *> ReachableBlocks;
-  const SILFunction *F;
-  bool isComputed = false;
+  llvm::SetVector<const SILBasicBlock *> reachableBlocks;
+  const SILFunction *f;
+  bool didComputeValue = false;
 
   void compute();
 
 public:
-  DeadEndBlocks(const SILFunction *F) : F(F) {}
+  DeadEndBlocks(const SILFunction *f) : f(f) {}
 
   /// Returns true if \p BB is a dead-end block.
   bool isDeadEnd(const SILBasicBlock *block) {
-    if (!isComputed) {
+    if (!didComputeValue) {
       // Lazily compute the dataflow.
       compute();
-      isComputed = true;
+      didComputeValue = true;
     }
-    return ReachableBlocks.count(block) == 0;
+    return reachableBlocks.count(block) == 0;
   }
 
-  const SILFunction *getFunction() const { return F; }
+  /// Return true if this dead end blocks has computed its internal cache yet.
+  ///
+  /// Used to determine if we need to verify a DeadEndBlocks.
+  bool isComputed() const { return didComputeValue; }
+
+  const SILFunction *getFunction() const { return f; }
 };
 
 /// A struct that contains the intermediate state used in computing

--- a/include/swift/SILOptimizer/Analysis/Analysis.def
+++ b/include/swift/SILOptimizer/Analysis/Analysis.def
@@ -47,5 +47,6 @@ ANALYSIS(RCIdentity)
 ANALYSIS(SideEffect)
 ANALYSIS(TypeExpansion)
 ANALYSIS(PassManagerVerifier)
+ANALYSIS(DeadEndBlocks)
 
 #undef ANALYSIS

--- a/include/swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h
@@ -1,0 +1,47 @@
+//===--- DeadEndBlocksAnalysis.h ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_DEADENDBLOCKSANALYSIS_H
+#define SWIFT_SILOPTIMIZER_DEADENDBLOCKSANALYSIS_H
+
+#include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+
+namespace swift {
+
+class DeadEndBlocksAnalysis final : public FunctionAnalysisBase<DeadEndBlocks> {
+public:
+  DeadEndBlocksAnalysis()
+      : FunctionAnalysisBase<DeadEndBlocks>(SILAnalysisKind::DeadEndBlocks) {}
+
+  DeadEndBlocksAnalysis(const DeadEndBlocksAnalysis &) = delete;
+  DeadEndBlocksAnalysis &operator=(const DeadEndBlocksAnalysis &) = delete;
+
+  static bool classof(const SILAnalysis *s) {
+    return s->getKind() == SILAnalysisKind::DeadEndBlocks;
+  }
+
+  std::unique_ptr<DeadEndBlocks> newFunctionAnalysis(SILFunction *f) override {
+    return std::make_unique<DeadEndBlocks>(f);
+  }
+
+  bool shouldInvalidate(SILAnalysis::InvalidationKind k) override {
+    return k & InvalidationKind::Branches;
+  }
+
+protected:
+  void verify(DeadEndBlocks *deBlocks) const override;
+};
+
+} // namespace swift
+
+#endif

--- a/lib/SIL/Utils/BasicBlockUtils.cpp
+++ b/lib/SIL/Utils/BasicBlockUtils.cpp
@@ -363,22 +363,22 @@ void swift::mergeBasicBlockWithSingleSuccessor(SILBasicBlock *BB,
 //===----------------------------------------------------------------------===//
 
 void DeadEndBlocks::compute() {
-  assert(ReachableBlocks.empty() && "Computed twice");
+  assert(reachableBlocks.empty() && "Computed twice");
 
   // First step: find blocks which end up in a no-return block (terminated by
   // an unreachable instruction).
   // Search for function-exiting blocks, i.e. return and throw.
-  for (const SILBasicBlock &BB : *F) {
+  for (const SILBasicBlock &BB : *f) {
     const TermInst *TI = BB.getTerminator();
     if (TI->isFunctionExiting())
-      ReachableBlocks.insert(&BB);
+      reachableBlocks.insert(&BB);
   }
   // Propagate the reachability up the control flow graph.
   unsigned Idx = 0;
-  while (Idx < ReachableBlocks.size()) {
-    const SILBasicBlock *BB = ReachableBlocks[Idx++];
+  while (Idx < reachableBlocks.size()) {
+    const SILBasicBlock *BB = reachableBlocks[Idx++];
     for (SILBasicBlock *Pred : BB->getPredecessorBlocks())
-      ReachableBlocks.insert(Pred);
+      reachableBlocks.insert(Pred);
   }
 }
 

--- a/lib/SILOptimizer/Analysis/CMakeLists.txt
+++ b/lib/SILOptimizer/Analysis/CMakeLists.txt
@@ -10,8 +10,9 @@ target_sources(swiftSILOptimizer PRIVATE
   ClassHierarchyAnalysis.cpp
   ClosureScope.cpp
   ColdBlockInfo.cpp
-  DifferentiableActivityAnalysis.cpp
+  DeadEndBlocksAnalysis.cpp
   DestructorAnalysis.cpp
+  DifferentiableActivityAnalysis.cpp
   EscapeAnalysis.cpp
   EpilogueARCAnalysis.cpp
   FunctionOrder.cpp

--- a/lib/SILOptimizer/Analysis/DeadEndBlocksAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DeadEndBlocksAnalysis.cpp
@@ -1,0 +1,57 @@
+//===--- DeadEndBlocksAnalysis.cpp ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
+#include "swift/AST/Decl.h"
+#include "swift/SIL/SILFunction.h"
+
+using namespace swift;
+
+void DeadEndBlocksAnalysis::verify(DeadEndBlocks *deBlocks) const {
+  // If the passed in deBlocks has not computed, there is nothing to check.
+  if (!deBlocks->isComputed())
+    return;
+
+  // Then create our new dead end blocks instance so we can check the internal
+  // state of our input against it.
+  auto *fn = deBlocks->getFunction();
+  DeadEndBlocks newBlocks(fn);
+
+  // Make sure that all values that deBlocks thinks is unreachable are
+  // actually unreachable.
+  //
+  // NOTE: We verify like this b/c DeadEndBlocks looks up state lazily so we
+  // can only check the work we have done so far.
+  for (auto &block : *fn) {
+    if (deBlocks->isDeadEnd(&block)) {
+      if (!newBlocks.isDeadEnd(&block)) {
+        llvm::errs() << "DeadEndBlocksAnalysis Error! Found dead end block "
+                        "that is no longer a dead end block?!";
+        llvm_unreachable("standard error assertion");
+      }
+    } else {
+      if (newBlocks.isDeadEnd(&block)) {
+        llvm::errs() << "DeadEndBlocksAnalysis Error! Found reachable block "
+                        "that is no longer reachable?!";
+        llvm_unreachable("standard error assertion");
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                              Main Entry Point
+//===----------------------------------------------------------------------===//
+
+SILAnalysis *swift::createDeadEndBlocksAnalysis(SILModule *) {
+  return new DeadEndBlocksAnalysis();
+}

--- a/lib/SILOptimizer/SemanticARC/Context.h
+++ b/lib/SILOptimizer/SemanticARC/Context.h
@@ -32,7 +32,7 @@ namespace semanticarc {
 struct LLVM_LIBRARY_VISIBILITY Context {
   SILFunction &fn;
   ARCTransformKind transformKind = ARCTransformKind::All;
-  Optional<DeadEndBlocks> deadEndBlocks;
+  DeadEndBlocks &deadEndBlocks;
   ValueLifetimeAnalysis::Frontier lifetimeFrontier;
   SmallMultiMapCache<SILValue, Operand *> addressToExhaustiveWriteListCache;
 
@@ -117,14 +117,11 @@ struct LLVM_LIBRARY_VISIBILITY Context {
   using FrozenMultiMapRange =
       decltype(joinedOwnedIntroducerToConsumedOperands)::PairToSecondEltRange;
 
-  DeadEndBlocks &getDeadEndBlocks() {
-    if (!deadEndBlocks)
-      deadEndBlocks.emplace(&fn);
-    return *deadEndBlocks;
-  }
+  DeadEndBlocks &getDeadEndBlocks() { return deadEndBlocks; }
 
-  Context(SILFunction &fn, bool onlyGuaranteedOpts, InstModCallbacks callbacks)
-      : fn(fn), deadEndBlocks(), lifetimeFrontier(),
+  Context(SILFunction &fn, DeadEndBlocks &deBlocks, bool onlyGuaranteedOpts,
+          InstModCallbacks callbacks)
+      : fn(fn), deadEndBlocks(deBlocks), lifetimeFrontier(),
         addressToExhaustiveWriteListCache(constructCacheValue),
         onlyGuaranteedOpts(onlyGuaranteedOpts), instModCallbacks(callbacks) {}
 

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -49,8 +49,9 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
 
   Context ctx;
 
-  explicit SemanticARCOptVisitor(SILFunction &fn, bool onlyGuaranteedOpts)
-      : ctx(fn, onlyGuaranteedOpts,
+  explicit SemanticARCOptVisitor(SILFunction &fn, DeadEndBlocks &deBlocks,
+                                 bool onlyGuaranteedOpts)
+      : ctx(fn, deBlocks, onlyGuaranteedOpts,
             InstModCallbacks(
                 [this](SILInstruction *inst) { eraseInstruction(inst); },
                 [this](Operand *use, SILValue newValue) {

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
@@ -17,6 +17,8 @@
 #include "Transforms.h"
 
 #include "swift/Basic/Defer.h"
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 
 #include "llvm/Support/CommandLine.h"
@@ -149,7 +151,9 @@ struct SemanticARCOpts : SILFunctionTransform {
            "Can not perform semantic arc optimization unless ownership "
            "verification is enabled");
 
-    SemanticARCOptVisitor visitor(f, guaranteedOptsOnly);
+    auto *deBlocksAnalysis = getAnalysis<DeadEndBlocksAnalysis>();
+    SemanticARCOptVisitor visitor(f, *deBlocksAnalysis->get(&f),
+                                  guaranteedOptsOnly);
 
 #ifndef NDEBUG
     // If we are being asked for testing purposes to run a series of transforms


### PR DESCRIPTION
Importantly this also lets us use the analysis framework to validate that we do
properly invalidate DeadEndBlocks, preventing bugs.

I did not thread this all over the compiler. Instead I just used it for now in
SemanticARCOpts just to add some coverage without threading it into too many
places.
