### PR TITLE
[cmake] This ld64 LTO flag is only used on Darwin.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -354,7 +354,7 @@ function(_add_host_variant_link_flags target)
       ${SWIFT_HOST_VARIANT_ARCH}_LIB)
     target_link_directories(${target} PRIVATE
       ${${SWIFT_HOST_VARIANT_ARCH}_LIB})
-  else()
+  elseif(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_APPLE_PLATFORMS)
     # If lto is enabled, we need to add the object path flag so that the LTO code
     # generator leaves the intermediate object file in a place where it will not
     # be touched. The reason why this must be done is that on OS X, debug info is
@@ -365,6 +365,8 @@ function(_add_host_variant_link_flags target)
         "SHELL:-Xlinker -object_path_lto"
         "SHELL:-Xlinker ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${target}-${SWIFT_HOST_VARIANT_SDK}-${SWIFT_HOST_VARIANT_ARCH}-lto${CMAKE_C_OUTPUT_EXTENSION}")
     endif()
+  else()
+    # Assume no extra libraries required.
   endif()
 
   if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)


### PR DESCRIPTION
If a SDK has no specified variant link flags and LTO is specified, then
we attempt to pass Apple platform specific linker flags (in this case,
`object_path_lto`) to the platform linker, which may indeed not be ld64.

SWIFT_USE_LINKER is set empty on Apple platforms, so it is somewhat
onerous to exclude every possible linker here. We could affirmatively set
cases to the branch, but then the next platform to be supported may run
into this platform.

The simplest thing to do is just to create a specific case for Apple
platforms, and the reasonable default is to assume no specific host
linker flags are required.