### PR TITLE
[ownership] Change all passes except for Mandatory Inlining to use DeadEndBlocksAnalysis.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -31,6 +31,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/SILInstructionWorklist.h"
 #include "swift/SIL/SILVisitor.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CanonicalizeInstruction.h"
@@ -398,8 +399,9 @@ public:
       return;
     }
 
-    DeadEndBlocks deadEndBlocks(function);
-    MandatoryCombiner combiner(optimized, createdInstructions, deadEndBlocks);
+    auto *deBlocksAnalysis = getAnalysis<DeadEndBlocksAnalysis>();
+    MandatoryCombiner combiner(optimized, createdInstructions,
+                               *deBlocksAnalysis->get(function));
     bool madeChange = combiner.runOnFunction(*function);
 
     if (madeChange) {

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-cse"
+
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/InstructionUtils.h"
@@ -27,6 +28,7 @@
 #include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/SideEffectAnalysis.h"
 #include "swift/SILOptimizer/Analysis/SimplifyInstruction.h"
@@ -1396,7 +1398,8 @@ class SILCSE : public SILFunctionTransform {
     SILOptFunctionBuilder FuncBuilder(*this);
 
     auto *Fn = getFunction();
-    DeadEndBlocks DeadEndBBs(Fn);
+    auto *DEBA = getAnalysis<DeadEndBlocksAnalysis>();
+    auto &DeadEndBBs = *DEBA->get(Fn);
     JointPostDominanceSetComputer Computer(DeadEndBBs);
     InstModCallbacks callbacks;
     OwnershipFixupContext FixupCtx{callbacks, DeadEndBBs, Computer};

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -23,6 +23,7 @@
 ///
 /// ===----------------------------------------------------------------------===
 
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #define DEBUG_TYPE "copy-propagation"
 
 #include "swift/SIL/BasicBlockUtils.h"
@@ -88,8 +89,7 @@ void CopyPropagation::run() {
     accessBlockAnalysis->lockInvalidation();
     invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
     accessBlockAnalysis->unlockInvalidation();
-    DeadEndBlocks deBlocks(f);
-    f->verifyOwnership(&deBlocks);
+    f->verifyOwnership(getAnalysis<DeadEndBlocksAnalysis>()->get(f));
   }
 }
 

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -24,8 +24,9 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "dead-object-elim"
-#include "swift/Basic/IndexTrie.h"
+
 #include "swift/AST/ResilienceExpansion.h"
+#include "swift/Basic/IndexTrie.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/InstructionUtils.h"
@@ -37,6 +38,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
@@ -702,7 +704,8 @@ class DeadObjectElimination : public SILFunctionTransform {
   bool processAllocApply(ApplyInst *AI, DeadEndBlocks &DEBlocks);
 
   bool processFunction(SILFunction &Fn) {
-    DeadEndBlocks DEBlocks(&Fn);
+    auto *DEBA = getAnalysis<DeadEndBlocksAnalysis>();
+    auto &DEBlocks = *DEBA->get(&Fn);
     Allocations.clear();
     DestructorAnalysisCache.clear();
     bool Changed = false;

--- a/lib/SILOptimizer/Transforms/StackPromotion.cpp
+++ b/lib/SILOptimizer/Transforms/StackPromotion.cpp
@@ -14,6 +14,7 @@
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/Analysis/EscapeAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -61,8 +62,9 @@ void StackPromotion::run() {
 
   LLVM_DEBUG(llvm::dbgs() << "** StackPromotion in " << F->getName() << " **\n");
 
-  auto *EA = PM->getAnalysis<EscapeAnalysis>();
-  DeadEndBlocks DEBlocks(F);
+  auto *EA = getAnalysis<EscapeAnalysis>();
+  auto *DEBA = getAnalysis<DeadEndBlocksAnalysis>();
+  auto &DEBlocks = *DEBA->get(F);
   bool Changed = false;
 
   // Search the whole function for stack promotable allocations.

--- a/lib/SILOptimizer/UtilityPasses/OwnershipVerifierTextualErrorDumper.cpp
+++ b/lib/SILOptimizer/UtilityPasses/OwnershipVerifierTextualErrorDumper.cpp
@@ -23,6 +23,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 
@@ -37,8 +38,7 @@ namespace {
 class OwnershipVerifierTextualErrorDumper : public SILFunctionTransform {
   void run() override {
     SILFunction *f = getFunction();
-    DeadEndBlocks deadEndBlocks(f);
-    f->verifyOwnership(&deadEndBlocks);
+    f->verifyOwnership(getAnalysis<DeadEndBlocksAnalysis>()->get(f));
   }
 };
 


### PR DESCRIPTION
I didn't change MandatoryInlining since from a comment there it seems that since
MandatoryInlining is a module pass still and we don't really manage invalidation
well there.
