### PR TITLE
IRGen: Fix unreachable lowering in async functions

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3162,6 +3162,10 @@ void IRGenSILFunction::visitStringLiteralInst(swift::StringLiteralInst *i) {
 }
 
 void IRGenSILFunction::visitUnreachableInst(swift::UnreachableInst *i) {
+  if (isAsync()) {
+    emitCoroutineOrAsyncExit();
+    return;
+  }
   Builder.CreateUnreachable();
 }
 

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: rdar73262638
 
 // REQUIRES: OS=macosx || OS=ios
 // FIXME: should not require Darwin to run this test once we have async main!

--- a/test/IRGen/async/unreachable.swift
+++ b/test/IRGen/async/unreachable.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-experimental-concurrency -disable-llvm-optzns -disable-swift-specific-llvm-optzns | %FileCheck %s
+// REQUIRES: concurrency
+
+// CHECK: call i1 @llvm.coro.end
+func foo() async -> Never {
+  await bar()
+  fatalError()
+}
+
+// CHECK: call i1 @llvm.coro.end
+func bar() async -> Never {
+  await foo()
+  fatalError()
+}


### PR DESCRIPTION
We need to add the coro.end intrinsic call for lowering to process
functions correctly.

rdar://73274012
