### PR TITLE
[Dependency Scanning] Install `lib_InternalSwiftScan.dylib` into the destination toolchain.

### DIFF
--- a/tools/libSwiftScan/CMakeLists.txt
+++ b/tools/libSwiftScan/CMakeLists.txt
@@ -26,3 +26,12 @@ add_llvm_symbol_exports(libSwiftScan ${LLVM_EXPORTED_SYMBOL_FILE})
 
 # Adds -dead_strip option
 add_link_opts(libSwiftScan)
+
+add_dependencies(compiler libSwiftScan)
+swift_install_in_component(TARGETS libSwiftScan
+  ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" COMPONENT compiler
+  LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" COMPONENT compiler
+  RUNTIME DESTINATION "bin" COMPONENT compiler)
+swift_install_in_component(DIRECTORY "${SWIFT_MAIN_INCLUDE_DIR}/swift-c/DependencyScan/"
+                           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SCAN_LIB_NAME}"
+                           COMPONENT compiler)


### PR DESCRIPTION
Adds the library to the list of default install components. 
Otherwise toolchains we create (e.g. development snapshots on swift.org) will not carry a copy of this library. 