### PR TITLE
Fix a crash in DeadArgumentTransform

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/DeadArgumentTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/DeadArgumentTransform.cpp
@@ -70,7 +70,6 @@ bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
       for (auto &AD : TransformDescriptor.ArgumentDescList) {
         if (AD.IsEntirelyDead) {
           AD.IsEntirelyDead = false;
-          break;
         }
       }
       TransformDescriptor.shouldModifySelfArgument =

--- a/test/SILOptimizer/dead_arg_transform.sil
+++ b/test/SILOptimizer/dead_arg_transform.sil
@@ -1,0 +1,35 @@
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts -sil-fso-optimize-if-not-called %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+public protocol View {
+}
+
+class DynamicStorage {
+}
+
+final class ItemStorage<V> : DynamicStorage where V : View {
+}
+
+extension View {
+  func dynamicStorage() -> DynamicStorage
+}
+
+sil @ItemStorage_init : $@convention(method) <V where V : View> (@in V, @owned ItemStorage<V>) -> @owned ItemStorage<V>
+
+// Test to check we don't attempt to specialize when we have only dead type args
+// Tests there is no crash in DeadArgTransform trying to erase a type arg with debug uses
+
+// CHECK-LABEL: sil @ItemStorage_alloc_init : 
+// CHECK-LABEL: } // end sil function 'ItemStorage_alloc_init'
+sil @ItemStorage_alloc_init : $@convention(method) <V where V : View> (@in V, @thick ItemStorage<V>.Type, @thick ItemStorage<V>.Type) -> @owned ItemStorage<V> {
+bb0(%0 : $*V, %1 : $@thick ItemStorage<V>.Type, %2 : $@thick ItemStorage<V>.Type):
+  %4 = alloc_ref $ItemStorage<V>
+  %5 = function_ref @ItemStorage_init : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in τ_0_0, @owned ItemStorage<τ_0_0>) -> @owned ItemStorage<τ_0_0>
+  %6 = apply %5<V>(%0, %4) : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in τ_0_0, @owned ItemStorage<τ_0_0>) -> @owned ItemStorage<τ_0_0>
+  return %6 : $ItemStorage<V>
+}
+


### PR DESCRIPTION
When there are no non-type dead args, DeadArgumentTransform should not
specialize the function. While marking dead type args as not dead, make
sure we go over all the args.
If not, the following incorrect things happen: 
- the function will be specialized with just dead type args
- a "dead" type arg with debug uses will be attempted to be deleted in FunctionSignatureTransform::DeadArgumentFinalizeOptimizedFunction.

