### PR TITLE
[IRGen] Fix crash when trying to compile `_Atomic(_Bool)`

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4158,7 +4158,10 @@ Explosion NativeConventionSchema::mapFromNative(IRGenModule &IGM,
       if (explosionTy != elt->getType()) {
         if (isa<llvm::IntegerType>(explosionTy) &&
             isa<llvm::IntegerType>(elt->getType())) {
-          elt = IGF.Builder.CreateTrunc(elt, explosionTy);
+          // [HACK: Atomic-Bool-IRGen] In the case of _Atomic(_Bool), Clang
+          // treats it as i8 whereas Swift works with i1, so we need to zext
+          // in that case.
+          elt = IGF.Builder.CreateZExtOrTrunc(elt, explosionTy);
         } else {
           elt = IGF.coerceValue(elt, explosionTy, DataLayout);
         }
@@ -4290,10 +4293,14 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
       auto *elt = fromNonNative.claimNext();
       if (nativeTy != elt->getType()) {
         if (isa<llvm::IntegerType>(nativeTy) &&
-            isa<llvm::IntegerType>(elt->getType()))
-          elt = IGF.Builder.CreateZExt(elt, nativeTy);
-        else
+            isa<llvm::IntegerType>(elt->getType())) {
+          // [HACK: Atomic-Bool-IRGen] In the case of _Atomic(_Bool), Clang
+          // treats it as i8 whereas Swift works with i1, so we need to trunc
+          // in that case.
+          elt = IGF.Builder.CreateZExtOrTrunc(elt, nativeTy);
+        } else {
           elt = IGF.coerceValue(elt, nativeTy, DataLayout);
+        }
       }
       nativeExplosion.add(elt);
       return nativeExplosion;

--- a/test/IRGen/Inputs/atomic_bool.h
+++ b/test/IRGen/Inputs/atomic_bool.h
@@ -1,0 +1,1 @@
+typedef struct { _Atomic(_Bool) value; } MyAtomicBool;

--- a/test/IRGen/Inputs/module.modulemap
+++ b/test/IRGen/Inputs/module.modulemap
@@ -21,3 +21,8 @@ module AutolinkElfCPragmaTransitive {
 module AutolinkModuleMapLink {
   link "autolink-module-map-link"
 }
+
+module AtomicBoolModule {
+  header "atomic_bool.h"
+  export *
+}

--- a/test/IRGen/atomic_bool.swift
+++ b/test/IRGen/atomic_bool.swift
@@ -1,4 +1,5 @@
-// RUN: not --crash %target-swift-emit-ir %s -I %S/Inputs
+// Check that IRGen doesn't crash. rdar://72999296
+// RUN: %target-swift-emit-ir %s -I %S/Inputs
 
 import AtomicBoolModule
 

--- a/test/IRGen/atomic_bool.swift
+++ b/test/IRGen/atomic_bool.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-emit-ir %s -I %S/Inputs
+
+import AtomicBoolModule
+
+public func f() -> MyAtomicBool {
+  return MyAtomicBool()
+}
+
+public func g(_ b: MyAtomicBool) {
+  let _ = b
+}


### PR DESCRIPTION
Fixes rdar://72999296. Previously an LLVM-side patch (https://reviews.llvm.org/D94854), but decided to fix this on the Swift-side after discussion with John.