### PR TITLE
[Diagnostics] Adjust OoO fix-it intervals to account for replacement of first argument

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4836,9 +4836,14 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
     SourceRange removalRange{Lexer::getLocForEndOfToken(SM, removalStartLoc),
                              firstRange.End};
 
+    // Move requires postfix comma only if argument is moved in-between
+    // other arguments.
+    bool requiresComma = !isExpr<BinaryExpr>(anchor) &&
+                         PrevArgIdx != tuple->getNumElements() - 1;
+
     diag.fixItRemove(removalRange);
     diag.fixItInsert(secondRange.Start,
-                     text.str() + (isExpr<BinaryExpr>(anchor) ? "" : ", "));
+                     text.str() + (requiresComma ? ", " : ""));
   };
 
   // There are 4 diagnostic messages variations depending on

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4823,10 +4823,19 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
     auto text = SM.extractText(
         Lexer::getCharSourceRangeFromSourceRange(SM, firstRange));
 
-    auto removalRange =
-        SourceRange(Lexer::getLocForEndOfToken(
-                        SM, tuple->getElement(ArgIdx - 1)->getEndLoc()),
-                    firstRange.End);
+    SourceLoc removalStartLoc;
+    // For the first argument, start is always next token after `(`.
+    if (ArgIdx == 0) {
+      removalStartLoc = tuple->getLParenLoc();
+    } else {
+      // For all other arguments, start is the next token past
+      // the previous argument.
+      removalStartLoc = tuple->getElement(ArgIdx - 1)->getEndLoc();
+    }
+
+    SourceRange removalRange{Lexer::getLocForEndOfToken(SM, removalStartLoc),
+                             firstRange.End};
+
     diag.fixItRemove(removalRange);
     diag.fixItInsert(secondRange.Start,
                      text.str() + (isExpr<BinaryExpr>(anchor) ? "" : ", "));

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1745,3 +1745,17 @@ func --- (_ lhs: String, _ rhs: String) -> Bool { true }
 
 let x = 1
 x --- x // expected-error 2 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+
+// rdar://problem/70764991 - out-of-order diagnostic crashes the compiler
+func rdar70764991() {
+  struct S {
+    static var foo: S { get { S() } }
+  }
+
+  func bar(_: Any, foo: String) {
+  }
+
+  func test(_ str: String) {
+    bar(str, foo: S.foo) // expected-error {{unnamed argument #1 must precede argument 'foo'}}  {{9-12=}} {{14-14=str, }}
+  }
+}

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1752,10 +1752,10 @@ func rdar70764991() {
     static var foo: S { get { S() } }
   }
 
-  func bar(_: Any, foo: String) {
+  func bar(_: Any, _: String) {
   }
 
   func test(_ str: String) {
-    bar(str, foo: S.foo) // expected-error {{unnamed argument #1 must precede argument 'foo'}}  {{9-12=}} {{14-14=str, }}
+    bar(str, S.foo) // expected-error {{unnamed argument #1 must precede unnamed argument #2}}  {{9-12=}} {{14-14=str}}
   }
 }


### PR DESCRIPTION
Current logic fix-it didn't account for the first argument being re-ordered.
The start position for the first argument should always be the next token
after left paren denoting a start of the argument list.

Resolves: rdar://problem/70764991
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
