### PR TITLE
[5.4][Diagnostics] Adjust OoO fix-it intervals to account for replacement of first argument

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4825,9 +4825,14 @@ bool OutOfOrderArgumentFailure::diagnoseAsError() {
     SourceRange removalRange{Lexer::getLocForEndOfToken(SM, removalStartLoc),
                              firstRange.End};
 
+    // Move requires postfix comma only if argument is moved in-between
+    // other arguments.
+    bool requiresComma = !isExpr<BinaryExpr>(anchor) &&
+                         PrevArgIdx != tuple->getNumElements() - 1;
+
     diag.fixItRemove(removalRange);
     diag.fixItInsert(secondRange.Start,
-                     text.str() + (isExpr<BinaryExpr>(anchor) ? "" : ", "));
+                     text.str() + (requiresComma ? ", " : ""));
   };
 
   // There are 4 diagnostic messages variations depending on

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1745,3 +1745,17 @@ func --- (_ lhs: String, _ rhs: String) -> Bool { true }
 
 let x = 1
 x --- x // expected-error 2 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+
+// rdar://problem/70764991 - out-of-order diagnostic crashes the compiler
+func rdar70764991() {
+  struct S {
+    static var foo: S { get { S() } }
+  }
+
+  func bar(_: Any, foo: String) {
+  }
+
+  func test(_ str: String) {
+    bar(str, foo: S.foo) // expected-error {{unnamed argument #1 must precede argument 'foo'}}  {{9-12=}} {{14-14=str, }}
+  }
+}

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1752,10 +1752,10 @@ func rdar70764991() {
     static var foo: S { get { S() } }
   }
 
-  func bar(_: Any, foo: String) {
+  func bar(_: Any, _: String) {
   }
 
   func test(_ str: String) {
-    bar(str, foo: S.foo) // expected-error {{unnamed argument #1 must precede argument 'foo'}}  {{9-12=}} {{14-14=str, }}
+    bar(str, S.foo) // expected-error {{unnamed argument #1 must precede unnamed argument #2}}  {{9-12=}} {{14-14=str}}
   }
 }


### PR DESCRIPTION
Current logic fix-it didn't account for the first argument being re-ordered.
The start position for the first argument should always be the next token
after left paren denoting a start of the argument list.

Resolves: rdar://problem/70764991

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
