### PR TITLE
IRGen: Plumb through a GenericSignature when mangling types for debug info

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -222,7 +222,7 @@ public:
                                       GenericSignature signature,
                                       ResilienceExpansion expansion);
 
-  std::string mangleTypeForDebugger(Type decl, const DeclContext *DC);
+  std::string mangleTypeForDebugger(Type decl, GenericSignature sig);
 
   /// Create a mangled name to be used for _typeName constant propagation.
   std::string mangleTypeForTypeName(Type type);
@@ -282,9 +282,7 @@ protected:
   void appendOpWithGenericParamIndex(StringRef,
                                      const GenericTypeParamType *paramTy);
 
-  void bindGenericParameters(const DeclContext *DC);
-
-  void bindGenericParameters(CanGenericSignature sig);
+  void bindGenericParameters(GenericSignature sig);
 
   /// Mangles a sugared type iff we are mangling for the debugger.
   template <class T> void appendSugaredType(Type type,

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -816,7 +816,7 @@ private:
           ->getKey();
 
     Type Ty = DbgTy.getType();
-    if (!Ty->hasTypeParameter())
+    if (Ty->hasArchetype())
       Ty = Ty->mapTypeOutOfContext();
 
     // Strip off top level of type sugar (except for type aliases).
@@ -842,7 +842,8 @@ private:
         IGM.getSILModule());
 
     Mangle::ASTMangler Mangler;
-    std::string Result = Mangler.mangleTypeForDebugger(Ty, nullptr);
+    GenericSignature Sig = IGM.getCurGenericContext();
+    std::string Result = Mangler.mangleTypeForDebugger(Ty, Sig);
 
     if (!Opts.DisableRoundTripDebugTypes) {
       // Make sure we can reconstruct mangled types for the debugger.

--- a/test/DebugInfo/retroactive_conformance_witness_thunk.swift
+++ b/test/DebugInfo/retroactive_conformance_witness_thunk.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-ir -g -primary-file %s
+
+// https://bugs.swift.org/browse/SR-14016
+
+public struct PowerCollection<C : Collection> : Collection {
+  public typealias Index = [C.Index]
+  public typealias Element = [C.Element]
+
+  public var startIndex, endIndex: Index
+
+  public subscript(position: Index) -> [C.Element] {
+    return []
+  }
+
+  public func index(after i: Index) -> Index {
+    return i
+  }
+
+}
+
+extension Array : Comparable where Element : Comparable {
+  public static func < (lhs: [Element], rhs: [Element]) -> Bool {
+    return false
+  }
+}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2293,7 +2293,8 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
     for (auto LTD : LocalTypeDecls) {
       Mangle::ASTMangler Mangler;
       std::string MangledName = Mangler.mangleTypeForDebugger(
-          LTD->getDeclaredInterfaceType(), LTD->getDeclContext());
+          LTD->getDeclaredInterfaceType(),
+          LTD->getInnermostDeclContext()->getGenericSignatureOfContext());
       MangledNames.push_back(MangledName);
     }
 
@@ -3420,7 +3421,8 @@ public:
 private:
   void tryDemangleType(Type T, const DeclContext *DC, CharSourceRange range) {
     Mangle::ASTMangler Mangler;
-    std::string mangledName(Mangler.mangleTypeForDebugger(T, DC));
+    auto sig = DC->getGenericSignatureOfContext();
+    std::string mangledName(Mangler.mangleTypeForDebugger(T, sig));
     Type ReconstructedType = DC->mapTypeIntoContext(
         Demangle::getTypeForMangling(Ctx, mangledName));
     Stream << "type: ";


### PR DESCRIPTION
The generic signature isn't used for a whole lot, so this all mostly
worked before; the test case I have hits the code path for mangling
a retroactive conformance.

Fixes <https://bugs.swift.org/browse/SR-14016> / <rdar://problem/72865083>.