### PR TITLE
IRGen: Plumb through a GenericSignature when mangling types for debug info [5.4]

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -222,7 +222,7 @@ public:
                                       GenericSignature signature,
                                       ResilienceExpansion expansion);
 
-  std::string mangleTypeForDebugger(Type decl, const DeclContext *DC);
+  std::string mangleTypeForDebugger(Type decl, GenericSignature sig);
 
   /// Create a mangled name to be used for _typeName constant propagation.
   std::string mangleTypeForTypeName(Type type);
@@ -280,9 +280,7 @@ protected:
   void appendOpWithGenericParamIndex(StringRef,
                                      const GenericTypeParamType *paramTy);
 
-  void bindGenericParameters(const DeclContext *DC);
-
-  void bindGenericParameters(CanGenericSignature sig);
+  void bindGenericParameters(GenericSignature sig);
 
   /// Mangles a sugared type iff we are mangling for the debugger.
   template <class T> void appendSugaredType(Type type,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -538,7 +538,7 @@ static Type getTypeForDWARFMangling(Type t) {
     SubstFlags::AllowLoweredTypes);
 }
 
-std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
+std::string ASTMangler::mangleTypeForDebugger(Type Ty, GenericSignature sig) {
   PrettyStackTraceType prettyStackTrace(Ty->getASTContext(),
                                         "mangling type for debugger", Ty);
 
@@ -548,9 +548,7 @@ std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC) {
 
   Ty = getTypeForDWARFMangling(Ty);
 
-  if (DC)
-    bindGenericParameters(DC);
-
+  bindGenericParameters(sig);
   appendType(Ty);
   appendOperator("D");
   return finalize();
@@ -676,7 +674,9 @@ std::string ASTMangler::mangleDeclAsUSR(const ValueDecl *Decl,
   beginManglingWithoutPrefix();
   llvm::SaveAndRestore<bool> allowUnnamedRAII(AllowNamelessEntities, true);
   Buffer << USRPrefix;
-  bindGenericParameters(Decl->getDeclContext());
+
+  auto Sig = Decl->getInnermostDeclContext()->getGenericSignatureOfContext();
+  bindGenericParameters(Sig);
 
   if (auto Ctor = dyn_cast<ConstructorDecl>(Decl)) {
     appendConstructorEntity(Ctor, /*isAllocating=*/false);
@@ -1369,15 +1369,9 @@ void ASTMangler::appendOpWithGenericParamIndex(StringRef Op,
 
 
 /// Bind the generic parameters from the given signature.
-void ASTMangler::bindGenericParameters(CanGenericSignature sig) {
+void ASTMangler::bindGenericParameters(GenericSignature sig) {
   if (sig)
-    CurGenericSignature = sig;
-}
-
-/// Bind the generic parameters from the given context and its parents.
-void ASTMangler::bindGenericParameters(const DeclContext *DC) {
-  if (auto sig = DC->getGenericSignatureOfContext())
-    bindGenericParameters(sig.getCanonicalSignature());
+    CurGenericSignature = sig.getCanonicalSignature();
 }
 
 void ASTMangler::appendFlatGenericArgs(SubstitutionMap subs) {
@@ -2853,12 +2847,13 @@ void ASTMangler::appendAccessorEntity(StringRef accessorKindCode,
                                       const AbstractStorageDecl *decl,
                                       bool isStatic) {
   appendContextOf(decl);
-  bindGenericParameters(decl->getDeclContext());
-  if (isa<VarDecl>(decl)) {
+  if (auto *varDecl = dyn_cast<VarDecl>(decl)) {
+    bindGenericParameters(varDecl->getDeclContext()->getGenericSignatureOfContext());
     appendDeclName(decl);
     appendDeclType(decl);
     appendOperator("v", accessorKindCode);
-  } else if (isa<SubscriptDecl>(decl)) {
+  } else if (auto *subscriptDecl = dyn_cast<SubscriptDecl>(decl)) {
+    bindGenericParameters(subscriptDecl->getGenericSignature());
     appendDeclType(decl);
 
     StringRef privateDiscriminator = getPrivateDiscriminatorIfNecessary(decl);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -816,7 +816,7 @@ private:
           ->getKey();
 
     Type Ty = DbgTy.getType();
-    if (!Ty->hasTypeParameter())
+    if (Ty->hasArchetype())
       Ty = Ty->mapTypeOutOfContext();
 
     // Strip off top level of type sugar (except for type aliases).
@@ -842,7 +842,8 @@ private:
         IGM.getSILModule());
 
     Mangle::ASTMangler Mangler;
-    std::string Result = Mangler.mangleTypeForDebugger(Ty, nullptr);
+    GenericSignature Sig = IGM.getCurGenericContext();
+    std::string Result = Mangler.mangleTypeForDebugger(Ty, Sig);
 
     if (!Opts.DisableRoundTripDebugTypes) {
       // Make sure we can reconstruct mangled types for the debugger.

--- a/test/DebugInfo/retroactive_conformance_witness_thunk.swift
+++ b/test/DebugInfo/retroactive_conformance_witness_thunk.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-ir -g -primary-file %s
+
+// https://bugs.swift.org/browse/SR-14016
+
+public struct PowerCollection<C : Collection> : Collection {
+  public typealias Index = [C.Index]
+  public typealias Element = [C.Element]
+
+  public var startIndex, endIndex: Index
+
+  public subscript(position: Index) -> [C.Element] {
+    return []
+  }
+
+  public func index(after i: Index) -> Index {
+    return i
+  }
+
+}
+
+extension Array : Comparable where Element : Comparable {
+  public static func < (lhs: [Element], rhs: [Element]) -> Bool {
+    return false
+  }
+}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2298,7 +2298,8 @@ static int doPrintLocalTypes(const CompilerInvocation &InitInvok,
     for (auto LTD : LocalTypeDecls) {
       Mangle::ASTMangler Mangler;
       std::string MangledName = Mangler.mangleTypeForDebugger(
-          LTD->getDeclaredInterfaceType(), LTD->getDeclContext());
+          LTD->getDeclaredInterfaceType(),
+          LTD->getInnermostDeclContext()->getGenericSignatureOfContext());
       MangledNames.push_back(MangledName);
     }
 
@@ -3410,7 +3411,8 @@ public:
 private:
   void tryDemangleType(Type T, const DeclContext *DC, CharSourceRange range) {
     Mangle::ASTMangler Mangler;
-    std::string mangledName(Mangler.mangleTypeForDebugger(T, DC));
+    auto sig = DC->getGenericSignatureOfContext();
+    std::string mangledName(Mangler.mangleTypeForDebugger(T, sig));
     Type ReconstructedType = DC->mapTypeIntoContext(
         Demangle::getTypeForMangling(Ctx, mangledName));
     Stream << "type: ";


### PR DESCRIPTION
The generic signature isn't used for a whole lot, so this all mostly
worked before; the test case I have hits the code path for mangling
a retroactive conformance.

Fixes <https://bugs.swift.org/browse/SR-14016> / <rdar://problem/72865083>.