### PR TITLE
[5.4] IRGen non-fatal legacy layouts fail

### DIFF
--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1420,8 +1420,9 @@ TypeConverter::TypeConverter(IRGenModule &IGM)
   }
 
   bool error = readLegacyTypeInfo(*fs, path);
-  if (error)
-    llvm::report_fatal_error("Cannot read '" + path + "'");
+  if (error) {
+    IGM.error(SourceLoc(), "Cannot read legacy layout file at '" + path + "'");
+  }
 }
 
 TypeConverter::~TypeConverter() {


### PR DESCRIPTION
Log out an error and continue, rather than just aborting compilation immediately.

Pick of #35389 

Resolves rdar://71439646