### PR TITLE
[Concurrency] Imported macros are actor independent

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8953,7 +8953,12 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
 
   // Mark the function transparent so that we inline it away completely.
   func->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-  
+  // If we're in concurrency mode, mark the constant as @actorIndependent
+  if (SwiftContext.LangOpts.EnableExperimentalConcurrency) {
+    auto actorIndependentAttr = new (C) ActorIndependentAttr(SourceLoc(),
+        SourceRange(), ActorIndependentKind::Safe);
+    var->getAttrs().add(actorIndependentAttr);
+  }
   // Set the function up as the getter.
   makeComputed(var, func, nullptr);
 

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -42,3 +42,5 @@ import _Concurrency
 // CHECK-NEXT: @MainActor func mainActorMethod()
 // CHECK-NEXT: {{^}}  optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}
+
+// CHECK: @actorIndependent var MAGIC_NUMBER: Int32 { get }

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -77,4 +77,6 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)missingAtAttributeMethod __attribute__((__swift_attr__("asyncHandler")));
 @end
 
+#define MAGIC_NUMBER 42
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
Macros are thread safe. Marking them actor-independent will avoid
imported macros being reported as not concurrency safe.

Fixes: rdar://73203807