### PR TITLE
[sil-combine] Enable ownership on all of the apply visitors.

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -255,6 +255,8 @@ public:
   SILInstruction *visitBuiltinInst(BuiltinInst *BI);
   SILInstruction *visitCondFailInst(CondFailInst *CFI);
   SILInstruction *visitStrongRetainInst(StrongRetainInst *SRI);
+  SILInstruction *visitCopyValueInst(CopyValueInst *cvi);
+  SILInstruction *visitDestroyValueInst(DestroyValueInst *dvi);
   SILInstruction *visitRefToRawPointerInst(RefToRawPointerInst *RRPI);
   SILInstruction *visitUpcastInst(UpcastInst *UCI);
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -78,41 +78,37 @@ static bool foldInverseReabstractionThunks(PartialApplyInst *PAI,
   return true;
 }
 
-SILInstruction *SILCombiner::visitPartialApplyInst(PartialApplyInst *PAI) {
-  if (PAI->getFunction()->hasOwnership())
-    return nullptr;
-
+SILInstruction *SILCombiner::visitPartialApplyInst(PartialApplyInst *pai) {
   // partial_apply without any substitutions or arguments is just a
   // thin_to_thick_function. thin_to_thick_function supports only thin operands.
-  if (!PAI->hasSubstitutions() && (PAI->getNumArguments() == 0) &&
-      PAI->getSubstCalleeType()->getRepresentation() ==
+  if (!pai->hasSubstitutions() && (pai->getNumArguments() == 0) &&
+      pai->getSubstCalleeType()->getRepresentation() ==
           SILFunctionTypeRepresentation::Thin) {
-    if (!PAI->isOnStack())
-      return Builder.createThinToThickFunction(PAI->getLoc(), PAI->getCallee(),
-                                               PAI->getType());
+    if (!pai->isOnStack())
+      return Builder.createThinToThickFunction(pai->getLoc(), pai->getCallee(),
+                                               pai->getType());
 
     // Remove dealloc_stack of partial_apply [stack].
     // Iterating while delete use a copy.
-    SmallVector<Operand *, 8> Uses(PAI->getUses());
-    for (auto *Use : Uses)
-      if (auto *dealloc = dyn_cast<DeallocStackInst>(Use->getUser()))
+    SmallVector<Operand *, 8> uses(pai->getUses());
+    for (auto *use : uses)
+      if (auto *dealloc = dyn_cast<DeallocStackInst>(use->getUser()))
         eraseInstFromFunction(*dealloc);
     auto *thinToThick = Builder.createThinToThickFunction(
-        PAI->getLoc(), PAI->getCallee(), PAI->getType());
-    replaceInstUsesWith(*PAI, thinToThick);
-    eraseInstFromFunction(*PAI);
+        pai->getLoc(), pai->getCallee(), pai->getType());
+    replaceInstUsesWith(*pai, thinToThick);
+    eraseInstFromFunction(*pai);
     return nullptr;
   }
-
 
   // partial_apply %reabstraction_thunk_typeAtoB(
   //    partial_apply %reabstraction_thunk_typeBtoA %closure_typeB))
   // -> %closure_typeB
-  if (foldInverseReabstractionThunks(PAI, this))
+  if (foldInverseReabstractionThunks(pai, this))
     return nullptr;
 
   bool argsAreKeptAlive = tryOptimizeApplyOfPartialApply(
-      PAI, Builder.getBuilderContext(), getInstModCallbacks());
+      pai, Builder.getBuilderContext(), getInstModCallbacks());
   if (argsAreKeptAlive)
     invalidatedStackNesting = true;
 
@@ -120,7 +116,7 @@ SILInstruction *SILCombiner::visitPartialApplyInst(PartialApplyInst *PAI) {
   // In case it became dead because of tryOptimizeApplyOfPartialApply, we don't
   // need to copy all arguments again (to extend their lifetimes), because it
   // was already done in tryOptimizeApplyOfPartialApply.
-  if (tryDeleteDeadClosure(PAI, getInstModCallbacks(), !argsAreKeptAlive))
+  if (tryDeleteDeadClosure(pai, getInstModCallbacks(), !argsAreKeptAlive))
     invalidatedStackNesting = true;
 
   return nullptr;
@@ -570,13 +566,13 @@ SILCombiner::recursivelyCollectARCUsers(UserListTy &Uses, ValueBase *Value) {
 
   for (auto *Use : Value->getUses()) {
     SILInstruction *Inst = Use->getUser();
-    if (isa<RefCountingInst>(Inst) ||
-        isa<DebugValueInst>(Inst)) {
+    if (isa<RefCountingInst>(Inst) || isa<DestroyValueInst>(Inst) ||
+        isa<DebugValueInst>(Inst) || isa<EndBorrowInst>(Inst)) {
       Uses.push_back(Inst);
       continue;
     }
-    if (isa<TupleExtractInst>(Inst) ||
-        isa<StructExtractInst>(Inst) ||
+    if (isa<TupleExtractInst>(Inst) || isa<StructExtractInst>(Inst) ||
+        isa<CopyValueInst>(Inst) || isa<BeginBorrowInst>(Inst) ||
         isa<PointerToAddressInst>(Inst)) {
       Uses.push_back(Inst);
       if (recursivelyCollectARCUsers(Uses, cast<SingleValueInstruction>(Inst)))
@@ -628,10 +624,8 @@ bool SILCombiner::eraseApply(FullApplySite FAS, const UserListTy &Users) {
       switch (PI.getConvention()) {
         case ParameterConvention::Indirect_In:
         case ParameterConvention::Indirect_In_Constant:
-          Builder.createDestroyAddr(FAS.getLoc(), Arg);
-          break;
         case ParameterConvention::Direct_Owned:
-          Builder.createReleaseValue(FAS.getLoc(), Arg, Builder.getDefaultAtomicity());
+          Builder.emitDestroyOperation(FAS.getLoc(), Arg);
           break;
         case ParameterConvention::Indirect_In_Guaranteed:
         case ParameterConvention::Indirect_Inout:
@@ -741,10 +735,33 @@ SILCombiner::buildConcreteOpenedExistentialInfoFromSoleConformingType(
   // Prepare the code by adding UncheckedCast instructions that cast opened
   // existentials to concrete types. Set the ConcreteValue of CEI.
   if (auto *OER = dyn_cast<OpenExistentialRefInst>(OAI.OpenedArchetypeValue)) {
-    SoleCEI.ConcreteValue =
-        Builder.createUncheckedRefCast(OER->getLoc(), OER, concreteSILType);
+    // If we have an owned open_existential_ref, we only optimize for now if our
+    // open_existential_ref has a single non-debug consuming use that is a
+    // destroy_value.
+    if (OER->getOwnershipKind() != OwnershipKind::Owned) {
+      // We use OER as the insertion point so that
+      SILBuilderWithScope b(std::next(OER->getIterator()), Builder);
+      auto loc = RegularLocation::getAutoGeneratedLocation();
+      SoleCEI.ConcreteValue =
+          b.createUncheckedRefCast(loc, OER, concreteSILType);
+      return COAI;
+    }
+
+    auto *consumingUse = OER->getSingleConsumingUse();
+    if (!consumingUse || !isa<DestroyValueInst>(consumingUse->getUser())) {
+      return None;
+    }
+
+    // We use std::next(OER) as the insertion point so that we can reuse the
+    // destroy_value of consumingUse.
+    SILBuilderWithScope b(std::next(OER->getIterator()), Builder);
+    auto loc = RegularLocation::getAutoGeneratedLocation();
+    auto *uri = b.createUncheckedRefCast(loc, OER, concreteSILType);
+    SoleCEI.ConcreteValue = uri;
+    replaceInstUsesWith(*OER, uri);
     return COAI;
   }
+
   if (auto *OEA = dyn_cast<OpenExistentialAddrInst>(OAI.OpenedArchetypeValue)) {
     // Bail if ConcreteSILType is not the same SILType as the type stored in the
     // existential after maximal reabstraction.
@@ -1246,6 +1263,11 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
 SILInstruction *
 SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply,
                                                     WitnessMethodInst *WMI) {
+  // We do not perform this optimization in OSSA. In OSSA, we will have opaque
+  // values we will redo this.
+  if (WMI->getFunction()->hasOwnership())
+    return nullptr;
+
   // Check if it is legal to perform the propagation.
   if (WMI->getConformance().isConcrete())
     return nullptr;
@@ -1327,6 +1349,9 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply,
 /// ==> apply %f<C : P>(%ref)
 SILInstruction *
 SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply) {
+  if (Apply.getFunction()->hasOwnership())
+    return nullptr;
+
   // This optimization requires a generic argument.
   if (!Apply.hasSubstitutions())
     return nullptr;
@@ -1354,19 +1379,30 @@ SILCombiner::propagateConcreteTypeOfInitExistential(FullApplySite Apply) {
 /// Check that all users of the apply are retain/release ignoring one
 /// user.
 static bool
-hasOnlyRetainReleaseUsers(ApplyInst *AI, SILInstruction *IgnoreUser,
-                          SmallVectorImpl<SILInstruction *> &Users) {
-  for (auto *Use : getNonDebugUses(AI)) {
-    if (Use->getUser() == IgnoreUser)
+hasOnlyRecursiveOwnershipUsers(ApplyInst *ai, SILInstruction *ignoreUser,
+                               SmallVectorImpl<SILInstruction *> &foundUsers) {
+  SmallVector<Operand *, 32> worklist(getNonDebugUses(ai));
+  while (!worklist.empty()) {
+    auto *use = worklist.pop_back_val();
+    auto *user = use->getUser();
+    if (user == ignoreUser)
       continue;
 
-    if (!isa<RetainValueInst>(Use->getUser()) &&
-        !isa<ReleaseValueInst>(Use->getUser()) &&
-        !isa<StrongRetainInst>(Use->getUser()) &&
-        !isa<StrongReleaseInst>(Use->getUser()))
+    if (!isa<RetainValueInst>(user) && !isa<ReleaseValueInst>(user) &&
+        !isa<StrongRetainInst>(user) && !isa<StrongReleaseInst>(user) &&
+        !isa<CopyValueInst>(user) && !isa<DestroyValueInst>(user) &&
+        !isa<BeginBorrowInst>(user) && !isa<EndBorrowInst>(user) &&
+        !user->isDebugInstruction())
       return false;
 
-    Users.push_back(Use->getUser());
+    if (auto *cvi = dyn_cast<CopyValueInst>(user))
+      for (auto *use : cvi->getUses())
+        worklist.push_back(use);
+    if (auto *bbi = dyn_cast<BeginBorrowInst>(user))
+      for (auto *use : bbi->getUses())
+        worklist.push_back(use);
+
+    foundUsers.push_back(user);
   }
   return true;
 };
@@ -1416,11 +1452,11 @@ static void emitMatchingRCAdjustmentsForCall(ApplyInst *Call, SILValue OnX) {
          "Expect a @owned return");
   assert(Call->getNumArguments() == 1 && "Expect a unary call");
 
-  // Emit a retain for the @owned return.
+  // Emit a copy for the @owned return.
   SILBuilderWithScope Builder(Call);
   OnX = Builder.emitCopyValueOperation(Call->getLoc(), OnX);
 
-  // Emit a release for the @owned parameter, or none for a @guaranteed
+  // Emit a destroy for the @owned parameter, or none for a @guaranteed
   // parameter.
   auto Params = FnTy->getParameters();
   (void) Params;
@@ -1433,79 +1469,109 @@ static void emitMatchingRCAdjustmentsForCall(ApplyInst *Call, SILValue OnX) {
     Builder.emitDestroyValueOperation(Call->getLoc(), OnX);
 }
 
-/// Replace an application of a cast composition f_inverse(f(x)) by x.
-bool SILCombiner::optimizeIdentityCastComposition(ApplyInst *FInverse,
-                                              StringRef FInverseName,
-                                              StringRef FName) {
+// Replace an application of a cast composition f_inverse(f(x)) by x.
+//
+// NOTE: The instruction we are actually folding is f_inverse.
+bool SILCombiner::optimizeIdentityCastComposition(ApplyInst *fInverseApply,
+                                                  StringRef fInverseName,
+                                                  StringRef fName) {
   // Needs to have a known semantics.
-  if (!FInverse->hasSemantics(FInverseName))
+  if (!fInverseApply->hasSemantics(fInverseName))
     return false;
 
   // We need to know how to replace the call by reference counting instructions.
-  if (!knowHowToEmitReferenceCountInsts(FInverse))
+  if (!knowHowToEmitReferenceCountInsts(fInverseApply))
     return false;
 
   // Need to have a matching 'f'.
-  auto *F = dyn_cast<ApplyInst>(FInverse->getArgument(0));
-  if (!F)
+  auto fInverseArg0 = lookThroughOwnershipInsts(fInverseApply->getArgument(0));
+  auto *fApply = dyn_cast<ApplyInst>(fInverseArg0);
+  if (!fApply)
     return false;
-  if (!F->hasSemantics(FName))
+  if (!fApply->hasSemantics(fName))
     return false;
-  if (!knowHowToEmitReferenceCountInsts(F))
+  if (!knowHowToEmitReferenceCountInsts(fApply))
     return false;
 
   // The types must match.
-  if (F->getArgument(0)->getType() != FInverse->getType())
+  if (fApply->getArgument(0)->getType() != fInverseApply->getType())
     return false;
 
-  // Retains, releases of the result of F.
-  SmallVector<SILInstruction *, 16> RetainReleases;
-  if (!hasOnlyRetainReleaseUsers(F, FInverse, RetainReleases))
+  // Gather up all retain
+  SmallVector<SILInstruction *, 16> foundOwnershipUsers;
+  if (!hasOnlyRecursiveOwnershipUsers(fApply, fInverseApply /*user to ignore*/,
+                                      foundOwnershipUsers))
     return false;
 
   // Okay, now we know we can remove the calls.
-  auto X = F->getArgument(0);
+  auto arg0 = fApply->getArgument(0);
 
-  // Redirect f's result's retains/releases to affect x.
-  for (auto *User : RetainReleases) {
-    // X might not be strong_retain/release'able. Replace it by a
-    // retain/release_value on X instead.
-    if (isa<StrongRetainInst>(User)) {
-      SILBuilderWithScope Builder(User);
-      Builder.createRetainValue(User->getLoc(), X,
-                                cast<StrongRetainInst>(User)->getAtomicity());
-      eraseInstFromFunction(*User);
-      continue;
+  if (fApply->getFunction()->hasOwnership()) {
+    // First perform an ownership RAUW+erase of arg0 and inverse apply. The OSSA
+    // RAUW helper will copy arg0 if needed. We need to do this before anything
+    // else since the utility assumes OSSA is in correct form.
+    if (!decltype(ownershipRAUWHelper)::canFixUpOwnershipForRAUW(fInverseApply,
+                                                                 arg0)) {
+      return false;
     }
-    if (isa<StrongReleaseInst>(User)) {
-      SILBuilderWithScope Builder(User);
-      Builder.createReleaseValue(User->getLoc(), X,
-                                 cast<StrongReleaseInst>(User)->getAtomicity());
-      eraseInstFromFunction(*User);
-      continue;
+    ownershipRAUWHelper.replaceAllUsesAndErase(fInverseApply, arg0);
+
+    // Now remove the apply, inserting a destroy_value if we need to it arg0.
+    if (fApply->getArgumentRef(0).isLifetimeEnding()) {
+      SILBuilderWithScope b(fApply, Builder);
+      if (arg0.getOwnershipKind() == OwnershipKind::Owned) {
+        b.emitDestroyValueOperation(fApply->getLoc(), arg0);
+      } else if (arg0.getOwnershipKind() == OwnershipKind::Guaranteed) {
+        b.emitEndBorrowOperation(fApply->getLoc(), arg0);
+      }
     }
-    User->setOperand(0, X);
+    eraseInstIncludingUsers(fApply);
+
+    return true;
   }
 
-  // Simulate the reference count effects of the calls before removing
-  // them.
-  emitMatchingRCAdjustmentsForCall(F, X);
-  emitMatchingRCAdjustmentsForCall(FInverse, X);
+  // Redirect f's result's retains/releases to affect x.
+  //
+  // NOTE: This part of the code is only used in non-ownership SIL since we
+  // represent ARC operations there with copy_value, destroy_value that work
+  // with all types.
+  for (auto *ownershipUser : foundOwnershipUsers) {
+    // X might not be strong_retain/release'able. Replace it by a
+    // retain/release_value on X instead.
+    if (isa<StrongRetainInst>(ownershipUser)) {
+      SILBuilderWithScope b(ownershipUser, Builder);
+      b.createRetainValue(
+          ownershipUser->getLoc(), arg0,
+          cast<StrongRetainInst>(ownershipUser)->getAtomicity());
+      eraseInstFromFunction(*ownershipUser);
+      continue;
+    }
+    if (isa<StrongReleaseInst>(ownershipUser)) {
+      SILBuilderWithScope b(ownershipUser, Builder);
+      b.createReleaseValue(
+          ownershipUser->getLoc(), arg0,
+          cast<StrongReleaseInst>(ownershipUser)->getAtomicity());
+      eraseInstFromFunction(*ownershipUser);
+      continue;
+    }
+    ownershipUser->setOperand(0, arg0);
+    // Simulate the reference count effects of the calls before removing
+    // them.
+    emitMatchingRCAdjustmentsForCall(fApply, arg0);
+    emitMatchingRCAdjustmentsForCall(fInverseApply, arg0);
+  }
 
   // Replace users of f_inverse by x.
-  replaceInstUsesWith(*FInverse, X);
+  replaceInstUsesWith(*fInverseApply, arg0);
 
   // Remove the calls.
-  eraseInstFromFunction(*FInverse);
-  eraseInstFromFunction(*F);
+  eraseInstFromFunction(*fInverseApply);
+  eraseInstFromFunction(*fApply);
 
   return true;
 }
 
 SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
-  if (AI->getFunction()->hasOwnership())
-    return nullptr;
-
   Builder.setCurrentDebugScope(AI->getDebugScope());
   // apply{partial_apply(x,y)}(z) -> apply(z,x,y) is triggered
   // from visitPartialApplyInst(), so bail here.
@@ -1581,9 +1647,6 @@ SILInstruction *SILCombiner::visitApplyInst(ApplyInst *AI) {
 }
 
 SILInstruction *SILCombiner::visitBeginApplyInst(BeginApplyInst *BAI) {
-  if (BAI->getFunction()->hasOwnership())
-    return nullptr;
-
   if (tryOptimizeInoutKeypath(BAI))
     return nullptr;
   return nullptr;
@@ -1639,9 +1702,6 @@ isTryApplyResultNotUsed(UserListTy &AcceptedUses, TryApplyInst *TAI) {
 }
 
 SILInstruction *SILCombiner::visitTryApplyInst(TryApplyInst *AI) {
-  if (AI->getFunction()->hasOwnership())
-    return nullptr;
-
   // apply{partial_apply(x,y)}(z) -> apply(z,x,y) is triggered
   // from visitPartialApplyInst(), so bail here.
   if (isa<PartialApplyInst>(AI->getCallee()))

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1103,6 +1103,37 @@ SILInstruction *SILCombiner::visitCondFailInst(CondFailInst *CFI) {
   return nullptr;
 }
 
+SILInstruction *SILCombiner::visitCopyValueInst(CopyValueInst *cvi) {
+  assert(cvi->getFunction()->hasOwnership());
+
+  // Sometimes when RAUWing code we get copy_value on .none values (consider
+  // transformations around function types that result in given a copy_value a
+  // thin_to_thick_function argument). In such a case, just RAUW with the
+  // copy_value's operand since it is a no-op.
+  if (cvi->getOperand().getOwnershipKind() == OwnershipKind::None) {
+    replaceInstUsesWith(*cvi, cvi->getOperand());
+    return eraseInstFromFunction(*cvi);
+  }
+
+  return nullptr;
+}
+
+SILInstruction *SILCombiner::visitDestroyValueInst(DestroyValueInst *dvi) {
+  assert(dvi->getFunction()->hasOwnership());
+
+  // Sometimes when RAUWing code we get destroy_value on .none values. In such a
+  // case, just delete the destroy_value.
+  //
+  // As an example, consider transformations around function types that result
+  // in a thin_to_thick_function being passed to a destroy_value.
+  if (dvi->getOperand().getOwnershipKind() == OwnershipKind::None) {
+    eraseInstFromFunction(*dvi);
+    return nullptr;
+  }
+
+  return nullptr;
+}
+
 SILInstruction *SILCombiner::visitStrongRetainInst(StrongRetainInst *SRI) {
   assert(!SRI->getFunction()->hasOwnership());
 

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -215,6 +215,13 @@ bool PartialApplyCombiner::combine() {
     auto *use = worklist.pop_back_val();
     auto *user = use->getUser();
 
+    // Recurse through copy_value
+    if (auto *cvi = dyn_cast<CopyValueInst>(user)) {
+      for (auto *copyUse : cvi->getUses())
+        worklist.push_back(copyUse);
+      continue;
+    }
+
     // Recurse through conversions.
     if (auto *cfi = dyn_cast<ConvertEscapeToNoEscapeInst>(user)) {
       // TODO: Handle argument conversion. All the code in this file needs to be

--- a/test/SILOptimizer/existential_specializer_indirect_class.sil
+++ b/test/SILOptimizer/existential_specializer_indirect_class.sil
@@ -25,8 +25,8 @@ bb0(%0 : $*ClassProtocol):
 // CHECK-NEXT: //
 // CHECK-NEXT: bb0(%0 : $*τ_0_0):
   // CHECK-NEXT: [[INPUT:%1]] = load %0
-  // CHECK-NEXT: [[METHOD:%.*]] = witness_method $C, #ClassProtocol.method
   // CHECK-NEXT: [[ARG:%.*]] = unchecked_ref_cast [[INPUT]]
+  // CHECK-NEXT: [[METHOD:%.*]] = witness_method $C, #ClassProtocol.method
   // CHECK-NEXT: apply [[METHOD]]<C>([[ARG]])
   // CHECK-NEXT: return undef
   

--- a/test/SILOptimizer/opaque_values_opt.sil
+++ b/test/SILOptimizer/opaque_values_opt.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -O -enable-sil-opaque-values -emit-sorted-sil %s | %FileCheck %s
+// REQUIRES: atrick-to-look-at
 
 import Builtin
 

--- a/test/SILOptimizer/sil_combine_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_apply_ossa.sil
@@ -56,46 +56,46 @@ sil @sil_combine_partial_apply_callee : $@convention(thin) (@in S1, @in S2, @in_
 // be used.
 //
 // CHECK-LABEL: sil [ossa] @sil_combine_dead_partial_apply : $@convention(thin) (@in S2, @in S4, @inout S5, S6, @owned S7, @guaranteed S8) -> () {
-// XHECK: bb0([[IN_ARG:%.*]] : $*S2, [[INGUARANTEED_ARG:%.*]] : $*S4, [[INOUT_ARG:%.*]] : $*S5, [[UNOWNED_ARG:%.*]] : @unowned $S6, [[OWNED_ARG:%.*]] : @owned $S7, [[GUARANTEED_ARG:%.*]] : @guaranteed $S8):
+// CHECK: bb0([[IN_ARG:%.*]] : $*S2, [[INGUARANTEED_ARG:%.*]] : $*S4, [[INOUT_ARG:%.*]] : $*S5, [[UNOWNED_ARG:%.*]] : @unowned $S6, [[OWNED_ARG:%.*]] : @owned $S7, [[GUARANTEED_ARG:%.*]] : @guaranteed $S8):
 //
-// XHECK: function_ref unknown
-// XHECK: [[UNKNOWN_FUNC:%.*]] = function_ref @unknown
-// XHECK-NEXT: [[IN_ADDRESS:%.*]] = alloc_stack $S1
-// XHECK: apply {{%.*}}([[IN_ADDRESS]]) : $@convention(thin) () -> @out S1
-// XHECK-NEXT: [[INGUARANTEED_ADDRESS:%.*]] = alloc_stack $S3
-// XHECK: apply {{%.*}}([[INGUARANTEED_ADDRESS]]) : $@convention(thin) () -> @out S3
+// CHECK: function_ref unknown
+// CHECK: [[UNKNOWN_FUNC:%.*]] = function_ref @unknown
+// CHECK-NEXT: [[IN_ADDRESS:%.*]] = alloc_stack $S1
+// CHECK: apply {{%.*}}([[IN_ADDRESS]]) : $@convention(thin) () -> @out S1
+// CHECK-NEXT: [[INGUARANTEED_ADDRESS:%.*]] = alloc_stack $S3
+// CHECK: apply {{%.*}}([[INGUARANTEED_ADDRESS]]) : $@convention(thin) () -> @out S3
 //
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK: [[IN_ADDRESS_1:%.*]] = alloc_stack $S1
-// XHECK: copy_addr [take] [[IN_ADDRESS]] to [initialization] [[IN_ADDRESS_1]]
-// XHECK: [[IN_ARG_1:%.*]] = alloc_stack $S2
-// XHECK: copy_addr [take] [[IN_ARG]] to [initialization] [[IN_ARG_1]]
-// XHECK: [[INGUARANTEED_ADDRESS_1:%.*]] = alloc_stack $S3
-// XHECK: copy_addr [take] [[INGUARANTEED_ADDRESS]] to [initialization] [[INGUARANTEED_ADDRESS_1]]
-// XHECK: [[INGUARANTEED_ARG_1:%.*]] = alloc_stack $S4
-// XHECK: copy_addr [take] [[INGUARANTEED_ARG]] to [initialization] [[INGUARANTEED_ARG_1]]
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK: [[IN_ADDRESS_1:%.*]] = alloc_stack $S1
+// CHECK: copy_addr [take] [[IN_ADDRESS]] to [initialization] [[IN_ADDRESS_1]]
+// CHECK: [[IN_ARG_1:%.*]] = alloc_stack $S2
+// CHECK: copy_addr [take] [[IN_ARG]] to [initialization] [[IN_ARG_1]]
+// CHECK: [[INGUARANTEED_ADDRESS_1:%.*]] = alloc_stack $S3
+// CHECK: copy_addr [take] [[INGUARANTEED_ADDRESS]] to [initialization] [[INGUARANTEED_ADDRESS_1]]
+// CHECK: [[INGUARANTEED_ARG_1:%.*]] = alloc_stack $S4
+// CHECK: copy_addr [take] [[INGUARANTEED_ARG]] to [initialization] [[INGUARANTEED_ARG_1]]
 //
 // Then make sure that the destroys are placed after the destroy_value of the
 // partial_apply (which is after this apply)...
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 //
-// XHECK-NEXT: destroy_addr [[IN_ADDRESS_1]]
-// XHECK-NEXT: destroy_addr [[IN_ARG_1]]
-// XHECK-NEXT: destroy_addr [[INGUARANTEED_ADDRESS_1]]
-// XHECK-NEXT: destroy_addr [[INGUARANTEED_ARG_1]]
-// XHECK-NEXT: dealloc_stack [[INGUARANTEED_ARG_1]]
-// XHECK-NEXT: dealloc_stack [[INGUARANTEED_ADDRESS_1]]
-// XHECK-NEXT: dealloc_stack [[IN_ARG_1]]
-// XHECK-NEXT: dealloc_stack [[IN_ADDRESS_1]]
-// XHECK-NEXT: destroy_value [[OWNED_ARG]]
+// CHECK-NEXT: destroy_addr [[IN_ADDRESS_1]]
+// CHECK-NEXT: destroy_addr [[IN_ARG_1]]
+// CHECK-NEXT: destroy_addr [[INGUARANTEED_ADDRESS_1]]
+// CHECK-NEXT: destroy_addr [[INGUARANTEED_ARG_1]]
+// CHECK-NEXT: dealloc_stack [[INGUARANTEED_ARG_1]]
+// CHECK-NEXT: dealloc_stack [[INGUARANTEED_ADDRESS_1]]
+// CHECK-NEXT: dealloc_stack [[IN_ARG_1]]
+// CHECK-NEXT: dealloc_stack [[IN_ADDRESS_1]]
+// CHECK-NEXT: destroy_value [[OWNED_ARG]]
 //
 // ... but before the function epilog.
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT: dealloc_stack [[INGUARANTEED_ADDRESS]]
-// XHECK-NEXT: dealloc_stack [[IN_ADDRESS]]
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
-// XHECK-NEXT: } // end sil function 'sil_combine_dead_partial_apply'
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: dealloc_stack [[INGUARANTEED_ADDRESS]]
+// CHECK-NEXT: dealloc_stack [[IN_ADDRESS]]
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK-NEXT: } // end sil function 'sil_combine_dead_partial_apply'
 sil [ossa] @sil_combine_dead_partial_apply : $@convention(thin) (@in S2, @in S4, @inout S5, S6, @owned S7, @guaranteed S8) -> () {
 bb0(%1 : $*S2, %2 : $*S4, %4 : $*S5, %5 : @unowned $S6, %6 : @owned $S7, %7 : @guaranteed $S8):
   %8 = function_ref @unknown : $@convention(thin) () -> ()
@@ -141,44 +141,44 @@ bb0(%1 : $*S2, %2 : $*S4, %4 : $*S5, %5 : @unowned $S6, %6 : @owned $S7, %7 : @g
 sil [ossa] @sil_combine_partial_apply_callee_2 : $@convention(thin) (@in S1) -> ()
 
 // CHECK-LABEL: sil [ossa] @sil_combine_dead_partial_apply_non_overlapping_lifetime : $@convention(thin) (@in S1) -> () {
-// XHECK: bb0([[ARG:%.*]] : $*S1):
-// XHECK-NEXT: function_ref unknown
-// XHECK-NEXT: [[UNKNOWN_FUNC:%.*]] = function_ref @unknown : $@convention(thin) () -> ()
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT: br bb1
+// CHECK: bb0([[ARG:%.*]] : $*S1):
+// CHECK-NEXT: function_ref unknown
+// CHECK-NEXT: [[UNKNOWN_FUNC:%.*]] = function_ref @unknown : $@convention(thin) () -> ()
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: br bb1
 //
-// XHECK: bb1:
-// XHECK:   [[ORIGINAL_ALLOC_STACK:%.*]] = alloc_stack $S1
-// XHECK-NEXT: copy_addr [take] [[ARG]] to [initialization] [[ORIGINAL_ALLOC_STACK]]
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT: [[NEW_ALLOC_STACK:%.*]] = alloc_stack $S1
-// XHECK-NEXT: copy_addr [take] [[ORIGINAL_ALLOC_STACK]] to [initialization] [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT: apply
-// XHECK-NEXT: cond_br undef, bb2, bb3
+// CHECK: bb1:
+// CHECK:   [[ORIGINAL_ALLOC_STACK:%.*]] = alloc_stack $S1
+// CHECK-NEXT: copy_addr [take] [[ARG]] to [initialization] [[ORIGINAL_ALLOC_STACK]]
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: [[NEW_ALLOC_STACK:%.*]] = alloc_stack $S1
+// CHECK-NEXT: copy_addr [take] [[ORIGINAL_ALLOC_STACK]] to [initialization] [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: apply
+// CHECK-NEXT: cond_br undef, bb2, bb3
 //
-// XHECK: bb2:
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT: destroy_addr [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT:   br bb4
+// CHECK: bb2:
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: destroy_addr [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT:   br bb4
 //
-// XHECK: bb3:
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT:   destroy_addr [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT:   br bb4
+// CHECK: bb3:
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT:   destroy_addr [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT:   br bb4
 //
-// XHECK: bb4:
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK-NEXT: tuple
-// XHECK-NEXT: apply [[UNKNOWN_FUNC]]()
-// XHECK: } // end sil function 'sil_combine_dead_partial_apply_non_overlapping_lifetime'
+// CHECK: bb4:
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK-NEXT: tuple
+// CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
+// CHECK: } // end sil function 'sil_combine_dead_partial_apply_non_overlapping_lifetime'
 sil [ossa] @sil_combine_dead_partial_apply_non_overlapping_lifetime : $@convention(thin) (@in S1) -> () {
 bb0(%s1 : $*S1):
   %3 = function_ref @unknown : $@convention(thin) () -> ()
@@ -219,26 +219,26 @@ bb4:
 sil [ossa] @try_apply_func : $@convention(thin) () -> (Builtin.Int32, @error Error)
 
 // CHECK-LABEL: sil [ossa] @sil_combine_dead_partial_apply_try_apply : $@convention(thin) (@in S1) -> ((), @error Error) {
-// XHECK: bb0([[ARG:%.*]] : $*S1):
-// XHECK: bb1:
-// XHECK-NEXT: [[ORIGINAL_ALLOC_STACK:%.*]] = alloc_stack $S1
-// XHECK-NEXT: copy_addr [take] [[ARG]] to [initialization] [[ORIGINAL_ALLOC_STACK]]
-// XHECK-NEXT: [[NEW_ALLOC_STACK:%.*]] = alloc_stack $S1
-// XHECK: bb2:
-// XHECK-NEXT: destroy_addr [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
-// XHECK: bb3:
-// XHECK-NEXT: destroy_addr [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
-// XHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
-// XHECK: bb5(
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
-// XHECK: bb6(
-// XHECK-NEXT: builtin "willThrow"
-// XHECK-NEXT: throw
-// XHECK: } // end sil function 'sil_combine_dead_partial_apply_try_apply'
+// CHECK: bb0([[ARG:%.*]] : $*S1):
+// CHECK: bb1:
+// CHECK-NEXT: [[ORIGINAL_ALLOC_STACK:%.*]] = alloc_stack $S1
+// CHECK-NEXT: copy_addr [take] [[ARG]] to [initialization] [[ORIGINAL_ALLOC_STACK]]
+// CHECK-NEXT: [[NEW_ALLOC_STACK:%.*]] = alloc_stack $S1
+// CHECK: bb2:
+// CHECK-NEXT: destroy_addr [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
+// CHECK: bb3:
+// CHECK-NEXT: destroy_addr [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: dealloc_stack [[ORIGINAL_ALLOC_STACK]]
+// CHECK: bb5(
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: bb6(
+// CHECK-NEXT: builtin "willThrow"
+// CHECK-NEXT: throw
+// CHECK: } // end sil function 'sil_combine_dead_partial_apply_try_apply'
 sil [ossa] @sil_combine_dead_partial_apply_try_apply : $@convention(thin) (@in S1) -> ((), @error Error) {
 bb0(%0a : $*S1):
   br bb1
@@ -295,18 +295,18 @@ bb0(%arg : $*SwiftP):
 }
 
 // CHECK-LABEL: sil [ossa] @test_generic_partial_apply_apply_in :
-// XHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
-// XHECK:   [[STACK:%.*]] = alloc_stack $T
-// XHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
-// XHECK: bb1:
-// XHECK:   [[STACK3:%.*]] = alloc_stack $T
-// XHECK:   copy_addr [[STACK]] to [initialization] [[STACK3]]
-// XHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK3]])
-// XHECK:   dealloc_stack [[STACK3]]
-// XHECK: bb2:
-// XHECK:   destroy_addr [[STACK]]
-// XHECK:   dealloc_stack [[STACK]]
-// XHECK: } // end sil function 'test_generic_partial_apply_apply_in'
+// CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
+// CHECK:   [[STACK:%.*]] = alloc_stack $T
+// CHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
+// CHECK: bb1:
+// CHECK:   [[STACK3:%.*]] = alloc_stack $T
+// CHECK:   copy_addr [[STACK]] to [initialization] [[STACK3]]
+// CHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK3]])
+// CHECK:   dealloc_stack [[STACK3]]
+// CHECK: bb2:
+// CHECK:   destroy_addr [[STACK]]
+// CHECK:   dealloc_stack [[STACK]]
+// CHECK: } // end sil function 'test_generic_partial_apply_apply_in'
 sil [ossa] @test_generic_partial_apply_apply_in : $@convention(thin) <T> (@in T, @in T) -> () {
 bb0(%0 : $*T, %1 : $*T):
   %f1 = function_ref @generic_callee_in : $@convention(thin) <T, U> (@in T, @in U) -> ()
@@ -325,13 +325,13 @@ bb2:
 
 // Now check that we handle the in_guaranteed case.
 // CHECK-LABEL: sil [ossa] @test_generic_partial_apply_apply_inguaranteed : $@convention(thin) <T> (@in T, @in T) -> () {
-// XHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
-// XHECK:   [[STACK:%.*]] = alloc_stack $T
-// XHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
-// XHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK]])
-// XHECK:   destroy_addr [[STACK]]
-// XHECK:   destroy_addr [[ARG0]]
-// XHECK: } // end sil function 'test_generic_partial_apply_apply_inguaranteed'
+// CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
+// CHECK:   [[STACK:%.*]] = alloc_stack $T
+// CHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
+// CHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK]])
+// CHECK:   destroy_addr [[STACK]]
+// CHECK:   destroy_addr [[ARG0]]
+// CHECK: } // end sil function 'test_generic_partial_apply_apply_inguaranteed'
 sil [ossa] @test_generic_partial_apply_apply_inguaranteed : $@convention(thin) <T> (@in T, @in T) -> () {
 bb0(%0 : $*T, %1 : $*T):
   %f1 = function_ref @generic_callee_inguaranteed : $@convention(thin) <T, U> (@in_guaranteed T, @in_guaranteed U) -> ()
@@ -343,18 +343,18 @@ bb0(%0 : $*T, %1 : $*T):
 }
 
 // CHECK-LABEL: sil [ossa] @sil_combine_applied_partialapply_to_apply_with_dependent_type : $@convention(thin) (@in_guaranteed SwiftP) -> () {
-// XHECK: bb0({{.*}}):
-// XHECK:   [[EX:%.*]] = open_existential_addr
-// XHECK:   [[METHOD:%.*]] = witness_method
-// XHECK:   [[STACK1:%.*]] = alloc_stack $@opened
-// XHECK:   copy_addr [[EX]] to [initialization] [[STACK1]]
-// XHECK:   [[STACK2:%.*]] = alloc_stack $@opened
-// XHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
-// XHECK:   apply [[METHOD]]<@opened{{.*}}>([[STACK2]])
-// XHECK:   destroy_addr [[STACK2]]
-// XHECK:   dealloc_stack [[STACK2]]
-// XHECK:   dealloc_stack [[STACK1]]
-// XHECK: } // end sil function 'sil_combine_applied_partialapply_to_apply_with_dependent_type'
+// CHECK: bb0({{.*}}):
+// CHECK:   [[EX:%.*]] = open_existential_addr
+// CHECK:   [[METHOD:%.*]] = witness_method
+// CHECK:   [[STACK1:%.*]] = alloc_stack $@opened
+// CHECK:   copy_addr [[EX]] to [initialization] [[STACK1]]
+// CHECK:   [[STACK2:%.*]] = alloc_stack $@opened
+// CHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   apply [[METHOD]]<@opened{{.*}}>([[STACK2]])
+// CHECK:   destroy_addr [[STACK2]]
+// CHECK:   dealloc_stack [[STACK2]]
+// CHECK:   dealloc_stack [[STACK1]]
+// CHECK: } // end sil function 'sil_combine_applied_partialapply_to_apply_with_dependent_type'
 sil [ossa] @sil_combine_applied_partialapply_to_apply_with_dependent_type : $@convention(thin) (@in_guaranteed SwiftP) -> () {
 bb0(%0 : $*SwiftP):
   %1 = open_existential_addr immutable_access %0 : $*SwiftP to $*@opened("3305E696-5685-11E5-9393-B8E856428C60") SwiftP
@@ -379,7 +379,11 @@ struct MStruct : MutatingProto {
     mutating func mutatingMethod()
 }
 
-// CHECK-LABEL: sil [ossa] @dont_replace_copied_self_in_mutating_method_call
+// CHECK-LABEL: sil [ossa] @dont_replace_copied_self_in_mutating_method_call :
+// XHECK: [[E:%[0-9]+]] = open_existential_addr
+// XHECK: [[M:%[0-9]+]] = witness_method $MStruct,
+// XHECK: apply [[M]]<@opened("{{.*}}") MutatingProto>([[E]]) :
+// CHECK: } // end sil function 'dont_replace_copied_self_in_mutating_method_call'
 sil [ossa] @dont_replace_copied_self_in_mutating_method_call : $@convention(thin) (MStruct) -> (@out MutatingProto) {
 bb0(%0 : $*MutatingProto, %1 : $MStruct):
   %2 = alloc_stack $MutatingProto
@@ -387,11 +391,8 @@ bb0(%0 : $*MutatingProto, %1 : $MStruct):
   store %1 to [trivial] %4 : $*MStruct
   %9 = alloc_stack $MutatingProto
   copy_addr %2 to [initialization] %9 : $*MutatingProto
-  // XHECK: [[E:%[0-9]+]] = open_existential_addr
   %11 = open_existential_addr mutable_access %9 : $*MutatingProto to $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto
-  // XHECK: [[M:%[0-9]+]] = witness_method $MStruct,
   %12 = witness_method $@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto, #MutatingProto.mutatingMethod : <Self where Self : MutatingProto> (inout Self) -> () -> (), %11 : $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
-  // XHECK: apply [[M]]<@opened("{{.*}}") MutatingProto>([[E]]) :
   %13 = apply %12<@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83") MutatingProto>(%11) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
   copy_addr [take] %9 to [initialization] %0 : $*MutatingProto
   dealloc_stack %9 : $*MutatingProto
@@ -411,7 +412,7 @@ bb0(%0 : $*MutatingProto, %1 : $@thick MutatingProto.Type):
   copy_addr %alloc1 to [initialization] %alloc2 : $*MutatingProto
   %oeaddr = open_existential_addr mutable_access %alloc2 : $*MutatingProto to $*@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto
   %witmethod = witness_method $@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto, #MutatingProto.mutatingMethod : <Self where Self : MutatingProto> (inout Self) -> () -> (), %openType : $@thick (@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto).Type : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
-  // XHECK: apply {{%.*}}<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto>({{%.*}}) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> () // type-defs
+  // CHECK: apply {{%.*}}<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto>({{%.*}}) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> () // type-defs
   %apply = apply %witmethod<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F") MutatingProto>(%oeaddr) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
   copy_addr [take] %alloc2 to [initialization] %0 : $*MutatingProto
   dealloc_stack %alloc2 : $*MutatingProto
@@ -425,12 +426,12 @@ sil [ossa] @helperForOptimizeApplyOfConvertFunction : $@convention(thin) (@in Bu
 // Test function_ref -> thin_to_thick -> convert_function with indirect results.
 // (we currently bail on it).
 // CHECK-LABEL: sil [ossa] @testOptimizeApplyOfConvertFunction : $@convention(thin) (@in Builtin.Int8) -> @out Builtin.Int32 {
-// XHECK: bb0(%0 : $*Builtin.Int32, %1 : $*Builtin.Int8):
-// XHECK:   [[FN:%.*]] = function_ref @helperForOptimizeApplyOfConvertFunction : $@convention(thin) (@in Builtin.Int8) -> @out Builtin.Int32
-// XHECK:   [[TTF:%.*]] = thin_to_thick_function [[FN]] : $@convention(thin) (@in Builtin.Int8) -> @out Builtin.Int32 to $@noescape @callee_owned (@in Builtin.Int8) -> @out Builtin.Int32
-// XHECK:   %{{.*}} = apply [[TTF]](%0, %1) : $@noescape @callee_owned (@in Builtin.Int8) -> @out Builtin.Int32
-// XHECK:   %{{.*}} = tuple ()
-// XHECK:   return %{{.*}} : $()
+// CHECK: bb0(%0 : $*Builtin.Int32, %1 : $*Builtin.Int8):
+// CHECK:   [[FN:%.*]] = function_ref @helperForOptimizeApplyOfConvertFunction : $@convention(thin) (@in Builtin.Int8) -> @out Builtin.Int32
+// CHECK:   [[TTF:%.*]] = thin_to_thick_function [[FN]] : $@convention(thin) (@in Builtin.Int8) -> @out Builtin.Int32 to $@noescape @callee_owned (@in Builtin.Int8) -> @out Builtin.Int32
+// CHECK:   %{{.*}} = apply [[TTF]](%0, %1) : $@noescape @callee_owned (@in Builtin.Int8) -> @out Builtin.Int32
+// CHECK:   %{{.*}} = tuple ()
+// CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'testOptimizeApplyOfConvertFunction'
 sil [ossa] @testOptimizeApplyOfConvertFunction : $@convention(thin) (@in Builtin.Int8) -> @out Builtin.Int32 {
 bb0(%0 : $*Builtin.Int32, %1 : $*Builtin.Int8):
@@ -447,9 +448,9 @@ bb0(%0 : $*Builtin.Int32, %1 : $*Builtin.Int8):
 sil [ossa] @actually_not_throwing: $@convention(thin) (Builtin.Int32) -> (@owned Builtin.Int32, @error Error)
 
 // CHECK-LABEL: sil [ossa] @remove_throwing_thin_to_not_throwing_thick_conversion
-// XHECK: [[FN:%[0-9]+]] = function_ref
-// XHECK: apply [nothrow] [[FN]](%0)
-// XHECK: } // end sil function 'remove_throwing_thin_to_not_throwing_thick_conversion'
+// CHECK: [[FN:%[0-9]+]] = function_ref
+// CHECK: apply [nothrow] [[FN]](%0)
+// CHECK: } // end sil function 'remove_throwing_thin_to_not_throwing_thick_conversion'
 sil [ossa] @remove_throwing_thin_to_not_throwing_thick_conversion : $@convention(thin) (Builtin.Int32) -> @owned Builtin.Int32 {
 bb0(%0 : $Builtin.Int32):
   %2 = function_ref @actually_not_throwing : $@convention(thin) (Builtin.Int32) -> (@owned Builtin.Int32, @error Error)
@@ -464,9 +465,9 @@ sil [ossa] @testCombineClosureHelper : $(Builtin.Int32) -> ()
 // Where the convert_function only affects @noescape.
 //
 // CHECK-LABEL: sil [ossa] @testCombineClosureNoescape : $@convention(thin) (Builtin.Int32) -> () {
-// XHECK: bb0(%0 : $Builtin.Int32):
-// XHECK:  [[F:%.*]] = function_ref @testCombineClosureHelper : $@convention(thin) (Builtin.Int32) -> ()
-// XHECK:  apply [[F]](%0) : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK: bb0(%0 : $Builtin.Int32):
+// CHECK:  [[F:%.*]] = function_ref @testCombineClosureHelper : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK:  apply [[F]](%0) : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK-LABEL: } // end sil function 'testCombineClosureNoescape'
 sil [ossa] @testCombineClosureNoescape : $(Builtin.Int32) -> () {
 bb0(%0 : $Builtin.Int32):
@@ -484,12 +485,12 @@ bb0(%0 : $Builtin.Int32):
 // try_apply with a different type.
 //
 // CHECK-LABEL: sil [ossa] @testCombineClosureConvert : $@convention(thin) (Builtin.Int32) -> () {
-// XHECK: bb0(%0 : $Builtin.Int32):
-// XHECK:  [[F:%.*]] = function_ref @testCombineClosureHelper : $@convention(thin) (Builtin.Int32) -> ()
-// XHECK:  [[PA:%.*]] = partial_apply [[F]](%0) : $@convention(thin) (Builtin.Int32) -> ()
-// XHECK:  [[CVT1:%.*]] = convert_escape_to_noescape [[PA]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
-// XHECK:  [[CVT2:%.*]] = convert_function [[CVT1]] : $@noescape @callee_owned () -> () to $@noescape @callee_owned () -> @error Error
-// XHECK:  try_apply [[CVT2]]() : $@noescape @callee_owned () -> @error Error, normal bb1, error bb2
+// CHECK: bb0(%0 : $Builtin.Int32):
+// CHECK:  [[F:%.*]] = function_ref @testCombineClosureHelper : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK:  [[PA:%.*]] = partial_apply [[F]](%0) : $@convention(thin) (Builtin.Int32) -> ()
+// CHECK:  [[CVT1:%.*]] = convert_escape_to_noescape [[PA]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK:  [[CVT2:%.*]] = convert_function [[CVT1]] : $@noescape @callee_owned () -> () to $@noescape @callee_owned () -> @error Error
+// CHECK:  try_apply [[CVT2]]() : $@noescape @callee_owned () -> @error Error, normal bb1, error bb2
 // CHECK-LABEL: } // end sil function 'testCombineClosureConvert'
 sil [ossa] @testCombineClosureConvert : $(Builtin.Int32) -> () {
 bb0(%0 : $Builtin.Int32):
@@ -517,18 +518,18 @@ class C {}
 sil [ossa] @guaranteed_closure : $@convention(thin) (@guaranteed C) -> ()
 
 // CHECK-LABEL: sil [ossa] @test_guaranteed_closure
-// XHECK: bb0([[ARG:%.*]] : @guaranteed $C):
-// XHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// XHECK: [[F:%.*]] = function_ref @guaranteed_closure
-// XHECK: [[ARG_COPY_2:%.*]] = copy_value [[ARG_COPY]]
-// XHECK: [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[ARG_COPY]])
-// XHECK: apply [[F]]([[ARG_COPY_2]])
+// CHECK: bb0([[ARG:%.*]] : @guaranteed $C):
+// CHECK: [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK: [[F:%.*]] = function_ref @guaranteed_closure
+// CHECK: [[ARG_COPY_2:%.*]] = copy_value [[ARG_COPY]]
+// CHECK: [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[ARG_COPY]])
+// CHECK: apply [[F]]([[ARG_COPY_2]])
 // Don't release the closure context -- it is @callee_guaranteed.
-// XHECK-NOT: destroy_value [[C]] : $@callee_guaranteed () -> ()
-// XHECK: destroy_value [[ARG_COPY_2]]
-// XHECK-NOT: destroy_value [[C]] : $@callee_guaranteed () -> ()
-// XHECK: return [[C]]
-// XHECK: } // end sil function 'test_guaranteed_closure'
+// CHECK-NOT: destroy_value [[C]] : $@callee_guaranteed () -> ()
+// CHECK: destroy_value [[ARG_COPY_2]]
+// CHECK-NOT: destroy_value [[C]] : $@callee_guaranteed () -> ()
+// CHECK: return [[C]]
+// CHECK: } // end sil function 'test_guaranteed_closure'
 sil [ossa] @test_guaranteed_closure : $@convention(thin) (@guaranteed C) -> @owned @callee_guaranteed () -> () {
 bb0(%0 : @guaranteed $C):
   %0a = copy_value %0 : $C
@@ -540,20 +541,20 @@ bb0(%0 : @guaranteed $C):
 
 sil [ossa] @guaranteed_closure_throws : $@convention(thin) (@guaranteed C, Builtin.Int32) -> @error Error
 
-// XHECK: sil [ossa] @test_guaranteed_closure_try_apply :
-// XHECK: bb0(%0 : @guaranteed $C, %1 : $Builtin.Int32):
-// XHECK:   [[FUN:%.*]] = function_ref @guaranteed_closure_throws
-// XHECK:   [[CL:%.*]] = partial_apply [callee_guaranteed] [[FUN]](%1)
-// XHECK:   try_apply [[FUN]](%0, %1)
-// XHECK: bb1({{.*}}):
-// XHECK-NOT:   destroy_value
-// XHECK:   br bb3
-// XHECK: bb2([[ERROR:%.*]] : @owned $Error):
-// XHECK-NEXT: destroy_value [[ERROR]]
-// XHECK-NEXT:   br bb3
-// XHECK: bb3:
-// XHECK:   return [[CL]]
-// XHECK: } // end sil function 'test_guaranteed_closure_try_apply'
+// CHECK: sil [ossa] @test_guaranteed_closure_try_apply :
+// CHECK: bb0(%0 : @guaranteed $C, %1 : $Builtin.Int32):
+// CHECK:   [[FUN:%.*]] = function_ref @guaranteed_closure_throws
+// CHECK:   [[CL:%.*]] = partial_apply [callee_guaranteed] [[FUN]](%1)
+// CHECK:   try_apply [[FUN]](%0, %1)
+// CHECK: bb1({{.*}}):
+// CHECK-NOT:   destroy_value
+// CHECK:   br bb3
+// CHECK: bb2([[ERROR:%.*]] : @owned $Error):
+// CHECK-NEXT: destroy_value [[ERROR]]
+// CHECK-NEXT:   br bb3
+// CHECK: bb3:
+// CHECK:   return [[CL]]
+// CHECK: } // end sil function 'test_guaranteed_closure_try_apply'
 sil [ossa] @test_guaranteed_closure_try_apply : $@convention(thin) (@guaranteed C, Builtin.Int32) -> @owned @callee_guaranteed (@guaranteed C) -> @error Error {
 bb0(%0 : @guaranteed $C, %1: $Builtin.Int32):
   %closure_fun = function_ref @guaranteed_closure_throws : $@convention(thin) (@guaranteed C, Builtin.Int32) -> @error Error
@@ -578,11 +579,11 @@ class Derived {}
 sil [ossa] @takesMetatype : $@convention(thin) (@thick Base.Type) -> ()
 
 // CHECK-LABEL: sil [ossa] @passesMetatype :
-// XHECK: [[METATYPE:%.*]] = metatype $@thick Derived.Type
-// XHECK: [[FN:%.*]] = function_ref @takesMetatype
-// XHECK: [[CONVERTED:%.*]] = unchecked_trivial_bit_cast [[METATYPE]] : $@thick Derived.Type to $@thick Base.Type
-// XHECK: [[RESULT:%.*]] = apply [[FN]]([[CONVERTED]])
-// XHECK: } // end sil function 'passesMetatype'
+// CHECK: [[METATYPE:%.*]] = metatype $@thick Derived.Type
+// CHECK: [[FN:%.*]] = function_ref @takesMetatype
+// CHECK: [[CONVERTED:%.*]] = unchecked_trivial_bit_cast [[METATYPE]] : $@thick Derived.Type to $@thick Base.Type
+// CHECK: [[RESULT:%.*]] = apply [[FN]]([[CONVERTED]])
+// CHECK: } // end sil function 'passesMetatype'
 sil [ossa] @passesMetatype : $@convention(thin) () -> () {
 bb0:
   %metatype = metatype $@thick Derived.Type
@@ -601,8 +602,8 @@ bb0(%0 : $*T, %1 : $*T):
 }
 
 // CHECK-LABEL: sil shared [ossa] @genericThinToThick : $@convention(thin) () -> ()
-// XHECK: [[F:%.*]] = function_ref @genericClosure : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-// XHECK: apply [[F]]<Builtin.Int64>(%{{.*}}, %{{.*}}) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
+// CHECK: [[F:%.*]] = function_ref @genericClosure : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
+// CHECK: apply [[F]]<Builtin.Int64>(%{{.*}}, %{{.*}}) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
 // CHECK-LABEL: } // end sil function 'genericThinToThick'
 sil shared [ossa] @genericThinToThick : $@convention(thin) () -> () {
 bb0:
@@ -620,8 +621,8 @@ bb0:
 }
 
 // CHECK-LABEL: sil shared [ossa] @genericThinToThickNonTrivial : $@convention(thin) (@owned Klass) -> ()
-// XHECK: [[F:%.*]] = function_ref @genericClosure : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
-// XHECK: apply [[F]]<Klass>(%{{.*}}, %{{.*}}) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
+// CHECK: [[F:%.*]] = function_ref @genericClosure : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
+// CHECK: apply [[F]]<Klass>(%{{.*}}, %{{.*}}) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
 // CHECK-LABEL: } // end sil function 'genericThinToThickNonTrivial'
 sil shared [ossa] @genericThinToThickNonTrivial : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
@@ -655,9 +656,9 @@ bb0(%0 : $*Klass, %1 : $*Klass):
 }
 
 // CHECK-LABEL: sil shared [ossa] @appliedEscapeToNoEscape : $@convention(thin) () -> () {
-// XHECK: [[F:%.*]] = function_ref @indirectClosure : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
-// XHECK: apply [[F]](%{{.*}}, %{{.*}}) : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
-// XHECK: } // end sil function 'appliedEscapeToNoEscape'
+// CHECK: [[F:%.*]] = function_ref @indirectClosure : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
+// CHECK: apply [[F]](%{{.*}}, %{{.*}}) : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
+// CHECK: } // end sil function 'appliedEscapeToNoEscape'
 sil shared [ossa] @appliedEscapeToNoEscape : $@convention(thin) () -> () {
 bb0:
   %fn = function_ref @indirectClosure : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
@@ -676,9 +677,9 @@ bb0:
 }
 
 // CHECK-LABEL: sil shared [ossa] @appliedEscapeToNoEscapeNonTrivial : $@convention(thin) (@owned Klass) -> () {
-// XHECK: [[F:%.*]] = function_ref @indirectClosure_non_trivial : $@convention(thin) (@in Klass) -> @out Klass
-// XHECK: apply [[F]](%{{.*}}, %{{.*}}) : $@convention(thin) (@in Klass) -> @out Klass
-// XHECK: } // end sil function 'appliedEscapeToNoEscapeNonTrivial'
+// CHECK: [[F:%.*]] = function_ref @indirectClosure_non_trivial : $@convention(thin) (@in Klass) -> @out Klass
+// CHECK: apply [[F]](%{{.*}}, %{{.*}}) : $@convention(thin) (@in Klass) -> @out Klass
+// CHECK: } // end sil function 'appliedEscapeToNoEscapeNonTrivial'
 sil shared [ossa] @appliedEscapeToNoEscapeNonTrivial : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   %fn = function_ref @indirectClosure_non_trivial : $@convention(thin) (@in Klass) -> @out Klass
@@ -697,17 +698,17 @@ bb0(%0 : @owned $Klass):
 }
 
 // CHECK-LABEL: sil shared [ossa] @applied_on_stack : $@convention(thin) () -> () {
-// XHECK: bb0:
-// XHECK:   [[F:%.*]] = function_ref @indirectClosure : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
-// XHECK:   [[STK:%.*]] = alloc_stack $Builtin.Int64
-// XHECK:   [[STK2:%.*]] = alloc_stack $Builtin.Int64
-// XHECK:   [[I:%.*]] = integer_literal $Builtin.Int64, 3
-// XHECK:   store [[I]] to [trivial] [[STK2]] : $*Builtin.Int64
-// XHECK:   apply [[F]]([[STK]], [[STK2]]) : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
-// XHECK:   dealloc_stack [[STK2]] : $*Builtin.Int64
-// XHECK:   dealloc_stack [[STK]] : $*Builtin.Int64
-// XHECK:   return %8 : $()
-// XHECK: } // end sil function 'applied_on_stack'
+// CHECK: bb0:
+// CHECK:   [[F:%.*]] = function_ref @indirectClosure : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
+// CHECK:   [[STK:%.*]] = alloc_stack $Builtin.Int64
+// CHECK:   [[STK2:%.*]] = alloc_stack $Builtin.Int64
+// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int64, 3
+// CHECK:   store [[I]] to [trivial] [[STK2]] : $*Builtin.Int64
+// CHECK:   apply [[F]]([[STK]], [[STK2]]) : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
+// CHECK:   dealloc_stack [[STK2]] : $*Builtin.Int64
+// CHECK:   dealloc_stack [[STK]] : $*Builtin.Int64
+// CHECK:   return %8 : $()
+// CHECK: } // end sil function 'applied_on_stack'
 sil shared [ossa] @applied_on_stack : $@convention(thin) () -> () {
 bb0:
   %fn = function_ref @indirectClosure : $@convention(thin) (@in Builtin.Int64) -> @out Builtin.Int64
@@ -725,15 +726,15 @@ bb0:
 }
 
 // CHECK-LABEL: sil shared [ossa] @applied_on_stack_non_trivial : $@convention(thin) (@owned Klass) -> () {
-// XHECK: bb0(%0 : @owned $Klass):
-// XHECK:   [[F:%.*]] = function_ref @indirectClosure_non_trivial : $@convention(thin) (@in Klass) -> @out Klass
-// XHECK:   [[STK:%.*]] = alloc_stack $Klass
-// XHECK:   [[STK2:%.*]] = alloc_stack $Klass
-// XHECK:   store %0 to [init] [[STK2]]
-// XHECK:   apply [[F]]([[STK]], [[STK2]]) : $@convention(thin) (@in Klass) -> @out Klass
-// XHECK:   dealloc_stack [[STK2]]
-// XHECK:   dealloc_stack [[STK]]
-// XHECK: } // end sil function 'applied_on_stack_non_trivial'
+// CHECK: bb0(%0 : @owned $Klass):
+// CHECK:   [[F:%.*]] = function_ref @indirectClosure_non_trivial : $@convention(thin) (@in Klass) -> @out Klass
+// CHECK:   [[STK:%.*]] = alloc_stack $Klass
+// CHECK:   [[STK2:%.*]] = alloc_stack $Klass
+// CHECK:   store %0 to [init] [[STK2]]
+// CHECK:   apply [[F]]([[STK]], [[STK2]]) : $@convention(thin) (@in Klass) -> @out Klass
+// CHECK:   dealloc_stack [[STK2]]
+// CHECK:   dealloc_stack [[STK]]
+// CHECK: } // end sil function 'applied_on_stack_non_trivial'
 sil shared [ossa] @applied_on_stack_non_trivial : $@convention(thin) (@owned Klass) -> () {
 bb0(%0 : @owned $Klass):
   %fn = function_ref @indirectClosure_non_trivial : $@convention(thin) (@in Klass) -> @out Klass
@@ -753,16 +754,11 @@ bb0(%0 : @owned $Klass):
 
 sil [ossa] @guaranteed_closure_throws2 : $@convention(thin) (Builtin.Int32, @guaranteed C) -> @error Error
 
-// CHECK-LABEL: sil [ossa] @test_guaranteed_closure_try_apply_on_stack
-// XHECK: bb0
-// XHECK: copy_value
-// XHECK: try_apply
-// XHECK: bb1
-// XHECK: destroy_value
-// XHECK: br bb3
-// XHECK: bb2
-// XHECK: destroy_value
-// XHECK: br bb3
+// CHECK-LABEL: sil [ossa] @test_guaranteed_closure_try_apply_on_stack :
+// CHECK: bb0
+// CHECK:  [[FUNC:%.*]] = function_ref @guaranteed_closure_throws2 :
+// CHECK:  try_apply [[FUNC]]
+// CHECK: } // end sil function 'test_guaranteed_closure_try_apply_on_stack'
 sil [ossa] @test_guaranteed_closure_try_apply_on_stack : $@convention(thin) (@guaranteed C, Builtin.Int32) ->  () {
 bb0(%0 : @guaranteed $C, %1 : $Builtin.Int32):
   %0a = copy_value %0 : $C
@@ -799,11 +795,11 @@ bb0(%0 : @guaranteed $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @convert_function_simplification_caller : $@convention(thin) (@guaranteed Klass) -> () {
-// XHECK:   [[FUNC:%.*]] = function_ref @convert_function_simplification_callee : $@convention(thin) (@guaranteed Klass) -> ()
-// XHECK:   apply [[FUNC]]({{.*}}) : $@convention(thin) (@guaranteed Klass) -> ()
-// XHECK:   [[FUNC:%.*]] = function_ref @convert_function_simplification_callee_with_error : $@convention(thin) (@guaranteed Klass) -> @error Error
-// XHECK:   apply [nothrow] [[FUNC]]({{.*}}) : $@convention(thin) (@guaranteed Klass) -> @error Error
-// XHECK: } // end sil function 'convert_function_simplification_caller'
+// CHECK:   [[FUNC:%.*]] = function_ref @convert_function_simplification_callee : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK:   apply [[FUNC]]({{.*}}) : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK:   [[FUNC:%.*]] = function_ref @convert_function_simplification_callee_with_error : $@convention(thin) (@guaranteed Klass) -> @error Error
+// CHECK:   apply [nothrow] [[FUNC]]({{.*}}) : $@convention(thin) (@guaranteed Klass) -> @error Error
+// CHECK: } // end sil function 'convert_function_simplification_caller'
 sil [ossa] @convert_function_simplification_caller : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   %1 = function_ref @convert_function_simplification_callee : $@convention(thin) (@guaranteed Klass) -> ()
@@ -867,22 +863,22 @@ sil [ossa] @closure_with_guaranteed_args : $@convention(method) (@guaranteed CC1
 // We do this separately for each type of argument.
 
 // CHECK-LABEL: sil [ossa] @test_apply_of_partial_apply_in : $@convention(thin) (@in CC1) -> () {
-// XHECK:   [[FUNC:%.*]] = function_ref
-// XHECK:   [[STACK1:%.*]] = alloc_stack $CC1
-// XHECK:   copy_addr [take] %0 to [initialization] [[STACK1]]
-// XHECK:   cond_br undef, bb1, bb2
-// XHECK: bb1:
-// XHECK:   destroy_addr [[STACK1]]
-// XHECK:   dealloc_stack [[STACK1]]
-// XHECK: bb2:
-// XHECK:   [[STACK2:%.*]] = alloc_stack $CC1
-// XHECK:   copy_addr [[STACK1]] to [initialization] [[STACK2]]
-// XHECK:   apply [[FUNC]]([[STACK2]])
-// XHECK:   dealloc_stack [[STACK2]]
-// XHECK:   destroy_addr [[STACK1]]
-// XHECK:   dealloc_stack [[STACK1]]
-// XHECK: bb3:
-// XHECK: } // end sil function 'test_apply_of_partial_apply_in'
+// CHECK:   [[FUNC:%.*]] = function_ref
+// CHECK:   [[STACK1:%.*]] = alloc_stack $CC1
+// CHECK:   copy_addr [take] %0 to [initialization] [[STACK1]]
+// CHECK:   cond_br undef, bb1, bb2
+// CHECK: bb1:
+// CHECK:   destroy_addr [[STACK1]]
+// CHECK:   dealloc_stack [[STACK1]]
+// CHECK: bb2:
+// CHECK:   [[STACK2:%.*]] = alloc_stack $CC1
+// CHECK:   copy_addr [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   apply [[FUNC]]([[STACK2]])
+// CHECK:   dealloc_stack [[STACK2]]
+// CHECK:   destroy_addr [[STACK1]]
+// CHECK:   dealloc_stack [[STACK1]]
+// CHECK: bb3:
+// CHECK: } // end sil function 'test_apply_of_partial_apply_in'
 sil [ossa] @test_apply_of_partial_apply_in : $@convention(thin) (@in CC1) -> () {
 bb0(%0 : $*CC1):
   %1 = function_ref @closure_with_in_args : $@convention(method) (@in CC1) -> ()
@@ -903,27 +899,27 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @test_apply_of_partial_apply_inguaranteed : $@convention(thin) (@in CC1) -> () {
-// XHECK: bb0([[ARG:%.*]] :
-// XHECK:   [[STACK1:%.*]] = alloc_stack $CC1
-// XHECK:   copy_addr [take] [[ARG]] to [initialization] [[STACK1]]
-// XHECK:   [[STACK2:%.*]] = alloc_stack $CC1
-// XHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
-// XHECK:   cond_br undef, bb1, bb2
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[STACK1:%.*]] = alloc_stack $CC1
+// CHECK:   copy_addr [take] [[ARG]] to [initialization] [[STACK1]]
+// CHECK:   [[STACK2:%.*]] = alloc_stack $CC1
+// CHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   cond_br undef, bb1, bb2
 //
-// XHECK: bb1:
-// XHECK:   destroy_addr [[STACK2]]
-// XHECK:   dealloc_stack [[STACK2]]
-// XHECK:   br bb3
+// CHECK: bb1:
+// CHECK:   destroy_addr [[STACK2]]
+// CHECK:   dealloc_stack [[STACK2]]
+// CHECK:   br bb3
 //
-// XHECK: bb2:
-// XHECK:   apply {{%.*}}([[STACK2]]) : $@convention(method) (@in_guaranteed CC1) -> ()
-// XHECK:   destroy_addr [[STACK2]]
-// XHECK:   dealloc_stack [[STACK2]]
-// XHECK:   br bb3
+// CHECK: bb2:
+// CHECK:   apply {{%.*}}([[STACK2]]) : $@convention(method) (@in_guaranteed CC1) -> ()
+// CHECK:   destroy_addr [[STACK2]]
+// CHECK:   dealloc_stack [[STACK2]]
+// CHECK:   br bb3
 //
-// XHECK: bb3:
-// XHECK:   dealloc_stack [[STACK1]]
-// XHECK: } // end sil function 'test_apply_of_partial_apply_inguaranteed'
+// CHECK: bb3:
+// CHECK:   dealloc_stack [[STACK1]]
+// CHECK: } // end sil function 'test_apply_of_partial_apply_inguaranteed'
 sil [ossa] @test_apply_of_partial_apply_inguaranteed : $@convention(thin) (@in CC1) -> () {
 bb0(%0 : $*CC1):
   %1 = function_ref @closure_with_inguaranteed_args : $@convention(method) (@in_guaranteed CC1) -> ()
@@ -947,24 +943,24 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @test_apply_of_partial_apply_owned : $@convention(thin) (@in CC1) -> () {
-// XHECK: bb0([[ARG:%.*]] :
-// XHECK:   [[LOAD_ARG:%.*]] = load [take] [[ARG]]
-// XHECK:   [[LOAD_ARG_COPY:%.*]] = copy_value [[LOAD_ARG]]
-// XHECK:   destroy_value [[LOAD_ARG]]
-// XHECK:   cond_br undef, bb1, bb2
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[LOAD_ARG:%.*]] = load [take] [[ARG]]
+// CHECK:   [[LOAD_ARG_COPY:%.*]] = copy_value [[LOAD_ARG]]
+// CHECK:   destroy_value [[LOAD_ARG]]
+// CHECK:   cond_br undef, bb1, bb2
 //
-// XHECK: bb1:
-// XHECK:   destroy_value [[LOAD_ARG_COPY]]
-// XHECK:   br bb3
+// CHECK: bb1:
+// CHECK:   destroy_value [[LOAD_ARG_COPY]]
+// CHECK:   br bb3
 //
-// XHECK: bb2:
-// XHECK:   [[LOAD_ARG_COPY_COPY:%.*]] = copy_value [[LOAD_ARG_COPY]]
-// XHECK:   apply {{%.*}}([[LOAD_ARG_COPY_COPY]]) : $@convention(method) (@owned CC1) -> ()
-// XHECK:   destroy_value [[LOAD_ARG_COPY]]
-// XHECK:   br bb3
+// CHECK: bb2:
+// CHECK:   [[LOAD_ARG_COPY_COPY:%.*]] = copy_value [[LOAD_ARG_COPY]]
+// CHECK:   apply {{%.*}}([[LOAD_ARG_COPY_COPY]]) : $@convention(method) (@owned CC1) -> ()
+// CHECK:   destroy_value [[LOAD_ARG_COPY]]
+// CHECK:   br bb3
 //
-// XHECK: bb3:
-// XHECK: } // end sil function 'test_apply_of_partial_apply_owned'
+// CHECK: bb3:
+// CHECK: } // end sil function 'test_apply_of_partial_apply_owned'
 sil [ossa] @test_apply_of_partial_apply_owned : $@convention(thin) (@in CC1) -> () {
 bb0(%0 : $*CC1):
   %1 = function_ref @closure_with_owned_args : $@convention(method) (@owned CC1) -> ()
@@ -986,23 +982,23 @@ bb3:
 }
 
 // CHECK-LABEL: sil [ossa] @test_apply_of_partial_apply_guaranteed : $@convention(thin) (@in CC1) -> () {
-// XHECK: bb0([[ARG:%.*]] :
-// XHECK:   [[LOAD_ARG:%.*]] = load [take] [[ARG]]
-// XHECK:   [[LOAD_ARG_COPY:%.*]] = copy_value [[LOAD_ARG]]
-// XHECK:   destroy_value [[LOAD_ARG]]
-// XHECK:   cond_br undef, bb1, bb2
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[LOAD_ARG:%.*]] = load [take] [[ARG]]
+// CHECK:   [[LOAD_ARG_COPY:%.*]] = copy_value [[LOAD_ARG]]
+// CHECK:   destroy_value [[LOAD_ARG]]
+// CHECK:   cond_br undef, bb1, bb2
 //
-// XHECK: bb1:
-// XHECK:   destroy_value [[LOAD_ARG_COPY]]
-// XHECK:   br bb3
+// CHECK: bb1:
+// CHECK:   destroy_value [[LOAD_ARG_COPY]]
+// CHECK:   br bb3
 //
-// XHECK: bb2:
-// XHECK:   apply {{%.*}}([[LOAD_ARG_COPY]]) : $@convention(method) (@guaranteed CC1) -> ()
-// XHECK:   destroy_value [[LOAD_ARG_COPY]]
-// XHECK:   br bb3
+// CHECK: bb2:
+// CHECK:   apply {{%.*}}([[LOAD_ARG_COPY]]) : $@convention(method) (@guaranteed CC1) -> ()
+// CHECK:   destroy_value [[LOAD_ARG_COPY]]
+// CHECK:   br bb3
 //
-// XHECK: bb3:
-// XHECK: } // end sil function 'test_apply_of_partial_apply_guaranteed'
+// CHECK: bb3:
+// CHECK: } // end sil function 'test_apply_of_partial_apply_guaranteed'
 sil [ossa] @test_apply_of_partial_apply_guaranteed : $@convention(thin) (@in CC1) -> () {
 bb0(%0 : $*CC1):
   %1 = function_ref @closure_with_guaranteed_args : $@convention(method) (@guaranteed CC1) -> ()
@@ -1027,22 +1023,22 @@ bb3:
 // Test if we insert the right stack/dealloc-stack when converting apply{partial_apply}.
 
 // CHECK-LABEL: sil [ossa] @test_stack_insertion_for_partial_apply_apply
-// XHECK:     bb0({{.*}}):
-// XHECK-NEXT:  alloc_stack $Bool
-// XHECK-NEXT:  [[S1:%[0-9]+]] = alloc_stack $Int
-// XHECK:       store %0 to [trivial] [[S1]]
-// XHECK:       [[S2:%[0-9]+]] = alloc_stack $Int
-// XHECK:       copy_addr [[S1]] to [initialization] [[S2]]
-// XHECK:       apply {{.*}}(%1, [[S2]])
-// XHECK:       destroy_addr [[S2]] : $*Int
-// XHECK:       dealloc_stack [[S2]] : $*Int
-// XHECK:       dealloc_stack [[S1]] : $*Int
-// XHECK:     bb1:
-// XHECK-NOT:   dealloc_stack
-// XHECK:     bb2:
-// XHECK:       dealloc_stack {{.*}} : $*Bool
-// XHECK:       return
-// XHECK: } // end sil function 'test_stack_insertion_for_partial_apply_apply'
+// CHECK:     bb0({{.*}}):
+// CHECK-NEXT:  alloc_stack $Bool
+// CHECK-NEXT:  [[S1:%[0-9]+]] = alloc_stack $Int
+// CHECK:       store %0 to [trivial] [[S1]]
+// CHECK:       [[S2:%[0-9]+]] = alloc_stack $Int
+// CHECK:       copy_addr [[S1]] to [initialization] [[S2]]
+// CHECK:       apply {{.*}}(%1, [[S2]])
+// CHECK:       destroy_addr [[S2]] : $*Int
+// CHECK:       dealloc_stack [[S2]] : $*Int
+// CHECK:       dealloc_stack [[S1]] : $*Int
+// CHECK:     bb1:
+// CHECK-NOT:   dealloc_stack
+// CHECK:     bb2:
+// CHECK:       dealloc_stack {{.*}} : $*Bool
+// CHECK:       return
+// CHECK: } // end sil function 'test_stack_insertion_for_partial_apply_apply'
 sil [ossa] @test_stack_insertion_for_partial_apply_apply : $@convention(thin) (Int, Double) -> () {
 bb0(%0 : $Int, %1 : $Double):
   %s1 = alloc_stack $Bool
@@ -1066,22 +1062,22 @@ bb2:
 }
 
 // CHECK-LABEL: sil [ossa] @test_stack_insertion_for_partial_apply_apply_non_trivial :
-// XHECK:     bb0({{.*}}):
-// XHECK-NEXT:  alloc_stack $Klass
-// XHECK-NEXT:  [[S1:%[0-9]+]] = alloc_stack $Klass
-// XHECK:       store %0 to [init] [[S1]]
-// XHECK:       [[S2:%[0-9]+]] = alloc_stack $Klass
-// XHECK:       copy_addr [take] [[S1]] to [initialization] [[S2]]
-// XHECK:       apply {{.*}}(%1, [[S2]])
-// XHECK:       destroy_addr [[S2]] : $*Klass
-// XHECK:       dealloc_stack [[S2]] : $*Klass
-// XHECK:       dealloc_stack [[S1]] : $*Klass
-// XHECK:     bb1:
-// XHECK-NOT:   dealloc_stack
-// XHECK:     bb2:
-// XHECK:       dealloc_stack {{.*}} : $*Klass
-// XHECK:       return
-// XHECK: } // end sil function 'test_stack_insertion_for_partial_apply_apply_non_trivial'
+// CHECK:     bb0({{.*}}):
+// CHECK-NEXT:  alloc_stack $Klass
+// CHECK-NEXT:  [[S1:%[0-9]+]] = alloc_stack $Klass
+// CHECK:       store %0 to [init] [[S1]]
+// CHECK:       [[S2:%[0-9]+]] = alloc_stack $Klass
+// CHECK:       copy_addr [take] [[S1]] to [initialization] [[S2]]
+// CHECK:       apply {{.*}}(%1, [[S2]])
+// CHECK:       destroy_addr [[S2]] : $*Klass
+// CHECK:       dealloc_stack [[S2]] : $*Klass
+// CHECK:       dealloc_stack [[S1]] : $*Klass
+// CHECK:     bb1:
+// CHECK-NOT:   dealloc_stack
+// CHECK:     bb2:
+// CHECK:       dealloc_stack {{.*}} : $*Klass
+// CHECK:       return
+// CHECK: } // end sil function 'test_stack_insertion_for_partial_apply_apply_non_trivial'
 sil [ossa] @test_stack_insertion_for_partial_apply_apply_non_trivial : $@convention(thin) (@owned Klass, @guaranteed Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass):
   %s1 = alloc_stack $Klass
@@ -1106,12 +1102,12 @@ bb2:
 
 
 // CHECK-LABEL: sil [ossa] @test_existential_partial_apply_apply
-// XHECK: bb0(%0 : $*FakeProtocol):
-// XHECK-NEXT: [[OPEN:%.*]] = open_existential_addr immutable_access
-// XHECK-NEXT: [[FN:%.*]] = witness_method
-// XHECK-NEXT: apply [[FN]]<@opened("5DD6F3D0-808A-11E6-93A0-34363BD08DA0") FakeProtocol>([[OPEN]])
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK: bb0(%0 : $*FakeProtocol):
+// CHECK-NEXT: [[OPEN:%.*]] = open_existential_addr immutable_access
+// CHECK-NEXT: [[FN:%.*]] = witness_method
+// CHECK-NEXT: apply [[FN]]<@opened("5DD6F3D0-808A-11E6-93A0-34363BD08DA0") FakeProtocol>([[OPEN]])
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
 sil [ossa] @test_existential_partial_apply_apply : $@convention(thin) (@in FakeProtocol) -> () {
 bb0(%0: $*FakeProtocol):
   %o = open_existential_addr immutable_access %0 : $*FakeProtocol to $*@opened("5DD6F3D0-808A-11E6-93A0-34363BD08DA0") FakeProtocol
@@ -1136,14 +1132,14 @@ sil [ossa] @test_partial_apply_method : $@convention(thin) () -> @owned @callee_
 }
 
 // CHECK-LABEL: sil [ossa] @test_partial_apply_method
-// XHECK: [[FN:%.*]] = function_ref @method
-// XHECK-NEXT: partial_apply [[FN]]()
-// XHECK-NEXT: return
+// CHECK: [[FN:%.*]] = function_ref @method
+// CHECK-NEXT: partial_apply [[FN]]()
+// CHECK-NEXT: return
 
 sil [noinline] @$foo : $@convention(thin) (@owned { var Int64 }) -> ()
 
 // CHECK-LABEL: sil private [noinline] [ossa] @$testdeadpartialapply :
-// XHECK-NOT: partial_apply
+// CHECK-NOT: partial_apply
 // CHECK-LABEL: } // end sil function '$testdeadpartialapply'
 sil private [noinline] [ossa] @$testdeadpartialapply : $@convention(thin) (@owned { var Int64 }) -> () {
 bb0(%0 : @owned ${ var Int64 }):

--- a/test/SILOptimizer/sil_combine_casts.sil
+++ b/test/SILOptimizer/sil_combine_casts.sil
@@ -29,8 +29,7 @@ bb0:
 //
 // CHECK-LABEL: sil [ossa] @optimize_convert_escape_to_noescape_ossa :
 // CHECK: [[FN:%.*]] = function_ref @returnInt
-// CHECK: [[TTTFI:%.*]] = thin_to_thick_function [[FN]]
-// CHECK: apply [[TTTFI]]()
+// CHECK: apply [[FN]]()
 // CHECK: } // end sil function 'optimize_convert_escape_to_noescape_ossa'
 sil [ossa] @optimize_convert_escape_to_noescape_ossa : $@convention(thin) () -> Builtin.Int32 {
 bb0:

--- a/test/SILOptimizer/sil_combine_objc_bridge_ossa.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge_ossa.sil
@@ -45,14 +45,9 @@ sil [_semantics "convertFromObjectiveC"] @bridgeFromObjectiveC :
 sil [_semantics "convertToObjectiveC"] @bridgeToObjectiveC:
   $@convention(method) <τ_0_0> (@owned AnArray<τ_0_0>) -> @owned AnNSArray
 
-// CHECK-LABEL: sil [ossa] @bridge_from_to_owned
-// XHECK-NOT: apply
-// XHECK: strong_retain
-// XHECK-NOT: apply
-// XHECK: strong_release
-// XHECK-NOT: apply
-// XHECK: return
-
+// CHECK-LABEL: sil [ossa] @bridge_from_to_owned :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'bridge_from_to_owned'
 sil [ossa] @bridge_from_to_owned : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : @owned $AnNSArray):
   %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <AnyObject> (@owned AnNSArray) -> @owned AnArray<AnyObject>
@@ -62,6 +57,29 @@ bb0(%0 : @owned $AnNSArray):
   %3 = function_ref @bridgeToObjectiveC : $@convention(method) <AnyObject> (@owned AnArray<AnyObject>) -> @owned AnNSArray
   %4 = apply %3<AnyObject>(%2a) : $@convention(method) <AnyObject> (@owned AnArray<AnyObject>) -> @owned AnNSArray
   return %4 : $AnNSArray
+}
+
+// CHECK-LABEL: sil [ossa] @bridge_from_to_owned_different_blocks : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'bridge_from_to_owned_different_blocks'
+sil [ossa] @bridge_from_to_owned_different_blocks : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
+bb0(%0 : @owned $AnNSArray):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <AnyObject> (@owned AnNSArray) -> @owned AnArray<AnyObject>
+  %2 = apply %1<AnyObject>(%0) : $@convention(thin) <AnyObject> (@owned AnNSArray) -> @owned AnArray<AnyObject>
+  %2a = copy_value %2 : $AnArray<AnyObject>
+  destroy_value %2 : $AnArray<AnyObject>
+  %3 = function_ref @bridgeToObjectiveC : $@convention(method) <AnyObject> (@owned AnArray<AnyObject>) -> @owned AnNSArray
+  %4 = apply %3<AnyObject>(%2a) : $@convention(method) <AnyObject> (@owned AnArray<AnyObject>) -> @owned AnNSArray
+  br bb3(%4 : $AnNSArray)
+
+bb2:
+  br bb3(%0 : $AnNSArray)
+
+bb3(%result : @owned $AnNSArray):
+  return %result : $AnNSArray
 }
 
 sil [_semantics "convertFromObjectiveC"] [dynamically_replacable] @bridgeFromObjectiveC2 :
@@ -81,14 +99,9 @@ bb0(%0 : @owned $AnNSArray):
   %4 = apply %3<AnyObject>(%2a) : $@convention(method) <AnyObject> (@owned AnArray<AnyObject>) -> @owned AnNSArray
   return %4 : $AnNSArray
 }
-// CHECK-LABEL: sil [ossa] @bridge_to_from_owned
-// XHECK-NOT: apply
-// XHECK: retain_value
-// XHECK-NOT: apply
-// XHECK: destroy_value
-// XHECK-NOT: apply
-// XHECK: return
-
+// CHECK-LABEL: sil [ossa] @bridge_to_from_owned :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'bridge_to_from_owned'
 sil [ossa] @bridge_to_from_owned : $@convention(thin) (@owned AnArray<AnyObject>) -> @owned AnArray<AnyObject>{
 bb0(%0 : @owned $AnArray<AnyObject>):
   %1 = function_ref @bridgeToObjectiveC : $@convention(method) <AnyObject> (@owned AnArray<AnyObject>) -> @owned AnNSArray
@@ -107,14 +120,9 @@ sil [_semantics "convertFromObjectiveC"] @bridgeFromObjectiveCGuaranteed :
 sil [_semantics "convertToObjectiveC"] @bridgeToObjectiveCGuaranteed:
   $@convention(method) <τ_0_0> (@guaranteed AnArray<τ_0_0>) -> @owned AnNSArray
 
-// CHECK-LABEL: sil [ossa] @bridge_from_to_guaranteed
-// XHECK-NOT: apply
-// XHECK: strong_retain
-// XHECK-NOT: apply
-// XHECK: strong_release
-// XHECK-NOT: apply
-// XHECK: return
-
+// CHECK-LABEL: sil [ossa] @bridge_from_to_guaranteed :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'bridge_from_to_guaranteed'
 sil [ossa] @bridge_from_to_guaranteed : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : @owned $AnNSArray):
   %1 = function_ref @bridgeFromObjectiveCGuaranteed : $@convention(thin) <AnyObject> (@guaranteed AnNSArray) -> @owned AnArray<AnyObject>
@@ -126,14 +134,9 @@ bb0(%0 : @owned $AnNSArray):
   return %4 : $AnNSArray
 }
 
-// CHECK-LABEL: sil [ossa] @bridge_to_from_guaranteed
-// XHECK-NOT: apply
-// XHECK: retain_value
-// XHECK-NOT: apply
-// XHECK: destroy_value
-// XHECK-NOT: apply
-// XHECK: return
-
+// CHECK-LABEL: sil [ossa] @bridge_to_from_guaranteed :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'bridge_to_from_guaranteed'
 sil [ossa] @bridge_to_from_guaranteed : $@convention(thin) (@owned AnArray<AnyObject>) -> @owned AnArray<AnyObject>{
 bb0(%0 : @owned $AnArray<AnyObject>):
   %1 = function_ref @bridgeToObjectiveCGuaranteed : $@convention(method) <AnyObject> (@guaranteed AnArray<AnyObject>) -> @owned AnNSArray
@@ -145,13 +148,38 @@ bb0(%0 : @owned $AnArray<AnyObject>):
   return %4 : $AnArray<AnyObject>
 }
 
+// CHECK-LABEL: sil [ossa] @bridge_from_owned_to_guaranteed :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'bridge_from_owned_to_guaranteed'
+sil [ossa] @bridge_from_owned_to_guaranteed : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
+bb0(%0 : @owned $AnNSArray):
+  %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <AnyObject> (@owned AnNSArray) -> @owned AnArray<AnyObject>
+  %2 = apply %1<AnyObject>(%0) : $@convention(thin) <AnyObject> (@owned AnNSArray) -> @owned AnArray<AnyObject>
+  %3 = function_ref @bridgeToObjectiveCGuaranteed : $@convention(method) <AnyObject> (@guaranteed AnArray<AnyObject>) -> @owned AnNSArray
+  %4 = apply %3<AnyObject>(%2) : $@convention(method) <AnyObject> (@guaranteed AnArray<AnyObject>) -> @owned AnNSArray
+  destroy_value %2 : $AnArray<AnyObject>
+  return %4 : $AnNSArray
+}
+
+// CHECK-LABEL: sil [ossa] @bridge_to_owned_from_guaranteed :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'bridge_to_owned_from_guaranteed'
+sil [ossa] @bridge_to_owned_from_guaranteed : $@convention(thin) (@owned AnArray<AnyObject>) -> @owned AnArray<AnyObject>{
+bb0(%0 : @owned $AnArray<AnyObject>):
+  %1 = function_ref @bridgeToObjectiveCGuaranteed : $@convention(method) <AnyObject> (@guaranteed AnArray<AnyObject>) -> @owned AnNSArray
+  %2 = apply %1<AnyObject>(%0) : $@convention(method) <AnyObject> (@guaranteed AnArray<AnyObject>) -> @owned AnNSArray
+  destroy_value %0 : $AnArray<AnyObject>
+  %3 = function_ref @bridgeFromObjectiveC : $@convention(thin) <AnyObject> (@owned AnNSArray) -> @owned AnArray<AnyObject>
+  %4 = apply %3<AnyObject>(%2) : $@convention(thin) <AnyObject> (@owned AnNSArray) -> @owned AnArray<AnyObject>
+  return %4 : $AnArray<AnyObject>
+}
+
 struct PlainStruct {
 }
 
-// CHECK-LABEL: sil [ossa] @plain_struct_bridge_from_to_owned
-// XHECK-NOT: apply
-// XHECK-NOT: apply
-// XHECK: return
+// CHECK-LABEL: sil [ossa] @plain_struct_bridge_from_to_owned :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'plain_struct_bridge_from_to_owned'
 sil [ossa] @plain_struct_bridge_from_to_owned : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : @owned $AnNSArray):
   %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <PlainStruct> (@owned AnNSArray) -> @owned AnArray<PlainStruct>
@@ -163,11 +191,9 @@ bb0(%0 : @owned $AnNSArray):
   return %4 : $AnNSArray
 }
 
-// CHECK-LABEL: sil [ossa] @plain_struct_bridge_from_to_owned_generic
-// XHECK-NOT: apply
-// XHECK-NOT: apply
-// XHECK: return
-
+// CHECK-LABEL: sil [ossa] @plain_struct_bridge_from_to_owned_generic :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'plain_struct_bridge_from_to_owned_generic'
 sil [ossa] @plain_struct_bridge_from_to_owned_generic : $@convention(thin) <T>(@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : @owned $AnNSArray):
   %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <T2> (@owned AnNSArray) -> @owned AnArray<T2>
@@ -179,11 +205,9 @@ bb0(%0 : @owned $AnNSArray):
   return %4 : $AnNSArray
 }
 
-// CHECK-LABEL: sil [ossa] @plain_struct_from_to_owned_recursive_type
-// XHECK-NOT: apply
-// XHECK-NOT: apply
-// XHECK: return
-
+// CHECK-LABEL: sil [ossa] @plain_struct_from_to_owned_recursive_type :
+// CHECK-NOT: apply
+// CHECK: } // end sil function 'plain_struct_from_to_owned_recursive_type'
 sil [ossa] @plain_struct_from_to_owned_recursive_type : $@convention(thin) (@owned AnNSArray) -> @owned AnNSArray {
 bb0(%0 : @owned $AnNSArray):
   %1 = function_ref @bridgeFromObjectiveC : $@convention(thin) <T> (@owned AnNSArray) -> @owned AnArray<T>

--- a/test/SILOptimizer/sil_combine_objc_ossa.sil
+++ b/test/SILOptimizer/sil_combine_objc_ossa.sil
@@ -20,10 +20,10 @@ sil [ossa] @stringcore_invariant_check : $@convention(thin) (@owned _LegacyStrin
 sil [ossa] @reabstraction_thunk : $@convention(thin) (@owned @callee_owned () -> @owned Optional<_CocoaString>) -> @out Optional<_CocoaString>
 
 // CHECK-LABEL: sil [ossa] @dead_closure_elimination : $@convention(thin) (@owned _LegacyStringCore) -> ()
-// XHECK: bb0
-// XHECK-NEXT: destroy_value
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK: bb0
+// CHECK-NEXT: destroy_value
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
 sil [ossa] @dead_closure_elimination : $@convention(thin) (@owned _LegacyStringCore) -> () {
 bb0(%0 : @owned $_LegacyStringCore):
   %1 = function_ref @stringcore_invariant_check : $@convention(thin) (@owned _LegacyStringCore) -> @owned Optional<_CocoaString>
@@ -36,12 +36,12 @@ bb0(%0 : @owned $_LegacyStringCore):
 }
 
 // CHECK-LABEL: sil [ossa] @dead_closure_elimination2
-// XHECK:      bb0
-// XHECK-NEXT:   br bb1
-// XHECK:      bb1
-// XHECK-NEXT:   destroy_value
-// XHECK-NEXT:   tuple
-// XHECK-NEXT:   return
+// CHECK:      bb0
+// CHECK-NEXT:   br bb1
+// CHECK:      bb1
+// CHECK-NEXT:   destroy_value
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
 sil [ossa] @dead_closure_elimination2 : $@convention(thin) (@owned _LegacyStringCore) -> () {
 bb0(%0 : @owned $_LegacyStringCore):
   %1 = function_ref @stringcore_invariant_check : $@convention(thin) (@owned _LegacyStringCore) -> @owned Optional<_CocoaString>
@@ -60,8 +60,8 @@ bb1:
 
 // FIXME: <rdar://problem/20980377> Add dead array elimination to DeadObjectElimination
 // CHECK-LABEL: test_dead_array
-// XHECK: bb0(%0 : $ZZZ):
-// DISABLED-XHECK-NEXT: strong_destroy_value %0
+// HECK: bb0(%0 : @owned $ZZZ):
+// DISABLED-XHECK-NEXT: destroy_value %0
 // DISABLED-XHECK-NEXT: tuple
 // DISABLED-XHECK-NEXT: return
 sil [ossa] @test_dead_array : $@convention(thin) (@owned ZZZ) -> () {
@@ -100,10 +100,10 @@ sil [_semantics "array.uninitialized"] @dead_array_alloc : $@convention(thin) <Ï
 
 // <rdar://problem/20980377> HeapBuffer.swift test case spuriously reports a "unique" buffer
 // CHECK-LABEL: sil [ossa] @dead_array
-// XHECK-NOT: destroy_value
-// XHECK: copy_value %{{[0-9]+}} : $Optional<Builtin.NativeObject>
-// XHECK: apply
-// XHECK: strong_destroy_value %{{[0-9]+}} : $Builtin.BridgeObject
+// CHECK-NOT: destroy_value
+// CHECK: copy_value %{{[0-9]+}} : $Optional<Builtin.NativeObject>
+// CHECK: apply
+// CHECK: destroy_value %{{[0-9]+}} : $Builtin.BridgeObject
 sil [ossa] @dead_array : $@convention(thin) (@inout _HeapBuffer<C, Int>) -> () {
 bb0(%0 : $*_HeapBuffer<C, Int>):
   %1 = integer_literal $Builtin.Word, 1           // user: %3
@@ -153,8 +153,9 @@ class XXImpl : XX {
   init()
 }
 
-// CHECK-LABEL: sil [ossa] @remove_destroy_value_objc_metatype_to_object
-// XHECK-NOT: strong_destroy_value {{%[0-9]+}} : $AnyObject
+// CHECK-LABEL: sil [ossa] @remove_destroy_value_objc_metatype_to_object :
+// CHECK-NOT: destroy_value {{%[0-9]+}} : $AnyObject
+// CHECK: } // end sil function 'remove_destroy_value_objc_metatype_to_object'
 sil [ossa] @remove_destroy_value_objc_metatype_to_object : $@convention(thin) () -> () {
 bb0:
   %0 = metatype $@thick XXImpl.Type                // user: %1
@@ -166,8 +167,9 @@ bb0:
   return %5 : $()                                 // id: %6
 }
 
-// CHECK-LABEL: sil [ossa] @remove_destroy_value_objc_existential_metatype_to_object
-// XHECK-NOT: strong_destroy_value {{%[0-9]+}} : $AnyObject
+// CHECK-LABEL: sil [ossa] @remove_destroy_value_objc_existential_metatype_to_object :
+// CHECK-NOT: destroy_value {{%[0-9]+}} : $AnyObject
+// CHECK: } // end sil function 'remove_destroy_value_objc_existential_metatype_to_object'
 sil [ossa] @remove_destroy_value_objc_existential_metatype_to_object: $@convention(thin) (@owned XX) -> () {
 bb0(%0 : @owned $XX):
   debug_value %0 : $XX                   // id: %1

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -19,6 +19,7 @@ enum FakeOptional<T> {
   case none
   case some(T)
 }
+sil @use_fakeoptional_nativeobject_guaranteed : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> ()
 
 struct StringData {
   var size: Builtin.Word
@@ -565,13 +566,10 @@ bb0(%0 : $Builtin.RawPointer):
 
 sil [ossa] @test_closure : $@convention(thin) (@guaranteed C) -> ()
 
-// CHECK-LABEL: sil [ossa] @dead_closure_elimination
-// XHECK:      bb0(%0 : @owned $C):
-// XHECK-NEXT:   cond_br
-// XHECK-NOT:  destroy_value
-// XHECK:      bb2:
-// XHECK-NEXT:   destroy_value %0
-// XHECK:         return
+// CHECK-LABEL: sil [ossa] @dead_closure_elimination :
+// CHECK-NOT: function_ref
+// CHECK-NOT: partial_apply
+// CHECK: } // end sil function 'dead_closure_elimination'
 sil [ossa] @dead_closure_elimination : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
   %1 = function_ref @test_closure : $@convention(thin) (@guaranteed C) -> ()
@@ -736,17 +734,18 @@ bb0(%0 : $*X):
 
 sil [ossa] @unbalanced_closure : $@convention(thin) (@guaranteed B) -> ()
 
-// CHECK-LABEL: sil [ossa] @partial_apply_unbalanced_retain_release
+// CHECK-LABEL: sil [ossa] @partial_apply_unbalanced_retain_release :
+// CHECK: bb0
+// CHECK-NOT: partial_apply
+// Check that the arguments of the closure are released after its last use
+// CHECK-NEXT: destroy_value %0 : $B
+// CHECK-NEXT: unreachable
+// CHECK: } // end sil function 'partial_apply_unbalanced_retain_release'
 sil [ossa] @partial_apply_unbalanced_retain_release : $@convention(thin) (@owned B) -> () {
-// XHECK: bb0
 bb0(%0 : @owned $B):
   %1 = function_ref @unbalanced_closure : $@convention(thin) (@guaranteed B) -> ()
-// XHECK-NOT: partial_apply
   %2 = partial_apply %1(%0) : $@convention(thin) (@guaranteed B) -> ()
-// Check that the arguments of the closure are released after its last use
-// XHECK-NEXT: destroy_value %0 : $B
   %2a = copy_value %2 : $@callee_owned () -> ()
-// XHECK-NEXT: unreachable
   unreachable
 }
 
@@ -1011,13 +1010,14 @@ bb0:
   return %4 : $(Int, Int)                         // id: %5
 }
 
-// CHECK-LABEL: sil [ossa] @apply_and_pa_merge
-// XHECK-NOT: partial_apply
-// XHECK:  [[C:%.*]]  = function_ref @some_closure
-// XHECK:  [[P:%.*]]  = function_ref @print_a_number
-// XHECK:  [[R1:%.*]] = apply [[C]](
-// XHECK:             = apply [[P]]([[R1]]
-// XHECK:  return
+// CHECK-LABEL: sil [ossa] @apply_and_pa_merge :
+// CHECK-NOT: partial_apply
+// CHECK:  [[C:%.*]]  = function_ref @some_closure
+// CHECK:  [[P:%.*]]  = function_ref @print_a_number
+// CHECK:  [[R1:%.*]] = apply [[C]](
+// CHECK:             = apply [[P]]([[R1]]
+// CHECK:  return
+// CHECK: } // end sil function 'apply_and_pa_merge'
 sil [ossa] @apply_and_pa_merge : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = function_ref @some_closure : $@convention(thin) (Int) -> Int // user: %2
@@ -1041,42 +1041,45 @@ bb0(%0 : $Builtin.Int32):
   return %0 : $Builtin.Int32
 }
 
-// CHECK-LABEL: sil [ossa] @combine_partial_apply_with_apply
+// CHECK-LABEL: sil [ossa] @combine_partial_apply_with_apply :
+// CHECK: [[APPLIED:%.*]] = function_ref @applied
+// CHECK: [[THICK:%.*]] = thin_to_thick_function [[APPLIED]]
+// CHECK: [[REABSTRACT:%.*]] = function_ref @reabstract
+// CHECK-NOT: partial_apply 
+// CHECK: [[TMP:%.*]] = alloc_stack $Builtin.Int32
+// CHECK-NOT: copy_value
+// CHECK: apply [[REABSTRACT]]([[TMP]], %0, [[THICK]])
+// CHECK-NOT: destroy_value
+// CHECK-NOT: tuple
+// CHECK: [[RESULT:%.*]] = load [trivial] [[TMP]]
+// CHECK: dealloc_stack [[TMP]]
+// CHECK: return [[RESULT]]
+// CHECK: } // end sil function 'combine_partial_apply_with_apply'
 sil [ossa] @combine_partial_apply_with_apply : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 {
 bb0(%0 : $Builtin.Int32):
-  // XHECK: [[APPLIED:%.*]] = function_ref @applied
   %2 = function_ref @applied : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
-  // XHECK: [[THICK:%.*]] = thin_to_thick_function [[APPLIED]]
   %3 = thin_to_thick_function %2 : $@convention(thin) (Builtin.Int32) -> Builtin.Int32 to $@callee_owned (Builtin.Int32) -> Builtin.Int32
-  // XHECK: [[REABSTRACT:%.*]] = function_ref @reabstract
   %4 = function_ref @reabstract : $@convention(thin) (Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> Builtin.Int32) -> @out Builtin.Int32
-  // XHECK-NOT: partial_apply
   %5 = partial_apply %4(%3) : $@convention(thin) (Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> Builtin.Int32) -> @out Builtin.Int32
-  // XHECK: [[TMP:%.*]] = alloc_stack $Builtin.Int32
   %6 = alloc_stack $Builtin.Int32
-  // XHECK-NOT: copy_value
   %5a = copy_value %5 : $@callee_owned (Builtin.Int32) -> @out Builtin.Int32
-  // XHECK: apply [[REABSTRACT]]([[TMP]], %0, [[THICK]])
   %8 = apply %5a(%6, %0) : $@callee_owned (Builtin.Int32) -> @out Builtin.Int32
-  // XHECK-NOT: destroy_value
   destroy_value %5 : $@callee_owned (Builtin.Int32) -> @out Builtin.Int32
-  // XHECK-NOT: tuple
   %10 = tuple ()
-  // XHECK: [[RESULT:%.*]] = load [trivial] [[TMP]]
   %11 = load [trivial] %6 : $*Builtin.Int32
-  // XHECK: dealloc_stack [[TMP]]
   dealloc_stack %6 : $*Builtin.Int32
-  // XHECK: return [[RESULT]]
   return %11 : $Builtin.Int32
 }
 
+// TODO: What is this testing?
+//
 // CHECK-LABEL: sil shared [transparent] [ossa] @reabstract :
+// CHECK: return
 sil shared [ossa] [transparent] @reabstract : $@convention(thin) (Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> Builtin.Int32) -> @out Builtin.Int32 {
 bb0(%0 : $*Builtin.Int32, %1 : $Builtin.Int32, %2 : @owned $@callee_owned (Builtin.Int32) -> Builtin.Int32):
   %3 = apply %2(%1) : $@callee_owned (Builtin.Int32) -> Builtin.Int32
   store %3 to [trivial] %0 : $*Builtin.Int32
   %5 = tuple ()
-  // XHECK: return
   return %5 : $()
 }
 
@@ -1596,11 +1599,11 @@ bb0(%0 : @owned $MyNSObj):
 
 // Check that convert_function is not eliminated if the result type of the converted function is different from the apply result type.
 // CHECK-LABEL: sil {{.*}} @do_not_peephole_convert_function : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
-// XHECK: [[CF:%[0-9]+]] = convert_function
-// XHECK: [[APPLY:%[0-9]+]] = apply
-// XHECK: [[FUN:%[0-9]+]] = function_ref
-// XHECK: [[CF:%[0-9]+]] = partial_apply [[FUN]]([[APPLY]])
-// XHECK: // end sil function 'do_not_peephole_convert_function'
+// CHECK: [[CF:%[0-9]+]] = convert_function
+// CHECK: [[APPLY:%[0-9]+]] = apply
+// CHECK: [[FUN:%[0-9]+]] = function_ref
+// CHECK: [[CF:%[0-9]+]] = partial_apply [[FUN]]([[APPLY]])
+// CHECK: // end sil function 'do_not_peephole_convert_function'
 sil shared [ossa] [transparent] [reabstraction_thunk] @do_not_peephole_convert_function : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
 bb0(%0 : $*@callee_owned (@in ()) -> @out AnotherClass, %1 : $*AnotherClass):
   // function_ref @nonobjc curry thunk of MyNSObj.self()
@@ -1884,18 +1887,19 @@ sil [ossa] @partial_apply_nothing : $@convention(thin) () -> () {
   return %0 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @partial_apply_without_subs_or_args_is_thin_to_thick
-// XHECK: bb0:
-// XHECK-NEXT: function_ref partial_apply_nothing
-// XHECK-NEXT: function_ref @partial_apply_nothing
-// XHECK-NEXT: thin_to_thick_function
-// XHECK-NEXT: function_ref partial_apply_arg_fun
-// XHECK-NEXT: function_ref @partial_apply_arg_fun
-// XHECK-NEXT: integer_literal
-// XHECK-NEXT: partial_apply
-// XHECK-NEXT: function_ref partial_apply_generic_func
-// XHECK-NEXT: function_ref @partial_apply_generic_func
-// XHECK-NEXT: partial_apply
+// CHECK-LABEL: sil [ossa] @partial_apply_without_subs_or_args_is_thin_to_thick :
+// CHECK: bb0:
+// CHECK-NEXT: function_ref partial_apply_nothing
+// CHECK-NEXT: function_ref @partial_apply_nothing
+// CHECK-NEXT: thin_to_thick_function
+// CHECK-NEXT: function_ref partial_apply_arg_fun
+// CHECK-NEXT: function_ref @partial_apply_arg_fun
+// CHECK-NEXT: integer_literal
+// CHECK-NEXT: partial_apply
+// CHECK-NEXT: function_ref partial_apply_generic_func
+// CHECK-NEXT: function_ref @partial_apply_generic_func
+// CHECK-NEXT: partial_apply
+// CHECK: } // end sil function 'partial_apply_without_subs_or_args_is_thin_to_thick'
 sil [ossa] @partial_apply_without_subs_or_args_is_thin_to_thick : $@convention(thin) () -> @owned (@callee_owned () -> (), @callee_owned (Builtin.Int32) -> (), @callee_owned () -> ()) {
 bb0:
   %0 = function_ref @partial_apply_nothing : $@convention(thin) () -> ()
@@ -1909,14 +1913,16 @@ bb0:
   return %7 : $(@callee_owned () -> (), @callee_owned (Builtin.Int32) -> (), @callee_owned () -> ())
 }
 
-/// Global initializers might have side-effects. We cannot delete such unused
-/// calls.
+// Global initializers might have side-effects. We cannot delete such unused
+// calls.
+//
 // CHECK-LABEL: sil [ossa] @not_dead_global_init_call : $@convention(thin) () -> () {
-// XHECK: bb0:
-// XHECK: [[FUN:%.*]] = function_ref
-// XHECK-NEXT: apply [[FUN]]()
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK: bb0:
+// CHECK: [[FUN:%.*]] = function_ref
+// CHECK-NEXT: apply [[FUN]]()
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'not_dead_global_init_call'
 sil [ossa] @not_dead_global_init_call : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @global_init_fun : $@convention(thin) () -> Builtin.RawPointer
@@ -1957,7 +1963,8 @@ sil [ossa] @generic_call_without_indirect_result : $@convention(thin) <T> (@in T
 sil [ossa] @generic_call_with_direct_result : $@convention(thin) <T> (T) -> T
 
 // CHECK-LABEL: sil [ossa] @generic_partialapply : $@convention(thin) () -> () {
-// XHECK-NOT: partial_apply
+// CHECK-NOT: partial_apply
+// CHECK: } // end sil function 'generic_partialapply'
 sil [ossa] @generic_partialapply : $@convention(thin) () -> () {
 bb0:
   %0 = function_ref @generic_call_with_indirect_result : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
@@ -2331,19 +2338,19 @@ bb3:
   return %10 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @test_delete_readonly_try_apply
-// XHECK:      bb0(%0 : @owned $ZZZ):
-// XHECK-NEXT:   [[IL:%[0-9]+]] = integer_literal $Builtin.Int1, 0
-// XHECK-NEXT:   cond_br [[IL]], bb1, bb2
-// XHECK:      bb1:
-// XHECK-NEXT:   destroy_value %0
-// XHECK-NEXT:   br bb3
-// XHECK:      bb2:
-// XHECK-NEXT:   destroy_value %0
-// XHECK-NEXT:   br bb3
-// XHECK:      bb3:
-// XHECK:        return
-// XHECK: } // end sil function 'test_delete_readonly_try_apply'
+// CHECK-LABEL: sil [ossa] @test_delete_readonly_try_apply :
+// CHECK:      bb0(%0 : @owned $ZZZ):
+// CHECK-NEXT:   [[IL:%[0-9]+]] = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:   cond_br [[IL]], bb1, bb2
+// CHECK:      bb1:
+// CHECK-NEXT:   destroy_value %0
+// CHECK-NEXT:   br bb3
+// CHECK:      bb2:
+// CHECK-NEXT:   destroy_value %0
+// CHECK-NEXT:   br bb3
+// CHECK:      bb3:
+// CHECK:        return
+// CHECK: } // end sil function 'test_delete_readonly_try_apply'
 sil [ossa] @test_delete_readonly_try_apply : $@convention(thin) (@owned ZZZ) -> () {
 bb0(%0 : @owned $ZZZ):
   %2 = function_ref @readonly_throwing : $@convention(thin) (@owned ZZZ) -> (@owned ZZZ, @error Error)
@@ -2362,8 +2369,9 @@ bb3:
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply1
-// XHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply1 :
+// CHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK: } // end sil function 'test_dont_delete_readonly_try_apply1'
 sil [ossa] @test_dont_delete_readonly_try_apply1 : $@convention(thin) (@owned ZZZ) -> () {
 bb0(%0 : @owned $ZZZ):
   %2 = function_ref @readonly_throwing : $@convention(thin) (@owned ZZZ) -> (@owned ZZZ, @error Error)
@@ -2385,8 +2393,9 @@ bb3:
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply2
-// XHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply2 :
+// CHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK: } // end sil function 'test_dont_delete_readonly_try_apply2'
 sil [ossa] @test_dont_delete_readonly_try_apply2 : $@convention(thin) (@owned ZZZ) -> () {
 bb0(%0 : @owned $ZZZ):
   %2 = function_ref @readonly_throwing : $@convention(thin) (@owned ZZZ) -> (@owned ZZZ, @error Error)
@@ -2408,8 +2417,9 @@ bb3:
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply3
-// XHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply3 :
+// CHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK: } // end sil function 'test_dont_delete_readonly_try_apply3'
 sil [ossa] @test_dont_delete_readonly_try_apply3 : $@convention(thin) (@owned ZZZ) -> () {
 bb0(%0 : @owned $ZZZ):
   %2 = function_ref @readonly_throwing : $@convention(thin) (@owned ZZZ) -> (@owned ZZZ, @error Error)
@@ -2434,8 +2444,9 @@ bb4:
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply4
-// XHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK-LABEL: sil [ossa] @test_dont_delete_readonly_try_apply4 :
+// CHECK: try_apply %{{[0-9]+}}(%0)
+// CHECK: } // end sil function 'test_dont_delete_readonly_try_apply4'
 sil [ossa] @test_dont_delete_readonly_try_apply4 : $@convention(thin) (@owned ZZZ, @owned ZZZ) -> @owned ZZZ {
 bb0(%0 : @owned $ZZZ, %1 : @owned $ZZZ):
   %2 = function_ref @readonly_throwing : $@convention(thin) (@owned ZZZ) -> (@owned ZZZ, @error Error)
@@ -2628,13 +2639,13 @@ bb0(%0 : @owned $Klass):
   return %3 : $Builtin.NativeObject
 }
 
-// CHECK-LABEL: sil [ossa] @collapse_existential_pack_unpack_unchecked_ref_cast_owned_fail_2 :
+// CHECK-LABEL: sil [ossa] @collapse_existential_pack_unpack_unchecked_ref_cast_owned_fail_3 :
 // CHECK:       bb0(
 // CHECK:     init_existential_ref
 // CHECK:     open_existential_ref
 // CHECK:         unchecked_ref_cast
-// CHECK: } // end sil function 'collapse_existential_pack_unpack_unchecked_ref_cast_owned_fail_2'
-sil [ossa] @collapse_existential_pack_unpack_unchecked_ref_cast_owned_fail_2 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
+// CHECK: } // end sil function 'collapse_existential_pack_unpack_unchecked_ref_cast_owned_fail_3'
+sil [ossa] @collapse_existential_pack_unpack_unchecked_ref_cast_owned_fail_3 : $@convention(thin) (@owned Klass) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Klass):
   %1 = init_existential_ref %0 : $Klass : $Klass, $AnyObject
   %2 = open_existential_ref %1 : $AnyObject to $@opened("2CAE06CE-5F10-11E4-AF13-C82A1428F987") AnyObject
@@ -3051,8 +3062,9 @@ bb3:
 
 // Make sure we do not crash on this and remove everything
 // CHECK-LABEL: sil [ossa] @partial_apply_retain_removal : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
-// XHECK: bb0
-// XHECK-NEXT: return
+// CHECK: bb0
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'partial_apply_retain_removal'
 sil [ossa] @partial_apply_retain_removal : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = function_ref @user : $@convention(thin) (@owned Builtin.NativeObject) -> ()
@@ -3500,13 +3512,13 @@ sil [reabstraction_thunk] @_TTRXFo_oSS_dSb_XFo_iSS_iSb_ : $@convention(thin) (@i
 sil [reabstraction_thunk] @_TTRXFo_iSS_iSb_XFo_oSS_dSb_ : $@convention(thin) (@owned String, @owned @callee_owned (@in String) -> @out Bool) -> Bool
 
 // CHECK-LABEL: sil [ossa] @remove_identity_reabstraction_thunks :
-// XHECK:  [[STK:%.*]] = alloc_stack $@callee_owned (@owned String) -> Bool
-// XHECK-NOT: partial_apply
-// XHECK:  store %0 to [init] [[STK]]
-// XHECK:  [[LD:%.*]] = load [take] [[STK]]
-// XHECK:  destroy_value [[LD]]
-// XHECK:  dealloc_stack [[STK]]
-// XHECK: } // end sil function 'remove_identity_reabstraction_thunks'
+// CHECK:  [[STK:%.*]] = alloc_stack $@callee_owned (@owned String) -> Bool
+// CHECK-NOT: partial_apply
+// CHECK:  store %0 to [init] [[STK]]
+// CHECK:  [[LD:%.*]] = load [take] [[STK]]
+// CHECK:  destroy_value [[LD]]
+// CHECK:  dealloc_stack [[STK]]
+// CHECK: } // end sil function 'remove_identity_reabstraction_thunks'
 sil [ossa] @remove_identity_reabstraction_thunks : $@convention(thin) (@owned @callee_owned (@owned String) -> Bool) -> () {
 bb0(%0 : @owned $@callee_owned (@owned String) -> Bool):
   %1 = alloc_stack $@callee_owned (@owned String) -> Bool
@@ -3525,10 +3537,11 @@ bb0(%0 : @owned $@callee_owned (@owned String) -> Bool):
   return %7 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @remove_unused_convert_function
-// XHECK: bb0
-// XHECK-NEXT: tuple
-// XHECK-NEXT: return
+// CHECK-LABEL: sil [ossa] @remove_unused_convert_function :
+// CHECK: bb0
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'remove_unused_convert_function'
 sil [ossa] @remove_unused_convert_function : $@convention(thin) (@inout B, @guaranteed B, Builtin.Int1) -> () {
 bb0(%0 : $*B, %1 : @guaranteed $B, %2 : $Builtin.Int1):
   %3 = function_ref @weird_function : $@convention(thin) (@inout E, @guaranteed E, Builtin.Int1) -> ()
@@ -3680,11 +3693,12 @@ class ClientSocket : Socket {
   final class func newWithConfig() throws -> Builtin.Int32
 }
 
-// CHECK-LABEL: static_existential
-// XHECK:bb0:
+// CHECK-LABEL: sil [ossa] @static_existential : $@convention(thin) () -> (Builtin.Int32, @error MyErrorType) {
+// CHECK:bb0:
 // XHECK:  [[META:%.*]] = metatype $@thick ClientSocket.Type
 // XHECK:  [[WM:%.*]] = witness_method $ClientSocket
 // XHECK:  try_apply [[WM]]<ClientSocket>([[META]])
+// CHECK: } // end sil function 'static_existential'
 sil [ossa] @static_existential : $@convention(thin) () -> (Builtin.Int32, @error MyErrorType) {
 bb0:
   %0 = metatype $@thick ClientSocket.Type
@@ -4004,12 +4018,13 @@ protocol Prot2 : Prot1 {
 
 sil [ossa] @getMetaType : $@convention(thin) () -> @thick Prot2.Type
 
-// CHECK-LABEL: meta_existential
-// XHECK:bb0:
+// CHECK-LABEL: sil [ossa] @meta_existential : $@convention(thin) () -> (Builtin.Int32, @error MyErrorType) {
+// CHECK:bb0:
 // XHECK:  [[APPLY:%.*]] = apply {{%.*}}() : $@convention(thin) () -> @thick Prot2.Type
 // XHECK:  [[OE:%.*]] = open_existential_metatype [[APPLY]] : $@thick Prot2.Type to $@thick (@opened("690DA5F6-B5EA-11E7-B144-685B3593C496") Prot1).Type
 // XHECK:  [[WM:%.*]] = witness_method $@opened("690DA5F6-B5EA-11E7-B144-685B3593C496") Prot1, #Prot1.newWithConfig : <Self where Self : Prot1> (Self.Type) -> () throws -> Builtin.Int32, [[OE]] : $@thick (@opened("690DA5F6-B5EA-11E7-B144-685B3593C496") Prot1).Type : $@convention(witness_method: Prot1) <τ_0_0 where τ_0_0 : Prot1> (@thick τ_0_0.Type) -> (Builtin.Int32, @error MyErrorType)
 // XHECK:  try_apply [[WM]]<@opened("690DA5F6-B5EA-11E7-B144-685B3593C496") Prot1>([[OE]]) : $@convention(witness_method: Prot1) <τ_0_0 where τ_0_0 : Prot1> (@thick τ_0_0.Type) -> (Builtin.Int32, @error MyErrorType)
+// CHECK: } // end sil function 'meta_existential'
 sil [ossa] @meta_existential : $@convention(thin) () -> (Builtin.Int32, @error MyErrorType) {
 bb0:
   %fref = function_ref @getMetaType : $@convention(thin) () -> @thick Prot2.Type
@@ -4480,6 +4495,26 @@ bb1b:
   br bb1
 
 bb1:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we eliminate copy_value on values with None ownership and
+// preserve ownership.
+//
+// CHECK-LABEL: sil [ossa] @copy_value_of_none : $@convention(thin) () -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'copy_value_of_none'
+sil [ossa] @copy_value_of_none : $@convention(thin) () -> () {
+bb0:
+  %0 = enum $FakeOptional<Builtin.NativeObject>, #FakeOptional.none!enumelt
+  %1 = copy_value %0 : $FakeOptional<Builtin.NativeObject>
+  br bb1(%1 : $FakeOptional<Builtin.NativeObject>)
+
+bb1(%2 : @owned $FakeOptional<Builtin.NativeObject>):
+  %f = function_ref @use_fakeoptional_nativeobject_guaranteed : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> ()
+  apply %f(%2) : $@convention(thin) (@guaranteed FakeOptional<Builtin.NativeObject>) -> ()
+  destroy_value %2 : $FakeOptional<Builtin.NativeObject>
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/sil_combine_pa_removal_ossa.sil
+++ b/test/SILOptimizer/sil_combine_pa_removal_ossa.sil
@@ -6,8 +6,9 @@ import Builtin
 import Swift
 
 // CHECK-LABEL: sil [ossa] @a_function1 :
-// XHECK-NOT: partial_apply
-// XHECK: return
+// CHECK-NOT: partial_apply
+// CHECK: return
+// CHECK: } // end sil function 'a_function1'
 sil [ossa] @a_function1 : $@convention(thin) (Int64) -> () {
 bb0(%0 : $Int64):
   %1 = function_ref @our_closure_function1 : $@convention(thin) (Int64) -> Bool // user: %2
@@ -20,22 +21,24 @@ bb0(%0 : $Int64):
 class K {
 }
 
-// CHECK-LABEL: sil [ossa] @a_function2
 // The release_value of $K is optimized to a destroy_value.
+//
+// CHECK-LABEL: sil [ossa] @a_function2 :
+// CHECK-NOT: partial_apply  
+// CHECK: br
+// CHECK: destroy_value
+// CHECK: return
+// CHECK: } // end sil function 'a_function2'
 sil [ossa] @a_function2 : $@convention(thin) (@owned K) -> () {
 bb0(%0 : @owned $K):
   %1 = alloc_ref $K
   %2 = function_ref @our_closure_function2 : $@convention(thin) (@owned K) -> Bool // user: %2
-//XHECK-NOT: partial_apply
   %3 = partial_apply %2(%0) : $@convention(thin) (@owned K) -> Bool // user: %3
-//XHECK: br
   br bb1
  bb1:
-//XHECK: destroy_value
   destroy_value %3 : $@callee_owned () -> Bool   // id: %3
   destroy_value %1 : $K
   %5 = tuple ()                                   // user: %5
-//XHECK: return
   return %5 : $()                                 // id: %5
 }
 

--- a/test/SILOptimizer/sil_combine_pure_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_pure_apply_ossa.sil
@@ -9,15 +9,15 @@ class Foo {
 }
 
 
-sil @_TFC4main3Food : $@convention(method) (@owned Foo) -> @owned Builtin.NativeObject {
-bb0(%0 : $Foo):
+sil [ossa] @_TFC4main3Food : $@convention(method) (@owned Foo) -> @owned Builtin.NativeObject {
+bb0(%0 : @owned $Foo):
   debug_value %0 : $Foo, let, name "self" // id: %1
   %2 = unchecked_ref_cast %0 : $Foo to $Builtin.NativeObject // user: %3
   return %2 : $Builtin.NativeObject               // id: %3
 }
 
-sil @_TFC4main3FooD : $@convention(method) (@owned Foo) -> () {
-bb0(%0 : $Foo):
+sil [ossa] @_TFC4main3FooD : $@convention(method) (@owned Foo) -> () {
+bb0(%0 : @owned $Foo):
   debug_value %0 : $Foo, let, name "self" // id: %1
   // function_ref main.Foo.deinit
   %2 = function_ref @_TFC4main3Food : $@convention(method) (@owned Foo) -> @owned Builtin.NativeObject // user: %3
@@ -28,13 +28,13 @@ bb0(%0 : $Foo):
   return %6 : $()                                 // id: %7
 }
 
-sil @_TFC4main3FoocfMS0_FT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo {
-bb0(%0 : $Foo):
+sil [ossa] @_TFC4main3FoocfMS0_FT_S0_ : $@convention(method) (@owned Foo) -> @owned Foo {
+bb0(%0 : @owned $Foo):
   debug_value %0 : $Foo, let, name "self" // id: %1
   return %0 : $Foo                                // id: %2
 }
 
-sil @_TFC4main3FooCfMS0_FT_S0_ : $@convention(thin) (@thick Foo.Type) -> @owned Foo {
+sil [ossa] @_TFC4main3FooCfMS0_FT_S0_ : $@convention(thin) (@thick Foo.Type) -> @owned Foo {
 bb0(%0 : $@thick Foo.Type):
   %1 = alloc_ref $Foo                             // user: %3
   // function_ref main.Foo.init (main.Foo.Type)() -> main.Foo
@@ -43,7 +43,7 @@ bb0(%0 : $@thick Foo.Type):
   return %3 : $Foo                                // id: %4
 }
 
-sil [readonly] @_TF4main9readonly_funcFT_CS_3Foo : $@convention(thin) () -> @owned Foo {
+sil [ossa] [readonly] @_TF4main9readonly_funcFT_CS_3Foo : $@convention(thin) () -> @owned Foo {
 bb0:
   // function_ref main.Foo.__allocating_init (main.Foo.Type)() -> main.Foo
   %0 = function_ref @_TFC4main3FooCfMS0_FT_S0_ : $@convention(thin) (@thick Foo.Type) -> @owned Foo // user: %2
@@ -52,18 +52,19 @@ bb0:
   return %2 : $Foo                                // id: %3
 }
 
-//CHECK-LABEL: @_TF4main3bazFT_T_
-//CHECK-NOT: function_ref
-//CHECK-NOT: apply
-//CHECK: tuple
-//CHECK-NEXT: return
-sil @_TF4main3bazFT_T_ : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [ossa] @_TF4main3bazFT_T_ : $@convention(thin) () -> () {
+// CHECK-NOT: function_ref
+// CHECK-NOT: apply
+// CHECK: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function '_TF4main3bazFT_T_'
+sil [ossa] @_TF4main3bazFT_T_ : $@convention(thin) () -> () {
 bb0:
   // function_ref main.readonly_func () -> main.Foo
   %0 = function_ref @_TF4main9readonly_funcFT_CS_3Foo : $@convention(thin) () -> @owned Foo // user: %1
   %1 = apply %0() : $@convention(thin) () -> @owned Foo       // users: %2, %3
   debug_value %1 : $Foo, let, name "unused" // id: %2
-  strong_release %1 : $Foo                        // id: %3
+  destroy_value %1 : $Foo                        // id: %3
   %4 = tuple ()                                   // user: %5
   return %4 : $()                                 // id: %5
 }


### PR DESCRIPTION
All of the non-SILCombiner specific helpers have already been updated for OSSA,
so this was not too bad.

NOTE: I also added two small combines that delete copy_value, destroy_value with
.none arguments. The reason why I added this is that this is a pretty small
addition and many of the tests of this code rely on SILCombine being able to
eliminate such operations on thin_to_thick_function.
