### PR TITLE
[ CanonicalOSSALifetime ] Fix visitLocalScopeEndingUses call

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -117,7 +117,7 @@ bool CanonicalizeOSSALifetime::computeBorrowLiveness() {
   if (!EnableRewriteBorrows) {
     return false;
   }
-  borrowedVal.visitLocalScopeEndingUses([this](Operand *use) {
+  borrowedVal->visitLocalScopeEndingUses([this](Operand *use) {
     liveness.updateForUse(use->getUser(), /*lifetimeEnding*/ true);
   });
 


### PR DESCRIPTION
Resolves rdar://problem/73379135

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
