### PR TITLE
[SR-12033] [Sema] Do not allow inferring defaultable closure `() -> $T` for autoclosure arguments result

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -336,8 +336,12 @@ void PotentialBindings::inferTransitiveBindings(
       addLiteral(literal.second.getSource());
 
     // Infer transitive defaults.
-    for (const auto &def : bindings.Defaults)
+    for (const auto &def : bindings.Defaults) {
+      if (def.getSecond()->getKind() == ConstraintKind::DefaultClosureType)
+        continue;
+
       addDefault(def.second);
+    }
 
     // TODO: We shouldn't need this in the future.
     if (entry.second->getKind() != ConstraintKind::Subtype)
@@ -366,11 +370,45 @@ void PotentialBindings::inferTransitiveBindings(
   }
 }
 
+// If potential binding type variable is a closure that has a subtype relation
+// associated with argument conversion constraint located directly on an
+// autoclosure parameter.
+static bool
+isClosureInAutoClosureArgumentConversion(PotentialBindings &bindings) {
+
+  if (!bindings.TypeVar->getImpl().isClosureType())
+    return false;
+
+  return llvm::any_of(
+      bindings.SubtypeOf,
+      [](std::pair<TypeVariableType *, Constraint *> subType) {
+        if (subType.second->getKind() != ConstraintKind::ArgumentConversion)
+          return false;
+        return subType.second->getLocator()
+            ->isLastElement<LocatorPathElt::AutoclosureResult>();
+      });
+}
+
 void PotentialBindings::finalize(
     llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
         &inferredBindings) {
   inferTransitiveProtocolRequirements(inferredBindings);
   inferTransitiveBindings(inferredBindings);
+
+  // For autoclosure parameters if we have a closure argument which could
+  // default to `() -> $T`, we avoid infering defaultable binding because
+  // an autoclosure cannot accept a closure paramenter unless the result `$T`
+  // is bound to a function type via another contextual binding. Also consider
+  // adjacent vars because they can also default transitively.
+  if (isClosureInAutoClosureArgumentConversion(*this)) {
+    auto closureDefault = llvm::find_if(
+        Defaults, [](const std::pair<CanType, Constraint *> &entry) {
+          return entry.second->getKind() == ConstraintKind::DefaultClosureType;
+        });
+    if (closureDefault != Defaults.end()) {
+      Defaults.erase(closureDefault);
+    }
+  }
 }
 
 PotentialBindings::BindingScore

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2520,7 +2520,7 @@ namespace {
       closure->walk(collectVarRefs);
 
       // If walker discovered error expressions, let's fail constraint
-      // genreation only if closure is going to participate
+      // generation only if closure is going to participate
       // in the type-check. This allows us to delay validation of
       // multi-statement closures until body is opened.
       if (shouldTypeCheckInEnclosingExpression(closure) &&


### PR DESCRIPTION
<!-- What's in this pull request? -->
Prevent defaultable closure binding to be added if its connected to an auto closure argument. 
Sorry it took some time, but have been between other things and actually giving a thought if this would be the correct 
approach and about source compatibility in this case. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-12033.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
