### PR TITLE
[NFC] Update comment that mentioned old mark as `FullyBound` way to delay bindings

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1035,11 +1035,11 @@ bool ConstraintSystem::PotentialBindings::infer(
     break;
   }
   case ConstraintKind::KeyPathApplication: {
-    // If this variable is in the application projected result type, mark the
-    // result as `FullyBound` to ensure we delay binding until we've bound
-    // other type variables in the KeyPathApplication constraint. This ensures
-    // we try to bind the key path type first, which can allow us to discover
-    // additional bindings for the result type.
+    // If this variable is in the application projected result type, delay
+    // binding until we've bound other type variables in the key-path
+    // application constraint. This ensures we try to bind the key path type
+    // first, which can allow us to discover additional bindings for the result
+    // type.
     SmallPtrSet<TypeVariableType *, 4> typeVars;
     findInferableTypeVars(cs.simplifyType(constraint->getThirdType()),
                           typeVars);


### PR DESCRIPTION
Does that make sense? There is no more explicit mark as `FullyBounded` and it seems like it doesn't exist as a concept anymore since introduction of `isDelayed()`, I thought this could be an improvement. 
But let me know if indeed makes sense =] 

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
