### PR TITLE
[test] This test should check for codegen support.

### DIFF
--- a/test/Interop/Cxx/class/constructors-copy-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen.swift
@@ -1,5 +1,7 @@
 // Target-specific tests for C++ copy constructor code generation.
 
+// REQUIRES: CODEGENERATOR=ARM && CODEGENERATOR=X86
+
 // RUN: %swift -module-name Swift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
 // RUN: %swift -module-name Swift -target armv7-none-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 // RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64

--- a/test/Interop/Cxx/class/constructors-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-irgen.swift
@@ -1,5 +1,7 @@
 // Target-specific tests for C++ constructor call code generation.
 
+// REQUIRES: CODEGENERATOR=ARM && CODEGENERATOR=X86
+
 // RUN: %swift -module-name Swift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
 // RUN: %swift -module-name Swift -target armv7-unknown-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 // RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64


### PR DESCRIPTION
This test checks for x86_64-* targets and armv7-* targets. If LLVM is
not built with support for these targets, this test will trip. It
appears the way to check for this is by REQUIRES CODEGENERATOR, so add
this to properly condition this test.