### PR TITLE
[stdlib] Use Clang type macros on OpenBSD.

### DIFF
--- a/stdlib/public/SwiftShims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__)
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;


### PR DESCRIPTION
Per the code comment, stdint.h is provided by clang and therefore
conflicts with Glibc; additionally, clang defines some particular
type macros for making the appropriate `typedef`s.

OpenBSD uses clang-10, so we can also use these types on this platform.
This also addresses a test case that has gone awry 
(ClangImporter/ctypes_parse_msvc.swift).