### PR TITLE
[update-checkout] Add swift-crypto to the list of repos

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -10,12 +10,12 @@
             "remote": { "id": "apple/swift-llbuild" } },
         "swift-argument-parser": {
             "remote": { "id": "apple/swift-argument-parser" } },
+        "swift-crypto": {
+            "remote": { "id": "apple/swift-crypto" } },
         "swift-driver": {
             "remote": { "id": "apple/swift-driver" } },
         "swift-tools-support-core": {
             "remote": { "id": "apple/swift-tools-support-core" } },
-        "swift-crypto": {
-            "remote": { "id": "apple/swift-crypto" } },
         "swiftpm": {
             "remote": { "id": "apple/swift-package-manager" } },
         "swift-syntax": {
@@ -66,6 +66,7 @@
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
                 "swift-argument-parser": "0.3.0",
+                "swift-crypto": "main",
                 "swift-driver": "main",
                 "swift-syntax": "main",
                 "swift-stress-tester": "main",
@@ -93,6 +94,7 @@
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
                 "swift-argument-parser": "0.3.0",
+                "swift-crypto": "main",
                 "swift-driver": "main",
                 "swift-syntax": "main",
                 "swift-stress-tester": "main",
@@ -123,6 +125,7 @@
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
                 "swift-argument-parser": "0.3.0",
+                "swift-crypto": "main",
                 "swift-driver": "main",
                 "swift-syntax": "main",
                 "swift-stress-tester": "main",

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -14,6 +14,8 @@
             "remote": { "id": "apple/swift-driver" } },
         "swift-tools-support-core": {
             "remote": { "id": "apple/swift-tools-support-core" } },
+        "swift-crypto": {
+            "remote": { "id": "apple/swift-crypto" } },
         "swiftpm": {
             "remote": { "id": "apple/swift-package-manager" } },
         "swift-syntax": {


### PR DESCRIPTION
This is for https://github.com/apple/swift-package-manager/pull/3202, which adds swift-crypto as a new dependency to SwiftPM to support the upcoming package collection feature.
