### PR TITLE
[CodeCompletion][ASTPrinter] Fix a null pointer dereference in PrintAST

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -735,7 +735,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
   void printType(Type T) { printTypeWithOptions(T, Options); }
 
   void printTransformedTypeWithOptions(Type T, PrintOptions options) {
-    if (CurrentType) {
+    if (CurrentType && Current) {
       if (T->hasArchetype()) {
         // Get the interface type, since TypeLocs still have
         // contextual types in them.
@@ -1527,7 +1527,7 @@ void PrintAST::printSingleDepthOfGenericSignature(
     (flags & SwapSelfAndDependentMemberType);
 
   SubstitutionMap subMap;
-  if (CurrentType) {
+  if (CurrentType && Current) {
     if (!CurrentType->isExistentialType()) {
       auto *DC = Current->getInnermostDeclContext()->getInnermostTypeContext();
       auto *M = DC->getParentModule();

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -66,6 +66,8 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONFORM_SEQUENCE | %FileCheck %s -check-prefix=CONFORM_SEQUENCE
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_CLOSUREARG | %FileCheck %s -check-prefix=GENERIC_CLOSUREARG
+
 // NO_STDLIB_PRIVATE: Begin completions
 // NO_STDLIB_PRIVATE: End completions
 
@@ -291,3 +293,13 @@ class TestSequence : Sequence {
 // CONFORM_SEQUENCE-DAG: Decl[InstanceMethod]/Super/IsSystem: func withContiguousStorageIfAvailable<R>(_ body: (UnsafeBufferPointer<Element>) throws -> R) rethrows -> R? {|};
 // CONFORM_SEQUENCE: End completions
 }
+
+public func rdar_70057258<T>(_ f: T) {}
+extension Result {
+  public init(_ value: Success?) {
+    self = value.map(#^GENERIC_CLOSUREARG^#)
+  }
+}
+// GENERIC_CLOSUREARG: Begin completions
+// GENERIC_CLOSUREARG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: rdar_70057258(_:)[#<T> (T) -> ()#]; name=rdar_70057258(_:)
+// GENERIC_CLOSUREARG: End completions


### PR DESCRIPTION
The code assumed that if the `Type CurrentType` member was set the `Decl *Current` member would be too. When printing the types rather than decls (like code completion does in CompletionLookup::addTypeAnnotation()) this doesn't always hold.

Resolves https://bugs.swift.org/browse/SR-13703
Resolves rdar://problem/70057258