### PR TITLE
CrossModuleOptimization: fix crash when importing a module as implementationOnly

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -626,6 +626,10 @@ public:
   /// This assumes that \p module was imported.
   bool isImportedImplementationOnly(const ModuleDecl *module) const;
 
+  /// Returns true if a function, which is using \p nominal, can be serialized
+  /// by cross-module-optimization.
+  bool canBeUsedForCrossModuleOptimization(NominalTypeDecl *nominal) const;
+
   /// Finds all top-level decls of this module.
   ///
   /// This does a simple local lookup, not recursively looking through imports.

--- a/test/SILOptimizer/Inputs/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module.swift
@@ -1,4 +1,5 @@
 import Submodule
+@_implementationOnly import PrivateSubmodule
 
 private enum PE<T> {
   case A
@@ -266,5 +267,12 @@ public func callUnrelated<T>(_ t: T) -> T {
   unrelated(43)
   return t
 }
+
+public func callImplementationOnly<T>(_ t: T) -> T {
+  let p = PrivateStr(i: 27)
+  print(p.test())
+  return t
+}
+
 
 public let globalLet = 529387

--- a/test/SILOptimizer/Inputs/cross-private-submodule.swift
+++ b/test/SILOptimizer/Inputs/cross-private-submodule.swift
@@ -1,0 +1,14 @@
+
+public struct PrivateStr {
+  var i: Int
+
+  public init(i: Int) {
+    self.i = i
+  }
+
+  @inline(never)
+  public func test() -> Int {
+    return i
+  }
+}
+


### PR DESCRIPTION
If a function uses a type imported as implementationOnly (or similar), it cannot be serialized.

I added a new API in ModuleDecl (canBeUsedForCrossModuleOptimization), which performs this check.

https://bugs.swift.org/browse/SR-14006
rdar://72864719

Cherry-picked from https://github.com/apple/swift/pull/35472