### PR TITLE
[Concurrency] Suggest replacing 'async' with 'await' at call site

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -958,7 +958,6 @@ ERROR(snake_case_deprecated,none,
       "%0 has been replaced with %1 in Swift 3",
       (StringRef, StringRef))
 
-
 // Assignment statement
 ERROR(expected_expr_assignment,none,
       "expected expression in assignment", ())
@@ -985,6 +984,10 @@ NOTE(indent_expression_to_silence,none,
 // Throw Statement
 ERROR(expected_expr_throw,PointsToFirstBadToken,
       "expected expression in 'throw' statement", ())
+
+// Await/Async
+ERROR(expected_await_not_async,none,
+      "found 'async' in expression; did you mean 'await'?", ())
 
 // Yield Statment
 ERROR(expected_expr_yield,PointsToFirstBadToken,

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -519,7 +519,15 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
         diag.highlight(UDRE->getSourceRange());
         typo->addFixits(diag);
       } else {
-        emitBasicError();
+        if (Name.isSimpleName("async")) {
+          auto diag = Context.Diags.diagnose(Loc,
+              diag::cannot_find_in_scope_corrected, Name,
+              /*isOperator=*/false, "await");
+          diag.highlight(UDRE->getSourceRange());
+          diag.fixItReplace(Loc, "await");
+        } else {
+          emitBasicError();
+        }
       }
 
       corrections.noteAllCandidates();

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -519,15 +519,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
         diag.highlight(UDRE->getSourceRange());
         typo->addFixits(diag);
       } else {
-        if (Name.isSimpleName("async")) {
-          auto diag = Context.Diags.diagnose(Loc,
-              diag::cannot_find_in_scope_corrected, Name,
-              /*isOperator=*/false, "await");
-          diag.highlight(UDRE->getSourceRange());
-          diag.fixItReplace(Loc, "await");
-        } else {
-          emitBasicError();
-        }
+        emitBasicError();
       }
 
       corrections.noteAllCandidates();

--- a/test/Concurrency/await_typo_correction.swift
+++ b/test/Concurrency/await_typo_correction.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -parse-as-library
+// REQUIRES: concurrency
+
+func asyncFunc() async throws {}
+
+func anotherAsyncFunc() async -> Int {
+  return 42
+}
+
+@main struct MyProgram {
+  static func main() async throws {
+    // expected-error@+7 {{cannot find 'async' in scope; did you mean 'await'?}}{{9-14=await}}
+    // expected-error@+6 {{consecutive statements on a line must be separated by ';'}}
+    // expected-error@+5 {{call is 'async' but is not marked with 'await'}}
+    // expected-error@+4 {{call can throw but is not marked with 'try'}}
+    // expected-note@+3 {{did you mean to use 'try'?}}
+    // expected-note@+2 {{did you mean to handle error as optional value?}}
+    // expected-note@+1 {{did you mean to disable error propagation?}}
+    try async asyncFunc()
+
+    // expected-error@+4 {{consecutive statements on a line must be separated by ';'}}
+    // expected-error@+3 {{cannot find 'async' in scope; did you mean 'await'?}}{{13-18=await}}
+    // expected-warning@+2 {{result of call to 'anotherAsyncFunc()' is unused}}
+    // expected-error@+1 {{call is 'async' but is not marked with 'await'}}
+    let _ = async anotherAsyncFunc()
+
+    // Don't emit a diagnostic here
+    async let foo = anotherAsyncFunc()
+    let _ = await foo
+  }
+}

--- a/test/Concurrency/await_typo_correction.swift
+++ b/test/Concurrency/await_typo_correction.swift
@@ -7,25 +7,21 @@ func anotherAsyncFunc() async -> Int {
   return 42
 }
 
+func async() throws { }
+
 @main struct MyProgram {
   static func main() async throws {
-    // expected-error@+7 {{cannot find 'async' in scope; did you mean 'await'?}}{{9-14=await}}
-    // expected-error@+6 {{consecutive statements on a line must be separated by ';'}}
-    // expected-error@+5 {{call is 'async' but is not marked with 'await'}}
-    // expected-error@+4 {{call can throw but is not marked with 'try'}}
-    // expected-note@+3 {{did you mean to use 'try'?}}
-    // expected-note@+2 {{did you mean to handle error as optional value?}}
-    // expected-note@+1 {{did you mean to disable error propagation?}}
+    // expected-error@+1 {{found 'async' in expression; did you mean 'await'?}}{{9-14=await}}
     try async asyncFunc()
 
-    // expected-error@+4 {{consecutive statements on a line must be separated by ';'}}
-    // expected-error@+3 {{cannot find 'async' in scope; did you mean 'await'?}}{{13-18=await}}
-    // expected-warning@+2 {{result of call to 'anotherAsyncFunc()' is unused}}
-    // expected-error@+1 {{call is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{found 'async' in expression; did you mean 'await'?}}{{13-18=await}}
     let _ = async anotherAsyncFunc()
 
     // Don't emit a diagnostic here
     async let foo = anotherAsyncFunc()
     let _ = await foo
+
+    // I question the name choice, but it's valid
+    try async()
   }
 }

--- a/test/Concurrency/await_typo_correction.swift
+++ b/test/Concurrency/await_typo_correction.swift
@@ -14,6 +14,10 @@ func async() throws { }
     // expected-error@+1 {{found 'async' in expression; did you mean 'await'?}}{{9-14=await}}
     try async asyncFunc()
 
+    // expected-error@+2 {{found 'async' in expression; did you mean 'await'?}}{{5-10=await}}
+    // expected-warning@+1 {{'try' must precede 'await'}}{{5-11=}}{{15-15=await }}
+    async try asyncFunc()
+
     // expected-error@+1 {{found 'async' in expression; did you mean 'await'?}}{{13-18=await}}
     let _ = async anotherAsyncFunc()
 


### PR DESCRIPTION
It's pretty easy to typo-replace 'await' with 'async' and get a
confusing error about 'async' not being in scope. This patch updates the
diagnostic to suggest replacing 'async' with 'await' at the call-sites
so that users aren't left scratching their heads.

Fixes: rdar://72968205