### PR TITLE
[AST] Introduce "all members" query to reduce non-determinism in serialization & interface printing

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -333,7 +333,7 @@ protected:
     NumElements : 32
   );
 
-  SWIFT_INLINE_BITFIELD(ValueDecl, Decl, 1+1+1,
+  SWIFT_INLINE_BITFIELD(ValueDecl, Decl, 1+1+1+1,
     AlreadyInLookupTable : 1,
 
     /// Whether we have already checked whether this declaration is a 
@@ -342,7 +342,11 @@ protected:
 
     /// Whether the decl can be accessed by swift users; for instance,
     /// a.storage for lazy var a is a decl that cannot be accessed.
-    IsUserAccessible : 1
+    IsUserAccessible : 1,
+
+    /// Whether this member was synthesized as part of a derived
+    /// protocol conformance.
+    Synthesized : 1
   );
 
   SWIFT_INLINE_BITFIELD(AbstractStorageDecl, ValueDecl, 1,
@@ -387,7 +391,7 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
-  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+8+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
 
@@ -405,10 +409,6 @@ protected:
 
     /// Whether the function body throws.
     Throws : 1,
-
-    /// Whether this member was synthesized as part of a derived
-    /// protocol conformance.
-    Synthesized : 1,
 
     /// Whether this member's body consists of a single expression.
     HasSingleExpressionBody : 1,
@@ -2020,6 +2020,7 @@ protected:
     Bits.ValueDecl.AlreadyInLookupTable = false;
     Bits.ValueDecl.CheckedRedeclaration = false;
     Bits.ValueDecl.IsUserAccessible = true;
+    Bits.ValueDecl.Synthesized = false;
   }
 
   // MemberLookupTable borrows a bit from this type
@@ -2055,6 +2056,14 @@ public:
 
   bool isUserAccessible() const {
     return Bits.ValueDecl.IsUserAccessible;
+  }
+
+  bool isSynthesized() const {
+    return Bits.ValueDecl.Synthesized;
+  }
+
+  void setSynthesized(bool value = true) {
+    Bits.ValueDecl.Synthesized = value;
   }
 
   bool hasName() const { return bool(Name); }
@@ -5577,7 +5586,6 @@ protected:
     Bits.AbstractFunctionDecl.Overridden = false;
     Bits.AbstractFunctionDecl.Async = Async;
     Bits.AbstractFunctionDecl.Throws = Throws;
-    Bits.AbstractFunctionDecl.Synthesized = false;
     Bits.AbstractFunctionDecl.HasSingleExpressionBody = false;
     Bits.AbstractFunctionDecl.HasNestedTypeDeclarations = false;
   }
@@ -5783,14 +5791,6 @@ public:
   /// For a method of a class, checks whether it will require a new entry in the
   /// vtable.
   bool needsNewVTableEntry() const;
-
-  bool isSynthesized() const {
-    return Bits.AbstractFunctionDecl.Synthesized;
-  }
-
-  void setSynthesized(bool value = true) {
-    Bits.AbstractFunctionDecl.Synthesized = value;
-  }
 
 public:
   /// Retrieve the source range of the function body.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3541,7 +3541,7 @@ class ClassDecl final : public NominalTypeDecl {
 
   friend class SuperclassDeclRequest;
   friend class SuperclassTypeRequest;
-  friend class SemanticMembersRequest;
+  friend class ABIMembersRequest;
   friend class HasMissingDesignatedInitializersRequest;
   friend class InheritsSuperclassInitializersRequest;
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -778,10 +778,11 @@ public:
   /// the implementation.
   ArrayRef<Decl *> getParsedMembers() const;
 
-  /// Get all the members that are semantically within this context,
-  /// including any implicitly-synthesized members.
+  /// Get all of the members within this context that can affect ABI, including
+  /// any implicitly-synthesized members.
+  ///
   /// The resulting list of members will be stable across translation units.
-  ArrayRef<Decl *> getSemanticMembers() const;
+  ArrayRef<Decl *> getABIMembers() const;
 
   /// Retrieve the set of members in this context without loading any from the
   /// associated lazy loader; this should only be used as part of implementing

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -784,6 +784,12 @@ public:
   /// The resulting list of members will be stable across translation units.
   ArrayRef<Decl *> getABIMembers() const;
 
+  /// Get all of the members within this context, including any
+  /// implicitly-synthesized members.
+  ///
+  /// The resulting list of members will be stable across translation units.
+  ArrayRef<Decl *> getAllMembers() const;
+
   /// Retrieve the set of members in this context without loading any from the
   /// associated lazy loader; this should only be used as part of implementing
   /// abstractions on top of member loading, such as a name lookup table.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -304,6 +304,11 @@ struct PrintOptions {
   /// such as _silgen_name, transparent, etc.
   bool PrintUserInaccessibleAttrs = true;
 
+  /// Whether to limit ourselves to printing only the "current" set of members
+  /// in a nominal type or extension, which is semantically unstable but can
+  /// prevent printing from doing "extra" work.
+  bool PrintCurrentMembersOnly = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {DAK_Transparent, DAK_Effects,
                                               DAK_FixedLayout,
@@ -517,6 +522,7 @@ struct PrintOptions {
     result.ShouldQualifyNestedDeclarations =
         QualifyNestedDeclarations::TypesOnly;
     result.PrintDocumentationComments = false;
+    result.PrintCurrentMembersOnly = true;
     return result;
   }
 
@@ -538,6 +544,7 @@ struct PrintOptions {
     result.SkipUnderscoredKeywords = true;
     result.EnumRawValues = EnumRawValueMode::PrintObjCOnly;
     result.MapCrossImportOverlaysToDeclaringModule = true;
+    result.PrintCurrentMembersOnly = false;
     return result;
   }
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1220,8 +1220,8 @@ public:
   void cacheResult(AccessorDecl *value) const;
 };
 
-class SemanticMembersRequest :
-    public SimpleRequest<SemanticMembersRequest,
+class ABIMembersRequest :
+    public SimpleRequest<ABIMembersRequest,
                          ArrayRef<Decl *>(IterableDeclContext *),
                          RequestFlags::Cached> {
 public:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1238,6 +1238,24 @@ public:
   bool isCached() const { return true; }
 };
 
+class AllMembersRequest :
+    public SimpleRequest<AllMembersRequest,
+                         ArrayRef<Decl *>(IterableDeclContext *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ArrayRef<Decl *>
+  evaluate(Evaluator &evaluator, IterableDeclContext *idc) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 class IsImplicitlyUnwrappedOptionalRequest :
     public SimpleRequest<IsImplicitlyUnwrappedOptionalRequest,
                          bool(ValueDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -67,6 +67,8 @@ SWIFT_REQUEST(TypeChecker, DynamicallyReplacedDeclRequest,
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ABIMembersRequest,
               ArrayRef<Decl *>(IterableDeclContext *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, AllMembersRequest,
+              ArrayRef<Decl *>(IterableDeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SpecializeAttrTargetDeclRequest,
               ValueDecl *(const ValueDecl *, SpecializeAttr *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -65,7 +65,7 @@ SWIFT_REQUEST(TypeChecker, TypeEraserHasViableInitRequest,
 SWIFT_REQUEST(TypeChecker, DynamicallyReplacedDeclRequest,
               ValueDecl *(ValueDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, SemanticMembersRequest,
+SWIFT_REQUEST(TypeChecker, ABIMembersRequest,
               ArrayRef<Decl *>(IterableDeclContext *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SpecializeAttrTargetDeclRequest,
               ValueDecl *(const ValueDecl *, SpecializeAttr *),

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -148,7 +148,7 @@ protected:
     if (!theClass->hasKnownSwiftImplementation())
       return;
 
-    for (auto member : theClass->getSemanticMembers())
+    for (auto member : theClass->getABIMembers())
       maybeAddMember(member);
   }
 };

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -189,7 +189,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
             localModule->isImportedImplementationOnly(nominalModule)) {
 
           bool shouldPrintMembers = llvm::any_of(
-                                      ED->getMembers(),
+                                      ED->getAllMembers(),
                                       [&](const Decl *member) -> bool {
             return shouldPrint(member, options);
           });
@@ -1750,7 +1750,7 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
     getInheritedForPrinting(Ext, Options, ProtocolsToPrint);
     if (ProtocolsToPrint.empty()) {
       bool HasMemberToPrint = false;
-      for (auto Member : Ext->getMembers()) {
+      for (auto Member : Ext->getAllMembers()) {
         if (shouldPrint(Member, Options)) {
           HasMemberToPrint = true;
           break;
@@ -2050,24 +2050,24 @@ void PrintAST::printMembersOfDecl(Decl *D, bool needComma,
                                   bool openBracket,
                                   bool closeBracket) {
   llvm::SmallVector<Decl *, 3> Members;
-  auto AddDeclFunc = [&](DeclRange Range) {
+  auto AddDeclFunc = [&](ArrayRef<Decl *> Range) {
     for (auto RD : Range)
       Members.push_back(RD);
   };
 
   if (auto Ext = dyn_cast<ExtensionDecl>(D)) {
-    AddDeclFunc(Ext->getMembers());
+    AddDeclFunc(Ext->getAllMembers());
   } else if (auto NTD = dyn_cast<NominalTypeDecl>(D)) {
-    AddDeclFunc(NTD->getMembers());
+    AddDeclFunc(NTD->getAllMembers());
     for (auto Ext : NTD->getExtensions()) {
       if (Options.printExtensionContentAsMembers(Ext))
-        AddDeclFunc(Ext->getMembers());
+        AddDeclFunc(Ext->getAllMembers());
     }
     if (Options.PrintExtensionFromConformingProtocols) {
       for (auto Conf : NTD->getAllConformances()) {
         for (auto Ext : Conf->getProtocol()->getExtensions()) {
           if (Options.printExtensionContentAsMembers(Ext))
-            AddDeclFunc(Ext->getMembers());
+            AddDeclFunc(Ext->getAllMembers());
         }
       }
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2050,24 +2050,29 @@ void PrintAST::printMembersOfDecl(Decl *D, bool needComma,
                                   bool openBracket,
                                   bool closeBracket) {
   llvm::SmallVector<Decl *, 3> Members;
-  auto AddDeclFunc = [&](ArrayRef<Decl *> Range) {
-    for (auto RD : Range)
-      Members.push_back(RD);
+  auto AddMembers = [&](IterableDeclContext *idc) {
+    if (Options.PrintCurrentMembersOnly) {
+      for (auto RD : idc->getMembers())
+        Members.push_back(RD);
+    } else {
+      for (auto RD : idc->getAllMembers())
+        Members.push_back(RD);
+    }
   };
 
   if (auto Ext = dyn_cast<ExtensionDecl>(D)) {
-    AddDeclFunc(Ext->getAllMembers());
+    AddMembers(Ext);
   } else if (auto NTD = dyn_cast<NominalTypeDecl>(D)) {
-    AddDeclFunc(NTD->getAllMembers());
+    AddMembers(NTD);
     for (auto Ext : NTD->getExtensions()) {
       if (Options.printExtensionContentAsMembers(Ext))
-        AddDeclFunc(Ext->getAllMembers());
+        AddMembers(Ext);
     }
     if (Options.PrintExtensionFromConformingProtocols) {
       for (auto Conf : NTD->getAllConformances()) {
         for (auto Ext : Conf->getProtocol()->getExtensions()) {
           if (Options.printExtensionContentAsMembers(Ext))
-            AddDeclFunc(Ext->getAllMembers());
+            AddMembers(Ext);
         }
       }
     }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -766,6 +766,14 @@ ArrayRef<Decl *> IterableDeclContext::getABIMembers() const {
       ArrayRef<Decl *>());
 }
 
+ArrayRef<Decl *> IterableDeclContext::getAllMembers() const {
+  ASTContext &ctx = getASTContext();
+  return evaluateOrDefault(
+      ctx.evaluator,
+      AllMembersRequest{const_cast<IterableDeclContext *>(this)},
+      ArrayRef<Decl *>());
+}
+
 void IterableDeclContext::addMemberPreservingSourceOrder(Decl *member) {
   auto &SM = getASTContext().SourceMgr;
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -758,11 +758,11 @@ ArrayRef<Decl *> IterableDeclContext::getParsedMembers() const {
     .members;
 }
 
-ArrayRef<Decl *> IterableDeclContext::getSemanticMembers() const {
+ArrayRef<Decl *> IterableDeclContext::getABIMembers() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(
       ctx.evaluator,
-      SemanticMembersRequest{const_cast<IterableDeclContext *>(this)},
+      ABIMembersRequest{const_cast<IterableDeclContext *>(this)},
       ArrayRef<Decl *>());
 }
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1038,7 +1038,7 @@ public:
 
     // Build a vtable if this is a class.
     if (auto theClass = dyn_cast<ClassDecl>(theType)) {
-      for (Decl *member : theClass->getSemanticMembers())
+      for (Decl *member : theClass->getABIMembers())
         visit(member);
 
       SILGenVTable genVTable(SGM, theClass);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -319,6 +319,7 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
 
   // Mark implicit.
   ctor->setImplicit();
+  ctor->setSynthesized();
   ctor->setAccess(accessLevel);
 
   if (ICK == ImplicitConstructorKind::Memberwise) {

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -239,6 +239,7 @@ static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
   auto *enumDecl = new (C) EnumDecl(SourceLoc(), C.Id_CodingKeys, SourceLoc(),
                                     inherited, nullptr, target);
   enumDecl->setImplicit();
+  enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);
 
   // For classes which inherit from something Encodable or Decodable, we
@@ -349,6 +350,7 @@ static VarDecl *createKeyedContainer(ASTContext &C, DeclContext *DC,
   auto *containerDecl = new (C) VarDecl(/*IsStatic=*/false, introducer,
                                         SourceLoc(), C.Id_container, DC);
   containerDecl->setImplicit();
+  containerDecl->setSynthesized();
   containerDecl->setInterfaceType(containerType);
   return containerDecl;
 }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -333,6 +333,7 @@ static ValueDecl *deriveDifferentiable_method(
       /*Async=*/false,
       /*Throws=*/false,
       /*GenericParams=*/nullptr, params, returnType, parentDC);
+  funcDecl->setSynthesized();
   if (!nominal->getSelfClassDecl())
     funcDecl->setSelfAccessKind(SelfAccessKind::Mutating);
   funcDecl->setBodySynthesizer(bodySynthesizer.Fn, bodySynthesizer.Context);
@@ -458,6 +459,7 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
                          /*GenericParams*/ {}, parentDC);
   structDecl->setBraces({synthesizedLoc, synthesizedLoc});
   structDecl->setImplicit();
+  structDecl->setSynthesized();
   structDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/ true);
 
   // Add stored properties to the `TangentVector` struct.
@@ -467,6 +469,7 @@ getOrSynthesizeTangentVectorStruct(DerivedConformance &derived, Identifier id) {
     auto *tangentProperty = new (C) VarDecl(
         member->isStatic(), member->getIntroducer(),
         /*NameLoc*/ SourceLoc(), member->getName(), structDecl);
+    tangentProperty->setSynthesized();
     // Note: `tangentProperty` is not marked as implicit here, because that
     // incorrectly affects memberwise initializer synthesis.
     auto memberContextualType =

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -882,6 +882,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
     new (C) VarDecl(/*IsStatic*/false, VarDecl::Introducer::Var,
                     SourceLoc(), C.Id_hashValue, parentDC);
   hashValueDecl->setInterfaceType(intType);
+  hashValueDecl->setSynthesized();
 
   ParameterList *params = ParameterList::createEmpty(C);
 
@@ -894,6 +895,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
       intType, parentDC);
   getterDecl->setImplicit();
   getterDecl->setBodySynthesizer(&deriveBodyHashable_hashValue);
+  getterDecl->setSynthesized();
   getterDecl->setIsTransparent(false);
 
   getterDecl->copyFormalAccessFrom(derived.Nominal,

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -464,6 +464,7 @@ DerivedConformance::declareDerivedProperty(Identifier name,
       VarDecl(/*IsStatic*/ isStatic, VarDecl::Introducer::Var,
               SourceLoc(), name, parentDC);
   propDecl->setImplicit();
+  propDecl->setSynthesized();
   propDecl->copyFormalAccessFrom(Nominal, /*sourceIsParentContext*/ true);
   propDecl->setInterfaceType(propertyInterfaceType);
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2551,8 +2551,8 @@ struct SortedDeclList {
 } // end namespace
 
 ArrayRef<Decl *>
-SemanticMembersRequest::evaluate(Evaluator &evaluator,
-                                IterableDeclContext *idc) const {
+ABIMembersRequest::evaluate(
+    Evaluator &evaluator, IterableDeclContext *idc) const {
   auto dc = cast<DeclContext>(idc->getDecl());
   auto &Context = dc->getASTContext();
   SmallVector<Decl *, 8> result;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2129,7 +2129,7 @@ public:
 
     TypeChecker::checkDeclAttributes(CD);
 
-    for (Decl *Member : CD->getSemanticMembers())
+    for (Decl *Member : CD->getABIMembers())
       visit(Member);
 
     TypeChecker::checkPatternBindingCaptures(CD);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2129,7 +2129,7 @@ public:
 
     TypeChecker::checkDeclAttributes(CD);
 
-    for (Decl *Member : CD->getABIMembers())
+    for (Decl *Member : CD->getAllMembers())
       visit(Member);
 
     TypeChecker::checkPatternBindingCaptures(CD);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2129,7 +2129,7 @@ public:
 
     TypeChecker::checkDeclAttributes(CD);
 
-    for (Decl *Member : CD->getAllMembers())
+    for (Decl *Member : CD->getABIMembers())
       visit(Member);
 
     TypeChecker::checkPatternBindingCaptures(CD);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4650,7 +4650,7 @@ ConformanceChecker::getObjCRequirements(ObjCMethodKey key) {
 
   // Fill in the data structure if we haven't done so yet.
   if (!computedObjCMethodRequirements) {
-    for (auto requirement : proto->getSemanticMembers()) {
+    for (auto requirement : proto->getABIMembers()) {
       auto funcRequirement = dyn_cast<AbstractFunctionDecl>(requirement);
       if (!funcRequirement)
         continue;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2934,6 +2934,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     aliasDecl->setUnderlyingType(type);
     
     aliasDecl->setImplicit();
+    aliasDecl->setSynthesized();
     if (type->hasError())
       aliasDecl->setInvalid();
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1901,6 +1901,7 @@ static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
       getterParams,
       Type(),
       storage->getDeclContext());
+  getter->setSynthesized();
 
   // If we're stealing the 'self' from a lazy initializer, set it now.
   // Note that we don't re-parent the 'self' declaration to be part of
@@ -1950,6 +1951,7 @@ static AccessorDecl *createSetterPrototype(AbstractStorageDecl *storage,
       genericParams, params,
       Type(),
       storage->getDeclContext());
+  setter->setSynthesized();
 
   if (isMutating)
     setter->setSelfAccessKind(SelfAccessKind::Mutating);
@@ -2060,7 +2062,8 @@ createCoroutineAccessorPrototype(AbstractStorageDecl *storage,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
       genericParams, params, retTy, dc);
-  
+  accessor->setSynthesized();
+
   if (isMutating)
     accessor->setSelfAccessKind(SelfAccessKind::Mutating);
   else

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2712,7 +2712,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
   /// \param members The decls within the context.
   /// \param isClass True if the context could be a class context (class,
   ///        class extension, or protocol).
-  void writeMembers(DeclID parentID, DeclRange members, bool isClass) {
+  void writeMembers(DeclID parentID, ArrayRef<Decl *> members, bool isClass) {
     using namespace decls_block;
 
     SmallVector<DeclID, 16> memberIDs;
@@ -2853,7 +2853,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
     SmallVector<DeclID, 16> witnessIDs;
 
-    for (auto member : proto->getMembers()) {
+    for (auto member : proto->getAllMembers()) {
       if (auto *value = dyn_cast<ValueDecl>(member)) {
         auto witness = proto->getDefaultWitness(value);
         if (!witness)
@@ -3032,7 +3032,7 @@ public:
     for (auto *genericParams : llvm::reverse(allGenericParams))
       writeGenericParams(genericParams);
 
-    writeMembers(id, extension->getMembers(), isClassExtension);
+    writeMembers(id, extension->getAllMembers(), isClassExtension);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3248,7 +3248,7 @@ public:
 
 
     writeGenericParams(theStruct->getGenericParams());
-    writeMembers(id, theStruct->getMembers(), false);
+    writeMembers(id, theStruct->getAllMembers(), false);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3305,7 +3305,7 @@ public:
                             inheritedAndDependencyTypes);
 
     writeGenericParams(theEnum->getGenericParams());
-    writeMembers(id, theEnum->getMembers(), false);
+    writeMembers(id, theEnum->getAllMembers(), false);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3364,7 +3364,7 @@ public:
                             inheritedAndDependencyTypes);
 
     writeGenericParams(theClass->getGenericParams());
-    writeMembers(id, theClass->getMembers(), true);
+    writeMembers(id, theClass->getAllMembers(), true);
     S.writeConformances(conformances, S.DeclTypeAbbrCodes);
   }
 
@@ -3413,7 +3413,7 @@ public:
     writeGenericParams(proto->getGenericParams());
     S.writeGenericRequirements(
       proto->getRequirementSignature(), S.DeclTypeAbbrCodes);
-    writeMembers(id, proto->getMembers(), true);
+    writeMembers(id, proto->getAllMembers(), true);
     writeDefaultWitnessTable(proto);
   }
 
@@ -5149,7 +5149,7 @@ static void collectInterestingNestedDeclarations(
 
     // Recurse into nested declarations.
     if (auto iterable = dyn_cast<IterableDeclContext>(member)) {
-      collectInterestingNestedDeclarations(S, iterable->getMembers(),
+      collectInterestingNestedDeclarations(S, iterable->getAllMembers(),
                                            operatorMethodDecls,
                                            objcMethods, nestedTypeDecls,
                                            derivativeConfigs,
@@ -5231,7 +5231,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
         if (auto bodyFP = IDC->getBodyFingerprint()) {
           declFingerprints.insert({addDeclRef(D), *bodyFP});
         }
-        collectInterestingNestedDeclarations(*this, IDC->getMembers(),
+        collectInterestingNestedDeclarations(*this, IDC->getAllMembers(),
                                              operatorMethodDecls, objcMethods,
                                              nestedTypeDecls,
                                              uniquedDerivativeConfigs);
@@ -5264,7 +5264,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
         if (auto bodyFP = IDC->getBodyFingerprint()) {
           declFingerprints.insert({addDeclRef(TD), *bodyFP});
         }
-        collectInterestingNestedDeclarations(*this, IDC->getMembers(),
+        collectInterestingNestedDeclarations(*this, IDC->getAllMembers(),
                                              operatorMethodDecls, objcMethods,
                                              nestedTypeDecls,
                                              uniquedDerivativeConfigs,

--- a/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
@@ -10,12 +10,12 @@ struct GenericTangentVectorMember<T: Differentiable>: Differentiable,
 
 // CHECK-AST-LABEL: internal struct GenericTangentVectorMember<T> : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} where T : Differentiable
 // CHECK-AST:   internal var x: T.TangentVector
-// CHECK-AST:   internal init(x: T.TangentVector)
-// CHECK-AST:   internal typealias TangentVector = GenericTangentVectorMember<T>
-// CHECK-AST:   internal static var zero: GenericTangentVectorMember<T> { get }
 // CHECK-AST:   internal static func + (lhs: GenericTangentVectorMember<T>, rhs: GenericTangentVectorMember<T>) -> GenericTangentVectorMember<T>
 // CHECK-AST:   internal static func - (lhs: GenericTangentVectorMember<T>, rhs: GenericTangentVectorMember<T>) -> GenericTangentVectorMember<T>
 // CHECK-AST:   @_implements(Equatable, ==(_:_:)) internal static func __derived_struct_equals(_ a: GenericTangentVectorMember<T>, _ b: GenericTangentVectorMember<T>) -> Bool
+// CHECK-AST:   internal typealias TangentVector = GenericTangentVectorMember<T>
+// CHECK-AST:   internal init(x: T.TangentVector)
+// CHECK-AST:   internal static var zero: GenericTangentVectorMember<T> { get }
 
 public struct ConditionallyDifferentiable<T> {
   public var x: T
@@ -69,17 +69,17 @@ final class AdditiveArithmeticClass<T: AdditiveArithmetic & Differentiable>: Add
 public struct FrozenStruct: Differentiable {}
 
 // CHECK-AST-LABEL: @frozen public struct FrozenStruct : Differentiable {
-// CHECK-AST:   internal init()
 // CHECK-AST:   @frozen public struct TangentVector : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
+// CHECK-AST:   internal init()
 
 @usableFromInline
 struct UsableFromInlineStruct: Differentiable {}
 
 // CHECK-AST-LABEL: @usableFromInline
 // CHECK-AST: struct UsableFromInlineStruct : Differentiable {
-// CHECK-AST:   internal init()
 // CHECK-AST:   @usableFromInline
 // CHECK-AST:   struct TangentVector : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
+// CHECK-AST:   internal init()
 
 // Test property wrappers.
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -241,8 +241,8 @@ struct d0100_FooStruct {
   static func overloadedStaticFunc2(x: Double) -> Int { return 0 }
 // PASS_COMMON-NEXT: {{^}}  static func overloadedStaticFunc2(x: Double) -> Int{{$}}
 }
-// PASS_COMMON-NEXT: {{^}}  init(instanceVar1: Int = 0){{$}}
 // PASS_COMMON-NEXT: {{^}}  init(){{$}}
+// PASS_COMMON-NEXT: {{^}}  init(instanceVar1: Int = 0){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
 extension d0100_FooStruct {
@@ -596,8 +596,8 @@ struct d0200_EscapedIdentifiers {
 // PASS_COMMON-NEXT: {{^}}  enum `enum` {{{$}}
 // PASS_COMMON-NEXT: {{^}}    case `case`{{$}}
 // PASS_COMMON-NEXT: {{^}}    {{.*}}static func __derived_enum_equals(_ a: d0200_EscapedIdentifiers.`enum`, _ b: d0200_EscapedIdentifiers.`enum`) -> Bool
-// PASS_COMMON-NEXT: {{^}}    var hashValue: Int { get }{{$}}
 // PASS_COMMON-NEXT: {{^}}    func hash(into hasher: inout Hasher)
+// PASS_COMMON-NEXT: {{^}}    var hashValue: Int { get }{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   class `class` {}
@@ -613,8 +613,8 @@ struct d0200_EscapedIdentifiers {
   class `extension` : `class` {}
 // PASS_ONE_LINE_TYPE-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : d0200_EscapedIdentifiers.`class` {{{$}}
 // PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : `class` {{{$}}
-// PASS_COMMON:      {{^}}    @objc deinit{{$}}
-// PASS_COMMON-NEXT: {{^}}    {{(override )?}}init(){{$}}
+// PASS_COMMON:      {{^}}    {{(override )?}}init(){{$}}
+// PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   func `func`<`let`: `protocol`, `where`>(
@@ -1025,8 +1025,8 @@ enum d2000_EnumDecl1 {
 // PASS_COMMON-NEXT: {{^}}  case ED1_First{{$}}
 // PASS_COMMON-NEXT: {{^}}  case ED1_Second{{$}}
 // PASS_COMMON-NEXT: {{^}}  {{.*}}static func __derived_enum_equals(_ a: d2000_EnumDecl1, _ b: d2000_EnumDecl1) -> Bool
-// PASS_COMMON-NEXT: {{^}}  var hashValue: Int { get }{{$}}
 // PASS_COMMON-NEXT: {{^}}  func hash(into hasher: inout Hasher)
+// PASS_COMMON-NEXT: {{^}}  var hashValue: Int { get }{{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
 enum d2100_EnumDecl2 {
@@ -1179,8 +1179,8 @@ struct d2800_ProtocolWithAssociatedType1Impl : d2700_ProtocolWithAssociatedType1
 
 // PASS_COMMON: {{^}}struct d2800_ProtocolWithAssociatedType1Impl : d2700_ProtocolWithAssociatedType1 {{{$}}
 // PASS_COMMON-NEXT: {{^}}  func returnsTA1() -> Int{{$}}
-// PASS_COMMON-NEXT: {{^}}  init(){{$}}
 // PASS_COMMON-NEXT: {{^}}  typealias TA1 = Int
+// PASS_COMMON-NEXT: {{^}}  init(){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
 
 //===---

--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -26,10 +26,10 @@ public class Base<In, Out> {
 
 // CHECK: public class Derived<T> : {{(main.)?}}Base<T, T> {
 public class Derived<T> : Base<T, T> {
-// CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
 // CHECK-NEXT: override public init<A>(_ argument: A, _ argument: A)
 // CHECK-NEXT: override public init<C>(_ argument: C) where C : main.Base<T, T>
+// CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: }
 }
 

--- a/test/ModuleInterface/modifiers.swift
+++ b/test/ModuleInterface/modifiers.swift
@@ -68,9 +68,9 @@ public class Base {
 
 // CHECK-LABEL: public class SubImplicit : {{(Test[.])?Base}} {
 public class SubImplicit: Base {
-  // CHECK-NEXT: @objc deinit{{$}}
   // CHECK-NEXT: @objc override public init(){{$}}
   // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
+  // CHECK-NEXT: @objc deinit{{$}}
 } // CHECK-NEXT: {{^}$}}
 
 

--- a/test/SILGen/deterministic-dtor-ordering.swift
+++ b/test/SILGen/deterministic-dtor-ordering.swift
@@ -3,8 +3,8 @@
 
 public class Horse {}
 
-// CHECK-LABEL: sil hidden [exact_self_class] [ossa] @$s5horse5HorseCACycfC : $@convention(method) (@thick Horse.Type) -> @owned Horse {
-// CHECK-LABEL: sil hidden [ossa] @$s5horse5HorseCACycfc : $@convention(method) (@owned Horse) -> @owned Horse {
 // CHECK-LABEL: sil [ossa] @$s5horse5HorseCfd : $@convention(method) (@guaranteed Horse) -> @owned Builtin.NativeObject {
 // CHECK-LABEL: sil [ossa] @$s5horse5HorseCfD : $@convention(method) (@owned Horse) -> () {
+// CHECK-LABEL: sil hidden [exact_self_class] [ossa] @$s5horse5HorseCACycfC : $@convention(method) (@thick Horse.Type) -> @owned Horse {
+// CHECK-LABEL: sil hidden [ossa] @$s5horse5HorseCACycfc : $@convention(method) (@owned Horse) -> @owned Horse {
 

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -8,17 +8,17 @@ final class Final<T> {
 // CHECK-LABEL: final class Final<T> {
 // CHECK:   @_hasStorage final var x: T { get set }
 // CHECK:   init(x: T)
-// CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
 // CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Final<T>.CodingKeys, _ b: Final<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
 // CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var stringValue: String { get }
 // CHECK:     init?(stringValue: String)
-// CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
+// CHECK:     var hashValue: Int { get }
+// CHECK:     var intValue: Int? { get }
+// CHECK:     var stringValue: String { get }
 // CHECK:   }
+// CHECK:   deinit
 // CHECK: }
 
 class Nonfinal<T> {
@@ -28,17 +28,17 @@ class Nonfinal<T> {
 // CHECK-LABEL: class Nonfinal<T> {
 // CHECK:   @_hasStorage var x: T { get set }
 // CHECK:   init(x: T)
-// CHECK:   deinit
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
 // CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Nonfinal<T>.CodingKeys, _ b: Nonfinal<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
 // CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var stringValue: String { get }
 // CHECK:     init?(stringValue: String)
-// CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
+// CHECK:     var hashValue: Int { get }
+// CHECK:     var intValue: Int? { get }
+// CHECK:     var stringValue: String { get }
 // CHECK:   }
+// CHECK:   deinit
 // CHECK: }
 
 // CHECK-LABEL: extension Final : Encodable where T : Encodable {

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -15,8 +15,8 @@ enum NoValues {
 // CHECK:   case a, b
 // CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: NoValues, _ b: NoValues) -> Bool
 // CHECK-RESILIENT: static func == (a: NoValues, b: NoValues) -> Bool
-// CHECK:   var hashValue: Int { get }
 // CHECK:   func hash(into hasher: inout Hasher)
+// CHECK:   var hashValue: Int { get }
 // CHECK: }
 
 // CHECK-LABEL: extension Enum : Equatable where T : Equatable {
@@ -24,8 +24,8 @@ enum NoValues {
 // CHECK-RESILIENT: static func == (a: Enum<T>, b: Enum<T>) -> Bool
 // CHECK: }
 // CHECK-LABEL: extension Enum : Hashable where T : Hashable {
-// CHECK:   var hashValue: Int { get }
 // CHECK:   func hash(into hasher: inout Hasher)
+// CHECK:   var hashValue: Int { get }
 // CHECK: }
 
 // CHECK-LABEL: extension NoValues : CaseIterable {

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -7,30 +7,30 @@ struct Struct<T> {
 
 // CHECK-LABEL: struct Struct<T> {
 // CHECK:   @_hasStorage var x: T { get set }
-// CHECK:   init(x: T)
 // CHECK:   enum CodingKeys : CodingKey {
 // CHECK:     case x
 // CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Struct<T>.CodingKeys, _ b: Struct<T>.CodingKeys) -> Bool
 // CHECK-RESILIENT: static func == (a: Struct<T>.CodingKeys, b: Struct<T>.CodingKeys) -> Bool
-// CHECK:     var hashValue: Int { get }
 // CHECK:     func hash(into hasher: inout Hasher)
-// CHECK:     var stringValue: String { get }
 // CHECK:     init?(stringValue: String)
-// CHECK:     var intValue: Int? { get }
 // CHECK:     init?(intValue: Int)
+// CHECK:     var hashValue: Int { get }
+// CHECK:     var intValue: Int? { get }
+// CHECK:     var stringValue: String { get }
 // CHECK:   }
+// CHECK:   init(x: T)
 // CHECK: }
 // CHECK-LABEL: extension Struct : Equatable where T : Equatable {
 // CHECK-FRAGILE:   @_implements(Equatable, ==(_:_:)) static func __derived_struct_equals(_ a: Struct<T>, _ b: Struct<T>) -> Bool
 // CHECK-RESILIENT: static func == (a: Struct<T>, b: Struct<T>) -> Bool
 // CHECK: }
 // CHECK-LABEL: extension Struct : Hashable where T : Hashable {
-// CHECK:   var hashValue: Int { get }
 // CHECK:   func hash(into hasher: inout Hasher)
+// CHECK:   var hashValue: Int { get }
 // CHECK: }
 // CHECK-LABEL: extension Struct : Decodable & Encodable where T : Decodable, T : Encodable {
-// CHECK:   init(from decoder: Decoder) throws
 // CHECK:   func encode(to encoder: Encoder) throws
+// CHECK:   init(from decoder: Decoder) throws
 // CHECK: }
 
 extension Struct: Equatable where T: Equatable {}

--- a/test/Serialization/attr-actorindependent.swift
+++ b/test/Serialization/attr-actorindependent.swift
@@ -14,10 +14,10 @@
 // look for correct annotation after first deserialization's module print:
 
 // MODULE-CHECK:      actor class UnsafeCounter {
+// MODULE-CHECK-NEXT:   @actorIndependent(unsafe) func enqueue(partialTask: PartialAsyncTask)
 // MODULE-CHECK-NEXT:   @actorIndependent(unsafe) var storage: Int
 // MODULE-CHECK-NEXT:   @actorIndependent var count: Int
 // MODULE-CHECK-NEXT:   var actorCount: Int
-// MODULE-CHECK-NEXT:   @actorIndependent(unsafe) func enqueue(partialTask: PartialAsyncTask)
 // MODULE-CHECK-NEXT:   init()
 // MODULE-CHECK-NEXT: }
 

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -539,23 +539,6 @@
           "moduleName": "cake"
         },
         {
-          "kind": "TypeAlias",
-          "name": "RawValue",
-          "printedName": "RawValue",
-          "children": [
-            {
-              "kind": "TypeNominal",
-              "name": "Int",
-              "printedName": "Swift.Int",
-              "usr": "s:Si"
-            }
-          ],
-          "declKind": "TypeAlias",
-          "usr": "s:4cake6NumberO8RawValuea",
-          "moduleName": "cake",
-          "implicit": true
-        },
-        {
           "kind": "Constructor",
           "name": "init",
           "printedName": "init(rawValue:)",
@@ -589,6 +572,23 @@
             "Inlinable"
           ],
           "init_kind": "Designated"
+        },
+        {
+          "kind": "TypeAlias",
+          "name": "RawValue",
+          "printedName": "RawValue",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Int",
+              "printedName": "Swift.Int",
+              "usr": "s:Si"
+            }
+          ],
+          "declKind": "TypeAlias",
+          "usr": "s:4cake6NumberO8RawValuea",
+          "moduleName": "cake",
+          "implicit": true
         },
         {
           "kind": "Var",

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -29,8 +29,8 @@ struct BA_DefaultStruct {
 private struct BB_PrivateStruct {
   // CHECK: internal var x
   var x = 0
-  // CHECK: internal init(x: Int = 0)
   // CHECK: internal init()
+  // CHECK: internal init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: internal{{(\*/)?}} struct BC_InternalStruct {
@@ -44,24 +44,24 @@ internal struct BC_InternalStruct {
 public struct BD_PublicStruct {
   // CHECK: internal var x
   var x = 0
-  // CHECK: internal init(x: Int = 0)
   // CHECK: internal init()
+  // CHECK: internal init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: public{{(\*/)?}} struct BE_PublicStructPrivateMembers {
 public struct BE_PublicStructPrivateMembers {
   // CHECK: private{{(\*/)?}} var x
   private var x = 0
-  // CHECK: private init(x: Int = 0)
   // CHECK: internal init()
+  // CHECK: private init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: {{^}}fileprivate{{(\*/)?}} struct BF_FilePrivateStruct {
 fileprivate struct BF_FilePrivateStruct {
   // CHECK: {{^}} internal var x
   var x = 0
-  // CHECK: {{^}} internal init(x: Int = 0)
   // CHECK: {{^}} internal init()
+  // CHECK: {{^}} internal init(x: Int = 0)
 } // CHECK: {{^[}]}}
 
 
@@ -337,16 +337,16 @@ fileprivate protocol IB_FilePrivateAssocTypeProto {
 public class IC_PublicAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
   public var publicValue: Int = 0
   public var filePrivateValue: Int = 0
-  // CHECK-DAG: {{^}} public typealias PublicValue
   // CHECK-DAG: {{^}} public typealias FilePrivateValue
+  // CHECK-DAG: {{^}} public typealias PublicValue
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: private{{(\*/)?}} class ID_PrivateAssocTypeImpl : IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
 private class ID_PrivateAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
   public var publicValue: Int = 0
   public var filePrivateValue: Int = 0
-  // CHECK-DAG: {{^}} fileprivate typealias PublicValue
   // CHECK-DAG: {{^}} fileprivate typealias FilePrivateValue
+  // CHECK-DAG: {{^}} fileprivate typealias PublicValue
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: class MultipleAttributes {

--- a/test/attr/accessibility_print_inferred_type_witnesses.swift
+++ b/test/attr/accessibility_print_inferred_type_witnesses.swift
@@ -27,8 +27,8 @@ fileprivate protocol FilePrivateAssocTypeProto {
 private class PrivateImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
   fileprivate var publicValue: InternalStruct?
   fileprivate var filePrivateValue: Int?
-  // CHECK-DAG: {{^}} fileprivate typealias PublicValue
   // CHECK-DAG: {{^}} fileprivate typealias FilePrivateValue
+  // CHECK-DAG: {{^}} fileprivate typealias PublicValue
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: public{{(\*/)?}} class PublicImpl : PublicAssocTypeProto, FilePrivateAssocTypeProto {
@@ -36,6 +36,6 @@ public class PublicImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
   public var publicValue: Int?
   fileprivate var filePrivateValue: InternalStruct?
   // CHECK-DAG: {{^}} public typealias PublicValue
-  // CHECK-4-DAG: {{^}} internal typealias FilePrivateValue
   // CHECK-5-DAG: {{^}} fileprivate typealias FilePrivateValue
+  // CHECK-4-DAG: {{^}} internal typealias FilePrivateValue
 } // CHECK: {{^[}]}}


### PR DESCRIPTION
Eliminate some problematic sources of non-determinism involving the ordering of the members within an iterable declaration context. This pull request does a few things in that direction:

* Mark more declarations (and more kinds of declarations) as "synthesized" when the compiler creates them, including (e.g.) properties (like `hashValue`), enums (like `CodingKeys`), and type aliases (inferred from associated types).
* Rename "semantic members" query to "ABI members", because it is the set that is needed to make the ABI of a type (particularly classes) deterministic. This includes synthesized properties like `hashValue`.
* Introduce an "all members" query based on the same infrastructure, which also includes synthesized types like enums and type aliases, as mentioned above. Use this for serialization and interface printing, to make those operations more deterministic.

The combination of the second and third bullets fixes rdar://63294687, a crash that occurs due to the synthesized `hashValue` property getting a different vtable slot in the defining module vs. a client module.