### PR TITLE
[5.4] [IRGen] Fix crash when trying to compile `_Atomic(_Bool)`

### DIFF
--- a/test/IRGen/Inputs/atomic_bool.h
+++ b/test/IRGen/Inputs/atomic_bool.h
@@ -1,0 +1,1 @@
+typedef struct { _Atomic(_Bool) value; } MyAtomicBool;

--- a/test/IRGen/Inputs/module.modulemap
+++ b/test/IRGen/Inputs/module.modulemap
@@ -21,3 +21,8 @@ module AutolinkElfCPragmaTransitive {
 module AutolinkModuleMapLink {
   link "autolink-module-map-link"
 }
+
+module AtomicBoolModule {
+  header "atomic_bool.h"
+  export *
+}

--- a/test/IRGen/atomic_bool.swift
+++ b/test/IRGen/atomic_bool.swift
@@ -1,4 +1,5 @@
-// RUN: not --crash %target-swift-emit-ir %s -I %S/Inputs
+// Check that IRGen doesn't crash. rdar://72999296
+// RUN: %target-swift-emit-ir %s -I %S/Inputs
 
 import AtomicBoolModule
 

--- a/test/IRGen/atomic_bool.swift
+++ b/test/IRGen/atomic_bool.swift
@@ -1,0 +1,11 @@
+// RUN: not --crash %target-swift-emit-ir %s -I %S/Inputs
+
+import AtomicBoolModule
+
+public func f() -> MyAtomicBool {
+  return MyAtomicBool()
+}
+
+public func g(_ b: MyAtomicBool) {
+  let _ = b
+}


### PR DESCRIPTION
Fixes rdar://72999296.

Cherry-picked from https://github.com/apple/swift/pull/35488.