### PR TITLE
Platform: add Direct3D11 module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -159,6 +159,14 @@ module WinSDK [system] {
   }
 
   explicit module DirectX {
+    module Direct3D11 {
+      header "d3d11.h"
+      export *
+
+      link "d3d12.lib"
+      link "dxgi.lib"
+    }
+
     module Direct3D12 {
       header "d3d12.h"
       export *


### PR DESCRIPTION
This adds the Direct3D v11 module for Windows.  This is required to gain
access to the DXGI interfaces, which homes the DXGISwapChain interface.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
