### PR TITLE
Use the Correct DeclContext When Simplifying Member Constraints

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7478,11 +7478,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
           if (!paramDecl)
             continue;
 
-          auto descriptor = UnqualifiedLookupDescriptor(
+          auto descriptor = UnqualifiedLookupDescriptor{
               DeclNameRef(param->getName()),
-              paramDecl->getDeclContext()->getParentSourceFile(),
+              paramDecl->getDeclContext()->getModuleScopeContext(),
               SourceLoc(),
-              UnqualifiedLookupFlags::TypeLookup);
+              UnqualifiedLookupFlags::TypeLookup};
           auto lookup = evaluateOrDefault(
               Context.evaluator, UnqualifiedLookupRequest{descriptor}, {});
           for (auto &result : lookup) {

--- a/validation-test/compiler_crashers_2_fixed/rdar73379770.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar73379770.swift
@@ -1,0 +1,8 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+typealias IndexResult = Result<Bol, Error>
+extension IndexResult {
+  func perfect() -> Self {
+    Success(true)
+  }
+}


### PR DESCRIPTION
Looking for the parent source file is going to fail when the paramter
we're interested in comes from a module context. Request the correct
top-level context in those situations.

rdar://73379770