### PR TITLE
[CSBindings] Inference cannot fail

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -464,7 +464,7 @@ private:
   Optional<PotentialBinding> inferFromRelational(Constraint *constraint);
 
 public:
-  bool infer(Constraint *constraint);
+  void infer(Constraint *constraint);
 
   /// Finalize binding computation for this type variable by
   /// inferring bindings from context e.g. transitive bindings.


### PR DESCRIPTION
Any constraints which would previously cause binding inference to
fail should instead delay associated type variable and preserve
all of the collected information.

This is vital for incremental binding computation that cannot
re-introduce constraints after "failure" because it's too expensive.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
