### PR TITLE
Enable DCE on OSSA

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -20,6 +20,8 @@
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -43,6 +45,17 @@ static bool seemsUseful(SILInstruction *I) {
   // begin_access is defined to have side effects, but this is not relevant for
   // DCE.
   if (isa<BeginAccessInst>(I))
+    return false;
+
+  // Even though begin_borrow/destroy_value/copy_value have side-effects, they
+  // can be DCE'ed if they do not have useful dependencies/reverse dependencies
+  if (isa<BeginBorrowInst>(I))
+    return false;
+
+  if (isa<DestroyValueInst>(I))
+    return false;
+
+  if (isa<CopyValueInst>(I))
     return false;
 
   if (I->mayHaveSideEffects())
@@ -94,15 +107,16 @@ class DCE : public SILFunctionTransform {
   // Dependencies which go in the reverse direction. Usually for a pair
   //   %1 = inst_a
   //   inst_b(%1)
-  // the dependency goes from inst_b to inst_a: if inst_b is alive then also
-  // inst_a is alive.
+  // the dependency goes from inst_b to inst_a: if inst_b is alive then
+  // inst_a is also alive.
   // For some instructions the dependency is exactly the other way round, e.g.
   //   %1 = inst_which_can_fail
   //   cond_fail(%1)
   // In this case cond_fail is alive only if inst_which_can_fail is alive.
   // The key of this map is the source of the dependency (inst_a), the
-  // value is the destination (inst_b).
-  llvm::DenseMap<SILInstruction *, SILInstruction *> ReverseDependencies;
+  // value is the set of instructions dependent on it (inst_b).
+  llvm::DenseMap<SILValue, SmallPtrSet<SILInstruction *, 4>>
+      ReverseDependencies;
 
   /// Tracks if the pass changed branches.
   bool BranchesChanged;
@@ -115,11 +129,6 @@ class DCE : public SILFunctionTransform {
     CallsChanged = false;
 
     SILFunction *F = getFunction();
-
-    // FIXME: Support ownership.
-    if (F->hasOwnership())
-      return;
-
     auto *DA = PM->getAnalysis<PostDominanceAnalysis>();
     PDT = DA->get(F);
 
@@ -150,8 +159,12 @@ class DCE : public SILFunctionTransform {
       using InvalidationKind = SILAnalysis::InvalidationKind;
 
       unsigned Inv = InvalidationKind::Instructions;
-      if (CallsChanged)        Inv |= (unsigned) InvalidationKind::Calls;
-      if (BranchesChanged)     Inv |= (unsigned) InvalidationKind::Branches;
+      if (CallsChanged)
+        Inv |= (unsigned)InvalidationKind::Calls;
+      if (BranchesChanged) {
+        removeUnreachableBlocks(*F);
+        Inv |= (unsigned)InvalidationKind::Branches;
+      }
 
       invalidateAnalysis(SILAnalysis::InvalidationKind(Inv));
     }
@@ -164,7 +177,9 @@ class DCE : public SILFunctionTransform {
 
   bool precomputeControlInfo(SILFunction &F);
   void markLive(SILFunction &F);
-  void addReverseDependency(SILInstruction *From, SILInstruction *To);
+  /// Record a reverse dependency from \p from to \p to meaning \p to is live
+  /// if \p from is also live.
+  void addReverseDependency(SILValue from, SILInstruction *to);
   bool removeDead(SILFunction &F);
 
   void computeLevelNumbers(PostDomTreeNode *root);
@@ -186,7 +201,9 @@ class DCE : public SILFunctionTransform {
                                 llvm::SmallPtrSetImpl<SILBasicBlock *> &);
   SILBasicBlock *nearestUsefulPostDominator(SILBasicBlock *Block);
   void replaceBranchWithJump(SILInstruction *Inst, SILBasicBlock *Block);
-
+  /// If \p value is live, insert a lifetime ending operation in ossa.
+  /// destroy_value for @owned value and end_borrow for a @guaranteed value.
+  void endLifetimeOfLiveValue(SILValue value, SILInstruction *insertPt);
 };
 
 // Keep track of the fact that V is live and add it to our worklist
@@ -220,7 +237,7 @@ void DCE::markValueLive(SILNode *V) {
 /// Gets the producing instruction of a cond_fail condition. Currently these
 /// are overflow builtins but may be extended to other instructions in the
 /// future.
-static SILInstruction *getProducer(CondFailInst *CFI) {
+static BuiltinInst *getProducer(CondFailInst *CFI) {
   // Check for the pattern:
   //   %1 = builtin "some_operation_with_overflow"
   //   %2 = tuple_extract %1
@@ -236,42 +253,47 @@ static SILInstruction *getProducer(CondFailInst *CFI) {
 
 // Determine which instructions from this function we need to keep.
 void DCE::markLive(SILFunction &F) {
-
   // Find the initial set of instructions in this function that appear
   // to be live in the sense that they are not trivially something we
   // can delete by examining only that instruction.
   for (auto &BB : F) {
     for (auto &I : BB) {
-      if (auto *CFI = dyn_cast<CondFailInst>(&I)) {
-        // A cond_fail is only alive if its (identifiable) producer is alive.
-        if (SILInstruction *Prod = getProducer(CFI)) {
-          addReverseDependency(Prod, CFI);
+      switch (I.getKind()) {
+      case SILInstructionKind::CondFailInst: {
+        if (auto *Prod = getProducer(cast<CondFailInst>(&I))) {
+          addReverseDependency(Prod, &I);
         } else {
-          markValueLive(CFI);
+          markValueLive(&I);
         }
-        continue;
+        break;
       }
-      if (auto *FLI = dyn_cast<FixLifetimeInst>(&I)) {
-        // A fix_lifetime (with a non-address type) is only alive if it's
-        // definition is alive.
-        SILValue Op = FLI->getOperand();
-        auto *OpInst = Op->getDefiningInstruction();
-        if (OpInst && !Op->getType().isAddress()) {
-          addReverseDependency(OpInst, FLI);
+      case SILInstructionKind::FixLifetimeInst: {
+        SILValue Op = I.getOperand(0);
+        if (!Op->getType().isAddress()) {
+          addReverseDependency(Op, &I);
         } else {
-          markValueLive(FLI);
+          markValueLive(&I);
         }
-        continue;
+        break;
       }
-      if (auto *endAccess = dyn_cast<EndAccessInst>(&I)) {
-        addReverseDependency(endAccess->getBeginAccess(), &I);
-        continue;
+      case SILInstructionKind::EndAccessInst: {
+        // An end_access is live only if it's begin_access is also live.
+        auto *beginAccess = cast<EndAccessInst>(&I)->getBeginAccess();
+        addReverseDependency(beginAccess, &I);
+        break;
       }
-      if (seemsUseful(&I))
-        markValueLive(&I);
+      case SILInstructionKind::DestroyValueInst:
+      case SILInstructionKind::EndBorrowInst: {
+        // The instruction is live only if it's operand value is also live
+        addReverseDependency(I.getOperand(0), &I);
+        break;
+      }
+      default:
+        if (seemsUseful(&I))
+          markValueLive(&I);
+      }
     }
   }
-
   // Now propagate liveness backwards from each instruction in our
   // worklist, adding new instructions to the worklist as we discover
   // more that we need to keep.
@@ -281,17 +303,11 @@ void DCE::markLive(SILFunction &F) {
   }
 }
 
-// Records a reverse dependency. See DCE::ReverseDependencies.
-void DCE::addReverseDependency(SILInstruction *From, SILInstruction *To) {
-  assert(!ReverseDependencies.lookup(To) &&
-         "Target of reverse dependency already in map");
-  SILInstruction *&Target = ReverseDependencies[From];
-  SILInstruction *ExistingTarget = Target;
-  Target = To;
-  if (ExistingTarget) {
-    // Create a single linked chain if From has multiple targets.
-    ReverseDependencies[To] = ExistingTarget;
-  }
+// Records a reverse dependency if needed. See DCE::ReverseDependencies.
+void DCE::addReverseDependency(SILValue from, SILInstruction *to) {
+  LLVM_DEBUG(llvm::dbgs() << "Adding reverse dependency from " << from << " to "
+                          << to);
+  ReverseDependencies[from].insert(to);
 }
 
 // Mark as live the terminator argument at index ArgIndex in Pred that
@@ -366,8 +382,10 @@ void DCE::propagateLiveBlockArgument(SILArgument *Arg) {
   for (Operand *DU : getDebugUses(Arg))
     markValueLive(DU->getUser());
 
-  if (isa<SILFunctionArgument>(Arg))
-    return;
+  // Mark all reverse dependencies on the Arg live
+  for (auto *depInst : ReverseDependencies.lookup(Arg)) {
+    markValueLive(depInst);
+  }
 
   auto *Block = Arg->getParent();
   auto ArgIndex = Arg->getIndex();
@@ -390,10 +408,13 @@ void DCE::propagateLiveness(SILInstruction *I) {
       for (Operand *DU : getDebugUses(result))
         markValueLive(DU->getUser());
 
-    // Handle all other reverse-dependency instructions, like cond_fail and
-    // fix_lifetime. Only if the definition is alive, the user itself is alive.
-    if (SILInstruction *DepInst = ReverseDependencies.lookup(I)) {
-      markValueLive(DepInst);
+    // Handle all other reverse-dependency instructions, like cond_fail,
+    // fix_lifetime, destroy_value, etc. Only if the definition is alive, the
+    // user itself is alive.
+    for (auto res : I->getResults()) {
+      for (auto *depInst : ReverseDependencies.lookup(res)) {
+        markValueLive(depInst);
+      }
     }
     return;
   }
@@ -471,22 +492,75 @@ void DCE::replaceBranchWithJump(SILInstruction *Inst, SILBasicBlock *Block) {
   (void)Branch;
 }
 
+void DCE::endLifetimeOfLiveValue(SILValue value, SILInstruction *insertPt) {
+  if (!LiveValues.count(value->getRepresentativeSILNodeInObject())) {
+    return;
+  }
+  SILBuilderWithScope builder(insertPt);
+  if (value.getOwnershipKind() == OwnershipKind::Owned) {
+    builder.emitDestroyOperation(RegularLocation::getAutoGeneratedLocation(),
+                                 value);
+  }
+  if (value.getOwnershipKind() == OwnershipKind::Guaranteed) {
+    builder.emitEndBorrowOperation(RegularLocation::getAutoGeneratedLocation(),
+                                   value);
+  }
+}
+
 // Remove the instructions that are not potentially useful.
 bool DCE::removeDead(SILFunction &F) {
   bool Changed = false;
 
   for (auto &BB : F) {
-    for (auto I = BB.args_begin(), E = BB.args_end(); I != E;) {
-      auto Inst = *I++;
-      if (LiveValues.count(Inst))
+    for (unsigned i = 0; i < BB.getArguments().size();) {
+      auto *arg = BB.getArgument(i);
+      if (LiveValues.count(arg)) {
+        i++;
         continue;
+      }
 
       LLVM_DEBUG(llvm::dbgs() << "Removing dead argument:\n");
-      LLVM_DEBUG(Inst->dump());
+      LLVM_DEBUG(arg->dump());
 
-      Inst->replaceAllUsesWithUndef();
+      arg->replaceAllUsesWithUndef();
 
+      if (!F.hasOwnership() || arg->getType().isTrivial(F)) {
+        i++;
+        Changed = true;
+        BranchesChanged = true;
+        continue;
+      }
+
+      if (!arg->isPhiArgument()) {
+        // We cannot delete a non phi arg. If it was @owned, insert a
+        // destroy_value, because its consuming user has already been marked
+        // dead and will be deleted.
+        // We do not have to end lifetime of a @guaranteed non phi arg.
+        if (arg->getOwnershipKind() == OwnershipKind::Owned) {
+          auto insertPt = getInsertAfterPoint(arg).getValue();
+          SILBuilderWithScope builder(insertPt);
+          auto *destroy = builder.createDestroyValue(insertPt->getLoc(), arg);
+          LiveValues.insert(destroy->getRepresentativeSILNodeInObject());
+        }
+        i++;
+        Changed = true;
+        BranchesChanged = true;
+        continue;
+      }
+      // In OSSA, we have to delete a dead phi argument and insert destroy or
+      // end_borrow at its predecessors if the incoming values are live.
+      // This is not necessary in non-OSSA, and will infact be incorrect.
+      // Because, passing a value as a phi argument does not imply end of
+      // lifetime in non-OSSA.
+      BB.eraseArgument(i);
+      for (auto *pred : BB.getPredecessorBlocks()) {
+        auto *predTerm = pred->getTerminator();
+        auto predArg = predTerm->getAllOperands()[i].get();
+        endLifetimeOfLiveValue(predArg, predTerm);
+        deleteEdgeValue(pred->getTerminator(), &BB, i);
+      }
       Changed = true;
+      BranchesChanged = true;
     }
 
     for (auto I = BB.begin(), E = BB.end(); I != E; ) {
@@ -501,7 +575,11 @@ bool DCE::removeDead(SILFunction &F) {
         SILBasicBlock *postDom = nearestUsefulPostDominator(Inst->getParent());
         if (!postDom)
           continue;
-  
+
+        LLVM_DEBUG(llvm::dbgs() << "Replacing branch: ");
+        LLVM_DEBUG(Inst->dump());
+        LLVM_DEBUG(llvm::dbgs() << "with jump to: BB" << postDom->getDebugID());
+
         replaceBranchWithJump(Inst, postDom);
         Inst->eraseFromParent();
         BranchesChanged = true;
@@ -514,6 +592,13 @@ bool DCE::removeDead(SILFunction &F) {
       LLVM_DEBUG(llvm::dbgs() << "Removing dead instruction:\n");
       LLVM_DEBUG(Inst->dump());
 
+      if (F.hasOwnership()) {
+        for (auto &Op : Inst->getAllOperands()) {
+          if (Op.isLifetimeEnding()) {
+            endLifetimeOfLiveValue(Op.get(), Inst);
+          }
+        }
+      }
       Inst->replaceAllUsesOfAllResultsWithUndef();
 
       if (isa<ApplyInst>(Inst))

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -1,0 +1,326 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -dce %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class Klass {
+
+}
+
+struct NonTrivialStruct {
+  var val:Klass
+}
+
+sil [ossa] @$testtryapplyklassgen : $@convention(thin) () -> (@owned Klass, @error Error)
+sil [ossa] @$use_klass1 : $@convention(thin) (@owned Klass) -> ()
+sil [ossa] @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+sil [ossa] @$use_nontrivialstruct1 : $@convention(thin) (@owned NonTrivialStruct) -> ()
+sil [ossa] @$use_nontrivialstruct2 : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+
+// We cannot DCE a function argument
+// CHECK-LABEL: sil [ossa] @dce_dontoptarg1 :
+// CHECK: destroy_value %0
+// CHECK-LABEL: } // end sil function 'dce_dontoptarg1'
+sil [ossa] @dce_dontoptarg1 : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  destroy_value %0 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_dontoptarg2 :
+// CHECK: copy_value
+// CHECK: destroy_value
+// CHECK-LABEL: } // end sil function 'dce_dontoptarg2'
+sil [ossa] @dce_dontoptarg2 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  br bb1(%1 : $Klass)
+
+bb1(%2 : @owned $Klass):
+  %3 = copy_value %2 : $Klass
+  %4 = function_ref @$use_klass1 : $@convention(thin) (@owned Klass) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@owned Klass) -> ()
+  destroy_value %2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// Don't dce due to a useful dependency due to apply
+// CHECK-LABEL: sil [ossa] @dce_dontoptrevdep1 :
+// CHECK: [[RES:%.*]] = load_borrow %0
+// CHECK: end_borrow [[RES]]
+// CHECK-LABEL: } // end sil function 'dce_dontoptrevdep1'
+sil [ossa] @dce_dontoptrevdep1 : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load_borrow %0 : $*Klass
+  %2 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = apply %2(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %1 : $Klass
+  destroy_addr %0 : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// Don't dce due to a useful dependency due to apply
+// CHECK-LABEL: sil [ossa] @dce_dontoptendborrow1 :
+// CHECK: [[RES:%.*]] = begin_borrow %0
+// CHECK: end_borrow
+// CHECK-LABEL: } // end sil function 'dce_dontoptendborrow1'
+sil [ossa] @dce_dontoptendborrow1 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = begin_borrow %0 : $Klass
+  br bb1(%1 : $Klass)
+
+bb1(%2 : @guaranteed $Klass):
+  %3 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %4 = apply %3(%2) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// Cannot optimize dead non phi args
+// CHECK-LABEL: sil [ossa] @dce_dontoptarg3 :
+// CHECK: destroy_value
+// CHECK-LABEL: } // end sil function 'dce_dontoptarg3'
+sil [ossa] @dce_dontoptarg3 : $@convention(thin) (@guaranteed Klass) -> @error Error {
+bb0(%0 : @guaranteed $Klass):
+  %2 = function_ref @$testtryapplyklassgen : $@convention(thin) () -> (@owned Klass, @error Error)
+  try_apply %2() : $@convention(thin) () -> (@owned Klass, @error Error), normal bb1, error bb2
+
+bb1(%3 : @owned $Klass):
+  destroy_value %3 : $Klass
+  %res = tuple ()
+  return %res : $()
+
+bb2(%4 : $Error):
+  throw %4 : $Error
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadcopy1 :
+// CHECK-NOT: copy_value
+// CHECK: destroy_value %0
+// CHECK-LABEL: } // end sil function 'dce_deadcopy1'
+sil [ossa] @dce_deadcopy1 : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = copy_value %0 : $Klass
+  destroy_value %1 : $Klass
+  destroy_value %0 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadcopy2 :
+// CHECK-NOT: copy_value
+// CHECK-NOT: destroy_value
+// CHECK-LABEL: } // end sil function 'dce_deadcopy2'
+sil [ossa] @dce_deadcopy2 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  destroy_value %1 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadcopy3 :
+// CHECK: bb0([[ARG:%.*]])
+// CHECK-NEXT: br bb1
+// CHECK: bb1:
+// CHECK-NEXT: [[RES:%.*]] = tuple ()
+// CHECK-NEXT: return [[RES]]
+// CHECK-LABEL: } // end sil function 'dce_deadcopy3'
+sil [ossa] @dce_deadcopy3 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  br bb1(%1 : $Klass)
+
+bb1(%2 : @owned $Klass):
+  destroy_value %2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadcopy4 :
+// CHECK-NOT: copy_value
+// CHECK-NOT: destroy_value
+// CHECK-LABEL: } // end sil function 'dce_deadcopy4'
+sil [ossa] @dce_deadcopy4 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%1 : $Klass)
+
+bb2:
+  br bb3(%1 : $Klass)
+
+bb3(%2 : @owned $Klass):
+  destroy_value %2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadcopy5 :
+// CHECK: bb0([[ARG:%.*]])
+// CHECK-NEXT: br bb1
+// CHECK: bb1:
+// CHECK-NEXT: [[RES:%.*]] = tuple ()
+// CHECK-NEXT: return [[RES]]
+// CHECK-LABEL: } // end sil function 'dce_deadcopy5'
+sil [ossa] @dce_deadcopy5 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  cond_br undef, bb1, bb2
+
+bb3(%2 : @owned $Klass):
+  destroy_value %2 : $Klass
+  %res = tuple ()
+  return %res : $()
+
+bb1:
+  br bb3(%1 : $Klass)
+
+bb2:
+  br bb3(%1 : $Klass)
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadcopy6 :
+// CHECK: bb0([[ARG:%.*]])
+// CHECK-NEXT: br bb1
+// CHECK: bb1:
+// CHECK-NEXT: [[RES:%.*]] = tuple ()
+// CHECK-NEXT: return [[RES]]
+// CHECK-LABEL: } // end sil function 'dce_deadcopy6'
+sil [ossa] @dce_deadcopy6 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  cond_br undef, bb1a, bb2a
+
+bb1a:
+  br bb1(%1 : $Klass)
+
+bb2a:
+  br bb2(%1 : $Klass)
+
+bb1(%1a : @owned $Klass):
+  br bb3(%1a : $Klass)
+
+bb2(%1b : @owned $Klass):
+  br bb3(%1b : $Klass)
+
+bb3(%2 : @owned $Klass):
+  destroy_value %2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_destructure1 :
+// CHECK: bb0(%0 : {{.*}})
+// CHECK-NEXT: destroy_value %0
+// CHECK-NEXT: [[RES:%.*]] = tuple ()
+// CHECK-NEXT: return [[RES]]
+// CHECK-LABEL: } // end sil function 'dce_destructure1'
+sil [ossa] @dce_destructure1 : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  (%1) = destructure_struct %0 : $NonTrivialStruct
+  destroy_value %1 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_destructure2 :
+// CHECK: bb0(%0 : {{.*}})
+// CHECK-NEXT: [[RES:%.*]] = tuple ()
+// CHECK-NEXT: return [[RES]]
+// CHECK-LABEL: } // end sil function 'dce_destructure2'
+sil [ossa] @dce_destructure2 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  (%1) = destructure_struct %0 : $NonTrivialStruct
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_destructure3 :
+// CHECK: bb0(%0 : {{.*}})
+// CHECK-NOT: destructure_struct
+// CHECK-LABEL: } // end sil function 'dce_destructure3'
+sil [ossa] @dce_destructure3 : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %1 = copy_value %0 : $NonTrivialStruct
+  %func = function_ref @$use_nontrivialstruct2 : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %funcres = apply %func(%1) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  (%2) = destructure_struct %1 : $NonTrivialStruct
+  destroy_value %2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// This test shows that when we delete a dead instruction which has lifetime ending ops,
+// we need to insert destroys of ops to end their lifetime correctly
+// CHECK-LABEL: sil [ossa] @dce_insertdestroy1 :
+// CHECK-NOT: struct
+// CHECK-LABEL: } // end sil function 'dce_insertdestroy1'
+sil [ossa] @dce_insertdestroy1 : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = copy_value %0 : $Klass
+  %func = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %funcres = apply %func(%1) : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = struct $NonTrivialStruct(%1 : $Klass)
+  destroy_value %3 : $NonTrivialStruct
+  destroy_value %0 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// This test shows that when we delete a dead phi arg and its incoming values are live,
+// we need to insert destroys of the incoming values in its pred blocks.
+// CHECK-LABEL: sil [ossa] @dce_insertdestroy2 :
+// CHECK: bb1(%3 : {{.*}})
+// CHECK-NEXT: destroy_value %3
+// CHECK-NEXT: br bb3
+// CHECK-LABEL: } // end sil function 'dce_insertdestroy2'
+sil [ossa] @dce_insertdestroy2 : $@convention(thin) (@guaranteed Klass) -> @error Error {
+bb0(%0 : @guaranteed $Klass):
+  %2 = function_ref @$testtryapplyklassgen : $@convention(thin) () -> (@owned Klass, @error Error)
+  try_apply %2() : $@convention(thin) () -> (@owned Klass, @error Error), normal bb1, error bb2
+
+bb1(%3 : @owned $Klass):
+  br bb3(%3 : $Klass)
+
+bb2(%4 : $Error):
+  throw %4 : $Error
+
+bb3(%5 : @owned $Klass):
+  destroy_value %5 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_multiplerevdepdests :
+// CHECK-NOT: destroy_value
+// CHECK-LABEL: } // end sil function 'dce_multiplerevdepdests'
+sil [ossa] @dce_multiplerevdepdests : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  br bb1(%1 : $Klass)
+
+bb1(%2 : @owned $Klass):
+  cond_br undef, bb2, bb3
+
+bb2:
+  destroy_value %2 : $Klass
+  br bb4
+
+bb3:
+  destroy_value %2 : $Klass
+  br bb4
+
+bb4:
+  %res = tuple()
+  return %res : $()
+}
+

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -5,9 +5,11 @@ sil_stage canonical
 import Builtin
 import Swift
 
-// CHECK-LABEL: sil @dead1
-sil @dead1 : $@convention(thin) (Int32, Int32) -> Int32 {
+// CHECK-LABEL: sil [ossa] @dead1 :
 // CHECK: bb0
+// CHECK-NEXT: return %0
+// CHECK-LABEL: } // end sil function 'dead1'
+sil [ossa] @dead1 : $@convention(thin) (Int32, Int32) -> Int32 {
 bb0(%0 : $Int32, %1 : $Int32):
   %3 = struct_extract %0 : $Int32, #Int32._value
   %4 = struct_extract %1 : $Int32, #Int32._value
@@ -15,24 +17,17 @@ bb0(%0 : $Int32, %1 : $Int32):
   %6 = builtin "sadd_with_overflow_Int32"(%3 : $Builtin.Int32, %4 : $Builtin.Int32, %5 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
   %7 = tuple_extract %6 : $(Builtin.Int32, Builtin.Int1), 0
   %8 = struct $Int32 (%7 : $Builtin.Int32)
-// CHECK-NEXT: return %0
   return %0 : $Int32
 }
 
-// CHECK-LABEL: sil @dead2
-sil @dead2 : $@convention(thin) () -> () {
-// CHECK: bb0
+// CHECK-LABEL: sil [ossa] @dead2 :
+sil [ossa] @dead2 : $@convention(thin) () -> () {
 bb0:
-// CHECK-NOT: integer_literal $Builtin.Int32, 2
   %0 = integer_literal $Builtin.Int32, 2
-// CHECK-NOT: integer_literal $Builtin.Int32, 0
   %1 = integer_literal $Builtin.Int32, 0
-// CHECK-NEXT: br bb1
   br bb1(%0 : $Builtin.Int32, %1 : $Builtin.Int32)
 
-// CHECK: bb1
 bb1(%3 : $Builtin.Int32, %4 : $Builtin.Int32):
-// CHECK-NEXT: br bb2
   %5 = integer_literal $Builtin.Int32, 100
   %7 = builtin "cmp_slt_Int32"(%4 : $Builtin.Int32, %5 : $Builtin.Int32) : $Builtin.Int1
   cond_br %7, bb2, bb3
@@ -47,16 +42,14 @@ bb2:
   %16 = tuple_extract %15 : $(Builtin.Int32, Builtin.Int1), 0
   br bb1(%13 : $Builtin.Int32, %16 : $Builtin.Int32)
 
-// CHECK: bb2
 bb3:
-// CHECK-NEXT: [[RESULT:%[a-zA-Z0-9]+]] = tuple ()
   %18 = tuple ()
-// CHECK-NEXT: return [[RESULT]]
   return %18 : $()
 }
+// CHECK-LABEL: } // end sil function 'dead2'
 
-// CHECK-LABEL: sil @dead3
-sil @dead3 : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [ossa] @dead3 :
+sil [ossa] @dead3 : $@convention(thin) () -> () {
 bb0:
 // CHECK: bb0
   br bb1
@@ -67,9 +60,10 @@ bb1:
   %0 = integer_literal $Builtin.Int32, 0
   br bb1
 }
+// CHECK-LABEL: } // end sil function 'dead3'
 
-// CHECK-LABEL: sil hidden @test_dce_bbargs
-sil hidden @test_dce_bbargs : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [ossa] @test_dce_bbargs :
+sil [ossa] @test_dce_bbargs : $@convention(thin) () -> () {
 bb0:
   %0 = integer_literal $Builtin.Int32, 0
   %1 = struct $Int32 (%0 : $Builtin.Int32)
@@ -91,13 +85,12 @@ bb1(%13 : $Int32, %14 : $Int32, %15 : $Int32, %16 : $Int32, %17 : $Int32):
   %21 = builtin "cmp_slt_Int32"(%20 : $Builtin.Int32, %18 : $Builtin.Int32) : $Builtin.Int1
   %22 = struct $Bool (%21 : $Builtin.Int1)
   %23 = struct_extract %22 : $Bool, #Bool._value
-  cond_br %23, bb2, bb10
+  cond_br %23, bb2, bb12
 
 // CHECK: bb2:
 bb2:
   %25 = integer_literal $Builtin.Int32, 0
   %26 = struct $Int32 (%25 : $Builtin.Int32)
-// br bb3(undef : $Int32, undef : $Int32,
   br bb3(%13 : $Int32, %14 : $Int32, %26 : $Int32, %17 : $Int32)
 
 bb3(%28 : $Int32, %29 : $Int32, %30 : $Int32, %31 : $Int32):
@@ -106,7 +99,7 @@ bb3(%28 : $Int32, %29 : $Int32, %30 : $Int32, %31 : $Int32):
   %35 = builtin "cmp_slt_Int32"(%34 : $Builtin.Int32, %32 : $Builtin.Int32) : $Builtin.Int1
   %36 = struct $Bool (%35 : $Builtin.Int1)
   %37 = struct_extract %36 : $Bool, #Bool._value
-  cond_br %37, bb4, bb9
+  cond_br %37, bb4, bb11
 
 // CHECK: bb4:
 bb4:
@@ -122,23 +115,29 @@ bb4:
 bb5:
   %46 = integer_literal $Builtin.Int32, 0
   %47 = struct $Int32 (%46 : $Builtin.Int32)
-  br bb6(%47 : $Int32)
+  br bb7(%47 : $Int32)
 
-bb6(%49 : $Int32):
+bb6(%28a : $Int32):
+ br bb7(%28a : $Int32)
+
+bb7(%49 : $Int32):
   %50 = integer_literal $Builtin.Int32, 10
   %52 = struct_extract %29 : $Int32, #Int32._value
   %53 = builtin "cmp_eq_Int32"(%50 : $Builtin.Int32, %52 : $Builtin.Int32) : $Builtin.Int1
   %54 = struct $Bool (%53 : $Builtin.Int1)
   %55 = struct_extract %54 : $Bool, #Bool._value
-  cond_br %55, bb7, bb8(%29 : $Int32)
+  cond_br %55, bb8, bb9(%29 : $Int32)
 
-bb7:
+bb8:
   %57 = integer_literal $Builtin.Int32, 0
   %58 = struct $Int32 (%57 : $Builtin.Int32)
-  br bb8(%58 : $Int32)
+  br bb10(%58 : $Int32)
 
-// CHECK: bb5(%{{[0-9]+}} : $Int32):
-bb8(%60 : $Int32):
+bb9(%29a : $Int32):
+  br bb10(%29a : $Int32)
+
+// CHECK: bb5([[BBARG:%.*]]):
+bb10(%60 : $Int32):
   %61 = struct_extract %31 : $Int32, #Int32._value
   %62 = integer_literal $Builtin.Int32, 1
   %64 = integer_literal $Builtin.Int1, -1
@@ -161,11 +160,11 @@ bb8(%60 : $Int32):
   %78 = struct $Int32 (%75 : $Builtin.Int32)
   %tif = function_ref @take_int32 : $@convention(thin) (Int32) -> ()
   %atif = apply %tif(%78) : $@convention(thin) (Int32) -> ()
-// CHECK: br bb3(undef : $Int32, undef : $Int32,
+// CHECK: br bb3
   br bb3(%49 : $Int32, %60 : $Int32, %78 : $Int32, %69 : $Int32)
 
 // CHECK: bb6:
-bb9:
+bb11:
   %80 = struct_extract %15 : $Int32, #Int32._value
   %81 = integer_literal $Builtin.Int32, 1
   %83 = integer_literal $Builtin.Int1, -1
@@ -174,23 +173,25 @@ bb9:
   %86 = tuple_extract %84 : $(Builtin.Int32, Builtin.Int1), 1
   cond_fail %86 : $Builtin.Int1
   %88 = struct $Int32 (%85 : $Builtin.Int32)
-// CHECK: br bb1(undef : $Int32, undef : $Int32,
+// CHECK: br bb1
   br bb1(%28 : $Int32, %29 : $Int32, %88 : $Int32, %30 : $Int32, %31 : $Int32)
 
 // CHECK: bb7:
-bb10:
+bb12:
   %90 = tuple ()
 // CHECK: return
   return %90 : $()
 }
+// CHECK-LABEL: } // end sil function 'test_dce_bbargs'
 
-sil @take_int32 : $@convention(thin) (Int32) -> ()
+sil [ossa] @take_int32 : $@convention(thin) (Int32) -> ()
 
-// CHECK-LABEL: sil @remove_fix_lifetime
+// CHECK-LABEL: sil [ossa] @remove_fix_lifetime :
 // CHECK: bb0:
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
-sil @remove_fix_lifetime : $@convention(thin) () -> () {
+// CHECK-LABEL: } // end sil function 'remove_fix_lifetime'
+sil [ossa] @remove_fix_lifetime : $@convention(thin) () -> () {
 bb0:
   %0 = integer_literal $Builtin.Int32, 0
   %1 = struct $Int32 (%0 : $Builtin.Int32)
@@ -202,11 +203,12 @@ bb0:
   return %90 : $()
 }
 
-// CHECK-LABEL: sil @dont_remove_fix_lifetime
+// CHECK-LABEL: sil [ossa] @dont_remove_fix_lifetime :
 // CHECK: fix_lifetime
 // CHECK: fix_lifetime
 // CHECK: return
-sil @dont_remove_fix_lifetime : $@convention(thin) () -> Int32 {
+// CHECK-LABEL: } // end sil function 'dont_remove_fix_lifetime'
+sil [ossa] @dont_remove_fix_lifetime : $@convention(thin) () -> Int32 {
 bb0:
   %0 = integer_literal $Builtin.Int32, 0
   %1 = struct $Int32 (%0 : $Builtin.Int32)
@@ -221,11 +223,12 @@ struct Container {
 	var i: Int32
 }
 
-// CHECK-LABEL: sil @dont_remove_addr_fix_lifetime
+// CHECK-LABEL: sil [ossa] @dont_remove_addr_fix_lifetime :
 // CHECK: fix_lifetime
 // CHECK: fix_lifetime
 // CHECK: return
-sil @dont_remove_addr_fix_lifetime : $@convention(thin) (@in Container) -> () {
+// CHECK-LABEL: } // end sil function 'dont_remove_addr_fix_lifetime'
+sil [ossa] @dont_remove_addr_fix_lifetime : $@convention(thin) (@in Container) -> () {
 bb0(%0 : $*Container):
   %1 = struct_element_addr %0 : $*Container, #Container.i
 
@@ -237,9 +240,10 @@ bb0(%0 : $*Container):
 }
 
 // Check that DCE does not crash with an infinite loop through a cond_br.
-// CHECK-LABEL: sil @deal_with_infinite_loop
+// CHECK-LABEL: sil [ossa] @deal_with_infinite_loop :
 // CHECK: cond_br
-sil @deal_with_infinite_loop : $@convention(thin) () -> () {
+// CHECK-LABEL: } // end sil function 'deal_with_infinite_loop'
+sil [ossa] @deal_with_infinite_loop : $@convention(thin) () -> () {
 bb0:
   br bb1
 
@@ -254,19 +258,20 @@ bb3:
 }
 
 // Check that DCE eliminates dead access instructions.
-// CHECK-LABEL: sil @dead_access
+// CHECK-LABEL: sil [ossa] @dead_access :
 // CHECK: bb0
 // CHECK-NEXT: tuple
 // CHECK-NEXT: return
-// CHECK-LABEL: end sil function 'dead_access'
-sil @dead_access : $@convention(thin) (@in Container) -> () {
+// CHECK-LABEL: } // end sil function 'dead_access'
+sil [ossa] @dead_access : $@convention(thin) (@in Container) -> () {
 bb0(%0 : $*Container):
   %1 = begin_access [modify] [dynamic] %0 : $*Container
   end_access %1 : $*Container
-  
+
   %3 = begin_access [read] [static] %0 : $*Container
   end_access %3 : $*Container
 
   %999 = tuple ()
   return %999 : $()
 }
+


### PR DESCRIPTION
- Support destroy_value/copy_value/begin_borrow/end_borrow
- Support adding reverse dependencies for SILArgument
- Insert lifetime end instructions (destroy_value/end_borrow) while deleting instructions which would have ended the lifetime of its operands
