### PR TITLE
[NFC] Remove include to Visibility.h from Runtime/Config.h [WIP]

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -145,9 +145,6 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 # define SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 #endif
 
-// Bring in visibility attribute macros
-#include "../../../stdlib/public/SwiftShims/Visibility.h"
-
 // Define mappings for calling conventions.
 
 // Annotation for specifying a calling convention of


### PR DESCRIPTION
From what I can see this include isn't actually needed. It also causes a problem
when building the Runtime/Config.h header within a Clang module: The SwiftShim
module depends on the Runtime/Config.h module, but due to this include
the Runtime/Config.h module would also depend on the SwiftShims module (and
this cyclic dependency breaks the module build).