### PR TITLE
[build-script] Add swift-disable-dead-stripping option for disabling dead stripping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,9 @@ endif()
 set(SWIFT_USE_LINKER ${SWIFT_USE_LINKER_default} CACHE STRING
     "Build Swift with a non-default linker")
 
+option(SWIFT_DISABLE_DEAD_STRIPPING 
+      "Turn off Darwin-specific dead stripping for Swift host tools." FALSE)
+
 set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One
     must specify the form of LTO by setting this to one of: 'full', 'thin'. This
     option only affects the tools that run on the host (the compiler), and has

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -380,8 +380,8 @@ function(_add_host_variant_link_flags target)
   #
   # TODO: Evaluate/enable -f{function,data}-sections --gc-sections for bfd,
   # gold, and lld.
-  if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-    if(CMAKE_SYSTEM_NAME MATCHES Darwin)
+  if(NOT CMAKE_BUILD_TYPE STREQUAL Debug AND CMAKE_SYSTEM_NAME MATCHES Darwin)
+    if (NOT SWIFT_DISABLE_DEAD_STRIPPING)
       # See rdar://48283130: This gives 6MB+ size reductions for swift and
       # SourceKitService, and much larger size reductions for sil-opt etc.
       target_link_options(${target} PRIVATE

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -246,13 +246,13 @@ Phew, that's a lot to digest! Now let's proceed to the actual build itself!
      ```sh
      utils/build-script --skip-build-benchmarks \
        --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "$(uname -m)" \
-       --sccache --release-debuginfo --test
+       --sccache --release-debuginfo --swift-disable-dead-stripping --test
      ```
    - Via Xcode:
      ```sh
      utils/build-script --skip-build-benchmarks \
        --skip-ios --skip-watchos --skip-tvos --swift-darwin-supported-archs "$(uname -m)" \
-       --sccache --release-debuginfo --test \
+       --sccache --release-debuginfo --swift-disable-dead-stripping --test \
        --xcode
      ```
    This will create a directory

--- a/utils/build-script
+++ b/utils/build-script
@@ -600,6 +600,9 @@ class BuildScriptInvocation(object):
             impl_args += ["--skip-build"]
         if not args.build_benchmarks:
             impl_args += ["--skip-build-benchmarks"]
+        
+        if args.swift_disable_dead_stripping:
+            args.extra_cmake_options.append('-DSWIFT_DISABLE_DEAD_STRIPPING:BOOL=TRUE')
 
         # Then add subproject install flags that either skip building them /or/
         # if we are going to build them and install_all is set, we also install

--- a/utils/build-script
+++ b/utils/build-script
@@ -600,7 +600,7 @@ class BuildScriptInvocation(object):
             impl_args += ["--skip-build"]
         if not args.build_benchmarks:
             impl_args += ["--skip-build-benchmarks"]
-        
+
         if args.swift_disable_dead_stripping:
             args.extra_cmake_options.append('-DSWIFT_DISABLE_DEAD_STRIPPING:BOOL=TRUE')
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -199,6 +199,7 @@ KNOWN_SETTINGS=(
     swift-stdlib-single-threaded-runtime          "0"               "whether to build stdlib as a single-threaded runtime only"
     swift-stdlib-os-versioning                    "1"               "whether to build stdlib with availability based on OS versions (Darwin only)"
     swift-stdlib-stable-abi                       ""                "should stdlib be built with stable ABI, if not set defaults to true on Darwin, false otherwise"
+    swift-disable-dead-stripping                  "0"               "turns off Darwin-specific dead stripping for Swift host tools"
 
     ## FREESTANDING Stdlib Options
     swift-freestanding-sdk                      ""                "which SDK to use when building the FREESTANDING stdlib"

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -334,6 +334,9 @@ def create_argument_parser():
            default=defaults.SWIFT_ANALYZE_CODE_COVERAGE,
            help='enable code coverage analysis in Swift (false, not-merged, '
                 'merged).')
+                
+    option('--swift-disable-dead-stripping', toggle_true, 
+           help="Turn off Darwin-specific dead stripping for Swift host tools")
 
     option('--build-subdir', store,
            metavar='PATH',

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -334,7 +334,7 @@ def create_argument_parser():
            default=defaults.SWIFT_ANALYZE_CODE_COVERAGE,
            help='enable code coverage analysis in Swift (false, not-merged, '
                 'merged).')
-                
+
     option('--swift-disable-dead-stripping', toggle_true, 
            help="Turn off Darwin-specific dead stripping for Swift host tools")
 

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -631,6 +631,10 @@ class TestDriverArgumentParser(unittest.TestCase):
         self.assertFalse(namespace.test_android_host)
         self.assertFalse(namespace.build_libparser_only)
 
+    def test_implied_defaults_swift_disable_dead_stripping(self):
+        namespace = self.parse_default_args(['--swift-disable-dead-stripping'])
+        self.assertTrue(namespace.swift_disable_dead_stripping)
+
     def test_build_lib_swiftsyntaxparser_only(self):
         namespace = self.parse_default_args(['--build-libparser-only'])
         self.assertTrue(namespace.build_libparser_only)

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -552,6 +552,7 @@ EXPECTED_OPTIONS = [
     EnableOption('--verbose-build'),
     EnableOption('--watchos'),
     EnableOption('--xctest', dest='build_xctest'),
+    EnableOption('--swift-disable-dead-stripping'),
 
     DisableOption('--skip-build-cmark', dest='build_cmark'),
     DisableOption('--skip-build-llvm', dest='build_llvm'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -202,6 +202,7 @@ EXPECTED_DEFAULTS = {
     'swift_assertions': True,
     'swift_build_variant': 'Debug',
     'swift_compiler_version': None,
+    'swift_disable_dead_stripping': False,
     'swift_darwin_module_archs': None,
     'swift_darwin_supported_archs': None,
     'swift_stdlib_assertions': True,


### PR DESCRIPTION
<!-- What's in this pull request? -->
With the new build script flag `--swift-disable-dead-stripping`, swift frontend will be built without dead stripping which can improve debugging. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-13631](https://bugs.swift.org/browse/SR-13631).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
