### PR TITLE
Platform: extend the D3D v10 module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -161,9 +161,13 @@ module WinSDK [system] {
   explicit module DirectX {
     module Direct3D11 {
       header "d3d11.h"
+      header "d3d11_1.h"
+      header "d3d11_2.h"
+      header "d3d11_3.h"
+      header "d3d11_4.h"
       export *
 
-      link "d3d12.lib"
+      link "d3d11.lib"
       link "dxgi.lib"
     }
 


### PR DESCRIPTION
Add the extensions for the Direct3D v10 API to enable access to the
newer DXGISwapChain interfaces.  Additionally, correct the linking to
ensure that we pick up the v10 version of the import library.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
