### PR TITLE
test: update Interop.cxx tests for newer clang

### DIFF
--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-irgen.swift
@@ -6,4 +6,4 @@ public func getIncrementorValue() -> CInt {
   return callConstructor(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor* %this, i32 %t)
+// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor* nonnull dereferenceable(1) %this, i32 %t)

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-irgen.swift
@@ -6,4 +6,4 @@ public func getValueFromMethod() -> CInt {
   return callMethod(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN13IncrementUser11Incrementor9incrementEi|"\?increment@Incrementor@IncrementUser@@QEAAHH@Z"}}(%"struct.IncrementUser::Incrementor"* %this, i32 %t)
+// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN13IncrementUser11Incrementor9incrementEi|"\?increment@Incrementor@IncrementUser@@QEAAHH@Z"}}(%"struct.IncrementUser::Incrementor"* nonnull dereferenceable(1) %this, i32 %t)

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-irgen.swift
@@ -6,4 +6,4 @@ public func getValueFromMethod() -> CInt {
   return callMethod(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor* %this, i32 %t)
+// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor* nonnull dereferenceable(1) %this, i32 %t)


### PR DESCRIPTION
Clang will properly mark the C++ `this` parameter as `nonnull` and
`dereferenceable(1)` as per the C++ specification.  Update the tests to
accept the newer attributes.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
