### PR TITLE
async: Allocate memory in the caller for direct return results

### DIFF
--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -113,7 +113,7 @@ namespace irgen {
     bool canHaveValidError;
     bool isCoroutine;
     SmallVector<SILYieldInfo, 4> yieldInfos;
-    SmallVector<SILResultInfo, 4> directReturnInfos;
+    Optional<SILType> directReturnSILType;
     SmallVector<SILResultInfo, 4> indirectReturnInfos;
     Optional<ArgumentInfo> localContextInfo;
     NecessaryBindings bindings;
@@ -266,14 +266,18 @@ namespace irgen {
     ElementLayout getSelfWitnessTableLayout() {
       return getElement(getSelfWitnessTableIndex());
     }
-
     unsigned getDirectReturnCount() {
-      assert(!isCoroutine);
-      return directReturnInfos.size();
+      if (directReturnSILType)
+        return 1;
+      else
+        return 0;
     }
-    ElementLayout getDirectReturnLayout(unsigned index) {
+    ElementLayout getDirectReturnAddrLayout() {
       assert(!isCoroutine);
-      return getElement(getFirstDirectReturnIndex() + index);
+      return getElement(getFirstDirectReturnIndex());
+    }
+    Optional<SILType> getDirectReturnSILType() {
+      return directReturnSILType;
     }
     unsigned getYieldCount() {
       assert(isCoroutine);
@@ -289,7 +293,7 @@ namespace irgen {
         bool canHaveValidError, ArrayRef<ArgumentInfo> argumentInfos,
         bool isCoroutine, ArrayRef<SILYieldInfo> yieldInfos,
         ArrayRef<SILResultInfo> indirectReturnInfos,
-        ArrayRef<SILResultInfo> directReturnInfos,
+        Optional<SILType> directReturnSILType,
         Optional<ArgumentInfo> localContextInfo);
   };
 

--- a/stdlib/public/Concurrency/AsyncCall.h
+++ b/stdlib/public/Concurrency/AsyncCall.h
@@ -68,7 +68,7 @@ struct AsyncFrameLayout<AsyncSignature<void(ArgTys...), HasErrorResult>> {
 };
 template <class ResultTy, class... ArgTys, bool HasErrorResult>
 struct AsyncFrameLayout<AsyncSignature<ResultTy(ArgTys...), HasErrorResult>> {
-  using BasicLayout = BasicLayout<0, SwiftError*, ResultTy, ArgTys...>;
+  using BasicLayout = BasicLayout<0, SwiftError*, ResultTy*, ArgTys...>;
   static constexpr size_t firstArgIndex = 2;
 };
 


### PR DESCRIPTION
This will allow us to destroy the async context in the callee.
