### PR TITLE
[nfc] Enable member function templates silgen test.

### DIFF
--- a/test/Interop/Cxx/templates/member-templates-silgen.swift
+++ b/test/Interop/Cxx/templates/member-templates-silgen.swift
@@ -8,10 +8,10 @@ import MemberTemplates
 
 // CHECK-LABEL: sil hidden @$s4main9basicTestyyF : $@convention(thin) () -> ()
 
-// CHECK: [[ADD:%.*]] = function_ref @_ZN18HasMemberTemplates3addSameTypeParamsIiEET_S1_S1_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK: [[ADD:%.*]] = function_ref @_ZN18HasMemberTemplates17addSameTypeParamsIiEET_S1_S1_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 // CHECK: apply [[ADD]]({{.*}}) : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK: [[ADD_TWO_TEMPLATES:%.*]] = function_ref @_ZN18HasMemberTemplates15addMixedTypeParamsIiiEET_S1_T0_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32 // user: %26
+// CHECK: [[ADD_TWO_TEMPLATES:%.*]] = function_ref @_ZN18HasMemberTemplates18addMixedTypeParamsIiiEET_S1_T0_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32 // user: %26
 // CHECK: apply [[ADD_TWO_TEMPLATES]]({{.*}}) : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
 // CHECK: [[ADD_ALL:%.*]] = function_ref @_ZN18HasMemberTemplates6addAllIiiEEiiT_T0_ : $@convention(c) (Int32, Int32, Int32, @inout HasMemberTemplates) -> Int32 // user: %39
@@ -30,9 +30,9 @@ func basicTest() {
   obj.doNothingConstRef(&i)
 }
 
-// CHECK-LABEL: sil hidden_external [clang HasMemberTemplates._ZN18HasMemberTemplates3addSameTypeParamsIiEET_S1_S1_] @_ZN18HasMemberTemplates3addSameTypeParamsIiEET_S1_S1_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK-LABEL: sil hidden_external [clang HasMemberTemplates._ZN18HasMemberTemplates17addSameTypeParamsIiEET_S1_S1_] @_ZN18HasMemberTemplates17addSameTypeParamsIiEET_S1_S1_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
-// CHECK-LABEL: sil hidden_external [clang HasMemberTemplates._ZN18HasMemberTemplates15addMixedTypeParamsIiiEET_S1_T0_] @_ZN18HasMemberTemplates15addMixedTypeParamsIiiEET_S1_T0_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
+// CHECK-LABEL: sil hidden_external [clang HasMemberTemplates._ZN18HasMemberTemplates18addMixedTypeParamsIiiEET_S1_T0_] @_ZN18HasMemberTemplates18addMixedTypeParamsIiiEET_S1_T0_ : $@convention(c) (Int32, Int32, @inout HasMemberTemplates) -> Int32
 
 // CHECK-LABEL: sil hidden_external [clang HasMemberTemplates._ZN18HasMemberTemplates6addAllIiiEEiiT_T0_] @_ZN18HasMemberTemplates6addAllIiiEEiiT_T0_ : $@convention(c) (Int32, Int32, Int32, @inout HasMemberTemplates) -> Int32
 

--- a/test/Interop/Cxx/templates/member-templates-silgen.swift
+++ b/test/Interop/Cxx/templates/member-templates-silgen.swift
@@ -2,7 +2,6 @@
 
 // We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: OS=windows-msvc
-// REQUIRES: fixing-after-30630
 
 import MemberTemplates
 


### PR DESCRIPTION
This test was disabled until #30630 (support calling C++ constructors) landed. That patch landed a while ago, so this test should be enabled.