### PR TITLE
[cxx-interop] Correctly import static function templates.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -121,7 +121,8 @@ static ConcreteDeclRef generateDeclRefForSpecializedCXXFunctionTemplate(
   // In either case, we only want the result of that function type because that
   // is the function type with the generic params that need to be substituted:
   //   (Generic) -> CType
-  if (isa<ConstructorDecl>(oldDecl) || oldDecl->isInstanceMember())
+  if (isa<ConstructorDecl>(oldDecl) || oldDecl->isInstanceMember() ||
+      oldDecl->isStatic())
     newFnType = cast<FunctionType>(newFnType->getResult().getPointer());
   SmallVector<ParamDecl *, 4> newParams;
   unsigned i = 0;
@@ -162,6 +163,10 @@ static ConcreteDeclRef generateDeclRefForSpecializedCXXFunctionTemplate(
       /*Async=*/false, oldDecl->hasThrows(), newParamList,
       newFnType->getResult(), /*GenericParams=*/nullptr,
       oldDecl->getDeclContext(), specialized);
+  if (oldDecl->isStatic()) {
+    newFnDecl->setStatic();
+    newFnDecl->setImportAsStaticMember();
+  }
   newFnDecl->setSelfAccessKind(cast<FuncDecl>(oldDecl)->getSelfAccessKind());
   return ConcreteDeclRef(newFnDecl);
 }

--- a/test/Interop/Cxx/templates/Inputs/member-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/member-templates.h
@@ -33,4 +33,10 @@ template <class T> struct TemplateClassWithMemberTemplates {
 
 using IntWrapper = TemplateClassWithMemberTemplates<int>;
 
+struct HasStaticMemberTemplates {
+  template <class T> static T add(T a, T b) { return a + b; }
+  template <class T, class U> static T addTwoTemplates(T a, U b) { return a + b; }
+  template <class T> static T removeReference(T &a) { return a; }
+};
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_MEMBER_TEMPLATES_H

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -19,3 +19,10 @@
 // CHECK: }
 
 // CHECK: typealias IntWrapper = __CxxTemplateInst32TemplateClassWithMemberTemplatesIiE
+
+// CHECK: struct HasStaticMemberTemplates {
+// CHECK:   init()
+// CHECK:   static func add<T>(_ a: T, _ b: T) -> T
+// CHECK:   static func addTwoTemplates<T, U>(_ a: T, _ b: U) -> T
+// CHECK:   static func removeReference<T>(_ a: UnsafeMutablePointer<T>) -> T
+// CHECK: }

--- a/test/Interop/Cxx/templates/member-templates-silgen.swift
+++ b/test/Interop/Cxx/templates/member-templates-silgen.swift
@@ -47,3 +47,29 @@ func testSetValue() {
   var w = IntWrapper(11)
   w.setValue(42)
 }
+
+// CHECK-LABEL: sil hidden @$s4main17testStaticMembersyyF : $@convention(thin) () -> ()
+
+// CHECK: [[ADD_FN:%.*]] = function_ref @_ZN24HasStaticMemberTemplates3addIlEET_S1_S1_ : $@convention(c) (Int, Int) -> Int
+// CHECK: apply [[ADD_FN]]({{.*}}) : $@convention(c) (Int, Int) -> Int
+
+// CHECK: [[ADD_TWO_TEMPLATES_FN:%.*]] = function_ref @_ZN24HasStaticMemberTemplates15addTwoTemplatesIlcEET_S1_T0_ : $@convention(c) (Int, Int8) -> Int
+// CHECK: apply [[ADD_TWO_TEMPLATES_FN]]({{.*}}) : $@convention(c) (Int, Int8) -> Int
+
+// CHECK: [[REMOVE_REFERENCE_FN:%.*]] = function_ref @_ZN24HasStaticMemberTemplates15removeReferenceIlEET_RS1_ : $@convention(c) (UnsafeMutablePointer<Int>) -> Int
+// CHECK: apply [[REMOVE_REFERENCE_FN]]({{.*}}) : $@convention(c) (UnsafeMutablePointer<Int>) -> Int
+
+// CHECK-LABEL: end sil function '$s4main17testStaticMembersyyF'
+func testStaticMembers() {
+  var x: Int = 0
+  let y: CChar = 0
+  HasStaticMemberTemplates.add(x, x)
+  HasStaticMemberTemplates.addTwoTemplates(x, y)
+  HasStaticMemberTemplates.removeReference(&x)
+}
+
+// CHECK: sil hidden_external [clang HasStaticMemberTemplates._ZN24HasStaticMemberTemplates3addIlEET_S1_S1_] @_ZN24HasStaticMemberTemplates3addIlEET_S1_S1_ : $@convention(c) (Int, Int) -> Int
+
+// CHECK: sil hidden_external [clang HasStaticMemberTemplates._ZN24HasStaticMemberTemplates15addTwoTemplatesIlcEET_S1_T0_] @_ZN24HasStaticMemberTemplates15addTwoTemplatesIlcEET_S1_T0_ : $@convention(c) (Int, Int8) -> Int
+
+// CHECK: sil hidden_external [clang HasStaticMemberTemplates._ZN24HasStaticMemberTemplates15removeReferenceIlEET_RS1_] @_ZN24HasStaticMemberTemplates15removeReferenceIlEET_RS1_ : $@convention(c) (UnsafeMutablePointer<Int>) -> Int


### PR DESCRIPTION
Handle static members the same way we handle other member function templates. Also, set the "static"ness of the new (specialized) function decl.