### PR TITLE
SIL: Use TinyPtrVector for the argument list in SILBasicBlock

### DIFF
--- a/include/swift/SIL/LinearLifetimeChecker.h
+++ b/include/swift/SIL/LinearLifetimeChecker.h
@@ -17,6 +17,8 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/SmallPtrSet.h"
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -17,6 +17,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"

--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -22,6 +22,7 @@
 #define SWIFT_SIL_PATTERNMATCH_H
 
 #include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILUndef.h"
 namespace swift {
 

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -22,6 +22,7 @@
 #include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILArgument.h"
+#include "llvm/ADT/TinyPtrVector.h"
 
 namespace swift {
 
@@ -49,7 +50,9 @@ private:
   SILSuccessor *PredList;
 
   /// This is the list of basic block arguments for this block.
-  std::vector<SILArgument *> ArgumentList;
+  /// A TinyPtrVector is the right choice, because ~98% of blocks have 0 or 1
+  /// arguments.
+  TinyPtrVector<SILArgument *> ArgumentList;
 
   /// The ordered set of instructions in the SILBasicBlock.
   InstListType InstList;
@@ -178,8 +181,8 @@ public:
   // SILBasicBlock Argument List Inspection and Manipulation
   //===--------------------------------------------------------------------===//
 
-  using arg_iterator = std::vector<SILArgument *>::iterator;
-  using const_arg_iterator = std::vector<SILArgument *>::const_iterator;
+  using arg_iterator = TinyPtrVector<SILArgument *>::iterator;
+  using const_arg_iterator = TinyPtrVector<SILArgument *>::const_iterator;
 
   bool args_empty() const { return ArgumentList.empty(); }
   size_t args_size() const { return ArgumentList.size(); }

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -21,6 +21,7 @@
 #include "swift/Basic/Range.h"
 #include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILArgument.h"
 
 namespace swift {
 
@@ -241,13 +242,9 @@ public:
                                               const ValueDecl *D = nullptr,
                                               bool disableEntryBlockVerification = false);
 
-  SILFunctionArgument *insertFunctionArgument(unsigned Index, SILType Ty,
+  SILFunctionArgument *insertFunctionArgument(unsigned AtArgPos, SILType Ty,
                                               ValueOwnershipKind OwnershipKind,
-                                              const ValueDecl *D = nullptr) {
-    arg_iterator Pos = ArgumentList.begin();
-    std::advance(Pos, Index);
-    return insertFunctionArgument(Pos, Ty, OwnershipKind, D);
-  }
+                                              const ValueDecl *D = nullptr);
 
   /// Replace the \p{i}th Function arg with a new Function arg with SILType \p
   /// Ty and ValueDecl \p D.
@@ -277,18 +274,10 @@ public:
                                     const ValueDecl *D = nullptr);
 
   /// Insert a new SILPhiArgument with type \p Ty and \p Decl at position \p
-  /// Pos.
-  SILPhiArgument *insertPhiArgument(arg_iterator Pos, SILType Ty,
+  /// AtArgPos.
+  SILPhiArgument *insertPhiArgument(unsigned AtArgPos, SILType Ty,
                                     ValueOwnershipKind Kind,
                                     const ValueDecl *D = nullptr);
-
-  SILPhiArgument *insertPhiArgument(unsigned Index, SILType Ty,
-                                    ValueOwnershipKind Kind,
-                                    const ValueDecl *D = nullptr) {
-    arg_iterator Pos = ArgumentList.begin();
-    std::advance(Pos, Index);
-    return insertPhiArgument(Pos, Ty, Kind, D);
-  }
 
   /// Remove all block arguments.
   void dropAllArguments() { ArgumentList.clear(); }
@@ -456,12 +445,6 @@ private:
   void insertArgument(arg_iterator Iter, SILArgument *Arg) {
     ArgumentList.insert(Iter, Arg);
   }
-
-  /// Insert a new SILFunctionArgument with type \p Ty and \p Decl at position
-  /// \p Pos.
-  SILFunctionArgument *insertFunctionArgument(arg_iterator Pos, SILType Ty,
-                                              ValueOwnershipKind OwnershipKind,
-                                              const ValueDecl *D = nullptr);
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -33,23 +33,6 @@ SILArgument::SILArgument(ValueKind subClassKind,
   inputParentBlock->insertArgument(inputParentBlock->args_end(), this);
 }
 
-SILArgument::SILArgument(ValueKind subClassKind,
-                         SILBasicBlock *inputParentBlock,
-                         SILBasicBlock::arg_iterator argArrayInsertPt,
-                         SILType type, ValueOwnershipKind ownershipKind,
-                         const ValueDecl *inputDecl)
-    : ValueBase(subClassKind, type, IsRepresentative::Yes),
-      parentBlock(inputParentBlock), decl(inputDecl) {
-  Bits.SILArgument.VOKind = static_cast<unsigned>(ownershipKind);
-  // Function arguments need to have a decl.
-  assert(!inputParentBlock->getParent()->isBare() &&
-                 inputParentBlock->getParent()->size() == 1
-             ? decl != nullptr
-             : true);
-  inputParentBlock->insertArgument(argArrayInsertPt, this);
-}
-
-
 SILFunction *SILArgument::getFunction() {
   return getParent()->getParent();
 }
@@ -61,6 +44,33 @@ const SILFunction *SILArgument::getFunction() const {
 SILModule &SILArgument::getModule() const {
   return getFunction()->getModule();
 }
+
+unsigned SILArgument::getIndex() const {
+  for (auto p : llvm::enumerate(getParent()->getArguments())) {
+    if (p.value() == this) {
+      return p.index();
+    }
+  }
+  llvm_unreachable("SILArgument not argument of its parent BB");
+}
+
+bool SILFunctionArgument::isIndirectResult() const {
+  auto numIndirectResults =
+      getFunction()->getConventions().getNumIndirectSILResults();
+  return getIndex() < numIndirectResults;
+}
+
+SILArgumentConvention SILFunctionArgument::getArgumentConvention() const {
+  return getFunction()->getConventions().getSILArgumentConvention(getIndex());
+}
+
+/// Given that this is an entry block argument, and given that it does
+/// not correspond to an indirect result, return the corresponding
+/// SILParameterInfo.
+SILParameterInfo SILFunctionArgument::getKnownParameterInfo() const {
+  return getFunction()->getConventions().getParamInfoForSILArg(getIndex());
+}
+
 
 //===----------------------------------------------------------------------===//
 //                              SILBlockArgument

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -193,7 +193,7 @@ SILFunctionArgument *SILBasicBlock::replaceFunctionArgument(
 
   // TODO: When we switch to malloc/free allocation we'll be leaking memory
   // here.
-  ArgumentList[i] = NewArg;
+  *(ArgumentList.begin() + i) = NewArg;
 
   return NewArg;
 }
@@ -219,7 +219,7 @@ SILPhiArgument *SILBasicBlock::replacePhiArgument(unsigned i, SILType Ty,
 
   // TODO: When we switch to malloc/free allocation we'll be leaking memory
   // here.
-  ArgumentList[i] = NewArg;
+  *(ArgumentList.begin() + i) = NewArg;
 
   return NewArg;
 }

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -163,12 +163,15 @@ SILBasicBlock::createFunctionArgument(SILType Ty, const ValueDecl *D,
   return new (getModule()) SILFunctionArgument(this, Ty, OwnershipKind, D);
 }
 
-SILFunctionArgument *SILBasicBlock::insertFunctionArgument(arg_iterator Iter,
+SILFunctionArgument *SILBasicBlock::insertFunctionArgument(unsigned AtArgPos,
                                                            SILType Ty,
                                                            ValueOwnershipKind OwnershipKind,
                                                            const ValueDecl *D) {
   assert(isEntry() && "Function Arguments can only be in the entry block");
-  return new (getModule()) SILFunctionArgument(this, Iter, Ty, OwnershipKind, D);
+  auto *arg = new (getModule()) SILFunctionArgument(Ty, OwnershipKind, D);
+  arg->parentBlock = this;
+  insertArgument(ArgumentList.begin() + AtArgPos, arg);
+  return arg;
 }
 
 SILFunctionArgument *SILBasicBlock::replaceFunctionArgument(
@@ -255,13 +258,16 @@ SILPhiArgument *SILBasicBlock::createPhiArgument(SILType Ty,
   return new (getModule()) SILPhiArgument(this, Ty, Kind, D);
 }
 
-SILPhiArgument *SILBasicBlock::insertPhiArgument(arg_iterator Iter, SILType Ty,
+SILPhiArgument *SILBasicBlock::insertPhiArgument(unsigned AtArgPos, SILType Ty,
                                                  ValueOwnershipKind Kind,
                                                  const ValueDecl *D) {
   assert(!isEntry() && "PHI Arguments can not be in the entry block");
   if (Ty.isTrivial(*getParent()))
     Kind = OwnershipKind::None;
-  return new (getModule()) SILPhiArgument(this, Iter, Ty, Kind, D);
+  auto *arg = new (getModule()) SILPhiArgument(Ty, Kind, D);
+  arg->parentBlock = this;
+  insertArgument(ArgumentList.begin() + AtArgPos, arg);
+  return arg;
 }
 
 void SILBasicBlock::eraseArgument(int Index) {

--- a/lib/SILOptimizer/ARC/RCStateTransition.cpp
+++ b/lib/SILOptimizer/ARC/RCStateTransition.cpp
@@ -14,6 +14,7 @@
 
 #include "RCStateTransition.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILFunction.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Debug.h"
 


### PR DESCRIPTION
A TinyPtrVector is the right choice, because ~98% of blocks have 0 or 1 arguments.

This change also required to fix a header-file layering violation.