### PR TITLE
[Stats] Fix a second/nanoseconds bug in process-stats-dir

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1965,7 +1965,7 @@ config.substitutions.append(('%round-trip-syntax-test',
                                         config.round_trip_syntax_test)))
 config.substitutions.append(('%rth', '%s %s' % (shell_quote(sys.executable), config.rth)))
 config.substitutions.append(('%scale-test',
-                             '{} {} --swiftc-binary={} --tmpdir=%t'.format(
+                             '{} {} --swiftc-binary={} --tmpdir=%t --exclude-timers'.format(
                                  shell_quote(sys.executable), config.scale_test,
                                  config.swiftc)))
 config.substitutions.append(('%empty-directory\(([^)]+)\)',

--- a/utils/jobstats/jobstats.py
+++ b/utils/jobstats/jobstats.py
@@ -328,11 +328,12 @@ def load_stats_dir(path, select_module=[], select_stat=[],
             for (k, v) in j.items():
                 if sre.search(k) is None:
                     continue
+                if k.startswith('time.'):
+                    v = int(1000000.0 * float(v))
                 if k.startswith('time.') and exclude_timers:
                     continue
                 tm = match_timerpat(k)
                 if tm:
-                    v = int(1000000.0 * float(v))
                     if tm['jobkind'] == jobkind and \
                        tm['timerkind'] == 'wall':
                         dur_usec = v

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -175,7 +175,8 @@ def run_once_with_primary(args, ast, rng, primary_idx):
         if not args.save_temps:
             shutil.rmtree(d)
 
-    return {k: v for (k, v) in r.items() if args.select in k}
+    return {k: v for (k, v) in r.items() if args.select in k and 
+            not (args.exclude_timers and k.startswith('time.'))}
 
 
 def run_once(args, ast, rng):
@@ -759,6 +760,10 @@ def main():
     parser.add_argument(
         '--select',
         default="", help='substring of counters/symbols to limit attention to')
+    parser.add_argument(
+        '--exclude-timers', action="store_true",
+        default=False, help='Exclude timers (starting with \'time.\') from the '
+                            'analysis')
     parser.add_argument(
         '--debug', action='store_true',
         default=False, help='invoke lldb on each scale test')


### PR DESCRIPTION
Times are expected to be represented in nanoseconds in process-stats-dir, but times with the 'swift.time.' prefix (e.g. times for specific requests) were not converted.

It appears the reasons that this hasn’t been caught so far, is that these times are not shown in Swift-CI's please test compiler performance report.

Because of this bug (almost) all the timers returned `process-stats-dir.py` were zero and thus the values for the timing always passed `scale-test`. Fixing the bug made a bunch of `scale-test` fail non-deterministically because the timings are too noisy. To fix this, I’ve added an option `--exclude-timers` to `scale-test` which explicitly ignores any values that start with `time.`.