### PR TITLE
Update guide to mention correct subdirectory

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -68,7 +68,8 @@ toolchain as a one-off, there are a couple of differences:
      If you plan on contributing regularly, cloning over SSH provides a better
      experience. After you've [uploaded your SSH keys to GitHub][]:
      ```sh
-     git clone git@github.com:apple/swift.git .
+     git clone git@github.com:apple/swift.git swift
+     cd swift
      utils/update-checkout --clone-with-ssh
      ```
    - Via HTTPS:
@@ -76,7 +77,8 @@ toolchain as a one-off, there are a couple of differences:
      or are not familiar with setting up SSH,
      you can use HTTPS instead:
      ```sh
-     git clone https://github.com/apple/swift.git .
+     git clone https://github.com/apple/swift.git swift
+     cd swift
      utils/update-checkout --clone
      ```
    **Note:** If you've already forked the project on GitHub at this stage,


### PR DESCRIPTION
The guide as written results in lots of repositories being placed as siblings to `swift-project`, instead of inside of it. This also results in the `build` directory being a sibling. Changing the clone to the `swift` directory fixes this.