### PR TITLE
Revert "[Concurrency] isCanceled spelling to follow guidance"

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -93,9 +93,9 @@ static_assert(alignof(Job) == 2 * alignof(void*),
 /// The current state of a task's status records.
 class ActiveTaskStatus {
   enum : uintptr_t {
-    IsCanceled = 0x1,
+    IsCancelled = 0x1,
     IsLocked = 0x2,
-    RecordMask = ~uintptr_t(IsCanceled | IsLocked)
+    RecordMask = ~uintptr_t(IsCancelled | IsLocked)
   };
 
   uintptr_t Value;
@@ -106,10 +106,10 @@ public:
                    bool cancelled, bool locked)
     : Value(reinterpret_cast<uintptr_t>(innermostRecord)
                 + (locked ? IsLocked : 0)
-                + (cancelled ? IsCanceled : 0)) {}
+                + (cancelled ? IsCancelled : 0)) {}
 
   /// Is the task currently cancelled?
-  bool isCanceled() const { return Value & IsCanceled; }
+  bool isCancelled() const { return Value & IsCancelled; }
 
   /// Is there an active lock on the cancellation information?
   bool isLocked() const { return Value & IsLocked; }
@@ -178,8 +178,8 @@ public:
 
   /// Check whether this task has been cancelled.
   /// Checking this is, of course, inherently race-prone on its own.
-  bool isCanceled() const {
-    return Status.load(std::memory_order_relaxed).isCanceled();
+  bool isCancelled() const {
+    return Status.load(std::memory_order_relaxed).isCancelled();
   }
 
   /// A fragment of an async task structure that happens to be a child task.

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -223,7 +223,7 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 size_t swift_task_getJobFlags(AsyncTask* task);
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-bool swift_task_isCanceled(AsyncTask* task);
+bool swift_task_isCancelled(AsyncTask* task);
 
 /// This should have the same representation as an enum like this:
 ///    enum NearestTaskDeadline {

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -526,8 +526,8 @@ void swift::swift_continuation_throwingResumeWithError(/* +1 */ SwiftError *erro
   resumeTaskAfterContinuation(task, context);
 }
 
-bool swift::swift_task_isCanceled(AsyncTask *task) {
-  return task->isCanceled();
+bool swift::swift_task_isCancelled(AsyncTask *task) {
+  return task->isCancelled();
 }
 
 SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -317,7 +317,7 @@ func getJobFlags(_ task: Builtin.NativeObject) -> Task.JobFlags
 @usableFromInline
 func _enqueueJobGlobal(_ task: Builtin.Job)
 
-@_silgen_name("swift_task_isCanceled")
+@_silgen_name("swift_task_isCancelled")
 func isTaskCancelled(_ task: Builtin.NativeObject) -> Bool
 
 @_silgen_name("swift_task_runAndBlockThread")
@@ -415,8 +415,8 @@ public func _runGroupChildTask<T>(
 @_silgen_name("swift_task_cancel")
 func _taskCancel(_ task: Builtin.NativeObject)
 
-@_silgen_name("swift_task_isCanceled")
-func _taskIsCanceled(_ task: Builtin.NativeObject) -> Bool
+@_silgen_name("swift_task_isCancelled")
+func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
 #if _runtime(_ObjC)
 

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -24,8 +24,8 @@ extension Task {
   ///
   /// - SeeAlso: `checkCancellation()`
   /* @instantaneous */
-  public static func isCanceled() async -> Bool {
-     _taskIsCanceled(Builtin.getCurrentAsyncTask())
+  public static func isCancelled() async -> Bool {
+     _taskIsCancelled(Builtin.getCurrentAsyncTask())
   }
 
   /// Check if the task is cancelled and throw an `CancellationError` if it was.
@@ -41,10 +41,10 @@ extension Task {
   /// ### Suspension
   /// This function returns instantly and will never suspend.
   ///
-  /// - SeeAlso: `isCanceled()`
+  /// - SeeAlso: `isCancelled()`
   /* @instantaneous */
   public static func checkCancellation() async throws {
-    if await Task.isCanceled() {
+    if await Task.isCancelled() {
       throw CancellationError()
     }
   }
@@ -108,7 +108,7 @@ extension Task {
   /// regardless of the inner deadlines of the specific child tasks.
   ///
   /// Cancellation is co-operative and must be checked for by the operation, e.g.
-  /// by invoking `Task.checkCancellation`, or `Task.isCanceled`.
+  /// by invoking `Task.checkCancellation`, or `Task.isCancelled`.
   ///
   /// ### Suspension
   /// This function returns instantly and will never suspend.
@@ -135,7 +135,7 @@ extension Task {
   /// regardless of the inner deadlines of the specific child tasks.
   ///
   /// Cancellation is co-operative and must be checked for by the operation, e.g.
-  /// by invoking `Task.checkCancellation` or `Task.isCanceled`.
+  /// by invoking `Task.checkCancellation` or `Task.isCancelled`.
   ///
   /// ### Suspension
   /// This function returns instantly and will never suspend.

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -226,7 +226,7 @@ extension Task {
     ///
     /// - SeeAlso: `Task.addCancellationHandler`
     /// - SeeAlso: `Task.checkCancelled`
-    /// - SeeAlso: `Task.isCanceled`
+    /// - SeeAlso: `Task.isCancelled`
     public mutating func cancelAll() {
       _taskCancel(self.task) // TODO: do we also have to go over all child tasks and cancel there?
     }

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -184,7 +184,7 @@ static void waitForStatusRecordUnlock(AsyncTask *task,
 /// If `forCancellation` is true, the cancelled bit will be set in the
 /// state, and the lock will not be acquired if the task is already
 /// cancelled or can be cancelled without the lock.  If this occurs,
-/// `isCanceled()` will be true for the return value.
+/// `isCancelled()` will be true for the return value.
 static ActiveTaskStatus
 acquireStatusRecordLock(AsyncTask *task,
                         Optional<StatusRecordLockRecord> &recordLockRecord,
@@ -204,7 +204,7 @@ acquireStatusRecordLock(AsyncTask *task,
     // Cancellation should be idempotent: if the task has already
     // been cancelled (or is being cancelled concurrently), there
     // shouldn't be any need to do this work again.
-    if (oldStatus.isCanceled() && forCancellation)
+    if (oldStatus.isCancelled() && forCancellation)
       return oldStatus;
 
     // If the old info says we're locked, wait for the lock to clear.
@@ -238,9 +238,9 @@ acquireStatusRecordLock(AsyncTask *task,
 
     // Install the lock record as the active cancellation info, or
     // restart if that fails.
-    bool newIsCanceled = forCancellation || oldStatus.isCanceled();
+    bool newIsCancelled = forCancellation || oldStatus.isCancelled();
     ActiveTaskStatus newStatus(&*recordLockRecord,
-                               /*cancelled*/ newIsCanceled,
+                               /*cancelled*/ newIsCancelled,
                                /*locked*/ true);
     if (task->Status.compare_exchange_weak(oldStatus, newStatus,
            /*success*/ std::memory_order_release,
@@ -288,12 +288,12 @@ bool swift::swift_task_addStatusRecord(AsyncTask *task,
     // We have to use a release on success to make the initialization of
     // the new record visible to the cancelling thread.
     ActiveTaskStatus newStatus(newRecord,
-                               oldStatus.isCanceled(),
+                               oldStatus.isCancelled(),
                                /*locked*/ false);
     if (task->Status.compare_exchange_weak(oldStatus, newStatus,
            /*success*/ std::memory_order_release,
            /*failure*/ std::memory_order_relaxed))
-      return !oldStatus.isCanceled();
+      return !oldStatus.isCancelled();
   }
 }
 
@@ -305,14 +305,14 @@ bool swift::swift_task_tryAddStatusRecord(AsyncTask *task,
 
   while (true) {
     // If the old info is already cancelled, do nothing.
-    if (oldStatus.isCanceled())
+    if (oldStatus.isCancelled())
       return false;
 
     // Wait for any active lock to be released.
     if (oldStatus.isLocked()) {
       waitForStatusRecordUnlock(task, oldStatus);
 
-      if (oldStatus.isCanceled())
+      if (oldStatus.isCancelled())
         return false;
     }
 
@@ -345,12 +345,12 @@ bool swift::swift_task_removeStatusRecord(AsyncTask *task,
     // If the record is the innermost record, try to just pop it off.
     if (oldStatus.getInnermostRecord() == record) {
       ActiveTaskStatus newStatus(record->getParent(),
-                                 oldStatus.isCanceled(),
+                                 oldStatus.isCancelled(),
                                  /*locked*/ false);
       if (task->Status.compare_exchange_weak(oldStatus, newStatus,
              /*success*/ std::memory_order_release,
              /*failure*/ std::memory_order_relaxed))
-        return !oldStatus.isCanceled();
+        return !oldStatus.isCancelled();
 
       // Otherwise, restart.
       continue;
@@ -389,7 +389,7 @@ bool swift::swift_task_removeStatusRecord(AsyncTask *task,
   // exactly what we want to restore.
   releaseStatusRecordLock(task, oldStatus, recordLockRecord);
 
-  return !oldStatus.isCanceled();
+  return !oldStatus.isCancelled();
 }
 
 /**************************************************************************/
@@ -443,7 +443,7 @@ void swift::swift_task_cancel(AsyncTask *task) {
 
   // If we were already cancelled or were able to cancel without acquiring
   // the lock, there's nothing else to do.
-  if (oldStatus.isCanceled())
+  if (oldStatus.isCancelled())
     return;
 
   // Otherwise, we've installed the lock record and are now the
@@ -561,7 +561,7 @@ NearestTaskDeadline swift::swift_task_getNearestDeadline(AsyncTask *task) {
   NearestTaskDeadline result;
 
   // If it's already cancelled, we're done.
-  if (oldStatus.isCanceled()) {
+  if (oldStatus.isCancelled()) {
     result.ValueKind = NearestTaskDeadline::AlreadyCancelled;
     return result;
   }

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -15,7 +15,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
       await group.add { () async -> Int in
         sleep(1)
         print("  inside group.add { \(n) }")
-        let cancelled = await Task.isCanceled()
+        let cancelled = await Task.isCancelled()
         print("  inside group.add { \(n) } (canceled: \(cancelled))")
         return n
       }
@@ -24,7 +24,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
     group.cancelAll()
 
     // return immediately; the group should wait on the tasks anyway
-    print("return immediately 0 (canceled: \(await Task.isCanceled()))")
+    print("return immediately 0 (canceled: \(await Task.isCancelled()))")
     return 0
   }
 

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
@@ -14,13 +14,13 @@ func test_skipCallingNext() async {
       print("group.add { \(n) }")
       await group.add { () async -> Int in
         sleep(1)
-        print("  inside group.add { \(n) } (canceled: \(await Task.isCanceled()))")
+        print("  inside group.add { \(n) } (canceled: \(await Task.isCancelled()))")
         return n
       }
     }
 
     // return immediately; the group should wait on the tasks anyway
-    print("return immediately 0 (canceled: \(await Task.isCanceled()))")
+    print("return immediately 0 (canceled: \(await Task.isCancelled()))")
     return 0
   }
 

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -39,7 +39,7 @@ func test_taskGroup_throws() async {
         print("error caught in group: \(error)")
 
         await group.add { () async -> Int in
-          print("task 3 (cancelled: \(await Task.isCanceled()))")
+          print("task 3 (cancelled: \(await Task.isCancelled()))")
           return 3
         }
 

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -10,8 +10,8 @@ func test_cancellation_checkCancellation() async throws {
   try await Task.checkCancellation()
 }
 
-func test_cancellation_guard_isCanceled(_ any: Any) async -> PictureData {
-  guard await !Task.isCanceled() else {
+func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
+  guard await !Task.isCancelled() else {
     return PictureData.failedToLoadImagePlaceholder
   }
 
@@ -29,7 +29,7 @@ func test_cancellation_withCancellationHandler(_ anything: Any) async -> Picture
     return try await Task.withCancellationHandler(
       handler: { file.close() },
       operation: {
-      await test_cancellation_guard_isCanceled(file)
+      await test_cancellation_guard_isCancelled(file)
     })
   }
 
@@ -41,7 +41,7 @@ func test_cancellation_loop() async -> Int {
 
   let tasks = [SampleTask(), SampleTask()]
   var processed = 0
-  for t in tasks where await !Task.isCanceled() {
+  for t in tasks where await !Task.isCancelled() {
     await t.process()
     processed += 1
   }

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -6,7 +6,7 @@ func asyncThrowsFunc() async throws -> Int { 42 }
 func asyncThrowsOnCancel() async throws -> Int {
   // terrible suspend-spin-loop -- do not do this
   // only for purposes of demonstration
-  while await !Task.isCanceled() {
+  while await !Task.isCancelled() {
     await Task.sleep(until: Task.Deadline.in(.seconds(1)))
   }
 

--- a/unittests/runtime/TaskStatus.cpp
+++ b/unittests/runtime/TaskStatus.cpp
@@ -127,11 +127,11 @@ TEST(TaskStatusTest, cancellation_simple) {
   withSimpleTask(Storage{47},
     [&](AsyncTask *task, ExecutorRef executor,
         ValueContext<Storage> *context) {
-    EXPECT_FALSE(task->isCanceled());
+    EXPECT_FALSE(task->isCancelled());
     swift_task_cancel(task);
-    EXPECT_TRUE(task->isCanceled());
+    EXPECT_TRUE(task->isCancelled());
     swift_task_cancel(task);
-    EXPECT_TRUE(task->isCanceled());
+    EXPECT_TRUE(task->isCancelled());
   }, [&](AsyncTask *task) {
     task->run(createFakeExecutor(1234));
   });
@@ -145,7 +145,7 @@ TEST(TaskStatusTest, deadline) {
   withSimpleTask(Storage{47},
     [&](AsyncTask *task, ExecutorRef executor,
         ValueContext<Storage> *context) {
-    EXPECT_FALSE(task->isCanceled());
+    EXPECT_FALSE(task->isCancelled());
 
     TaskDeadline deadlineOne = { 1234 };
     TaskDeadline deadlineTwo = { 2345 };
@@ -252,7 +252,7 @@ TEST(TaskStatusTest, deadline) {
 
     // Cancel.
     swift_task_cancel(task);
-    EXPECT_TRUE(task->isCanceled());
+    EXPECT_TRUE(task->isCancelled());
 
     // We should report already cancelled now.
     nearest = swift_task_getNearestDeadline(task);
@@ -277,7 +277,7 @@ TEST(TaskStatusTest, deadline) {
     nearest = swift_task_getNearestDeadline(task);
     EXPECT_EQ(NearestTaskDeadline::AlreadyCancelled, nearest.ValueKind);
 
-    EXPECT_TRUE(task->isCanceled());
+    EXPECT_TRUE(task->isCancelled());
   }, [&](AsyncTask *task) {
     task->run(createFakeExecutor(1234));
   });


### PR DESCRIPTION
Reverts apple/swift#35549