### PR TITLE
[Parse] Diagnose default argument for subscript in protocols

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -791,6 +791,8 @@ ERROR(protocol_method_argument_init,none,
       "default argument not permitted in a protocol method", ())
 ERROR(protocol_init_argument_init,none,
       "default argument not permitted in a protocol initializer", ())
+ERROR(protocol_subscript_argument_init,none,
+      "default argument not permitted in a protocol subscript", ())
 ERROR(tuple_type_multiple_labels,none,
       "tuple element cannot have two labels", ())
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7416,6 +7416,12 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
 
   diagnoseWhereClauseInGenericParamList(GenericParams);
 
+  // Protocol requirement arguments may not have default values.
+  if (Flags.contains(PD_InProtocol) && DefaultArgs.HasDefaultArgument) {
+    diagnose(SubscriptLoc, diag::protocol_subscript_argument_init);
+    return nullptr;
+  }
+
   // Build an AST for the subscript declaration.
   DeclName name = DeclName(Context, DeclBaseName::createSubscript(),
                            argumentNames);

--- a/test/decl/protocol/protocol_with_default_args.swift
+++ b/test/decl/protocol/protocol_with_default_args.swift
@@ -11,4 +11,5 @@ struct X : P {
 
 protocol Q {
   init(truth: Bool = false) // expected-error{{default argument not permitted in a protocol initializer}}
+  subscript(x: Int, default: Int = 0) -> Self { get } // expected-error {{default argument not permitted in a protocol subscript}}
 }


### PR DESCRIPTION
Protocol requirements don't support default arguments. Although this is a "semantic" diagnostics, we currently do this for 'func' and 'init' in Parser. So for fixing a crash, for now, let's to it for 'subscript' in Parser too.

rdar://problem/73159041
