### PR TITLE
[Test] Ran some execution tests on more platforms.

### DIFF
--- a/test/IRGen/prespecialized-metadata/class-class-flags-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-class-flags-run.swift
@@ -5,12 +5,10 @@
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main
 
-// REQUIRES: OS=macosx
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: swift_test_mode_optimize
 // UNSUPPORTED: swift_test_mode_optimize_size
-// UNSUPPORTED: remote_run
 
 func ptr<T>(to ty: T.Type) -> UnsafeMutableRawPointer {
     UnsafeMutableRawPointer(mutating: unsafePointerToMetadata(of: ty))!

--- a/test/IRGen/prespecialized-metadata/enum-extradata-run.swift
+++ b/test/IRGen/prespecialized-metadata/enum-extradata-run.swift
@@ -1,14 +1,15 @@
 // RUN: %empty-directory(%t)
 // RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/extraDataFields.cpp -o %t/extraDataFields.o -I %clang-include-dir -I %swift_src_root/include/ -I %llvm_src_root/include -I %llvm_obj_root/include -L %clang-include-dir/../lib/swift/macosx
 
-// RUN: %target-build-swift -c %S/Inputs/enum-extra-data-fields.swift -emit-library -emit-module -enable-library-evolution -module-name ExtraDataFieldsNoTrailingFlags -target %module-target-future -Xfrontend -disable-generic-metadata-prespecialization -emit-module-path %t/ExtraDataFieldsNoTrailingFlags.swiftmodule -o %t/%target-library-name(ExtraDataFieldsNoTrailingFlags)
-// RUN: %target-build-swift -c %S/Inputs/enum-extra-data-fields.swift -emit-library -emit-module -enable-library-evolution -module-name ExtraDataFieldsTrailingFlags -target %module-target-future -Xfrontend -prespecialize-generic-metadata -emit-module-path %t/ExtraDataFieldsTrailingFlags.swiftmodule -o %t/%target-library-name(ExtraDataFieldsTrailingFlags)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ExtraDataFieldsNoTrailingFlags)) %S/Inputs/enum-extra-data-fields.swift -emit-module -enable-library-evolution -module-name ExtraDataFieldsNoTrailingFlags -target %module-target-future -Xfrontend -disable-generic-metadata-prespecialization -emit-module-path %t/ExtraDataFieldsNoTrailingFlags.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(ExtraDataFieldsNoTrailingFlags)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ExtraDataFieldsTrailingFlags)) %S/Inputs/enum-extra-data-fields.swift -emit-module -enable-library-evolution -module-name ExtraDataFieldsTrailingFlags -target %module-target-future -Xfrontend -prespecialize-generic-metadata -emit-module-path %t/ExtraDataFieldsTrailingFlags.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(ExtraDataFieldsTrailingFlags)
 // RUN: %target-build-swift -v %mcp_opt %s %t/extraDataFields.o -import-objc-header %S/Inputs/extraDataFields.h -Xfrontend -disable-generic-metadata-prespecialization -target %module-target-future -lc++ -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main -I %t -L %t -lExtraDataFieldsTrailingFlags -lExtraDataFieldsNoTrailingFlags -module-name main
 
 // RUN: %target-codesign %t/main
-// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-run %t/main %t/%target-library-name(ExtraDataFieldsTrailingFlags) %t/%target-library-name(ExtraDataFieldsNoTrailingFlags) | %FileCheck %s
 
-// REQUIRES: OS=macosx
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: swift_test_mode_optimize

--- a/test/IRGen/prespecialized-metadata/struct-extradata-run.swift
+++ b/test/IRGen/prespecialized-metadata/struct-extradata-run.swift
@@ -1,14 +1,15 @@
 // RUN: %empty-directory(%t)
 // RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/extraDataFields.cpp -o %t/extraDataFields.o -I %clang-include-dir -I %swift_src_root/include/ -I %llvm_src_root/include -I %llvm_obj_root/include -L %clang-include-dir/../lib/swift/macosx -I %swift_obj_root/include
 
-// RUN: %target-build-swift -c %S/Inputs/struct-extra-data-fields.swift -emit-library -emit-module -module-name ExtraDataFieldsNoTrailingFlags -target %module-target-future -Xfrontend -disable-generic-metadata-prespecialization -emit-module-path %t/ExtraDataFieldsNoTrailingFlags.swiftmodule -o %t/%target-library-name(ExtraDataFieldsNoTrailingFlags)
-// RUN: %target-build-swift -c %S/Inputs/struct-extra-data-fields.swift -emit-library -emit-module -module-name ExtraDataFieldsTrailingFlags -target %module-target-future -Xfrontend -prespecialize-generic-metadata -emit-module-path %t/ExtraDataFieldsTrailingFlags.swiftmodule -o %t/%target-library-name(ExtraDataFieldsTrailingFlags)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ExtraDataFieldsNoTrailingFlags)) %S/Inputs/struct-extra-data-fields.swift -emit-module -module-name ExtraDataFieldsNoTrailingFlags -target %module-target-future -Xfrontend -disable-generic-metadata-prespecialization -emit-module-path %t/ExtraDataFieldsNoTrailingFlags.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(ExtraDataFieldsNoTrailingFlags)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ExtraDataFieldsTrailingFlags)) %S/Inputs/struct-extra-data-fields.swift -emit-library -emit-module -module-name ExtraDataFieldsTrailingFlags -target %module-target-future -Xfrontend -prespecialize-generic-metadata -emit-module-path %t/ExtraDataFieldsTrailingFlags.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(ExtraDataFieldsTrailingFlags)
 // RUN: %target-build-swift -v %mcp_opt %s %t/extraDataFields.o -import-objc-header %S/Inputs/extraDataFields.h -Xfrontend -disable-generic-metadata-prespecialization -target %module-target-future -lc++ -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main -I %t -L %t -lExtraDataFieldsTrailingFlags -lExtraDataFieldsNoTrailingFlags -module-name main
 
 // RUN: %target-codesign %t/main
-// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-run %t/main %t/%target-library-name(ExtraDataFieldsNoTrailingFlags) %t/%target-library-name(ExtraDataFieldsTrailingFlags) | %FileCheck %s
 
-// REQUIRES: OS=macosx
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: swift_test_mode_optimize

--- a/test/IRGen/prespecialized-metadata/struct-outmodule-run.swift
+++ b/test/IRGen/prespecialized-metadata/struct-outmodule-run.swift
@@ -1,19 +1,18 @@
 // RUN: %empty-directory(%t)
 // RUN: %clang -c -v %target-cc-options -g -O0 -isysroot %sdk %S/Inputs/isPrespecialized.cpp -o %t/isPrespecialized.o -I %clang-include-dir -I %swift_src_root/include/ -I %llvm_src_root/include -I %llvm_obj_root/include -L %clang-include-dir/../lib/swift/macosx
 
-// RUN: %target-build-swift %S/Inputs/struct-public-nonfrozen-1argument.swift -emit-module -emit-library -module-name Module -Xfrontend -prespecialize-generic-metadata -target %module-target-future -emit-module-path %t/Module.swiftmodule -o %t/%target-library-name(Module)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Module)) %S/Inputs/struct-public-nonfrozen-1argument.swift -emit-module -emit-library -module-name Module -Xfrontend -prespecialize-generic-metadata -target %module-target-future -emit-module-path %t/Module.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(Module)
 
 // RUN: %target-build-swift -v %mcp_opt %s %S/Inputs/main.swift %S/Inputs/consume-logging-metadata-value.swift %t/isPrespecialized.o -import-objc-header %S/Inputs/isPrespecialized.h -Xfrontend -prespecialize-generic-metadata -target %module-target-future -lc++ -I %t -L %t -lModule -L %clang-include-dir/../lib/swift/macosx -sdk %sdk -o %t/main
 // RUN: %target-codesign %t/main
-// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-run %t/main %t/%target-library-name(Module) | %FileCheck %s
 
 
-// REQUIRES: OS=macosx
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: swift_test_mode_optimize
 // UNSUPPORTED: swift_test_mode_optimize_size
-// UNSUPPORTED: remote_run
 
 import Module
 
@@ -51,27 +50,27 @@ func consumeType_OneArgumentAtFirstUsageDynamic_Dynamic(line: UInt = #line) {
 
 @inline(never)
 func doit() {
-  // CHECK: [[STATIC_METADATA_ADDRESS:[0-9a-f]+]] @ 55
+  // CHECK: [[STATIC_METADATA_ADDRESS:[0-9a-f]+]] @ 54
   consumeType_OneArgumentAtFirstUsageStatic_Static()
-  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 57
+  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 56
   consumeType_OneArgumentAtFirstUsageStatic_Dynamic()
-  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 59
+  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 58
   consumeType_OneArgumentAtFirstUsageStatic_Dynamic()
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ 61
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ 60
   consumeType_OneArgumentAtFirstUsageDynamic_Dynamic()
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ 63
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS:[0-9a-f]+]] @ 62
   consumeType_OneArgumentAtFirstUsageDynamic_Dynamic()
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ 65
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ 64
   consumeType_OneArgumentAtFirstUsageDynamic_Static()
 
   let staticMetadata = ptr(to: OneArgument<FirstUsageStatic>.self)
-  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 69
+  // CHECK: [[STATIC_METADATA_ADDRESS]] @ 68
   print(staticMetadata, "@", #line)
   assert(isStaticallySpecializedGenericMetadata(staticMetadata))
   assert(!isCanonicalStaticallySpecializedGenericMetadata(staticMetadata))
 
   let dynamicMetadata = ptr(to: OneArgument<FirstUsageDynamic>.self)
-  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ 75
+  // CHECK: [[DYNAMIC_METADATA_ADDRESS]] @ 74
   print(dynamicMetadata, "@", #line)
   assert(!isStaticallySpecializedGenericMetadata(dynamicMetadata))
   assert(!isCanonicalStaticallySpecializedGenericMetadata(dynamicMetadata))


### PR DESCRIPTION
A few of the prespecialized metadata execution tests were previously unnecessarily limited to run on only mac.  Here that restriction is lifted, primarily by passing the name of built libraries to %target-run.