### PR TITLE
Fix reflection_Optional_Any test to work on non-Apple platforms

### DIFF
--- a/validation-test/Reflection/reflect_Optional_Any.swift
+++ b/validation-test/Reflection/reflect_Optional_Any.swift
@@ -8,7 +8,6 @@
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=tvos || OS=watchos || OS=ios
 // UNSUPPORTED: use_os_stdlib
 
 import SwiftReflectionTest

--- a/validation-test/Reflection/reflect_Optional_Any.swift
+++ b/validation-test/Reflection/reflect_Optional_Any.swift
@@ -4,7 +4,7 @@
 // RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Optional_Any
 // RUN: %target-codesign %t/reflect_Optional_Any
 
-// RUN: %target-run %target-swift-reflection-test %t/reflect_Optional_Any | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Optional_Any | %FileCheck %s --check-prefix=CHECK-%target-ptrsize %add_num_extra_inhabitants
 
 // REQUIRES: reflection_test_support
 // REQUIRES: executable_test
@@ -31,11 +31,11 @@ reflect(enum: optionalAnyNonNil)
 // CHECK-64:   (protocol_composition))
 
 // CHECK-64: Type info:
-// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=some index=0 offset=0
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))
 // CHECK-64:   (case name=none index=1))
 
 // CHECK-64: Mangled name: $sypSg
@@ -80,11 +80,11 @@ reflect(enum: optionalAnyNil)
 // CHECK-64:   (protocol_composition))
 
 // CHECK-64: Type info:
-// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:   (case name=some index=0 offset=0
-// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:     (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:       (field name=metadata offset=24
-// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
+// CHECK-64:         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))
 // CHECK-64:   (case name=none index=1))
 
 // CHECK-64: Mangled name: $sypSg
@@ -127,13 +127,13 @@ reflect(enum: optionalOptionalAnyNil)
 // CHECK-64:     (protocol_composition)))
 
 // CHECK-64: Type info:
-// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:   (case name=some index=0 offset=0
-// CHECK-64:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=metadata offset=24
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (case name=none index=1))
 
@@ -180,13 +180,13 @@ reflect(enum: optionalOptionalAnySomeNil)
 // CHECK-64:     (protocol_composition)))
 
 // CHECK-64: Type info:
-// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:   (case name=some index=0 offset=0
-// CHECK-64:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=metadata offset=24
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (case name=none index=1))
 
@@ -239,13 +239,13 @@ reflect(enum: optionalOptionalAnyNonNil)
 // CHECK-64:     (protocol_composition)))
 
 // CHECK-64: Type info:
-// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483645 bitwise_takable=1
+// CHECK-64: (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-2]] bitwise_takable=1
 // CHECK-64:   (case name=some index=0 offset=0
-// CHECK-64:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=2147483646 bitwise_takable=1
+// CHECK-64:     (single_payload_enum size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit-1]] bitwise_takable=1
 // CHECK-64:       (case name=some index=0 offset=0
-// CHECK-64:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=2147483647 bitwise_takable=1
+// CHECK-64:         (opaque_existential size=32 alignment=8 stride=32 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1
 // CHECK-64:           (field name=metadata offset=24
-// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=2147483647 bitwise_takable=1))))
+// CHECK-64:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=[[#num_extra_inhabitants_64bit]] bitwise_takable=1))))
 // CHECK-64:       (case name=none index=1)))
 // CHECK-64:   (case name=none index=1))
 


### PR DESCRIPTION
This fixes up the new reflection_Optional_Any test to correctly work on Linux and other non-Apple platforms.

Background:  Apple reserves 4G at the beginning of the address space for 64-bit processes to catch 32-bit errors in software.  As a result, any 64-bit pointer with value < 4G is invalid, which allowed Swift to allocate 2G invalid pointer values as "extra inhabitants" for enum coding.  But many other platforms reserve only a 4K initial page, so Swift for non-Apple platforms has standardized on 4K "extra inhabitants" for such.

We put in some infrastructure to account for this difference, this PR just adapts this new test to use that infrastructure.