### PR TITLE
OSSA ownership optimization RAUW utility fixes.

### DIFF
--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -38,6 +38,9 @@ struct OwnershipFixupContext {
   DeadEndBlocks &deBlocks;
   JointPostDominanceSetComputer &jointPostDomSetComputer;
 
+  SmallVector<Operand *, 8> transitiveBorrowedUses;
+  SmallVector<BorrowingOperand, 8> recursiveReborrows;
+
   /// Extra state initialized by OwnershipRAUWFixupHelper::get() that we use
   /// when RAUWing addresses. This ensures we do not need to recompute this
   /// state when we perform the actual RAUW.
@@ -67,6 +70,8 @@ struct OwnershipFixupContext {
 
   void clear() {
     jointPostDomSetComputer.clear();
+    transitiveBorrowedUses.clear();
+    recursiveReborrows.clear();
     extraAddressFixupInfo.allAddressUsesFromOldValue.clear();
     extraAddressFixupInfo.intPtrOp = InteriorPointerOperand();
   }

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -381,7 +381,7 @@ bool SILValueOwnershipChecker::gatherUsers(
                          << "Address User: " << *op->getUser();
           });
         };
-        foundError |= interiorPointerOperand.getImplicitUses(
+        foundError |= interiorPointerOperand.findTransitiveUses(
             nonLifetimeEndingUsers, &onError);
       }
 

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -331,7 +331,7 @@ static bool canJoinIfCopyDiesInFunctionExitingBlock(
 }
 
 static Operand *lookThroughSingleForwardingUse(Operand *use) {
-  auto forwardingOperand = ForwardingOperand::get(use);
+  ForwardingOperand forwardingOperand(use);
   if (!forwardingOperand)
     return nullptr;
   auto forwardedValue = forwardingOperand.getSingleForwardedValue();
@@ -423,7 +423,7 @@ static bool tryJoinIfDestroyConsumingUseInSameBlock(
     // If not, see if this use did have a forwardedValue but that forwardedValue
     // has multiple end lifetime uses. In that case, we can optimize if there
     // aren't any uses/etc
-    auto forwardingOperand = ForwardingOperand::get(currentForwardingUse);
+    ForwardingOperand forwardingOperand(currentForwardingUse);
     if (!forwardingOperand)
       return false;
     auto forwardedValue = forwardingOperand.getSingleForwardedValue();

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -228,7 +228,7 @@ void OwnershipLiveRange::convertOwnedGeneralForwardingUsesToGuaranteed() && {
   while (!ownershipForwardingUses.empty()) {
     auto *use = ownershipForwardingUses.back();
     ownershipForwardingUses = ownershipForwardingUses.drop_back();
-    auto operand = ForwardingOperand::get(use);
+    ForwardingOperand operand(use);
     operand.replaceOwnershipKind(OwnershipKind::Owned,
                                  OwnershipKind::Guaranteed);
   }


### PR DESCRIPTION
Verify that the OwnershipRAUWUtility always preserves the original
borrow scope by exhaustively switching over OperandOwnership.

And related cleanup.
