### PR TITLE
[Refactoring] Add async refactorings

### DIFF
--- a/include/swift/AST/DiagnosticsRefactoring.def
+++ b/include/swift/AST/DiagnosticsRefactoring.def
@@ -54,5 +54,23 @@ WARNING(mismatched_rename, none, "the name at the given location cannot be renam
 
 ERROR(no_insert_position, none, "cannot find inserting position", ())
 
+ERROR(missing_callback_arg, none, "cannot refactor as callback closure argument missing", ())
+
+ERROR(mismatched_callback_args, none, "cannot refactor as callback arguments do not match declaration", ())
+
+ERROR(unknown_callback_conditions, none, "cannot refactor complex if conditions", ())
+
+ERROR(mixed_callback_conditions, none, "cannot refactor mixed nil and not-nil conditions", ())
+
+ERROR(callback_multiple_bound_names, none, "cannot refactor when multiple names bound to single declaration, had '%0' and found '%1'", (StringRef, StringRef))
+
+ERROR(callback_with_fallthrough, none, "cannot refactor switch with fallthrough", ())
+
+ERROR(callback_with_default, none, "cannot refactor switch with default case", ())
+
+ERROR(callback_multiple_case_items, none, "cannot refactor switch using a case with multiple items", ())
+
+ERROR(callback_where_case_item, none, "cannot refactor switch using a case with where clause", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/KnownStdlibTypes.def
+++ b/include/swift/AST/KnownStdlibTypes.def
@@ -91,4 +91,6 @@ KNOWN_STDLIB_TYPE_DECL(KeyedEncodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(KeyedDecodingContainer, NominalTypeDecl, 1)
 KNOWN_STDLIB_TYPE_DECL(RangeReplaceableCollection, ProtocolDecl, 1)
 
+KNOWN_STDLIB_TYPE_DECL(Result, NominalTypeDecl, 2)
+
 #undef KNOWN_STDLIB_TYPE_DECL

--- a/include/swift/IDE/Refactoring.h
+++ b/include/swift/IDE/Refactoring.h
@@ -137,7 +137,8 @@ collectAvailableRefactorings(SourceFile *SF, RangeConfig Range,
                              llvm::ArrayRef<DiagnosticConsumer*> DiagConsumers);
 
 ArrayRef<RefactoringKind>
-collectAvailableRefactorings(SourceFile *SF, ResolvedCursorInfo CursorInfo,
+collectAvailableRefactorings(SourceFile *SF,
+                             const ResolvedCursorInfo &CursorInfo,
                              std::vector<RefactoringKind> &Scratch,
                              bool ExcludeRename);
 

--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -54,6 +54,12 @@ CURSOR_REFACTORING(MemberwiseInitLocalRefactoring, "Generate Memberwise Initiali
 
 CURSOR_REFACTORING(AddEquatableConformance, "Add Equatable Conformance", add.equatable.conformance)
 
+CURSOR_REFACTORING(ConvertCallToAsyncAlternative, "Convert Call to Async Alternative", convert.call-to-async)
+
+CURSOR_REFACTORING(ConvertToAsync, "Convert Function to Async", convert.func-to-async)
+
+CURSOR_REFACTORING(AddAsyncAlternative, "Add Async Alternative", add.async-alternative)
+
 RANGE_REFACTORING(ExtractExpr, "Extract Expression", extract.expr)
 
 RANGE_REFACTORING(ExtractFunction, "Extract Method", extract.function)

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -547,6 +547,7 @@ public:
   }
 };
 
+/// Outputs replacements as JSON, see `writeEditsInJson`
 class SourceEditJsonConsumer : public SourceEditConsumer {
   struct Implementation;
   Implementation &Impl;
@@ -556,6 +557,25 @@ public:
   void accept(SourceManager &SM, RegionType RegionType, ArrayRef<Replacement> Replacements) override;
 };
 
+/// Outputs replacements to `OS` in the form
+/// ```
+/// // </path/to/file> [startLine:startCol, endLine:endCol)
+/// text
+/// to
+/// replace
+///
+/// ```
+class SourceEditTextConsumer : public SourceEditConsumer {
+  llvm::raw_ostream &OS;
+
+public:
+  SourceEditTextConsumer(llvm::raw_ostream &OS);
+
+  void accept(SourceManager &SM, RegionType RegionType,
+              ArrayRef<Replacement> Replacements) override;
+};
+
+/// Outputs the rewritten buffer to `OS` with RUN and CHECK lines removed
 class SourceEditOutputConsumer : public SourceEditConsumer {
   struct Implementation;
   Implementation &Impl;

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -161,7 +161,6 @@ struct ResolvedCursorInfo {
   bool IsRef = true;
   bool IsKeywordArgument = false;
   Type Ty;
-  DeclContext *DC = nullptr;
   Type ContainerType;
   Stmt *TrailingStmt = nullptr;
   Expr *TrailingExpr = nullptr;
@@ -187,7 +186,6 @@ struct ResolvedCursorInfo {
     this->ExtTyRef = ExtTyRef;
     this->IsRef = IsRef;
     this->Ty = Ty;
-    this->DC = ValueD->getDeclContext();
     this->ContainerType = ContainerType;
   }
   void setModuleRef(ModuleEntity Mod) {

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -559,10 +559,9 @@ public:
 
 /// Outputs replacements to `OS` in the form
 /// ```
-/// // </path/to/file> [startLine:startCol, endLine:endCol)
+/// // </path/to/file> startLine:startCol -> endLine:endCol
+/// replacement
 /// text
-/// to
-/// replace
 ///
 /// ```
 class SourceEditTextConsumer : public SourceEditConsumer {

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -11,12 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/IDE/Refactoring.h"
-#include "swift/IDE/IDERequests.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsRefactoring.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/GenericParamList.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -26,13 +26,14 @@
 #include "swift/Basic/Edit.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/IDE/IDERequests.h"
 #include "swift/Index/Index.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Subsystems.h"
 #include "clang/Rewrite/Core/RewriteBuffer.h"
-#include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/StringSet.h"
 
 using namespace swift;
 using namespace swift::ide;
@@ -3889,7 +3890,1453 @@ bool RefactoringActionConvertToComputedProperty::performChange() {
   return false; // success
 }
 
-}// end of anonymous namespace
+namespace asyncrefactorings {
+
+// TODO: Should probably split the refactorings into separate files
+
+/// Whether the given parameter name identifies a completion callback
+bool isCompletionHandlerName(StringRef Name) {
+  return Name.startswith("completion") || Name.contains("Completion") ||
+         Name.contains("Complete");
+}
+
+/// Whether the given type is the stdlib Result type
+bool isResultType(Type Ty) {
+  if (!Ty)
+    return false;
+  if (auto *NTD = Ty->getAnyNominal())
+    return NTD == NTD->getASTContext().getResultDecl();
+  return false;
+}
+
+/// Whether the given type is (or conforms to) the stdlib Error type
+bool isErrorType(Type Ty, ModuleDecl *MD) {
+  if (!Ty)
+    return false;
+  return !MD->conformsToProtocol(Ty, Ty->getASTContext().getErrorDecl())
+              .isInvalid();
+}
+
+// The single Decl* subject of a switch statement, or nullptr if none
+Decl *singleSwitchSubject(const SwitchStmt *Switch) {
+  if (auto *DRE = dyn_cast<DeclRefExpr>(Switch->getSubjectExpr()))
+    return DRE->getDecl();
+  return nullptr;
+}
+
+// Wrapper to make dealing with single elements easier (ie. for Paren|TupleExpr
+// arguments)
+template <typename T>
+class PtrArrayRef {
+  bool IsSingle = false;
+  union Storage {
+    ArrayRef<T> ManyElements;
+    T SingleElement;
+  } Storage = {ArrayRef<T>()};
+
+public:
+  PtrArrayRef() {}
+  PtrArrayRef(T Element) : IsSingle(true) { Storage.SingleElement = Element; }
+  PtrArrayRef(ArrayRef<T> Ref) : IsSingle(Ref.size() == 1), Storage({Ref}) {
+    if (IsSingle)
+      Storage.SingleElement = Ref[0];
+  }
+
+  ArrayRef<T> ref() {
+    if (IsSingle)
+      return ArrayRef<T>(Storage.SingleElement);
+    return Storage.ManyElements;
+  }
+};
+
+PtrArrayRef<Expr *> callArgs(const ApplyExpr *AE) {
+  if (auto *PE = dyn_cast<ParenExpr>(AE->getArg())) {
+    return PtrArrayRef<Expr *>(PE->getSubExpr());
+  } else if (auto *TE = dyn_cast<TupleExpr>(AE->getArg())) {
+    return PtrArrayRef<Expr *>(TE->getElements());
+  }
+  return PtrArrayRef<Expr *>();
+}
+
+FuncDecl *getUnderlyingFunc(const Expr *Fn) {
+  Fn = Fn->getSemanticsProvidingExpr();
+  if (auto *DRE = dyn_cast<DeclRefExpr>(Fn))
+    return dyn_cast_or_null<FuncDecl>(DRE->getDecl());
+  if (auto ApplyE = dyn_cast<SelfApplyExpr>(Fn))
+    return getUnderlyingFunc(ApplyE->getFn());
+  if (auto *ACE = dyn_cast<AutoClosureExpr>(Fn)) {
+    if (auto *Unwrapped = ACE->getUnwrappedCurryThunkExpr())
+      return getUnderlyingFunc(Unwrapped);
+  }
+  return nullptr;
+}
+
+/// Find the outermost call of the given location
+CallExpr *findOuterCall(const ResolvedCursorInfo &CursorInfo) {
+  auto IncludeInContext = [](ASTNode N) {
+    if (auto *E = N.dyn_cast<Expr *>())
+      return !E->isImplicit();
+    return false;
+  };
+
+  // TODO: Bit pointless using the "ContextFinder" here. Ideally we would have
+  //       already generated a slice of the AST for anything that contains
+  //       the cursor location
+  ContextFinder Finder(*CursorInfo.SF, CursorInfo.Loc, IncludeInContext);
+  Finder.resolve();
+  auto Contexts = Finder.getContexts();
+  if (Contexts.empty())
+    return nullptr;
+
+  CallExpr *CE = dyn_cast<CallExpr>(Contexts[0].get<Expr *>());
+  if (!CE)
+    return nullptr;
+
+  SourceManager &SM = CursorInfo.SF->getASTContext().SourceMgr;
+  if (!SM.rangeContains(CE->getFn()->getSourceRange(), CursorInfo.Loc))
+    return nullptr;
+  return CE;
+}
+
+/// Find the function matching the given location if it is not an accessor and
+/// either has a body or is a member of a protocol
+FuncDecl *findFunction(const ResolvedCursorInfo &CursorInfo) {
+  auto IncludeInContext = [](ASTNode N) {
+    if (auto *D = N.dyn_cast<Decl *>())
+      return !D->isImplicit();
+    return false;
+  };
+
+  ContextFinder Finder(*CursorInfo.SF, CursorInfo.Loc, IncludeInContext);
+  Finder.resolve();
+
+  auto Contexts = Finder.getContexts();
+  if (Contexts.empty())
+    return nullptr;
+
+  if (Contexts.back().isDecl(DeclKind::Param))
+    Contexts = Contexts.drop_back();
+
+  auto *FD = dyn_cast_or_null<FuncDecl>(Contexts.back().get<Decl *>());
+  if (!FD || isa<AccessorDecl>(FD))
+    return nullptr;
+
+  auto *Body = FD->getBody();
+  if (!Body && !isa<ProtocolDecl>(FD->getDeclContext()))
+    return nullptr;
+
+  SourceManager &SM = CursorInfo.SF->getASTContext().SourceMgr;
+  SourceLoc DeclEnd = Body ? Body->getLBraceLoc() : FD->getEndLoc();
+  if (!SM.rangeContains(SourceRange(FD->getStartLoc(), DeclEnd),
+                        CursorInfo.Loc))
+    return nullptr;
+
+  return FD;
+}
+
+FuncDecl *isOperator(const BinaryExpr *BE) {
+  auto *AE = dyn_cast<ApplyExpr>(BE->getFn());
+  if (AE) {
+    auto *Callee = AE->getCalledValue();
+    if (Callee && Callee->isOperator() && isa<FuncDecl>(Callee))
+      return cast<FuncDecl>(Callee);
+  }
+  return nullptr;
+}
+
+/// Describes the expressions to be kept from a call to the handler in a
+/// function that has (or will have ) and async alternative. Eg.
+/// ```
+/// func toBeAsync(completion: (String?, Error?) -> Void) {
+///   ...
+///   completion("something", nil) // Result = ["something"], IsError = false
+///   ...
+///   completion(nil, MyError.Bad) // Result = [MyError.Bad], IsError = true
+/// }
+class HandlerResult {
+  PtrArrayRef<Expr *> Results;
+  bool IsError = false;
+
+public:
+  HandlerResult() {}
+
+  HandlerResult(ArrayRef<Expr *> Results)
+      : Results(PtrArrayRef<Expr *>(Results)) {}
+
+  HandlerResult(Expr *Result, bool IsError)
+      : Results(PtrArrayRef<Expr *>(Result)), IsError(IsError) {}
+
+  bool isError() { return IsError; }
+
+  ArrayRef<Expr *> args() { return Results.ref(); }
+};
+
+/// The type of the handler, ie. whether it takes regular parameters or a
+/// single parameter of `Result` type.
+enum class HandlerType { INVALID, PARAMS, RESULT };
+
+/// Given a function with an async alternative (or one that *could* have an
+/// async alternative), stores information about the handler parameter.
+struct AsyncHandlerDesc {
+  const ParamDecl *Handler = nullptr;
+  int Index = -1;
+  HandlerType Type = HandlerType::INVALID;
+  bool HasError = false;
+
+  static AsyncHandlerDesc find(const FuncDecl *FD, bool ignoreName = false) {
+    if (!FD || FD->hasAsync() || FD->hasThrows())
+      return AsyncHandlerDesc();
+
+    // Require at least one parameter and void return type
+    auto *Params = FD->getParameters();
+    if (Params->size() == 0 || !FD->getResultInterfaceType()->isVoid())
+      return AsyncHandlerDesc();
+
+    AsyncHandlerDesc HandlerDesc;
+
+    // Assume the handler is the last parameter for now
+    HandlerDesc.Index = Params->size() - 1;
+    HandlerDesc.Handler = Params->get(HandlerDesc.Index);
+
+    // Callback must not be attributed with @autoclosure
+    if (HandlerDesc.Handler->isAutoClosure())
+      return AsyncHandlerDesc();
+
+    // Callback must have a completion-like name (if we're not ignoring it)
+    if (!ignoreName &&
+        !isCompletionHandlerName(HandlerDesc.Handler->getNameStr()))
+      return AsyncHandlerDesc();
+
+    // Callback must be a function type and return void. Doesn't need to have
+    // any parameters - may just be a "I'm done" callback
+    auto *HandlerTy = HandlerDesc.Handler->getType()->getAs<AnyFunctionType>();
+    if (!HandlerTy || !HandlerTy->getResult()->isVoid())
+      return AsyncHandlerDesc();
+
+    // Find the type of result in the handler (eg. whether it's a Result<...>,
+    // just parameters, or nothing).
+    auto HandlerParams = HandlerTy->getParams();
+    if (HandlerParams.size() == 1) {
+      auto ParamTy =
+          HandlerParams.back().getPlainType()->getAs<BoundGenericType>();
+      if (isResultType(ParamTy)) {
+        auto GenericArgs = ParamTy->getGenericArgs();
+        assert(GenericArgs.size() == 2 && "Result should have two params");
+        HandlerDesc.Type = HandlerType::RESULT;
+        HandlerDesc.HasError = !GenericArgs.back()->isUninhabited();
+      }
+    }
+
+    if (HandlerDesc.Type != HandlerType::RESULT) {
+      // Only handle non-result parameters
+      for (auto &Param : HandlerParams) {
+        if (isResultType(Param.getPlainType()))
+          return AsyncHandlerDesc();
+      }
+
+      HandlerDesc.Type = HandlerType::PARAMS;
+      if (!HandlerParams.empty()) {
+        auto LastParamTy = HandlerParams.back().getParameterType();
+        HandlerDesc.HasError = isErrorType(LastParamTy->getOptionalObjectType(),
+                                           FD->getModuleContext());
+      }
+    }
+
+    return HandlerDesc;
+  }
+
+  bool isValid() const { return Type != HandlerType::INVALID; }
+
+  ArrayRef<AnyFunctionType::Param> params() const {
+    auto Ty = Handler->getType()->getAs<AnyFunctionType>();
+    assert(Ty && "Type must be a function type");
+    return Ty->getParams();
+  }
+
+  /// The `CallExpr` if the given node is a call to the `Handler`
+  CallExpr *getAsHandlerCall(ASTNode Node) const {
+    if (!isValid())
+      return nullptr;
+
+    if (Node.isExpr(swift::ExprKind::Call)) {
+      CallExpr *CE = cast<CallExpr>(Node.dyn_cast<Expr *>());
+      if (CE->getFn()->getReferencedDecl().getDecl() == Handler)
+        return CE;
+    }
+    return nullptr;
+  }
+
+  /// Given a call to the `Handler`, extract the expressions to be returned or
+  /// thrown, taking care to remove the `.success`/`.failure` if it's a
+  /// `RESULT` handler type.
+  HandlerResult extractResultArgs(const CallExpr *CE) const {
+    auto ArgList = callArgs(CE);
+    auto Args = ArgList.ref();
+
+    if (Type == HandlerType::PARAMS) {
+      if (!HasError)
+        return HandlerResult(Args);
+
+      if (!isa<NilLiteralExpr>(Args.back()))
+        return HandlerResult(Args.back(), true);
+
+      return HandlerResult(Args.drop_back());
+    } else if (Type == HandlerType::RESULT) {
+      if (Args.size() != 1)
+        return HandlerResult(Args);
+
+      auto *ResultCE = dyn_cast<CallExpr>(Args[0]);
+      if (!ResultCE)
+        return HandlerResult(Args);
+
+      auto *DSC = dyn_cast<DotSyntaxCallExpr>(ResultCE->getFn());
+      if (!DSC)
+        return HandlerResult(Args);
+
+      auto *D = dyn_cast<EnumElementDecl>(
+          DSC->getFn()->getReferencedDecl().getDecl());
+      if (!D)
+        return HandlerResult(Args);
+
+      auto ResultArgList = callArgs(ResultCE);
+      return HandlerResult(ResultArgList.ref()[0],
+                           D->getNameStr() == StringRef("failure"));
+    }
+
+    llvm_unreachable("Unhandled result type");
+  }
+};
+
+enum class ConditionType { INVALID, NIL, NOT_NIL };
+
+/// Finds the `Subject` being compared to in various conditions. Also finds any
+/// pattern that may have a bound name.
+struct CallbackCondition {
+  ConditionType Type = ConditionType::INVALID;
+  const Decl *Subject = nullptr;
+  const Pattern *BindPattern = nullptr;
+  // Bit of a hack. When the `Subject` is a `Result` type we use this to
+  // distinguish between the `.success` and `.failure` case (as opposed to just
+  // checking whether `Subject` == `TheErrDecl`)
+  bool ErrorCase = false;
+
+  CallbackCondition() = default;
+
+  /// Initializes a `CallbackCondition` with a `!=` or `==` comparison of
+  /// an `Optional` typed `Subject` to `nil`, ie.
+  ///   - `<Subject> != nil`
+  ///   - `<Subject> == nil`
+  CallbackCondition(const BinaryExpr *BE, const FuncDecl *Operator) {
+    bool FoundNil = false;
+    for (auto *Operand : BE->getArg()->getElements()) {
+      if (isa<NilLiteralExpr>(Operand)) {
+        FoundNil = true;
+      } else if (auto *DRE = dyn_cast<DeclRefExpr>(Operand)) {
+        Subject = DRE->getDecl();
+      }
+    }
+
+    if (Subject && FoundNil) {
+      if (Operator->getBaseName() == "==") {
+        Type = ConditionType::NIL;
+      } else if (Operator->getBaseName() == "!=") {
+        Type = ConditionType::NOT_NIL;
+      }
+    }
+  }
+
+  /// Initializes a `CallbackCondition` with binding of an `Optional` or
+  /// `Result` typed `Subject`, ie.
+  ///   - `let bind = <Subject>`
+  ///   - `case .success(let bind) = <Subject>`
+  ///   - `case .failure(let bind) = <Subject>`
+  ///   - `let bind = try? <Subject>.get()`
+  CallbackCondition(const Pattern *P, const Expr *Init) {
+    if (auto *DRE = dyn_cast<DeclRefExpr>(Init)) {
+      if (auto *OSP = dyn_cast<OptionalSomePattern>(P)) {
+        // `let bind = <Subject>`
+        Type = ConditionType::NOT_NIL;
+        Subject = DRE->getDecl();
+        BindPattern = OSP->getSubPattern();
+      } else if (auto *EEP = dyn_cast<EnumElementPattern>(P)) {
+        // `case .<func>(let <bind>) = <Subject>`
+        initFromEnumPattern(DRE->getDecl(), EEP);
+      }
+    } else if (auto *OTE = dyn_cast<OptionalTryExpr>(Init)) {
+      // `let bind = try? <Subject>.get()`
+      if (auto *OSP = dyn_cast<OptionalSomePattern>(P))
+        initFromOptionalTry(OSP->getSubPattern(), OTE);
+    }
+  }
+
+  /// Initializes a `CallbackCondtion` from a case statement inside a switch
+  /// on `Subject` with `Result` type, ie.
+  /// ```
+  /// switch <Subject> {
+  /// case .success(let bind):
+  /// case .failure(let bind):
+  /// }
+  /// ```
+  CallbackCondition(const Decl *Subject, const CaseLabelItem *CaseItem) {
+    if (auto *EEP = dyn_cast<EnumElementPattern>(CaseItem->getPattern())) {
+      // `case .<func>(let <bind>)`
+      initFromEnumPattern(Subject, EEP);
+    }
+  }
+
+  bool isValid() const { return Type != ConditionType::INVALID; }
+
+  /// Given an `if` condition `Cond` and a set of `Decls`, find any
+  /// `CallbackCondition`s in `Cond` that use one of those `Decls` and add them
+  /// to the map `AddTo`. Return `true` if all elements in the condition are
+  /// "handled", ie. every condition can be mapped to a single `Decl` in
+  /// `Decls`.
+  static bool all(StmtCondition Cond, llvm::DenseSet<const Decl *> Decls,
+                  llvm::DenseMap<const Decl *, CallbackCondition> &AddTo) {
+    bool Handled = true;
+    for (auto &CondElement : Cond) {
+      if (auto *BoolExpr = CondElement.getBooleanOrNull()) {
+        SmallVector<Expr *, 1> Exprs;
+        Exprs.push_back(BoolExpr);
+
+        while (!Exprs.empty()) {
+          auto *Next = Exprs.pop_back_val();
+          if (auto *ACE = dyn_cast<AutoClosureExpr>(Next))
+            Next = ACE->getSingleExpressionBody();
+
+          if (auto *BE = dyn_cast_or_null<BinaryExpr>(Next)) {
+            auto *Operator = isOperator(BE);
+            if (Operator) {
+              if (Operator->getBaseName() == "&&") {
+                auto Args = BE->getArg()->getElements();
+                Exprs.insert(Exprs.end(), Args.begin(), Args.end());
+              } else {
+                addCond(CallbackCondition(BE, Operator), Decls, AddTo, Handled);
+              }
+              continue;
+            }
+          }
+
+          Handled = false;
+        }
+      } else if (auto *P = CondElement.getPatternOrNull()) {
+        addCond(CallbackCondition(P, CondElement.getInitializer()), Decls,
+                AddTo, Handled);
+      }
+    }
+    return Handled && !AddTo.empty();
+  }
+
+private:
+  static void addCond(const CallbackCondition &CC,
+                      llvm::DenseSet<const Decl *> Decls,
+                      llvm::DenseMap<const Decl *, CallbackCondition> &AddTo,
+                      bool &Handled) {
+    if (!CC.isValid() || !Decls.count(CC.Subject) ||
+        !AddTo.try_emplace(CC.Subject, CC).second)
+      Handled = false;
+  }
+
+  void initFromEnumPattern(const Decl *D, const EnumElementPattern *EEP) {
+    if (auto *EED = EEP->getElementDecl()) {
+      if (!isResultType(EED->getParentEnum()->getDeclaredType()))
+        return;
+      if (EED->getNameStr() == StringRef("failure"))
+        ErrorCase = true;
+      Type = ConditionType::NOT_NIL;
+      Subject = D;
+      BindPattern = EEP->getSubPattern();
+    }
+  }
+
+  void initFromOptionalTry(const class Pattern *P, const OptionalTryExpr *OTE) {
+    auto *ICE = dyn_cast<ImplicitConversionExpr>(OTE->getSubExpr());
+    if (!ICE)
+      return;
+    auto *CE = dyn_cast<CallExpr>(ICE->getSyntacticSubExpr());
+    if (!CE)
+      return;
+    auto *DSC = dyn_cast<DotSyntaxCallExpr>(CE->getFn());
+    if (!DSC)
+      return;
+
+    auto *BaseDRE = dyn_cast<DeclRefExpr>(DSC->getBase());
+    if (!isResultType(BaseDRE->getType()))
+      return;
+
+    auto *FnDRE = dyn_cast<DeclRefExpr>(DSC->getFn());
+    if (!FnDRE)
+      return;
+    auto *FD = dyn_cast<FuncDecl>(FnDRE->getDecl());
+    if (!FD || FD->getNameStr() != StringRef("get"))
+      return;
+
+    Type = ConditionType::NOT_NIL;
+    Subject = BaseDRE->getDecl();
+    BindPattern = P;
+  }
+};
+
+/// The statements within the closure of call to a function taking a callback
+/// are split into a `SuccessBlock` and `ErrorBlock` (`ClassifiedBlocks`).
+/// This class stores the nodes for each block, as well as a mapping of
+/// decls to any patterns they are used in.
+class ClassifiedBlock {
+  SmallVector<ASTNode, 0> Nodes;
+  // closure param -> name
+  llvm::DenseMap<const Decl *, StringRef> BoundNames;
+  bool AllLet = true;
+
+public:
+  ArrayRef<ASTNode> nodes() const { return llvm::makeArrayRef(Nodes); }
+
+  StringRef boundName(const Decl *D) const { return BoundNames.lookup(D); }
+
+  bool allLet() const { return AllLet; }
+
+  void addAllNodes(ArrayRef<ASTNode> Nodes) {
+    for (auto Node : Nodes) {
+      addNode(Node);
+    }
+  }
+
+  void addNode(const ASTNode Node) {
+    if (!Node.isDecl(DeclKind::Var))
+      Nodes.push_back(Node);
+  }
+
+  void addBinding(const CallbackCondition &FromCondition,
+                  DiagnosticEngine &DiagEngine) {
+    if (!FromCondition.BindPattern)
+      return;
+
+    if (auto *BP =
+            dyn_cast_or_null<BindingPattern>(FromCondition.BindPattern)) {
+      if (!BP->isLet())
+        AllLet = false;
+    }
+
+    StringRef Name = FromCondition.BindPattern->getBoundName().str();
+    if (Name.empty())
+      return;
+
+    auto Res = BoundNames.try_emplace(FromCondition.Subject, Name);
+    if (Res.second)
+      return;
+
+    // Already inserted, only handle cases where the name is the same
+    // TODO: This wouldn't be that hard to handle, just need to keep track
+    //       of the decl and replace its name with the same as the original
+    StringRef OldName = Res.first->second;
+    if (OldName != Name) {
+      DiagEngine.diagnose(FromCondition.BindPattern->getLoc(),
+                          diag::callback_multiple_bound_names,
+                          StringRef(OldName), Name);
+    }
+  }
+
+  void addAllBindings(
+      const llvm::DenseMap<const Decl *, CallbackCondition> &FromConditions,
+      DiagnosticEngine &DiagEngine) {
+    for (auto &Entry : FromConditions) {
+      addBinding(Entry.second, DiagEngine);
+      if (DiagEngine.hadAnyError())
+        return;
+    }
+  }
+};
+
+struct ClassifiedBlocks {
+  ClassifiedBlock SuccessBlock;
+  ClassifiedBlock ErrorBlock;
+};
+
+/// Classifer of callback closure statements that that have either multiple
+/// non-Result parameters or a single Result parameter and return Void.
+///
+/// It performs a (possibly incorrect) best effort and may give up in certain
+/// cases. Aims to cover the idiomatic cases of either having no error
+/// parameter at all, or having success/error code wrapped in ifs/guards/switch
+/// using either pattern binding or nil checks.
+///
+/// Code outside any clear conditions is assumed to be solely part of the
+/// success block for now, though some heuristics could be added to classify
+/// these better in the future.
+struct CallbackClassifier {
+  /// Updates the success and error block of `Blocks` with nodes and bound
+  /// names from `Body`. Errors are added through `DiagEngine`, possibly
+  /// resulting in partially filled out blocks.
+  static void classifyInto(ClassifiedBlocks &Blocks,
+                           DiagnosticEngine &DiagEngine,
+                           ArrayRef<const ParamDecl *> SuccessParams,
+                           const ParamDecl *ErrParam, HandlerType ResultType,
+                           ArrayRef<ASTNode> Body) {
+    assert(!Body.empty() && "Cannot classify empty body");
+
+    auto ParamsSet = llvm::DenseSet<const Decl *>(SuccessParams.begin(),
+                                                  SuccessParams.end());
+    if (ErrParam)
+      ParamsSet.insert(ErrParam);
+
+    CallbackClassifier Classifier(Blocks, DiagEngine, ParamsSet, ErrParam,
+                                  ResultType == HandlerType::RESULT);
+    Classifier.classifyNodes(Body);
+  }
+
+private:
+  ClassifiedBlocks &Blocks;
+  DiagnosticEngine &DiagEngine;
+  ClassifiedBlock *CurrentBlock;
+  llvm::DenseSet<const Decl *> ParamsSet;
+  const ParamDecl *ErrParam;
+  bool IsResultParam;
+
+  CallbackClassifier(ClassifiedBlocks &Blocks, DiagnosticEngine &DiagEngine,
+                     llvm::DenseSet<const Decl *> ParamsSet,
+                     const ParamDecl *ErrParam, bool IsResultParam)
+      : Blocks(Blocks), DiagEngine(DiagEngine),
+        CurrentBlock(&Blocks.SuccessBlock), ParamsSet(ParamsSet),
+        ErrParam(ErrParam), IsResultParam(IsResultParam) {}
+
+  void classifyNodes(ArrayRef<ASTNode> Nodes) {
+    for (auto I = Nodes.begin(), E = Nodes.end(); I < E; ++I) {
+      auto *Statement = I->dyn_cast<Stmt *>();
+      if (auto *IS = dyn_cast_or_null<IfStmt>(Statement)) {
+        ArrayRef<ASTNode> TempNodes;
+        if (auto *BS = dyn_cast<BraceStmt>(IS->getThenStmt())) {
+          TempNodes = BS->getElements();
+        } else {
+          TempNodes = ArrayRef<ASTNode>(IS->getThenStmt());
+        }
+
+        classifyConditional(IS, IS->getCond(), TempNodes, IS->getElseStmt());
+      } else if (auto *GS = dyn_cast_or_null<GuardStmt>(Statement)) {
+        classifyConditional(GS, GS->getCond(), ArrayRef<ASTNode>(),
+                            GS->getBody());
+      } else if (auto *SS = dyn_cast_or_null<SwitchStmt>(Statement)) {
+        classifySwitch(SS);
+      } else {
+        CurrentBlock->addNode(*I);
+      }
+
+      if (DiagEngine.hadAnyError())
+        return;
+    }
+  }
+
+  void classifyConditional(Stmt *Statement, StmtCondition Condition,
+                           ArrayRef<ASTNode> ThenNodes, Stmt *ElseStmt) {
+    llvm::DenseMap<const Decl *, CallbackCondition> CallbackConditions;
+    bool UnhandledConditions =
+        !CallbackCondition::all(Condition, ParamsSet, CallbackConditions);
+    CallbackCondition ErrCondition = CallbackConditions.lookup(ErrParam);
+
+    if (UnhandledConditions) {
+      // Some unknown conditions. If there's an else, assume we can't handle
+      // and use the fallback case. Otherwise add to either the success or
+      // error block depending on some heuristics, known conditions will have
+      // placeholders added (ideally we'd remove them)
+      // TODO: Remove known conditions and split the `if` statement
+
+      if (CallbackConditions.empty()) {
+        // Technically this has a similar problem, ie. the else could have
+        // conditions that should be in either success/error
+        CurrentBlock->addNode(Statement);
+      } else if (ElseStmt) {
+        DiagEngine.diagnose(Statement->getStartLoc(),
+                            diag::unknown_callback_conditions);
+      } else if (ErrCondition.isValid() &&
+                 ErrCondition.Type == ConditionType::NOT_NIL) {
+        Blocks.ErrorBlock.addNode(Statement);
+      } else {
+        for (auto &Entry : CallbackConditions) {
+          if (Entry.second.Type == ConditionType::NIL) {
+            Blocks.ErrorBlock.addNode(Statement);
+            return;
+          }
+        }
+        Blocks.SuccessBlock.addNode(Statement);
+      }
+      return;
+    }
+
+    ClassifiedBlock *ThenBlock = &Blocks.SuccessBlock;
+    ClassifiedBlock *ElseBlock = &Blocks.ErrorBlock;
+
+    if (ErrCondition.isValid() && (!IsResultParam || ErrCondition.ErrorCase) &&
+        ErrCondition.Type == ConditionType::NOT_NIL) {
+      ClassifiedBlock *TempBlock = ThenBlock;
+      ThenBlock = ElseBlock;
+      ElseBlock = TempBlock;
+    } else {
+      ConditionType CondType = ConditionType::INVALID;
+      for (auto &Entry : CallbackConditions) {
+        if (IsResultParam || Entry.second.Subject != ErrParam) {
+          if (CondType == ConditionType::INVALID) {
+            CondType = Entry.second.Type;
+          } else if (CondType != Entry.second.Type) {
+            // Similar to the unknown conditions case. Add the whole if unless
+            // there's an else, in which case use the fallback instead.
+            // TODO: Split the `if` statement
+
+            if (ElseStmt) {
+              DiagEngine.diagnose(Statement->getStartLoc(),
+                                  diag::mixed_callback_conditions);
+            } else {
+              CurrentBlock->addNode(Statement);
+            }
+            return;
+          }
+        }
+      }
+
+      if (CondType == ConditionType::NIL) {
+        ClassifiedBlock *TempBlock = ThenBlock;
+        ThenBlock = ElseBlock;
+        ElseBlock = TempBlock;
+      }
+    }
+
+    ThenBlock->addAllBindings(CallbackConditions, DiagEngine);
+    if (DiagEngine.hadAnyError())
+      return;
+
+    // TODO: Handle nested ifs
+    setNodes(ThenBlock, ElseBlock, ThenNodes);
+
+    if (ElseStmt) {
+      if (auto *BS = dyn_cast<BraceStmt>(ElseStmt)) {
+        setNodes(ElseBlock, ThenBlock, BS->getElements());
+      } else {
+        classifyNodes(ArrayRef<ASTNode>(ElseStmt));
+      }
+    }
+  }
+
+  void setNodes(ClassifiedBlock *Block, ClassifiedBlock *OtherBlock,
+                ArrayRef<ASTNode> Nodes) {
+    if (Nodes.empty())
+      return;
+    if ((Nodes.back().isStmt(StmtKind::Return) ||
+         Nodes.back().isStmt(StmtKind::Break)) &&
+        !Nodes.back().isImplicit()) {
+      CurrentBlock = OtherBlock;
+      Block->addAllNodes(Nodes.drop_back());
+    } else {
+      Block->addAllNodes(Nodes);
+    }
+  }
+
+  void classifySwitch(SwitchStmt *SS) {
+    if (!IsResultParam || singleSwitchSubject(SS) != ErrParam) {
+      CurrentBlock->addNode(SS);
+    }
+
+    for (auto *CS : SS->getCases()) {
+      if (CS->hasFallthroughDest()) {
+        DiagEngine.diagnose(CS->getLoc(), diag::callback_with_fallthrough);
+        return;
+      }
+
+      if (CS->isDefault()) {
+        DiagEngine.diagnose(CS->getLoc(), diag::callback_with_default);
+        return;
+      }
+
+      auto Items = CS->getCaseLabelItems();
+      if (Items.size() > 1) {
+        DiagEngine.diagnose(CS->getLoc(), diag::callback_multiple_case_items);
+        return;
+      }
+
+      if (Items[0].getWhereLoc().isValid()) {
+        DiagEngine.diagnose(CS->getLoc(), diag::callback_where_case_item);
+        return;
+      }
+
+      CallbackCondition CC(ErrParam, &Items[0]);
+      ClassifiedBlock *Block = &Blocks.SuccessBlock;
+      ClassifiedBlock *OtherBlock = &Blocks.ErrorBlock;
+      if (CC.ErrorCase) {
+        Block = &Blocks.ErrorBlock;
+        OtherBlock = &Blocks.SuccessBlock;
+      }
+
+      setNodes(Block, OtherBlock, CS->getBody()->getElements());
+      Block->addBinding(CC, DiagEngine);
+      if (DiagEngine.hadAnyError())
+        return;
+    }
+  }
+};
+
+/// Builds up async-converted code for any added AST nodes.
+///
+/// Function declarations will have `async` added. If a completion handler is
+/// present, it will be removed and the return type of the function will
+/// reflect the parameters of the handler, including an added `throws` if
+/// necessary.
+///
+/// Calls to the completion handler are replaced with either a `return` or
+/// `throws` depending on the arguments.
+///
+/// Calls to functions with an async alternative will be replaced with a call
+/// to the alternative, possibly wrapped in a do/catch. The do/catch is skipped
+/// if the the closure either:
+///   1. Has no error
+///   2. Has an error but no error handling (eg. just ignores)
+///   3. Has error handling that only calls the containing function's handler
+///      with an error matching the error argument
+///
+/// (2) is technically not the correct translation, but in practice it's likely
+/// the code a user would actually want.
+///
+/// If the success vs error handling split inside the closure cannot be
+/// determined and the closure takes regular parameters (ie. not a Result), a
+/// fallback translation is used that keeps all the same variable names and
+/// simply moves the code within the closure out.
+///
+/// The fallback is generally avoided, however, since it's quite unlikely to be
+/// the code the user intended. In most cases the refactoring will continue,
+/// with any unhandled decls wrapped in placeholders instead.
+class AsyncConversionStringBuilder : private SourceEntityWalker {
+  SourceManager &SM;
+  DiagnosticEngine &DiagEngine;
+  const AsyncHandlerDesc &TopHandler;
+  SmallString<0> Buffer;
+  llvm::raw_svector_ostream OS;
+
+  llvm::DenseSet<const Decl *> Unwraps;
+  llvm::DenseSet<const Decl *> Placeholders;
+  llvm::DenseMap<const Decl *, std::string> Names;
+
+  SourceLoc LastAddedLoc;
+  int NestedExprCount = 0;
+
+public:
+  AsyncConversionStringBuilder(SourceManager &SM, DiagnosticEngine &DiagEngine,
+                               const AsyncHandlerDesc &TopHandler)
+      : SM(SM), DiagEngine(DiagEngine), TopHandler(TopHandler), Buffer(),
+        OS(Buffer) {
+    Placeholders.insert(TopHandler.Handler);
+  }
+
+  void replace(ASTNode Node, SourceEditConsumer &EditConsumer) {
+    CharSourceRange Range =
+        Lexer::getCharSourceRangeFromSourceRange(SM, Node.getSourceRange());
+    EditConsumer.accept(SM, Range, Buffer.str());
+    Buffer.clear();
+  }
+
+  void insertAfter(ASTNode Node, SourceEditConsumer &EditConsumer) {
+    EditConsumer.insertAfter(SM, Node.getEndLoc(), "\n\n");
+    EditConsumer.insertAfter(SM, Node.getEndLoc(), Buffer.str());
+    Buffer.clear();
+  }
+
+  void convertFunction(const FuncDecl *FD) {
+    addFuncDecl(FD);
+    if (FD->getBody()) {
+      convertNode(FD->getBody());
+    }
+  }
+
+  void convertNodes(ArrayRef<ASTNode> Nodes) {
+    for (auto Node : Nodes) {
+      OS << "\n";
+      convertNode(Node);
+    }
+  }
+
+  void convertNode(ASTNode Node, SourceLoc StartOverride = {},
+                   bool ConvertCalls = true) {
+    if (!StartOverride.isValid())
+      StartOverride = Node.getStartLoc();
+
+    llvm::SaveAndRestore<SourceLoc> RestoreLoc(LastAddedLoc, StartOverride);
+    llvm::SaveAndRestore<int> RestoreCount(NestedExprCount,
+                                           ConvertCalls ? 0 : 1);
+    walk(Node);
+    addRange(LastAddedLoc, Node.getEndLoc(), /*ToEndOfToken=*/true);
+  }
+
+private:
+  bool walkToDeclPre(Decl *D, CharSourceRange Range) override { return false; }
+
+#define PLACEHOLDER_START "<#"
+#define PLACEHOLDER_END "#>"
+  bool walkToExprPre(Expr *E) override {
+    // TODO: Handle Result.get as well
+    if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
+      if (auto *D = DRE->getDecl()) {
+        bool AddPlaceholder = Placeholders.count(D);
+        StringRef Name = newNameFor(D, false);
+        if (AddPlaceholder || !Name.empty())
+          return addCustom(DRE->getStartLoc(),
+                           Lexer::getLocForEndOfToken(SM, DRE->getEndLoc()),
+                           [&]() {
+                             if (AddPlaceholder)
+                               OS << PLACEHOLDER_START;
+                             if (!Name.empty())
+                               OS << Name;
+                             else
+                               D->getName().print(OS);
+                             if (AddPlaceholder)
+                               OS << PLACEHOLDER_END;
+                           });
+      }
+    } else if (auto *FTE = dyn_cast<ForceValueExpr>(E)) {
+      if (auto *D = FTE->getReferencedDecl().getDecl()) {
+        if (Unwraps.count(D))
+          return addCustom(FTE->getStartLoc(),
+                           FTE->getEndLoc().getAdvancedLoc(1),
+                           [&]() { OS << newNameFor(D, true); });
+      }
+    } else if (NestedExprCount == 0) {
+      if (CallExpr *CE = TopHandler.getAsHandlerCall(E))
+        return addCustom(CE->getStartLoc(), CE->getEndLoc().getAdvancedLoc(1),
+                         [&]() { addHandlerCall(CE); });
+
+      if (auto *CE = dyn_cast<CallExpr>(E)) {
+        auto HandlerDesc =
+            AsyncHandlerDesc::find(getUnderlyingFunc(CE->getFn()),
+                                   /*ignoreName=*/true);
+        if (HandlerDesc.isValid())
+          return addCustom(CE->getStartLoc(), CE->getEndLoc().getAdvancedLoc(1),
+                           [&]() { addAsyncAlternativeCall(CE, HandlerDesc); });
+      }
+    }
+
+    NestedExprCount++;
+    return true;
+  }
+#undef PLACEHOLDER_START
+#undef PLACEHOLDER_END
+
+  bool walkToExprPost(Expr *E) override {
+    NestedExprCount--;
+    return true;
+  }
+
+  bool addCustom(SourceLoc End, SourceLoc NextAddedLoc,
+                 std::function<void()> Custom = {}) {
+    addRange(LastAddedLoc, End);
+    Custom();
+    LastAddedLoc = NextAddedLoc;
+    return false;
+  }
+
+  void addRange(SourceLoc Start, SourceLoc End, bool ToEndOfToken = false) {
+    if (ToEndOfToken) {
+      OS << Lexer::getCharSourceRangeFromSourceRange(SM,
+                                                     SourceRange(Start, End))
+                .str();
+    } else {
+      OS << CharSourceRange(SM, Start, End).str();
+    }
+  }
+
+  void addRange(SourceRange Range, bool ToEndOfToken = false) {
+    addRange(Range.Start, Range.End, ToEndOfToken);
+  }
+
+  void addFuncDecl(const FuncDecl *FD) {
+    auto *Params = FD->getParameters();
+
+    // First chunk: start -> the parameter to remove (if any)
+    SourceLoc LeftEndLoc = Params->getLParenLoc().getAdvancedLoc(1);
+    if (TopHandler.Index - 1 >= 0) {
+      LeftEndLoc = Lexer::getLocForEndOfToken(
+          SM, Params->get(TopHandler.Index - 1)->getEndLoc());
+    }
+    addRange(FD->getSourceRangeIncludingAttrs().Start, LeftEndLoc);
+
+    // Second chunk: end of the parameter to remove -> right parenthesis
+    SourceLoc MidStartLoc = LeftEndLoc;
+    SourceLoc MidEndLoc = Params->getRParenLoc().getAdvancedLoc(1);
+    if (TopHandler.isValid()) {
+      if ((size_t)(TopHandler.Index + 1) < Params->size()) {
+        MidStartLoc = Params->get(TopHandler.Index + 1)->getStartLoc();
+      } else {
+        MidStartLoc = Params->getRParenLoc();
+      }
+    }
+    addRange(MidStartLoc, MidEndLoc);
+
+    // Third chunk: add in async and throws if necessary
+    OS << " async";
+    if (FD->hasThrows() || TopHandler.HasError)
+      // TODO: Add throws if converting a function and it has a converted call
+      //       without a do/catch
+      OS << " " << tok::kw_throws;
+
+    // Fourth chunk: if no parent handler (ie. not adding an async
+    // alternative), the rest of the decl. Otherwise, add in the new return
+    // type
+    if (!TopHandler.isValid()) {
+      SourceLoc RightStartLoc = MidEndLoc;
+      if (FD->hasThrows()) {
+        RightStartLoc = Lexer::getLocForEndOfToken(SM, FD->getThrowsLoc());
+      }
+      SourceLoc RightEndLoc =
+          FD->getBody() ? FD->getBody()->getLBraceLoc() : FD->getEndLoc();
+      addRange(RightStartLoc, RightEndLoc);
+      return;
+    }
+
+    auto HandlerParams = TopHandler.params();
+    if (TopHandler.Type == HandlerType::PARAMS && TopHandler.HasError) {
+      HandlerParams = HandlerParams.drop_back();
+    }
+
+    if (HandlerParams.empty()) {
+      OS << " ";
+      return;
+    }
+
+    OS << " -> ";
+
+    if (HandlerParams.size() > 1) {
+      OS << "(";
+    }
+    for (size_t I = 0, E = HandlerParams.size(); I < E; ++I) {
+      if (I > 0) {
+        OS << ", ";
+      }
+
+      auto &Param = HandlerParams[I];
+      if (TopHandler.Type == HandlerType::PARAMS) {
+        Type ToPrint = Param.getPlainType();
+        if (TopHandler.HasError)
+          ToPrint = ToPrint->lookThroughSingleOptionalType();
+        ToPrint->print(OS);
+      } else if (TopHandler.Type == HandlerType::RESULT) {
+        auto ResultTy = Param.getPlainType()->getAs<BoundGenericType>();
+        assert(ResultTy && "Result must have generic type");
+        ResultTy->getGenericArgs()[0]->print(OS);
+      } else {
+        llvm_unreachable("Unhandled handler type");
+      }
+    }
+    if (HandlerParams.size() > 1) {
+      OS << ")";
+    }
+
+    if (FD->hasBody())
+      OS << " ";
+
+    // TODO: Should remove the generic param and where clause for the error
+    //       param if it exists (and no other parameter uses that type)
+    TrailingWhereClause *TWC = FD->getTrailingWhereClause();
+    if (TWC && TWC->getWhereLoc().isValid()) {
+      auto Range = TWC->getSourceRange();
+      OS << Lexer::getCharSourceRangeFromSourceRange(SM, Range).str();
+      if (FD->hasBody())
+        OS << " ";
+    }
+  }
+
+  void addFallbackVars(ArrayRef<const ParamDecl *> FallbackParams,
+                       ClassifiedBlocks &Blocks) {
+    for (auto Param : FallbackParams) {
+      OS << tok::kw_var << " " << newNameFor(Param) << ": ";
+      auto Ty = Param->getType();
+      Ty->print(OS);
+      if (!Ty->getOptionalObjectType())
+        OS << "?";
+
+      OS << " = " << tok::kw_nil << "\n";
+    }
+  }
+
+  void addDo() { OS << tok::kw_do << " " << tok::l_brace << "\n"; }
+
+  void addHandlerCall(const CallExpr *CE) {
+    auto Exprs = TopHandler.extractResultArgs(CE);
+
+    if (!Exprs.isError()) {
+      OS << tok::kw_return;
+    } else {
+      OS << tok::kw_throw;
+    }
+
+    ArrayRef<Expr *> Args = Exprs.args();
+    if (!Args.empty()) {
+      OS << " ";
+      if (Args.size() > 1)
+        OS << tok::l_paren;
+      for (size_t I = 0, E = Args.size(); I < E; ++I) {
+        if (I > 0)
+          OS << tok::comma << " ";
+        // Can't just add the range as we need to perform replacements
+        convertNode(Args[I], /*StartOverride=*/CE->getArgumentLabelLoc(I),
+                    /*ConvertCalls=*/false);
+      }
+      if (Args.size() > 1)
+        OS << tok::r_paren;
+    }
+  }
+
+  void addAsyncAlternativeCall(const CallExpr *CE,
+                               const AsyncHandlerDesc &HandlerDesc) {
+    auto ArgList = callArgs(CE);
+    if ((size_t)HandlerDesc.Index >= ArgList.ref().size()) {
+      DiagEngine.diagnose(CE->getStartLoc(), diag::missing_callback_arg);
+      return;
+    }
+    auto Callback = dyn_cast<ClosureExpr>(ArgList.ref()[HandlerDesc.Index]);
+    if (!Callback) {
+      DiagEngine.diagnose(CE->getStartLoc(), diag::missing_callback_arg);
+      return;
+    }
+
+    ParameterList *CallbackParams = Callback->getParameters();
+    ArrayRef<ASTNode> CallbackBody = Callback->getBody()->getElements();
+    if (HandlerDesc.params().size() != CallbackParams->size()) {
+      DiagEngine.diagnose(CE->getStartLoc(), diag::mismatched_callback_args);
+      return;
+    }
+
+    // Note that the `ErrParam` may be a Result (in which case it's also the
+    // only element in `SuccessParams`)
+    ArrayRef<const ParamDecl *> SuccessParams = CallbackParams->getArray();
+    const ParamDecl *ErrParam = nullptr;
+    if (HandlerDesc.HasError) {
+      ErrParam = SuccessParams.back();
+      if (HandlerDesc.Type == HandlerType::PARAMS)
+        SuccessParams = SuccessParams.drop_back();
+    }
+    ArrayRef<const ParamDecl *> ErrParams;
+    if (ErrParam)
+      ErrParams = llvm::makeArrayRef(ErrParam);
+
+    ClassifiedBlocks Blocks;
+    if (!HandlerDesc.HasError) {
+      Blocks.SuccessBlock.addAllNodes(CallbackBody);
+    } else if (!CallbackBody.empty()) {
+      CallbackClassifier::classifyInto(Blocks, DiagEngine, SuccessParams,
+                                       ErrParam, HandlerDesc.Type,
+                                       CallbackBody);
+      if (DiagEngine.hadAnyError()) {
+        // Can only fallback when the results are params, in which case only
+        // the names are used (defaulted to the names of the params if none)
+        if (HandlerDesc.Type != HandlerType::PARAMS)
+          return;
+        DiagEngine.resetHadAnyError();
+
+        setNames(ClassifiedBlock(), CallbackParams->getArray());
+
+        addFallbackVars(CallbackParams->getArray(), Blocks);
+        addDo();
+        addAwaitCall(CE, ArgList.ref(), Blocks.SuccessBlock, SuccessParams,
+                     /*HasError=*/HandlerDesc.HasError,
+                     /*AddDeclarations=*/!HandlerDesc.HasError);
+        addFallbackCatch(ErrParam);
+        OS << "\n";
+        convertNodes(CallbackBody);
+
+        clearParams(CallbackParams->getArray());
+        return;
+      }
+    }
+
+    bool RequireDo = !Blocks.ErrorBlock.nodes().empty();
+    // Check if we *actually* need a do/catch (see class comment)
+    if (Blocks.ErrorBlock.nodes().size() == 1) {
+      auto Node = Blocks.ErrorBlock.nodes()[0];
+      if (auto *HandlerCall = TopHandler.getAsHandlerCall(Node)) {
+        auto Res = TopHandler.extractResultArgs(HandlerCall);
+        if (Res.args().size() == 1) {
+          // Skip if we have the param itself or the name it's bound to
+          auto *SingleDecl = Res.args()[0]->getReferencedDecl().getDecl();
+          auto ErrName = Blocks.ErrorBlock.boundName(ErrParam);
+          RequireDo = SingleDecl != ErrParam &&
+                      !(Res.isError() && SingleDecl &&
+                        SingleDecl->getName().isSimpleName(ErrName));
+        }
+      }
+    }
+
+    if (RequireDo) {
+      addDo();
+    }
+
+    setNames(Blocks.SuccessBlock, SuccessParams);
+    addAwaitCall(CE, ArgList.ref(), Blocks.SuccessBlock, SuccessParams,
+                 /*HasError=*/HandlerDesc.HasError,
+                 /*AddDeclarations=*/true);
+
+    prepareNamesForBody(HandlerDesc.Type, SuccessParams, ErrParams);
+    convertNodes(Blocks.SuccessBlock.nodes());
+
+    if (RequireDo) {
+      clearParams(SuccessParams);
+      // Always use the ErrParam name if none is bound
+      setNames(Blocks.ErrorBlock, ErrParams,
+               HandlerDesc.Type != HandlerType::RESULT);
+      addCatch(ErrParam);
+
+      prepareNamesForBody(HandlerDesc.Type, ErrParams, SuccessParams);
+      addCatchBody(ErrParam, Blocks.ErrorBlock);
+    }
+
+    clearParams(CallbackParams->getArray());
+  }
+
+  void addAwaitCall(const CallExpr *CE, ArrayRef<Expr *> Args,
+                    const ClassifiedBlock &SuccessBlock,
+                    ArrayRef<const ParamDecl *> SuccessParams, bool HasError,
+                    bool AddDeclarations) {
+    if (!SuccessParams.empty()) {
+      if (AddDeclarations) {
+        if (SuccessBlock.allLet()) {
+          OS << tok::kw_let;
+        } else {
+          OS << tok::kw_var;
+        }
+        OS << " ";
+      }
+      if (SuccessParams.size() > 1)
+        OS << tok::l_paren;
+      OS << newNameFor(SuccessParams.front());
+      for (const auto Param : SuccessParams.drop_front()) {
+        OS << tok::comma << " ";
+        OS << newNameFor(Param);
+      }
+      if (SuccessParams.size() > 1) {
+        OS << tok::r_paren;
+      }
+      OS << " " << tok::equal << " ";
+    }
+
+    if (HasError) {
+      OS << tok::kw_try << " ";
+    }
+    OS << "await ";
+    addRange(CE->getStartLoc(), CE->getFn()->getEndLoc(),
+             /*ToEndOfToken=*/true);
+
+    OS << tok::l_paren;
+    for (size_t I = 0, E = Args.size() - 1; I < E; ++I) {
+      if (I > 0)
+        OS << tok::comma << " ";
+      // Can't just add the range as we need to perform replacements
+      convertNode(Args[I], /*StartOverride=*/CE->getArgumentLabelLoc(I),
+                  /*ConvertCalls=*/false);
+    }
+    OS << tok::r_paren;
+  }
+
+  void addFallbackCatch(const ParamDecl *ErrParam) {
+    auto ErrName = newNameFor(ErrParam);
+    OS << "\n"
+       << tok::r_brace << " " << tok::kw_catch << " " << tok::l_brace << "\n"
+       << ErrName << " = error\n"
+       << tok::r_brace;
+  }
+
+  void addCatch(const ParamDecl *ErrParam) {
+    OS << "\n" << tok::r_brace << " " << tok::kw_catch << " ";
+    auto ErrName = newNameFor(ErrParam, false);
+    if (!ErrName.empty()) {
+      OS << tok::kw_let << " " << ErrName << " ";
+    }
+    OS << tok::l_brace;
+  }
+
+  void addCatchBody(const ParamDecl *ErrParam,
+                    const ClassifiedBlock &ErrorBlock) {
+    convertNodes(ErrorBlock.nodes());
+    OS << "\n" << tok::r_brace;
+  }
+
+  void prepareNamesForBody(HandlerType ResultType,
+                           ArrayRef<const ParamDecl *> CurrentParams,
+                           ArrayRef<const ParamDecl *> OtherParams) {
+    switch (ResultType) {
+    case HandlerType::PARAMS:
+      for (auto *Param : CurrentParams) {
+        if (Param->getType()->getOptionalObjectType()) {
+          Unwraps.insert(Param);
+          Placeholders.insert(Param);
+        }
+      }
+      // Use of the other params is invalid within the current body
+      Placeholders.insert(OtherParams.begin(), OtherParams.end());
+      break;
+    case HandlerType::RESULT:
+      // Any uses of the result parameter in the current body (that
+      // isn't replaced) are invalid, so replace them with a placeholder
+      Placeholders.insert(CurrentParams.begin(), CurrentParams.end());
+      break;
+    default:
+      llvm_unreachable("Unhandled handler type");
+    }
+  }
+
+  // TODO: Check for clashes with existing names
+  void setNames(const ClassifiedBlock &Block,
+                ArrayRef<const ParamDecl *> Params, bool AddIfMissing = true) {
+    for (auto *Param : Params) {
+      StringRef Name = Block.boundName(Param);
+      if (!Name.empty()) {
+        Names[Param] = Name.str();
+        continue;
+      }
+
+      if (!AddIfMissing)
+        continue;
+
+      auto ParamName = Param->getNameStr();
+      if (ParamName.startswith("$")) {
+        Names[Param] = "val" + ParamName.drop_front().str();
+      } else {
+        Names[Param] = ParamName.str();
+      }
+    }
+  }
+
+  StringRef newNameFor(const Decl *D, bool Required = true) {
+    auto Res = Names.find(D);
+    if (Res == Names.end()) {
+      assert(!Required && "Missing name for decl when one was required");
+      return StringRef();
+    }
+    return StringRef(Res->second);
+  }
+
+  void clearParams(ArrayRef<const ParamDecl *> Params) {
+    for (auto *Param : Params) {
+      Unwraps.erase(Param);
+      Placeholders.erase(Param);
+      Names.erase(Param);
+    }
+  }
+};
+} // namespace asyncrefactorings
+
+bool RefactoringActionConvertCallToAsyncAlternative::isApplicable(
+    const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
+  using namespace asyncrefactorings;
+
+  if (!CursorInfo.SF->getASTContext().LangOpts.EnableExperimentalConcurrency)
+    return false;
+
+  // Currently doesn't check that the call is in an async context. This seems
+  // possibly useful in some situations, so we'll see what the feedback is.
+  // May need to change in the future
+  auto *CE = findOuterCall(CursorInfo);
+  if (!CE)
+    return false;
+
+  auto HandlerDesc = AsyncHandlerDesc::find(getUnderlyingFunc(CE->getFn()),
+                                            /*ignoreName=*/true);
+  return HandlerDesc.isValid();
+}
+
+/// Converts a call of a function with a possible async alternative, to use it
+/// instead. Currently this is any function that
+///   1. has a void return type,
+///   2. has a void returning closure as its last parameter, and
+///   3. is not already async
+///
+/// For now the call need not be in an async context, though this may change
+/// depending on feedback.
+bool RefactoringActionConvertCallToAsyncAlternative::performChange() {
+  using namespace asyncrefactorings;
+
+  auto *CE = findOuterCall(CursorInfo);
+  assert(CE &&
+         "Should not run performChange when refactoring is not applicable");
+
+  AsyncConversionStringBuilder Builder(SM, DiagEngine, AsyncHandlerDesc());
+  Builder.convertNode(CE);
+
+  if (DiagEngine.hadAnyError())
+    return true;
+
+  Builder.replace(CE, EditConsumer);
+  return false;
+}
+
+bool RefactoringActionConvertToAsync::isApplicable(
+    const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
+  using namespace asyncrefactorings;
+
+  if (!CursorInfo.SF->getASTContext().LangOpts.EnableExperimentalConcurrency)
+    return false;
+
+  // As with the call refactoring, should possibly only apply if there's
+  // actually calls to async alternatives. At the moment this will just add
+  // `async` if there are no calls, which is probably fine.
+  return findFunction(CursorInfo);
+}
+
+/// Converts a whole function to async, converting any calls to functions with
+/// async alternatives as above.
+bool RefactoringActionConvertToAsync::performChange() {
+  using namespace asyncrefactorings;
+
+  auto *FD = findFunction(CursorInfo);
+  assert(FD &&
+         "Should not run performChange when refactoring is not applicable");
+
+  AsyncConversionStringBuilder Builder(SM, DiagEngine, AsyncHandlerDesc());
+  Builder.convertFunction(FD);
+
+  if (DiagEngine.hadAnyError())
+    return true;
+
+  Builder.replace(FD, EditConsumer);
+  return false;
+}
+
+bool RefactoringActionAddAsyncAlternative::isApplicable(
+    const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
+  using namespace asyncrefactorings;
+
+  if (!CursorInfo.SF->getASTContext().LangOpts.EnableExperimentalConcurrency)
+    return false;
+
+  auto *FD = findFunction(CursorInfo);
+  if (!FD)
+    return false;
+
+  auto HandlerDesc = AsyncHandlerDesc::find(FD, /*ignoreName=*/true);
+  return HandlerDesc.isValid();
+}
+
+/// Adds an async alternative and marks the current function as deprecated.
+/// Equivalent to the conversion but
+///   1. only works on functions that themselves are a possible async
+///      alternative, and
+///   2. has extra handling to convert the completion/handler/callback closure
+///      parameter to either `return`/`throws`
+bool RefactoringActionAddAsyncAlternative::performChange() {
+  using namespace asyncrefactorings;
+
+  auto *FD = findFunction(CursorInfo);
+  assert(FD &&
+         "Should not run performChange when refactoring is not applicable");
+
+  auto HandlerDesc = AsyncHandlerDesc::find(FD, /*ignoreName=*/true);
+  assert(HandlerDesc.isValid() &&
+         "Should not run performChange when refactoring is not applicable");
+
+  AsyncConversionStringBuilder Builder(SM, DiagEngine, HandlerDesc);
+  Builder.convertFunction(FD);
+
+  if (DiagEngine.hadAnyError())
+    return true;
+
+  EditConsumer.accept(SM, FD->getAttributeInsertionLoc(false),
+                      "@available(*, deprecated, message: \"Prefer async "
+                      "alternative instead\")\n");
+  Builder.insertAfter(FD, EditConsumer);
+
+  return false;
+}
+} // end of anonymous namespace
 
 StringRef swift::ide::
 getDescriptiveRefactoringKindName(RefactoringKind Kind) {

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -1018,6 +1018,26 @@ accept(SourceManager &SM, RegionType Type, ArrayRef<Replacement> Replacements) {
     Impl.accept(SM, Replacement.Range, Replacement.Text);
   }
 }
+
+swift::ide::SourceEditTextConsumer::
+SourceEditTextConsumer(llvm::raw_ostream &OS) : OS(OS) { }
+
+void swift::ide::SourceEditTextConsumer::
+accept(SourceManager &SM, RegionType Type, ArrayRef<Replacement> Replacements) {
+  for (const auto &Replacement: Replacements) {
+    CharSourceRange Range = Replacement.Range;
+    unsigned BufID = SM.findBufferContainingLoc(Range.getStart());
+    auto Path(SM.getIdentifierForBuffer(BufID));
+    auto Start = SM.getLineAndColumnInBuffer(Range.getStart());
+    auto End = SM.getLineAndColumnInBuffer(Range.getEnd());
+
+    OS << "// " << Path.str() << " ";
+    OS << "[" << Start.first << ":" << Start.second << ", ";
+    OS << End.first << ":" << End.second << ")\n";
+    OS << Replacement.Text << "\n";
+  }
+}
+
 namespace {
 class ClangFileRewriterHelper {
   unsigned InterestedId;

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -1032,8 +1032,8 @@ accept(SourceManager &SM, RegionType Type, ArrayRef<Replacement> Replacements) {
     auto End = SM.getLineAndColumnInBuffer(Range.getEnd());
 
     OS << "// " << Path.str() << " ";
-    OS << "[" << Start.first << ":" << Start.second << ", ";
-    OS << End.first << ":" << End.second << ")\n";
+    OS << Start.first << ":" << Start.second << " -> ";
+    OS << End.first << ":" << End.second << "\n";
     OS << Replacement.Text << "\n";
   }
 }

--- a/test/SourceKit/Refactoring/basic.swift
+++ b/test/SourceKit/Refactoring/basic.swift
@@ -116,6 +116,11 @@ HasInitWithDefaultArgs(y: 45, z: 89)
 func `hasBackticks`(`x`: Int) {}
 `hasBackticks`(`x`:2)
 
+func hasAsyncAlternative(completion: (String?, Error?) -> Void) { }
+func hasCallToAsyncAlternative() {
+  hasAsyncAlternative { str, err in print(str!) }
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=3:1 -end-pos=5:13 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK1
 
 // CHECK1: ACTIONS BEGIN
@@ -161,6 +166,11 @@ func `hasBackticks`(`x`: Int) {}
 // RUN: %sourcekitd-test -req=cursor -pos=117:16  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 // RUN: %sourcekitd-test -req=cursor -pos=117:17  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-GLOBAL
 
+// RUN: %sourcekitd-test -req=cursor -pos=119:6  -cursor-action %s -- -Xfrontend -enable-experimental-concurrency %s | %FileCheck %s -check-prefix=CHECK-ASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=121:3  -cursor-action %s -- -Xfrontend -enable-experimental-concurrency %s | %FileCheck %s -check-prefix=CHECK-CALLASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=119:6  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NOASYNC
+// RUN: %sourcekitd-test -req=cursor -pos=121:3  -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-NOASYNC
+
 // RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 // RUN: %sourcekitd-test -req=cursor -pos=35:10 -end-pos=35:16 -cursor-action %s -- %s | %FileCheck %s -check-prefix=CHECK-RENAME-EXTRACT
 
@@ -179,10 +189,12 @@ func `hasBackticks`(`x`: Int) {}
 // CHECK-NORENAME-NOT: Local Rename
 
 // CHECK2: ACTIONS BEGIN
-// CHECK2-NEXT: source.refactoring.kind.rename.global
+// CHECK2-NOT: Local Rename
+// CHECK2: source.refactoring.kind.rename.global
 // CHECK2-NEXT: Global Rename
 // CHECK2-NEXT: symbol from system module cannot be renamed
-// CHECK2-NEXT: ACTIONS END
+// CHECK2-NOT: Local Rename
+// CHECK2: ACTIONS END
 
 // CHECK3: ACTIONS BEGIN
 // CHECK3-NEXT: source.refactoring.kind.rename.global
@@ -196,14 +208,18 @@ func `hasBackticks`(`x`: Int) {}
 // CHECK4-NEXT: Expand Default
 
 // CHECK-GLOBAL: ACTIONS BEGIN
-// CHECK-GLOBAL-NEXT: source.refactoring.kind.rename.global
+// CHECK-GLOBAL-NOT: Local Rename
+// CHECK-GLOBAL: source.refactoring.kind.rename.global
 // CHECK-GLOBAL-NEXT: Global Rename
-// CHECK-GLOBAL-NEXT: ACTIONS END
+// CHECK-GLOBAL-NOT: Local Rename
+// CHECK-GLOBAL: ACTIONS END
 
 // CHECK-LOCAL: ACTIONS BEGIN
-// CHECK-LOCAL-NEXT: source.refactoring.kind.rename.local
+// CHECK-LOCAL-NOT: Global Rename
+// CHECK-LOCAL: source.refactoring.kind.rename.local
 // CHECK-LOCAL-NEXT: Local Rename
-// CHECK-LOCAL-NEXT: ACTIONS END
+// CHECK-LOCAL-NOT: Global Rename
+// CHECK-LOCAL: ACTIONS END
 
 // CHECK-RENAME-EXTRACT: Global Rename
 // CHECK-RENAME-EXTRACT: Extract Method
@@ -223,5 +239,29 @@ func `hasBackticks`(`x`: Int) {}
 // CHECK-IMPLICIT-SELF: Global Rename
 
 // CHECK-LOCALIZE-STRING: source.refactoring.kind.localize.string
+
+// CHECK-ASYNC: ACTIONS BEGIN
+// CHECK-ASYNC-NOT: source.refactoring.kind.convert.call-to-async
+// CHECK-ASYNC: source.refactoring.kind.convert.func-to-async
+// CHECK-ASYNC-NEXT: Convert Function to Async
+// CHECK-ASYNC-NEXT: source.refactoring.kind.add.async-alternative
+// CHECK-ASYNC-NEXT: Add Async Alternative
+// CHECK-ASYNC-NOT: source.refactoring.kind.convert.call-to-async
+// CHECK-ASYNC: ACTIONS END
+
+// CHECK-CALLASYNC: ACTIONS BEGIN
+// CHECK-ASYNC-NOT: source.refactoring.kind.add.async-alternative
+// CHECK-ASYNC-NOT: source.refactoring.kind.convert.func-to-async
+// CHECK-CALLASYNC: source.refactoring.kind.convert.call-to-async
+// CHECK-CALLASYNC-NEXT: Convert Call to Async Alternative
+// CHECK-ASYNC-NOT: source.refactoring.kind.add.async-alternative
+// CHECK-ASYNC-NOT: source.refactoring.kind.convert.func-to-async
+// CHECK-CALLASYNC: ACTIONS END
+
+// CHECK-NOASYNC: ACTIONS BEGIN
+// CHECK-NOASYNC-NOT: source.refactoring.kind.add.async-alternative
+// CHECK-NOASYNC-NOT: source.refactoring.kind.convert.func-to-async
+// CHECK-NOASYNC-NOT: source.refactoring.kind.convert.call-to-async
+// CHECK-NOASYNC: ACTIONS END
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/test/refactoring/ConvertAsync/basic.swift
+++ b/test/refactoring/ConvertAsync/basic.swift
@@ -1,0 +1,273 @@
+enum CustomError: Error {
+  case invalid
+  case insecure
+}
+
+typealias SomeCallback = (String) -> Void
+typealias SomeResultCallback = (Result<String, CustomError>) -> Void
+typealias NestedAliasCallback = SomeCallback
+
+// 1. Check various functions for having/not having async alternatives
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+4):1 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+3):6 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):12 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):13 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
+func simple(completion: (String) -> Void) { }
+// ASYNC-SIMPLE: basic.swift [[# @LINE-1]]:1 -> [[# @LINE-1]]:1
+// ASYNC-SIMPLE-NEXT: @available(*, deprecated, message: "Prefer async alternative instead")
+// ASYNC-SIMPLE-EMPTY:
+// ASYNC-SIMPLE-NEXT: basic.swift [[# @LINE-4]]:46 -> [[# @LINE-4]]:46
+// ASYNC-SIMPLE-EMPTY:
+// ASYNC-SIMPLE-EMPTY:
+// ASYNC-SIMPLE-EMPTY:
+// ASYNC-SIMPLE-NEXT: basic.swift [[# @LINE-8]]:46 -> [[# @LINE-8]]:46
+// ASYNC-SIMPLE-NEXT: func simple() async -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLENOLABEL %s
+func simpleWithoutLabel(_ completion: (String) -> Void) { }
+// ASYNC-SIMPLENOLABEL: func simpleWithoutLabel() async -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLEWITHARG %s
+func simpleWithArg(a: Int, completion: (String) -> Void) { }
+// ASYNC-SIMPLEWITHARG: func simpleWithArg(a: Int) async -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-MULTIPLERESULTS %s
+func multipleResults(completion: (String, Int) -> Void) { }
+// ASYNC-MULTIPLERESULTS: func multipleResults() async -> (String, Int) { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-NONOPTIONALERROR %s
+func nonOptionalError(completion: (String, Error) -> Void) { }
+// ASYNC-NONOPTIONALERROR: func nonOptionalError() async -> (String, Error) { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-NOPARAMS %s
+func noParams(completion: () -> Void) { }
+// ASYNC-NOPARAMS: func noParams() async { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERROR %s
+func error(completion: (String?, Error?) -> Void) { }
+// ASYNC-ERROR: func error() async throws -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORONLY %s
+func errorOnly(completion: (Error?) -> Void) { }
+// ASYNC-ERRORONLY: func errorOnly() async throws { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORNONOPTIONALRESULT %s
+func errorNonOptionalResult(completion: (String, Error?) -> Void) { }
+// ASYNC-ERRORNONOPTIONALRESULT: func errorNonOptionalResult() async throws -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-CUSTOMERROR %s
+func customError(completion: (String?, CustomError?) -> Void) { }
+// ASYNC-CUSTOMERROR: func customError() async throws -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ALIAS %s
+func alias(completion: SomeCallback) { }
+// ASYNC-ALIAS: func alias() async -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-NESTEDALIAS %s
+func nestedAlias(completion: NestedAliasCallback) { }
+// ASYNC-NESTEDALIAS: func nestedAlias() async -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLERESULT %s
+func simpleResult(completion: (Result<String, Never>) -> Void) { }
+// ASYNC-SIMPLERESULT: func simpleResult() async -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERRORRESULT %s
+func errorResult(completion: (Result<String, Error>) -> Void) { }
+// ASYNC-ERRORRESULT: func errorResult() async throws -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-CUSTOMERRORRESULT %s
+func customErrorResult(completion: (Result<String, CustomError>) -> Void) { }
+// ASYNC-CUSTOMERRORRESULT: func customErrorResult() async throws -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ALIASRESULT %s
+func aliasedResult(completion: SomeResultCallback) { }
+// ASYNC-ALIASRESULT: func aliasedResult() async throws -> String { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MANY %s
+func many(_ completion: (String, Int) -> Void) { }
+// MANY: func many() async -> (String, Int) { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=OPTIONAL-SINGLE %s
+func optionalSingle(completion: (String?) -> Void) { }
+// OPTIONAL-SINGLE: func optionalSingle() async -> String? { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MANY-OPTIONAL %s
+func manyOptional(_ completion: (String?, Int?) -> Void) { }
+// MANY-OPTIONAL: func manyOptional() async -> (String?, Int?) { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=GENERIC %s
+func generic<T, R>(completion: (T, R) -> Void) { }
+// GENERIC: func generic<T, R>() async -> (T, R) { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=GENERIC-RESULT %s
+func genericResult<T>(completion: (T?, Error?) -> Void) where T: Numeric { }
+// GENERIC-RESULT: func genericResult<T>() async throws -> T where T: Numeric { }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=GENERIC-ERROR %s
+func genericError<E>(completion: (String?, E?) -> Void) where E: Error { }
+// GENERIC-ERROR: func genericError<E>() async throws -> String where E: Error { }
+
+struct MyStruct {
+  var someVar: (Int) -> Void {
+    get {
+      return {_ in }
+    }
+    // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):5
+    set (completion) {
+    }
+  }
+
+  init() { }
+
+  // RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
+  init(completion: (String) -> Void) { }
+
+  func retSelf() -> MyStruct { return self }
+
+  // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):10 | %FileCheck -check-prefix=MODIFIERS %s
+  public func publicMember(completion: (String) -> Void) { }
+  // MODIFIERS: public func publicMember() async -> String { }
+
+  // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=STATIC %s
+  static func staticMember(completion: (String) -> Void) { }
+  // STATIC: static func staticMember() async -> String { }
+
+  // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+2):11 | %FileCheck -check-prefix=DEPRECATED %s
+  @available(*, deprecated, message: "Deprecated")
+  private func deprecated(completion: (String) -> Void) { }
+  // DEPRECATED: @available(*, deprecated, message: "Deprecated")
+  // DEPRECATED-NEXT: private func deprecated() async -> String { }
+}
+func retStruct() -> MyStruct { return MyStruct() }
+
+protocol MyProtocol {
+  // RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=PROTO-MEMBER %s
+  func protoMember(completion: (String) -> Void)
+  // PROTO-MEMBER: func protoMember() async -> String{{$}}
+}
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func nonCompletion(a: Int) { }
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func multipleResults(completion: (Result<String, Error>, Result<String, Error>) -> Void) { }
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func completionNotLast(completion: (String) -> Void, a: Int) { }
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func nonVoid(completion: (String) -> Void) -> Int { return 0 }
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func completionNonVoid(completion: (String) -> Int) -> Void { }
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func alreadyThrows(completion: (String) -> Void) throws { }
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func noParamAutoclosure(completion: @autoclosure () -> Void) { }
+
+// 2. Check that the various ways to call a function (and the positions the
+//    refactoring is called from) are handled correctly
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefixes=CONVERT-FUNC,CALL,CALL-NOLABEL,CALL-WRAPPED,TRAILING,TRAILING-PARENS,TRAILING-WRAPPED,TRAILING-ARG %s
+func testCalls() {
+// CONVERT-FUNC: {{^}}func testCalls() async {
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+4):3 | %FileCheck -check-prefix=CALL %s
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):10
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):24
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):28
+  simple(completion: { str in
+    // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):5
+    print("with label")
+  })
+  // CALL: let str = await simple(){{$}}
+  // CALL-NEXT: {{^}}print("with label")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=CALL-NOLABEL %s
+  simpleWithoutLabel({ str in
+    print("without label")
+  })
+  // CALL-NOLABEL: let str = await simpleWithoutLabel(){{$}}
+  // CALL-NOLABEL-NEXT: {{^}}print("without label")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=CALL-WRAPPED %s
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 | %FileCheck -check-prefix=CALL-WRAPPED %s
+  ((simple))(completion: { str in
+    print("wrapped call")
+  })
+  // CALL-WRAPPED: let str = await ((simple))(){{$}}
+  // CALL-WRAPPED-NEXT: {{^}}print("wrapped call")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):3 | %FileCheck -check-prefix=TRAILING %s
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):12
+  simple { str in
+    print("trailing")
+  }
+  // TRAILING: let str = await simple(){{$}}
+  // TRAILING-NEXT: {{^}}print("trailing")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=TRAILING-PARENS %s
+  simple() { str in
+    print("trailing with parens")
+  }
+  // TRAILING-PARENS: let str = await simple(){{$}}
+  // TRAILING-PARENS-NEXT: {{^}}print("trailing with parens")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):5 | %FileCheck -check-prefix=TRAILING-WRAPPED %s
+  ((simple)) { str in
+    print("trailing with wrapped call")
+  }
+  // TRAILING-WRAPPED: let str = await ((simple))(){{$}}
+  // TRAILING-WRAPPED-NEXT: {{^}}print("trailing with wrapped call")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=CALL-ARG %s
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):17
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):20
+  simpleWithArg(a: 10) { str in
+    print("with arg")
+  }
+  // CALL-ARG: let str = await simpleWithArg(a: 10){{$}}
+  // CALL-ARG-NEXT: {{^}}print("with arg")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANY-CALL %s
+  many { str, num in
+    print("many")
+  }
+  // MANY-CALL: let (str, num) = await many(){{$}}
+  // MANY-CALL-NEXT: {{^}}print("many")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):15 | %FileCheck -check-prefix=MEMBER-CALL %s
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MEMBER-CALL %s
+  retStruct().publicMember { str in
+    print("call on member")
+  }
+  // MEMBER-CALL: let str = await retStruct().publicMember(){{$}}
+  // MEMBER-CALL-NEXT: {{^}}print("call on member")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):25 | %FileCheck -check-prefix=MEMBER-CALL2 %s
+  retStruct().retSelf().publicMember { str in
+    print("call on member 2")
+  }
+  // MEMBER-CALL2: let str = await retStruct().retSelf().publicMember(){{$}}
+  // MEMBER-CALL2-NEXT: {{^}}print("call on member 2")
+
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+3):3 | %FileCheck -check-prefix=MEMBER-PARENS %s
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+2):5 | %FileCheck -check-prefix=MEMBER-PARENS %s
+  // RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):15 | %FileCheck -check-prefix=MEMBER-PARENS %s
+  (((retStruct().retSelf()).publicMember)) { str in
+    print("call on member parens")
+  }
+  // MEMBER-PARENS: let str = await (((retStruct().retSelf()).publicMember))(){{$}}
+  // MEMBER-PARENS-NEXT: {{^}}print("call on member parens")
+
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):13
+  let _: Void = simple { str in
+    print("assigned")
+  }
+
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
+  noParamAutoclosure(completion: print("autoclosure"))
+}
+// CONVERT-FUNC: {{^}}}

--- a/test/refactoring/ConvertAsync/convert_function.swift
+++ b/test/refactoring/ConvertAsync/convert_function.swift
@@ -1,0 +1,136 @@
+enum CustomError : Error {
+  case Bad
+}
+
+func simple(_ completion: (String) -> Void) { }
+func simple2(arg: String, _ completion: (String) -> Void) { }
+func simpleErr(arg: String, _ completion: (String?, Error?) -> Void) { }
+func simpleRes(arg: String, _ completion: (Result<String, Error>) -> Void) { }
+func run(block: () -> Bool) -> Bool { return false }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTED %s
+func nested() {
+  simple {
+    simple2(arg: $0) { str2 in
+      print(str2)
+    }
+  }
+}
+// NESTED: func nested() async {
+// NESTED-NEXT: let val0 = await simple()
+// NESTED-NEXT: let str2 = await simple2(arg: val0)
+// NESTED-NEXT: print(str2)
+// NESTED-NEXT: }
+
+// RUN: %refactor -convert-to-async -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=MANY-NESTED %s
+func manyNested() {
+  simple { str1 in
+    print("simple")
+    simple2(arg: str1) { str2 in
+      print("simple2")
+      simpleErr(arg: str2) { str3, err in
+        print("simpleErr")
+        guard let str3 = str3, err == nil else {
+          return
+        }
+        simpleRes(arg: str3) { res in
+          print("simpleRes")
+          if case .success(let str4) = res {
+            print("\(str1) \(str2) \(str3) \(str4)")
+            print("after")
+          }
+        }
+      }
+    }
+  }
+}
+// MANY-NESTED: func manyNested() async {
+// MANY-NESTED-NEXT: let str1 = await simple()
+// MANY-NESTED-NEXT: print("simple")
+// MANY-NESTED-NEXT: let str2 = await simple2(arg: str1)
+// MANY-NESTED-NEXT: print("simple2")
+// MANY-NESTED-NEXT: let str3 = try await simpleErr(arg: str2)
+// MANY-NESTED-NEXT: print("simpleErr")
+// MANY-NESTED-NEXT: let str4 = try await simpleRes(arg: str3)
+// MANY-NESTED-NEXT: print("simpleRes")
+// MANY-NESTED-NEXT: print("\(str1) \(str2) \(str3) \(str4)")
+// MANY-NESTED-NEXT: print("after")
+// MANY-NESTED-NEXT: }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
+func asyncParams(arg: String, _ completion: (String?, Error?) -> Void) {
+  simpleErr(arg: arg) { str, err in
+    print("simpleErr")
+    guard let str = str, err == nil else {
+      completion(nil, err!)
+      return
+    }
+    completion(str, nil)
+    print("after")
+  }
+}
+// ASYNC-SIMPLE: func {{[a-zA-Z_]+}}(arg: String) async throws -> String {
+// ASYNC-SIMPLE-NEXT: let str = try await simpleErr(arg: arg)
+// ASYNC-SIMPLE-NEXT: print("simpleErr")
+// ASYNC-SIMPLE-NEXT: return str
+// ASYNC-SIMPLE-NEXT: print("after")
+// ASYNC-SIMPLE-NEXT: }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-SIMPLE %s
+func asyncResErrPassed(arg: String, _ completion: (Result<String, Error>) -> Void) {
+  simpleErr(arg: arg) { str, err in
+    print("simpleErr")
+    guard let str = str, err == nil else {
+      completion(.failure(err!))
+      return
+    }
+    completion(.success(str))
+    print("after")
+  }
+}
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-ERR %s
+func asyncResNewErr(arg: String, _ completion: (Result<String, Error>) -> Void) {
+  simpleErr(arg: arg) { str, err in
+    print("simpleErr")
+    guard let str = str, err == nil else {
+      completion(.failure(CustomError.Bad))
+      return
+    }
+    completion(.success(str))
+    print("after")
+  }
+}
+// ASYNC-ERR: func asyncResNewErr(arg: String) async throws -> String {
+// ASYNC-ERR-NEXT: do {
+// ASYNC-ERR-NEXT: let str = try await simpleErr(arg: arg)
+// ASYNC-ERR-NEXT: print("simpleErr")
+// ASYNC-ERR-NEXT: return str
+// ASYNC-ERR-NEXT: print("after")
+// ASYNC-ERR-NEXT: } catch let err {
+// ASYNC-ERR-NEXT: throw CustomError.Bad
+// ASYNC-ERR-NEXT: }
+// ASYNC-ERR-NEXT: }
+
+// RUN: %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=ASYNC-UNHANDLED %s
+func asyncUnhandledCompletion(_ completion: (String) -> Void) {
+  simple { str in
+    let success = run {
+      completion(str)
+      return true
+    }
+    if !success {
+      completion("bad")
+    }
+  }
+}
+// ASYNC-UNHANDLED: func asyncUnhandledCompletion() async -> String {
+// ASYNC-UNHANDLED-NEXT: let str = await simple()
+// ASYNC-UNHANDLED-NEXT: let success = run {
+// ASYNC-UNHANDLED-NEXT: <#completion#>(str)
+// ASYNC-UNHANDLED-NEXT: return true
+// ASYNC-UNHANDLED-NEXT: }
+// ASYNC-UNHANDLED-NEXT: if !success {
+// ASYNC-UNHANDLED-NEXT: return "bad"
+// ASYNC-UNHANDLED-NEXT: }
+// ASYNC-UNHANDLED-NEXT: }

--- a/test/refactoring/ConvertAsync/convert_params_multi.swift
+++ b/test/refactoring/ConvertAsync/convert_params_multi.swift
@@ -1,0 +1,162 @@
+func manyWithError(_ completion: (String?, Int?, Error?) -> Void) { }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYBOUND %s
+manyWithError { res1, res2, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+    return
+  }
+  if let str = res1, let i = res2 {
+    print("got result \(str)")
+    print("got result \(i)")
+  }
+  print("after")
+}
+// MANYBOUND: do {
+// MANYBOUND-NEXT: let (str, i) = try await manyWithError()
+// MANYBOUND-NEXT: print("before")
+// MANYBOUND-NEXT: print("got result \(str)")
+// MANYBOUND-NEXT: print("got result \(i)")
+// MANYBOUND-NEXT: print("after")
+// MANYBOUND-NEXT: } catch let bad {
+// MANYBOUND-NEXT: print("got error \(bad)")
+// MANYBOUND-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYUNBOUND-ERR %s
+manyWithError { res1, res2, err in
+  print("before")
+  if let str = res1 {
+    print("got result \(str)")
+  } else if let i = res2 {
+    print("got result \(i)")
+  } else {
+    print("got error \(err!)")
+  }
+  print("after")
+}
+// MANYUNBOUND-ERR: do {
+// MANYUNBOUND-ERR-NEXT: let (str, i) = try await manyWithError()
+// MANYUNBOUND-ERR-NEXT: print("before")
+// MANYUNBOUND-ERR-NEXT: print("got result \(str)")
+// MANYUNBOUND-ERR-NEXT: print("got result \(i)")
+// MANYUNBOUND-ERR-NEXT: print("after")
+// MANYUNBOUND-ERR-NEXT: } catch let err {
+// MANYUNBOUND-ERR-NEXT: print("got error \(err)")
+// MANYUNBOUND-ERR-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYBOUND %s
+manyWithError { res1, res2, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+    return
+  }
+  if let str = res1 {
+    print("got result \(str)")
+  }
+  if let i = res2 {
+    print("got result \(i)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-COND %s
+manyWithError { res1, res2, err in
+  print("before")
+  if res1 != nil && res2 == nil {
+    print("got result \(res1!)")
+  }
+  print("after")
+}
+//  MIXED-COND: convert_params_multi.swift
+//  MIXED-COND-NEXT: let (res1, res2) = try await manyWithError()
+//  MIXED-COND-NEXT: print("before")
+//  MIXED-COND-NEXT: if <#res1#> != nil && <#res2#> == nil {
+//  MIXED-COND-NEXT: print("got result \(res1)")
+//  MIXED-COND-NEXT: }
+//  MIXED-COND-NEXT: print("after")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MIXED-CONDELSE %s
+manyWithError { res1, res2, err in
+  print("before")
+  if res1 != nil && res2 == nil {
+    print("got result \(res1!)")
+  } else {
+    print("bad")
+  }
+  print("after")
+}
+// MIXED-CONDELSE: var res1: String? = nil
+// MIXED-CONDELSE-NEXT: var res2: Int? = nil
+// MIXED-CONDELSE-NEXT: var err: Error? = nil
+// MIXED-CONDELSE-NEXT: do {
+// MIXED-CONDELSE-NEXT: (res1, res2) = try await manyWithError()
+// MIXED-CONDELSE-NEXT: } catch {
+// MIXED-CONDELSE-NEXT: err = error
+// MIXED-CONDELSE-NEXT: }
+// MIXED-CONDELSE-EMPTY:
+// MIXED-CONDELSE-NEXT: print("before")
+// MIXED-CONDELSE-NEXT: if res1 != nil && res2 == nil {
+// MIXED-CONDELSE-NEXT: print("got result \(res1!)")
+// MIXED-CONDELSE-NEXT: } else {
+// MIXED-CONDELSE-NEXT: print("bad")
+// MIXED-CONDELSE-NEXT: }
+// MIXED-CONDELSE-NEXT: print("after")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYUNBOUND-ERR %s
+manyWithError { res1, res2, err in
+  print("before")
+  guard let str = res1, let i = res2 else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(str)")
+  print("got result \(i)")
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYUNBOUND %s
+manyWithError { res1, res2, err in
+  print("before")
+  guard res1 != nil && res2 != nil && err == nil else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(res1!)")
+  print("got result \(res2!)")
+  print("after")
+}
+// MANYUNBOUND: do {
+// MANYUNBOUND-NEXT: let (res1, res2) = try await manyWithError()
+// MANYUNBOUND-NEXT: print("before")
+// MANYUNBOUND-NEXT: print("got result \(res1)")
+// MANYUNBOUND-NEXT: print("got result \(res2)")
+// MANYUNBOUND-NEXT: print("after")
+// MANYUNBOUND-NEXT: } catch let err {
+// MANYUNBOUND-NEXT: print("got error \(err)")
+// MANYUNBOUND-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYUNBOUND %s
+manyWithError { res1, res2, err in
+  print("before")
+  guard res1 != nil else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(res1!)")
+  print("got result \(res2!)")
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MANYUNBOUND %s
+manyWithError { res1, res2, err in
+  print("before")
+  guard err == nil else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(res1!)")
+  print("got result \(res2!)")
+  print("after")
+}

--- a/test/refactoring/ConvertAsync/convert_params_single.swift
+++ b/test/refactoring/ConvertAsync/convert_params_single.swift
@@ -1,0 +1,408 @@
+func withError(_ completion: (String?, Error?) -> Void) { }
+func test(_ str: String) -> Bool { return false }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNRELATED %s
+withError { res, err in
+  if test("unrelated") {
+    print("unrelated")
+  } else {
+    print("else unrelated")
+  }
+}
+// UNRELATED: convert_params_single.swift
+// UNRELATED-NEXT: let res = try await withError()
+// UNRELATED-NEXT: if test("unrelated") {
+// UNRELATED-NEXT: print("unrelated")
+// UNRELATED-NEXT: } else {
+// UNRELATED-NEXT: print("else unrelated")
+// UNRELATED-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=BOUND %s
+withError { res, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+    return
+  }
+  if let str = res {
+    print("got result \(str)")
+  }
+  print("after")
+}
+// BOUND: do {
+// BOUND-NEXT: let str = try await withError()
+// BOUND-NEXT: print("before")
+// BOUND-NEXT: print("got result \(str)")
+// BOUND-NEXT: print("after")
+// BOUND-NEXT: } catch let bad {
+// BOUND-NEXT: print("got error \(bad)")
+// BOUND-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-ERR %s
+withError { res, err in
+  print("before")
+  guard let str = res else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(str)")
+  print("after")
+}
+// UNBOUND-ERR: do {
+// UNBOUND-ERR-NEXT: let str = try await withError()
+// UNBOUND-ERR-NEXT: print("before")
+// UNBOUND-ERR-NEXT: print("got result \(str)")
+// UNBOUND-ERR-NEXT: print("after")
+// UNBOUND-ERR-NEXT: } catch let err {
+// UNBOUND-ERR-NEXT: print("got error \(err)")
+// UNBOUND-ERR-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=BOUND %s
+withError { res, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+  } else if let str = res {
+    print("got result \(str)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=BOUND %s
+withError { res, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+    return
+  }
+  if let str = res {
+    print("got result \(str)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-RES %s
+withError { res, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+    return
+  }
+  print("got result \(res!)")
+  print("after")
+}
+// UNBOUND-RES: do {
+// UNBOUND-RES-NEXT: let res = try await withError()
+// UNBOUND-RES-NEXT: print("before")
+// UNBOUND-RES-NEXT: print("got result \(res)")
+// UNBOUND-RES-NEXT: print("after")
+// UNBOUND-RES-NEXT: } catch let bad {
+// UNBOUND-RES-NEXT: print("got error \(bad)")
+// UNBOUND-RES-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-ERR %s
+withError { res, err in
+  print("before")
+  if let str = res {
+    print("got result \(str)")
+    print("after")
+    return
+  }
+  print("got error \(err!)")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-RES %s
+withError { res, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+  } else {
+    print("got result \(res!)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-ERR %s
+withError { res, err in
+  print("before")
+  if let str = res {
+    print("got result \(str)")
+  } else {
+    print("got error \(err!)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  if err != nil {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(res!)")
+  print("after")
+}
+// UNBOUND: do {
+// UNBOUND-NEXT: let res = try await withError()
+// UNBOUND-NEXT: print("before")
+// UNBOUND-NEXT: print("got result \(res)")
+// UNBOUND-NEXT: print("after")
+// UNBOUND-NEXT: } catch let err {
+// UNBOUND-NEXT: print("got error \(err)")
+// UNBOUND-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  if res != nil {
+    print("got result \(res!)")
+    print("after")
+    return
+  }
+  print("got error \(err!)")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  if err != nil {
+    print("got error \(err!)")
+  } else {
+    print("got result \(res!)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  if res != nil {
+    print("got result \(res!)")
+  } else {
+    print("got error \(err!)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  if err == nil {
+    print("got result \(res!)")
+  } else {
+    print("got error \(err!)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  if res == nil {
+    print("got error \(err!)")
+  } else {
+    print("got result \(res!)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNHANDLEDNESTED %s
+withError { res, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+  } else {
+    if let str = res {
+      print("got result \(str)")
+    }
+  }
+  print("after")
+}
+// UNHANDLEDNESTED: do {
+// UNHANDLEDNESTED-NEXT: let res = try await withError()
+// UNHANDLEDNESTED-NEXT: print("before")
+// UNHANDLEDNESTED-NEXT: if let str = <#res#> {
+// UNHANDLEDNESTED-NEXT: print("got result \(str)")
+// UNHANDLEDNESTED-NEXT: }
+// UNHANDLEDNESTED-NEXT: print("after")
+// UNHANDLEDNESTED-NEXT: } catch let bad {
+// UNHANDLEDNESTED-NEXT: print("got error \(bad)")
+// UNHANDLEDNESTED-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=NOERR %s
+withError { res, err in
+  print("before")
+  if let str = res {
+    print("got result \(str)")
+  }
+  print("after")
+}
+// NOERR: convert_params_single.swift
+// NOERR-NEXT: let str = try await withError()
+// NOERR-NEXT: print("before")
+// NOERR-NEXT: print("got result \(str)")
+// NOERR-NEXT: print("after")
+// NOERR-NOT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=NORES %s
+withError { res, err in
+  print("before")
+  if let bad = err {
+    print("got error \(bad)")
+  }
+  print("after")
+}
+// NORES: do {
+// NORES-NEXT: let res = try await withError()
+// NORES-NEXT: print("before")
+// NORES-NEXT: print("after")
+// NORES-NEXT: } catch let bad {
+// NORES-NEXT: print("got error \(bad)")
+// NORES-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  if res != nil && err == nil {
+    print("got result \(res!)")
+  } else {
+    print("got error \(err!)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNKNOWN-COND %s
+withError { res, err in
+  print("before")
+  if res != nil && test(res!) {
+    print("got result \(res!)")
+  }
+  print("after")
+}
+// UNKNOWN-COND: convert_params_single.swift
+// UNKNOWN-COND-NEXT: let res = try await withError()
+// UNKNOWN-COND-NEXT: print("before")
+// UNKNOWN-COND-NEXT: if <#res#> != nil && test(res) {
+// UNKNOWN-COND-NEXT: print("got result \(res)")
+// UNKNOWN-COND-NEXT: }
+// UNKNOWN-COND-NEXT: print("after")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNKNOWN-CONDELSE %s
+withError { res, err in
+  print("before")
+  if res != nil && test(res!) {
+    print("got result \(res!)")
+  } else {
+    print("bad")
+  }
+  print("after")
+}
+// UNKNOWN-CONDELSE: var res: String? = nil
+// UNKNOWN-CONDELSE-NEXT: var err: Error? = nil
+// UNKNOWN-CONDELSE-NEXT: do {
+// UNKNOWN-CONDELSE-NEXT: res = try await withError()
+// UNKNOWN-CONDELSE-NEXT: } catch {
+// UNKNOWN-CONDELSE-NEXT: err = error
+// UNKNOWN-CONDELSE-NEXT: }
+// UNKNOWN-CONDELSE-EMPTY:
+// UNKNOWN-CONDELSE-NEXT: print("before")
+// UNKNOWN-CONDELSE-NEXT: if res != nil && test(res!) {
+// UNKNOWN-CONDELSE-NEXT: print("got result \(res!)")
+// UNKNOWN-CONDELSE-NEXT: } else {
+// UNKNOWN-CONDELSE-NEXT: print("bad")
+// UNKNOWN-CONDELSE-NEXT: }
+// UNKNOWN-CONDELSE-NEXT: print("after")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=MULTIBIND %s
+withError { res, err in
+  print("before")
+  if let str = res {
+    print("got result \(str)")
+  }
+  if let str2 = res {
+    print("got result \(str2)")
+  }
+  print("after")
+}
+// MULTIBIND: var res: String? = nil
+// MULTIBIND-NEXT: var err: Error? = nil
+// MULTIBIND-NEXT: do {
+// MULTIBIND-NEXT: res = try await withError()
+// MULTIBIND-NEXT: } catch {
+// MULTIBIND-NEXT: err = error
+// MULTIBIND-NEXT: }
+// MULTIBIND-EMPTY:
+// MULTIBIND-NEXT: print("before")
+// MULTIBIND-NEXT: if let str = res {
+// MULTIBIND-NEXT: print("got result \(str)")
+// MULTIBIND-NEXT: }
+// MULTIBIND-NEXT: if let str2 = res {
+// MULTIBIND-NEXT: print("got result \(str2)")
+// MULTIBIND-NEXT: }
+// MULTIBIND-NEXT: print("after")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=NESTEDRET %s
+withError { res, err in
+  print("before")
+  if let str = res {
+    if test(str) {
+      return
+    }
+    print("got result \(str)")
+  }
+  print("after")
+}
+// NESTEDRET: convert_params_single.swift
+// NESTEDRET-NEXT: let str = try await withError()
+// NESTEDRET-NEXT: print("before")
+// NESTEDRET-NEXT: if test(str) {
+// NESTEDRET-NEXT: return
+// NESTEDRET-NEXT: }
+// NESTEDRET-NEXT: print("got result \(str)")
+// NESTEDRET-NEXT: print("after")
+// NESTEDRET-NOT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND-ERR %s
+withError { res, err in
+  print("before")
+  guard let str = res, err == nil else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(str)")
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  guard res != nil else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(res!)")
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  guard err == nil else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(res!)")
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3 | %FileCheck -check-prefix=UNBOUND %s
+withError { res, err in
+  print("before")
+  guard res != nil && err == nil else {
+    print("got error \(err!)")
+    return
+  }
+  print("got result \(res!)")
+  print("after")
+}

--- a/test/refactoring/ConvertAsync/convert_result.swift
+++ b/test/refactoring/ConvertAsync/convert_result.swift
@@ -1,0 +1,303 @@
+func simple(_ completion: (Result<String, Error>) -> Void) { }
+func noError(_ completion: (Result<String, Never>) -> Void) { }
+func test(_ str: String) -> Bool { return false }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SIMPLE %s
+simple { res in
+  print("result \(res)")
+}
+// SIMPLE: let res = try await simple()
+// SIMPLE-NEXT: print("result \(<#res#>)")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NOERROR %s
+noError { res in
+  print("result \(res)")
+}
+// NOERROR: let res = await noError()
+// NOERROR-NEXT: print("result \(<#res#>)")
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DOBLOCK %s
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str):
+    print("result \(str)")
+  case .failure(let err):
+    print("error \(err)")
+  }
+  print("after")
+}
+// DOBLOCK: do {
+// DOBLOCK-NEXT: let str = try await simple()
+// DOBLOCK-NEXT: print("before")
+// DOBLOCK-NEXT: print("result \(str)")
+// DOBLOCK-NEXT: print("after")
+// DOBLOCK-NEXT: } catch let err {
+// DOBLOCK-NEXT: print("error \(err)")
+// DOBLOCK-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DOBLOCK %s
+simple { res in
+  print("before")
+  if case .success(let str) = res {
+    print("result \(str)")
+  } else if case .failure(let err) = res {
+    print("error \(err)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DOBLOCK %s
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str):
+    print("result \(str)")
+    break
+  case .failure(let err):
+    print("error \(err)")
+    break
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DOBLOCK %s
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str):
+    print("result \(str)")
+    return
+  case .failure(let err):
+    print("error \(err)")
+    return
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SUCCESS %s
+simple { res in
+  print("before")
+  if case .success(let str) = res {
+    print("result \(str)")
+  }
+  print("after")
+}
+// SUCCESS: convert_result.swift
+// SUCCESS-NEXT: let str = try await simple()
+// SUCCESS-NEXT: print("before")
+// SUCCESS-NEXT: print("result \(str)")
+// SUCCESS-NEXT: print("after")
+// SUCCESS-NOT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SUCCESS %s
+simple { res in
+  print("before")
+  guard case .success(let str) = res else {
+    return
+  }
+  print("result \(str)")
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DOBLOCKUNBOUND %s
+simple { res in
+  print("before")
+  guard case .success(let str) = res else {
+    print("err")
+    return
+  }
+  print("result \(str)")
+  print("after")
+}
+// DOBLOCKUNBOUND: do {
+// DOBLOCKUNBOUND-NEXT: let str = try await simple()
+// DOBLOCKUNBOUND-NEXT: print("before")
+// DOBLOCKUNBOUND-NEXT: print("result \(str)")
+// DOBLOCKUNBOUND-NEXT: print("after")
+// DOBLOCKUNBOUND-NEXT: } catch {
+// DOBLOCKUNBOUND-NEXT: print("err")
+// DOBLOCKUNBOUND-NEXT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=SUCCESS %s
+simple { res in
+  print("before")
+  if let str = try? res.get() {
+    print("result \(str)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=DOBLOCKUNBOUND %s
+simple { res in
+  print("before")
+  guard let str = try? res.get() else {
+    print("err")
+    return
+  }
+  print("result \(str)")
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=UNKNOWN %s
+simple { res in
+  print("before \(res)")
+  if case .success(let str) = res {
+    print("result \(str) \(try! res.get())")
+  }
+  print("after")
+}
+// UNKNOWN: convert_result.swift
+// UNKNOWN-NEXT: let str = try await simple()
+// UNKNOWN-NEXT: print("before \(<#str#>)")
+// UNKNOWN-NEXT: print("result \(str) \(try! <#str#>.get())")
+// UNKNOWN-NEXT: print("after")
+// UNKNOWN-NOT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=UNKNOWNUNBOUND %s
+simple { res in
+  print("before \(res)")
+  if case .success = res {
+    print("result \(res) \(try! res.get())")
+  }
+  print("after")
+}
+// UNKNOWNUNBOUND: convert_result.swift
+// UNKNOWNUNBOUND-NEXT: let res = try await simple()
+// UNKNOWNUNBOUND-NEXT: print("before \(<#res#>)")
+// UNKNOWNUNBOUND-NEXT: print("result \(<#res#>) \(try! <#res#>.get())")
+// UNKNOWNUNBOUND-NEXT: print("after")
+// UNKNOWN-NOT: }
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+simple { res in
+  print("before")
+  if case .success(let str) = res {
+    print("result \(str)")
+  }
+  if case .success(let str2) = res {
+    print("result \(str2)")
+  }
+  print("after")
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str):
+    print("result \(str)")
+  case .failure(let err):
+    print("error \(err)")
+  default:
+    print("default")
+  }
+  print("after")
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str):
+    print("result \(str)")
+  default:
+    print("err")
+  }
+  print("after")
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+simple { res in
+  print("before")
+  switch res {
+  case .success, .failure:
+    print("either")
+  }
+  print("after")
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+simple { res in
+  print("before")
+  switch res {
+  case .success, .failure:
+    print("either")
+  }
+  print("after")
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+simple { res in
+  print("before")
+  switch res {
+  case .success:
+    fallthrough
+  case .failure:
+    print("either")
+  }
+  print("after")
+}
+
+// RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str) where str.hasPrefix("match"):
+    print("pattern matched result \(str)")
+  case .success(let str):
+    print("result \(str)")
+  case .failure(let err):
+    print("error \(err)")
+  }
+  print("after")
+}
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTEDRET %s
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str):
+    if test(str) {
+      return
+    }
+    print("result \(str)")
+  case .failure:
+    break
+  }
+  print("after")
+}
+// NESTEDRET: convert_result.swift
+// NESTEDRET-NEXT: let str = try await simple()
+// NESTEDRET-NEXT: print("before")
+// NESTEDRET-NEXT: if test(str) {
+// NESTEDRET-NEXT: return
+// NESTEDRET-NEXT: }
+// NESTEDRET-NEXT: print("result \(str)")
+// NESTEDRET-NEXT: print("after")
+// NESTEDRET-NOT: }
+
+// RUN: %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):1 | %FileCheck -check-prefix=NESTEDBREAK %s
+simple { res in
+  print("before")
+  switch res {
+  case .success(let str):
+    if test(str) {
+      break
+    }
+    print("result \(str)")
+  case .failure:
+    break
+  }
+  print("after")
+}
+// NESTEDBREAK: convert_result.swift
+// NESTEDBREAK-NEXT: let str = try await simple()
+// NESTEDBREAK-NEXT: print("before")
+// NESTEDBREAK-NEXT: if test(str) {
+// NESTEDBREAK-NEXT: break
+// NESTEDBREAK-NEXT: }
+// NESTEDBREAK-NEXT: print("result \(str)")
+// NESTEDBREAK-NEXT: print("after")
+// NESTEDBREAK-NOT: }
+

--- a/test/refactoring/ConvertAsync/errors.swift
+++ b/test/refactoring/ConvertAsync/errors.swift
@@ -1,0 +1,19 @@
+func simple(completion: (String?, Error?) -> Void) { }
+
+func mismatches() {
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
+  simple()
+
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
+  simple(10) { res, err in
+    print("call mismatch")
+  }
+
+  // RUN: not %refactor -convert-call-to-async-alternative -dump-text -source-filename %s -pos=%(line+1):3
+  simple { res in
+    print("closure mismatch")
+  }
+}
+
+// RUN: not %refactor -add-async-alternative -dump-text -source-filename %s -pos=%(line+1):1
+func missingBody(complete: (Int?, Error?) -> Void)

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3293,8 +3293,8 @@ static int doPrintTypeInterface(const CompilerInvocation &InitInvok,
   StreamPrinter Printer(llvm::outs());
   std::string Error;
   std::string TypeName;
-  if (printTypeInterface(SemaT.DC->getParentModule(), SemaT.Ty, Printer,
-                         TypeName, Error)) {
+  if (printTypeInterface(SemaT.ValueD->getDeclContext()->getParentModule(),
+                         SemaT.Ty, Printer, TypeName, Error)) {
     llvm::errs() << Error;
     return 1;
   }

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -77,6 +77,12 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
            clEnumValN(RefactoringKind::ConvertToComputedProperty,
                       "convert-to-computed-property", "Convert from field initialization to computed property"),
            clEnumValN(RefactoringKind::ConvertToSwitchStmt, "convert-to-switch-stmt", "Perform convert to switch statement"),
+           clEnumValN(RefactoringKind::ConvertCallToAsyncAlternative,
+                      "convert-call-to-async-alternative", "Convert call to use its async alternative (if any)"),
+           clEnumValN(RefactoringKind::ConvertToAsync,
+                      "convert-to-async", "Convert the entire function to async"),
+           clEnumValN(RefactoringKind::AddAsyncAlternative,
+                      "add-async-alternative", "Add an async alternative of a function taking a callback")));
 
 
 static llvm::cl::opt<std::string>
@@ -266,6 +272,7 @@ int main(int argc, char *argv[]) {
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().CollectParsedToken = true;
   Invocation.getLangOptions().BuildSyntaxTree = true;
+  Invocation.getLangOptions().EnableExperimentalConcurrency = true;
 
   for (auto FileName : options::InputFilenames)
     Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(FileName);

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -112,10 +112,21 @@ static llvm::cl::opt<bool>
 IsNonProtocolType("is-non-protocol-type",
                   llvm::cl::desc("The symbol being renamed is a type and not a protocol"));
 
-static llvm::cl::opt<bool>
-DumpInJson("dump-json",
-            llvm::cl::desc("Whether to dump refactoring edits in json"),
-            llvm::cl::init(false));
+enum class DumpType {
+  REWRITTEN,
+  JSON,
+  TEXT
+};
+static llvm::cl::opt<DumpType> DumpIn(
+    llvm::cl::desc("Dump edits to stdout as:"),
+    llvm::cl::init(DumpType::REWRITTEN),
+    llvm::cl::values(
+        clEnumValN(DumpType::REWRITTEN, "dump-rewritten",
+                   "rewritten file"),
+        clEnumValN(DumpType::JSON, "dump-json",
+                   "JSON"),
+        clEnumValN(DumpType::TEXT, "dump-text",
+                   "text")));
 
 static llvm::cl::opt<bool>
 AvailableActions("actions",
@@ -373,12 +384,19 @@ int main(int argc, char *argv[]) {
   RefactoringConfig.PreferredName = options::NewName;
   std::string Error;
   std::unique_ptr<SourceEditConsumer> pConsumer;
-  if (options::DumpInJson)
-    pConsumer.reset(new SourceEditJsonConsumer(llvm::outs()));
-  else
+  switch (options::DumpIn) {
+  case options::DumpType::REWRITTEN:
     pConsumer.reset(new SourceEditOutputConsumer(SF->getASTContext().SourceMgr,
-                                                      BufferID,
-                                                      llvm::outs()));
+                                                 BufferID,
+                                                 llvm::outs()));
+    break;
+  case options::DumpType::JSON:
+    pConsumer.reset(new SourceEditJsonConsumer(llvm::outs()));
+    break;
+  case options::DumpType::TEXT:
+    pConsumer.reset(new SourceEditTextConsumer(llvm::outs()));
+    break;
+  }
 
   return refactorSwiftModule(CI.getMainModule(), RefactoringConfig, *pConsumer,
                              PrintDiags);

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -51,11 +51,11 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
            clEnumValN(RefactoringKind::ConvertStringsConcatenationToInterpolation,
                       "strings-concatenation-to-interpolation", "Perform strings concatenation to interpolation refactoring"),
            clEnumValN(RefactoringKind::ExpandTernaryExpr,
-                     "expand-ternary-expr", "Perform expand ternary expression"),
+                      "expand-ternary-expr", "Perform expand ternary expression"),
            clEnumValN(RefactoringKind::ConvertToTernaryExpr,
                       "convert-to-ternary-expr", "Perform convert to ternary expression"),
-		   clEnumValN(RefactoringKind::ConvertIfLetExprToGuardExpr,
-					   "convert-to-guard", "Perform convert to guard expression"),
+		       clEnumValN(RefactoringKind::ConvertIfLetExprToGuardExpr,
+                      "convert-to-guard", "Perform convert to guard expression"),
            clEnumValN(RefactoringKind::ConvertGuardExprToIfLetExpr,
                       "convert-to-iflet", "Perform convert to iflet expression"),
            clEnumValN(RefactoringKind::ExtractFunction,
@@ -75,8 +75,8 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
            clEnumValN(RefactoringKind::MemberwiseInitLocalRefactoring, "memberwise-init", "Generate member wise initializer"),
            clEnumValN(RefactoringKind::AddEquatableConformance, "add-equatable-conformance", "Add Equatable conformance"),
            clEnumValN(RefactoringKind::ConvertToComputedProperty,
-                   "convert-to-computed-property", "Convert from field initialization to computed property"),
-           clEnumValN(RefactoringKind::ConvertToSwitchStmt, "convert-to-switch-stmt", "Perform convert to switch statement")));
+                      "convert-to-computed-property", "Convert from field initialization to computed property"),
+           clEnumValN(RefactoringKind::ConvertToSwitchStmt, "convert-to-switch-stmt", "Perform convert to switch statement"),
 
 
 static llvm::cl::opt<std::string>
@@ -113,8 +113,8 @@ IsNonProtocolType("is-non-protocol-type",
                   llvm::cl::desc("The symbol being renamed is a type and not a protocol"));
 
 static llvm::cl::opt<bool>
-DumpInJason("dump-json",
-            llvm::cl::desc("Whether to dump refactoring edits in Json"),
+DumpInJson("dump-json",
+            llvm::cl::desc("Whether to dump refactoring edits in json"),
             llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
@@ -373,7 +373,7 @@ int main(int argc, char *argv[]) {
   RefactoringConfig.PreferredName = options::NewName;
   std::string Error;
   std::unique_ptr<SourceEditConsumer> pConsumer;
-  if (options::DumpInJason)
+  if (options::DumpInJson)
     pConsumer.reset(new SourceEditJsonConsumer(llvm::outs()));
   else
     pConsumer.reset(new SourceEditOutputConsumer(SF->getASTContext().SourceMgr,


### PR DESCRIPTION
Adds three refactorings intended to help users migrate their existing
code to use the new async language features:
  1. Convert call to use async alternative
  2. Convert function to async
  3. Add async alternative function

A function is considered to have an async alternative if it has a void
return type and has a void returning closure as its last parameter. A
method to explicitly mark functions as having an async alternative may
be added to make this more accurate in the future (required for eg.
a warning about a call to the non-async version of a function in an
async context).

(1) converts a call to use the new `await` async language syntax. If the
async alternative throws, it will also add `try`. The closure itself is
hoisted out of the call, see the comments on
`AsyncConversionStringBuilder` for specifics.

(2) converts a whole function to `async`, using (1) to convert any calls
in the function to their async alternatives. (3) is similar to (2), but
instead *adds* a function and replaces calls to its
completion/handler/callback closure parameter with `return` or `throws`.

Resolves rdar://68254700