### PR TITLE
Platform: add dxgi1_6 to the Direct3D module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -165,6 +165,9 @@ module WinSDK [system] {
       header "d3d11_2.h"
       header "d3d11_3.h"
       header "d3d11_4.h"
+
+      header "../shared/dxgi1_6.h"
+
       export *
 
       link "d3d11.lib"


### PR DESCRIPTION
There is no usermode header which has the DXGI1.6 interfaces included
unfortunately.  This adds the interfaces to the module which is required
for IDXGIAdapter4 interface.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
