### PR TITLE
Basic: add explicit template parameters for disambiguation

### DIFF
--- a/include/swift/Basic/Fingerprint.h
+++ b/include/swift/Basic/Fingerprint.h
@@ -123,9 +123,9 @@ template <> struct StableHasher::Combiner<Fingerprint> {
     // raw bytes from the core by hand.
     uint8_t buffer[8];
     memcpy(buffer, &Val.core.first, sizeof(buffer));
-    hasher.combine(buffer);
+    hasher.combine<sizeof(buffer)>(buffer);
     memcpy(buffer, &Val.core.second, sizeof(buffer));
-    hasher.combine(buffer);
+    hasher.combine<sizeof(buffer)>(buffer);
   }
 };
 


### PR DESCRIPTION
When building with MSVC, this would fail to compile due to the `buffer`
type (`uint8_t [8]`) being treated as `unsigned char *`, which is
expecting to be SFINAE'd to fail find an overload for the hash
combination.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
