### PR TITLE
SourceKit: do not print implementation-only imports

### DIFF
--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -607,6 +607,9 @@ void swift::ide::printModuleInterface(
     }
 
     auto ShouldPrintImport = [&](ImportDecl *ImportD) -> bool {
+      if (ImportD->getAttrs().hasAttribute<ImplementationOnlyAttr>())
+        return false;
+
       if (!TargetClangMod)
         return true;
       if (ImportD->getModule() == TargetMod)

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -499,6 +499,10 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
       if (Dep.isExported())
         ID->getAttrs().add(
             new (Ctx) ExportedAttr(/*IsImplicit=*/false));
+      if (Dep.isImplementationOnly())
+        ID->getAttrs().add(
+            new (Ctx) ImplementationOnlyAttr(/*IsImplicit=*/false));
+
       ImportDecls.push_back(ID);
     }
     Bits.ComputedImportDecls = true;

--- a/test/Serialization/Recovery/implementation-only-override.swift
+++ b/test/Serialization/Recovery/implementation-only-override.swift
@@ -4,7 +4,7 @@
 // RUN: %FileCheck %s < %t/Library.txt
 
 // CHECK: import FooKit
-// CHECK: import FooKit_SECRET
+// CHECK-NOT: import FooKit_SECRET
 
 import FooKit
 @_implementationOnly import FooKit_SECRET


### PR DESCRIPTION
Implementation-only imports are unnecessary in generated module interfaces, since they don't have an effect on the module's public interface: 
* implementation-only imports aren't exported to the module's dependencies
* module's public API cannot reference symbols imported as implementation-only.


This change hides `@_implementationOnly` imports from generated Swift module interfaces.

It allows, for example, to hide `import Darwin`/`import WinSDK`/`import Glibc` statements from SwiftPM's `PackageDescription` library interface.