### PR TITLE
Platform: add HLSL compiler to the WinSDK modulemap

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -165,9 +165,6 @@ module WinSDK [system] {
       header "d3d11_2.h"
       header "d3d11_3.h"
       header "d3d11_4.h"
-
-      header "../shared/dxgi1_6.h"
-
       export *
 
       link "d3d11.lib"
@@ -180,6 +177,23 @@ module WinSDK [system] {
 
       link "d3d12.lib"
       link "dxgi.lib"
+    }
+
+    // FIXME(compnerd) DXGI is part of the Direct3D interfaces currently; we
+    // should split it out, but because it is part of the D3D11 interfaces, this
+    // separate module is meant to augment the uncovered portions only.
+    module _DXGI {
+      header "../shared/dxgi1_6.h"
+      export *
+
+      link "dxgi.lib"
+    }
+
+    module D3DCompiler {
+      header "d3dcompiler.h"
+      export *
+
+      link "d3dcompiler.lib"
     }
 
     module XAudio29 {


### PR DESCRIPTION
The DirectX subsystem may require access to the HLSL compiler for
building the shaders before uploading to the GPU.  This is adds to the
modulemap the D3DCompiler module to get access to the compiler.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
