### PR TITLE
[SR-14050][Sema] Removing check on subtype validation at matchFunctionRepresentations

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1560,8 +1560,7 @@ isSubtypeOf(FunctionTypeRepresentation potentialSubRepr,
 /// Returns true if `constraint rep1 rep2` is satisfied.
 static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
                                          FunctionTypeRepresentation rep2,
-                                         ConstraintKind kind,
-                                         ConstraintLocatorBuilder locator) {
+                                         ConstraintKind kind) {
   switch (kind) {
   case ConstraintKind::Bind:
   case ConstraintKind::BindParam:
@@ -1570,13 +1569,8 @@ static bool matchFunctionRepresentations(FunctionTypeRepresentation rep1,
     return rep1 == rep2;
       
   case ConstraintKind::Subtype: {
-    auto last = locator.last();
-    if (!(last && last->is<LocatorPathElt::FunctionArgument>()))
-      return true;
-
     return isSubtypeOf(rep1, rep2);
   }
-
 
   // [NOTE: diagnose-swift-to-c-convention-change]: @convention(swift) ->
   // @convention(c) conversions are permitted only in certain cases.
@@ -1916,7 +1910,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
   if (!matchFunctionRepresentations(func1->getExtInfo().getRepresentation(),
                                     func2->getExtInfo().getRepresentation(),
-                                    kind, locator)) {
+                                    kind)) {
     return getTypeMatchFailure(locator);
   }
 


### PR DESCRIPTION

<!-- What's in this pull request? -->
For what I could see and test seems is just fine to remove this check and just adding a bit more information. Most relations between function types are handled by conversions. 
I'm running the tests to make sure, but let me know if you think there are some situation where the check still be necessary.


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14050.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
