### PR TITLE
Concurrency: support draining the main queue in single threaded mode

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -536,6 +536,12 @@ void swift::swift_continuation_logFailedCheck(const char *message) {
 }
 
 void swift::swift_task_asyncMainDrainQueue() {
+#if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+  bool Finished = false;
+  donateThreadToGlobalExecutorUntil([](void *context) {
+    return *reinterpret_cast<bool*>(context);
+  }, &Finished);
+#else
 #if defined(_WIN32)
   static void(FAR *pfndispatch_main)(void) = NULL;
 
@@ -560,5 +566,6 @@ void swift::swift_task_asyncMainDrainQueue() {
     runLoop();
   else
     dispatch_main();
+#endif
 #endif
 }


### PR DESCRIPTION
When built in single threaded mode, the runtime does not use dispatch to
queue the tasks.  As a result, pumping the dispatch main queue will
simply wait indefinitely.  In the single threaded mode, simply halt
execution and drain all pending tasks before returning.  This allows
forward progress in the single threaded mode.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
