### PR TITLE
Concurrency: avoid `CFRunLoopRun` on non-Darwin

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -554,11 +554,17 @@ void swift::swift_task_asyncMainDrainQueue() {
 
   pfndispatch_main();
 #else
+  // CFRunLoop is not available on non-Darwin targets.  Foundation has an
+  // implementation, but CoreFoundation is not meant to be exposed.  We can only
+  // assume the existence of `CFRunLoopRun` on Darwin platforms, where the
+  // system provides an implementation of CoreFoundation.
+#if defined(__APPLE__)
   auto runLoop =
       reinterpret_cast<void (*)(void)>(dlsym(RTLD_DEFAULT, "CFRunLoopRun"));
   if (runLoop)
-    runLoop();
-  else
+    return runLoop();
+#endif
+
     dispatch_main();
 #endif
 }


### PR DESCRIPTION
The CoreFoundation implementation on non-Darwin platforms included in
Foundation is not meant to be used as a general purpose CoreFoundation
implementation.  Since non-Darwin targets do not default to providing a
CoreFoundation implementation, we should generally assume that the
symbol is not present.  This changes the non-Darwin paths to always use
`dispatch_main` rather than `CFRunLoopRun`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
