### PR TITLE
[Concurrency] Emit extended method type descriptors for @objc async methods

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1184,7 +1184,8 @@ irgen::emitObjCMethodDescriptorParts(IRGenModule &IGM,
   /// elements.
   CanSILFunctionType methodType = getObjCMethodType(IGM, method);
   descriptor.typeEncoding =
-      getObjCEncodingForMethod(IGM, methodType, /*extended*/ false, method);
+      getObjCEncodingForMethod(IGM, methodType, /*extended*/ method->hasAsync(),
+                               method);
   
   /// The third element is the method implementation pointer.
   if (!concrete) {

--- a/test/IRGen/objc_async_metadata.swift
+++ b/test/IRGen/objc_async_metadata.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -enable-experimental-concurrency %s -emit-ir | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+
+import Foundation
+
+// CHECK: [[ENCODE_ASYNC_STRING:@.*]] = private unnamed_addr constant [28 x i8] c"v24@0:8@?<v@?@\22NSString\22>16\00"
+// CHECK: [[ENCODE_ASYNC_THROWS_STRING:@.*]] = private unnamed_addr constant [38 x i8] c"v24@0:8@?<v@?@\22NSString\22@\22NSError\22>16\00"
+
+// CHECK: @_INSTANCE_METHODS__TtC19objc_async_metadata7MyClass = internal constant
+// CHECK-SAME: methodWithCompletionHandler:
+// CHECK-SAME: [[ENCODE_ASYNC_STRING]]
+// CHECK-SAME: throwingMethodWithCompletionHandler:
+// CHECK-SAME: [[ENCODE_ASYNC_THROWS_STRING]]
+class MyClass: NSObject {
+  @objc func method() async -> String { "" }
+  @objc func throwingMethod() async throws -> String { "" }
+}


### PR DESCRIPTION
For `@objc async` methods, all of the important information about the
"result" type and whether it throws or not is within the type of the
completion handler block. Enable extended type information for the
generated Objective-C metadata of such methods, so that clients can
understand how to invoke them using reflection facilities.

Implements rdar://73048313.
