### PR TITLE
[Test] Propagate XDG_CACHE_HOME to lit tests

### DIFF
--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -75,4 +75,5 @@ config.test_format = lit.formats.GoogleTest(config.build_mode, 'Tests')
 
 # XDG_CACHE_HOME can be used to influence the position of the clang
 # module cache for all those tests that do not set that explicitly
-config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
+if 'XDG_CACHE_HOME' in os.environ:
+  config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']

--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -72,3 +72,7 @@ config.test_source_root = config.test_exec_root
 
 # testFormat: The test format to use to interpret tests.
 config.test_format = lit.formats.GoogleTest(config.build_mode, 'Tests')
+
+# XDG_CACHE_HOME can be used to influence the position of the clang
+# module cache for all those tests that do not set that explicitly
+config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2113,6 +2113,10 @@ if platform.system() == 'Linux':
         config.available_features.add("LinuxDistribution=" + distributor + '-' + release)
         lit_config.note('Running tests on %s-%s' % (distributor, release))
 
+# XDG_CACHE_HOME can be used to influence the position of the clang
+# module cache for all those tests that do not set that explicitly
+config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
+
 # Copy environment variables specified in --param copy_env=..., overriding
 # anything computed here. It's assumed that the person setting this knows what
 # they're doing.

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2115,7 +2115,8 @@ if platform.system() == 'Linux':
 
 # XDG_CACHE_HOME can be used to influence the position of the clang
 # module cache for all those tests that do not set that explicitly
-config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
+if 'XDG_CACHE_HOME' in os.environ:
+  config.environment['XDG_CACHE_HOME'] = os.environ['XDG_CACHE_HOME']
 
 # Copy environment variables specified in --param copy_env=..., overriding
 # anything computed here. It's assumed that the person setting this knows what


### PR DESCRIPTION
This is another tool we can leverage to configure separate caches for CI
runs in Linux to hopefully reduce the likelihood of module cache
related issues.
Also this will allow us to respect the default values for the
environment we are running in.

As per clang source code, the environment variable only impacts Linux environments.

Addresses rdar://73582047