### PR TITLE
[ModuleInterface] Update wording of the "failed to build module" error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -719,11 +719,10 @@ ERROR(sema_opening_import,Fatal,
 ERROR(serialization_load_failed,Fatal,
       "failed to load module '%0'", (StringRef))
 ERROR(module_interface_build_failed,Fatal,
-      "failed to %select{build module '%1' from its module interface|verify "
-      "module interface of '%1'}0; %select{the compiler that produced it, "
-      "'%3', may have used features that aren't supported by this compiler, "
-      "'%4'|it may have been damaged or it may have triggered a bug in the "
-      "Swift compiler when it was produced}2",
+      "failed to %select{build module '%1' for importation|"
+      "verify module interface of '%1'}0 due to the errors above; "
+      "the textual interface may be broken by project issues"
+      "%select{, differences between compilers (the producer '%3' and this compiler '%4')|}2 or a compiler bug",
       (bool, StringRef, bool, StringRef, StringRef))
 ERROR(serialization_malformed_module,Fatal,
       "malformed compiled module: %0", (StringRef))

--- a/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
@@ -57,8 +57,8 @@
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR <%t/err.txt
 // CHECK-ERROR: LeafModule.swiftinterface:7:8: error: no such module 'NotAModule'
-// CHECK-ERROR: OtherModule.swiftinterface:4:8: error: failed to build module 'LeafModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
-// CHECK-ERROR: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to build module 'OtherModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
+// CHECK-ERROR: OtherModule.swiftinterface:4:8: error: failed to build module 'LeafModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
+// CHECK-ERROR: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to build module 'OtherModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
 // CHECK-ERROR-NOT: error:
 //
 //
@@ -82,8 +82,8 @@
 // RUN: %{python} %S/Inputs/check-is-old.py %t/modulecache/OtherModule-*.swiftmodule %t/modulecache/LeafModule-*.swiftmodule
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR-INLINE <%t/err-inline.txt
 // CHECK-ERROR-INLINE: LeafModule.swiftinterface:6:33: error: cannot find 'unresolved' in scope
-// CHECK-ERROR-INLINE: OtherModule.swiftinterface:4:8: error: failed to build module 'LeafModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
-// CHECK-ERROR-INLINE: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to build module 'OtherModule' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
+// CHECK-ERROR-INLINE: OtherModule.swiftinterface:4:8: error: failed to build module 'LeafModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
+// CHECK-ERROR-INLINE: module-cache-diagnostics.swift:{{[0-9]+}}:8: error: failed to build module 'OtherModule' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
 // CHECK-ERROR-INLINE-NOT: error:
 //
 //

--- a/test/ModuleInterface/invalid-opaque-result-types.swift
+++ b/test/ModuleInterface/invalid-opaque-result-types.swift
@@ -19,5 +19,5 @@
 
 // CHECK: cannot find type 'InvalidParameter' in scope
 // CHECK: unable to resolve type for _opaqueReturnTypeOf attribute
-// CHECK: failed to build module 'InvalidOpaqueResultType' from its module interface
+// CHECK: failed to build module 'InvalidOpaqueResultType' for importation
 import InvalidOpaqueResultType

--- a/test/ModuleInterface/unbuildable.swift
+++ b/test/ModuleInterface/unbuildable.swift
@@ -26,11 +26,11 @@
 
 #if CURRENT
 import UnbuildableCurrent
-// CURRENT: unbuildable.swift:[[@LINE-1]]:8: error: failed to build module 'UnbuildableCurrent' from its module interface; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
+// CURRENT: unbuildable.swift:[[@LINE-1]]:8: error: failed to build module 'UnbuildableCurrent' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
 #else
 import UnbuildableFuture
-// FUTURE: unbuildable.swift:[[@LINE-1]]:8: error: failed to build module 'UnbuildableFuture' from its module interface; the compiler that produced it, 'NeoTokyoSwift 2000.42', may have used features that aren't supported by this compiler, '{{.*Swift version.*}}'
+// FUTURE: unbuildable.swift:[[@LINE-1]]:8: error: failed to build module 'UnbuildableFuture' for importation due to the errors above; the textual interface may be broken by project issues, differences between compilers (the producer 'NeoTokyoSwift 2000.42' and this compiler '{{.*Swift version.*}}') or a compiler bug
 #endif
 
-// CURRENT-VERIFY: UnbuildableCurrent.swiftinterface:1:1: error: failed to verify module interface of 'UnbuildableCurrent'; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
-// FUTURE-VERIFY: UnbuildableFuture.swiftinterface:1:1: error: failed to verify module interface of 'UnbuildableFuture'; the compiler that produced it, 'NeoTokyoSwift 2000.42', may have used features that aren't supported by this compiler, '{{.*Swift version.*}}'
+// CURRENT-VERIFY: UnbuildableCurrent.swiftinterface:1:1: error: failed to verify module interface of 'UnbuildableCurrent' due to the errors above; the textual interface may be broken by project issues or a compiler bug
+// FUTURE-VERIFY: UnbuildableFuture.swiftinterface:1:1: error: failed to verify module interface of 'UnbuildableFuture' due to the errors above; the textual interface may be broken by project issues, differences between compilers (the producer 'NeoTokyoSwift 2000.42' and this compiler '{{.*Swift version.*}}') or a compiler bug

--- a/test/ModuleInterface/verify-module-interfaces.swift
+++ b/test/ModuleInterface/verify-module-interfaces.swift
@@ -12,4 +12,4 @@
 public struct MyStruct {}
 
 // CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: use of unknown directive '#__debug_emit_invalid_swiftinterface_syntax__'
-// CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: failed to verify module interface of 'MyModule'; it may have been damaged or it may have triggered a bug in the Swift compiler when it was produced
+// CHECK: MyModule.swiftinterface:{{[0-9]+}}:{{[0-9]+}}: error: failed to verify module interface of 'MyModule' due to the errors above; the textual interface may be broken by project issues or a compiler bug

--- a/validation-test/ParseableInterface/failing-overlay.swift
+++ b/validation-test/ParseableInterface/failing-overlay.swift
@@ -3,4 +3,4 @@
 
 import ImportsOverlay
 
-// CHECK: HasOverlay.swiftinterface:1:1: error: failed to build module 'HasOverlay' from its module interface; the compiler that produced it, '(unspecified, file possibly handwritten)', may have used features that aren't supported by this compiler, '{{.*}}Swift version{{.*}}'
+// CHECK: HasOverlay.swiftinterface:1:1: error: failed to build module 'HasOverlay' for importation due to the errors above; the textual interface may be broken by project issues, differences between compilers (the producer '(unspecified, file possibly handwritten)' and this compiler '{{.*Swift version.*}}') or a compiler bug


### PR DESCRIPTION
The error shown when the compiler fails to build a module from its textual interface has been creating some confusion. This is a proposal to make it more useful to the programmer not working in the SDK, insist on looking at the previous errors first, put less emphasis on possible compiler bugs, and always show alternatives to the incompatible compilers issue as this is the most common case now.