### PR TITLE
Use erasePhiArgument instead of eraseArgument in DCE

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -552,13 +552,12 @@ bool DCE::removeDead(SILFunction &F) {
       // This is not necessary in non-OSSA, and will infact be incorrect.
       // Because, passing a value as a phi argument does not imply end of
       // lifetime in non-OSSA.
-      BB.eraseArgument(i);
       for (auto *pred : BB.getPredecessorBlocks()) {
         auto *predTerm = pred->getTerminator();
         auto predArg = predTerm->getAllOperands()[i].get();
         endLifetimeOfLiveValue(predArg, predTerm);
-        deleteEdgeValue(pred->getTerminator(), &BB, i);
       }
+      erasePhiArgument(&BB, i);
       Changed = true;
       BranchesChanged = true;
     }


### PR DESCRIPTION
Fixes rdar://73500476

There could be iterator invalidation while deleting edge values. Use api `erasePhiArgument` which correctly deletes phi arguments.