### PR TITLE
[5.4][Parse] Diagnose default argument for subscript in protocols

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -790,6 +790,8 @@ ERROR(protocol_method_argument_init,none,
       "default argument not permitted in a protocol method", ())
 ERROR(protocol_init_argument_init,none,
       "default argument not permitted in a protocol initializer", ())
+ERROR(protocol_subscript_argument_init,none,
+      "default argument not permitted in a protocol subscript", ())
 ERROR(tuple_type_multiple_labels,none,
       "tuple element cannot have two labels", ())
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7366,6 +7366,12 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
 
   diagnoseWhereClauseInGenericParamList(GenericParams);
 
+  // Protocol requirement arguments may not have default values.
+  if (Flags.contains(PD_InProtocol) && DefaultArgs.HasDefaultArgument) {
+    diagnose(SubscriptLoc, diag::protocol_subscript_argument_init);
+    return nullptr;
+  }
+
   // Build an AST for the subscript declaration.
   DeclName name = DeclName(Context, DeclBaseName::createSubscript(),
                            argumentNames);

--- a/test/decl/protocol/protocol_with_default_args.swift
+++ b/test/decl/protocol/protocol_with_default_args.swift
@@ -11,4 +11,5 @@ struct X : P {
 
 protocol Q {
   init(truth: Bool = false) // expected-error{{default argument not permitted in a protocol initializer}}
+  subscript(x: Int, default: Int = 0) -> Self { get } // expected-error {{default argument not permitted in a protocol subscript}}
 }


### PR DESCRIPTION
(Cherry-pick of #35567 into `release/5.4`)

* **Explanation**: Protocol requirements don't support default arguments. Not-emitting a diagnostics for it caused a crash in SILGen which doesn't expect such inputs. Fix an issue by diagnosing it in Parser. We currently do this diagnosis for `func` and `init`, but didn't do it for `subscript`
* **Scope**: Subscript declaration parsing
* **Risk**: Low.
* **Testing**: Added a regression test
* **Issue**: rdar://problem/73159041
* **Reviewer**: Robert Widmann (@CodaFi), Slava Pestov (@slavapestov)