### PR TITLE
[AST Verifier] Handle ObjC requirements satisfied by alternative requirements

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2620,6 +2620,41 @@ public:
         abort();
       }
 
+      // Tracking for those Objective-C requirements that have witnesses.
+      llvm::SmallDenseSet<std::pair<ObjCSelector, char>> hasObjCWitnessMap;
+      bool populatedObjCWitnesses = false;
+      auto populateObjCWitnesses = [&] {
+        if (populatedObjCWitnesses)
+          return;
+
+        populatedObjCWitnesses = true;
+        for (auto req : proto->getMembers()) {
+          if (auto reqFunc = dyn_cast<AbstractFunctionDecl>(req)) {
+            if (normal->hasWitness(reqFunc)) {
+              hasObjCWitnessMap.insert(
+                  {reqFunc->getObjCSelector(), reqFunc->isInstanceMember()});
+            }
+          }
+        }
+      };
+
+      // Check whether there is a witness with the same selector and kind as
+      // this requirement.
+      auto hasObjCWitness = [&](ValueDecl *req) {
+        if (!proto->isObjC())
+          return false;
+
+        auto func = dyn_cast<AbstractFunctionDecl>(req);
+        if (!func)
+          return false;
+
+        populateObjCWitnesses();
+
+        std::pair<ObjCSelector, char> key(
+            func->getObjCSelector(), func->isInstanceMember());
+        return hasObjCWitnessMap.count(key) > 0;
+      };
+
       // Check that a normal protocol conformance is complete.
       for (auto member : proto->getMembers()) {
         if (auto assocType = dyn_cast<AssociatedTypeDecl>(member)) {
@@ -2649,7 +2684,6 @@ public:
         if (isa<AccessorDecl>(member))
           continue;
 
-
         if (auto req = dyn_cast<ValueDecl>(member)) {
           if (!normal->hasWitness(req)) {
             if ((req->getAttrs().isUnavailable(Ctx) ||
@@ -2657,6 +2691,10 @@ public:
                 proto->isObjC()) {
               continue;
             }
+
+            // Check if *any* witness matches the Objective-C selector.
+            if (hasObjCWitness(req))
+              continue;
 
             dumpRef(decl);
             Out << " is missing witness for "

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -enable-experimental-concurrency %s -verify
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+import Foundation
+import ObjCConcurrency
+
+// Conform via async method
+class C1: ConcurrentProtocol {
+  func askUser(toSolvePuzzle puzzle: String) async throws -> String { "" }
+
+  func askUser(toJumpThroughHoop hoop: String) async -> String { "hello" }
+}


### PR DESCRIPTION
With 'async' imports of Objective-C protocol requirements, a single
Objective-C method will produce two different requirements in the
protocol, with the same Objective-C selector. Teach the AST verifier
that it is sufficient for just one of the requirements with that
Objective-C selector to be satisfied by a witness.

Fixes rdar://72742910.
