### PR TITLE
[Async CC] Make error indirect.

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -600,8 +600,10 @@ public:
     /// The type of the result that will be produced by the future.
     const Metadata *resultType;
 
-    // Trailing storage for the result itself. The storage will be uninitialized,
-    // contain an instance of \c resultType, or contain an an \c Error.
+    SwiftError *error = nullptr;
+
+    // Trailing storage for the result itself. The storage will be
+    // uninitialized, contain an instance of \c resultType.
 
     friend class AsyncTask;
 
@@ -620,25 +622,20 @@ public:
     }
 
     /// Retrieve the error.
-    SwiftError *&getError() {
-      return *reinterpret_cast<SwiftError **>(
-           reinterpret_cast<char *>(this) + storageOffset(resultType));
-    }
+    SwiftError *&getError() { return *&error; }
 
     /// Compute the offset of the storage from the base of the future
     /// fragment.
     static size_t storageOffset(const Metadata *resultType)  {
       size_t offset = sizeof(FutureFragment);
-      size_t alignment =
-          std::max(resultType->vw_alignment(), alignof(SwiftError *));
+      size_t alignment = resultType->vw_alignment();
       return (offset + alignment - 1) & ~(alignment - 1);
     }
 
     /// Determine the size of the future fragment given a particular future
     /// result type.
     static size_t fragmentSize(const Metadata *resultType) {
-      return storageOffset(resultType) +
-          std::max(resultType->vw_size(), sizeof(SwiftError *));
+      return storageOffset(resultType) + resultType->vw_size();
     }
   };
 
@@ -791,7 +788,7 @@ public:
 /// futures.
 class FutureAsyncContext : public AsyncContext {
 public:
-  SwiftError *errorResult = nullptr;
+  SwiftError **errorResult = nullptr;
   OpaqueValue *indirectResult;
 
   using AsyncContext::AsyncContext;

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -95,7 +95,7 @@ public:
   /// Set the arguments to the function from an explosion.
   virtual void setArgs(Explosion &arg, bool isOutlined,
                        WitnessMetadata *witnessMetadata);
-  virtual Address getCalleeErrorSlot(SILType errorType) = 0;
+  virtual Address getCalleeErrorSlot(SILType errorType, bool isCalleeAsync) = 0;
 
   void addAttribute(unsigned Index, llvm::Attribute::AttrKind Attr);
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -150,10 +150,11 @@ irgen::getAsyncContextLayout(IRGenModule &IGM, CanSILFunctionType originalType,
     addTaskContinuationFunction();
   }
 
-  //   SwiftError *errorResult;
+  //   SwiftError **errorResult;
   auto errorCanType = IGM.Context.getExceptionType();
   auto errorType = SILType::getPrimitiveObjectType(errorCanType);
-  auto &errorTypeInfo = IGM.getTypeInfoForLowered(errorCanType);
+  auto &errorTypeInfo =
+      IGM.getTypeInfoForLowered(CanInOutType::get(errorCanType));
   typeInfos.push_back(&errorTypeInfo);
   valTypes.push_back(errorType);
 
@@ -2320,7 +2321,7 @@ public:
 
     out = nativeSchema.mapFromNative(IGF.IGM, IGF, nativeExplosion, resultType);
   }
-  Address getCalleeErrorSlot(SILType errorType) override {
+  Address getCalleeErrorSlot(SILType errorType, bool isCalleeAsync) override {
     return IGF.getCalleeErrorResultSlot(errorType);
   };
 };
@@ -2378,10 +2379,10 @@ public:
     context = layout.emitCastTo(IGF, contextBuffer.getAddress());
     if (layout.canHaveError()) {
       auto fieldLayout = layout.getErrorLayout();
-      auto addr = fieldLayout.project(IGF, context, /*offsets*/ llvm::None);
-      auto &ti = fieldLayout.getType();
-      auto nullError = llvm::Constant::getNullValue(ti.getStorageType());
-      IGF.Builder.CreateStore(nullError, addr);
+      auto ptrToAddr =
+          fieldLayout.project(IGF, context, /*offsets*/ llvm::None);
+      auto errorSlot = IGF.getAsyncCalleeErrorResultSlot(layout.getErrorType());
+      IGF.Builder.CreateStore(errorSlot.getAddress(), ptrToAddr);
     }
   }
   void end() override {
@@ -2504,11 +2505,18 @@ public:
       loadValue(fieldLayout, out);
     }
   }
-  Address getCalleeErrorSlot(SILType errorType) override {
-    auto layout = getAsyncContextLayout();
-    auto errorLayout = layout.getErrorLayout();
-    auto address = errorLayout.project(IGF, context, /*offsets*/ llvm::None);
-    return address;
+  Address getCalleeErrorSlot(SILType errorType, bool isCalleeAsync) override {
+    if (isCalleeAsync) {
+      auto layout = getAsyncContextLayout();
+      auto errorLayout = layout.getErrorLayout();
+      auto pointerToAddress =
+          errorLayout.project(IGF, context, /*offsets*/ llvm::None);
+      auto load = IGF.Builder.CreateLoad(pointerToAddress);
+      auto address = Address(load, IGF.IGM.getPointerAlignment());
+      return address;
+    } else {
+      return IGF.getCalleeErrorResultSlot(errorType);
+    }
   };
 
   llvm::CallInst *createCall(const FunctionPointer &fn,
@@ -3931,42 +3939,60 @@ Explosion IRGenFunction::collectParameters() {
   return params;
 }
 
+Address IRGenFunction::createErrorResultSlot(SILType errorType, bool isAsync) {
+  auto &errorTI = cast<FixedTypeInfo>(getTypeInfo(errorType));
+
+  IRBuilder builder(IGM.getLLVMContext(), IGM.DebugInfo != nullptr);
+  builder.SetInsertPoint(AllocaIP->getParent(), AllocaIP->getIterator());
+
+  // Create the alloca.  We don't use allocateStack because we're
+  // not allocating this in stack order.
+  auto addr = createAlloca(errorTI.getStorageType(),
+                           errorTI.getFixedAlignment(), "swifterror");
+
+  // Only add the swifterror attribute on ABIs that pass it in a register.
+  // We create a shadow stack location of the swifterror parameter for the
+  // debugger on platforms that pass swifterror by reference and so we can't
+  // mark the parameter with a swifterror attribute for these.
+  // The slot for async callees cannot be annotated swifterror because those
+  // errors are never passed in registers but rather are always passed
+  // indirectly in the async context.
+  if (IGM.IsSwiftErrorInRegister && !isAsync)
+    cast<llvm::AllocaInst>(addr.getAddress())->setSwiftError(true);
+
+  // Initialize at the alloca point.
+  auto nullError = llvm::ConstantPointerNull::get(
+      cast<llvm::PointerType>(errorTI.getStorageType()));
+  builder.CreateStore(nullError, addr);
+
+  return addr;
+}
+
 /// Fetch the error result slot.
 Address IRGenFunction::getCalleeErrorResultSlot(SILType errorType) {
   if (!CalleeErrorResultSlot) {
-    auto &errorTI = cast<FixedTypeInfo>(getTypeInfo(errorType));
-
-    IRBuilder builder(IGM.getLLVMContext(), IGM.DebugInfo != nullptr);
-    builder.SetInsertPoint(AllocaIP->getParent(), AllocaIP->getIterator());
-
-    // Create the alloca.  We don't use allocateStack because we're
-    // not allocating this in stack order.
-    auto addr = createAlloca(errorTI.getStorageType(),
-                             errorTI.getFixedAlignment(),
-                             "swifterror");
-
-    // Only add the swifterror attribute on ABIs that pass it in a register.
-    // We create a shadow stack location of the swifterror parameter for the
-    // debugger on platforms that pass swifterror by reference and so we can't
-    // mark the parameter with a swifterror attribute for these.
-    if (IGM.IsSwiftErrorInRegister)
-      cast<llvm::AllocaInst>(addr.getAddress())->setSwiftError(true);
-
-    // Initialize at the alloca point.
-    auto nullError = llvm::ConstantPointerNull::get(
-                            cast<llvm::PointerType>(errorTI.getStorageType()));
-    builder.CreateStore(nullError, addr);
-
-    CalleeErrorResultSlot = addr.getAddress();
+    CalleeErrorResultSlot =
+        createErrorResultSlot(errorType, /*isAsync=*/false).getAddress();
   }
   return Address(CalleeErrorResultSlot, IGM.getPointerAlignment());
+}
+
+/// Fetch the error result slot.
+Address IRGenFunction::getAsyncCalleeErrorResultSlot(SILType errorType) {
+  assert(isAsync() &&
+         "throwing async functions must be called from async functions");
+  if (!AsyncCalleeErrorResultSlot) {
+    AsyncCalleeErrorResultSlot =
+        createErrorResultSlot(errorType, /*isAsync=*/true).getAddress();
+  }
+  return Address(AsyncCalleeErrorResultSlot, IGM.getPointerAlignment());
 }
 
 /// Fetch the error result slot received from the caller.
 Address IRGenFunction::getCallerErrorResultSlot() {
   assert(CallerErrorResultSlot && "no error result slot!");
   assert(isa<llvm::Argument>(CallerErrorResultSlot) && !isAsync() ||
-         isa<llvm::GetElementPtrInst>(CallerErrorResultSlot) && isAsync() &&
+         isa<llvm::LoadInst>(CallerErrorResultSlot) && isAsync() &&
              "error result slot is local!");
   return Address(CallerErrorResultSlot, IGM.getPointerAlignment());
 }

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -70,7 +70,7 @@ namespace irgen {
   //   SwiftPartialFunction * __ptrauth(...) returnToCaller;
   //   SwiftActor * __ptrauth(...) callerActor;
   //   SwiftPartialFunction * __ptrauth(...) yieldToCaller?;
-  //   SwiftError *errorResult;
+  //   SwiftError **errorResult;
   //   IndirectResultTypes *indirectResults...;
   //   union {
   //     struct {

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -89,7 +89,10 @@ public:
 
   friend class Scope;
 
-//--- Function prologue and epilogue -------------------------------------------
+  Address createErrorResultSlot(SILType errorType, bool isAsync);
+
+  //--- Function prologue and epilogue
+  //-------------------------------------------
 public:
   Explosion collectParameters();
   void emitScalarReturn(SILType returnResultType, SILType funcResultType,
@@ -106,6 +109,7 @@ public:
   /// For async functions, this is different from the caller result slot because
   /// that is a gep into the %swift.context.
   Address getCalleeErrorResultSlot(SILType errorType);
+  Address getAsyncCalleeErrorResultSlot(SILType errorType);
 
   /// Return the error result slot provided by the caller.
   Address getCallerErrorResultSlot();
@@ -165,6 +169,7 @@ private:
   Address ReturnSlot;
   llvm::BasicBlock *ReturnBB;
   llvm::Value *CalleeErrorResultSlot = nullptr;
+  llvm::Value *AsyncCalleeErrorResultSlot = nullptr;
   llvm::Value *CallerErrorResultSlot = nullptr;
   llvm::Value *CoroutineHandle = nullptr;
   llvm::Value *AsyncCoroutineCurrentResume = nullptr;

--- a/stdlib/public/Concurrency/AsyncCall.h
+++ b/stdlib/public/Concurrency/AsyncCall.h
@@ -63,12 +63,12 @@ struct AsyncFrameLayout;
 
 template <class... ArgTys, bool HasErrorResult>
 struct AsyncFrameLayout<AsyncSignature<void(ArgTys...), HasErrorResult>> {
-  using BasicLayout = BasicLayout<0, SwiftError*, ArgTys...>;
+  using BasicLayout = BasicLayout<0, SwiftError **, ArgTys...>;
   static constexpr size_t firstArgIndex = 1;
 };
 template <class ResultTy, class... ArgTys, bool HasErrorResult>
 struct AsyncFrameLayout<AsyncSignature<ResultTy(ArgTys...), HasErrorResult>> {
-  using BasicLayout = BasicLayout<0, SwiftError*, ResultTy, ArgTys...>;
+  using BasicLayout = BasicLayout<0, SwiftError **, ResultTy, ArgTys...>;
   static constexpr size_t firstArgIndex = 2;
 };
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -94,7 +94,7 @@ void AsyncTask::completeFuture(AsyncContext *context, ExecutorRef executor) {
   // If an error was thrown, save it in the future fragment.
   auto futureContext = static_cast<FutureAsyncContext *>(context);
   bool hadErrorResult = false;
-  if (auto errorObject = futureContext->errorResult) {
+  if (auto errorObject = *futureContext->errorResult) {
     fragment->getError() = errorObject;
     hadErrorResult = true;
   }
@@ -283,7 +283,7 @@ AsyncTaskAndContext swift::swift_task_create_future_f(
     // Set up the context for the future so there is no error, and a successful
     // result will be written into the future fragment's storage.
     auto futureContext = static_cast<FutureAsyncContext *>(initialContext);
-    futureContext->errorResult = nullptr;
+    futureContext->errorResult = &futureFragment->getError();
     futureContext->indirectResult = futureFragment->getStoragePtr();
   }
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -74,7 +74,7 @@ void AsyncTask::groupOffer(AsyncTask *completedTask, AsyncContext *context,
   // If an error was thrown, save it in the future fragment.
   auto futureContext = static_cast<FutureAsyncContext *>(context);
   bool hadErrorResult = false;
-  if (auto errorObject = futureContext->errorResult) {
+  if (auto errorObject = *futureContext->errorResult) {
     // instead we need to enqueue this result:
     hadErrorResult = true;
   }

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -60,7 +60,7 @@ namespace {
 class TaskFutureWaitAsyncContext : public AsyncContext {
 public:
   // Error result is always present.
-  SwiftError *errorResult = nullptr;
+  SwiftError **errorResult = nullptr;
 
   // No indirect results.
 

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -14,8 +14,8 @@ final actor MyActor {
 // CHECK-LABEL: define{{.*}} void @test_simple(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
 // CHECK: [[TASK_LOC:%[0-9]+]] = alloca %swift.task*
 // CHECK: [[CTX:%[0-9]+]] = bitcast %swift.context* %2
-// CHECK-32: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, %swift.error*, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 5
-// CHECK-64: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error*, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 6
+// CHECK-32: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, %swift.error**, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 5
+// CHECK-64: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error**, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 6
 // CHECK: [[ACTOR:%[0-9]+]] = load %T4test7MyActorC*, %T4test7MyActorC** [[ACTOR_ADDR]]
 // CHECK: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
 // CHECK: [[TASK:%[0-9]+]] = load %swift.task*, %swift.task** [[TASK_LOC]]

--- a/test/IRGen/async/throwing.swift
+++ b/test/IRGen/async/throwing.swift
@@ -1,0 +1,153 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+struct E : Error {}
+
+func asyncCanThrowDoesThrow() async throws -> Int {
+  throw E()
+}
+
+func asyncCanThrowDoesntThrow() async throws -> Int {
+  return 0
+}
+
+func syncCanThrowDoesThrow() throws -> Int {
+  throw E()
+}
+
+func syncCanThrowDoesntThrow() throws -> Int {
+  return 0
+}
+
+func asyncCanThrowDoesThrowRecursive(_ index: Int) async throws -> Int {
+  if index > 0 {
+    return try await asyncCanThrowDoesThrowRecursive(index - 1)
+  } else {
+    return try await asyncCanThrowDoesThrow()
+  }
+}
+
+func asyncCanThrowDoesntThrowRecursive(_ index: Int) async throws -> Int {
+  if index > 0 {
+    return try await asyncCanThrowDoesntThrowRecursive(index - 1)
+  } else {
+    return try await asyncCanThrowDoesntThrow()
+  }
+}
+
+func syncCanThrowDoesThrowRecursive(_ index: Int) async throws -> Int {
+  if index > 0 {
+    return try await syncCanThrowDoesThrowRecursive(index - 1)
+  } else {
+    return try syncCanThrowDoesThrow()
+  }
+}
+
+func syncCanThrowDoesntThrowRecursive(_ index: Int) async throws -> Int {
+  if index > 0 {
+    return try await syncCanThrowDoesntThrowRecursive(index - 1)
+  } else {
+    return try syncCanThrowDoesntThrow()
+  }
+}
+
+func test<T>(_ work: () async throws -> T) async {
+  do {
+    let value = try await work()
+    print(value)
+  }
+  catch let error {
+    print(error)
+  }
+}
+
+// CHECK: E()
+// CHECK: 0
+// CHECK: E()
+// CHECK: 0
+func testRecursion() async {
+  await test { try await asyncCanThrowDoesThrowRecursive(10) }
+  await test { try await asyncCanThrowDoesntThrowRecursive(10) }
+  await test { try await syncCanThrowDoesThrowRecursive(10) }
+  await test { try await syncCanThrowDoesntThrowRecursive(10) }
+}
+
+func testAsyncDoesThrowThenSyncDoesThrow() async throws -> (Int, Int) {
+  let async = try await asyncCanThrowDoesThrow()
+  let sync = try syncCanThrowDoesThrow()
+  return (async, sync)
+}
+
+func testAsyncDoesThrowThenSyncDoesntThrow() async throws -> (Int, Int) {
+  let async = try await asyncCanThrowDoesThrow()
+  let sync = try syncCanThrowDoesntThrow()
+  return (async, sync)
+}
+
+func testAsyncDoesntThrowThenSyncDoesThrow() async throws -> (Int, Int) {
+  let async = try await asyncCanThrowDoesntThrow()
+  let sync = try syncCanThrowDoesThrow()
+  return (async, sync)
+}
+
+func testAsyncDoesntThrowThenSyncDoesntThrow() async throws -> (Int, Int) {
+  let async = try await asyncCanThrowDoesntThrow()
+  let sync = try syncCanThrowDoesntThrow()
+  return (async, sync)
+}
+
+
+func testSyncDoesThrowThenAsyncDoesThrow() async throws -> (Int, Int) {
+  let sync = try syncCanThrowDoesThrow()
+  let async = try await asyncCanThrowDoesThrow()
+  return (sync, async)
+}
+
+func testSyncDoesThrowThenAsyncDoesntThrow() async throws -> (Int, Int) {
+  let sync = try syncCanThrowDoesThrow()
+  let async = try await asyncCanThrowDoesntThrow()
+  return (sync, async)
+}
+
+func testSyncDoesntThrowThenAsyncDoesThrow() async throws -> (Int, Int) {
+  let sync = try syncCanThrowDoesntThrow()
+  let async = try await asyncCanThrowDoesThrow()
+  return (sync, async)
+}
+
+func testSyncDoesntThrowThenAsyncDoesntThrow() async throws -> (Int, Int) {
+  let sync = try syncCanThrowDoesntThrow()
+  let async = try await asyncCanThrowDoesntThrow()
+  return (sync, async)
+}
+
+// CHECK: E()
+// CHECK: E()
+// CHECK: E()
+// CHECK: (0, 0)
+// CHECK: E()
+// CHECK: E()
+// CHECK: E()
+// CHECK: (0, 0)
+func testMixture() async {
+  await test { try await testAsyncDoesThrowThenSyncDoesThrow() }
+  await test { try await testAsyncDoesThrowThenSyncDoesntThrow() }
+  await test { try await testAsyncDoesntThrowThenSyncDoesThrow() }
+  await test { try await testAsyncDoesntThrowThenSyncDoesntThrow() }
+
+  await test { try await testSyncDoesThrowThenAsyncDoesThrow() }
+  await test { try await testSyncDoesThrowThenAsyncDoesntThrow() }
+  await test { try await testSyncDoesntThrowThenAsyncDoesThrow() }
+  await test { try await testSyncDoesntThrowThenAsyncDoesntThrow() }
+}
+
+runAsyncAndBlock {
+  await testRecursion()
+  await testMixture()
+}


### PR DESCRIPTION
Previously, the error stored in the async context was of type `SwiftError *`.  In order to enable the context to be callee released, make it indirect and change its type to `SwiftError **`.

rdar://71378532