### PR TITLE
[build-presets] Test Swift Syntax during macOS PR smoke testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -588,6 +588,7 @@ build-ninja
 libcxx
 llbuild
 swiftpm
+swiftsyntax
 swift-driver
 indexstore-db
 sourcekit-lsp
@@ -595,6 +596,7 @@ install-llvm
 install-swift
 install-llbuild
 install-swiftpm
+install-swiftsyntax
 install-swift-driver
 install-libcxx
 


### PR DESCRIPTION
There have been occasions in the past where changes to the gyb_syntax_support broke the SwiftSyntax build that weren't caught in CI because smoke test didn't build/test the downstream Swift Syntax project.