### PR TITLE
ABI: convert some `unsigned long` to `unsigned long long`

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -343,16 +343,16 @@ public:
     };
 
     struct GroupStatus {
-        static const unsigned long maskReady      = 0x00FFFFF0000000000l;
-        static const unsigned long oneReadyTask   = 0x00000010000000000l;
+        static const unsigned long long maskReady      = 0x00FFFFF0000000000ll;
+        static const unsigned long long oneReadyTask   = 0x00000010000000000ll;
 
-        static const unsigned long maskPending    = 0x0000000FFFFF00000l;
-        static const unsigned long onePendingTask = 0x00000000000100000l;
+        static const unsigned long long maskPending    = 0x0000000FFFFF00000ll;
+        static const unsigned long long onePendingTask = 0x00000000000100000ll;
 
-        static const unsigned long maskWaiting    = 0x000000000000FFFFFl;
-        static const unsigned long oneWaitingTask = 0x00000000000000001l;
+        static const unsigned long long maskWaiting    = 0x000000000000FFFFFll;
+        static const unsigned long long oneWaitingTask = 0x00000000000000001ll;
 
-        unsigned long status;
+        unsigned long long status;
 
         unsigned int readyTasks() {
           return (status & maskReady) >> 40;
@@ -436,7 +436,7 @@ public:
     mutable std::mutex mutex;
 
     /// Used for queue management, counting number of waiting and ready tasks
-    std::atomic<unsigned long> status;
+    std::atomic<unsigned long long> status;
 
     /// Queue containing completed tasks offered into this channel.
     ///


### PR DESCRIPTION
This path is not yet ABI stable so take advantage to correct the
storage.  This ABI compatible on most platforms, however, is not
compatible on Windows, which is a ILLP64 platform rather than ILP64.
This extends the storage to 64-bits from 32-bits.  In the process, it
avoids some warnings on the windows builds as well.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
