### PR TITLE
Platform: add dxgidebug.h to _DXGI module

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -184,6 +184,7 @@ module WinSDK [system] {
     // separate module is meant to augment the uncovered portions only.
     module _DXGI {
       header "../shared/dxgi1_6.h"
+      header "dxgidebug.h"
       export *
 
       link "dxgi.lib"


### PR DESCRIPTION
The debug header is used for enumeration of certain DXGI interfaces
related to debugging of the pipeline.  Add this to gain access to the
interfaces and some of the global GUIDs associated with it.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
