### PR TITLE
[test] Allow setting extra environment for running tests.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,6 +135,8 @@ set(LIT "${LLVM_MAIN_SRC_DIR}/utils/lit/lit.py")
 # consecutive execution, which makes local builds fail faster.
 set(SWIFT_LIT_ARGS "--incremental" CACHE STRING "Arguments to pass to lit")
 
+set(SWIFT_LIT_ENVIRONMENT "" CACHE STRING "Environment to use for lit invocations")
+
 if(NOT SWIFT_INCLUDE_TOOLS)
   list(APPEND SWIFT_LIT_ARGS
        "--path=${SWIFT_NATIVE_LLVM_TOOLS_PATH}"
@@ -390,6 +392,7 @@ foreach(SDK ${SWIFT_SDKS})
               ${command_upload_swift_reflection_test}
               ${command_clean_test_results_dir}
               COMMAND
+                ${CMAKE_COMMAND} -E env ${SWIFT_LIT_ENVIRONMENT}
                 $<TARGET_FILE:Python3::Interpreter> "${LIT}"
                 ${LIT_ARGS}
                 "--param" "swift_test_subset=${test_subset}"
@@ -409,6 +412,7 @@ foreach(SDK ${SWIFT_SDKS})
               ${command_upload_swift_reflection_test}
               ${command_clean_test_results_dir}
               COMMAND
+                ${CMAKE_COMMAND} -E env ${SWIFT_LIT_ENVIRONMENT}
                 $<TARGET_FILE:Python3::Interpreter> "${LIT}"
                 ${LIT_ARGS}
                 "--param" "swift_test_subset=${test_subset}"


### PR DESCRIPTION
In some situations, in order to set the correct environment during some
tests, extra environment has to be provided to the LLVM Lit invocations.
It seems that the preferred way is using `cmake -E env` to be
cross-platform.

The environment can be set using a cached variable so it can be set from
CMake cache files, or passing parameters to the CMake configuration
step.

/cc @rmaz 
