### PR TITLE
[Concurrency] Add a debug variable pointing to the metadata for AsyncTask.

### DIFF
--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -1,0 +1,30 @@
+//===--- Debug.h - Swift Concurrency debug helpers --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Debugging and inspection support.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_CONCURRENCY_DEBUG_H
+#define SWIFT_CONCURRENCY_DEBUG_H
+
+#include "swift/Runtime/Config.h"
+
+namespace swift {
+
+/// The metadata pointer used for async task objects.
+SWIFT_RUNTIME_STDLIB_SPI
+const void *const _swift_concurrency_debug_asyncTaskMetadata;
+
+} // namespace swift
+
+#endif

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -21,6 +21,7 @@
 #include "swift/Runtime/HeapObject.h"
 #include "TaskPrivate.h"
 #include "AsyncCall.h"
+#include "Debug.h"
 
 #include <dispatch/dispatch.h>
 
@@ -167,6 +168,9 @@ static FullMetadata<HeapMetadata> taskHeapMetadata = {
     MetadataKind::Task
   }
 };
+
+const void *const swift::_swift_concurrency_debug_asyncTaskMetadata =
+    static_cast<Metadata *>(&taskHeapMetadata);
 
 /// The function that we put in the context of a simple task
 /// to handle the final return.


### PR DESCRIPTION
Debugging tools can use _swift_concurrency_debug_asyncTaskMetadata to identify memory blocks as async task allocations by looking at their isa/metadata pointer.

rdar://72906895