### PR TITLE
[TBDGen] don't add "_" when adding objc classes to swift TBD

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -396,10 +396,16 @@ void TBDGenVisitor::addLinkerDirectiveSymbolsLdHide(StringRef name,
 
 void TBDGenVisitor::addSymbol(StringRef name, SymbolSource source,
                               SymbolKind kind) {
-  // The linker expects to see mangled symbol names in TBD files, so make sure
-  // to mangle before inserting the symbol.
+  // The linker expects to see mangled symbol names in TBD files,
+  // except when being passed objective c classes,
+  // so make sure to mangle before inserting the symbol.
   SmallString<32> mangled;
-  llvm::Mangler::getNameWithPrefix(mangled, name, DataLayout);
+  if (kind == SymbolKind::ObjectiveCClass) {
+    mangled = name;
+  } else {
+    llvm::Mangler::getNameWithPrefix(mangled, name, DataLayout);
+  }
+
   addSymbolInternal(mangled, kind, source);
   if (previousInstallNameMap) {
     addLinkerDirectiveSymbolsLdPrevious(mangled, kind);

--- a/test/TBD/implied_objc_symbols.swift
+++ b/test/TBD/implied_objc_symbols.swift
@@ -1,0 +1,10 @@
+// REQUIRES: VENDOR=apple
+ // RUN: %empty-directory(%t)
+
+ // RUN: echo "import Foundation" > %t/main.swift
+ // RUN: echo "@objc(CApi) public class Api {}" >> %t/main.swift
+ // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module -emit-tbd -emit-tbd-path %t/main.tbd
+
+ // RUN: %FileCheck %s < %t/main.tbd
+
+ // CHECK: objc-classes: [ CApi ]


### PR DESCRIPTION
 When a class definition is marked with `@objc`, the swift tbd emits a special section with of the tbd labeled objc-classes, and the values are incorrectly given leading underscores, this causes tapi verification in `Pedantic` mode to fail, and this change is needed to apply the enhanced swift installapi updates. 

<rdar://problem/73664795>
