### PR TITLE
Revert " [runtime] unittests should use just-built compiler if the ru…

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -2,10 +2,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
    ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
 
   if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-    if(NOT SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
-      set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_CLANG_TOOLS_PATH}/clang++")
-      set(CMAKE_C_COMPILER "${SWIFT_NATIVE_CLANG_TOOLS_PATH}/clang")
-    endif()
+    # Do nothing
   elseif(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
     if(NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
       message(FATAL_ERROR "Building the swift runtime is not supported with ${CMAKE_C_COMPILER_ID}. Use the just-built clang instead.")


### PR DESCRIPTION
…ntime did"

This seems to be causing issues with the ASAN bot. And I don't think
this was actually causing issues in the tests.

rdar://73664504
