### PR TITLE
[test] Mark concurrency tests with appropiate REQUIRES.

### DIFF
--- a/test/IDE/complete_async_context.swift
+++ b/test/IDE/complete_async_context.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
 
+// REQUIRES: concurrency
+
 func funcThrows() throws {
     fatalError()
 }

--- a/test/IDE/complete_asyncannotation.swift
+++ b/test/IDE/complete_asyncannotation.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
 
+// REQUIRES: concurrency
+
 func globalFuncAsync() async {}
 func globalFuncAsyncThrows() async throws {}
 func globalFuncAsyncRethrows(_ x: () async throws -> ()) async rethrows {}

--- a/test/IDE/complete_concurrency_keyword.swift
+++ b/test/IDE/complete_concurrency_keyword.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
 
+// REQUIRES: concurrency
+
 // CHECK_DECL: NOT
 
 #^GLOBAL^#

--- a/test/IDE/complete_concurrency_specifier.swift
+++ b/test/IDE/complete_concurrency_specifier.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -enable-experimental-concurrency
 
+// REQUIRES: concurrency
+
 // SPECIFIER: Begin completions
 // SPECIFIER-DAG: Keyword/None:                       async; name=async
 // SPECIFIER-DAG: Keyword[throws]/None:               throws; name=throws

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-verify-all %s -optimize-hop-to-executor -enable-experimental-concurrency | %FileCheck %s
 
+// REQUIRES: concurrency
+
 sil_stage canonical
 
 import Builtin

--- a/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
@@ -14,6 +14,8 @@ func test(act: MyActor) async throws {
     try await act.asyncFunc {}
 }
 
+// REQUIRES: concurrency
+
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 

--- a/test/TBD/async-function-pointer.swift
+++ b/test/TBD/async-function-pointer.swift
@@ -1,4 +1,5 @@
-// REQUIRES: VENDOR=apple 
+// REQUIRES: VENDOR=apple
+// REQUIRES: concurrency
 // RUN: %target-swift-frontend -emit-ir %s -enable-experimental-concurrency -validate-tbd-against-ir=all -module-name test | %FileCheck %s
 
 // CHECK: @"$s4test6testityyYFTu" = hidden global %swift.async_func_pointer

--- a/validation-test/compiler_crashers_2_fixed/rdar71260972.sil
+++ b/validation-test/compiler_crashers_2_fixed/rdar71260972.sil
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-ir -enable-experimental-concurrency -parse-sil
 
+// REQUIRES: concurrency
+
 import Swift
 
 struct Pack {


### PR DESCRIPTION
The Python build system always enables concurrency, but CMake has it
disable by default. Collaborators that do not use the Python build
system and use directly CMake will have it disable, unless they
explicitely enable it. If the tests are not marked as requiring the
concurrency features, the tests will fail to execute when concurrency is
disabled.

The changes add the `REQUIRES: concurrency` line to many tests that deal
with concurrency, but wasn't marked as such.

The tests were found using the following: `grep -L -e  'REQUIRES: concurrency' $(grep -r -l -e 'enable-experimental-concurrency' validation-test/ test/)`.

This is a more complete version of #35557 (with a proper explanation).