### PR TITLE
SymbolGraphGen: don't print USRs for type parameters

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -146,6 +146,10 @@ void DeclarationFragmentPrinter::printTypeRef(Type T, const TypeDecl *RefTo,
         ShouldLink = false;
       }
     }
+
+    if (T->isTypeParameter()) {
+      ShouldLink = false;
+    }
   }
 
   if (ShouldLink) {

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
@@ -539,7 +539,6 @@ enum MyEnum {
 // CHECKBAR_ALL:         },
 // CHECKBAR_ALL:         {
 // CHECKBAR_ALL:           "kind": "typeIdentifier",
-// CHECKBAR_GEN:           "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
 // CHECKBAR_GEN:           "spelling": "T"
 // CHECKBAR_INT:           "preciseIdentifier": "s:Si",
 // CHECKBAR_INT:           "spelling": "Int"
@@ -564,7 +563,6 @@ enum MyEnum {
 // CHECKBAR_GEN:         },
 // CHECKBAR_GEN:         {
 // CHECKBAR_GEN:           "kind": "typeIdentifier",
-// CHECKBAR_GEN:           "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
 // CHECKBAR_GEN:           "spelling": "T"
 // CHECKBAR_GEN:         },
 // CHECKBAR_GEN:         {
@@ -608,7 +606,6 @@ enum MyEnum {
 // CHECKBAR_ALL:               },
 // CHECKBAR_ALL:               {
 // CHECKBAR_ALL:                 "kind": "typeIdentifier",
-// CHECKBAR_GEN:                 "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
 // CHECKBAR_GEN:                 "spelling": "T"
 // CHECKBAR_INT:                 "preciseIdentifier": "s:Si",
 // CHECKBAR_INT:                 "spelling": "Int"
@@ -669,7 +666,6 @@ enum MyEnum {
 // CHECKBAR_ALL:           },
 // CHECKBAR_ALL:           {
 // CHECKBAR_ALL:             "kind": "typeIdentifier",
-// CHECKBAR_GEN:             "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
 // CHECKBAR_GEN:             "spelling": "T"
 // CHECKBAR_INT:             "preciseIdentifier": "s:Si",
 // CHECKBAR_INT:             "spelling": "Int"
@@ -708,7 +704,6 @@ enum MyEnum {
 // CHECKBAR_ALL:           },
 // CHECKBAR_ALL:           {
 // CHECKBAR_ALL:             "kind": "typeIdentifier",
-// CHECKBAR_GEN:             "preciseIdentifier": "s:19cursor_symbol_graph3FooV1Txmfp",
 // CHECKBAR_GEN:             "spelling": "T"
 // CHECKBAR_INT:             "preciseIdentifier": "s:Si",
 // CHECKBAR_INT:             "spelling": "Int"

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Function.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Function.swift
@@ -81,8 +81,7 @@ public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) where S: Seque
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "kind": "typeIdentifier",
-// CHECK-NEXT:          "spelling": "S",
-// CHECK-NEXT:          "preciseIdentifier": "s:8Function3foo1f3ext1syyyc_SixtSTRzlF1SL_xmfp"
+// CHECK-NEXT:          "spelling": "S"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "kind": "text",
@@ -98,8 +97,7 @@ public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) where S: Seque
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "kind": "typeIdentifier",
-// CHECK-NEXT:          "spelling": "S",
-// CHECK-NEXT:          "preciseIdentifier": "s:8Function3foo1f3ext1syyyc_SixtSTRzlF1SL_xmfp"
+// CHECK-NEXT:          "spelling": "S"
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "kind": "text",

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/NominalTypes.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/NominalTypes.swift
@@ -54,8 +54,7 @@ public protocol P {}
 // STRUCT-NEXT:   },
 // STRUCT-NEXT:   {
 // STRUCT-NEXT:     "kind": "typeIdentifier",
-// STRUCT-NEXT:     "spelling": "T",
-// STRUCT-NEXT:     "preciseIdentifier": "s:12NominalTypes1SV1Txmfp"
+// STRUCT-NEXT:     "spelling": "T"
 // STRUCT-NEXT:   }
 // STRUCT-NEXT:   {
 // STRUCT-NEXT:     "kind": "text",
@@ -106,8 +105,7 @@ public class C<T> where T: Sequence {}
 // CLASS-NEXT:   },
 // CLASS-NEXT:   {
 // CLASS-NEXT:     "kind": "typeIdentifier",
-// CLASS-NEXT:     "spelling": "T",
-// CLASS-NEXT:     "preciseIdentifier": "s:12NominalTypes1CC1Txmfp"
+// CLASS-NEXT:     "spelling": "T"
 // CLASS-NEXT:   }
 // CLASS-NEXT:   {
 // CLASS-NEXT:     "kind": "text",
@@ -158,8 +156,7 @@ public enum E<T> where T: Sequence {}
 // ENUM-NEXT:   },
 // ENUM-NEXT:   {
 // ENUM-NEXT:     "kind": "typeIdentifier",
-// ENUM-NEXT:     "spelling": "T",
-// ENUM-NEXT:     "preciseIdentifier": "s:12NominalTypes1EO1Txmfp"
+// ENUM-NEXT:     "spelling": "T"
 // ENUM-NEXT:   }
 // ENUM-NEXT:   {
 // ENUM-NEXT:     "kind": "text",
@@ -211,8 +208,7 @@ public typealias TA<T> = S<T> where T: Sequence
 // TYPEALIAS-NEXT:   },
 // TYPEALIAS-NEXT:   {
 // TYPEALIAS-NEXT:     "kind": "typeIdentifier",
-// TYPEALIAS-NEXT:     "spelling": "T",
-// TYPEALIAS-NEXT:     "preciseIdentifier": "s:12NominalTypes2TAa1Txmfp"
+// TYPEALIAS-NEXT:     "spelling": "T"
 // TYPEALIAS-NEXT:   }
 // TYPEALIAS-NEXT:   {
 // TYPEALIAS-NEXT:     "kind": "text",
@@ -228,8 +224,7 @@ public typealias TA<T> = S<T> where T: Sequence
 // TYPEALIAS-NEXT:   },
 // TYPEALIAS-NEXT:   {
 // TYPEALIAS-NEXT:     "kind": "typeIdentifier",
-// TYPEALIAS-NEXT:     "spelling": "T",
-// TYPEALIAS-NEXT:     "preciseIdentifier": "s:12NominalTypes2TAa1Txmfp"
+// TYPEALIAS-NEXT:     "spelling": "T"
 // TYPEALIAS-NEXT:   }
 // TYPEALIAS-NEXT:   {
 // TYPEALIAS-NEXT:     "kind": "text",

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator/Navigator.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator/Navigator.swift
@@ -82,8 +82,7 @@ public struct MyStruct<S> { public var x: S
 // BAR-NEXT:          }
 // BAR-NEXT:          {
 // BAR-NEXT:            "kind": "typeIdentifier",
-// BAR-NEXT:            "spelling": "T",
-// BAR-NEXT:            "preciseIdentifier": "s:9Navigator8MyStructV3bar1xyqd___tSTRd__lF1TL_qd__mfp"
+// BAR-NEXT:            "spelling": "T"
 // BAR-NEXT:          }
 // BAR-NEXT:          {
 // BAR-NEXT:            "kind": "text",

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Subheading/Function.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Subheading/Function.swift
@@ -70,8 +70,7 @@ public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) where S: Seque
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "kind": "typeIdentifier",
-// CHECK-NEXT:     "spelling": "S",
-// CHECK-NEXT:     "preciseIdentifier": "s:8Function3foo1f3ext1syyyc_SixtSTRzlF1SL_xmfp"
+// CHECK-NEXT:     "spelling": "S"
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "kind": "text",


### PR DESCRIPTION
rdar://73478316

When rendering declaration fragments into a symbol graph, it's not necessary to print USRs for type parameters, since they don't have their own symbols to link against. This can cause issues for tools that want to render or verify links in declarations. By skipping USR printing for these, we can preserve their fragments showing up as a type identifier, but leave the erroneous USRs out.