### PR TITLE
[android][test] Mark other-entry-point-function-name as executable.

### DIFF
--- a/test/SILGen/other-entry-point-function-name.swift
+++ b/test/SILGen/other-entry-point-function-name.swift
@@ -3,6 +3,8 @@
 // RUN: %target-build-swift %s %t/forward.o -Xfrontend -entry-point-function-name -Xfrontend foobar -o %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 
+// REQUIRES: executable_test
+
 // CHECK: howdy from foobar
 print("howdy from foobar")
 


### PR DESCRIPTION
The test other-entry-point-function-name needs to be executed to be
checked. Some platforms (like Android) do not execute the test in CI
(because there's no device attached to the build machines), so the tests
need to be marked as executable to be skipped.

The test was introduced in #35595 and started failing in CI in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/9018/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/7441/.