### PR TITLE
Add visitTransitiveScopeEndingUses and related cleanup

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -227,6 +227,14 @@ struct BorrowingOperand {
   /// closure requested to stop early.
   bool visitLocalScopeEndingUses(function_ref<bool(Operand *)> func) const;
 
+  /// Visit the scope ending operands after transitively searching through
+  /// reborrows. These uses might not be dominated by this BorrowingOperand.
+  ///
+  /// Returns false and early exits if the visitor \p func returns false.
+  ///
+  /// Note: this currently does not visit the intermediate reborrows.
+  bool visitTransitiveScopeEndingUses(function_ref<bool(Operand *)> func) const;
+
   /// Returns true if this borrow scope operand consumes guaranteed
   /// values and produces a new scope afterwards.
   ///

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -225,7 +225,7 @@ struct BorrowingOperand {
   ///
   /// NOTE: Return false from func to stop iterating. Returns false if the
   /// closure requested to stop early.
-  bool visitLocalEndScopeUses(function_ref<bool(Operand *)> func) const;
+  bool visitLocalScopeEndingUses(function_ref<bool(Operand *)> func) const;
 
   /// Returns true if this borrow scope operand consumes guaranteed
   /// values and produces a new scope afterwards.

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -191,7 +191,7 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
   return os;
 }
 
-bool BorrowingOperand::visitLocalEndScopeUses(
+bool BorrowingOperand::visitLocalScopeEndingUses(
     function_ref<bool(Operand *)> func) const {
   switch (kind) {
   case BorrowingOperandKind::Invalid:
@@ -313,7 +313,7 @@ void BorrowingOperand::visitUserResultConsumingUses(
 void BorrowingOperand::getImplicitUses(
     SmallVectorImpl<Operand *> &foundUses,
     std::function<void(Operand *)> *errorFunction) const {
-  visitLocalEndScopeUses([&](Operand *op) {
+  visitLocalScopeEndingUses([&](Operand *op) {
     foundUses.push_back(op);
     return true;
   });

--- a/lib/SIL/Verifier/ReborrowVerifier.cpp
+++ b/lib/SIL/Verifier/ReborrowVerifier.cpp
@@ -41,7 +41,7 @@ void ReborrowVerifier::verifyReborrows(BorrowingOperand initialScopedOperand,
                                        SILValue value) {
   SmallVector<std::tuple<Operand *, SILValue>, 4> worklist;
   // Initialize the worklist with borrow lifetime ending uses
-  initialScopedOperand.visitLocalEndScopeUses([&](Operand *op) {
+  initialScopedOperand.visitLocalScopeEndingUses([&](Operand *op) {
     worklist.emplace_back(op, value);
     return true;
   });

--- a/lib/SIL/Verifier/ReborrowVerifier.cpp
+++ b/lib/SIL/Verifier/ReborrowVerifier.cpp
@@ -88,6 +88,7 @@ void ReborrowVerifier::verifyReborrows(BorrowingOperand initialScopedOperand,
       scopedValue.visitLocalScopeEndingUses([&](Operand *op) {
         addVisitedOp(op, newBaseVal);
         worklist.emplace_back(op, newBaseVal);
+        return true;
       });
     }
   }

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -475,7 +475,7 @@ static bool tryJoinIfDestroyConsumingUseInSameBlock(
     // singleConsumingUse (the original forwarded use) and the destroy_value. In
     // such a case, we must bail!
     if (auto operand = BorrowingOperand::get(use))
-      if (!operand.visitLocalEndScopeUses([&](Operand *endScopeUse) {
+      if (!operand.visitLocalScopeEndingUses([&](Operand *endScopeUse) {
             // Return false if we did see the relevant end scope instruction
             // in the block. That means that we are going to exit early and
             // return false.

--- a/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
@@ -241,7 +241,7 @@ public:
     // borrow it's based on.
     SmallVector<Operand *, 4> endScopeInsts;
     value.visitLocalScopeEndingUses(
-        [&](Operand *use) { endScopeInsts.push_back(use); });
+      [&](Operand *use) { endScopeInsts.push_back(use); return true; });
 
     LinearLifetimeChecker checker(ctx.getDeadEndBlocks());
 

--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -249,7 +249,7 @@ bool CanonicalizeOSSALifetime::consolidateBorrowScope() {
         recordOuterUse(use);
         // For borrows, record the scope-ending instructions in addition to the
         // borrow instruction as an outer use point.
-        borrowOper.visitLocalEndScopeUses([&](Operand *endBorrow) {
+        borrowOper.visitLocalScopeEndingUses([&](Operand *endBorrow) {
           if (!isUserInLiveOutBlock(endBorrow->getUser())) {
             outerUseInsts.insert(endBorrow->getUser());
           }
@@ -288,7 +288,7 @@ bool CanonicalizeOSSALifetime::consolidateBorrowScope() {
       }
       // For sub-borrows also check that the scope-ending instructions are
       // within the scope.
-      if (borrowOper.visitLocalEndScopeUses([&](Operand *endBorrow) {
+      if (borrowOper.visitLocalScopeEndingUses([&](Operand *endBorrow) {
             return !outerUseInsts.count(endBorrow->getUser());
           })) {
         continue;
@@ -389,7 +389,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
       case OperandOwnership::Borrow:
         // An entire borrow scope is considered a single use that occurs at the
         // point of the end_borrow.
-        BorrowingOperand(use).visitLocalEndScopeUses([this](Operand *end) {
+        BorrowingOperand(use).visitLocalScopeEndingUses([this](Operand *end) {
           liveness.updateForUse(end->getUser(), /*lifetimeEnding*/ false);
           return true;
         });

--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -81,6 +81,7 @@ SILValue CanonicalizeOSSALifetime::getCanonicalCopiedDef(SILValue v) {
         borrowedVal.visitLocalScopeEndingUses([&](Operand *endBorrow) {
           if (endBorrow->getUser()->getParent() != def->getParentBlock())
             localScope = false;
+          return true;
         });
         if (localScope) {
           return def;
@@ -145,6 +146,7 @@ bool CanonicalizeOSSALifetime::computeBorrowLiveness() {
   }
   borrowedVal.visitLocalScopeEndingUses([this](Operand *use) {
     liveness.updateForUse(use->getUser(), /*lifetimeEnding*/ true);
+    return true;
   });
 
   // TODO: Fix getCanonicalCopiedDef to allow multi-block borrows and remove

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -161,7 +161,7 @@ static bool findTransitiveBorrowedUses(
       // Try to grab additional end scope instructions to find more liveness
       // info. Stash any reborrow uses so that we can eliminate the reborrow
       // before we are done processing.
-      BorrowingOperand(use).visitLocalEndScopeUses(
+      BorrowingOperand(use).visitLocalScopeEndingUses(
         [&](Operand *scopeEndingUse) {
           if (auto scopeEndingBorrowingOp = BorrowingOperand(scopeEndingUse)) {
             if (scopeEndingBorrowingOp.isReborrow()) {


### PR DESCRIPTION
In preparation for adding support for "reborrows" particularly in CanonicalizeOSSA.

It will be tested in the next PR. This just gets the CI pipeline rolling.