### PR TITLE
Diagnostics: improve error message at attr diagnosis failure

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -51,12 +51,14 @@ namespace {
     assert(!D->hasClangNode() && "Clang importer propagated a bogus attribute");
     if (!D->hasClangNode()) {
       SourceLoc loc = attr->getLocation();
+#ifndef NDEBUG
       if (!loc.isValid()) {
         llvm::errs() << "Attribute '";
         attr->print(llvm::errs());
         llvm::errs() << "' has invalid location, failed to diagnose!\n";
         assert(false && "Diagnosing attribute with invalid location");
       }
+#endif
       if (loc.isInvalid()) {
         loc = D->getLoc();
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -51,7 +51,12 @@ namespace {
     assert(!D->hasClangNode() && "Clang importer propagated a bogus attribute");
     if (!D->hasClangNode()) {
       SourceLoc loc = attr->getLocation();
-      assert(loc.isValid() && "Diagnosing attribute with invalid location");
+      if (!loc.isValid()) {
+        llvm::errs() << "Attribute '";
+        attr->print(llvm::errs());
+        llvm::errs() << "' has invalid location, failed to diagnose!\n";
+        assert(false && "Diagnosing attribute with invalid location");
+      }
       if (loc.isInvalid()) {
         loc = D->getLoc();
       }


### PR DESCRIPTION
Used to just crash:

> Assertion failed: (loc.isValid() && "Diagnosing attribute with invalidlocation"), function diagnoseAndRemoveAttr

but now includes at least information what attribute caused the crash:

> Attribute '@actorIndependent ' has invalid location, failed to diagnose!
> Assertion failed: (false && "Diagnosing attribute with invalid location"), function diagnoseAndRemoveAttr


---

This way _at least_ we know what attr caused the crash right away and I would have wasted less hours chasing the completely wrong thing 😉 