### PR TITLE
Revert JumpThreadingCost improvements

### DIFF
--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -318,8 +318,6 @@ bool SimplifyCFG::threadEdge(const ThreadInfo &ti) {
     return false;
 
   Cloner.cloneBranchTarget(SrcTerm);
-  JumpThreadingCost[Cloner.getNewBB()] = JumpThreadingCost[SrcTerm->getDestBB()];
-
 
   // We have copied the threaded block into the edge.
   auto *clonedSrc = Cloner.getNewBB();
@@ -1132,10 +1130,6 @@ bool SimplifyCFG::tryJumpThreading(BranchInst *BI) {
   // to use the branch arguments as we go.
   Cloner.cloneBranchTarget(BI);
   Cloner.updateSSAAfterCloning();
-
-  // Also account the costs to the cloned DestBB, so the jump threading cannot
-  // loop by cloning the cloned block again.
-  JumpThreadingCost[Cloner.getNewBB()] += copyCosts;
 
   // Once all the instructions are copied, we can nuke BI itself.  We also add
   // the threaded and edge block to the worklist now that they (likely) can be
@@ -2878,8 +2872,6 @@ bool SimplifyCFG::tailDuplicateObjCMethodCallSuccessorBlocks() {
 
     Cloner.cloneBranchTarget(Branch);
     Cloner.updateSSAAfterCloning();
-
-    JumpThreadingCost[Cloner.getNewBB()] = JumpThreadingCost[DestBB];
 
     Changed = true;
     // Simplify the cloned block and continue tail duplicating through its new


### PR DESCRIPTION
Reverting until the ASAN failure can be debugged.

rdar://73726295 (AddressSanitizer: heap-use-after-free SimplifyCFG::dominatorBasedSimplify)