### PR TITLE
cmake: fix Xcode project generation to include all header files.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -435,8 +435,9 @@ function(add_swift_host_library name)
   endif()
 
   if(XCODE)
-    get_filename_component(dir ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
-
+    string(REGEX MATCHALL "/[^/]+" split_path ${CMAKE_CURRENT_SOURCE_DIR})
+    list(GET split_path -1 dir)
+  
     file(GLOB_RECURSE ASHL_HEADERS
       ${SWIFT_SOURCE_DIR}/include/swift${dir}/*.h
       ${SWIFT_SOURCE_DIR}/include/swift${dir}/*.def


### PR DESCRIPTION
This was broken by commit cf1f240534b8fbf2406f4d345fd43c41541d8800.
This commit reverts the 2 lines which broke the inclusion of header files in the generated Xcode project.
