### PR TITLE
[libSyntax] Require RawSyntax to always live inside a SyntaxArena 

### DIFF
--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -164,7 +164,7 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
       unsigned nodeId = std::atoi(nodeIdString.data());
       value = swift::RawSyntax::makeAndCalcLength(
           tokenKind, swift::OwnedString::makeRefCounted(text), leadingTrivia,
-          trailingTrivia, presence, /*Arena=*/nullptr, nodeId);
+          trailingTrivia, presence, swift::SyntaxArena::make(), nodeId);
     } else {
       swift::SyntaxKind kind;
       in.mapRequired("kind", kind);
@@ -178,8 +178,8 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
       StringRef nodeIdString;
       in.mapRequired("id", nodeIdString);
       unsigned nodeId = std::atoi(nodeIdString.data());
-      value = swift::RawSyntax::makeAndCalcLength(kind, layout, presence,
-                                                  /*Arena=*/nullptr, nodeId);
+      value = swift::RawSyntax::makeAndCalcLength(
+          kind, layout, presence, swift::SyntaxArena::make(), nodeId);
     }
   }
 };

--- a/include/swift/Syntax/SyntaxArena.h
+++ b/include/swift/Syntax/SyntaxArena.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_SYNTAX_SYNTAXARENA_H
 #define SWIFT_SYNTAX_SYNTAXARENA_H
 
+#include "swift/Syntax/References.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/Allocator.h"
 
@@ -32,6 +33,8 @@ class SyntaxArena : public llvm::ThreadSafeRefCountedBase<SyntaxArena> {
 
 public:
   SyntaxArena() {}
+
+  static RC<SyntaxArena> make() { return RC<SyntaxArena>(new SyntaxArena()); }
 
   llvm::BumpPtrAllocator &getAllocator() { return Allocator; }
   void *Allocate(size_t size, size_t alignment) {

--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -33,7 +33,7 @@ class SyntaxArena;
 %   if node.is_buildable():
 %     child_count = len(node.children)
 class ${node.name}Builder {
-  RC<SyntaxArena> Arena = nullptr;
+  RC<SyntaxArena> Arena;
   RC<RawSyntax> Layout[${child_count}] = {
 %     for child in node.children:
     nullptr,
@@ -41,8 +41,8 @@ class ${node.name}Builder {
   };
 
 public:
-  ${node.name}Builder() = default;
-  ${node.name}Builder(const RC<SyntaxArena> &Arena) : Arena(Arena) {}
+  ${node.name}Builder(const RC<SyntaxArena> &Arena = SyntaxArena::make())
+      : Arena(Arena) {}
 
 %     for child in node.children:
   ${node.name}Builder &use${child.name}(${child.type_name} ${child.name});

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -46,22 +46,25 @@ class SyntaxArena;
 struct SyntaxFactory {
   /// Make any kind of token.
   static TokenSyntax makeToken(tok Kind,
-                               OwnedString Text, const Trivia &LeadingTrivia,
-                               const Trivia &TrailingTrivia,
-                               SourcePresence Presence,
-                               RC<SyntaxArena> Arena = nullptr);
+      OwnedString Text, const Trivia &LeadingTrivia,
+      const Trivia &TrailingTrivia, SourcePresence Presence,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Collect a list of tokens into a piece of "unknown" syntax.
   static UnknownSyntax makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
-                                         RC<SyntaxArena> Arena = nullptr);
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   static Optional<Syntax> createSyntax(SyntaxKind Kind,
-                                       llvm::ArrayRef<Syntax> Elements,
-                                       RC<SyntaxArena> Arena = nullptr);
+      llvm::ArrayRef<Syntax> Elements,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   static RC<RawSyntax> createRaw(SyntaxKind Kind,
-                                 llvm::ArrayRef<RC<RawSyntax>> Elements,
-                                 RC<SyntaxArena> Arena = nullptr);
+      llvm::ArrayRef<RC<RawSyntax>> Elements,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Count the number of children for a given syntax node kind,
   /// returning a pair of mininum and maximum count of children. The gap
@@ -83,36 +86,39 @@ struct SyntaxFactory {
 %     end
 %     child_params = ', '.join(child_params)
   static ${node.name} make${node.syntax_kind}(${child_params},
-                                              RC<SyntaxArena> Arena = nullptr);
+      const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   elif node.is_syntax_collection():
   static ${node.name} make${node.syntax_kind}(
       const std::vector<${node.collection_element_type}> &elts,
-      RC<SyntaxArena> Arena = nullptr);
+      const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   end
 
-  static ${node.name} makeBlank${node.syntax_kind}(RC<SyntaxArena> Arena = nullptr);
+  static ${node.name} makeBlank${node.syntax_kind}(
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 % end
 
 % for token in SYNTAX_TOKENS:
 %   if token.is_keyword:
   static TokenSyntax make${token.name}Keyword(const Trivia &LeadingTrivia,
-                                              const Trivia &TrailingTrivia,
-                                              RC<SyntaxArena> Arena = nullptr);
+      const Trivia &TrailingTrivia,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   elif token.text:
   static TokenSyntax make${token.name}Token(const Trivia &LeadingTrivia,
-                                            const Trivia &TrailingTrivia,
-                                            RC<SyntaxArena> Arena = nullptr);
+      const Trivia &TrailingTrivia,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   else:
   static TokenSyntax make${token.name}(OwnedString Text,
-                                       const Trivia &LeadingTrivia,
-                                       const Trivia &TrailingTrivia,
-                                       RC<SyntaxArena> Arena = nullptr);
+      const Trivia &LeadingTrivia, const Trivia &TrailingTrivia,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   end
 % end
 
 #pragma mark - Convenience APIs
 
-  static TupleTypeSyntax makeVoidTupleType(RC<SyntaxArena> Arena = nullptr);
+  static TupleTypeSyntax makeVoidTupleType(
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates an labelled TupleTypeElementSyntax with the provided label,
   /// colon, type and optional trailing comma.
@@ -120,53 +126,61 @@ struct SyntaxFactory {
       llvm::Optional<TokenSyntax> Label,
       llvm::Optional<TokenSyntax> Colon, TypeSyntax Type,
       llvm::Optional<TokenSyntax> TrailingComma = llvm::None,
-      RC<SyntaxArena> Arena = nullptr);
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates an unlabelled TupleTypeElementSyntax with the provided type and
   /// optional trailing comma.
   static TupleTypeElementSyntax
   makeTupleTypeElement(TypeSyntax Type,
-                       llvm::Optional<TokenSyntax> TrailingComma = llvm::None,
-                       RC<SyntaxArena> Arena = nullptr);
+      llvm::Optional<TokenSyntax> TrailingComma = llvm::None,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates a TypeIdentifierSyntax with the provided name and leading/trailing
   /// trivia.
   static TypeSyntax makeTypeIdentifier(OwnedString TypeName,
-                                       const Trivia &LeadingTrivia = {},
-                                       const Trivia &TrailingTrivia = {},
-                                       RC<SyntaxArena> Arena = nullptr);
+      const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {},
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates a GenericParameterSyntax with no inheritance clause and an
   /// optional trailing comma.
   static GenericParameterSyntax
   makeGenericParameter(TokenSyntax Name,
-                       llvm::Optional<TokenSyntax> TrailingComma,
-                       RC<SyntaxArena> Arena = nullptr);
+      llvm::Optional<TokenSyntax> TrailingComma,
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates a TypeIdentifierSyntax for the `Any` type.
   static TypeSyntax makeAnyTypeIdentifier(const Trivia &LeadingTrivia = {},
-                                          const Trivia &TrailingTrivia = {},
-                                          RC<SyntaxArena> Arena = nullptr);
+      const Trivia &TrailingTrivia = {},
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates a TypeIdentifierSyntax for the `Self` type.
   static TypeSyntax makeSelfTypeIdentifier(const Trivia &LeadingTrivia = {},
-                                           const Trivia &TrailingTrivia = {},
-                                           RC<SyntaxArena> Arena = nullptr);
+      const Trivia &TrailingTrivia = {},
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates a TokenSyntax for the `Type` identifier.
   static TokenSyntax makeTypeToken(const Trivia &LeadingTrivia = {},
-                                   const Trivia &TrailingTrivia = {},
-                                   RC<SyntaxArena> Arena = nullptr);
+      const Trivia &TrailingTrivia = {},
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates a TokenSyntax for the `Protocol` identifier.
   static TokenSyntax makeProtocolToken(const Trivia &LeadingTrivia = {},
-                                       const Trivia &TrailingTrivia = {},
-                                       RC<SyntaxArena> Arena = nullptr);
+      const Trivia &TrailingTrivia = {},
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Creates an `==` operator token.
   static TokenSyntax makeEqualityOperator(const Trivia &LeadingTrivia = {},
-                                          const Trivia &TrailingTrivia = {},
-                                          RC<SyntaxArena> Arena = nullptr);
+      const Trivia &TrailingTrivia = {},
+      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  );
 
   /// Whether a raw node kind `MemberKind` can serve as a member in a syntax
   /// collection of the given syntax collection kind.

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -42,14 +42,14 @@ TokenSyntax SyntaxFactory::makeToken(tok Kind, OwnedString Text,
                                      const Trivia &LeadingTrivia,
                                      const Trivia &TrailingTrivia,
                                      SourcePresence Presence,
-                                     RC<SyntaxArena> Arena) {
+                                     const RC<SyntaxArena> &Arena) {
   return makeRoot<TokenSyntax>(RawSyntax::makeAndCalcLength(Kind, Text, 
     LeadingTrivia.Pieces, TrailingTrivia.Pieces, Presence, Arena));
 }
 
 UnknownSyntax
 SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
-                                 RC<SyntaxArena> Arena) {
+                                 const RC<SyntaxArena> &Arena) {
   std::vector<RC<RawSyntax>> Layout;
   Layout.reserve(Tokens.size());
   for (auto &Token : Tokens) {
@@ -122,7 +122,7 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
 
 RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
                                        llvm::ArrayRef<RC<RawSyntax>> Elements,
-                                       RC<SyntaxArena> Arena) {
+                                       const RC<SyntaxArena> &Arena) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
@@ -167,7 +167,7 @@ RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
 
 Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
                                              llvm::ArrayRef<Syntax> Elements,
-                                             RC<SyntaxArena> Arena) {
+                                             const RC<SyntaxArena> &Arena) {
   std::vector<RC<RawSyntax>> Layout;
   Layout.reserve(Elements.size());
   for (auto &E : Elements)
@@ -190,7 +190,7 @@ Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
 %     child_params = ', '.join(child_params)
 ${node.name}
 SyntaxFactory::make${node.syntax_kind}(${child_params},
-                                       RC<SyntaxArena> Arena) {
+                                       const RC<SyntaxArena> &Arena) {
   auto Raw = RawSyntax::makeAndCalcLength(SyntaxKind::${node.syntax_kind}, {
 %     for child in node.children:
 %       if child.is_optional:
@@ -206,7 +206,7 @@ SyntaxFactory::make${node.syntax_kind}(${child_params},
 ${node.name}
 SyntaxFactory::make${node.syntax_kind}(
     const std::vector<${node.collection_element_type}> &elements,
-    RC<SyntaxArena> Arena) {
+    const RC<SyntaxArena> &Arena) {
   std::vector<RC<RawSyntax>> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
@@ -219,7 +219,7 @@ SyntaxFactory::make${node.syntax_kind}(
 %   end
 
 ${node.name}
-SyntaxFactory::makeBlank${node.syntax_kind}(RC<SyntaxArena> Arena) {
+SyntaxFactory::makeBlank${node.syntax_kind}(const RC<SyntaxArena> &Arena) {
   auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, {
 %   for child in node.children:
 %       if child.is_optional:
@@ -238,7 +238,7 @@ SyntaxFactory::makeBlank${node.syntax_kind}(RC<SyntaxArena> Arena) {
   TokenSyntax
   SyntaxFactory::make${token.name}Keyword(const Trivia &LeadingTrivia,
                                           const Trivia &TrailingTrivia,
-                                          RC<SyntaxArena> Arena) {
+                                          const RC<SyntaxArena> &Arena) {
     return makeToken(tok::${token.kind},
                      OwnedString::makeUnowned("${token.text}"),
                      LeadingTrivia, TrailingTrivia,
@@ -248,7 +248,7 @@ SyntaxFactory::makeBlank${node.syntax_kind}(RC<SyntaxArena> Arena) {
   TokenSyntax
   SyntaxFactory::make${token.name}Token(const Trivia &LeadingTrivia,
                                         const Trivia &TrailingTrivia,
-                                        RC<SyntaxArena> Arena) {
+                                        const RC<SyntaxArena> &Arena) {
     return makeToken(tok::${token.kind},
                      OwnedString::makeUnowned("${token.text}"),
                      LeadingTrivia, TrailingTrivia,
@@ -259,7 +259,7 @@ SyntaxFactory::makeBlank${node.syntax_kind}(RC<SyntaxArena> Arena) {
   SyntaxFactory::make${token.name}(OwnedString Text,
                                    const Trivia &LeadingTrivia,
                                    const Trivia &TrailingTrivia,
-                                   RC<SyntaxArena> Arena) {
+                                   const RC<SyntaxArena> &Arena) {
     return makeToken(tok::${token.kind}, Text,
                      LeadingTrivia, TrailingTrivia,
                      SourcePresence::Present, Arena);
@@ -267,7 +267,7 @@ SyntaxFactory::makeBlank${node.syntax_kind}(RC<SyntaxArena> Arena) {
 %   end
 % end
 
-TupleTypeSyntax SyntaxFactory::makeVoidTupleType(RC<SyntaxArena> Arena) {
+TupleTypeSyntax SyntaxFactory::makeVoidTupleType(const RC<SyntaxArena> &Arena) {
   return makeTupleType(makeLeftParenToken({}, {}, Arena),
                        makeBlankTupleTypeElementList(Arena),
                        makeRightParenToken({}, {}, Arena),
@@ -279,7 +279,7 @@ SyntaxFactory::makeTupleTypeElement(llvm::Optional<TokenSyntax> Label,
                                     llvm::Optional<TokenSyntax> Colon,
                                     TypeSyntax Type,
                                     llvm::Optional<TokenSyntax> TrailingComma,
-                                    RC<SyntaxArena> Arena) {
+                                    const RC<SyntaxArena> &Arena) {
   return makeTupleTypeElement(None, Label, None, Colon, Type, None, None,
                               TrailingComma, Arena);
 }
@@ -287,7 +287,7 @@ SyntaxFactory::makeTupleTypeElement(llvm::Optional<TokenSyntax> Label,
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
                                     llvm::Optional<TokenSyntax> TrailingComma,
-                                    RC<SyntaxArena> Arena) {
+                                    const RC<SyntaxArena> &Arena) {
   return makeTupleTypeElement(None, None, None, None, Type, None, None,
                               TrailingComma, Arena);
 }
@@ -295,14 +295,14 @@ SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
 GenericParameterSyntax
 SyntaxFactory::makeGenericParameter(TokenSyntax Name,
                                     llvm::Optional<TokenSyntax> TrailingComma,
-                                    RC<SyntaxArena> Arena) {
+                                    const RC<SyntaxArena> &Arena) {
   return makeGenericParameter(None, Name, None, None, TrailingComma, Arena);
 }
 
 TypeSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
                                              const Trivia &LeadingTrivia,
                                              const Trivia &TrailingTrivia,
-                                             RC<SyntaxArena> Arena) {
+                                             const RC<SyntaxArena> &Arena) {
   auto identifier =
       makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia, Arena);
   return makeSimpleTypeIdentifier(identifier, None, Arena);
@@ -310,35 +310,35 @@ TypeSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
 
 TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(const Trivia &LeadingTrivia,
                                                 const Trivia &TrailingTrivia,
-                                                RC<SyntaxArena> Arena) {
+                                                const RC<SyntaxArena> &Arena) {
   return makeTypeIdentifier(OwnedString::makeUnowned("Any"), LeadingTrivia,
                             TrailingTrivia, Arena);
 }
 
 TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(const Trivia &LeadingTrivia,
                                                  const Trivia &TrailingTrivia,
-                                                 RC<SyntaxArena> Arena) {
+                                                 const RC<SyntaxArena> &Arena) {
   return makeTypeIdentifier(OwnedString::makeUnowned("Self"),
                             LeadingTrivia, TrailingTrivia, Arena);
 }
 
 TokenSyntax SyntaxFactory::makeTypeToken(const Trivia &LeadingTrivia,
                                          const Trivia &TrailingTrivia,
-                                         RC<SyntaxArena> Arena) {
+                                         const RC<SyntaxArena> &Arena) {
   return makeIdentifier(OwnedString::makeUnowned("Type"),
                         LeadingTrivia, TrailingTrivia, Arena);
 }
 
 TokenSyntax SyntaxFactory::makeProtocolToken(const Trivia &LeadingTrivia,
                                              const Trivia &TrailingTrivia,
-                                             RC<SyntaxArena> Arena) {
+                                             const RC<SyntaxArena> &Arena) {
   return makeIdentifier(OwnedString::makeUnowned("Protocol"),
                         LeadingTrivia, TrailingTrivia, Arena);
 }
 
 TokenSyntax SyntaxFactory::makeEqualityOperator(const Trivia &LeadingTrivia,
                                                 const Trivia &TrailingTrivia,
-                                                RC<SyntaxArena> Arena) {
+                                                const RC<SyntaxArena> &Arena) {
   return makeToken(tok::oper_binary_spaced, OwnedString::makeUnowned("=="),
                    LeadingTrivia, TrailingTrivia, SourcePresence::Present,
                    Arena);


### PR DESCRIPTION
This way, we will later be able to store additional information about the node inside the same arena with a guarantee that they will always be alive as long as the node is alive.

These additional information will include
a) the token's text (which can be a StringRef into a copy of the source code that lives inside the SyntaxArena)
b) the token's unparsed trivia, which can be decomposed into pieces when needed.

### Performance checklist (performed on my local machine)
- [x] No regression during compilation
- [x] No regression during code completion
- [x] No regression during SwiftSyntax parsing