### PR TITLE
[libSyntax] Avoid lexing of trivia into pieces if possible

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -551,6 +551,7 @@ private:
   void lexHexNumber();
   void lexNumber();
   void lexTrivia(ParsedTrivia &T, bool IsForTrailingTrivia);
+  StringRef lexTrivia(bool IsForTrailingTrivia);
   static unsigned lexUnicodeEscape(const char *&CurPtr, Lexer *Diags);
 
   unsigned lexCharacter(const char *&CurPtr, char StopQuote,
@@ -572,7 +573,14 @@ private:
 
   NulCharacterKind getNulCharacterKind(const char *Ptr) const;
 };
-  
+
+/// A lexer that can lex trivia into its pieces
+class TriviaLexer {
+public:
+  /// Decompose the triva in \p TriviaStr into their pieces.
+  static ParsedTrivia lexTrivia(StringRef TriviaStr);
+};
+
 /// Given an ordered token \param Array , get the iterator pointing to the first
 /// token that is not before \param Loc .
 template<typename ArrayTy, typename Iterator = typename ArrayTy::iterator>

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -122,16 +122,13 @@ class Lexer {
 
   /// The current leading trivia for the next token.
   ///
-  /// This is only preserved if this Lexer was constructed with
-  /// `TriviaRetentionMode::WithTrivia`.
-  ParsedTrivia LeadingTrivia;
+  /// The StringRef points into the source buffer that is currently being lexed.
+  StringRef LeadingTrivia;
 
   /// The current trailing trivia for the next token.
-  ///
-  /// This is only preserved if this Lexer was constructed with
-  /// `TriviaRetentionMode::WithTrivia`.
-  ParsedTrivia TrailingTrivia;
-  
+  /// The StringRef points into the source buffer that is currently being lexed.
+  StringRef TrailingTrivia;
+
   Lexer(const Lexer&) = delete;
   void operator=(const Lexer&) = delete;
 
@@ -196,19 +193,19 @@ public:
 
   /// Lex a token. If \c TriviaRetentionMode is \c WithTrivia, passed pointers
   /// to trivias are populated.
-  void lex(Token &Result, ParsedTrivia &LeadingTriviaResult,
-           ParsedTrivia &TrailingTriviaResult) {
+  void lex(Token &Result, StringRef &LeadingTriviaResult,
+           StringRef &TrailingTriviaResult) {
     Result = NextToken;
     if (TriviaRetention == TriviaRetentionMode::WithTrivia) {
-      LeadingTriviaResult = {LeadingTrivia};
-      TrailingTriviaResult = {TrailingTrivia};
+      LeadingTriviaResult = LeadingTrivia;
+      TrailingTriviaResult = TrailingTrivia;
     }
     if (Result.isNot(tok::eof))
       lexImpl();
   }
 
   void lex(Token &Result) {
-    ParsedTrivia LeadingTrivia, TrailingTrivia;
+    StringRef LeadingTrivia, TrailingTrivia;
     lex(Result, LeadingTrivia, TrailingTrivia);
   }
 
@@ -240,7 +237,7 @@ public:
   /// After restoring the state, lexer will return this token and continue from
   /// there.
   State getStateForBeginningOfToken(const Token &Tok,
-                                    const ParsedTrivia &LeadingTrivia = {}) const {
+                                    const StringRef &LeadingTrivia = {}) const {
 
     // If the token has a comment attached to it, rewind to before the comment,
     // not just the start of the token.  This ensures that we will re-lex and
@@ -249,8 +246,11 @@ public:
     if (TokStart.isInvalid())
       TokStart = Tok.getLoc();
     auto S = getStateForBeginningOfTokenLoc(TokStart);
-    if (TriviaRetention == TriviaRetentionMode::WithTrivia)
+    if (TriviaRetention == TriviaRetentionMode::WithTrivia) {
       S.LeadingTrivia = LeadingTrivia;
+    } else {
+      S.LeadingTrivia = StringRef();
+    }
     return S;
   }
 
@@ -275,8 +275,7 @@ public:
 
     // Restore Trivia.
     if (TriviaRetention == TriviaRetentionMode::WithTrivia)
-      if (auto &LTrivia = S.LeadingTrivia)
-        LeadingTrivia = std::move(*LTrivia);
+      LeadingTrivia = S.LeadingTrivia;
   }
 
   /// Restore the lexer state to a given state that is located before
@@ -550,7 +549,6 @@ private:
   void lexOperatorIdentifier();
   void lexHexNumber();
   void lexNumber();
-  void lexTrivia(ParsedTrivia &T, bool IsForTrailingTrivia);
   StringRef lexTrivia(bool IsForTrailingTrivia);
   static unsigned lexUnicodeEscape(const char *&CurPtr, Lexer *Diags);
 

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -129,6 +129,10 @@ class Lexer {
   /// The StringRef points into the source buffer that is currently being lexed.
   StringRef TrailingTrivia;
 
+  /// The location at which the comment of the next token starts. \c nullptr if
+  /// the next token doesn't have a comment.
+  const char *CommentStart;
+
   Lexer(const Lexer&) = delete;
   void operator=(const Lexer&) = delete;
 

--- a/include/swift/Parse/LexerState.h
+++ b/include/swift/Parse/LexerState.h
@@ -39,7 +39,7 @@ public:
 private:
   explicit LexerState(SourceLoc Loc) : Loc(Loc) {}
   SourceLoc Loc;
-  llvm::Optional<ParsedTrivia> LeadingTrivia;
+  StringRef LeadingTrivia;
   friend class Lexer;
 };
 

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -44,13 +44,12 @@ public:
   explicit ParsedRawSyntaxRecorder(std::shared_ptr<SyntaxParseActions> spActions)
     : SPActions(std::move(spActions)) {}
 
-  ParsedRawSyntaxNode recordToken(const Token &tok,
-                                  const ParsedTrivia &leadingTrivia,
-                                  const ParsedTrivia &trailingTrivia);
+  ParsedRawSyntaxNode recordToken(const Token &tok, StringRef leadingTrivia,
+                                  StringRef trailingTrivia);
 
   ParsedRawSyntaxNode recordToken(tok tokenKind, CharSourceRange tokenRange,
-                                  ArrayRef<ParsedTriviaPiece> leadingTrivia,
-                                  ArrayRef<ParsedTriviaPiece> trailingTrivia);
+                                  StringRef leadingTrivia,
+                                  StringRef trailingTrivia);
 
   /// Record a missing token. \p loc can be invalid or an approximate location
   /// of where the token would be if not missing.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -207,13 +207,13 @@ public:
   /// This is the current token being considered by the parser.
   Token Tok;
 
-  /// leading trivias for \c Tok.
+  /// Leading trivia for \c Tok.
   /// Always empty if !SF.shouldBuildSyntaxTree().
-  ParsedTrivia LeadingTrivia;
+  StringRef LeadingTrivia;
 
-  /// trailing trivias for \c Tok.
+  /// Trailing trivia for \c Tok.
   /// Always empty if !SF.shouldBuildSyntaxTree().
-  ParsedTrivia TrailingTrivia;
+  StringRef TrailingTrivia;
 
   /// The receiver to collect all consumed tokens.
   ConsumeTokenReceiver *TokReceiver;
@@ -549,7 +549,7 @@ public:
   }
 
   SourceLoc leadingTriviaLoc() {
-    return Tok.getLoc().getAdvancedLoc(-LeadingTrivia.getLength());
+    return Tok.getLoc().getAdvancedLoc(-LeadingTrivia.size());
   }
 
   SourceLoc consumeIdentifier(Identifier &Result, bool diagnoseDollarPrefix) {

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -41,10 +41,9 @@ class SyntaxParseActions {
 public:
   virtual ~SyntaxParseActions() = default;
 
-  virtual OpaqueSyntaxNode recordToken(tok tokenKind,
-                                    ArrayRef<ParsedTriviaPiece> leadingTrivia,
-                                    ArrayRef<ParsedTriviaPiece> trailingTrivia,
-                                    CharSourceRange range) = 0;
+  virtual OpaqueSyntaxNode recordToken(tok tokenKind, StringRef leadingTrivia,
+                                       StringRef trailingTrivia,
+                                       CharSourceRange range) = 0;
 
   /// Record a missing token. \c loc can be invalid or an approximate location
   /// of where the token would be if not missing.

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -264,8 +264,7 @@ public:
   void addRawSyntax(ParsedRawSyntaxNode Raw);
 
   /// Add Token with Trivia to the parts.
-  void addToken(Token &Tok, const ParsedTrivia &LeadingTrivia,
-                const ParsedTrivia &TrailingTrivia);
+  void addToken(Token &Tok, StringRef LeadingTrivia, StringRef TrailingTrivia);
 
   /// Add Syntax to the parts.
   void addSyntax(ParsedSyntax Node);

--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -150,9 +150,9 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
     if (description.hasValue) {
       swift::tok tokenKind = description.Kind;
       StringRef text = description.Text;
-      std::vector<swift::TriviaPiece> leadingTrivia;
+      StringRef leadingTrivia;
       in.mapRequired("leadingTrivia", leadingTrivia);
-      std::vector<swift::TriviaPiece> trailingTrivia;
+      StringRef trailingTrivia;
       in.mapRequired("trailingTrivia", trailingTrivia);
       swift::SourcePresence presence;
       in.mapRequired("presence", presence);

--- a/include/swift/Syntax/SyntaxArena.h
+++ b/include/swift/Syntax/SyntaxArena.h
@@ -31,10 +31,24 @@ class SyntaxArena : public llvm::ThreadSafeRefCountedBase<SyntaxArena> {
 
   llvm::BumpPtrAllocator Allocator;
 
+  /// The start (inclusive) and end (exclusive) pointers of a memory region that
+  /// is frequently requested using \c containsPointer. Must be inside \c
+  /// Allocator but \c containsPointer will check this region first and will
+  /// thus return more quickly for pointers that lie within this region.
+  const void *HotUseMemoryRegionStart = nullptr;
+  const void *HotUseMemoryRegionEnd = nullptr;
+
 public:
   SyntaxArena() {}
 
   static RC<SyntaxArena> make() { return RC<SyntaxArena>(new SyntaxArena()); }
+
+  void setHotUseMemoryRegion(const void *Start, const void *End) {
+    assert(containsPointer(Start) &&
+           "The hot use memory region should be in the Arena's bump allocator");
+    HotUseMemoryRegionStart = Start;
+    HotUseMemoryRegionEnd = End;
+  }
 
   llvm::BumpPtrAllocator &getAllocator() { return Allocator; }
   void *Allocate(size_t size, size_t alignment) {
@@ -42,6 +56,9 @@ public:
   }
 
   bool containsPointer(const void *Ptr) {
+    if (HotUseMemoryRegionStart <= Ptr && Ptr < HotUseMemoryRegionEnd) {
+      return true;
+    }
     return getAllocator().identifyObject(Ptr) != llvm::None;
   }
 };

--- a/include/swift/Syntax/SyntaxArena.h
+++ b/include/swift/Syntax/SyntaxArena.h
@@ -40,6 +40,10 @@ public:
   void *Allocate(size_t size, size_t alignment) {
     return Allocator.Allocate(size, alignment);
   }
+
+  bool containsPointer(const void *Ptr) {
+    return getAllocator().identifyObject(Ptr) != llvm::None;
+  }
 };
 
 } // namespace syntax

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -46,8 +46,8 @@ class SyntaxArena;
 struct SyntaxFactory {
   /// Make any kind of token.
   static TokenSyntax makeToken(tok Kind,
-      OwnedString Text, const Trivia &LeadingTrivia,
-      const Trivia &TrailingTrivia, SourcePresence Presence,
+      OwnedString Text, StringRef LeadingTrivia, StringRef TrailingTrivia,
+      SourcePresence Presence,
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
 
@@ -100,16 +100,16 @@ struct SyntaxFactory {
 
 % for token in SYNTAX_TOKENS:
 %   if token.is_keyword:
-  static TokenSyntax make${token.name}Keyword(const Trivia &LeadingTrivia,
-      const Trivia &TrailingTrivia,
+  static TokenSyntax make${token.name}Keyword(StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
       const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   elif token.text:
-  static TokenSyntax make${token.name}Token(const Trivia &LeadingTrivia,
-      const Trivia &TrailingTrivia,
+  static TokenSyntax make${token.name}Token(StringRef LeadingTrivia,
+            StringRef TrailingTrivia,
       const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   else:
   static TokenSyntax make${token.name}(OwnedString Text,
-      const Trivia &LeadingTrivia, const Trivia &TrailingTrivia,
+            StringRef LeadingTrivia, StringRef TrailingTrivia,
       const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   end
 % end
@@ -140,7 +140,7 @@ struct SyntaxFactory {
   /// Creates a TypeIdentifierSyntax with the provided name and leading/trailing
   /// trivia.
   static TypeSyntax makeTypeIdentifier(OwnedString TypeName,
-      const Trivia &LeadingTrivia = {}, const Trivia &TrailingTrivia = {},
+      StringRef LeadingTrivia = {}, StringRef TrailingTrivia = {},
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
 
@@ -153,32 +153,32 @@ struct SyntaxFactory {
   );
 
   /// Creates a TypeIdentifierSyntax for the `Any` type.
-  static TypeSyntax makeAnyTypeIdentifier(const Trivia &LeadingTrivia = {},
-      const Trivia &TrailingTrivia = {},
+  static TypeSyntax makeAnyTypeIdentifier(StringRef LeadingTrivia = {},
+      StringRef TrailingTrivia = {},
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
 
   /// Creates a TypeIdentifierSyntax for the `Self` type.
-  static TypeSyntax makeSelfTypeIdentifier(const Trivia &LeadingTrivia = {},
-      const Trivia &TrailingTrivia = {},
+  static TypeSyntax makeSelfTypeIdentifier(StringRef LeadingTrivia = {},
+      StringRef TrailingTrivia = {},
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
 
   /// Creates a TokenSyntax for the `Type` identifier.
-  static TokenSyntax makeTypeToken(const Trivia &LeadingTrivia = {},
-      const Trivia &TrailingTrivia = {},
+  static TokenSyntax makeTypeToken(StringRef LeadingTrivia = {},
+      StringRef TrailingTrivia = {},
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
 
   /// Creates a TokenSyntax for the `Protocol` identifier.
-  static TokenSyntax makeProtocolToken(const Trivia &LeadingTrivia = {},
-      const Trivia &TrailingTrivia = {},
+  static TokenSyntax makeProtocolToken(StringRef LeadingTrivia = {},
+      StringRef TrailingTrivia = {},
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
 
   /// Creates an `==` operator token.
-  static TokenSyntax makeEqualityOperator(const Trivia &LeadingTrivia = {},
-      const Trivia &TrailingTrivia = {},
+  static TokenSyntax makeEqualityOperator(StringRef LeadingTrivia = {},
+      StringRef TrailingTrivia = {},
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
 

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -39,22 +39,22 @@ public:
     return makeRoot<TokenSyntax>(RawSyntax::missing(Kind, Text));
   }
 
-  Trivia getLeadingTrivia() const {
-    return Trivia { getRaw()->getLeadingTrivia().vec() };
+  StringRef getLeadingTrivia() const { return getRaw()->getLeadingTrivia(); }
+  Trivia getLeadingTriviaPieces() const { return getRaw()->getLeadingTriviaPieces(); }
+
+  StringRef getTrailingTrivia() const { return getRaw()->getTrailingTrivia(); }
+  Trivia getTrailingTriviaPieces() const {
+    return getRaw()->getTrailingTriviaPieces();
   }
 
-  Trivia getTrailingTrivia() const {
-    return Trivia { getRaw()->getTrailingTrivia().vec() };
+  TokenSyntax withLeadingTrivia(StringRef Trivia) const {
+    auto NewRaw = getRaw()->withLeadingTrivia(Trivia);
+    return TokenSyntax(getData().replacingSelf(NewRaw));
   }
 
-  TokenSyntax withLeadingTrivia(const Trivia &Trivia) const {
-    auto NewRaw = getRaw()->withLeadingTrivia(Trivia.Pieces);
-    return TokenSyntax(Data.replacingSelf(NewRaw));
-  }
-
-  TokenSyntax withTrailingTrivia(const Trivia &Trivia) const {
-    auto NewRaw = getRaw()->withTrailingTrivia(Trivia.Pieces);
-    return TokenSyntax(Data.replacingSelf(NewRaw));
+  TokenSyntax withTrailingTrivia(StringRef Trivia) const {
+    auto NewRaw = getRaw()->withTrailingTrivia(Trivia);
+    return TokenSyntax(getData().replacingSelf(NewRaw));
   }
 
   /* TODO: If we really need them.

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -15,6 +15,7 @@
 
 #include "swift/Parse/SyntaxParseActions.h"
 #include "swift/Syntax/References.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
   class RawSyntaxTokenCache;
@@ -37,6 +38,12 @@ class SyntaxTreeCreator: public SyntaxParseActions {
   SourceManager &SM;
   unsigned BufferID;
   RC<syntax::SyntaxArena> Arena;
+
+  /// A string allocated in \c Arena that contains an exact copy of the source
+  /// file for which this \c SyntaxTreeCreator creates a syntax tree. \c
+  /// RawSyntax nodes can safely reference text inside this buffer since they
+  /// retain the \c SyntaxArena which holds the buffer.
+  StringRef ArenaSourceBuffer;
 
   /// A cache of nodes that can be reused when creating the current syntax
   /// tree.

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -56,9 +56,8 @@ public:
   realizeSyntaxRoot(OpaqueSyntaxNode root, const SourceFile &SF) override;
 
 private:
-  OpaqueSyntaxNode recordToken(tok tokenKind,
-                               ArrayRef<ParsedTriviaPiece> leadingTrivia,
-                               ArrayRef<ParsedTriviaPiece> trailingTrivia,
+  OpaqueSyntaxNode recordToken(tok tokenKind, StringRef leadingTrivia,
+                               StringRef trailingTrivia,
                                CharSourceRange range) override;
 
   OpaqueSyntaxNode recordMissingToken(tok tokenKind, SourceLoc loc) override;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2531,6 +2531,15 @@ Token Lexer::getTokenAtLocation(const SourceManager &SM, SourceLoc Loc,
 }
 
 void Lexer::lexTrivia(ParsedTrivia &Pieces, bool IsForTrailingTrivia) {
+  auto TriviaString = lexTrivia(IsForTrailingTrivia);
+  auto ParsedPieces = TriviaLexer::lexTrivia(TriviaString);
+  Pieces.Pieces.insert(Pieces.Pieces.end(), ParsedPieces.Pieces.begin(),
+                       ParsedPieces.Pieces.end());
+}
+
+StringRef Lexer::lexTrivia(bool IsForTrailingTrivia) {
+  const char *AllTriviaStart = CurPtr;
+
 Restart:
   const char *TriviaStart = CurPtr;
 
@@ -2539,30 +2548,19 @@ Restart:
     if (IsForTrailingTrivia)
       break;
     NextToken.setAtStartOfLine(true);
-    Pieces.appendOrSquash(TriviaKind::Newline, 1);
     goto Restart;
   case '\r':
     if (IsForTrailingTrivia)
       break;
     NextToken.setAtStartOfLine(true);
     if (CurPtr[0] == '\n') {
-      Pieces.appendOrSquash(TriviaKind::CarriageReturnLineFeed, 2);
       ++CurPtr;
-    } else {
-      Pieces.appendOrSquash(TriviaKind::CarriageReturn, 1);
     }
     goto Restart;
   case ' ':
-    Pieces.appendOrSquash(TriviaKind::Space, 1);
-    goto Restart;
   case '\t':
-    Pieces.appendOrSquash(TriviaKind::Tab, 1);
-    goto Restart;
   case '\v':
-    Pieces.appendOrSquash(TriviaKind::VerticalTab, 1);
-    goto Restart;
   case '\f':
-    Pieces.appendOrSquash(TriviaKind::Formfeed, 1);
     goto Restart;
   case '/':
     if (IsForTrailingTrivia || isKeepingComments()) {
@@ -2571,19 +2569,11 @@ Restart:
       break;
     } else if (*CurPtr == '/') {
       // '// ...' comment.
-      bool isDocComment = CurPtr[1] == '/';
       skipSlashSlashComment(/*EatNewline=*/false);
-      size_t Length = CurPtr - TriviaStart;
-      Pieces.push_back(isDocComment ? TriviaKind::DocLineComment
-                                    : TriviaKind::LineComment, Length);
       goto Restart;
     } else if (*CurPtr == '*') {
       // '/* ... */' comment.
-      bool isDocComment = CurPtr[1] == '*';
       skipSlashStarComment();
-      size_t Length = CurPtr - TriviaStart;
-      Pieces.push_back(isDocComment ? TriviaKind::DocBlockComment
-                                    : TriviaKind::BlockComment, Length);
       goto Restart;
     }
     break;
@@ -2594,8 +2584,6 @@ Restart:
       if (!IsHashbangAllowed)
         diagnose(TriviaStart, diag::lex_hashbang_not_allowed);
       skipHashbang(/*EatNewline=*/false);
-      size_t Length = CurPtr - TriviaStart;
-      Pieces.push_back(TriviaKind::GarbageText, Length);
       goto Restart;
     }
     break;
@@ -2603,8 +2591,6 @@ Restart:
   case '>':
     if (tryLexConflictMarker(/*EatNewline=*/false)) {
       // Conflict marker.
-      size_t Length = CurPtr - TriviaStart;
-      Pieces.push_back(TriviaKind::GarbageText, Length);
       goto Restart;
     }
     break;
@@ -2612,8 +2598,6 @@ Restart:
     switch (getNulCharacterKind(CurPtr - 1)) {
     case NulCharacterKind::Embedded: {
       diagnoseEmbeddedNul(Diags, CurPtr - 1);
-      size_t Length = CurPtr - TriviaStart;
-      Pieces.push_back(TriviaKind::GarbageText, Length);
       goto Restart;
     }
     case NulCharacterKind::CodeCompletion:
@@ -2655,15 +2639,15 @@ Restart:
     bool ShouldTokenize = lexUnknown(/*EmitDiagnosticsIfToken=*/false);
     if (ShouldTokenize) {
       CurPtr = Tmp;
-      return;
+      size_t Length = CurPtr - AllTriviaStart;
+      return StringRef(AllTriviaStart, Length);
     }
-
-    size_t Length = CurPtr - TriviaStart;
-    Pieces.push_back(TriviaKind::GarbageText, Length);
     goto Restart;
   }
   // Reset the cursor.
   --CurPtr;
+  size_t Length = CurPtr - AllTriviaStart;
+  return StringRef(AllTriviaStart, Length);
 }
 
 SourceLoc Lexer::getLocForEndOfToken(const SourceManager &SM, SourceLoc Loc) {
@@ -2844,6 +2828,158 @@ StringRef Lexer::getIndentationForLine(SourceManager &SM, SourceLoc Loc,
     ++EndOfIndentation;
 
   return StringRef(StartOfLine, EndOfIndentation - StartOfLine);
+}
+
+bool tryAdvanceToEndOfConflictMarker(const char *&CurPtr,
+                                     const char *BufferEnd) {
+  const char *Ptr = CurPtr - 1;
+
+  // Check to see if we have <<<<<<< or >>>>.
+  StringRef restOfBuffer(Ptr, BufferEnd - Ptr);
+  if (!restOfBuffer.startswith("<<<<<<< ") && !restOfBuffer.startswith(">>>> "))
+    return false;
+
+  ConflictMarkerKind Kind =
+      *Ptr == '<' ? ConflictMarkerKind::Normal : ConflictMarkerKind::Perforce;
+  if (const char *End = findConflictEnd(Ptr, BufferEnd, Kind)) {
+    CurPtr = End;
+
+    // Skip ahead to the end of the marker.
+    if (CurPtr != BufferEnd) {
+      advanceToEndOfLine(CurPtr, End);
+    }
+
+    return true;
+  }
+
+  // No end of conflict marker found.
+  return false;
+}
+
+ParsedTrivia TriviaLexer::lexTrivia(StringRef TriviaStr) {
+  const char *CurPtr = TriviaStr.begin();
+  const char *BufferEnd = TriviaStr.end();
+
+  ParsedTrivia Pieces;
+
+  while (CurPtr < BufferEnd) {
+    // Iterate through the trivia and lex them into pieces. In the switch
+    // statement in this loop we can
+    //  - 'continue' if we have successfully lexed a trivia piece to continue
+    //    with the next piece. In this case CurPtr points to the next character
+    //    to be lexed (which is not part of the lexed trivia).
+    //  - 'break' to perform the default handling defined towards the bottom of
+    //    the loop.
+
+    const char *TriviaStart = CurPtr;
+
+    signed char CurChar = (signed char)*CurPtr;
+    CurPtr++;
+
+    switch (CurChar) {
+    case '\n':
+      Pieces.appendOrSquash(TriviaKind::Newline, 1);
+      continue;
+    case '\r':
+      if (CurPtr[0] == '\n') {
+        Pieces.appendOrSquash(TriviaKind::CarriageReturnLineFeed, 2);
+        ++CurPtr;
+        continue;
+      } else {
+        Pieces.appendOrSquash(TriviaKind::CarriageReturn, 1);
+        continue;
+      }
+    case ' ':
+      Pieces.appendOrSquash(TriviaKind::Space, 1);
+      continue;
+    case '\t':
+      Pieces.appendOrSquash(TriviaKind::Tab, 1);
+      continue;
+    case '\v':
+      Pieces.appendOrSquash(TriviaKind::VerticalTab, 1);
+      continue;
+    case '\f':
+      Pieces.appendOrSquash(TriviaKind::Formfeed, 1);
+      continue;
+    case '/':
+      if (*CurPtr == '/') {
+        // '// ...' comment.
+        bool isDocComment = CurPtr[1] == '/';
+        advanceToEndOfLine(CurPtr, BufferEnd);
+        size_t Length = CurPtr - TriviaStart;
+        Pieces.push_back(isDocComment ? TriviaKind::DocLineComment
+                                      : TriviaKind::LineComment,
+                         Length);
+        continue;
+      } else if (*CurPtr == '*') {
+        // '/* ... */' comment.
+        bool isDocComment = CurPtr[1] == '*';
+        skipToEndOfSlashStarComment(CurPtr, BufferEnd);
+        size_t Length = CurPtr - TriviaStart;
+        Pieces.push_back(isDocComment ? TriviaKind::DocBlockComment
+                                      : TriviaKind::BlockComment,
+                         Length);
+        continue;
+      }
+      break;
+    case '#':
+      if (*CurPtr == '!') {
+        // Hashbang '#!/path/to/swift'.
+        advanceToEndOfLine(CurPtr, BufferEnd);
+        size_t Length = CurPtr - TriviaStart;
+        Pieces.push_back(TriviaKind::GarbageText, Length);
+        continue;
+      }
+      break;
+    case '<':
+    case '>':
+      if (tryAdvanceToEndOfConflictMarker(CurPtr, BufferEnd)) {
+        // Conflict marker.
+        size_t Length = CurPtr - TriviaStart;
+        Pieces.push_back(TriviaKind::GarbageText, Length);
+        continue;
+      }
+      break;
+    case 0: {
+      size_t Length = CurPtr - TriviaStart;
+      Pieces.push_back(TriviaKind::GarbageText, Length);
+      continue;
+    }
+    default:
+      break;
+    }
+
+    // Default handling for anything that didn't 'continue' in the above switch
+    // statement.
+
+    for (; CurPtr < BufferEnd; ++CurPtr) {
+      bool HasFoundNextTriviaStart = false;
+      switch (*CurPtr) {
+      case '\n':
+      case '\r':
+      case ' ':
+      case '\t':
+      case '\v':
+      case '\f':
+      case '/':
+      case 0:
+        HasFoundNextTriviaStart = true;
+        break;
+      }
+      if (HasFoundNextTriviaStart) {
+        break;
+      }
+    }
+
+    size_t Length = CurPtr - TriviaStart;
+    Pieces.push_back(TriviaKind::GarbageText, Length);
+    continue;
+  }
+
+  assert(Pieces.getLength() == TriviaStr.size() &&
+         "Not all characters in the source string have been used in trivia "
+         "pieces");
+  return Pieces;
 }
 
 ArrayRef<Token> swift::

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -210,9 +210,7 @@ void Parser::parseTopLevel(SmallVectorImpl<Decl *> &decls) {
   }
 
   // Finalize the syntax context.
-  auto LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
-  auto TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
-  SyntaxContext->addToken(Tok, LeadingTriviaPieces, TrailingTriviaPieces);
+  SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
 }
 
 bool Parser::parseTopLevelSIL() {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -210,7 +210,9 @@ void Parser::parseTopLevel(SmallVectorImpl<Decl *> &decls) {
   }
 
   // Finalize the syntax context.
-  SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
+  auto LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  auto TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
+  SyntaxContext->addToken(Tok, LeadingTriviaPieces, TrailingTriviaPieces);
 }
 
 bool Parser::parseTopLevelSIL() {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2017,8 +2017,6 @@ ParserResult<Expr> Parser::parseExprStringLiteral() {
     SyntaxContext->addToken(CloseDelimiter, StringRef(), EntireTrailingTrivia);
   } else {
     // Without custom delimiter the quote owns trailing trivia.
-    auto EntireTrailingTriviaPieces =
-        TriviaLexer::lexTrivia(EntireTrailingTrivia);
     SyntaxContext->addToken(CloseQuote, StringRef(), EntireTrailingTrivia);
   }
 

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -52,23 +52,13 @@ ParsedRawSyntaxNode::makeDeferred(SyntaxKind k,
 }
 
 ParsedRawSyntaxNode
-ParsedRawSyntaxNode::makeDeferred(Token tok,
-                                  const ParsedTrivia &leadingTrivia,
-                                  const ParsedTrivia &trailingTrivia,
+ParsedRawSyntaxNode::makeDeferred(Token tok, StringRef leadingTrivia,
+                                  StringRef trailingTrivia,
                                   SyntaxParsingContext &ctx) {
   CharSourceRange tokRange = tok.getRange();
-  size_t piecesCount = leadingTrivia.size() + trailingTrivia.size();
-  ParsedTriviaPiece *piecesPtr = nullptr;
-  if (piecesCount > 0) {
-    piecesPtr = ctx.getScratchAlloc().Allocate<ParsedTriviaPiece>(piecesCount);
-    std::uninitialized_copy(leadingTrivia.begin(), leadingTrivia.end(),
-                            piecesPtr);
-    std::uninitialized_copy(trailingTrivia.begin(), trailingTrivia.end(),
-                            piecesPtr + leadingTrivia.size());
-  }
   return ParsedRawSyntaxNode(tok.getKind(), tokRange.getStart(),
-                             tokRange.getByteLength(), piecesPtr,
-                             leadingTrivia.size(), trailingTrivia.size());
+                             tokRange.getByteLength(), leadingTrivia,
+                             trailingTrivia);
 }
 
 void ParsedRawSyntaxNode::dump() const {

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Parse/ParsedRawSyntaxRecorder.h"
+#include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParsedRawSyntaxNode.h"
 #include "swift/Parse/ParsedTrivia.h"
 #include "swift/Parse/SyntaxParseActions.h"
@@ -27,26 +28,25 @@ using namespace swift;
 using namespace swift::syntax;
 
 ParsedRawSyntaxNode
-ParsedRawSyntaxRecorder::recordToken(const Token &tok,
-                                     const ParsedTrivia &leadingTrivia,
-                                     const ParsedTrivia &trailingTrivia) {
-  return recordToken(tok.getKind(), tok.getRange(),
-                     leadingTrivia.Pieces, trailingTrivia.Pieces);
+ParsedRawSyntaxRecorder::recordToken(const Token &tok, StringRef leadingTrivia,
+                                     StringRef trailingTrivia) {
+  return recordToken(tok.getKind(), tok.getRange(), leadingTrivia,
+                     trailingTrivia);
 }
 
 ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::recordToken(tok tokKind, CharSourceRange tokRange,
-                                ArrayRef<ParsedTriviaPiece> leadingTrivia,
-                                ArrayRef<ParsedTriviaPiece> trailingTrivia) {
-  size_t leadingTriviaLen = ParsedTriviaPiece::getTotalLength(leadingTrivia);
-  size_t trailingTriviaLen = ParsedTriviaPiece::getTotalLength(trailingTrivia);
-  SourceLoc offset = tokRange.getStart().getAdvancedLoc(-leadingTriviaLen);
-  unsigned length = leadingTriviaLen + tokRange.getByteLength() +
-      trailingTriviaLen;
-  CharSourceRange range{offset, length};
-  OpaqueSyntaxNode n = SPActions->recordToken(tokKind, leadingTrivia,
-                                              trailingTrivia, range);
-  return ParsedRawSyntaxNode{SyntaxKind::Token, tokKind, range, n};
+                                     StringRef leadingTrivia,
+                                     StringRef trailingTrivia) {
+  SourceLoc offset = tokRange.getStart().getAdvancedLoc(-leadingTrivia.size());
+  unsigned length =
+      leadingTrivia.size() + tokRange.getByteLength() + trailingTrivia.size();
+  CharSourceRange range(offset, length);
+  auto leadingTriviaPieces = TriviaLexer::lexTrivia(leadingTrivia).Pieces;
+  auto trailingTriviaPieces = TriviaLexer::lexTrivia(trailingTrivia).Pieces;
+  OpaqueSyntaxNode n = SPActions->recordToken(tokKind, leadingTriviaPieces,
+                                              trailingTriviaPieces, range);
+  return ParsedRawSyntaxNode(SyntaxKind::Token, tokKind, range, n);
 }
 
 ParsedRawSyntaxNode
@@ -67,9 +67,8 @@ getRecordedNode(ParsedRawSyntaxNode node, ParsedRawSyntaxRecorder &rec) {
   tok tokKind = node.getTokenKind();
   if (node.isMissing())
     return rec.recordMissingToken(tokKind, tokRange.getStart());
-  return rec.recordToken(tokKind,tokRange,
-                         node.getDeferredLeadingTriviaPieces(),
-                         node.getDeferredTrailingTriviaPieces());
+  return rec.recordToken(tokKind, tokRange, node.getDeferredLeadingTrivia(),
+                         node.getDeferredTrailingTrivia());
 }
 
 ParsedRawSyntaxNode

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -17,7 +17,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Parse/ParsedRawSyntaxRecorder.h"
-#include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParsedRawSyntaxNode.h"
 #include "swift/Parse/ParsedTrivia.h"
 #include "swift/Parse/SyntaxParseActions.h"
@@ -42,10 +41,8 @@ ParsedRawSyntaxRecorder::recordToken(tok tokKind, CharSourceRange tokRange,
   unsigned length =
       leadingTrivia.size() + tokRange.getByteLength() + trailingTrivia.size();
   CharSourceRange range(offset, length);
-  auto leadingTriviaPieces = TriviaLexer::lexTrivia(leadingTrivia).Pieces;
-  auto trailingTriviaPieces = TriviaLexer::lexTrivia(trailingTrivia).Pieces;
-  OpaqueSyntaxNode n = SPActions->recordToken(tokKind, leadingTriviaPieces,
-                                              trailingTriviaPieces, range);
+  OpaqueSyntaxNode n =
+      SPActions->recordToken(tokKind, leadingTrivia, trailingTrivia, range);
   return ParsedRawSyntaxNode(SyntaxKind::Token, tokKind, range, n);
 }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -606,9 +606,7 @@ void Parser::consumeExtraToken(Token Extra) {
 
 SourceLoc Parser::consumeToken() {
   TokReceiver->receive(Tok);
-  auto LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
-  auto TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
-  SyntaxContext->addToken(Tok, LeadingTriviaPieces, TrailingTriviaPieces);
+  SyntaxContext->addToken(Tok, LeadingTrivia, TrailingTrivia);
   return consumeTokenWithoutFeedingReceiver();
 }
 
@@ -643,9 +641,7 @@ SourceLoc Parser::consumeStartingCharacterOfCurrentToken(tok Kind, size_t Len) {
 void Parser::markSplitToken(tok Kind, StringRef Txt) {
   SplitTokens.emplace_back();
   SplitTokens.back().setToken(Kind, Txt);
-  ParsedTrivia EmptyTrivia;
-  auto LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
-  SyntaxContext->addToken(SplitTokens.back(), LeadingTriviaPieces, EmptyTrivia);
+  SyntaxContext->addToken(SplitTokens.back(), LeadingTrivia, StringRef());
   TokReceiver->receive(SplitTokens.back());
 }
 

--- a/lib/Parse/SyntaxParsingCache.cpp
+++ b/lib/Parse/SyntaxParsingCache.cpp
@@ -46,9 +46,7 @@ bool SyntaxParsingCache::nodeCanBeReused(const Syntax &Node, size_t NodeStart,
     auto NextRawNode = NextLeafNode->getRaw();
     assert(NextRawNode->isPresent());
     NextLeafNodeLength += NextRawNode->getTokenText().size();
-    for (auto TriviaPiece : NextRawNode->getLeadingTrivia()) {
-      NextLeafNodeLength += TriviaPiece.getTextLength();
-    }
+    NextLeafNodeLength += NextRawNode->getLeadingTriviaLength();
   }
 
   auto NodeEnd = NodeStart + Node.getTextLength();

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -18,7 +18,6 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/Defer.h"
-#include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParsedRawSyntaxRecorder.h"
 #include "swift/Parse/ParsedSyntax.h"
 #include "swift/Parse/ParsedSyntaxRecorder.h"
@@ -209,16 +208,12 @@ void SyntaxParsingContext::addToken(Token &Tok, StringRef LeadingTrivia,
   if (!Enabled)
     return;
 
-  auto LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
-  auto TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
-
   ParsedRawSyntaxNode raw;
   if (shouldDefer()) {
-    raw = ParsedRawSyntaxNode::makeDeferred(Tok, LeadingTriviaPieces,
-                                            TrailingTriviaPieces, *this);
+    raw = ParsedRawSyntaxNode::makeDeferred(Tok, LeadingTrivia, TrailingTrivia,
+                                            *this);
   } else {
-    raw = getRecorder().recordToken(Tok, LeadingTriviaPieces,
-                                    TrailingTriviaPieces);
+    raw = getRecorder().recordToken(Tok, LeadingTrivia, TrailingTrivia);
   }
   addRawSyntax(std::move(raw));
 }

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -18,3 +18,5 @@ _swift_gyb_target_sources(swiftSyntax PRIVATE
     SyntaxVisitor.cpp.gyb
     Trivia.cpp.gyb
     SyntaxSerialization.cpp.gyb)
+target_link_libraries(swiftSyntax PRIVATE
+  swiftParse)

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Basic/ColorUtils.h"
 #include "swift/Syntax/RawSyntax.h"
+#include "swift/Basic/ColorUtils.h"
+#include "swift/Parse/Lexer.h"
 #include "swift/Syntax/SyntaxArena.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
@@ -67,6 +68,25 @@ void swift::dumpTokenKind(llvm::raw_ostream &OS, tok Kind) {
   }
 }
 
+/// Lex the given trivia string into its pieces
+Trivia lexTrivia(StringRef TriviaStr) {
+  // FIXME: The trivia lexer should directly create TriviaPieces so we don't
+  // need the conversion from ParsedTriviaPiece to TriviaPiece
+
+  // Lex the trivia into ParsedTriviaPiece
+  auto TriviaPieces = TriviaLexer::lexTrivia(TriviaStr).Pieces;
+
+  /// Convert the ParsedTriviaPiece to TriviaPiece
+  Trivia SyntaxTrivia;
+  size_t Offset = 0;
+  for (auto Piece : TriviaPieces) {
+    StringRef Text = TriviaStr.substr(Offset, Piece.getLength());
+    SyntaxTrivia.push_back(TriviaPiece::fromText(Piece.getKind(), Text));
+    Offset += Piece.getLength();
+  }
+  return SyntaxTrivia;
+}
+
 // FIXME: If we want thread-safety for tree creation, this needs to be atomic.
 unsigned RawSyntax::NextFreeNodeId = 1;
 
@@ -74,12 +94,11 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
                      size_t TextLength, SourcePresence Presence,
                      const RC<SyntaxArena> &Arena,
                      llvm::Optional<unsigned> NodeId)
-    : Arena(Arena) {
+    : Arena(Arena), Bits({{unsigned(TextLength), unsigned(Presence), false}}),
+      RefCount(0) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
   assert(Kind != SyntaxKind::Token &&
          "'token' syntax node must be constructed with dedicated constructor");
-
-  RefCount = 0;
 
   size_t TotalSubNodeCount = 0;
   for (auto Child : Layout) {
@@ -94,9 +113,6 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
   } else {
     this->NodeId = NextFreeNodeId++;
   }
-  Bits.Common.TextLength = TextLength;
-  Bits.Common.Presence = unsigned(Presence);
-  Bits.Common.IsToken = false;
   Bits.Layout.NumChildren = Layout.size();
   Bits.Layout.TotalSubNodeCount = TotalSubNodeCount;
   Bits.Layout.Kind = unsigned(Kind);
@@ -107,13 +123,12 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
 }
 
 RawSyntax::RawSyntax(tok TokKind, OwnedString Text, size_t TextLength,
-                     ArrayRef<TriviaPiece> LeadingTrivia,
-                     ArrayRef<TriviaPiece> TrailingTrivia,
+                     StringRef LeadingTrivia, StringRef TrailingTrivia,
                      SourcePresence Presence, const RC<SyntaxArena> &Arena,
                      llvm::Optional<unsigned> NodeId)
-    : Arena(Arena) {
+    : Arena(Arena), Bits({{unsigned(TextLength), unsigned(Presence), true}}),
+      RefCount(0) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
-  RefCount = 0;
 
   if (NodeId.hasValue()) {
     this->NodeId = NodeId.getValue();
@@ -121,32 +136,19 @@ RawSyntax::RawSyntax(tok TokKind, OwnedString Text, size_t TextLength,
   } else {
     this->NodeId = NextFreeNodeId++;
   }
-  Bits.Common.TextLength = TextLength;
-  Bits.Common.Presence = unsigned(Presence);
-  Bits.Common.IsToken = true;
   Bits.Token.TokenKind = unsigned(TokKind);
-  Bits.Token.NumLeadingTrivia = LeadingTrivia.size();
-  Bits.Token.NumTrailingTrivia = TrailingTrivia.size();
+  // FIXME: Copy the backing storage of the string into the arena
+  Bits.Token.LeadingTrivia = LeadingTrivia;
+  Bits.Token.TrailingTrivia = TrailingTrivia;
 
   // Initialize token text.
   ::new (static_cast<void *>(getTrailingObjects<OwnedString>()))
       OwnedString(Text);
-  // Initialize leading trivia.
-  std::uninitialized_copy(LeadingTrivia.begin(), LeadingTrivia.end(),
-                          getTrailingObjects<TriviaPiece>());
-  // Initialize trailing trivia.
-  std::uninitialized_copy(TrailingTrivia.begin(), TrailingTrivia.end(),
-                          getTrailingObjects<TriviaPiece>() +
-                              Bits.Token.NumLeadingTrivia);
 }
 
 RawSyntax::~RawSyntax() {
   if (isToken()) {
     getTrailingObjects<OwnedString>()->~OwnedString();
-    for (auto &trivia : getLeadingTrivia())
-      trivia.~TriviaPiece();
-    for (auto &trivia : getTrailingTrivia())
-      trivia.~TriviaPiece();
   } else {
     for (auto &child : getLayout())
       child.~RC<RawSyntax>();
@@ -158,26 +160,31 @@ RC<RawSyntax> RawSyntax::make(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
                               const RC<SyntaxArena> &Arena,
                               llvm::Optional<unsigned> NodeId) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
-  auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString, TriviaPiece>(
-      Layout.size(), 0, 0);
+  auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString>(Layout.size(), 0);
   void *data = Arena->Allocate(size, alignof(RawSyntax));
   return RC<RawSyntax>(
       new (data) RawSyntax(Kind, Layout, TextLength, Presence, Arena, NodeId));
 }
 
 RC<RawSyntax> RawSyntax::make(tok TokKind, OwnedString Text, size_t TextLength,
-                              ArrayRef<TriviaPiece> LeadingTrivia,
-                              ArrayRef<TriviaPiece> TrailingTrivia,
+                              StringRef LeadingTrivia, StringRef TrailingTrivia,
                               SourcePresence Presence,
                               const RC<SyntaxArena> &Arena,
                               llvm::Optional<unsigned> NodeId) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
-  auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString, TriviaPiece>(
-      0, 1, LeadingTrivia.size() + TrailingTrivia.size());
+  auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString>(0, 1);
   void *data = Arena->Allocate(size, alignof(RawSyntax));
   return RC<RawSyntax>(new (data)
                            RawSyntax(TokKind, Text, TextLength, LeadingTrivia,
                                      TrailingTrivia, Presence, Arena, NodeId));
+}
+
+Trivia RawSyntax::getLeadingTriviaPieces() const {
+  return lexTrivia(getLeadingTrivia());
+}
+
+Trivia RawSyntax::getTrailingTriviaPieces() const {
+  return lexTrivia(getTrailingTrivia());
 }
 
 RC<RawSyntax> RawSyntax::append(RC<RawSyntax> NewLayoutElement) const {
@@ -212,13 +219,9 @@ void RawSyntax::print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const {
     return;
 
   if (isToken()) {
-    for (const auto &Leader : getLeadingTrivia())
-      Leader.print(OS);
-
+    OS << getLeadingTrivia();
     OS << getTokenText();
-
-    for (const auto &Trailer : getTrailingTrivia())
-      Trailer.print(OS);
+    OS << getTrailingTrivia();
   } else {
     auto Kind = getKind();
     const bool PrintKind = Opts.PrintSyntaxKind && (Opts.PrintTrivialNodeKind ||
@@ -258,7 +261,7 @@ void RawSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
     OS << " ";
     dumpTokenKind(OS, getTokenKind());
 
-    for (auto &Leader : getLeadingTrivia()) {
+    for (auto &Leader : getLeadingTriviaPieces()) {
       OS << "\n";
       Leader.dump(OS, Indent + 1);
     }
@@ -269,7 +272,7 @@ void RawSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
     OS.write_escaped(getTokenText(), /*UseHexEscapes=*/true);
     OS << "\")";
 
-    for (auto &Trailer : getTrailingTrivia()) {
+    for (auto &Trailer : getTrailingTriviaPieces()) {
       OS << "\n";
       Trailer.dump(OS, Indent + 1);
     }
@@ -285,8 +288,8 @@ void RawSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
 }
 
 void RawSyntax::Profile(llvm::FoldingSetNodeID &ID, tok TokKind,
-                        OwnedString Text, ArrayRef<TriviaPiece> LeadingTrivia,
-                        ArrayRef<TriviaPiece> TrailingTrivia) {
+                        OwnedString Text, StringRef LeadingTrivia,
+                        StringRef TrailingTrivia) {
   ID.AddInteger(unsigned(TokKind));
   ID.AddInteger(LeadingTrivia.size());
   ID.AddInteger(TrailingTrivia.size());
@@ -301,8 +304,6 @@ void RawSyntax::Profile(llvm::FoldingSetNodeID &ID, tok TokKind,
     ID.AddString(Text.str());
     break;
   }
-  for (auto &Piece : LeadingTrivia)
-    Piece.Profile(ID);
-  for (auto &Piece : TrailingTrivia)
-    Piece.Profile(ID);
+  ID.AddString(LeadingTrivia);
+  ID.AddString(TrailingTrivia);
 }

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -39,12 +39,12 @@ using namespace swift;
 using namespace swift::syntax;
 
 TokenSyntax SyntaxFactory::makeToken(tok Kind, OwnedString Text,
-                                     const Trivia &LeadingTrivia,
-                                     const Trivia &TrailingTrivia,
+                                     StringRef LeadingTrivia,
+                                     StringRef TrailingTrivia,
                                      SourcePresence Presence,
                                      const RC<SyntaxArena> &Arena) {
   return makeRoot<TokenSyntax>(RawSyntax::makeAndCalcLength(Kind, Text, 
-    LeadingTrivia.Pieces, TrailingTrivia.Pieces, Presence, Arena));
+    LeadingTrivia, TrailingTrivia, Presence, Arena));
 }
 
 UnknownSyntax
@@ -236,8 +236,8 @@ SyntaxFactory::makeBlank${node.syntax_kind}(const RC<SyntaxArena> &Arena) {
 % for token in SYNTAX_TOKENS:
 %   if token.is_keyword:
   TokenSyntax
-  SyntaxFactory::make${token.name}Keyword(const Trivia &LeadingTrivia,
-                                          const Trivia &TrailingTrivia,
+  SyntaxFactory::make${token.name}Keyword(StringRef LeadingTrivia,
+                                          StringRef TrailingTrivia,
                                           const RC<SyntaxArena> &Arena) {
     return makeToken(tok::${token.kind},
                      OwnedString::makeUnowned("${token.text}"),
@@ -246,8 +246,8 @@ SyntaxFactory::makeBlank${node.syntax_kind}(const RC<SyntaxArena> &Arena) {
   }
 %   elif token.text:
   TokenSyntax
-  SyntaxFactory::make${token.name}Token(const Trivia &LeadingTrivia,
-                                        const Trivia &TrailingTrivia,
+  SyntaxFactory::make${token.name}Token(StringRef LeadingTrivia,
+                                        StringRef TrailingTrivia,
                                         const RC<SyntaxArena> &Arena) {
     return makeToken(tok::${token.kind},
                      OwnedString::makeUnowned("${token.text}"),
@@ -257,8 +257,8 @@ SyntaxFactory::makeBlank${node.syntax_kind}(const RC<SyntaxArena> &Arena) {
 %   else:
   TokenSyntax
   SyntaxFactory::make${token.name}(OwnedString Text,
-                                   const Trivia &LeadingTrivia,
-                                   const Trivia &TrailingTrivia,
+                                   StringRef LeadingTrivia,
+                                   StringRef TrailingTrivia,
                                    const RC<SyntaxArena> &Arena) {
     return makeToken(tok::${token.kind}, Text,
                      LeadingTrivia, TrailingTrivia,
@@ -300,44 +300,44 @@ SyntaxFactory::makeGenericParameter(TokenSyntax Name,
 }
 
 TypeSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
-                                             const Trivia &LeadingTrivia,
-                                             const Trivia &TrailingTrivia,
+                                             StringRef LeadingTrivia,
+                                             StringRef TrailingTrivia,
                                              const RC<SyntaxArena> &Arena) {
   auto identifier =
       makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia, Arena);
   return makeSimpleTypeIdentifier(identifier, None, Arena);
 }
 
-TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(const Trivia &LeadingTrivia,
-                                                const Trivia &TrailingTrivia,
+TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(StringRef LeadingTrivia,
+                                                StringRef TrailingTrivia,
                                                 const RC<SyntaxArena> &Arena) {
   return makeTypeIdentifier(OwnedString::makeUnowned("Any"), LeadingTrivia,
                             TrailingTrivia, Arena);
 }
 
-TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(const Trivia &LeadingTrivia,
-                                                 const Trivia &TrailingTrivia,
+TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(StringRef LeadingTrivia,
+                                                 StringRef TrailingTrivia,
                                                  const RC<SyntaxArena> &Arena) {
   return makeTypeIdentifier(OwnedString::makeUnowned("Self"),
                             LeadingTrivia, TrailingTrivia, Arena);
 }
 
-TokenSyntax SyntaxFactory::makeTypeToken(const Trivia &LeadingTrivia,
-                                         const Trivia &TrailingTrivia,
+TokenSyntax SyntaxFactory::makeTypeToken(StringRef LeadingTrivia,
+                                         StringRef TrailingTrivia,
                                          const RC<SyntaxArena> &Arena) {
   return makeIdentifier(OwnedString::makeUnowned("Type"),
                         LeadingTrivia, TrailingTrivia, Arena);
 }
 
-TokenSyntax SyntaxFactory::makeProtocolToken(const Trivia &LeadingTrivia,
-                                             const Trivia &TrailingTrivia,
+TokenSyntax SyntaxFactory::makeProtocolToken(StringRef LeadingTrivia,
+                                             StringRef TrailingTrivia,
                                              const RC<SyntaxArena> &Arena) {
   return makeIdentifier(OwnedString::makeUnowned("Protocol"),
                         LeadingTrivia, TrailingTrivia, Arena);
 }
 
-TokenSyntax SyntaxFactory::makeEqualityOperator(const Trivia &LeadingTrivia,
-                                                const Trivia &TrailingTrivia,
+TokenSyntax SyntaxFactory::makeEqualityOperator(StringRef LeadingTrivia,
+                                                StringRef TrailingTrivia,
                                                 const RC<SyntaxArena> &Arena) {
   return makeToken(tok::oper_binary_spaced, OwnedString::makeUnowned("=="),
                    LeadingTrivia, TrailingTrivia, SourcePresence::Present,

--- a/lib/SyntaxParse/RawSyntaxTokenCache.cpp
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.cpp
@@ -19,22 +19,19 @@ using namespace swift;
 using namespace swift::syntax;
 
 static bool shouldCacheNode(tok TokKind, size_t TextSize,
-                            ArrayRef<TriviaPiece> LeadingTrivia,
-                            ArrayRef<TriviaPiece> TrailingTrivia) {
+                            StringRef LeadingTrivia, StringRef TrailingTrivia) {
   // Is string_literal with >16 length.
   if (TokKind == tok::string_literal && TextSize > 16) {
     return false;
   }
 
-  // Has leading comment trivia et al.
-  if (any_of(LeadingTrivia,
-             [](const syntax::TriviaPiece &T) { return T.getText().size(); })) {
+  // Has a lot of leading comment trivia like comments.
+  if (LeadingTrivia.size() > 4) {
     return false;
   }
 
-  // Has trailing comment trivia et al.
-  if (any_of(TrailingTrivia,
-             [](const syntax::TriviaPiece &T) { return T.getText().size(); })) {
+  // Has a lot of trailing trivia
+  if (TrailingTrivia.size() > 4) {
     return false;
   }
 
@@ -42,9 +39,10 @@ static bool shouldCacheNode(tok TokKind, size_t TextSize,
   return true;
 }
 
-RC<RawSyntax> RawSyntaxTokenCache::getToken(
-    RC<SyntaxArena> &Arena, tok TokKind, size_t TextLength, OwnedString Text,
-    ArrayRef<TriviaPiece> LeadingTrivia, ArrayRef<TriviaPiece> TrailingTrivia) {
+RC<RawSyntax> RawSyntaxTokenCache::getToken(RC<SyntaxArena> &Arena, tok TokKind,
+                                            size_t TextLength, OwnedString Text,
+                                            StringRef LeadingTrivia,
+                                            StringRef TrailingTrivia) {
   // Determine whether this token is worth to cache.
   if (!shouldCacheNode(TokKind, Text.size(), LeadingTrivia, TrailingTrivia)) {
     // Do not use cache.

--- a/lib/SyntaxParse/RawSyntaxTokenCache.h
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.h
@@ -63,8 +63,8 @@ class RawSyntaxTokenCache {
 public:
   RC<syntax::RawSyntax> getToken(RC<syntax::SyntaxArena> &Arena, tok TokKind,
                                  size_t TextLength, OwnedString Text,
-                                 ArrayRef<syntax::TriviaPiece> LeadingTrivia,
-                                 ArrayRef<syntax::TriviaPiece> TrailingTrivia);
+                                 StringRef LeadingTrivia,
+                                 StringRef TrailingTrivia);
 
   ~RawSyntaxTokenCache();
 };

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -47,6 +47,8 @@ SyntaxTreeCreator::SyntaxTreeCreator(SourceManager &SM, unsigned bufferID,
   std::uninitialized_copy(BufferContent.begin(), BufferContent.end(), Data);
   ArenaSourceBuffer = StringRef(Data, BufferContent.size());
   assert(ArenaSourceBuffer == BufferContent);
+  Arena->setHotUseMemoryRegion(ArenaSourceBuffer.begin(),
+                               ArenaSourceBuffer.end());
 }
 
 SyntaxTreeCreator::~SyntaxTreeCreator() = default;

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -14,6 +14,7 @@
 #include "swift/Syntax/RawSyntax.h"
 #include "swift/Syntax/SyntaxVisitor.h"
 #include "swift/Syntax/Trivia.h"
+#include "swift/Parse/Lexer.h"
 #include "swift/Parse/ParsedTrivia.h"
 #include "swift/Parse/SyntaxParsingCache.h"
 #include "swift/Parse/Token.h"
@@ -109,18 +110,16 @@ SyntaxTreeCreator::realizeSyntaxRoot(OpaqueSyntaxNode rootN,
   return rootNode;
 }
 
-OpaqueSyntaxNode
-SyntaxTreeCreator::recordToken(tok tokenKind,
-                               ArrayRef<ParsedTriviaPiece> leadingTriviaPieces,
-                               ArrayRef<ParsedTriviaPiece> trailingTriviaPieces,
-                               CharSourceRange range) {
-  size_t leadingTriviaLen =
-    ParsedTriviaPiece::getTotalLength(leadingTriviaPieces);
-  size_t trailingTriviaLen =
-    ParsedTriviaPiece::getTotalLength(trailingTriviaPieces);
-  SourceLoc tokLoc = range.getStart().getAdvancedLoc(leadingTriviaLen);
-  unsigned tokLength = range.getByteLength() -
-      leadingTriviaLen - trailingTriviaLen;
+OpaqueSyntaxNode SyntaxTreeCreator::recordToken(tok tokenKind,
+                                                StringRef leadingTrivia,
+                                                StringRef trailingTrivia,
+                                                CharSourceRange range) {
+  auto leadingTriviaPieces = TriviaLexer::lexTrivia(leadingTrivia).Pieces;
+  auto trailingTriviaPieces = TriviaLexer::lexTrivia(trailingTrivia).Pieces;
+
+  SourceLoc tokLoc = range.getStart().getAdvancedLoc(leadingTrivia.size());
+  unsigned tokLength =
+      range.getByteLength() - leadingTrivia.size() - trailingTrivia.size();
   CharSourceRange tokRange = CharSourceRange{tokLoc, tokLength};
   SourceLoc leadingTriviaLoc = range.getStart();
   SourceLoc trailingTriviaLoc = tokLoc.getAdvancedLoc(tokLength);

--- a/test/Frontend/emit-syntax.swift
+++ b/test/Frontend/emit-syntax.swift
@@ -54,8 +54,7 @@ func CheckParameterList(arg1: String..., arg2: Int) {
 // CHECK: "kind":"r_brace"
 }
 
-// CHECK: "leadingTrivia":[
-// CHECK: "kind":"LineComment",
-// CHECK: "value":"\/\/ Comment at the end of the file"
+// CHECK: "leadingTrivia":"\n\/\/ Comment at the end of the file\n"
 
+func separator() {}
 // Comment at the end of the file

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -21,30 +21,8 @@
                   "tokenKind": {
                     "kind": "kw_struct"
                   },
-                  "leadingTrivia": [
-                    {
-                      "kind": "LineComment",
-                      "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
-                    },
-                    {
-                      "kind": "Newline",
-                      "value": 1
-                    },
-                    {
-                      "kind": "LineComment",
-                      "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_multiple_decls.json -u"
-                    },
-                    {
-                      "kind": "Newline",
-                      "value": 2
-                    }
-                  ],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t\n\/\/ RUN: diff %t %S\/Inputs\/serialize_multiple_decls.json -u\n\n",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 {
@@ -53,13 +31,8 @@
                     "kind": "identifier",
                     "text": "A"
                   },
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 null,
@@ -74,8 +47,8 @@
                       "tokenKind": {
                         "kind": "l_brace"
                       },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     },
                     {
@@ -89,13 +62,8 @@
                       "tokenKind": {
                         "kind": "r_brace"
                       },
-                      "leadingTrivia": [
-                        {
-                          "kind": "Newline",
-                          "value": 1
-                        }
-                      ],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "\n",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     }
                   ],
@@ -124,18 +92,8 @@
                   "tokenKind": {
                     "kind": "kw_struct"
                   },
-                  "leadingTrivia": [
-                    {
-                      "kind": "Newline",
-                      "value": 2
-                    }
-                  ],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "\n\n",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 {
@@ -144,13 +102,8 @@
                     "kind": "identifier",
                     "text": "B"
                   },
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 null,
@@ -165,8 +118,8 @@
                       "tokenKind": {
                         "kind": "l_brace"
                       },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     },
                     {
@@ -180,13 +133,8 @@
                       "tokenKind": {
                         "kind": "r_brace"
                       },
-                      "leadingTrivia": [
-                        {
-                          "kind": "Newline",
-                          "value": 1
-                        }
-                      ],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "\n",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     }
                   ],
@@ -209,13 +157,8 @@
         "kind": "eof",
         "text": ""
       },
-      "leadingTrivia": [
-        {
-          "kind": "Newline",
-          "value": 1
-        }
-      ],
-      "trailingTrivia": [],
+      "leadingTrivia": "\n",
+      "trailingTrivia": "",
       "presence": "Present"
     }
   ],

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -21,30 +21,8 @@
                   "tokenKind": {
                     "kind": "kw_struct"
                   },
-                  "leadingTrivia": [
-                    {
-                      "kind": "LineComment",
-                      "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
-                    },
-                    {
-                      "kind": "Newline",
-                      "value": 1
-                    },
-                    {
-                      "kind": "LineComment",
-                      "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_struct_decl.json -u"
-                    },
-                    {
-                      "kind": "Newline",
-                      "value": 2
-                    }
-                  ],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t\n\/\/ RUN: diff %t %S\/Inputs\/serialize_struct_decl.json -u\n\n",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 {
@@ -53,13 +31,8 @@
                     "kind": "identifier",
                     "text": "Foo"
                   },
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 null,
@@ -74,8 +47,8 @@
                       "tokenKind": {
                         "kind": "l_brace"
                       },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     },
                     {
@@ -97,22 +70,8 @@
                                   "tokenKind": {
                                     "kind": "kw_let"
                                   },
-                                  "leadingTrivia": [
-                                    {
-                                      "kind": "Newline",
-                                      "value": 1
-                                    },
-                                    {
-                                      "kind": "Space",
-                                      "value": 2
-                                    }
-                                  ],
-                                  "trailingTrivia": [
-                                    {
-                                      "kind": "Space",
-                                      "value": 3
-                                    }
-                                  ],
+                                  "leadingTrivia": "\n  ",
+                                  "trailingTrivia": "   ",
                                   "presence": "Present"
                                 },
                                 {
@@ -133,13 +92,8 @@
                                                 "kind": "identifier",
                                                 "text": "bar"
                                               },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [
-                                                {
-                                                  "kind": "Space",
-                                                  "value": 1
-                                                }
-                                              ],
+                                              "leadingTrivia": "",
+                                              "trailingTrivia": " ",
                                               "presence": "Present"
                                             }
                                           ],
@@ -154,13 +108,8 @@
                                               "tokenKind": {
                                                 "kind": "colon"
                                               },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [
-                                                {
-                                                  "kind": "Space",
-                                                  "value": 1
-                                                }
-                                              ],
+                                              "leadingTrivia": "",
+                                              "trailingTrivia": " ",
                                               "presence": "Present"
                                             },
                                             {
@@ -173,8 +122,8 @@
                                                     "kind": "identifier",
                                                     "text": "Int"
                                                   },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [],
+                                                  "leadingTrivia": "",
+                                                  "trailingTrivia": "",
                                                   "presence": "Present"
                                                 },
                                                 null
@@ -215,22 +164,8 @@
                                   "tokenKind": {
                                     "kind": "kw_let"
                                   },
-                                  "leadingTrivia": [
-                                    {
-                                      "kind": "Newline",
-                                      "value": 2
-                                    },
-                                    {
-                                      "kind": "Space",
-                                      "value": 2
-                                    }
-                                  ],
-                                  "trailingTrivia": [
-                                    {
-                                      "kind": "Space",
-                                      "value": 1
-                                    }
-                                  ],
+                                  "leadingTrivia": "\n\n  ",
+                                  "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
                                 {
@@ -251,13 +186,8 @@
                                                 "kind": "identifier",
                                                 "text": "baz"
                                               },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [
-                                                {
-                                                  "kind": "Space",
-                                                  "value": 1
-                                                }
-                                              ],
+                                              "leadingTrivia": "",
+                                              "trailingTrivia": " ",
                                               "presence": "Present"
                                             }
                                           ],
@@ -272,13 +202,8 @@
                                               "tokenKind": {
                                                 "kind": "colon"
                                               },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [
-                                                {
-                                                  "kind": "Space",
-                                                  "value": 1
-                                                }
-                                              ],
+                                              "leadingTrivia": "",
+                                              "trailingTrivia": " ",
                                               "presence": "Present"
                                             },
                                             {
@@ -291,13 +216,8 @@
                                                     "kind": "identifier",
                                                     "text": "Array"
                                                   },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [
-                                                    {
-                                                      "kind": "Space",
-                                                      "value": 1
-                                                    }
-                                                  ],
+                                                  "leadingTrivia": "",
+                                                  "trailingTrivia": " ",
                                                   "presence": "Present"
                                                 },
                                                 {
@@ -309,13 +229,8 @@
                                                       "tokenKind": {
                                                         "kind": "l_angle"
                                                       },
-                                                      "leadingTrivia": [],
-                                                      "trailingTrivia": [
-                                                        {
-                                                          "kind": "Space",
-                                                          "value": 1
-                                                        }
-                                                      ],
+                                                      "leadingTrivia": "",
+                                                      "trailingTrivia": " ",
                                                       "presence": "Present"
                                                     },
                                                     {
@@ -336,13 +251,8 @@
                                                                     "kind": "identifier",
                                                                     "text": "Int"
                                                                   },
-                                                                  "leadingTrivia": [],
-                                                                  "trailingTrivia": [
-                                                                    {
-                                                                      "kind": "Space",
-                                                                      "value": 1
-                                                                    }
-                                                                  ],
+                                                                  "leadingTrivia": "",
+                                                                  "trailingTrivia": " ",
                                                                   "presence": "Present"
                                                                 },
                                                                 null
@@ -361,8 +271,8 @@
                                                       "tokenKind": {
                                                         "kind": "r_angle"
                                                       },
-                                                      "leadingTrivia": [],
-                                                      "trailingTrivia": [],
+                                                      "leadingTrivia": "",
+                                                      "trailingTrivia": "",
                                                       "presence": "Present"
                                                     }
                                                   ],
@@ -398,17 +308,8 @@
                       "tokenKind": {
                         "kind": "r_brace"
                       },
-                      "leadingTrivia": [
-                        {
-                          "kind": "Newline",
-                          "value": 1
-                        },
-                        {
-                          "kind": "Space",
-                          "value": 6
-                        }
-                      ],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "\n      ",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     }
                   ],
@@ -431,13 +332,8 @@
         "kind": "eof",
         "text": ""
       },
-      "leadingTrivia": [
-        {
-          "kind": "Newline",
-          "value": 1
-        }
-      ],
-      "trailingTrivia": [],
+      "leadingTrivia": "\n",
+      "trailingTrivia": "",
       "presence": "Present"
     }
   ],

--- a/test/Syntax/serialize_tupletype.swift.result
+++ b/test/Syntax/serialize_tupletype.swift.result
@@ -21,30 +21,8 @@
                   "tokenKind": {
                     "kind": "kw_typealias"
                   },
-                  "leadingTrivia": [
-                    {
-                      "kind": "LineComment",
-                      "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t.result"
-                    },
-                    {
-                      "kind": "Newline",
-                      "value": 1
-                    },
-                    {
-                      "kind": "LineComment",
-                      "value": "\/\/ RUN: diff %t.result %s.result"
-                    },
-                    {
-                      "kind": "Newline",
-                      "value": 2
-                    }
-                  ],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t.result\n\/\/ RUN: diff %t.result %s.result\n\n",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 {
@@ -53,13 +31,8 @@
                     "kind": "identifier",
                     "text": "x"
                   },
-                  "leadingTrivia": [],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 null,
@@ -72,13 +45,8 @@
                       "tokenKind": {
                         "kind": "equal"
                       },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [
-                        {
-                          "kind": "Space",
-                          "value": 1
-                        }
-                      ],
+                      "leadingTrivia": "",
+                      "trailingTrivia": " ",
                       "presence": "Present"
                     },
                     {
@@ -90,8 +58,8 @@
                           "tokenKind": {
                             "kind": "l_paren"
                           },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
                           "presence": "Present"
                         },
                         {
@@ -108,13 +76,8 @@
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
-                                  "leadingTrivia": [],
-                                  "trailingTrivia": [
-                                    {
-                                      "kind": "Space",
-                                      "value": 1
-                                    }
-                                  ],
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
                                 {
@@ -123,8 +86,8 @@
                                     "kind": "identifier",
                                     "text": "b"
                                   },
-                                  "leadingTrivia": [],
-                                  "trailingTrivia": [],
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": "",
                                   "presence": "Present"
                                 },
                                 {
@@ -132,13 +95,8 @@
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
-                                  "leadingTrivia": [],
-                                  "trailingTrivia": [
-                                    {
-                                      "kind": "Space",
-                                      "value": 1
-                                    }
-                                  ],
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
                                 {
@@ -151,8 +109,8 @@
                                         "kind": "identifier",
                                         "text": "Int"
                                       },
-                                      "leadingTrivia": [],
-                                      "trailingTrivia": [],
+                                      "leadingTrivia": "",
+                                      "trailingTrivia": "",
                                       "presence": "Present"
                                     },
                                     null
@@ -166,13 +124,8 @@
                                   "tokenKind": {
                                     "kind": "comma"
                                   },
-                                  "leadingTrivia": [],
-                                  "trailingTrivia": [
-                                    {
-                                      "kind": "Space",
-                                      "value": 1
-                                    }
-                                  ],
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
                                   "presence": "Present"
                                 }
                               ],
@@ -188,8 +141,8 @@
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
-                                  "leadingTrivia": [],
-                                  "trailingTrivia": [],
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": "",
                                   "presence": "Present"
                                 },
                                 null,
@@ -198,13 +151,8 @@
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
-                                  "leadingTrivia": [],
-                                  "trailingTrivia": [
-                                    {
-                                      "kind": "Space",
-                                      "value": 1
-                                    }
-                                  ],
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
                                 {
@@ -217,8 +165,8 @@
                                         "kind": "identifier",
                                         "text": "String"
                                       },
-                                      "leadingTrivia": [],
-                                      "trailingTrivia": [],
+                                      "leadingTrivia": "",
+                                      "trailingTrivia": "",
                                       "presence": "Present"
                                     },
                                     null
@@ -239,8 +187,8 @@
                           "tokenKind": {
                             "kind": "r_paren"
                           },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
                           "presence": "Present"
                         }
                       ],
@@ -267,13 +215,8 @@
         "kind": "eof",
         "text": ""
       },
-      "leadingTrivia": [
-        {
-          "kind": "Newline",
-          "value": 1
-        }
-      ],
-      "trailingTrivia": [],
+      "leadingTrivia": "\n",
+      "trailingTrivia": "",
       "presence": "Present"
     }
   ],

--- a/test/incrParse/Outputs/extend-identifier-at-eof.json
+++ b/test/incrParse/Outputs/extend-identifier-at-eof.json
@@ -31,34 +31,8 @@
                           "tokenKind": {
                             "kind": "kw__"
                           },
-                          "leadingTrivia": [
-                            {
-                              "kind": "Newline",
-                              "value": 1
-                            },
-                            {
-                              "kind": "LineComment",
-                              "value": "\/\/ ATTENTION: This file is testing the EOF token. "
-                            },
-                            {
-                              "kind": "Newline",
-                              "value": 1
-                            },
-                            {
-                              "kind": "LineComment",
-                              "value": "\/\/ DO NOT PUT ANYTHING AFTER THE CHANGE, NOT EVEN A NEWLINE"
-                            },
-                            {
-                              "kind": "Newline",
-                              "value": 1
-                            }
-                          ],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
+                          "leadingTrivia": "\n\/\/ ATTENTION: This file is testing the EOF token. \n\/\/ DO NOT PUT ANYTHING AFTER THE CHANGE, NOT EVEN A NEWLINE\n",
+                          "trailingTrivia": " ",
                           "presence": "Present"
                         }
                       ],
@@ -73,13 +47,8 @@
                           "tokenKind": {
                             "kind": "equal"
                           },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
+                          "leadingTrivia": "",
+                          "trailingTrivia": " ",
                           "presence": "Present"
                         }
                       ],
@@ -95,8 +64,8 @@
                             "kind": "identifier",
                             "text": "xx"
                           },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
                           "presence": "Present"
                         },
                         null
@@ -123,8 +92,8 @@
         "kind": "eof",
         "text": ""
       },
-      "leadingTrivia": [],
-      "trailingTrivia": [],
+      "leadingTrivia": "",
+      "trailingTrivia": "",
       "presence": "Present"
     }
   ],

--- a/test/incrParse/Outputs/incrementalTransfer.json
+++ b/test/incrParse/Outputs/incrementalTransfer.json
@@ -25,18 +25,8 @@
                   "tokenKind": {
                     "kind": "kw_func"
                   },
-                  "leadingTrivia": [
-                    {
-                      "kind": "Newline",
-                      "value": 2
-                    }
-                  ],
-                  "trailingTrivia": [
-                    {
-                      "kind": "Space",
-                      "value": 1
-                    }
-                  ],
+                  "leadingTrivia": "\n\n",
+                  "trailingTrivia": " ",
                   "presence": "Present"
                 },
                 {
@@ -45,8 +35,8 @@
                     "kind": "identifier",
                     "text": "bar"
                   },
-                  "leadingTrivia": [],
-                  "trailingTrivia": [],
+                  "leadingTrivia": "",
+                  "trailingTrivia": "",
                   "presence": "Present"
                 },
                 null,
@@ -63,8 +53,8 @@
                           "tokenKind": {
                             "kind": "l_paren"
                           },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [],
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
                           "presence": "Present"
                         },
                         {
@@ -78,13 +68,8 @@
                           "tokenKind": {
                             "kind": "r_paren"
                           },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
+                          "leadingTrivia": "",
+                          "trailingTrivia": " ",
                           "presence": "Present"
                         }
                       ],
@@ -106,8 +91,8 @@
                       "tokenKind": {
                         "kind": "l_brace"
                       },
-                      "leadingTrivia": [],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     },
                     {
@@ -129,22 +114,8 @@
                                   "tokenKind": {
                                     "kind": "kw_let"
                                   },
-                                  "leadingTrivia": [
-                                    {
-                                      "kind": "Newline",
-                                      "value": 1
-                                    },
-                                    {
-                                      "kind": "Space",
-                                      "value": 2
-                                    }
-                                  ],
-                                  "trailingTrivia": [
-                                    {
-                                      "kind": "Space",
-                                      "value": 1
-                                    }
-                                  ],
+                                  "leadingTrivia": "\n  ",
+                                  "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
                                 {
@@ -165,13 +136,8 @@
                                                 "kind": "identifier",
                                                 "text": "x"
                                               },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [
-                                                {
-                                                  "kind": "Space",
-                                                  "value": 1
-                                                }
-                                              ],
+                                              "leadingTrivia": "",
+                                              "trailingTrivia": " ",
                                               "presence": "Present"
                                             }
                                           ],
@@ -187,13 +153,8 @@
                                               "tokenKind": {
                                                 "kind": "equal"
                                               },
-                                              "leadingTrivia": [],
-                                              "trailingTrivia": [
-                                                {
-                                                  "kind": "Space",
-                                                  "value": 1
-                                                }
-                                              ],
+                                              "leadingTrivia": "",
+                                              "trailingTrivia": " ",
                                               "presence": "Present"
                                             },
                                             {
@@ -206,8 +167,8 @@
                                                   "tokenKind": {
                                                     "kind": "string_quote"
                                                   },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [],
+                                                  "leadingTrivia": "",
+                                                  "trailingTrivia": "",
                                                   "presence": "Present"
                                                 },
                                                 {
@@ -224,8 +185,8 @@
                                                             "kind": "string_segment",
                                                             "text": "hello world"
                                                           },
-                                                          "leadingTrivia": [],
-                                                          "trailingTrivia": [],
+                                                          "leadingTrivia": "",
+                                                          "trailingTrivia": "",
                                                           "presence": "Present"
                                                         }
                                                       ],
@@ -239,8 +200,8 @@
                                                   "tokenKind": {
                                                     "kind": "string_quote"
                                                   },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [],
+                                                  "leadingTrivia": "",
+                                                  "trailingTrivia": "",
                                                   "presence": "Present"
                                                 },
                                                 null
@@ -278,13 +239,8 @@
                       "tokenKind": {
                         "kind": "r_brace"
                       },
-                      "leadingTrivia": [
-                        {
-                          "kind": "Newline",
-                          "value": 1
-                        }
-                      ],
-                      "trailingTrivia": [],
+                      "leadingTrivia": "\n",
+                      "trailingTrivia": "",
                       "presence": "Present"
                     }
                   ],
@@ -311,13 +267,8 @@
         "kind": "eof",
         "text": ""
       },
-      "leadingTrivia": [
-        {
-          "kind": "Newline",
-          "value": 1
-        }
-      ],
-      "trailingTrivia": [],
+      "leadingTrivia": "\n",
+      "trailingTrivia": "",
       "presence": "Present"
     }
   ],

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -154,13 +154,15 @@ private:
     node.present = true;
   }
 
-  OpaqueSyntaxNode recordToken(tok tokenKind,
-                               ArrayRef<ParsedTriviaPiece> leadingTrivia,
-                               ArrayRef<ParsedTriviaPiece> trailingTrivia,
+  OpaqueSyntaxNode recordToken(tok tokenKind, StringRef leadingTrivia,
+                               StringRef trailingTrivia,
                                CharSourceRange range) override {
+    auto leadingTriviaPieces = TriviaLexer::lexTrivia(leadingTrivia).Pieces;
+    auto trailingTriviaPieces = TriviaLexer::lexTrivia(trailingTrivia).Pieces;
+
     SmallVector<CTriviaPiece, 8> c_leadingTrivia, c_trailingTrivia;
-    makeCTrivia(c_leadingTrivia, leadingTrivia);
-    makeCTrivia(c_trailingTrivia, trailingTrivia);
+    makeCTrivia(c_leadingTrivia, leadingTriviaPieces);
+    makeCTrivia(c_trailingTrivia, trailingTriviaPieces);
     CRawSyntaxNode node;
     makeCRawToken(node, tokenKind, c_leadingTrivia, c_trailingTrivia,
                   range);

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -285,7 +285,7 @@ TEST_F(LexerTest, BOMNoCommentNoTrivia) {
           TriviaRetentionMode::WithoutTrivia);
   
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
@@ -293,16 +293,16 @@ TEST_F(LexerTest, BOMNoCommentNoTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::eof, Tok.getKind());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
 }
 
 TEST_F(LexerTest, BOMTokenCommentNoTrivia) {
@@ -317,7 +317,7 @@ TEST_F(LexerTest, BOMTokenCommentNoTrivia) {
           TriviaRetentionMode::WithoutTrivia);
   
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::comment, Tok.getKind());
@@ -325,8 +325,8 @@ TEST_F(LexerTest, BOMTokenCommentNoTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 3), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 3), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
@@ -334,8 +334,8 @@ TEST_F(LexerTest, BOMTokenCommentNoTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::comment, Tok.getKind());
@@ -343,8 +343,8 @@ TEST_F(LexerTest, BOMTokenCommentNoTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 18), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 18), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::comment, Tok.getKind());
@@ -352,16 +352,16 @@ TEST_F(LexerTest, BOMTokenCommentNoTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 24), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 24), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::eof, Tok.getKind());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
 }
 
 TEST_F(LexerTest, BOMAttachCommentNoTrivia) {
@@ -376,7 +376,7 @@ TEST_F(LexerTest, BOMAttachCommentNoTrivia) {
           TriviaRetentionMode::WithoutTrivia);
   
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
@@ -384,16 +384,16 @@ TEST_F(LexerTest, BOMAttachCommentNoTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 3), Tok.getCommentRange().getStart());
   ASSERT_EQ(10u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::eof, Tok.getKind());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 18), Tok.getCommentRange().getStart());
   ASSERT_EQ(13u, Tok.getCommentRange().getByteLength());
-  ASSERT_EQ((ParsedTrivia{{}}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  ASSERT_EQ(StringRef(), LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
 }
 
 TEST_F(LexerTest, BOMNoCommentTrivia) {
@@ -408,7 +408,7 @@ TEST_F(LexerTest, BOMNoCommentTrivia) {
           TriviaRetentionMode::WithTrivia);
   
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
@@ -416,26 +416,34 @@ TEST_F(LexerTest, BOMNoCommentTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
+  ASSERT_EQ("\xEF\xBB\xBF" "// comment" "\n", LeadingTrivia);
+  ASSERT_EQ(" ", TrailingTrivia);
+
+  ParsedTrivia LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  ParsedTrivia TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::GarbageText, strlen("\xEF\xBB\xBF")),
     ParsedTriviaPiece(TriviaKind::LineComment, strlen("// comment")),
     ParsedTriviaPiece(TriviaKind::Newline, 1)
-  }}), LeadingTrivia);
+  }}), LeadingTriviaPieces);
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::Space, 1)
-  }}), TrailingTrivia);
+  }}), TrailingTriviaPieces);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::eof, Tok.getKind());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getCommentRange().getStart());
   ASSERT_EQ(0u, Tok.getCommentRange().getByteLength());
+  ASSERT_EQ("//xx \n/* x */", LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
+
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::LineComment, strlen("//xx ")),
     ParsedTriviaPiece(TriviaKind::Newline, 1),
     ParsedTriviaPiece(TriviaKind::BlockComment, strlen("/* x */"))
-  }}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  }}), LeadingTriviaPieces);
 }
 
 TEST_F(LexerTest, BOMAttachCommentTrivia) {
@@ -450,7 +458,7 @@ TEST_F(LexerTest, BOMAttachCommentTrivia) {
           TriviaRetentionMode::WithTrivia);
   
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
@@ -458,26 +466,34 @@ TEST_F(LexerTest, BOMAttachCommentTrivia) {
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 14), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 3), Tok.getCommentRange().getStart());
   ASSERT_EQ(10u, Tok.getCommentRange().getByteLength());
+  ASSERT_EQ("\xEF\xBB\xBF" "// comment" "\n", LeadingTrivia);
+  ASSERT_EQ(" ", TrailingTrivia);
+
+  ParsedTrivia LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  ParsedTrivia TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::GarbageText, strlen("\xEF\xBB\xBF")),
     ParsedTriviaPiece(TriviaKind::LineComment, strlen("// comment")),
     ParsedTriviaPiece(TriviaKind::Newline, 1)
-  }}), LeadingTrivia);
+  }}), LeadingTriviaPieces);
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::Space, 1)
-  }}), TrailingTrivia);
+  }}), TrailingTriviaPieces);
   
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
   ASSERT_EQ(tok::eof, Tok.getKind());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 31), Tok.getLoc());
   ASSERT_EQ(SourceMgr.getLocForOffset(BufferID, 18), Tok.getCommentRange().getStart());
   ASSERT_EQ(13u, Tok.getCommentRange().getByteLength());
+  ASSERT_EQ("//xx \n/* x */", LeadingTrivia);
+  ASSERT_EQ(StringRef(), TrailingTrivia);
+
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::LineComment, strlen("//xx ")),
     ParsedTriviaPiece(TriviaKind::Newline, 1),
     ParsedTriviaPiece(TriviaKind::BlockComment, strlen("/* x */"))
-  }}), LeadingTrivia);
-  ASSERT_EQ((ParsedTrivia{{}}), TrailingTrivia);
+  }}), LeadingTriviaPieces);
 }
 
 TEST_F(LexerTest, RestoreBasic) {

--- a/unittests/Parse/LexerTriviaTests.cpp
+++ b/unittests/Parse/LexerTriviaTests.cpp
@@ -25,46 +25,63 @@ TEST_F(LexerTriviaTest, RestoreWithTrivia) {
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
+  ParsedTrivia LeadingTriviaPieces, TrailingTriviaPieces;
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("aaa", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia, ParsedTrivia());
-  ASSERT_EQ(TrailingTrivia,
+  ASSERT_EQ(LeadingTrivia, "");
+  ASSERT_EQ(TrailingTrivia, " ");
+  ASSERT_EQ(LeadingTriviaPieces, ParsedTrivia());
+  ASSERT_EQ(TrailingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(TriviaKind::Space, 1)}}));
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("bbb", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia,
+  ASSERT_EQ(LeadingTrivia, "\n ");
+  ASSERT_EQ(TrailingTrivia, " ");
+  ASSERT_EQ(LeadingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(TriviaKind::Newline, 1),
              ParsedTriviaPiece(TriviaKind::Space, 1)}}));
-  ASSERT_EQ(TrailingTrivia,
+  ASSERT_EQ(TrailingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(TriviaKind::Space, 1)}}));
 
   LexerState S = L.getStateForBeginningOfToken(Tok, LeadingTrivia);
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("ccc", Tok.getText());
   ASSERT_FALSE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia,
+  ASSERT_EQ(LeadingTrivia, "/*C*/");
+  ASSERT_EQ(TrailingTrivia, "");
+  ASSERT_EQ(LeadingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(
                              TriviaKind::BlockComment, strlen("/*C*/"))}}));
-  ASSERT_EQ(TrailingTrivia, ParsedTrivia());
+  ASSERT_EQ(TrailingTriviaPieces, ParsedTrivia());
 
   L.restoreState(S);
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("bbb", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia,
+  ASSERT_EQ(LeadingTrivia, "\n ");
+  ASSERT_EQ(TrailingTrivia, " ");
+  ASSERT_EQ(LeadingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(TriviaKind::Newline, 1),
                            ParsedTriviaPiece(TriviaKind::Space, 1)}}));
-  ASSERT_EQ(TrailingTrivia,
+  ASSERT_EQ(TrailingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(TriviaKind::Space, 1)}}));
 }
 
@@ -80,15 +97,21 @@ TEST_F(LexerTriviaTest, TriviaHashbang) {
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
+  ParsedTrivia LeadingTriviaPieces, TrailingTriviaPieces;
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
 
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("aaa", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia, (ParsedTrivia{{
+  ASSERT_EQ(LeadingTrivia, "#!/bin/swift\n");
+  ASSERT_EQ(TrailingTrivia, "");
+  ASSERT_EQ(LeadingTriviaPieces, (ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::GarbageText, strlen("#!/bin/swift")),
     ParsedTriviaPiece(TriviaKind::Newline, 1)}}));
+  ASSERT_EQ(TrailingTriviaPieces, ParsedTrivia());
 }
 
 TEST_F(LexerTriviaTest, TriviaHashbangAfterBOM) {
@@ -103,17 +126,23 @@ TEST_F(LexerTriviaTest, TriviaHashbangAfterBOM) {
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
+  ParsedTrivia LeadingTriviaPieces, TrailingTriviaPieces;
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
 
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("aaa", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
 
-  ASSERT_EQ(LeadingTrivia, (ParsedTrivia{{
+  ASSERT_EQ(LeadingTrivia, "\xEF\xBB\xBF" "#!/bin/swift\n");
+  ASSERT_EQ(TrailingTrivia, "");
+  ASSERT_EQ(LeadingTriviaPieces, (ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::GarbageText, strlen("\xEF\xBB\xBF")),
     ParsedTriviaPiece(TriviaKind::GarbageText, strlen("#!/bin/swift")),
     ParsedTriviaPiece(TriviaKind::Newline, 1)}}));
+  ASSERT_EQ(TrailingTriviaPieces, ParsedTrivia());
 }
 
 TEST_F(LexerTriviaTest, TriviaConflictMarker) {
@@ -136,13 +165,18 @@ TEST_F(LexerTriviaTest, TriviaConflictMarker) {
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
+  ParsedTrivia LeadingTriviaPieces, TrailingTriviaPieces;
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("aaa", Tok.getText());
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("bbb", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
@@ -152,10 +186,13 @@ TEST_F(LexerTriviaTest, TriviaConflictMarker) {
       "=======\n"
       "old\n"
       ">>>>>>> 18844bc65229786b96b89a9fc7739c0f:conflict_markers.swift";
-  ASSERT_EQ(LeadingTrivia, (ParsedTrivia{{
+  ASSERT_EQ(LeadingTrivia, ("\n" + expectedTrivia + "\n").str());
+  ASSERT_EQ(TrailingTrivia, "");
+  ASSERT_EQ(LeadingTriviaPieces, (ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::Newline, 1),
     ParsedTriviaPiece(TriviaKind::GarbageText, expectedTrivia.size()),
     ParsedTriviaPiece(TriviaKind::Newline, 1)}}));
+  ASSERT_EQ(TrailingTriviaPieces, ParsedTrivia());
 }
 
 TEST_F(LexerTriviaTest, TriviaCarriageReturn) {
@@ -171,29 +208,42 @@ TEST_F(LexerTriviaTest, TriviaCarriageReturn) {
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
+  ParsedTrivia LeadingTriviaPieces, TrailingTriviaPieces;
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("aaa", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia, ParsedTrivia());
-  ASSERT_EQ(TrailingTrivia, ParsedTrivia());
+  ASSERT_EQ(LeadingTrivia, "");
+  ASSERT_EQ(TrailingTrivia, "");
+  ASSERT_EQ(LeadingTriviaPieces, ParsedTrivia());
+  ASSERT_EQ(TrailingTriviaPieces, ParsedTrivia());
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("bbb", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia,
+  ASSERT_EQ(LeadingTrivia, "\r\r");
+  ASSERT_EQ(TrailingTrivia, "");
+  ASSERT_EQ(LeadingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(TriviaKind::CarriageReturn, 2)}}));
-  ASSERT_EQ(TrailingTrivia, ParsedTrivia());
+  ASSERT_EQ(TrailingTriviaPieces, ParsedTrivia());
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::eof, Tok.getKind());
   ASSERT_TRUE(Tok.isAtStartOfLine());
-  ASSERT_EQ(LeadingTrivia,
+  ASSERT_EQ(LeadingTrivia, "\r");
+  ASSERT_EQ(TrailingTrivia, "");
+  ASSERT_EQ(LeadingTriviaPieces,
             (ParsedTrivia{{ParsedTriviaPiece(TriviaKind::CarriageReturn, 1)}}));
-  ASSERT_EQ(TrailingTrivia, ParsedTrivia());
+  ASSERT_EQ(TrailingTriviaPieces, ParsedTrivia());
 }
 
 TEST_F(LexerTriviaTest, TriviaNewLines) {
@@ -213,12 +263,17 @@ TEST_F(LexerTriviaTest, TriviaNewLines) {
           TriviaRetentionMode::WithTrivia);
 
   Token Tok;
-  ParsedTrivia LeadingTrivia, TrailingTrivia;
+  StringRef LeadingTrivia, TrailingTrivia;
+  ParsedTrivia LeadingTriviaPieces, TrailingTriviaPieces;
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("aaa", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, "\n\r\r\n\r\r\r\n\r\n\n\n");
+  ASSERT_EQ(TrailingTrivia, "");
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::Newline, 1),
     ParsedTriviaPiece(TriviaKind::CarriageReturn, 1),
@@ -226,13 +281,17 @@ TEST_F(LexerTriviaTest, TriviaNewLines) {
     ParsedTriviaPiece(TriviaKind::CarriageReturn, 2),
     ParsedTriviaPiece(TriviaKind::CarriageReturnLineFeed, 4),
     ParsedTriviaPiece(TriviaKind::Newline, 2),
-  }}), LeadingTrivia);
-  ASSERT_EQ(ParsedTrivia(), TrailingTrivia);
+  }}), LeadingTriviaPieces);
+  ASSERT_EQ(ParsedTrivia(), TrailingTriviaPieces);
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::identifier, Tok.getKind());
   ASSERT_EQ("bbb", Tok.getText());
   ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, "\n\r\r\n\r\r\r\n\r\n\n\n");
+  ASSERT_EQ(TrailingTrivia, "");
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::Newline, 1),
     ParsedTriviaPiece(TriviaKind::CarriageReturn, 1),
@@ -240,12 +299,16 @@ TEST_F(LexerTriviaTest, TriviaNewLines) {
     ParsedTriviaPiece(TriviaKind::CarriageReturn, 2),
     ParsedTriviaPiece(TriviaKind::CarriageReturnLineFeed, 4),
     ParsedTriviaPiece(TriviaKind::Newline, 2),
-  }}), LeadingTrivia);
-  ASSERT_EQ(ParsedTrivia(), TrailingTrivia);
+  }}), LeadingTriviaPieces);
+  ASSERT_EQ(ParsedTrivia(), TrailingTriviaPieces);
 
   L.lex(Tok, LeadingTrivia, TrailingTrivia);
+  LeadingTriviaPieces = TriviaLexer::lexTrivia(LeadingTrivia);
+  TrailingTriviaPieces = TriviaLexer::lexTrivia(TrailingTrivia);
   ASSERT_EQ(tok::eof, Tok.getKind());
   ASSERT_TRUE(Tok.isAtStartOfLine());
+  ASSERT_EQ(LeadingTrivia, "\n\r\r\n\r\r\r\n\r\n\n\n");
+  ASSERT_EQ(TrailingTrivia, "");
   ASSERT_EQ((ParsedTrivia{{
     ParsedTriviaPiece(TriviaKind::Newline, 1),
     ParsedTriviaPiece(TriviaKind::CarriageReturn, 1),
@@ -253,6 +316,6 @@ TEST_F(LexerTriviaTest, TriviaNewLines) {
     ParsedTriviaPiece(TriviaKind::CarriageReturn, 2),
     ParsedTriviaPiece(TriviaKind::CarriageReturnLineFeed, 4),
     ParsedTriviaPiece(TriviaKind::Newline, 2),
-  }}), LeadingTrivia);
-  ASSERT_EQ(ParsedTrivia(), TrailingTrivia);
+  }}), LeadingTriviaPieces);
+  ASSERT_EQ(ParsedTrivia(), TrailingTriviaPieces);
 }

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -13,10 +13,10 @@ using namespace swift::syntax;
 #pragma mark - declaration-modifier
 
 DeclModifierSyntax getCannedDeclModifier() {
-  auto Private = SyntaxFactory::makeIdentifier("private", {}, {});
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto Set = SyntaxFactory::makeIdentifier("set", {}, {});
-  auto RParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto Private = SyntaxFactory::makeIdentifier("private", "", "");
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
+  auto Set = SyntaxFactory::makeIdentifier("set", "", "");
+  auto RParen = SyntaxFactory::makeRightParenToken("", "");
   return SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen);
 }
 
@@ -36,10 +36,10 @@ TEST(DeclSyntaxTests, DeclModifierMakeAPIs) {
 }
 
 TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
-  auto Private = SyntaxFactory::makeIdentifier("private", {}, {});
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto Set = SyntaxFactory::makeIdentifier("set", {}, {});
-  auto RParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto Private = SyntaxFactory::makeIdentifier("private", "", "");
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
+  auto Set = SyntaxFactory::makeIdentifier("set", "", "");
+  auto RParen = SyntaxFactory::makeRightParenToken("", "");
   auto Mod = SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen);
 
   ASSERT_EQ(Private.getRaw(), Mod.getName().getRaw());
@@ -49,10 +49,10 @@ TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
 }
 
 TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
-  auto Private = SyntaxFactory::makeIdentifier("private", {}, {});
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto Set = SyntaxFactory::makeIdentifier("set", {}, {});
-  auto RParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto Private = SyntaxFactory::makeIdentifier("private", "", "");
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
+  auto Set = SyntaxFactory::makeIdentifier("set", "", "");
+  auto RParen = SyntaxFactory::makeRightParenToken("", "");
 
   SmallString<24> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
@@ -77,30 +77,30 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
   {
     SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Typealias =
-      SyntaxFactory::makeTypealiasKeyword({}, { Trivia::spaces(1) });
-    auto Subsequence = SyntaxFactory::makeIdentifier("MyCollection", {}, {});
-    auto ElementName = SyntaxFactory::makeIdentifier("Element", {}, {});
+    auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ");
+    auto Subsequence = SyntaxFactory::makeIdentifier("MyCollection", "", "");
+    auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "");
     auto ElementParam =
       SyntaxFactory::makeGenericParameter(None, ElementName, None, None, None);
-    auto LeftAngle = SyntaxFactory::makeLeftAngleToken({}, {});
-    auto RightAngle = SyntaxFactory::makeRightAngleToken({}, Trivia::spaces(1));
+    auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "");
+    auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ");
     auto GenericParams = GenericParameterClauseSyntaxBuilder()
       .useLeftAngleBracket(LeftAngle)
       .useRightAngleBracket(RightAngle)
       .addGenericParameter(ElementParam)
       .build();
-    auto Assignment = SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
-    auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
+    auto Assignment = SyntaxFactory::makeEqualToken("", " ");
+    auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", "", "");
     auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
 
-    auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
-      .useLeftAngleBracket(LeftAngle)
-      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-      .addArgument(ElementArg)
-      .build();
+    auto GenericArgs =
+        GenericArgumentClauseSyntaxBuilder()
+            .useLeftAngleBracket(LeftAngle)
+            .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+            .addArgument(ElementArg)
+            .build();
 
-    auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
+    auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
     auto Array_Int =
         SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
     auto TypeInit = SyntaxFactory::makeTypeInitializerClause(Assignment,
@@ -114,31 +114,30 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
 }
 
 TEST(DeclSyntaxTests, TypealiasWithAPIs) {
-  auto Typealias =
-    SyntaxFactory::makeTypealiasKeyword({}, { Trivia::spaces(1) });
-  auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", {}, {});
-  auto ElementName = SyntaxFactory::makeIdentifier("Element", {}, {});
+  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ");
+  auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", "", "");
+  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "");
   auto ElementParam =
       SyntaxFactory::makeGenericParameter(None, ElementName, None, None, None);
-  auto LeftAngle = SyntaxFactory::makeLeftAngleToken({}, {});
-  auto RightAngle =
-    SyntaxFactory::makeRightAngleToken({}, { Trivia::spaces(1) });
+  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "");
+  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ");
   auto GenericParams = GenericParameterClauseSyntaxBuilder()
     .useLeftAngleBracket(LeftAngle)
     .useRightAngleBracket(RightAngle)
     .addGenericParameter(ElementParam)
     .build();
-  auto Equal = SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
+  auto Equal = SyntaxFactory::makeEqualToken("", " ");
 
-  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {} , {});
+  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", "", "");
   auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
-  auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
-    .useLeftAngleBracket(LeftAngle)
-    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgument(ElementArg)
-    .build();
+  auto GenericArgs =
+      GenericArgumentClauseSyntaxBuilder()
+          .useLeftAngleBracket(LeftAngle)
+          .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+          .addArgument(ElementArg)
+          .build();
 
-  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
   auto Array_Int = SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
   auto Type_Init = SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int);
   {
@@ -159,32 +158,30 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
   SmallString<64> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto Typealias =
-    SyntaxFactory::makeTypealiasKeyword({}, { Trivia::spaces(1) });
-  auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", {}, {});
-  auto ElementName = SyntaxFactory::makeIdentifier("Element", {}, {});
+  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ");
+  auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", "", "");
+  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "");
   auto ElementParam = SyntaxFactory::makeGenericParameter(ElementName, None);
-  auto LeftAngle = SyntaxFactory::makeLeftAngleToken({}, {});
-  auto RightAngle =
-    SyntaxFactory::makeRightAngleToken({}, { Trivia::spaces(1) });
+  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "");
+  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ");
   auto GenericParams = GenericParameterClauseSyntaxBuilder()
     .useLeftAngleBracket(LeftAngle)
     .useRightAngleBracket(RightAngle)
     .addGenericParameter(ElementParam)
     .build();
-  auto Equal =
-    SyntaxFactory::makeEqualToken({}, { Trivia::spaces(1) });
+  auto Equal = SyntaxFactory::makeEqualToken("", " ");
 
-  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", {}, {});
+  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", "", "");
   auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
 
-  auto GenericArgs = GenericArgumentClauseSyntaxBuilder()
-    .useLeftAngleBracket(LeftAngle)
-    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgument(ElementArg)
-    .build();
+  auto GenericArgs =
+      GenericArgumentClauseSyntaxBuilder()
+          .useLeftAngleBracket(LeftAngle)
+          .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+          .addArgument(ElementArg)
+          .build();
 
-  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
   auto Array_Int = SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
   auto Type_Init = SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int);
   TypealiasDeclSyntaxBuilder()
@@ -201,21 +198,19 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
 #pragma mark - parameter
 
 FunctionParameterSyntax getCannedFunctionParameter() {
-  auto ExternalName = SyntaxFactory::makeIdentifier("with", {},
-                                                    Trivia::spaces(1));
-  auto LocalName = SyntaxFactory::makeIdentifier("radius", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {},
-                                               Trivia::spaces(1));
+  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ");
+  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
   auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...");
-  auto Equal = SyntaxFactory::makeEqualToken({}, Trivia::spaces(1));
+  auto Equal = SyntaxFactory::makeEqualToken("", " ");
 
-  auto Sign = SyntaxFactory::makePrefixOperator("-", {}, {});
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
+  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "");
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
   auto One = SyntaxFactory::makePrefixOperatorExpr(Sign,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
   auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
 
   return SyntaxFactory::makeFunctionParameter(None, ExternalName, LocalName,
                                               Colon, Int, NoEllipsis,
@@ -238,21 +233,19 @@ TEST(DeclSyntaxTests, FunctionParameterMakeAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
-  auto ExternalName = SyntaxFactory::makeIdentifier("with", {},
-                                                    Trivia::spaces(1));
-  auto LocalName = SyntaxFactory::makeIdentifier("radius", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {},
-                                               Trivia::spaces(1));
+  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ");
+  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
   auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...");
-  auto Equal = SyntaxFactory::makeEqualToken({}, Trivia::spaces(1));
+  auto Equal = SyntaxFactory::makeEqualToken("", " ");
 
-  auto Sign = SyntaxFactory::makePrefixOperator("-", {}, {});
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
+  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "");
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
   auto One = SyntaxFactory::makePrefixOperatorExpr(Sign,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
   auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
-  auto Comma = SyntaxFactory::makeCommaToken({}, {});
+  auto Comma = SyntaxFactory::makeCommaToken("", "");
 
   auto Param = SyntaxFactory::makeFunctionParameter(None, ExternalName,
                                                     LocalName, Colon, Int,
@@ -285,20 +278,17 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
-  auto ExternalName = SyntaxFactory::makeIdentifier("for", {},
-                                                    Trivia::spaces(1));
-  auto LocalName = SyntaxFactory::makeIdentifier("integer", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken(Trivia::spaces(1),
-                                             Trivia::spaces(1));
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {},
-                                               Trivia::spaces(1));
-  auto Equal = SyntaxFactory::makeEqualToken({}, Trivia::spaces(1));
+  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ");
+  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "");
+  auto Colon = SyntaxFactory::makeColonToken(" ", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
+  auto Equal = SyntaxFactory::makeEqualToken("", " ");
 
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
   auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
   auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
-  auto Comma = SyntaxFactory::makeCommaToken({}, {});
+  auto Comma = SyntaxFactory::makeCommaToken("", "");
 
   {
     SmallString<48> Scratch;
@@ -325,21 +315,17 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionParameterWithEllipsis) {
-    auto ExternalName = SyntaxFactory::makeIdentifier("for", {},
-                                                      Trivia::spaces(1));
-    auto LocalName = SyntaxFactory::makeIdentifier("integer", {}, {});
-    auto Colon = SyntaxFactory::makeColonToken(Trivia::spaces(1),
-                                               Trivia::spaces(1));
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", {},
-                                                 Trivia::spaces(0));
-    auto Ellipsis = SyntaxFactory::makeEllipsisToken({},
-                                                     Trivia::spaces(1));
-    auto Comma = SyntaxFactory::makeCommaToken({}, {});
-    
-    {
-        SmallString<48> Scratch;
-        llvm::raw_svector_ostream OS(Scratch);
-        getCannedFunctionParameter()
+  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ");
+  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "");
+  auto Colon = SyntaxFactory::makeColonToken(" ", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+  auto Ellipsis = SyntaxFactory::makeEllipsisToken("", " ");
+  auto Comma = SyntaxFactory::makeCommaToken("", "");
+
+  {
+    SmallString<48> Scratch;
+    llvm::raw_svector_ostream OS(Scratch);
+    getCannedFunctionParameter()
         .withFirstName(ExternalName)
         .withSecondName(LocalName)
         .withColon(Colon)
@@ -348,8 +334,8 @@ TEST(DeclSyntaxTests, FunctionParameterWithEllipsis) {
         .withDefaultArgument(llvm::None)
         .withTrailingComma(Comma)
         .print(OS);
-        ASSERT_EQ(OS.str().str(), "for integer : Int... ,");
-    }
+    ASSERT_EQ(OS.str().str(), "for integer : Int... ,");
+  }
 }
 
 #pragma mark - parameter-list
@@ -375,18 +361,18 @@ TEST(DeclSyntaxTests, FunctionParameterListMakeAPIs) {
 #pragma mark - function-signature
 
 FunctionSignatureSyntax getCannedFunctionSignature() {
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
   auto Param = getCannedFunctionParameter();
   auto List = SyntaxFactory::makeBlankFunctionParameterList()
     .appending(Param)
     .appending(Param)
     .appending(Param)
     .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken({}, Trivia::spaces(1));
+  auto RParen = SyntaxFactory::makeRightParenToken("", " ");
   auto Parameter = SyntaxFactory::makeParameterClause(LParen, List, RParen);
-  auto Throws = SyntaxFactory::makeThrowsKeyword({}, Trivia::spaces(1));
-  auto Arrow = SyntaxFactory::makeArrowToken({}, Trivia::spaces(1));
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, Trivia::spaces(1));
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
   auto Return = SyntaxFactory::makeReturnClause(Arrow, Int);
 
   return SyntaxFactory::makeFunctionSignature(Parameter, None, Throws, Return);
@@ -411,18 +397,18 @@ TEST(DeclSyntaxTests, FunctionSignatureMakeAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
   auto Param = getCannedFunctionParameter();
   auto List = SyntaxFactory::makeBlankFunctionParameterList()
     .appending(Param)
     .appending(Param)
     .appending(Param)
     .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken({}, Trivia::spaces(1));
-  auto Throws = SyntaxFactory::makeThrowsKeyword({}, Trivia::spaces(1));
-  auto Arrow = SyntaxFactory::makeArrowToken({}, Trivia::spaces(1));
+  auto RParen = SyntaxFactory::makeRightParenToken("", " ");
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
 
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
 
   auto Sig = SyntaxFactory::makeFunctionSignature(
     SyntaxFactory::makeParameterClause(LParen, List, RParen),
@@ -461,17 +447,17 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
   auto Param = getCannedFunctionParameter();
   auto List = SyntaxFactory::makeBlankFunctionParameterList()
     .appending(Param)
     .appending(Param)
     .appending(Param)
     .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken({}, Trivia::spaces(1));
-  auto Throws = SyntaxFactory::makeThrowsKeyword({}, Trivia::spaces(1));
-  auto Arrow = SyntaxFactory::makeArrowToken({}, Trivia::spaces(1));
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+  auto RParen = SyntaxFactory::makeRightParenToken("", " ");
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
 
   auto Parameter = SyntaxFactory::makeParameterClause(LParen, List, RParen);
   auto Return = SyntaxFactory::makeReturnClause(Arrow, Int);
@@ -491,14 +477,14 @@ TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
 #pragma mark - function-declaration
 
 ModifierListSyntax getCannedModifiers() {
-  auto PublicID = SyntaxFactory::makePublicKeyword({}, Trivia::spaces(1));
+  auto PublicID = SyntaxFactory::makePublicKeyword("", " ");
   auto NoLParen = TokenSyntax::missingToken(tok::l_paren, "(");
   auto NoArgument = TokenSyntax::missingToken(tok::identifier, "");
   auto NoRParen = TokenSyntax::missingToken(tok::r_paren, ")");
   auto Public =
       SyntaxFactory::makeDeclModifier(PublicID, NoLParen, NoArgument, NoRParen);
 
-  auto StaticKW = SyntaxFactory::makeStaticKeyword({}, Trivia::spaces(1));
+  auto StaticKW = SyntaxFactory::makeStaticKeyword("", " ");
   auto Static =
       SyntaxFactory::makeDeclModifier(StaticKW, NoLParen, NoArgument, NoRParen);
 
@@ -510,12 +496,12 @@ ModifierListSyntax getCannedModifiers() {
 GenericParameterClauseSyntax getCannedGenericParams() {
   GenericParameterClauseSyntaxBuilder GB;
 
-  auto LAngle = SyntaxFactory::makeLeftAngleToken({}, {});
-  auto RAngle = SyntaxFactory::makeRightAngleToken({}, {});
-  auto TType = SyntaxFactory::makeIdentifier("T", {}, {});
-  auto UType = SyntaxFactory::makeIdentifier("U", {}, {});
+  auto LAngle = SyntaxFactory::makeLeftAngleToken("", "");
+  auto RAngle = SyntaxFactory::makeRightAngleToken("", "");
+  auto TType = SyntaxFactory::makeIdentifier("T", "", "");
+  auto UType = SyntaxFactory::makeIdentifier("U", "", "");
 
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
   auto T = SyntaxFactory::makeGenericParameter(TType, Comma);
   auto U = SyntaxFactory::makeGenericParameter(UType, None);
 
@@ -529,27 +515,25 @@ GenericParameterClauseSyntax getCannedGenericParams() {
 
 CodeBlockSyntax getCannedBody() {
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "-");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
   auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
-  auto ReturnKW =
-    SyntaxFactory::makeReturnKeyword(Trivia::newlines(1) + Trivia::spaces(2),
-                                     {});
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("\n  ", "");
   auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, One);
   auto ReturnItem = SyntaxFactory::makeCodeBlockItem(Return, None, None);
 
   auto Stmts = SyntaxFactory::makeCodeBlockItemList({ReturnItem});
 
-  auto LBrace = SyntaxFactory::makeLeftBraceToken({}, {});
-  auto RBrace = SyntaxFactory::makeRightBraceToken(Trivia::newlines(1), {});
+  auto LBrace = SyntaxFactory::makeLeftBraceToken("", "");
+  auto RBrace = SyntaxFactory::makeRightBraceToken("\n", "");
 
   return SyntaxFactory::makeCodeBlock(LBrace, Stmts, RBrace);
 }
 
 GenericWhereClauseSyntax getCannedWhereClause() {
-  auto WhereKW = SyntaxFactory::makeWhereKeyword({}, Trivia::spaces(1));
-  auto T = SyntaxFactory::makeTypeIdentifier("T", {}, Trivia::spaces(1));
-  auto EqualEqual = SyntaxFactory::makeEqualityOperator({}, Trivia::spaces(1));
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, Trivia::spaces(1));
+  auto WhereKW = SyntaxFactory::makeWhereKeyword("", " ");
+  auto T = SyntaxFactory::makeTypeIdentifier("T", "", " ");
+  auto EqualEqual = SyntaxFactory::makeEqualityOperator("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
   auto SameType = SyntaxFactory::makeSameTypeRequirement(T, EqualEqual, Int);
   auto Req = SyntaxFactory::makeGenericRequirement(SameType, None);
 
@@ -563,8 +547,8 @@ GenericWhereClauseSyntax getCannedWhereClause() {
 
 FunctionDeclSyntax getCannedFunctionDecl() {
   auto NoAttributes = SyntaxFactory::makeBlankAttributeList();
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-  auto FuncKW = SyntaxFactory::makeFuncKeyword({}, Trivia::spaces(1));
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+  auto FuncKW = SyntaxFactory::makeFuncKeyword("", " ");
   auto Modifiers = getCannedModifiers();
   auto GenericParams = getCannedGenericParams();
   auto GenericWhere = getCannedWhereClause();

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -10,8 +10,8 @@ using namespace swift::syntax;
 
 TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   {
-    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("100", {}, {});
-    auto Sign = SyntaxFactory::makePrefixOperator("-", {}, {});
+    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("100", "", "");
+    auto Sign = SyntaxFactory::makePrefixOperator("-", "", "");
     auto Literal = SyntaxFactory::makePrefixOperatorExpr(Sign,
       SyntaxFactory::makeIntegerLiteralExpr(LiteralToken));
 
@@ -22,7 +22,7 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(Literal.getKind(), SyntaxKind::PrefixOperatorExpr);
   }
   {
-    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("1_000", {}, {});
+    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("1_000", "", "");
     auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
     auto Literal = SyntaxFactory::makeIntegerLiteralExpr(LiteralToken);
 
@@ -32,10 +32,11 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(OS.str().str(), "1_000");
   }
   {
-    auto Literal = SyntaxFactory::makeBlankPrefixOperatorExpr()
-    .withOperatorToken(TokenSyntax::missingToken(tok::oper_prefix, ""))
-    .withPostfixExpression(SyntaxFactory::makeIntegerLiteralExpr(
-      SyntaxFactory::makeIntegerLiteral("0", {}, { Trivia::spaces(4) })));
+    auto Literal =
+        SyntaxFactory::makeBlankPrefixOperatorExpr()
+            .withOperatorToken(TokenSyntax::missingToken(tok::oper_prefix, ""))
+            .withPostfixExpression(SyntaxFactory::makeIntegerLiteralExpr(
+                SyntaxFactory::makeIntegerLiteral("0", "", "    ")));
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -44,8 +45,8 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   }
   {
     auto LiteralToken =
-      SyntaxFactory::makeIntegerLiteral("1_000_000_000_000", {}, {});
-    auto PlusSign = SyntaxFactory::makePrefixOperator("+", {}, {});
+        SyntaxFactory::makeIntegerLiteral("1_000_000_000_000", "", "");
+    auto PlusSign = SyntaxFactory::makePrefixOperator("+", "", "");
     auto OneThousand = SyntaxFactory::makePrefixOperatorExpr(PlusSign,
       SyntaxFactory::makeIntegerLiteralExpr(LiteralToken));
 
@@ -60,15 +61,14 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
   {
-    auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
-    auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
+    auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
+    auto Int = SyntaxFactory::makeIdentifier("Int", "", "");
     auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
     auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
     GenericArgumentClauseSyntaxBuilder ArgBuilder;
-    ArgBuilder
-      .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
-      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-      .addArgument(GenericArg);
+    ArgBuilder.useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", ""))
+        .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+        .addArgument(GenericArg);
 
     auto GenericArgs = ArgBuilder.build();
 
@@ -90,15 +90,14 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
 }
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
-  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
-  auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
+  auto Int = SyntaxFactory::makeIdentifier("Int", "", "");
   auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
   auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder;
-  ArgBuilder
-    .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
-    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgument(GenericArg);
+  ArgBuilder.useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", ""))
+      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+      .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
@@ -109,7 +108,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
   }
 
   {
-    auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     auto BlankArgs = SyntaxFactory::makeBlankGenericArgumentClause();
@@ -127,15 +126,14 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
 }
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
-  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
-  auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
+  auto Int = SyntaxFactory::makeIdentifier("Int", "", "");
   auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
   auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder;
-  ArgBuilder
-    .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
-    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgument(GenericArg);
+  ArgBuilder.useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", ""))
+      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+      .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
@@ -168,11 +166,11 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
 #pragma mark - function-call-argument
 
 TEST(ExprSyntaxTests, TupleExprElementGetAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto X = SyntaxFactory::makeIdentifier("x", "", "");
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
 
   {
     auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
@@ -194,11 +192,11 @@ TEST(ExprSyntaxTests, TupleExprElementGetAPIs) {
 }
 
 TEST(ExprSyntaxTests, TupleExprElementMakeAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto X = SyntaxFactory::makeIdentifier("x", "", "");
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
 
   {
     llvm::SmallString<48> Scratch;
@@ -225,11 +223,11 @@ TEST(ExprSyntaxTests, TupleExprElementMakeAPIs) {
 }
 
 TEST(ExprSyntaxTests, TupleExprElementWithAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto X = SyntaxFactory::makeIdentifier("x", "", "");
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
 
   {
     llvm::SmallString<48> Scratch;
@@ -248,13 +246,13 @@ TEST(ExprSyntaxTests, TupleExprElementWithAPIs) {
 
 namespace {
 TupleExprElementListSyntax getFullArgumentList() {
-  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
-  auto Y = SyntaxFactory::makeIdentifier("y", {}, {});
-  auto Z = SyntaxFactory::makeIdentifier("z", {}, {});
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto X = SyntaxFactory::makeIdentifier("x", "", "");
+  auto Y = SyntaxFactory::makeIdentifier("y", "", "");
+  auto Z = SyntaxFactory::makeIdentifier("z", "", "");
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
 
   auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
@@ -269,13 +267,13 @@ TupleExprElementListSyntax getFullArgumentList() {
 
 TupleExprElementListSyntax getLabellessArgumentList() {
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
-  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", {}, {});
-  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", {}, {});
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
+  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "");
+  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "");
   auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
   auto NoLabel = TokenSyntax::missingToken(tok::identifier, "");
   auto NoColon = TokenSyntax::missingToken(tok::colon, ":");
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
   auto Two = SyntaxFactory::makeIntegerLiteralExpr(TwoDigits);
   auto Three = SyntaxFactory::makeIntegerLiteralExpr(ThreeDigits);
@@ -296,13 +294,13 @@ TupleExprElementListSyntax getLabellessArgumentList() {
 } // end anonymous namespace
 
 TEST(ExprSyntaxTests, TupleExprElementListGetAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
-  auto Y = SyntaxFactory::makeIdentifier("y", {}, {});
-  auto Z = SyntaxFactory::makeIdentifier("z", {}, {});
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto X = SyntaxFactory::makeIdentifier("x", "", "");
+  auto Y = SyntaxFactory::makeIdentifier("y", "", "");
+  auto Z = SyntaxFactory::makeIdentifier("z", "", "");
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
 
   auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
@@ -355,14 +353,14 @@ TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
     ASSERT_EQ(OS.str().str(), "");
   }
   {
-    auto X = SyntaxFactory::makeIdentifier("x", {}, {});
-    auto Y = SyntaxFactory::makeIdentifier("y", {}, {});
-    auto Z = SyntaxFactory::makeIdentifier("z", {}, {});
-    auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-    auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+    auto X = SyntaxFactory::makeIdentifier("x", "", "");
+    auto Y = SyntaxFactory::makeIdentifier("y", "", "");
+    auto Z = SyntaxFactory::makeIdentifier("z", "", "");
+    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+    auto Colon = SyntaxFactory::makeColonToken("", " ");
     auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo,
                                                                 llvm::None);
-    auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+    auto Comma = SyntaxFactory::makeCommaToken("", " ");
     auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
 
     auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
@@ -394,11 +392,11 @@ TEST(ExprSyntaxTests, TupleExprElementListWithAPIs) {
 #pragma mark - function-call-expression
 
 TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList();
-  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
 
   auto Call = SyntaxFactory::makeFunctionCallExpr(
       SymbolicRef, LeftParen, ArgList, RightParen, None, None);
@@ -428,11 +426,11 @@ TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
 }
 
 TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList();
-  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
 
   {
     auto Call = SyntaxFactory::makeFunctionCallExpr(
@@ -452,11 +450,11 @@ TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
 }
 
 TEST(ExprSyntaxTests, FunctionCallExprWithAPIs) {
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList();
-  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
 
   {
     llvm::SmallString<64> Scratch;
@@ -491,8 +489,8 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
     ASSERT_EQ(OS.str().str(), "");
   }
 
-  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
 
   {
     llvm::SmallString<64> Scratch;
@@ -504,15 +502,15 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
   }
 
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
-  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", {}, {});
-  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", {}, {});
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
+  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "");
+  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "");
   auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
   auto NoLabel = TokenSyntax::missingToken(tok::identifier, "");
   auto NoColon = TokenSyntax::missingToken(tok::colon, ":");
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
 
   {

--- a/unittests/Syntax/StmtSyntaxTests.cpp
+++ b/unittests/Syntax/StmtSyntaxTests.cpp
@@ -11,7 +11,7 @@ TEST(StmtSyntaxTests, FallthroughStmtGetAPIs) {
   llvm::SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword({}, {});
+  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "");
 
   auto Fallthrough = SyntaxFactory::makeBlankFallthroughStmt()
     .withFallthroughKeyword(FallthroughKW);
@@ -25,7 +25,7 @@ TEST(StmtSyntaxTests, FallthroughStmtWithAPIs) {
   llvm::SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword({}, {});
+  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "");
 
   SyntaxFactory::makeBlankFallthroughStmt()
     .withFallthroughKeyword(FallthroughKW)
@@ -35,7 +35,7 @@ TEST(StmtSyntaxTests, FallthroughStmtWithAPIs) {
 }
 
 TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword({}, {});
+  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "");
 
   {
     llvm::SmallString<48> Scratch;
@@ -49,7 +49,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto NewFallthroughKW = FallthroughKW.withLeadingTrivia(Trivia::spaces(2));
+    auto NewFallthroughKW = FallthroughKW.withLeadingTrivia("  ");
 
     SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough");
@@ -59,8 +59,8 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto NewFallthroughKW = FallthroughKW.withLeadingTrivia(Trivia::spaces(2))
-                                         .withTrailingTrivia(Trivia::spaces(2));
+    auto NewFallthroughKW =
+        FallthroughKW.withLeadingTrivia("  ").withTrailingTrivia("  ");
 
     SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough  ");
@@ -78,8 +78,8 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 #pragma mark - break-statement
 
 TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
-  auto BreakKW = SyntaxFactory::makeBreakKeyword({}, Trivia::spaces(1));
-  auto Label = SyntaxFactory::makeIdentifier("sometimesYouNeedTo", {}, {});
+  auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ");
+  auto Label = SyntaxFactory::makeIdentifier("sometimesYouNeedTo", "", "");
   auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label);
 
   /// These should be directly shared through reference-counting.
@@ -88,8 +88,8 @@ TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
 }
 
 TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
-  auto BreakKW = SyntaxFactory::makeBreakKeyword({}, {});
-  auto Label = SyntaxFactory::makeIdentifier("theRules", {}, {});
+  auto BreakKW = SyntaxFactory::makeBreakKeyword("", "");
+  auto Label = SyntaxFactory::makeIdentifier("theRules", "", "");
 
   auto Break = SyntaxFactory::makeBlankBreakStmt();
 
@@ -115,9 +115,9 @@ TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    Break.withBreakKeyword(BreakKW.withTrailingTrivia(Trivia::spaces(1)))
-      .withLabel(Label)
-      .print(OS);
+    Break.withBreakKeyword(BreakKW.withTrailingTrivia(" "))
+        .withLabel(Label)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "break theRules"); // sometimes
   }
 }
@@ -126,8 +126,8 @@ TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto BreakKW = SyntaxFactory::makeBreakKeyword({}, Trivia::spaces(1));
-    auto Label = SyntaxFactory::makeIdentifier("theBuild", {}, {});
+    auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ");
+    auto Label = SyntaxFactory::makeIdentifier("theBuild", "", "");
     auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label);
     Break.print(OS);
     ASSERT_EQ(OS.str().str(), "break theBuild"); // don't you dare
@@ -143,8 +143,8 @@ TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
 #pragma mark - continue-statement
 
 TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
-  auto ContinueKW = SyntaxFactory::makeContinueKeyword({}, Trivia::spaces(1));
-  auto Label = SyntaxFactory::makeIdentifier("always", {}, {});
+  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ");
+  auto Label = SyntaxFactory::makeIdentifier("always", "", "");
   auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label);
 
   /// These should be directly shared through reference-counting.
@@ -153,8 +153,8 @@ TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
 }
 
 TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
-  auto ContinueKW = SyntaxFactory::makeContinueKeyword({}, {});
-  auto Label = SyntaxFactory::makeIdentifier("toCare", {}, {});
+  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", "");
+  auto Label = SyntaxFactory::makeIdentifier("toCare", "", "");
   auto Continue = SyntaxFactory::makeBlankContinueStmt();
 
   {
@@ -179,10 +179,9 @@ TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    Continue
-      .withContinueKeyword(ContinueKW.withTrailingTrivia(Trivia::spaces(1)))
-      .withLabel(Label)
-      .print(OS);
+    Continue.withContinueKeyword(ContinueKW.withTrailingTrivia(" "))
+        .withLabel(Label)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "continue toCare"); // for each other
   }
 }
@@ -191,8 +190,8 @@ TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto ContinueKW = SyntaxFactory::makeContinueKeyword({}, Trivia::spaces(1));
-    auto Label = SyntaxFactory::makeIdentifier("toLead", {}, {});
+    auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ");
+    auto Label = SyntaxFactory::makeIdentifier("toLead", "", "");
     auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label);
     Continue.print(OS);
     ASSERT_EQ(OS.str().str(), "continue toLead"); // by example
@@ -208,9 +207,9 @@ TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
 #pragma mark - return-statement
 
 TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
-  auto Minus = SyntaxFactory::makePrefixOperator("-", {}, {});
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ");
+  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "");
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
   auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(Minus,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
 
@@ -230,9 +229,9 @@ TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
 }
 
 TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
-  auto Minus = SyntaxFactory::makePrefixOperator("-", {}, {});
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ");
+  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "");
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
   auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(Minus,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
   auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne);
@@ -244,9 +243,9 @@ TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
 }
 
 TEST(StmtSyntaxTests, ReturnStmtWithAPIs) {
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword({}, Trivia::spaces(1));
-  auto Minus = SyntaxFactory::makePrefixOperator("-", {}, {});
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ");
+  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "");
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
   auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(Minus,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
 

--- a/unittests/Syntax/SyntaxCollectionTests.cpp
+++ b/unittests/Syntax/SyntaxCollectionTests.cpp
@@ -9,11 +9,11 @@ using namespace swift;
 using namespace swift::syntax;
 
 TupleExprElementSyntax getCannedArgument() {
-  auto X = SyntaxFactory::makeIdentifier("x", {}, {});
-  auto Foo = SyntaxFactory::makeIdentifier("foo", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+  auto X = SyntaxFactory::makeIdentifier("x", "", "");
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
   auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken({}, Trivia::spaces(1));
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
   auto NoComma = RawSyntax::missing(tok::comma, ",");
 
   return SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma);
@@ -105,10 +105,10 @@ TEST(SyntaxCollectionTests, prepending) {
   auto Arg = getCannedArgument();
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
   auto List = SyntaxFactory::makeBlankTupleExprElementList()
-    .prepending(Arg.withTrailingComma(NoComma))
-    .prepending(Arg
-                  .withLabel(SyntaxFactory::makeIdentifier("schwifty", {}, {})))
-    .prepending(Arg);
+                  .prepending(Arg.withTrailingComma(NoComma))
+                  .prepending(Arg.withLabel(
+                      SyntaxFactory::makeIdentifier("schwifty", "", "")))
+                  .prepending(Arg);
 
   ASSERT_EQ(List.size(), size_t(3));
 
@@ -138,11 +138,11 @@ TEST(SyntaxCollectionTests, removingFirst) {
   auto Arg = getCannedArgument();
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
   auto List = SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg
-                 .withLabel(SyntaxFactory::makeIdentifier("schwifty", {}, {})))
-    .appending(Arg)
-    .appending(Arg.withTrailingComma(NoComma))
-    .removingFirst();
+                  .appending(Arg.withLabel(
+                      SyntaxFactory::makeIdentifier("schwifty", "", "")))
+                  .appending(Arg)
+                  .appending(Arg.withTrailingComma(NoComma))
+                  .removingFirst();
   SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   List.print(OS);
@@ -200,12 +200,11 @@ TEST(SyntaxCollectionTests, inserting) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     SyntaxFactory::makeBlankTupleExprElementList()
-      .appending(Arg)
-      .appending(Arg)
-      .inserting(1,
-                 Arg.withLabel(SyntaxFactory::makeIdentifier("schwifty",
-                                                             {}, {})))
-      .print(OS);
+        .appending(Arg)
+        .appending(Arg)
+        .inserting(
+            1, Arg.withLabel(SyntaxFactory::makeIdentifier("schwifty", "", "")))
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "x: foo, schwifty: foo, x: foo, ");
   }
 }
@@ -261,10 +260,11 @@ TEST(SyntaxCollectionTests, Iteration) {
 TEST(SyntaxCollectionTests, Removing) {
   auto Arg = getCannedArgument();
   auto List = SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg)
-    .appending(Arg.withLabel(SyntaxFactory::makeIdentifier("first", {}, {})))
-    .appending(Arg)
-    .removing(1);
+                  .appending(Arg)
+                  .appending(Arg.withLabel(
+                      SyntaxFactory::makeIdentifier("first", "", "")))
+                  .appending(Arg)
+                  .removing(1);
 
   ASSERT_EQ(List.size(), static_cast<size_t>(2));
 

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -12,9 +12,9 @@ using namespace swift::syntax;
 #pragma mark - type-attribute
 
 TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
-  auto At = SyntaxFactory::makeAtSignToken({}, {});
+  auto At = SyntaxFactory::makeAtSignToken("", "");
   {
-    auto AutoclosureID = SyntaxFactory::makeIdentifier("autoclosure", {}, {});
+    auto AutoclosureID = SyntaxFactory::makeIdentifier("autoclosure", "", "");
     SmallString<24> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
     auto Autoclosure = SyntaxFactory::makeBlankAttribute()
@@ -25,9 +25,9 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
   }
 
   {
-    auto conventionID = SyntaxFactory::makeIdentifier("convention", {}, {});
-    auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
-    auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+    auto conventionID = SyntaxFactory::makeIdentifier("convention", "", "");
+    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
+    auto RightParen = SyntaxFactory::makeRightParenToken("", "");
 
     auto Convention = SyntaxFactory::makeBlankAttribute()
       .withAtSignToken(At)
@@ -38,7 +38,7 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto cID = SyntaxFactory::makeIdentifier("c", {}, {});
+      auto cID = SyntaxFactory::makeIdentifier("c", "", "");
       Convention.withArgument(cID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
@@ -46,7 +46,7 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto swiftID = SyntaxFactory::makeIdentifier("swift", {}, {});
+      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "");
       auto swiftArgs = SyntaxFactory::makeTokenList({LeftParen, swiftID, RightParen});
       Convention.withArgument(swiftID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
@@ -55,7 +55,7 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto blockID = SyntaxFactory::makeIdentifier("block", {}, {});
+      auto blockID = SyntaxFactory::makeIdentifier("block", "", "");
       auto blockArgs = SyntaxFactory::makeTokenList({LeftParen, blockID, RightParen});
       Convention.withArgument(blockID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
@@ -65,7 +65,7 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", {}, {});
+    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "");
     auto Escaping = SyntaxFactory::makeBlankAttribute()
       .withAtSignToken(At)
       .withAttributeName(EscapingID);
@@ -75,9 +75,9 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
 }
 
 TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
-  auto At = SyntaxFactory::makeAtSignToken({}, {});
+  auto At = SyntaxFactory::makeAtSignToken("", "");
   {
-    auto AutoclosureID = SyntaxFactory::makeIdentifier("autoclosure", {}, {});
+    auto AutoclosureID = SyntaxFactory::makeIdentifier("autoclosure", "", "");
     SmallString<24> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
     auto Autoclosure = SyntaxFactory::makeBlankAttribute()
@@ -88,14 +88,14 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
   }
 
   {
-    auto conventionID = SyntaxFactory::makeIdentifier("convention", {}, {});
-    auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
-    auto RightParen = SyntaxFactory::makeRightParenToken({}, {});
+    auto conventionID = SyntaxFactory::makeIdentifier("convention", "", "");
+    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
+    auto RightParen = SyntaxFactory::makeRightParenToken("", "");
 
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto cID = SyntaxFactory::makeIdentifier("c", {}, {});
+      auto cID = SyntaxFactory::makeIdentifier("c", "", "");
       SyntaxFactory::makeAttribute(At, conventionID, LeftParen, cID, RightParen,
                                    llvm::None)
           .print(OS);
@@ -105,7 +105,7 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto swiftID = SyntaxFactory::makeIdentifier("swift", {}, {});
+      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "");
       SyntaxFactory::makeAttribute(At, conventionID, LeftParen, swiftID,
                                    RightParen, llvm::None)
           .print(OS);
@@ -115,7 +115,7 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto blockID = SyntaxFactory::makeIdentifier("block", {}, {});
+      auto blockID = SyntaxFactory::makeIdentifier("block", "", "");
       SyntaxFactory::makeAttribute(At, conventionID, LeftParen, blockID,
                                    RightParen, llvm::None)
           .print(OS);
@@ -126,7 +126,7 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", {}, {});
+    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "");
     auto Escaping = SyntaxFactory::makeBlankAttribute()
       .withAtSignToken(At)
       .withAttributeName(EscapingID);
@@ -139,44 +139,40 @@ TEST(TypeSyntaxTests, TupleWithAPIs) {
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType()
-      .withLeftParen(SyntaxFactory::makeLeftParenToken({}, {}));
+    auto Void = SyntaxFactory::makeVoidTupleType().withLeftParen(
+        SyntaxFactory::makeLeftParenToken("", ""));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType()
-      .withLeftParen(SyntaxFactory::makeLeftParenToken({Trivia::spaces(2)},
-                                                       {Trivia::spaces(1)}));
+    auto Void = SyntaxFactory::makeVoidTupleType().withLeftParen(
+        SyntaxFactory::makeLeftParenToken("  ", " "));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "  ( )");
   }
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType()
-      .withRightParen(
-        SyntaxFactory::makeRightParenToken({Trivia::spaces(4)},
-                                           {Trivia::newlines(1)}));
+    auto Void = SyntaxFactory::makeVoidTupleType().withRightParen(
+        SyntaxFactory::makeRightParenToken("    ", "\n"));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "(    )\n");
   }
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType()
-      .withRightParen(SyntaxFactory::makeRightParenToken({}, {}));
+    auto Void = SyntaxFactory::makeVoidTupleType().withRightParen(
+        SyntaxFactory::makeRightParenToken("", ""));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Comma = SyntaxFactory::makeCommaToken({}, {});
-    auto Foo = SyntaxFactory::makeTypeIdentifier("Foo", {},
-                                                 { Trivia::spaces(2) });
+    auto Comma = SyntaxFactory::makeCommaToken("", "");
+    auto Foo = SyntaxFactory::makeTypeIdentifier("Foo", "", "  ");
     auto Void = SyntaxFactory::makeVoidTupleType()
       .withElements(SyntaxFactory::makeTupleTypeElementList({
         SyntaxFactory::makeTupleTypeElement(Foo, Comma),
@@ -193,19 +189,19 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     llvm::raw_svector_ostream OS { Scratch };
 
     TupleTypeSyntaxBuilder Builder;
-    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken({}, {}));
-    auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
-    auto IntId = SyntaxFactory::makeIdentifier("Int", {}, {});
+    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", ""));
+    auto Comma = SyntaxFactory::makeCommaToken("", " ");
+    auto IntId = SyntaxFactory::makeIdentifier("Int", "", "");
     auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(IntId, None);
     auto Int = SyntaxFactory::makeTupleTypeElement(IntType);
     auto IntWithComma = SyntaxFactory::makeTupleTypeElement(IntType, Comma);
-    auto StringId = SyntaxFactory::makeIdentifier("String", {}, {});
+    auto StringId = SyntaxFactory::makeIdentifier("String", "", "");
     auto StringType = SyntaxFactory::makeSimpleTypeIdentifier(StringId, None);
     auto String = SyntaxFactory::makeTupleTypeElement(StringType, Comma);
     Builder.addElement(IntWithComma);
     Builder.addElement(String);
     Builder.addElement(Int);
-    Builder.useRightParen(SyntaxFactory::makeRightParenToken({}, {}));
+    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", ""));
 
     auto TupleType = Builder.build();
 
@@ -217,21 +213,21 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     llvm::raw_svector_ostream OS { Scratch };
 
     TupleTypeSyntaxBuilder Builder;
-    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken({}, {}));
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-    auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
-    auto Colon = SyntaxFactory::makeColonToken({}, { Trivia::spaces(1) });
+    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", ""));
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+    auto Comma = SyntaxFactory::makeCommaToken("", " ");
+    auto Colon = SyntaxFactory::makeColonToken("", " ");
     auto xLabel = SyntaxFactory::makeIdentifier("x", {} , {});
     auto xTypeElt = SyntaxFactory::makeTupleTypeElement(xLabel, Colon,
                                                         Int, Comma);
-    auto inout = SyntaxFactory::makeInoutKeyword({}, { Trivia::spaces(1) });
+    auto inout = SyntaxFactory::makeInoutKeyword("", " ");
     auto yLabel = SyntaxFactory::makeIdentifier("y", {} , {});
     auto yTypeElt = SyntaxFactory::makeTupleTypeElement(yLabel, Colon,
                                                         Int)
       .withInOut(inout);
     Builder.addElement(xTypeElt);
     Builder.addElement(yTypeElt);
-    Builder.useRightParen(SyntaxFactory::makeRightParenToken({}, {}));
+    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", ""));
 
     auto TupleType = Builder.build();
     TupleType.print(OS);
@@ -252,19 +248,18 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-    auto Bool = SyntaxFactory::makeTypeIdentifier("Bool", {}, {});
-    auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+    auto Bool = SyntaxFactory::makeTypeIdentifier("Bool", "", "");
+    auto Comma = SyntaxFactory::makeCommaToken("", " ");
     auto TupleType = SyntaxFactory::makeTupleType(
-                        SyntaxFactory::makeLeftParenToken({}, {}),
-                        SyntaxFactory::makeTupleTypeElementList({
-                          SyntaxFactory::makeTupleTypeElement(Int, Comma),
-                          SyntaxFactory::makeTupleTypeElement(Bool, Comma),
-                          SyntaxFactory::makeTupleTypeElement(Int, Comma),
-                          SyntaxFactory::makeTupleTypeElement(Bool, Comma),
-                          SyntaxFactory::makeTupleTypeElement(Int, None)
-                        }),
-                        SyntaxFactory::makeRightParenToken({}, {}));
+        SyntaxFactory::makeLeftParenToken("", ""),
+        SyntaxFactory::makeTupleTypeElementList(
+            {SyntaxFactory::makeTupleTypeElement(Int, Comma),
+             SyntaxFactory::makeTupleTypeElement(Bool, Comma),
+             SyntaxFactory::makeTupleTypeElement(Int, Comma),
+             SyntaxFactory::makeTupleTypeElement(Bool, Comma),
+             SyntaxFactory::makeTupleTypeElement(Int, None)}),
+        SyntaxFactory::makeRightParenToken("", ""));
     TupleType.print(OS);
     ASSERT_EQ(OS.str().str(),
               "(Int, Bool, Int, Bool, Int)");
@@ -293,8 +288,8 @@ TEST(TypeSyntaxTests, OptionalTypeMakeAPIs) {
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-    auto Question = SyntaxFactory::makePostfixQuestionMarkToken({}, {});
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+    auto Question = SyntaxFactory::makePostfixQuestionMarkToken("", "");
     auto OptionalInt = SyntaxFactory::makeOptionalType(Int, Question);
     OptionalInt.print(OS);
     ASSERT_EQ(OS.str(), "Int?");
@@ -305,12 +300,11 @@ TEST(TypeSyntaxTests, OptionalTypeWithAPIs) {
   {
     SmallString<8> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto StringType = SyntaxFactory::makeTypeIdentifier("String",
-                                                        Trivia::spaces(1), {});
+    auto StringType = SyntaxFactory::makeTypeIdentifier("String", " ", "");
     SyntaxFactory::makeBlankOptionalType()
-      .withWrappedType(StringType)
-      .withQuestionMark(SyntaxFactory::makePostfixQuestionMarkToken({}, {}))
-      .print(OS);
+        .withWrappedType(StringType)
+        .withQuestionMark(SyntaxFactory::makePostfixQuestionMarkToken("", ""))
+        .print(OS);
     ASSERT_EQ(OS.str(), " String?");
   }
 }
@@ -319,8 +313,8 @@ TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeMakeAPIs) {
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-    auto Bang = SyntaxFactory::makeExclamationMarkToken({}, {});
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+    auto Bang = SyntaxFactory::makeExclamationMarkToken("", "");
     auto IntBang =
       SyntaxFactory::makeImplicitlyUnwrappedOptionalType(Int, Bang);
     IntBang.print(OS);
@@ -332,13 +326,11 @@ TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeWithAPIs) {
   {
     SmallString<8> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto StringType = SyntaxFactory::makeTypeIdentifier("String",
-                                                          { Trivia::spaces(1) },
-                                                          {});
+    auto StringType = SyntaxFactory::makeTypeIdentifier("String", " ", "");
     SyntaxFactory::makeBlankImplicitlyUnwrappedOptionalType()
-      .withWrappedType(StringType)
-      .withExclamationMark(SyntaxFactory::makeExclamationMarkToken({}, {}))
-      .print(OS);
+        .withWrappedType(StringType)
+        .withExclamationMark(SyntaxFactory::makeExclamationMarkToken("", ""))
+        .print(OS);
     ASSERT_EQ(OS.str(), " String!");
   }
 }
@@ -347,9 +339,9 @@ TEST(TypeSyntaxTests, MetatypeTypeMakeAPIs) {
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("T", {}, {});
-    auto Dot = SyntaxFactory::makePeriodToken({}, {});
-    auto Type = SyntaxFactory::makeTypeToken({}, {});
+    auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "");
+    auto Dot = SyntaxFactory::makePeriodToken("", "");
+    auto Type = SyntaxFactory::makeTypeToken("", "");
     SyntaxFactory::makeMetatypeType(Int, Dot, Type)
       .print(OS);
     ASSERT_EQ(OS.str(), "T.Type");
@@ -357,10 +349,10 @@ TEST(TypeSyntaxTests, MetatypeTypeMakeAPIs) {
 }
 
 TEST(TypeSyntaxTests, MetatypeTypeWithAPIs) {
-  auto Int = SyntaxFactory::makeTypeIdentifier("T", {}, {});
-  auto Dot = SyntaxFactory::makePeriodToken({}, {});
-  auto Type = SyntaxFactory::makeTypeToken({}, {});
-  auto Protocol = SyntaxFactory::makeProtocolToken({}, {});
+  auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "");
+  auto Dot = SyntaxFactory::makePeriodToken("", "");
+  auto Type = SyntaxFactory::makeTypeToken("", "");
+  auto Protocol = SyntaxFactory::makeProtocolToken("", "");
 
   {
     SmallString<4> Scratch;
@@ -384,12 +376,14 @@ TEST(TypeSyntaxTests, MetatypeTypeWithAPIs) {
   }
 
 #ifndef NDEBUG
-  ASSERT_DEATH({
-    SyntaxFactory::makeBlankMetatypeType()
-    .withBaseType(Int)
-    .withPeriod(Dot)
-    .withTypeOrProtocol(SyntaxFactory::makeIdentifier("WRONG", {}, {}));
-  }, "");
+  ASSERT_DEATH(
+      {
+        SyntaxFactory::makeBlankMetatypeType()
+            .withBaseType(Int)
+            .withPeriod(Dot)
+            .withTypeOrProtocol(SyntaxFactory::makeIdentifier("WRONG", "", ""));
+      },
+      "");
 #endif
 }
 
@@ -397,9 +391,9 @@ TEST(TypeSyntaxTests, ArrayTypeWithAPIs) {
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken({}, {});
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken({}, {});
-    auto Double = SyntaxFactory::makeTypeIdentifier("Double", {}, {});
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
+    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
+    auto Double = SyntaxFactory::makeTypeIdentifier("Double", "", "");
     SyntaxFactory::makeBlankArrayType()
       .withLeftSquareBracket(LeftSquare)
       .withElementType(Double)
@@ -413,8 +407,8 @@ TEST(TypeSyntaxTests, ArrayTypeMakeAPIs) {
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken({}, {});
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken({}, {});
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
+    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
     auto Void = SyntaxFactory::makeVoidTupleType();
     SyntaxFactory::makeArrayType(LeftSquare, Void, RightSquare)
       .print(OS);
@@ -427,12 +421,11 @@ TEST(TypeSyntaxTests, DictionaryTypeWithAPIs) {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken({}, {});
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken({}, {});
-    auto Key = SyntaxFactory::makeTypeIdentifier("String", {},
-                                                 { Trivia::spaces(1) });
-    auto Value = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-    auto Colon = SyntaxFactory::makeColonToken({}, { Trivia::spaces(1) });
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
+    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
+    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ");
+    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+    auto Colon = SyntaxFactory::makeColonToken("", " ");
     SyntaxFactory::makeBlankDictionaryType()
       .withLeftSquareBracket(LeftSquare)
       .withKeyType(Key)
@@ -449,12 +442,11 @@ TEST(TypeSyntaxTests, DictionaryTypeMakeAPIs) {
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken({}, {});
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken({}, {});
-    auto Key = SyntaxFactory::makeTypeIdentifier("String", {},
-                                                   { Trivia::spaces(1) });
-    auto Value = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-    auto Colon = SyntaxFactory::makeColonToken({}, { Trivia::spaces(1) });
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
+    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
+    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ");
+    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+    auto Colon = SyntaxFactory::makeColonToken("", " ");
     SyntaxFactory::makeDictionaryType(LeftSquare,
                                         Key, Colon, Value,
                                         RightSquare).print(OS);
@@ -463,27 +455,24 @@ TEST(TypeSyntaxTests, DictionaryTypeMakeAPIs) {
 }
 
 TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
-  auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
-  auto Colon = SyntaxFactory::makeColonToken({}, { Trivia::spaces(1) });
-  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto RightParen = SyntaxFactory::makeRightParenToken({},
-                                                       {Trivia::spaces(1)});
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
+  auto Colon = SyntaxFactory::makeColonToken("", " ");
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
+  auto RightParen = SyntaxFactory::makeRightParenToken("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
   auto IntArg = SyntaxFactory::makeBlankTupleTypeElement()
     .withType(Int);
-  auto Async = SyntaxFactory::makeIdentifier(
-      "async", { }, { Trivia::spaces(1) });
-  auto Throws = SyntaxFactory::makeThrowsKeyword({}, { Trivia::spaces(1) });
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword({},
-                                                       { Trivia::spaces(1) });
-  auto Arrow = SyntaxFactory::makeArrowToken({}, Trivia::spaces(1));
+  auto Async = SyntaxFactory::makeIdentifier("async", "", " ");
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
+  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ");
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto x = SyntaxFactory::makeIdentifier("x", {}, {});
-    auto y = SyntaxFactory::makeIdentifier("y", {}, {});
+    auto x = SyntaxFactory::makeIdentifier("x", "", "");
+    auto y = SyntaxFactory::makeIdentifier("y", "", "");
     auto xArg = SyntaxFactory::makeBlankTupleTypeElement()
       .withName(x)
       .withColon(Colon)
@@ -512,8 +501,8 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto x = SyntaxFactory::makeIdentifier("x", {}, {});
-    auto y = SyntaxFactory::makeIdentifier("y", {}, {});
+    auto x = SyntaxFactory::makeIdentifier("x", "", "");
+    auto y = SyntaxFactory::makeIdentifier("y", "", "");
     auto xArg = SyntaxFactory::makeBlankTupleTypeElement()
       .withName(x)
       .withColon(Colon)
@@ -572,23 +561,22 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
 } 
 
 TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
-  auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
-  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto RightParen = SyntaxFactory::makeRightParenToken({}, Trivia::spaces(1));
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
+  auto RightParen = SyntaxFactory::makeRightParenToken("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
   auto IntArg = SyntaxFactory::makeTupleTypeElement(None, None, None, None,
                                                     Int, None, None, None);
-  auto Throws = SyntaxFactory::makeThrowsKeyword({}, { Trivia::spaces(1) });
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword({},
-                                                       { Trivia::spaces(1) });
-  auto Arrow = SyntaxFactory::makeArrowToken({}, { Trivia::spaces(1) });
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
+  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ");
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto x = SyntaxFactory::makeIdentifier("x", {}, {});
-    auto y = SyntaxFactory::makeIdentifier("y", {}, {});
-    auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+    auto x = SyntaxFactory::makeIdentifier("x", "", "");
+    auto y = SyntaxFactory::makeIdentifier("y", "", "");
+    auto Colon = SyntaxFactory::makeColonToken("", " ");
     auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon,
                                                     Int, None, None, Comma);
     auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon,
@@ -638,23 +626,21 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
 }
 
 TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
-  auto Comma = SyntaxFactory::makeCommaToken({}, { Trivia::spaces(1) });
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", {}, {});
-  auto LeftParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto RightParen = SyntaxFactory::makeRightParenToken({},
-                                                         {Trivia::spaces(1)});
-  auto Throws = SyntaxFactory::makeThrowsKeyword({}, { Trivia::spaces(1) });
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword({},
-                                                       { Trivia::spaces(1) });
-  auto Arrow = SyntaxFactory::makeArrowToken({}, { Trivia::spaces(1) });
+  auto Comma = SyntaxFactory::makeCommaToken("", " ");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
+  auto RightParen = SyntaxFactory::makeRightParenToken("", " ");
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
+  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ");
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     FunctionTypeSyntaxBuilder Builder;
-    auto x = SyntaxFactory::makeIdentifier("x", {}, {});
-    auto y = SyntaxFactory::makeIdentifier("y", {}, {});
-    auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
+    auto x = SyntaxFactory::makeIdentifier("x", "", "");
+    auto y = SyntaxFactory::makeIdentifier("y", "", "");
+    auto Colon = SyntaxFactory::makeColonToken("", " ");
     auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon,
                                                     Int, None, None, Comma);
     auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon,


### PR DESCRIPTION
Most of the time, we don’t actually care about the pieces that trivia consist of. Instead of always lexing them into tokens (and keeping a slightly more expensive data structure that contains the tokens around), lex the trivia first into a `StringRef` that contains their raw content. If needed, this raw content can later be decomposed into pieces.

Note that this PR may subtly change the way garbage text is being split into pieces, because the new trivia lexer will only split garbage text on whitespace and comment markers whereas the old lexer was centered around boundaries of Swift identifiers etc. 
Since I don’t have strong opinions on how garbage text should be split, I chose to leave the `TriviaLexer` implementation simple instead of teaching it all the Swift identifier boundary rules.

### Performance checklist (performed on my local machine)
- [x] No regression during compilation → ~7% improvement in `ParseSourceFileRequest`, ~1.5% in `ParseMembersRequest`
- [x] No regression during code completion
- [x] No regression during SwiftSyntax parsing