### PR TITLE
Compatibility for Optional -> AnyHashable casts

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -759,7 +759,7 @@ tryCastToAnyHashable(
         srcValue, /*emptyCases=*/1);
       auto nonNil = (sourceEnumCase == 0);
       if (nonNil) {
-        return DynamicCast::Failure;  // Our caller will unwrap the optional and try again
+        return DynamicCastResult::Failure;  // Our caller will unwrap the optional and try again
       }
       // If it is nil, fall through to the general case to just wrap the nil
     }

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -881,4 +881,46 @@ CastsTests.test("NSDictionary -> Dictionary casting [SR-12025]") {
 }
 #endif
 
+// Casting optionals to AnyHashable is a little peculiar
+// TODO: It would be nice if AnyHashable(Optional("Foo")) == AnyHashable("Foo")
+// (including as dictionary keys).  That would make this a lot less confusing.
+CastsTests.test("Optional cast to AnyHashable") {
+  let d: [String?: String] = ["FooKey": "FooValue", nil: "NilValue"]
+  // In Swift 5.3, this cast DOES unwrap the non-nil key
+  // In Swift 5.4, the cast does NOT unwrap the non-nil key
+  let d2 = d as [AnyHashable: String]
+  let d3 = d2["FooKey" as String? as AnyHashable]
+  expectNotNil(d3)
+  let d4 = d2["FooKey" as String?]
+  expectNotNil(d4)
+  // In Swift 5.4, AnyHashable(String?) is never equal to AnyHashable(String)
+  // This is expected to change...
+  let d5 = d2["FooKey"]
+  expectNil(d5)
+  let d6 = d2["FooKey" as AnyHashable]
+  expectNil(d6)
+
+  // In both Swift 5.3 and 5.4, the nil key should be preserved and still function
+  let d7 = d2[nil]
+  expectNotNil(d7)
+
+  // Direct casts via the runtime unwrap the optional in 5.3 but not 5.4.
+  let a: String = "Foo"
+  let ah: AnyHashable = a
+  let b: String? = a
+  let bh = runtimeCast(b, to: AnyHashable.self)
+  // bh is an AnyHashable(Optional("Foo")) in Swift 5.4 but not earlier
+  // ah is an AnyHashable("Foo")
+  expectNotEqual(bh, ah)
+
+  // In both Swift 5.3 and 5.4, direct casts that don't go through the runtime don't unwrap the optional
+  let x: String = "Baz"
+  let xh = x as AnyHashable
+  let y: String? = x
+  let yh = y as AnyHashable // Doesn't unwrap the optional
+  // xh is AnyHashable("Baz")
+  // yh is AnyHashable(Optional("Baz")) in Swift 5.4 and earlier
+  expectNotEqual(xh, yh)
+}
+
 runAllTests()

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -901,7 +901,7 @@ CastsTests.test("Optional cast to AnyHashable") {
   expectNil(d6)
 
   // In both Swift 5.3 and 5.4, the nil key should be preserved and still function
-  let d7 = d2[nil]
+  let d7 = d2[String?.none as AnyHashable]
   expectNotNil(d7)
 
   // Direct casts via the runtime unwrap the optional in 5.3 but not 5.4.


### PR DESCRIPTION
As part of making casting more consistent, the behavior of Optional -> AnyHashable casts
was changed in some cases.  This PR restores the old behavior.

Background: Most of the time, casts from String? to AnyHashable get optimized
to just injects the String? into the AnyHashable, so the following
has long been true and remains true in Swift 5.4:
```
let s = "abc"
let o: String? = s

// Next test is true because s is promoted to Optional<String>
print(s == o)

// Next test is false: Optional<String> and String are different types
print(s as AnyHashable == o as AnyHashable)
```

But when casts ended up going through the runtime, Swift 5.3 behaved
differently, as you could see by casting a dictionary with `String?` keys (in
the generic array code, key and value casts always use the runtime logic).  In
the following code, both print statements behave differently in current builds than
before:
```
let a: [String?:String] = ["Foo":"Bar"]
let b = a as [AnyHashable:Any]
print(b["Foo"] == "Bar")  // Works in Swift 5.3 and before
print(b["Foo" as String?] == "Bar") // Broken in Swift 5.3 and before
```

Swift 5.3 and before: The `String?` keys would get unwrapped to `String` before being injected into AnyHashable.  This allows the first to work but strangely breaks the second.

Behavior after casting overhaul: The `String?` keys do not get unwrapped.  This breaks the first but makes the second work.

This change restores the behavior for this specific case to the Swift 5.3 behavior.

TODO: The long-term goal, of course, is for `AnyHashable("Foo" as String?)` to test equal to `AnyHashable("Foo")` (and hash the same, of course).  See SR-9047 for details.  Once that's done, we won't need to unwrap optionals in this case and can revert this change so the runtime behavior will precisely match the behavior of compiler-optimized casts.

Resolves rdar://73301155