### PR TITLE
[SIL] Add `@concurrent` function types to SIL 

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -625,7 +625,7 @@ mangled in to disambiguate.
   impl-function-type ::= type* 'I' FUNC-ATTRIBUTES '_'
   impl-function-type ::= type* generic-signature 'I' FUNC-ATTRIBUTES '_'
 
-  FUNC-ATTRIBUTES ::= PATTERN-SUBS? INVOCATION-SUBS? PSEUDO-GENERIC? CALLEE-ESCAPE? DIFFERENTIABILITY-KIND? CALLEE-CONVENTION FUNC-REPRESENTATION? COROUTINE-KIND? ASYNC? (PARAM-CONVENTION PARAM-DIFFERENTIABILITY?)* RESULT-CONVENTION* ('Y' PARAM-CONVENTION)* ('z' RESULT-CONVENTION RESULT-DIFFERENTIABILITY?)?
+  FUNC-ATTRIBUTES ::= PATTERN-SUBS? INVOCATION-SUBS? PSEUDO-GENERIC? CALLEE-ESCAPE? DIFFERENTIABILITY-KIND? CALLEE-CONVENTION FUNC-REPRESENTATION? COROUTINE-KIND? CONCURRENT? ASYNC? (PARAM-CONVENTION PARAM-DIFFERENTIABILITY?)* RESULT-CONVENTION* ('Y' PARAM-CONVENTION)* ('z' RESULT-CONVENTION RESULT-DIFFERENTIABILITY?)?
 
   PATTERN-SUBS ::= 's'                       // has pattern substitutions
   INVOCATION-SUB ::= 'I'                     // has invocation substitutions
@@ -654,6 +654,7 @@ mangled in to disambiguate.
   COROUTINE-KIND ::= 'A'                     // yield-once coroutine
   COROUTINE-KIND ::= 'G'                     // yield-many coroutine
 
+  CONCURRENT ::= 'h'                         // @concurrent
   ASYNC ::= 'H'                              // @async
 
   PARAM-CONVENTION ::= 'i'                   // indirect in

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -316,7 +316,7 @@ class alignas(1 << TypeAlignInBits) TypeBase {
 
 protected:
   enum { NumAFTExtInfoBits = 10 };
-  enum { NumSILExtInfoBits = 9 };
+  enum { NumSILExtInfoBits = 10 };
   union { uint64_t OpaqueBits;
 
   SWIFT_INLINE_BITFIELD_BASE(TypeBase, bitmax(NumTypeKindBits,8) +
@@ -4120,6 +4120,7 @@ public:
     return SILCoroutineKind(Bits.SILFunctionType.CoroutineKind);
   }
 
+  bool isConcurrent() const { return getExtInfo().isConcurrent(); }
   bool isAsync() const { return getExtInfo().isAsync(); }
 
   /// Return the array of all the yields.

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -240,52 +240,61 @@ class ImplFunctionTypeFlags {
   unsigned Rep : 3;
   unsigned Pseudogeneric : 1;
   unsigned Escaping : 1;
+  unsigned Concurrent : 1;
   unsigned Async : 1;
   unsigned DifferentiabilityKind : 2;
 
 public:
   ImplFunctionTypeFlags()
-      : Rep(0), Pseudogeneric(0), Escaping(0), Async(0),
+      : Rep(0), Pseudogeneric(0), Escaping(0), Concurrent(0), Async(0),
         DifferentiabilityKind(0) {}
 
   ImplFunctionTypeFlags(ImplFunctionRepresentation rep, bool pseudogeneric,
-                        bool noescape, bool async,
+                        bool noescape, bool concurrent, bool async,
                         ImplFunctionDifferentiabilityKind diffKind)
       : Rep(unsigned(rep)), Pseudogeneric(pseudogeneric), Escaping(noescape),
-        Async(async), DifferentiabilityKind(unsigned(diffKind)) {}
+        Concurrent(concurrent), Async(async),
+        DifferentiabilityKind(unsigned(diffKind)) {}
 
   ImplFunctionTypeFlags
   withRepresentation(ImplFunctionRepresentation rep) const {
     return ImplFunctionTypeFlags(
-        rep, Pseudogeneric, Escaping, Async,
+        rep, Pseudogeneric, Escaping, Concurrent, Async,
         ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
+  }
+
+  ImplFunctionTypeFlags
+  withConcurrent() const {
+    return ImplFunctionTypeFlags(
+        ImplFunctionRepresentation(Rep), Pseudogeneric, Escaping, true,
+        Async, ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
   }
 
   ImplFunctionTypeFlags
   withAsync() const {
     return ImplFunctionTypeFlags(
-        ImplFunctionRepresentation(Rep), Pseudogeneric, Escaping, true,
-        ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
+        ImplFunctionRepresentation(Rep), Pseudogeneric, Escaping, Concurrent,
+        true, ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
   }
 
   ImplFunctionTypeFlags
   withEscaping() const {
     return ImplFunctionTypeFlags(
-        ImplFunctionRepresentation(Rep), Pseudogeneric, true, Async,
+        ImplFunctionRepresentation(Rep), Pseudogeneric, true, Concurrent, Async,
         ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
   }
   
   ImplFunctionTypeFlags
   withPseudogeneric() const {
     return ImplFunctionTypeFlags(
-        ImplFunctionRepresentation(Rep), true, Escaping, Async,
+        ImplFunctionRepresentation(Rep), true, Escaping, Concurrent, Async,
         ImplFunctionDifferentiabilityKind(DifferentiabilityKind));
   }
 
   ImplFunctionTypeFlags
   withDifferentiabilityKind(ImplFunctionDifferentiabilityKind diffKind) const {
     return ImplFunctionTypeFlags(ImplFunctionRepresentation(Rep), Pseudogeneric,
-                                 Escaping, Async, diffKind);
+                                 Escaping, Concurrent, Async, diffKind);
   }
 
   ImplFunctionRepresentation getRepresentation() const {
@@ -295,6 +304,8 @@ public:
   bool isAsync() const { return Async; }
 
   bool isEscaping() const { return Escaping; }
+
+  bool isConcurrent() const { return Concurrent; }
 
   bool isPseudogeneric() const { return Pseudogeneric; }
 
@@ -731,7 +742,9 @@ public:
         } else if (child->getKind() == NodeKind::ImplFunctionAttribute) {
           if (!child->hasText())
             return MAKE_NODE_TYPE_ERROR0(child, "expected text");
-          if (child->getText() == "@async") {
+          if (child->getText() == "@concurrent") {
+            flags = flags.withConcurrent();
+          } else if (child->getText() == "@async") {
             flags = flags.withAsync();
           }
         } else if (child->getKind() == NodeKind::ImplDifferentiable) {

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -443,6 +443,7 @@ public:
       break;
     }
 
+    funcFlags = funcFlags.withConcurrent(flags.isConcurrent());
     funcFlags = funcFlags.withAsync(flags.isAsync());
 
     auto result = createTupleType({}, "");

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -559,7 +559,7 @@ Type ASTBuilder::createImplFunctionType(
   }
   auto einfo = SILFunctionType::ExtInfoBuilder(
                    representation, flags.isPseudogeneric(), !flags.isEscaping(),
-                   flags.isAsync(), diffKind, clangFnType)
+                   flags.isConcurrent(), flags.isAsync(), diffKind, clangFnType)
                    .build();
 
   return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1727,6 +1727,11 @@ void ASTMangler::appendImplFunctionType(SILFunctionType *fn) {
     break;
   }
 
+  // Concurrent functions.
+  if (fn->isConcurrent()) {
+    OpArgs.push_back('h');
+  }
+
   // Asynchronous functions.
   if (fn->isAsync()) {
     OpArgs.push_back('H');

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4293,6 +4293,9 @@ public:
     if (info.isNoEscape()) {
       Printer.printSimpleAttr("@noescape") << " ";
     }
+    if (info.isConcurrent()) {
+      Printer.printSimpleAttr("@concurrent") << " ";
+    }
     if (info.isAsync()) {
       Printer.printSimpleAttr("@async") << " ";
     }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1877,6 +1877,11 @@ NodePointer Demangler::demangleImplFunctionType() {
   if (CoroAttr)
     type->addChild(createNode(Node::Kind::ImplFunctionAttribute, CoroAttr), *this);
 
+  if (nextIf('h')) {
+    type->addChild(createNode(Node::Kind::ImplFunctionAttribute, "@concurrent"),
+                   *this);
+  }
+
   if (nextIf('H')) {
     type->addChild(createNode(Node::Kind::ImplFunctionAttribute, "@async"),
                    *this);

--- a/lib/Demangling/OldDemangler.cpp
+++ b/lib/Demangling/OldDemangler.cpp
@@ -2149,6 +2149,9 @@ private:
         return nullptr;
     }
 
+    if (Mangled.nextIf('h'))
+      addImplFunctionAttribute(type, "@concurrent");
+
     if (Mangled.nextIf('H'))
       addImplFunctionAttribute(type, "@async");
 

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1271,6 +1271,8 @@ void Remangler::mangleImplFunctionAttribute(Node *node) {
     Buffer << "A";
   } else if (text == "@yield_many") {
     Buffer << "G";
+  } else if (text == "@concurrent") {
+    Buffer << "h";
   } else if (text == "@async") {
     Buffer << "H";
   } else {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1600,6 +1600,7 @@ void Remangler::mangleImplFunctionType(Node *node) {
         char FuncAttr = llvm::StringSwitch<char>(Child->getText())
                         .Case("@yield_once", 'A')
                         .Case("@yield_many", 'G')
+                        .Case("@concurrent", 'h')
                         .Case("@async", 'H')
                         .Default(0);
         assert(FuncAttr && "invalid impl function attribute");

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2106,7 +2106,10 @@ static CanSILFunctionType getSILFunctionType(
   assert(
       (!foreignInfo.Async || substFnInterfaceType->getExtInfo().isAsync())
       && "foreignAsync was set but function type is not async?");
-  
+
+  // Map '@concurrent' to the appropriate `@concurrent` modifier.
+  bool isConcurrent = substFnInterfaceType->getExtInfo().isConcurrent();
+
   // Map 'async' to the appropriate `@async` modifier.
   bool isAsync = false;
   if (substFnInterfaceType->getExtInfo().isAsync() && !foreignInfo.Async) {
@@ -2221,6 +2224,7 @@ static CanSILFunctionType getSILFunctionType(
   }
   auto silExtInfo = extInfoBuilder.withClangFunctionType(clangType)
                         .withIsPseudogeneric(pseudogeneric)
+                        .withConcurrent(isConcurrent)
                         .withAsync(isAsync)
                         .build();
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2529,6 +2529,7 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
   auto innerExtInfo =
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
                                       funcType->isThrowing())
+          .withConcurrent(funcType->isConcurrent())
           .withAsync(funcType->isAsync())
           .build();
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2249,7 +2249,7 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
 
       auto extInfoBuilder = SILFunctionType::ExtInfoBuilder(
           rep, attrs.has(TAK_pseudogeneric), attrs.has(TAK_noescape),
-          attrs.has(TAK_async), diffKind,
+          attrs.has(TAK_concurrent), attrs.has(TAK_async), diffKind,
           parsedClangFunctionType);
 
       ty =

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5408,6 +5408,7 @@ public:
     uint8_t rawRepresentation;
     uint8_t rawDiffKind;
     bool pseudogeneric = false;
+    bool concurrent;
     bool noescape;
     bool hasErrorResult;
     unsigned numParams;
@@ -5420,6 +5421,7 @@ public:
     ClangTypeID clangFunctionTypeID;
 
     decls_block::SILFunctionTypeLayout::readRecord(scratch,
+                                             concurrent,
                                              async,
                                              rawCoroutineKind,
                                              rawCalleeConvention,
@@ -5457,7 +5459,7 @@ public:
 
     auto extInfo =
         SILFunctionType::ExtInfoBuilder(*representation, pseudogeneric,
-                                        noescape, async, *diffKind, 
+                                        noescape, concurrent, async, *diffKind, 
                                         clangFunctionType)
             .build();
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 591; // @concurrent function type
+const uint16_t SWIFTMODULE_VERSION_MINOR = 592; // @concurrent SIL function type
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1071,6 +1071,7 @@ namespace decls_block {
 
   using SILFunctionTypeLayout = BCRecordLayout<
     SIL_FUNCTION_TYPE,
+    BCFixed<1>,                         // concurrent?
     BCFixed<1>,                         // async?
     SILCoroutineKindField, // coroutine kind
     ParameterConventionField, // callee convention

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4379,7 +4379,7 @@ public:
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[SILFunctionTypeLayout::Code];
     SILFunctionTypeLayout::emitRecord(
-        S.Out, S.ScratchRecord, abbrCode,
+        S.Out, S.ScratchRecord, abbrCode, fnTy->isConcurrent(),
         fnTy->isAsync(), stableCoroutineKind, stableCalleeConvention,
         stableRepresentation, fnTy->isPseudogeneric(), fnTy->isNoEscape(),
         stableDiffKind, fnTy->hasErrorResult(), fnTy->getParameters().size(),

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -281,8 +281,11 @@ extension Task {
 
 }
 
-public func _runAsyncHandler(operation: @concurrent @escaping () async -> ()) {
-  _ = Task.runDetached(operation: operation)
+public func _runAsyncHandler(operation: @escaping () async -> ()) {
+  typealias ConcurrentFunctionType = @concurrent () async -> ()
+  _ = Task.runDetached(
+    operation: unsafeBitCast(operation, to: ConcurrentFunctionType.self)
+  )
 }
 
 // ==== Voluntary Suspension -----------------------------------------------------

--- a/test/SILGen/async_handler.swift
+++ b/test/SILGen/async_handler.swift
@@ -8,7 +8,7 @@ func take<T>(_ t: T) async {
 // CHECK-LABEL: sil [ossa] @$s4test13simpleHandleryySiF : $@convention(thin) (Int) -> () {
 // CHECK:   [[BODYFN:%[0-9]+]] = function_ref @$s4test13simpleHandleryySiYF : $@convention(thin) @async (Int) -> ()
 // CHECK:   [[FN:%[0-9]+]] = partial_apply [callee_guaranteed] [[BODYFN]](%0) : $@convention(thin) @async (Int) -> ()
-// CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYJc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+// CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
 // CHECK:   {{.*}} = apply [[INTRINSIC]]([[FN]]) : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
 // CHECK:   destroy_value [[FN]] : $@async @callee_guaranteed () -> ()
 // CHECK: } // end sil function '$s4test13simpleHandleryySiF'
@@ -21,7 +21,7 @@ public func simpleHandler(_ i: Int) {
 // CHECK:   [[COPY:%[0-9]+]] = copy_value %0 : $String
 // CHECK:   [[BODYFN:%[0-9]+]] = function_ref @$s4test20nonTrivialArgHandleryySSYF : $@convention(thin) @async (@guaranteed String) -> ()
 // CHECK:   [[FN:%[0-9]+]] = partial_apply [callee_guaranteed] [[BODYFN]]([[COPY]]) : $@convention(thin) @async (@guaranteed String) -> ()
-// CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYJc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+// CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
 // CHECK:   {{.*}} = apply [[INTRINSIC]]([[FN]]) : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
 // CHECK:   destroy_value [[FN]] : $@async @callee_guaranteed () -> ()
 // CHECK: } // end sil function '$s4test20nonTrivialArgHandleryySSF'
@@ -35,7 +35,7 @@ public func nonTrivialArgHandler(_ s: String) {
 // CHECK:   copy_addr %0 to [initialization] [[TMP]] : $*T
 // CHECK:   [[BODYFN:%[0-9]+]] = function_ref @$s4test14genericHandleryyxYlF : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 // CHECK:   [[FN:%[0-9]+]] = partial_apply [callee_guaranteed] [[BODYFN]]<T>([[TMP]]) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-// CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYJc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+// CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
 // CHECK:   {{.*}} = apply [[INTRINSIC]]([[FN]]) : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
 // CHECK:   destroy_value [[FN]] : $@async @callee_guaranteed () -> ()
 // CHECK: } // end sil function '$s4test14genericHandleryyxlF'
@@ -48,7 +48,7 @@ public struct Mystruct {
   // CHECK-LABEL: sil [ossa] @$s4test8MystructV13memberHandleryySiF : $@convention(method) (Int, Mystruct) -> () {
   // CHECK:   [[BODYFN:%[0-9]+]] = function_ref @$s4test8MystructV13memberHandleryySiYF : $@convention(method) @async (Int, Mystruct) -> ()
   // CHECK:   [[FN:%[0-9]+]] = partial_apply [callee_guaranteed] [[BODYFN]](%0, %1) : $@convention(method) @async (Int, Mystruct) -> ()
-  // CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYJc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
+  // CHECK:   [[INTRINSIC:%[0-9]+]] = function_ref @$s12_Concurrency16_runAsyncHandler9operationyyyYc_tF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
   // CHECK:   {{.*}} = apply [[INTRINSIC]]([[FN]]) : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> ()) -> ()
   // CHECK:   destroy_value [[FN]] : $@async @callee_guaranteed () -> ()
   // CHECK: } // end sil function '$s4test8MystructV13memberHandleryySiF'

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -16,13 +16,13 @@ enum SomeError: Error {
 // CHECK-LABEL: sil hidden [ossa] @$s4test0A11AsyncLetIntSiyYF : $@convention(thin) @async () -> Int
 func testAsyncLetInt() async -> Int {
   // CHECK: [[I:%.*]] = mark_uninitialized [var] %0
-  // CHECK: [[CLOSURE:%.*]] = function_ref @$s4test0A11AsyncLetIntSiyYFSiyYJcfu_ : $@convention(thin) @async () -> Int
-  // CHECK: [[THICK_CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) @async () -> Int to $@async @callee_guaranteed () -> Int
-  // CHECK: [[REABSTRACT_THUNK:%.*]] = function_ref @$sSiIegHd_Sis5Error_pIegHrzo_TR : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
-  // CHECK: [[REABSTRACT_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[THICK_CLOSURE]]) : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
-  // CHECK: [[CLOSURE_ARG:%.*]] = convert_function [[REABSTRACT_CLOSURE]] : $@async @callee_guaranteed () -> (@out Int, @error Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>
-  // CHECK: [[RUN_CHILD_TASK:%.*]] = function_ref @$s12_Concurrency13_runChildTask9operationBoxyYJKc_tYlF : $@convention(thin) @async <τ_0_0> (@guaranteed @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
-  // CHECK: [[CHILD_TASK:%.*]] = apply [[RUN_CHILD_TASK]]<Int>([[CLOSURE_ARG]]) : $@convention(thin) @async <τ_0_0> (@guaranteed @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
+  // CHECK: [[CLOSURE:%.*]] = function_ref @$s4test0A11AsyncLetIntSiyYFSiyYJcfu_ : $@convention(thin) @concurrent @async () -> Int
+  // CHECK: [[THICK_CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) @concurrent @async () -> Int to $@concurrent @async @callee_guaranteed () -> Int
+  // CHECK: [[REABSTRACT_THUNK:%.*]] = function_ref @$sSiIeghHd_Sis5Error_pIeghHrzo_TR : $@convention(thin) @concurrent @async (@guaranteed @concurrent @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
+  // CHECK: [[REABSTRACT_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[THICK_CLOSURE]]) : $@convention(thin) @concurrent @async (@guaranteed @concurrent @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
+  // CHECK: [[CLOSURE_ARG:%.*]] = convert_function [[REABSTRACT_CLOSURE]] : $@concurrent @async @callee_guaranteed () -> (@out Int, @error Error) to $@concurrent @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>
+  // CHECK: [[RUN_CHILD_TASK:%.*]] = function_ref @$s12_Concurrency13_runChildTask9operationBoxyYJKc_tYlF : $@convention(thin) @async <τ_0_0> (@guaranteed @concurrent @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
+  // CHECK: [[CHILD_TASK:%.*]] = apply [[RUN_CHILD_TASK]]<Int>([[CLOSURE_ARG]]) : $@convention(thin) @async <τ_0_0> (@guaranteed @concurrent @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
   async let i = await getInt()
 
   // CHECK: [[FUTURE_GET:%.*]] = function_ref @$s12_Concurrency14_taskFutureGetyxBoYlF : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0

--- a/test/SILGen/concurrent_functions.swift
+++ b/test/SILGen/concurrent_functions.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -enable-experimental-concurrency | %FileCheck %s
+// REQUIRES: concurrency
+
+func acceptsConcurrent(_: @escaping @concurrent () -> Int) { }
+
+func concurrentWithCaptures(i: Int) -> Int {
+  var i = i
+
+  // CHECK: sil private [ossa] @$s4test22concurrentWithCaptures1iS2i_tFSiyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> Int
+  acceptsConcurrent {
+    i + 1
+  }
+  i = i + 1
+
+  // CHECK: sil private [ossa] @$s4test22concurrentWithCaptures1iS2i_tF13localFunctionL_SiyJF : $@convention(thin) @concurrent (@guaranteed { var Int }) -> Int
+  @concurrent func localFunction() -> Int {
+    return i + 1
+  }
+  acceptsConcurrent(localFunction)
+  i = i + 1
+
+  return i
+}


### PR DESCRIPTION
Add `@concurrent` to SIL function types, mirroring what's available on
AST function types. `@concurrent` function types will have by-value
capture semantics.