### PR TITLE
[Build] Fix macOS version passed in -target parameter.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1289,7 +1289,7 @@ function common_cross_c_flags() {
 
     case $host in
         macosx-*)
-            echo -n " -arch ${arch} -target ${arch}-apple-macosx${SWIFT_DARWIN_DEPLOYMENT_VERSION_OSX}"
+            echo -n " -arch ${arch} -target ${arch}-apple-macosx${DARWIN_DEPLOYMENT_VERSION_OSX}"
             ;;
         iphonesimulator-*)
             echo -n " -arch ${arch} -target ${arch}-apple-ios${DARWIN_DEPLOYMENT_VERSION_IOS}-simulator"


### PR DESCRIPTION
This code was added in commit b4368259480ed2c895e8c855bbfde20c1805acd1, but the macOS variable expansion had an extra "SWIFT_" at the front.

Among other potential problems, this causes classes in the stdlib to always be built with the legacy is-swift bit, which causes havoc when libswiftCore is in the shared cache where those bits aren't fixed up.

rdar://73767816