### PR TITLE
[concurrency] fixes for conformance to async ObjC protocol requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4165,8 +4165,8 @@ ERROR(actor_isolated_objc,none,
       "actor-isolated %0 %1 cannot be @objc",
        (DescriptiveDeclKind, DeclName))
 NOTE(protocol_witness_async_conflict,none,
-     "candidate is %select{not |}0'async', but protocol requirement is%select{| not}0",
-     (bool))
+     "candidate is %select{not |}0'async', but%select{| @objc}1 protocol requirement is%select{| not}0",
+     (bool, bool))
 ERROR(async_autoclosure_nonasync_function,none,
       "'async' autoclosure parameter in a non-'async' function", ())
 
@@ -4214,9 +4214,6 @@ ERROR(objc_ambiguous_async_convention,none,
 NOTE(objc_ambiguous_async_convention_candidate,none,
      "%0 provides async here", (DeclName))
 
-ERROR(satisfy_async_objc,none,
-      "satisfying an asychronous @objc %select{method|initializer}0 with "
-      "a synchronous %select{method|initializer}0 is not supported", (bool))
 ERROR(async_objc_dynamic_self,none,
       "asynchronous method returning 'Self' cannot be '@objc'", ())
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1162,8 +1162,11 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
         if (CD->isObjCZeroParameterWithLongSelector())
           numParameters = 0;  // Something like "init(foo: ())"
 
-      // A throwing method has an error parameter.
-      if (func->hasThrows())
+      // An async method, even if it is also 'throws', has
+      // one additional completion handler parameter in ObjC.
+      if (func->hasAsync())
+        ++numParameters;
+      else if (func->hasThrows()) // A throwing method has an error parameter.
         ++numParameters;
 
       unsigned numArgumentNames = objcName->getNumArgs();

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1795,11 +1795,8 @@ void markAsObjC(ValueDecl *D, ObjCReason reason,
 
     // Attach the foreign async convention.
     if (inheritedAsyncConvention) {
-      if (!method->hasAsync())
-        method->diagnose(diag::satisfy_async_objc,
-                         isa<ConstructorDecl>(method));
-      else
-        method->setForeignAsyncConvention(*inheritedAsyncConvention);
+      assert(method->hasAsync() && "async objc req offered for sync witness?");
+      method->setForeignAsyncConvention(*inheritedAsyncConvention);
 
     } else if (method->hasAsync()) {
       assert(asyncConvention && "Missing async convention");

--- a/test/Concurrency/async_conformance.swift
+++ b/test/Concurrency/async_conformance.swift
@@ -1,0 +1,41 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+import Foundation
+
+// async objc requirement, sync witness
+@objc protocol Tracker {
+    func track(event: String) async // expected-note {{protocol requires function 'track(event:)' with type '(String) async -> ()'; do you want to add a stub?}}
+}
+class Dog: NSObject, Tracker { // expected-error {{type 'Dog' does not conform to protocol 'Tracker'}}
+    func track(event: String) {} // expected-note {{candidate is not 'async', but @objc protocol requirement is}}
+}
+
+// sync objc requirement, async witness
+@objc protocol Runner {
+    func run(event: String) // expected-note {{protocol requires function 'run(event:)' with type '(String) -> ()'; do you want to add a stub?}}
+}
+class Athlete: NSObject, Runner { // expected-error {{type 'Athlete' does not conform to protocol 'Runner'}}
+    func run(event: String) async {} // expected-note {{candidate is 'async', but @objc protocol requirement is not}}
+}
+
+
+// async swift protocol, sync witness
+protocol Snacker {
+    func snack(food: String) async
+}
+
+class Foodie: Snacker {
+    func snack(food: String) {}
+}
+
+
+// sync swift protocol, async witness
+protocol Backer {
+    func back(stonk: String) // expected-note {{protocol requires function 'back(stonk:)' with type '(String) -> ()'; do you want to add a stub?}}
+}
+
+class Investor: Backer {  // expected-error {{type 'Investor' does not conform to protocol 'Backer'}}
+    func back(stonk: String) async {}  // expected-note {{candidate is 'async', but protocol requirement is not}}
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -77,6 +77,24 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)missingAtAttributeMethod __attribute__((__swift_attr__("asyncHandler")));
 @end
 
+@protocol OptionalObserver <NSObject>
+@optional
+- (void)hello:(NSObject *)session completion:(void (^)(BOOL answer))completion;
+- (BOOL)hello:(NSObject *)session;
+@end
+
+@protocol RequiredObserverOnlyCompletion <NSObject>
+- (void)hello:(void (^)(BOOL answer))completion;
+@end
+
+@protocol RequiredObserver <RequiredObserverOnlyCompletion>
+- (BOOL)hello;
+@end
+
+@protocol Rollable <NSObject>
+- (void)rollWithCompletionHandler: (void (^)(void))completionHandler;
+@end
+
 #define MAGIC_NUMBER 42
 
 #pragma clang assume_nonnull end


### PR DESCRIPTION
This PR aims to fix and add more coverage for conformance checking of ObjC protocols that contain a requirement that can be conformed to in different ways by a Swift type: either as the ordinary sync version or an `async` version.

TODOs:
- [x] Fix incorrect diagnostic and then crash when typechecking an ObjC protocol with two optional methods that are projected into Swift with the same name, plus a Swift-side type that attempts to conform to that protocol using a sync witness (rdar://73326234).
- ~Fix unusual note that claims a protocol's requirements are not satisfied (rdar://73641790).~ **Will fix in a separate PR.**
- ~Fix a conformance serialization issue that might be related to the unusual note (rdar://73326224).~ **Will fix in a separate PR.**

a continuation of this work is in https://github.com/apple/swift/pull/35719

