### PR TITLE
Type check withoutActuallyEscaping on async functions

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1900,6 +1900,7 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto bodyClosure = FunctionType::get(arg, result,
                                          FunctionType::ExtInfoBuilder()
                                              .withNoEscape(true)
+                                             .withAsync(true)
                                              .withThrows(true)
                                              .build());
     FunctionType::Param args[] = {
@@ -1910,6 +1911,7 @@ static std::pair<Type, Type> getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     auto refType = FunctionType::get(args, result,
                                      FunctionType::ExtInfoBuilder()
                                          .withNoEscape(false)
+                                         .withAsync(true)
                                          .withThrows(true)
                                          .build());
     return {refType, refType};

--- a/test/decl/func/async.swift
+++ b/test/decl/func/async.swift
@@ -39,3 +39,12 @@ protocol P2 {
 struct ConformsToP2: P2 {
   func f() { }  // okay
 }
+
+// withoutActuallyEscaping on async functions
+func takeEscaping(_: @escaping () async -> Void) async { }
+
+func thereIsNoEscape(_ body: () async -> Void) async {
+  await withoutActuallyEscaping(body) { escapingBody in
+    await takeEscaping(escapingBody)
+  }
+}


### PR DESCRIPTION
Fixes rdar://73695354.
