### PR TITLE
Add support for access notes

### DIFF
--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -32,47 +32,79 @@ namespace swift {
 class ASTContext;
 class ValueDecl;
 
+/// The name of the declaration an access note should be applied to.
+///
+/// Grammatically, this is equivalent to a \c ParsedDeclName, but supports a
+/// subset of that type's features.
 class AccessNoteDeclName {
 public:
+  /// The names of the parent/contextual declarations containing the declaration
+  /// the access note should apply to.
   std::vector<Identifier> parentNames;
+
+  /// The name of the declaration the access note should be applied to. (For
+  /// accessors, this is actually the name of the storage it's attached to.)
   DeclName name;
+
+  /// For accessors, the kind of accessor; for non-accessors, \c None.
   Optional<AccessorKind> accessorKind;
 
   AccessNoteDeclName(ASTContext &ctx, StringRef str);
   AccessNoteDeclName();
 
+  /// If true, an access note with this name should apply to \p VD.
   bool matches(ValueDecl *VD) const;
+
+  /// If true, the name is empty and invalid.
   bool empty() const;
 
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP;
 };
 
+/// An individual access note specifying modifications to a declaration.
 class AccessNote {
 public:
-  AccessNoteDeclName name;
+  /// The name of the declaration to modify.
+  AccessNoteDeclName Name;
 
+  /// If \c true, add an @objc attribute; if \c false, delete an @objc
+  /// attribute; if \c None, do nothing.
   Optional<bool> ObjC;
+
+  /// If \c true, add a dynamic modifier; if \c false, delete a dynamic
+  /// modifier; if \c None, do nothing.
   Optional<bool> Dynamic;
+
+  /// If set, modify an @objc attribute to give it the specified \c ObjCName.
+  /// If \c ObjC would otherwise be \c None, it will be set to \c true.
   Optional<ObjCSelector> ObjCName;
 
   void dump(llvm::raw_ostream &os, int indent = 0) const;
   SWIFT_DEBUG_DUMP;
 };
 
-class AccessNotes {
+/// A set of access notes with module-wide metadata about them.
+class AccessNotesFile {
 public:
-  std::string reason;
-  std::vector<AccessNote> notes;
+  /// A human-readable string describing why the access notes are being applied.
+  /// Inserted into diagnostics about access notes in the file.
+  std::string Reason;
+
+  /// Access notes to apply to the module.
+  std::vector<AccessNote> Notes;
 
   /// Contains keys which were present in the JSON file but were not recognized
   /// by the compiler. Has no functional effect, but can be used for error
   /// handling.
   std::set<std::string> unknownKeys;
 
-  static llvm::Expected<AccessNotes> load(ASTContext &ctx,
-                                          llvm::MemoryBuffer *buffer);
+  /// Load the access notes from \p buffer, or return an error if they cannot
+  /// be loaded.
+  static llvm::Expected<AccessNotesFile> load(ASTContext &ctx,
+                                              llvm::MemoryBuffer *buffer);
 
+  /// Look up the access note in this file, if any, which applies to \p VD.
   NullablePtr<const AccessNote> lookup(ValueDecl *VD) const;
 
   void dump(llvm::raw_ostream &os) const;

--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -94,15 +94,10 @@ public:
   /// Access notes to apply to the module.
   std::vector<AccessNote> Notes;
 
-  /// Contains keys which were present in the JSON file but were not recognized
-  /// by the compiler. Has no functional effect, but can be used for error
-  /// handling.
-  std::set<std::string> unknownKeys;
-
-  /// Load the access notes from \p buffer, or return an error if they cannot
-  /// be loaded.
-  static llvm::Expected<AccessNotesFile> load(ASTContext &ctx,
-                                              llvm::MemoryBuffer *buffer);
+  /// Load the access notes from \p buffer, or \c None if they cannot be loaded.
+  /// Diagnoses any parsing issues with the access notes file.
+  static llvm::Optional<AccessNotesFile>
+      load(ASTContext &ctx, const llvm::MemoryBuffer *buffer);
 
   /// Look up the access note in this file, if any, which applies to \p VD.
   NullablePtr<const AccessNote> lookup(ValueDecl *VD) const;

--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -24,6 +24,8 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
+#include <set>
+#include <string>
 #include <vector>
 
 namespace swift {
@@ -62,6 +64,11 @@ class AccessNotes {
 public:
   std::string reason;
   std::vector<AccessNote> notes;
+
+  /// Contains keys which were present in the JSON file but were not recognized
+  /// by the compiler. Has no functional effect, but can be used for error
+  /// handling.
+  std::set<std::string> unknownKeys;
 
   static llvm::Expected<AccessNotes> load(ASTContext &ctx,
                                           llvm::MemoryBuffer *buffer);

--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -19,6 +19,7 @@
 #define ACCESSNOTES_H
 
 #include "swift/AST/Identifier.h"
+#include "swift/AST/StorageImpl.h"
 #include "swift/Basic/NullablePtr.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -33,6 +34,7 @@ class AccessNoteDeclName {
 public:
   std::vector<Identifier> parentNames;
   DeclName name;
+  Optional<AccessorKind> accessorKind;
 
   AccessNoteDeclName(ASTContext &ctx, StringRef str);
   AccessNoteDeclName();

--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -1,0 +1,61 @@
+//===--- AccessNotes.h - Access Notes ---------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Implements access notes, which allow certain modifiers or attributes to be
+//  added to the declarations in a module.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ACCESSNOTES_H
+#define ACCESSNOTES_H
+
+#include "swift/AST/Identifier.h"
+#include "swift/Basic/NullablePtr.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+#include <vector>
+
+namespace swift {
+class ASTContext;
+class ValueDecl;
+
+class AccessNote {
+public:
+  DeclName name;
+  std::vector<AccessNote> members;    // can't be SmallVector due to recursion
+
+  Optional<bool> ObjC;
+  Optional<bool> Dynamic;
+  Optional<ObjCSelector> ObjCName;
+
+  void dump(llvm::raw_ostream &os, int indent = 0) const;
+  SWIFT_DEBUG_DUMP;
+};
+
+class AccessNotes {
+public:
+  std::string reason;
+  std::vector<AccessNote> notes;
+
+  static llvm::Expected<AccessNotes> load(ASTContext &ctx,
+                                          llvm::MemoryBuffer *buffer);
+
+  NullablePtr<const AccessNote> lookup(ValueDecl *VD) const;
+
+  void dump(llvm::raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP;
+};
+
+}
+
+#endif

--- a/include/swift/AST/AccessNotes.h
+++ b/include/swift/AST/AccessNotes.h
@@ -29,10 +29,24 @@ namespace swift {
 class ASTContext;
 class ValueDecl;
 
+class AccessNoteDeclName {
+public:
+  std::vector<Identifier> parentNames;
+  DeclName name;
+
+  AccessNoteDeclName(ASTContext &ctx, StringRef str);
+  AccessNoteDeclName();
+
+  bool matches(ValueDecl *VD) const;
+  bool empty() const;
+
+  void print(llvm::raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP;
+};
+
 class AccessNote {
 public:
-  DeclName name;
-  std::vector<AccessNote> members;    // can't be SmallVector due to recursion
+  AccessNoteDeclName name;
 
   Optional<bool> ObjC;
   Optional<bool> Dynamic;

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -405,5 +405,10 @@ WARNING(module_incompatible_with_skip_function_bodies,none,
         "-experimental-skip-*-function-bodies* flags; they have "
         "been automatically disabled", (StringRef))
 
+WARNING(invalid_access_notes_file,none,
+        "access notes at '%0' will be ignored due to an error while loading "
+        "them: %1",
+        (StringRef, StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -405,13 +405,15 @@ WARNING(module_incompatible_with_skip_function_bodies,none,
         "-experimental-skip-*-function-bodies* flags; they have "
         "been automatically disabled", (StringRef))
 
-WARNING(invalid_access_notes_file,none,
-        "access notes at '%0' will be ignored due to an error while loading "
-        "them: %1",
+WARNING(access_notes_file_io_error,none,
+        "ignored access notes file at '%0' because it cannot be read: %1",
         (StringRef, StringRef))
-REMARK(unknown_keys_in_access_notes_file,none,
-       "compiler ignored unknown key%s0 '%1' in access notes at '%2'",
-       (bool, StringRef, StringRef))
+WARNING(error_in_access_notes_file,none,
+        "ignored access notes file because it cannot be parsed: %0",
+        (StringRef))
+REMARK(warning_in_access_notes_file,none,
+       "ignored invalid content in access notes file: %0",
+       (StringRef))
 
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -409,6 +409,10 @@ WARNING(invalid_access_notes_file,none,
         "access notes at '%0' will be ignored due to an error while loading "
         "them: %1",
         (StringRef, StringRef))
+REMARK(unknown_keys_in_access_notes_file,none,
+       "compiler ignored unknown key%s0 '%1' in access notes at '%2'",
+       (bool, StringRef, StringRef))
+
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5670,6 +5670,10 @@ WARNING(attr_objc_name_changed_by_access_note, none,
 WARNING(fixit_attr_objc_name_changed_by_access_note, none,
         "change '@objc' name in source code explicitly to silence this warning",
         ())
+WARNING(attr_objc_name_conflicts_with_access_note, none,
+        "access note for %0 changes the '@objc' name of this %1 to %2, but "
+        "source code specifies %3; the access note will be ignored",
+        (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5648,32 +5648,31 @@ ERROR(atomics_ordering_must_be_constant, none,
 // MARK: access notes
 //------------------------------------------------------------------------------
 
-WARNING(attr_added_by_access_note, none,
-        "access note for %0 adds %select{attribute|modifier}1 '%2' to "
-        "this %3",
-        (StringRef, bool, StringRef, DescriptiveDeclKind))
+REMARK(attr_added_by_access_note, none,
+       "access note for %0 adds %select{attribute|modifier}1 '%2' to this %3",
+       (StringRef, bool, StringRef, DescriptiveDeclKind))
 NOTE(fixit_attr_added_by_access_note, none,
      "add %select{attribute|modifier}0 explicitly to silence this warning",
      (bool))
 
-WARNING(attr_removed_by_access_note, none,
-        "access note for %0 removes %select{attribute|modifier}1 '%2' from "
-        "this %3",
-        (StringRef, bool, StringRef, DescriptiveDeclKind))
+REMARK(attr_removed_by_access_note, none,
+       "access note for %0 removes %select{attribute|modifier}1 '%2' from "
+       "this %3",
+       (StringRef, bool, StringRef, DescriptiveDeclKind))
 NOTE(fixit_attr_removed_by_access_note, none,
      "remove %select{attribute|modifier}0 explicitly to silence this warning",
      (bool))
 
-WARNING(attr_objc_name_changed_by_access_note, none,
+REMARK(attr_objc_name_changed_by_access_note, none,
         "access note for %0 changes the '@objc' name of this %1 to %2",
         (StringRef, DescriptiveDeclKind, ObjCSelector))
-WARNING(fixit_attr_objc_name_changed_by_access_note, none,
-        "change '@objc' name in source code explicitly to silence this warning",
-        ())
-WARNING(attr_objc_name_conflicts_with_access_note, none,
-        "access note for %0 changes the '@objc' name of this %1 to %2, but "
-        "source code specifies %3; the access note will be ignored",
-        (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
+NOTE(fixit_attr_objc_name_changed_by_access_note, none,
+     "change '@objc' name in source code explicitly to silence this warning",
+     ())
+REMARK(attr_objc_name_conflicts_with_access_note, none,
+       "access note for %0 changes the '@objc' name of this %1 to %2, but "
+       "source code specifies %3; the access note will be ignored",
+       (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5644,5 +5644,32 @@ ERROR(atomics_ordering_must_be_constant, none,
       "ordering argument must be a static method or property of %0",
       (Identifier))
 
+//------------------------------------------------------------------------------
+// MARK: access notes
+//------------------------------------------------------------------------------
+
+WARNING(attr_added_by_access_note, none,
+        "access note for %0 adds %select{attribute|modifier}1 '%2' to "
+        "this %3",
+        (StringRef, bool, StringRef, DescriptiveDeclKind))
+NOTE(fixit_attr_added_by_access_note, none,
+     "add %select{attribute|modifier}0 explicitly to silence this warning",
+     (bool))
+
+WARNING(attr_removed_by_access_note, none,
+        "access note for %0 removes %select{attribute|modifier}1 '%2' from "
+        "this %3",
+        (StringRef, bool, StringRef, DescriptiveDeclKind))
+NOTE(fixit_attr_removed_by_access_note, none,
+     "remove %select{attribute|modifier}0 explicitly to silence this warning",
+     (bool))
+
+WARNING(attr_objc_name_changed_by_access_note, none,
+        "access note for %0 changes the '@objc' name of this %1 to %2",
+        (StringRef, DescriptiveDeclKind, ObjCSelector))
+WARNING(fixit_attr_objc_name_changed_by_access_note, none,
+        "change '@objc' name in source code explicitly to silence this warning",
+        ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -820,6 +820,13 @@ public:
   /// Construct an invalid ObjCSelector.
   ObjCSelector() : Storage() {}
 
+  /// Split \p string into selector pieces on colons to create an ObjCSelector.
+  ///
+  /// This should not be used to parse selectors written directly in Swift
+  /// source source code (e.g. the argument of an @objc attribute). Use the
+  /// parser for that.
+  static llvm::Optional<ObjCSelector> parse(ASTContext &ctx, StringRef string);
+
   /// Convert to true if the decl name is valid.
   explicit operator bool() const { return (bool)Storage; }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_MODULE_H
 #define SWIFT_MODULE_H
 
+#include "swift/AST/AccessNotes.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DeclContext.h"
 #include "swift/AST/Identifier.h"
@@ -249,6 +250,8 @@ private:
   /// \see EntryPointInfoTy
   EntryPointInfoTy EntryPointInfo;
 
+  AccessNotes accessNotes;
+
   ModuleDecl(Identifier name, ASTContext &ctx, ImplicitImportInfo importInfo);
 
 public:
@@ -278,6 +281,9 @@ public:
   /// Retrieve a list of modules that each file of this module implicitly
   /// imports.
   ImplicitImportList getImplicitImports() const;
+
+  AccessNotes &getAccessNotes() { return accessNotes; }
+  const AccessNotes &getAccessNotes() const { return accessNotes; }
 
   ArrayRef<FileUnit *> getFiles() {
     assert(!Files.empty() || failedToLoad());

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -250,7 +250,7 @@ private:
   /// \see EntryPointInfoTy
   EntryPointInfoTy EntryPointInfo;
 
-  AccessNotes accessNotes;
+  AccessNotesFile accessNotes;
 
   ModuleDecl(Identifier name, ASTContext &ctx, ImplicitImportInfo importInfo);
 
@@ -282,8 +282,8 @@ public:
   /// imports.
   ImplicitImportList getImplicitImports() const;
 
-  AccessNotes &getAccessNotes() { return accessNotes; }
-  const AccessNotes &getAccessNotes() const { return accessNotes; }
+  AccessNotesFile &getAccessNotes() { return accessNotes; }
+  const AccessNotesFile &getAccessNotes() const { return accessNotes; }
 
   ArrayRef<FileUnit *> getFiles() {
     assert(!Files.empty() || failedToLoad());

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2311,6 +2311,25 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Looks up and applies the access note for a given declaration.
+class ApplyAccessNoteRequest
+    : public SimpleRequest<ApplyAccessNoteRequest,
+                           evaluator::SideEffect(ValueDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect evaluate(Evaluator &evaluator, ValueDecl *VD) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
+
 class TypeCheckSourceFileRequest
     : public SimpleRequest<
           TypeCheckSourceFileRequest, evaluator::SideEffect(SourceFile *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -20,6 +20,8 @@ SWIFT_REQUEST(TypeChecker, AbstractGenericSignatureRequest,
                                 SmallVector<GenericTypeParamType *, 2>,
                                 SmallVector<Requirement, 2>),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ApplyAccessNoteRequest,
+              evaluator::SideEffect(ValueDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AttachedResultBuilderRequest,
               CustomAttr *(ValueDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, AttachedPropertyWrapperTypeRequest,

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -78,7 +78,7 @@ public:
     FileSystem = FS;
   }
 
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> getFileSystem() {
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> getFileSystem() const {
     return FileSystem;
   }
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -467,7 +467,9 @@ public:
   DiagnosticEngine &getDiags() { return Diagnostics; }
   const DiagnosticEngine &getDiags() const { return Diagnostics; }
 
-  llvm::vfs::FileSystem &getFileSystem() { return *SourceMgr.getFileSystem(); }
+  llvm::vfs::FileSystem &getFileSystem() const {
+    return *SourceMgr.getFileSystem();
+  }
 
   ASTContext &getASTContext() { return *Context; }
   const ASTContext &getASTContext() const { return *Context; }

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -70,6 +70,9 @@ public:
   /// The path to which we should store indexing data, if any.
   std::string IndexStorePath;
 
+  /// The path to load access notes from.
+  std::string AccessNotesPath;
+
   /// The path to look in when loading a module interface file, to see if a
   /// binary module has already been built for use by the compiler.
   std::string PrebuiltModuleCachePath;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -33,6 +33,9 @@ def supplementary_output_file_map : Separate<["-"], "supplementary-output-file-m
 def frontend_parseable_output : Flag<["-"], "frontend-parseable-output">,
   HelpText<"Emit textual output in a parseable format">;
 
+def access_notes : Separate<["-"], "access-notes">, MetaVarName<"<path>">,
+  HelpText<"Specify YAML file to override attributes on Swift declarations in this module">;
+
 def emit_module_doc : Flag<["-"], "emit-module-doc">,
   HelpText<"Emit a module documentation file based on documentation "
            "comments">;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -33,9 +33,6 @@ def supplementary_output_file_map : Separate<["-"], "supplementary-output-file-m
 def frontend_parseable_output : Flag<["-"], "frontend-parseable-output">,
   HelpText<"Emit textual output in a parseable format">;
 
-def access_notes : Separate<["-"], "access-notes">, MetaVarName<"<path>">,
-  HelpText<"Specify YAML file to override attributes on Swift declarations in this module">;
-
 def emit_module_doc : Flag<["-"], "emit-module-doc">,
   HelpText<"Emit a module documentation file based on documentation "
            "comments">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -525,6 +525,13 @@ def lto : Joined<["-"], "lto=">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Specify the LTO type to either 'llvm-thin' or 'llvm-full'">;
 
+def access_notes_path : Separate<["-"], "access-notes-path">,
+  Flags<[FrontendOption, ArgumentIsPath]>,
+  HelpText<"Specify YAML file to override attributes on Swift declarations in this module">;
+def access_notes_path_EQ : Joined<["-"], "access-notes-path=">,
+  Flags<[FrontendOption, ArgumentIsPath]>,
+  Alias<access_notes_path>;
+
 // Experimental feature options
 
 // Note: this flag will be removed when JVP/differential generation in the

--- a/lib/AST/AccessNotes.cpp
+++ b/lib/AST/AccessNotes.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/lib/AST/AccessNotes.cpp
+++ b/lib/AST/AccessNotes.cpp
@@ -177,7 +177,7 @@ LLVM_YAML_DECLARE_MAPPING_TRAITS(swift::AccessNotesFile)
 // Not using macro to avoid validation issues.
 template <> struct llvm::yaml::MappingTraits<swift::AccessNote> {
   static void mapping(IO &IO, swift::AccessNote &Obj);
-  static StringRef validate(IO &IO, swift::AccessNote &Obj);
+  static std::string validate(IO &IO, swift::AccessNote &Obj);
 };
 
 namespace swift {
@@ -294,7 +294,7 @@ void MappingTraits<AccessNote>::mapping(IO &io, AccessNote &note) {
   io.mapOptional("ObjCName", note.ObjCName);
 }
 
-StringRef MappingTraits<AccessNote>::validate(IO &io, AccessNote &note) {
+std::string MappingTraits<AccessNote>::validate(IO &io, AccessNote &note) {
   if (note.ObjCName.hasValue()) {
     if (!note.ObjC)
       note.ObjC = true;

--- a/lib/AST/AccessNotes.cpp
+++ b/lib/AST/AccessNotes.cpp
@@ -1,0 +1,231 @@
+//===--- AccessNotes.cpp - Access Notes -------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Implements access notes, which allow certain modifiers or attributes to be
+//  added to the declarations in a module.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/AccessNotes.h"
+#include "swift/AST/Attr.h"
+#include "swift/AST/Decl.h"
+#include "swift/Parse/Parser.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/YAMLTraits.h"
+
+// FIXME: Copied from MiscDiagnostics--don't do that.
+static llvm::Optional<swift::ObjCSelector>
+parseObjCSelector(swift::ASTContext &ctx, llvm::StringRef string) {
+  using namespace swift;
+
+  // Find the first colon.
+  auto colonPos = string.find(':');
+
+  // If there is no colon, we have a nullary selector.
+  if (colonPos == StringRef::npos) {
+    if (string.empty() || !Lexer::isIdentifier(string)) return None;
+    return ObjCSelector(ctx, 0, { ctx.getIdentifier(string) });
+  }
+
+  SmallVector<Identifier, 2> pieces;
+  do {
+    // Check whether we have a valid selector piece.
+    auto piece = string.substr(0, colonPos);
+    if (piece.empty()) {
+      pieces.push_back(Identifier());
+    } else {
+      if (!Lexer::isIdentifier(piece)) return None;
+      pieces.push_back(ctx.getIdentifier(piece));
+    }
+
+    // Move to the next piece.
+    string = string.substr(colonPos+1);
+    colonPos = string.find(':');
+  } while (colonPos != StringRef::npos);
+
+  // If anything remains of the string, it's not a selector.
+  if (!string.empty()) return None;
+
+  return ObjCSelector(ctx, pieces.size(), pieces);
+}
+
+namespace swift {
+
+NullablePtr<const AccessNote> AccessNotes::lookup(ValueDecl *VD) const {
+  assert(VD != nullptr);
+
+  auto lookupVD = VD;
+  if (auto accessor = dyn_cast<AccessorDecl>(VD))
+    VD = accessor->getStorage();
+
+  auto lookupName = lookupVD->getName();
+
+  // FIXME: parseDeclName() doesn't handle the special `subscript` name.
+  // Fixing this without affecting existing uses in import-as-member will need
+  // a bit of work. Hack around this by changing to a normal identifier.
+  if (isa<SubscriptDecl>(lookupVD) &&
+      lookupName.getBaseName() == DeclBaseName::createSubscript()) {
+    ASTContext &ctx = lookupVD->getASTContext();
+    lookupName = DeclName(ctx, ctx.getIdentifier("subscript"),
+                          lookupName.getArgumentNames());
+  }
+
+  const std::vector<AccessNote> *notesToSearch = &notes;
+
+  // If nested, look at the parent context's notes.
+  if (auto parent = lookupVD->getDeclContext()->getSelfNominalTypeDecl()) {
+    if (auto parentNote = lookup(parent))
+      notesToSearch = &(parentNote.get()->members);
+    else
+      return nullptr;
+  }
+
+  auto iter = llvm::find_if(*notesToSearch, [&](const AccessNote &note) -> bool {
+    return lookupName.matchesRef(note.name);
+  });
+  return NullablePtr<const AccessNote>(iter == notesToSearch->end() ? nullptr : &*iter);
+}
+
+void AccessNotes::dump() const {
+  dump(llvm::dbgs());
+  llvm::dbgs() << "\n";
+}
+void AccessNote::dump() const {
+  dump(llvm::dbgs());
+  llvm::dbgs() << "\n";
+}
+
+void AccessNotes::dump(llvm::raw_ostream &os) const {
+  os << "(access_notes reason='" << reason << "'";
+  for (const auto &note : notes) {
+    os << "\n";
+    note.dump(os, /*indent=*/2);
+  }
+}
+
+void AccessNote::dump(llvm::raw_ostream &os, int indent) const {
+  os.indent(indent) << "(note name='" << name << "'";
+  if (name.getBaseName().isSpecial())
+    os << " is_special_name";
+
+  if (ObjC)
+    os << " objc=" << *ObjC;
+  if (ObjCName)
+    os << " objc_name='" << *ObjCName << "'";
+  if (Dynamic)
+    os << " dynamic=" << *Dynamic;
+
+  if (!members.empty()) {
+    os << "\n";
+    os.indent(indent + 2) << "(members";
+    for (const auto &member : members) {
+      os << "\n";
+      member.dump(os, indent + 4);
+    }
+    os << ")";
+  }
+
+  os << ")";
+}
+
+}
+
+LLVM_YAML_DECLARE_SCALAR_TRAITS(swift::DeclName, QuotingType::Single)
+LLVM_YAML_DECLARE_SCALAR_TRAITS(swift::ObjCSelector, QuotingType::Single);
+LLVM_YAML_IS_SEQUENCE_VECTOR(swift::AccessNote)
+LLVM_YAML_DECLARE_MAPPING_TRAITS(swift::AccessNotes)
+
+// Not using macro to avoid validation issues.
+template <> struct llvm::yaml::MappingTraits<swift::AccessNote> {
+  static void mapping(IO &IO, swift::AccessNote &Obj);
+  static StringRef validate(IO &IO, swift::AccessNote &Obj);
+};
+
+namespace swift {
+llvm::Expected<AccessNotes>
+AccessNotes::load(ASTContext &ctx, llvm::MemoryBuffer *buffer) {
+  llvm::yaml::Input yamlIn(buffer->getBuffer(), (void *)&ctx);
+
+  AccessNotes notes;
+  yamlIn >> notes;
+
+  if (yamlIn.error())
+    return llvm::errorCodeToError(yamlIn.error());
+
+  return notes;
+}
+}
+
+
+namespace llvm {
+namespace yaml {
+
+using AccessNote = swift::AccessNote;
+using AccessNotes = swift::AccessNotes;
+using ASTContext = swift::ASTContext;
+using DeclName = swift::DeclName;
+using ObjCSelector = swift::ObjCSelector;
+
+void ScalarTraits<DeclName>::output(const DeclName &name, void *ctxPtr,
+                                    raw_ostream &os) {
+  name.print(os, /*skipEmptyArgumentNames=*/false);
+}
+
+StringRef ScalarTraits<DeclName>::input(StringRef str, void *ctxPtr,
+                                        DeclName &name) {
+  ASTContext &ctx = *static_cast<ASTContext *>(ctxPtr);
+  name = parseDeclName(ctx, str);
+  return name ? "" : "invalid declaration name";
+}
+
+void ScalarTraits<ObjCSelector>::output(const ObjCSelector &selector,
+                                        void *ctxPtr, raw_ostream &os) {
+  os << selector;
+}
+
+StringRef ScalarTraits<ObjCSelector>::input(StringRef str, void *ctxPtr,
+                                            ObjCSelector &selector) {
+  ASTContext &ctx = *static_cast<ASTContext *>(ctxPtr);
+
+  if (auto sel = parseObjCSelector(ctx, str)) {
+    selector = *sel;
+    return "";
+  }
+
+  return "invalid selector";
+}
+
+void MappingTraits<AccessNote>::mapping(IO &io, AccessNote &note) {
+  io.mapRequired("Name", note.name);
+
+  io.mapOptional("ObjC", note.ObjC);
+  io.mapOptional("Dynamic", note.Dynamic);
+  io.mapOptional("ObjCName", note.ObjCName);
+
+  io.mapOptional("Members", note.members);
+}
+
+StringRef MappingTraits<AccessNote>::validate(IO &io, AccessNote &note) {
+  if (!note.ObjC.getValueOr(true) && note.ObjCName.hasValue())
+    return "cannot have an 'ObjCName' if 'ObjC' is false";
+
+  return "";
+}
+
+void MappingTraits<AccessNotes>::mapping(IO &io, AccessNotes &notes) {
+  io.mapRequired("Reason", notes.reason);
+  io.mapRequired("Notes", notes.notes);
+}
+
+}
+}

--- a/lib/AST/AccessNotes.cpp
+++ b/lib/AST/AccessNotes.cpp
@@ -255,8 +255,12 @@ void MappingTraits<AccessNote>::mapping(IO &io, AccessNote &note) {
 }
 
 StringRef MappingTraits<AccessNote>::validate(IO &io, AccessNote &note) {
-  if (!note.ObjC.getValueOr(true) && note.ObjCName.hasValue())
+  if (note.ObjCName.hasValue()) {
+    if (!note.ObjC)
+      note.ObjC = true;
+    else if (!*note.ObjC)
     return "cannot have an 'ObjCName' if 'ObjC' is false";
+  }
 
   return "";
 }

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -13,6 +13,7 @@ set_swift_llvm_is_available()
 
 add_swift_host_library(swiftAST STATIC
   AbstractSourceFileDepGraphFactory.cpp
+  AccessNotes.cpp
   AccessRequests.cpp
   ASTContext.cpp
   ASTDemangler.cpp

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -278,6 +278,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
       options::OPT_disable_fuzzy_forward_scan_trailing_closure_matching);
   inputArgs.AddLastArg(arguments,
                        options::OPT_verify_incremental_dependencies);
+  inputArgs.AddLastArg(arguments, options::OPT_access_notes_path);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -216,6 +216,9 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_module_link_name))
     Opts.ModuleLinkName = A->getValue();
 
+  if (const Arg *A = Args.getLastArg(OPT_access_notes))
+    Opts.AccessNotesPath = A->getValue();
+
   if (const Arg *A = Args.getLastArg(OPT_serialize_debugging_options,
                                      OPT_no_serialize_debugging_options)) {
     Opts.SerializeOptionsForDebugging =

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -216,7 +216,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_module_link_name))
     Opts.ModuleLinkName = A->getValue();
 
-  if (const Arg *A = Args.getLastArg(OPT_access_notes))
+  if (const Arg *A = Args.getLastArg(OPT_access_notes_path))
     Opts.AccessNotesPath = A->getValue();
 
   if (const Arg *A = Args.getLastArg(OPT_serialize_debugging_options,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -951,10 +951,10 @@ ModuleDecl *CompilerInstance::getMainModule() const {
           swift::vfs::getFileOrSTDIN(getFileSystem(), accessNotesPath));
 
       auto expectedAccessNotes =
-          flatMap<AccessNotes, std::unique_ptr<llvm::MemoryBuffer>>(
+          flatMap<AccessNotesFile, std::unique_ptr<llvm::MemoryBuffer>>(
               std::move(expectedBuffer),
               [&](auto &&buffer) -> auto {
-                return AccessNotes::load(*Context, buffer.get());
+                return AccessNotesFile::load(*Context, buffer.get());
               });
 
       if (expectedAccessNotes) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1472,6 +1472,9 @@ static void markAsObjC(ValueDecl *D, ObjCReason reason,
 
 
 bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
+  // Access notes may add attributes that affect this calculus.
+  (void)evaluateOrDefault(evaluator, ApplyAccessNoteRequest{VD}, {});
+
   auto dc = VD->getDeclContext();
   Optional<ObjCReason> isObjC;
   if (dc->getSelfClassDecl() && !isa<TypeDecl>(VD)) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1534,9 +1534,10 @@ static void applyAccessNote(ValueDecl *VD, const AccessNote &note,
         note.fixItInsertAfter(attr->getLocation(), newNameString);
     }
     else if (attr->getName() != *note.ObjCName) {
-      // TODO: diagnose conflict between explicit name in code and explicit
-      // name in access note
-      llvm::report_fatal_error("conflict between name in code and name in access note");
+      diagnoseForAccessNote(attr, VD,
+                            diag::attr_objc_name_conflicts_with_access_note,
+                            notes.reason, VD->getDescriptiveKind(),
+                            *note.ObjCName, *attr->getName());
     }
   }
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1500,7 +1500,7 @@ static void applyAccessNote(ValueDecl *VD, const AccessNote &note,
   ASTContext &ctx = VD->getASTContext();
 
   addOrRemoveAttr<ObjCAttr>(VD, notes, note.ObjC, [&]() {
-    return ObjCAttr::create(ctx, note.ObjCName, true);
+    return ObjCAttr::create(ctx, note.ObjCName, false);
   });
 
   addOrRemoveAttr<DynamicAttr>(VD, notes, note.Dynamic, [&]{
@@ -1509,11 +1509,9 @@ static void applyAccessNote(ValueDecl *VD, const AccessNote &note,
 
   if (note.ObjCName) {
     auto attr = VD->getAttrs().getAttribute<ObjCAttr>();
+    assert(attr && "ObjCName set, but ObjCAttr not true or did not apply???");
 
-    if (!attr) {
-      // TODO: diagnose use of ObjCName without ObjC: true
-    }
-    else if (!attr->hasName()) {
+    if (!attr->hasName()) {
       attr->setName(*note.ObjCName, true);
       ctx.Diags.diagnose(attr->getLocation(),
                          diag::attr_objc_name_changed_by_access_note,

--- a/test/Driver/access-notes.swift
+++ b/test/Driver/access-notes.swift
@@ -1,3 +1,3 @@
-// RUN: %swiftc_driver -emit-executable -o %t.exe %s -access-notes-path %S/Inputs/missing.accessnotes -### 2>&1 | %FileCheck --enable-windows-compatibility %s
+// RUN: %swiftc_driver -emit-executable -o %t.exe %s -access-notes-path %/S/Inputs/missing.accessnotes -### 2>&1 | %FileCheck %s
 
 // CHECK: -access-notes-path SOURCE_DIR/test/Driver/Inputs/missing.accessnotes

--- a/test/Driver/access-notes.swift
+++ b/test/Driver/access-notes.swift
@@ -1,0 +1,3 @@
+// RUN: %swiftc_driver -emit-executable -o %t.exe %s -access-notes-path %S/Inputs/missing.accessnotes -### 2>&1 | %FileCheck %s
+
+// CHECK: -access-notes-path SOURCE_DIR/test/Driver/Inputs/missing.accessnotes

--- a/test/Driver/access-notes.swift
+++ b/test/Driver/access-notes.swift
@@ -1,3 +1,3 @@
-// RUN: %swiftc_driver -emit-executable -o %t.exe %s -access-notes-path %S/Inputs/missing.accessnotes -### 2>&1 | %FileCheck %s
+// RUN: %swiftc_driver -emit-executable -o %t.exe %s -access-notes-path %S/Inputs/missing.accessnotes -### 2>&1 | %FileCheck --enable-windows-compatibility %s
 
 // CHECK: -access-notes-path SOURCE_DIR/test/Driver/Inputs/missing.accessnotes

--- a/test/SILGen/Inputs/objc_access_notes.accessnotes
+++ b/test/SILGen/Inputs/objc_access_notes.accessnotes
@@ -53,3 +53,4 @@ Notes:
   ObjC: true
 - Name: 'Wotsit.plain()'
   ObjC: true
+  ObjCName: 'fancy'

--- a/test/SILGen/Inputs/objc_access_notes.accessnotes
+++ b/test/SILGen/Inputs/objc_access_notes.accessnotes
@@ -32,7 +32,10 @@ Notes:
   ObjC: true
 - Name: 'Hoozit.propComputed'
   ObjC: true
-  # FIXME: Add a way to specify getter and setter names in an access note
+- Name: 'getter:Hoozit.propComputed()'
+  ObjCName: 'initPropComputedGetter'
+- Name: 'setter:Hoozit.propComputed(_:)'
+  ObjCName: 'initPropComputedSetter:'
 - Name: 'Hoozit.roProperty'
   ObjC: true
 - Name: 'Hoozit.rwProperty'

--- a/test/SILGen/Inputs/objc_access_notes.accessnotes
+++ b/test/SILGen/Inputs/objc_access_notes.accessnotes
@@ -1,47 +1,52 @@
 ---
 Reason: fancy test suite
 Notes:
-  - Name: Hoozit
-    Members:
-    - Name: 'typical(_:y:)'
-      ObjC: true
-    - Name: 'copyFoo()'
-      ObjC: true
-    - Name: 'mutableCopyFoo()'
-      ObjC: true
-    - Name: 'copy8()'
-      ObjC: true
-    - Name: 'makeDuplicate()'
-      ObjC: true
-      ObjCName: 'copyDuplicate'
-    - Name: 'mutableCopyFoo()'
-      ObjC: true
-    - Name: 'initFoo()'
-      ObjC: true
-    - Name: 'typicalProperty'
-      ObjC: true
-    - Name: 'copyProperty'
-      ObjC: true
-    - Name: 'propComputed'
-      ObjC: true
-      # FIXME: Add a way to specify getter and setter names in an access note
-    - Name: 'roProperty'
-      ObjC: true
-    - Name: 'rwProperty'
-      ObjC: true
-    - Name: 'copyRWProperty'
-      ObjC: true
-    - Name: 'initProperty'
-      ObjC: true
-    - Name: 'subscript(_:)'
-      ObjC: true
-    - Name: 'init(int:)'
-      ObjC: true
-      Dynamic: true
-    - Name: 'foof()'
-      ObjC: true
-  - Name: Wotsit
-    Members:
-    - Name: 'plain()'
-      ObjC: true
 
+# These two should not match anything, but could accidentally match Hoozit.typical(_:y:)
+- Name: 'typical(_:y:)'
+  ObjC: true
+  ObjCName: 'pickedNoteWithNameThatWasTooShallow_typical:y:'
+- Name: 'Hoozit.Hoozit.typical(_:y:)'
+  ObjC: true
+  ObjCName: 'pickedNoteWithNameThatWasTooDeep_typical:y:'
+
+# These entries should actually match things.
+- Name: 'Hoozit.typical(_:y:)'
+  ObjC: true
+- Name: 'Hoozit.copyFoo()'
+  ObjC: true
+- Name: 'Hoozit.mutableCopyFoo()'
+  ObjC: true
+- Name: 'Hoozit.copy8()'
+  ObjC: true
+- Name: 'Hoozit.makeDuplicate()'
+  ObjC: true
+  ObjCName: 'copyDuplicate'
+- Name: 'Hoozit.mutableCopyFoo()'
+  ObjC: true
+- Name: 'Hoozit.initFoo()'
+  ObjC: true
+- Name: 'Hoozit.typicalProperty'
+  ObjC: true
+- Name: 'Hoozit.copyProperty'
+  ObjC: true
+- Name: 'Hoozit.propComputed'
+  ObjC: true
+  # FIXME: Add a way to specify getter and setter names in an access note
+- Name: 'Hoozit.roProperty'
+  ObjC: true
+- Name: 'Hoozit.rwProperty'
+  ObjC: true
+- Name: 'Hoozit.copyRWProperty'
+  ObjC: true
+- Name: 'Hoozit.initProperty'
+  ObjC: true
+- Name: 'Hoozit.subscript(_:)'
+  ObjC: true
+- Name: 'Hoozit.init(int:)'
+  ObjC: true
+  Dynamic: true
+- Name: 'Hoozit.foof()'
+  ObjC: true
+- Name: 'Wotsit.plain()'
+  ObjC: true

--- a/test/SILGen/Inputs/objc_access_notes.accessnotes
+++ b/test/SILGen/Inputs/objc_access_notes.accessnotes
@@ -1,0 +1,47 @@
+---
+Reason: fancy test suite
+Notes:
+  - Name: Hoozit
+    Members:
+    - Name: 'typical(_:y:)'
+      ObjC: true
+    - Name: 'copyFoo()'
+      ObjC: true
+    - Name: 'mutableCopyFoo()'
+      ObjC: true
+    - Name: 'copy8()'
+      ObjC: true
+    - Name: 'makeDuplicate()'
+      ObjC: true
+      ObjCName: 'copyDuplicate'
+    - Name: 'mutableCopyFoo()'
+      ObjC: true
+    - Name: 'initFoo()'
+      ObjC: true
+    - Name: 'typicalProperty'
+      ObjC: true
+    - Name: 'copyProperty'
+      ObjC: true
+    - Name: 'propComputed'
+      ObjC: true
+      # FIXME: Add a way to specify getter and setter names in an access note
+    - Name: 'roProperty'
+      ObjC: true
+    - Name: 'rwProperty'
+      ObjC: true
+    - Name: 'copyRWProperty'
+      ObjC: true
+    - Name: 'initProperty'
+      ObjC: true
+    - Name: 'subscript(_:)'
+      ObjC: true
+    - Name: 'init(int:)'
+      ObjC: true
+      Dynamic: true
+    - Name: 'foof()'
+      ObjC: true
+  - Name: Wotsit
+    Members:
+    - Name: 'plain()'
+      ObjC: true
+

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -1,0 +1,597 @@
+
+// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 -access-notes %S/Inputs/objc_access_notes.accessnotes | %FileCheck %s
+// RUN-X: not %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import gizmo
+import ansible
+
+class Hoozit : Gizmo {
+  @objc func typical(_ x: Int, y: Gizmo) -> Gizmo { return y }
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtFTo : $@convention(objc_method) (Int, Gizmo, Hoozit) -> @autoreleased Gizmo {
+  // CHECK: bb0([[X:%.*]] : $Int, [[Y:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[Y_COPY:%.*]] = copy_value [[Y]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_Y_COPY:%.*]] = begin_borrow [[Y_COPY]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.typical
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtF : $@convention(method) (Int, @guaranteed Gizmo, @guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[X]], [[BORROWED_Y_COPY]], [[BORROWED_THIS_COPY]]) {{.*}} line:[[@LINE-9]]:14:auto_gen
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   end_borrow [[BORROWED_Y_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]] : $Hoozit
+  // CHECK-NEXT:   destroy_value [[Y_COPY]]
+  // CHECK-NEXT:   return [[RES]] : $Gizmo{{.*}} line:[[@LINE-14]]:14:auto_gen
+  // CHECK-NEXT: } // end sil function '$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtFTo'
+
+  // NS_CONSUMES_SELF by inheritance
+  override func fork() { }
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC4forkyyFTo : $@convention(objc_method) (@owned Hoozit) -> () {
+  // CHECK: bb0([[THIS:%.*]] : @owned $Hoozit):
+  // CHECK-NEXT:   [[BORROWED_THIS:%.*]] = begin_borrow [[THIS]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC4forkyyF : $@convention(method) (@guaranteed Hoozit) -> ()
+  // CHECK-NEXT:   apply [[NATIVE]]([[BORROWED_THIS]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS]]
+  // CHECK-NEXT:   destroy_value [[THIS]]
+  // CHECK-NEXT:   return
+  // CHECK-NEXT: }
+
+  // NS_CONSUMED 'gizmo' argument by inheritance
+  override class func consume(_ gizmo: Gizmo?) { }
+   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7consumeyySo5GizmoCSgFZTo : $@convention(objc_method) (@owned Optional<Gizmo>, @objc_metatype Hoozit.Type) -> () {
+  // CHECK: bb0([[GIZMO:%.*]] : @owned $Optional<Gizmo>, [[THIS:%.*]] : $@objc_metatype Hoozit.Type):
+  // CHECK-NEXT: [[BORROWED_GIZMO:%.*]] = begin_borrow [[GIZMO]]
+  // CHECK-NEXT: [[THICK_THIS:%[0-9]+]] = objc_to_thick_metatype [[THIS]] : $@objc_metatype Hoozit.Type to $@thick Hoozit.Type
+  // CHECK:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC7consumeyySo5GizmoCSgFZ : $@convention(method) (@guaranteed Optional<Gizmo>, @thick Hoozit.Type) -> ()
+  // CHECK-NEXT:   apply [[NATIVE]]([[BORROWED_GIZMO]], [[THICK_THIS]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_GIZMO]]
+  // CHECK-NEXT:   destroy_value [[GIZMO]]
+  // CHECK-NEXT:   return
+  // CHECK-NEXT: }
+
+  // NS_RETURNS_RETAINED by family (-copy)
+  @objc func copyFoo() -> Gizmo { return self }
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7copyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC7copyFooSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // NS_RETURNS_RETAINED by family (-mutableCopy)
+  @objc func mutableCopyFoo() -> Gizmo { return self }
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC14mutableCopyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC14mutableCopyFooSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // NS_RETURNS_RETAINED by family (-copy). This is different from Swift's
+  // normal notion of CamelCase, but it's what Clang does, so we should match
+  // it.
+  @objc func copy8() -> Gizmo { return self }
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC5copy8So5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC5copy8So5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // NS_RETURNS_RETAINED by family (-copy)
+  @objc(copyDuplicate) func makeDuplicate() -> Gizmo { return self }
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // Override the normal family conventions to make this non-consuming and
+  // returning at +0.
+  @objc func initFoo() -> Gizmo { return self }
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7initFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC7initFooSo5GizmoCyF : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  @objc var typicalProperty: Gizmo
+  // -- getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
+  // CHECK: bb0([[SELF:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK-NEXT:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
+  // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.typicalProperty.getter
+  // CHECK-NEXT:   [[GETIMPL:%.*]] = function_ref @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvg
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[GETIMPL]]([[BORROWED_SELF_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]]
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]]
+  // CHECK-NEXT:   return [[RES]] : $Gizmo
+  // CHECK-NEXT: }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK: bb0(%0 : @guaranteed $Hoozit):
+  // CHECK-NEXT:   debug_value %0
+  // CHECK-NEXT:   [[ADDR:%.*]] = ref_element_addr %0 : {{.*}}, #Hoozit.typicalProperty
+  // CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = load [copy] [[READ]] {{.*}}
+  // CHECK-NEXT:   end_access [[READ]] : $*Gizmo
+  // CHECK-NEXT:   return [[RES]]
+
+  // -- setter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvsTo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
+  // CHECK: bb0([[VALUE:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]] : $Gizmo
+  // CHECK:   [[THIS_COPY:%.*]] = copy_value [[THIS]] : $Hoozit
+  // CHECK:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK:   // function_ref objc_thunks.Hoozit.typicalProperty.setter
+  // CHECK:   [[FR:%.*]] = function_ref @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs
+  // CHECK:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
+  // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK:   destroy_value [[THIS_COPY]]
+  // CHECK:   return [[RES]] : $(), loc {{.*}}, scope {{.*}} // id: {{.*}} line:[[@LINE-34]]:13:auto_gen
+  // CHECK: } // end sil function '$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvsTo'
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs
+  // CHECK: bb0([[ARG0:%.*]] : @owned $Gizmo, [[ARG1:%.*]] : @guaranteed $Hoozit):
+  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
+  // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[BORROWED_ARG0]]
+  // CHECK:   [[ADDR:%.*]] = ref_element_addr [[ARG1]] : {{.*}}, #Hoozit.typicalProperty
+  // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo
+  // CHECK:   assign [[ARG0_COPY]] to [[WRITE]] : $*Gizmo
+  // CHECK:   end_access [[WRITE]] : $*Gizmo
+  // CHECK:   end_borrow [[BORROWED_ARG0]]
+  // CHECK:   destroy_value [[ARG0]]
+  // CHECK: } // end sil function '$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs'
+
+  // NS_RETURNS_RETAINED getter by family (-copy)
+  @objc var copyProperty: Gizmo
+  // -- getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo {
+  // CHECK: bb0([[SELF:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
+  // CHECK-NEXT:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
+  // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.copyProperty.getter
+  // CHECK-NEXT:   [[FR:%.*]] = function_ref @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvg
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]]([[BORROWED_SELF_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]]
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvg
+  // CHECK: bb0(%0 : @guaranteed $Hoozit):
+  // CHECK:        [[ADDR:%.*]] = ref_element_addr %0 : {{.*}}, #Hoozit.copyProperty
+  // CHECK-NEXT:   [[READ:%.*]] = begin_access [read] [dynamic] [[ADDR]] : $*Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = load [copy] [[READ]]
+  // CHECK-NEXT:   end_access [[READ]] : $*Gizmo
+  // CHECK-NEXT:   return [[RES]]
+
+  // -- setter is normal
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvsTo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
+  // CHECK: bb0([[VALUE:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.copyProperty.setter
+  // CHECK-NEXT:   [[FR:%.*]] = function_ref @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs
+  // CHECK: bb0([[ARG1:%.*]] : @owned $Gizmo, [[SELF:%.*]] : @guaranteed $Hoozit):
+  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
+  // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
+  // CHECK:   [[ADDR:%.*]] = ref_element_addr [[SELF]] : {{.*}}, #Hoozit.copyProperty
+  // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo
+  // CHECK:   assign [[ARG1_COPY]] to [[WRITE]]
+  // CHECK:   end_access [[WRITE]] : $*Gizmo
+  // CHECK:   end_borrow [[BORROWED_ARG1]]
+  // CHECK:   destroy_value [[ARG1]]
+  // CHECK: } // end sil function '$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs'
+
+  @objc var roProperty: Gizmo { return self }
+  // -- getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]] : $Hoozit
+  // CHECK-NEXT:   return [[RES]] : $Gizmo
+  // CHECK-NEXT: } // end sil function '$s11objc_thunks6HoozitC10roPropertySo5GizmoCvgTo'
+
+  // -- no setter
+  // CHECK-NOT: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvsTo
+
+  @objc var rwProperty: Gizmo {
+    get {
+      return self
+    }
+    set {}
+  }
+  // -- getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10rwPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo
+
+  // -- setter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10rwPropertySo5GizmoCvsTo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
+  // CHECK: bb0([[VALUE:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC10rwPropertySo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return
+  // CHECK-NEXT: }
+
+  @objc var copyRWProperty: Gizmo {
+    get {
+      return self
+    }
+    set {}
+  }
+  // -- getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC14copyRWPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo {
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC14copyRWPropertySo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NOT:    return
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // -- setter is normal
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC14copyRWPropertySo5GizmoCvsTo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
+  // CHECK: bb0([[VALUE:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC14copyRWPropertySo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return
+  // CHECK-NEXT: }
+
+  @objc var initProperty: Gizmo
+  // -- getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12initPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC12initPropertySo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // -- setter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12initPropertySo5GizmoCvsTo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
+  // CHECK: bb0([[VALUE:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC12initPropertySo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return
+  // CHECK-NEXT: }
+
+  @objc var propComputed: Gizmo {
+    @objc(initPropComputedGetter) get { return self }
+    @objc(initPropComputedSetter:) set {}
+  }
+  // -- getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12propComputedSo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
+  // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC12propComputedSo5GizmoCvg : $@convention(method) (@guaranteed Hoozit) -> @owned Gizmo
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return [[RES]]
+  // CHECK-NEXT: }
+
+  // -- setter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12propComputedSo5GizmoCvsTo : $@convention(objc_method) (Gizmo, Hoozit) -> () {
+  // CHECK: bb0([[VALUE:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
+  // CHECK-NEXT:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
+  // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
+  // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC12propComputedSo5GizmoCvs : $@convention(method) (@owned Gizmo, @guaranteed Hoozit) -> ()
+  // CHECK-NEXT:   apply [[NATIVE]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
+  // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
+  // CHECK-NEXT:   destroy_value [[THIS_COPY]]
+  // CHECK-NEXT:   return
+  // CHECK-NEXT: }
+
+  // Don't export generics to ObjC yet
+  func generic<T>(_ x: T) {}
+  // CHECK-NOT: sil hidden [thunk] [ossa] @_TToFC11objc_thunks6Hoozit7generic{{.*}}
+
+  // Constructor.
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC7bellsOnACSi_tcfc : $@convention(method) (Int, @owned Hoozit) -> @owned Hoozit {
+  // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Hoozit }
+  // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [derivedself] [[SELF_BOX]]
+  // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
+  // CHECK: [[GIZMO:%[0-9]+]] = upcast [[SELF:%[0-9]+]] : $Hoozit to $Gizmo
+  // CHECK: [[BORROWED_GIZMO:%.*]] = begin_borrow [[GIZMO]]
+  // CHECK: [[CAST_BORROWED_GIZMO:%.*]] = unchecked_ref_cast [[BORROWED_GIZMO]] : $Gizmo to $Hoozit
+  // CHECK: [[SUPERMETHOD:%[0-9]+]] = objc_super_method [[CAST_BORROWED_GIZMO]] : $Hoozit, #Gizmo.init!initializer.foreign : (Gizmo.Type) -> (Int) -> Gizmo?, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
+  // CHECK-NEXT: end_borrow [[BORROWED_GIZMO]]
+  // CHECK-NEXT: [[SELF_REPLACED:%[0-9]+]] = apply [[SUPERMETHOD]](%0, [[X:%[0-9]+]]) : $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
+  // CHECK-NOT: unconditional_checked_cast downcast [[SELF_REPLACED]] : $Gizmo to Hoozit
+  // CHECK: unchecked_ref_cast
+  // CHECK: return
+  override init(bellsOn x : Int) {
+    super.init(bellsOn: x)
+    other()
+  }
+
+  // Subscript
+  @objc subscript (i: Int) -> Hoozit {
+  // Getter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitCyACSicigTo : $@convention(objc_method) (Int, Hoozit) -> @autoreleased Hoozit
+  // CHECK: bb0([[I:%[0-9]+]] : $Int, [[SELF:%[0-9]+]] : @unowned $Hoozit):
+  // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Hoozit
+  // CHECK-NEXT: [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
+  // CHECK-NEXT: // function_ref
+  // CHECK-NEXT: [[NATIVE:%[0-9]+]] = function_ref @$s11objc_thunks6HoozitCyACSicig : $@convention(method) (Int, @guaranteed Hoozit) -> @owned Hoozit
+  // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[I]], [[BORROWED_SELF_COPY]]) : $@convention(method) (Int, @guaranteed Hoozit) -> @owned Hoozit
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]]
+  // CHECK-NEXT: destroy_value [[SELF_COPY]]
+  // CHECK-NEXT: return [[RESULT]] : $Hoozit
+  get {
+    return self
+  }
+
+  // Setter
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitCyACSicisTo : $@convention(objc_method) (Hoozit, Int, Hoozit) -> ()
+  // CHECK: bb0([[VALUE:%[0-9]+]] : @unowned $Hoozit, [[I:%[0-9]+]] : $Int, [[SELF:%[0-9]+]] : @unowned $Hoozit):
+  // CHECK:   [[VALUE_COPY:%.*]] = copy_value [[VALUE]] : $Hoozit
+  // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Hoozit
+  // CHECK:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
+  // CHECK:   [[NATIVE:%[0-9]+]] = function_ref @$s11objc_thunks6HoozitCyACSicis : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
+  // CHECK:   [[RESULT:%[0-9]+]] = apply [[NATIVE]]([[VALUE_COPY]], [[I]], [[BORROWED_SELF_COPY]]) : $@convention(method) (@owned Hoozit, Int, @guaranteed Hoozit) -> ()
+  // CHECK:   end_borrow [[BORROWED_SELF_COPY]]
+  // CHECK:   destroy_value [[SELF_COPY]]
+  // CHECK:   return [[RESULT]] : $()
+  // CHECK: } // end sil function '$s11objc_thunks6HoozitCyACSicisTo'
+  set {}
+  }
+}
+
+class Wotsit<T> : Gizmo {
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6WotsitC5plainyyFTo : $@convention(objc_method) <T> (Wotsit<T>) -> () {
+  // CHECK: bb0([[SELF:%.*]] : @unowned $Wotsit<T>):
+  // CHECK-NEXT: [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Wotsit<T>
+  // CHECK-NEXT: [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
+  // CHECK-NEXT: // function_ref
+  // CHECK-NEXT: [[NATIVE:%.*]] = function_ref @$s11objc_thunks6WotsitC5plainyyF : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> ()
+  // CHECK-NEXT: [[RESULT:%.*]] = apply [[NATIVE]]<T>([[BORROWED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> ()
+  // CHECK-NEXT: end_borrow [[BORROWED_SELF_COPY]]
+  // CHECK-NEXT: destroy_value [[SELF_COPY]] : $Wotsit<T>
+  // CHECK-NEXT: return [[RESULT]] : $()
+  // CHECK-NEXT: }
+  @objc func plain() { }
+
+  func generic<U>(_ x: U) {}
+
+  var property : T
+
+  init(t: T) {
+    self.property = t
+    super.init()
+  }
+
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6WotsitC11descriptionSSvgTo : $@convention(objc_method) <T> (Wotsit<T>) -> @autoreleased NSString {
+  // CHECK: bb0([[SELF:%.*]] : @unowned $Wotsit<T>):
+  // CHECK-NEXT:   [[SELF_COPY:%.*]] = copy_value [[SELF]] : $Wotsit<T>
+  // CHECK-NEXT:   [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6WotsitC11descriptionSSvg : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> @owned String
+  // CHECK-NEXT:   [[RESULT:%.*]] = apply [[NATIVE:%.*]]<T>([[BORROWED_SELF_COPY]]) : $@convention(method) <τ_0_0> (@guaranteed Wotsit<τ_0_0>) -> @owned String
+  // CHECK-NEXT:   end_borrow [[BORROWED_SELF_COPY]]
+  // CHECK-NEXT:   destroy_value [[SELF_COPY]] : $Wotsit<T>
+  // CHECK-NEXT:   // function_ref
+  // CHECK-NEXT:   [[BRIDGE:%.*]] = function_ref @$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF
+  // CHECK-NEXT:   [[BORROWED_RESULT:%.*]] = begin_borrow [[RESULT]]
+  // CHECK-NEXT:   [[NSRESULT:%.*]] = apply [[BRIDGE]]([[BORROWED_RESULT]]) : $@convention(method) (@guaranteed String) -> @owned NSString
+  // CHECK-NEXT:   end_borrow [[BORROWED_RESULT]]
+  // CHECK-NEXT:   destroy_value [[RESULT]]
+  // CHECK-NEXT:   return [[NSRESULT]] : $NSString
+  // CHECK-NEXT: }
+  override var description : String {
+    return "Hello, world."
+  }
+
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6WotsitCACyxGSgycfcTo : $@convention(objc_method) <T> (@owned Wotsit<T>) -> @owned Optional<Wotsit<T>>
+
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6WotsitC7bellsOnACyxGSgSi_tcfcTo : $@convention(objc_method) <T> (Int, @owned Wotsit<T>) -> @owned Optional<Wotsit<T>>
+
+  // Ivar destroyer
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6WotsitCfETo
+
+}
+
+// CHECK-NOT: sil hidden [thunk] [ossa] @_TToF{{.*}}Wotsit{{.*}}
+
+// Extension initializers, properties and methods need thunks too.
+extension Hoozit {
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC3intACSi_tcfcTo : $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
+  @objc dynamic convenience init(int i: Int) { self.init(bellsOn: i) }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC6doubleACSd_tcfC : $@convention(method) (Double, @thick Hoozit.Type) -> @owned Hoozit
+  convenience init(double d: Double) {
+    var x = X()
+    self.init(int:Int(d))
+    other()
+  }
+
+  @objc func foof() {}
+  // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC4foofyyFTo : $@convention(objc_method) (Hoozit) -> () {
+
+  var extensionProperty: Int { return 0 }
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC17extensionPropertySivg : $@convention(method) (@guaranteed Hoozit) -> Int
+}
+
+// Calling objc methods of subclass should go through native entry points
+func useHoozit(_ h: Hoozit) {
+// sil [ossa] @$s11objc_thunks9useHoozit1hyAA0D0C_tF
+  // In the class decl, overrides importd method, 'dynamic' was inferred
+  h.fork()
+  // CHECK: objc_method {{%.*}} : {{.*}}, #Hoozit.fork!foreign
+
+  // In an extension, 'dynamic' was inferred.
+  h.foof()
+  // CHECK: objc_method {{%.*}} : {{.*}}, #Hoozit.foof!foreign
+}
+
+func useWotsit(_ w: Wotsit<String>) {
+// sil [ossa] @$s11objc_thunks9useWotsit1wySo0D0CySSG_tF
+  w.plain()
+  // CHECK: class_method {{%.*}} : {{.*}}, #Wotsit.plain :
+  w.generic(2)
+  // CHECK: class_method {{%.*}} : {{.*}}, #Wotsit.generic :
+
+  // Inherited methods only have objc entry points
+  w.clone()
+  // CHECK: objc_method {{%.*}} : {{.*}}, #Gizmo.clone!foreign
+}
+
+func other() { }
+
+class X { }
+
+// CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks8propertyySiSo5GizmoCF
+func property(_ g: Gizmo) -> Int {
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
+  // CHECK:   objc_method [[ARG]] : $Gizmo, #Gizmo.count!getter.foreign
+  return g.count
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks13blockPropertyyySo5GizmoCF
+func blockProperty(_ g: Gizmo) {
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $Gizmo):
+  // CHECK:   objc_method [[ARG]] : $Gizmo, #Gizmo.block!setter.foreign
+  g.block = { }
+  // CHECK:   objc_method [[ARG]] : $Gizmo, #Gizmo.block!getter.foreign
+  g.block()
+}
+
+class DesignatedStubs : Gizmo {
+  var i: Int
+
+  override init() { i = 5 }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks15DesignatedStubsC7bellsOnACSgSi_tcfc
+  // CHECK: string_literal utf8 "objc_thunks.DesignatedStubs"
+  // CHECK: string_literal utf8 "init(bellsOn:)"
+  // CHECK: string_literal utf8 "{{.*}}objc_thunks.swift"
+  // CHECK: function_ref @$ss25_unimplementedInitializer9className04initD04file4line6columns5NeverOs12StaticStringV_A2JS2utF
+  // CHECK: return
+
+  // CHECK-NOT: sil hidden [ossa] @_TFCSo15DesignatedStubsc{{.*}}
+}
+
+class DesignatedOverrides : Gizmo {
+  var i: Int = 5
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks19DesignatedOverridesCACSgycfc
+  // CHECK-NOT: return
+  // CHECK: function_ref @$s11objc_thunks19DesignatedOverridesC1iSivpfi : $@convention(thin) () -> Int
+  // CHECK: objc_super_method [[SELF:%[0-9]+]] : $DesignatedOverrides, #Gizmo.init!initializer.foreign : (Gizmo.Type) -> () -> Gizmo?, $@convention(objc_method) (@owned Gizmo) -> @owned Optional<Gizmo>
+  // CHECK: return
+
+  // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks19DesignatedOverridesC7bellsOnACSgSi_tcfc
+  // CHECK: function_ref @$s11objc_thunks19DesignatedOverridesC1iSivpfi : $@convention(thin) () -> Int
+  // CHECK: objc_super_method [[SELF:%[0-9]+]] : $DesignatedOverrides, #Gizmo.init!initializer.foreign : (Gizmo.Type) -> (Int) -> Gizmo?, $@convention(objc_method) (Int, @owned Gizmo) -> @owned Optional<Gizmo>
+  // CHECK: return
+}
+
+// Make sure we copy blocks passed in as IUOs - <rdar://problem/22471309>
+
+func registerAnsible() {
+  // CHECK: function_ref @$s11objc_thunks15registerAnsibleyyFyyycSgcfU_
+  Ansible.anseAsync({ completion in completion!() })
+}
+@_silgen_name("noescape")
+func noescape(f: @convention(block) () -> ())
+
+// CHECK: sil hidden [ossa] @$s11objc_thunks21testObjCNoescapeThunkyyF : $@convention(thin) () -> () {
+// CHECK: [[REABSTRACT:%.*]] = function_ref @$sIeg_IyB_TR
+// CHECK: init_block_storage_header {{.*}} : $*@block_storage @callee_guaranteed () -> (), invoke [[REABSTRACT]]
+// CHECK: return
+func testObjCNoescapeThunk() {
+  noescape {
+  }
+}
+
+// Noescape verification relies on there not being a retain/release in order to
+// work in the presence of a objective c throwing implementation function.
+// CHECK: sil {{.*}} [ossa] @$sIeg_IyB_TR
+// CHECK: bb0([[T0:%.*]] : $*@block_storage @callee_guaranteed () -> ()):
+// CHECK-NEXT:  [[T1:%.*]] = project_block_storage [[T0]]
+// CHECK-NEXT:  [[T2:%.*]] = load_borrow [[T1]]
+// CHECK-NEXT:  [[T3:%.*]] = apply [[T2]]()
+// CHECK-NEXT:  [[T4:%.*]] = tuple ()
+// CHECK-NEXT:  end_borrow [[T2]]
+// CHECK-NEXT:  return [[T4]]
+
+// Call a convenience initializer
+func buildGizmo1() -> Gizmo {
+  return Gizmo(outBells: 10)
+}
+
+func buildGizmo2() -> Gizmo {
+  return Gizmo(whistles: 10)
+}

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -10,7 +10,7 @@ import gizmo
 import ansible
 
 class Hoozit : Gizmo {
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func typical(_ x: Int, y: Gizmo) -> Gizmo { return y }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtFTo : $@convention(objc_method) (Int, Gizmo, Hoozit) -> @autoreleased Gizmo {
@@ -56,7 +56,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func copyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7copyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
@@ -72,7 +72,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-mutableCopy)
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func mutableCopyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC14mutableCopyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
@@ -90,7 +90,7 @@ class Hoozit : Gizmo {
   // NS_RETURNS_RETAINED by family (-copy). This is different from Swift's
   // normal notion of CamelCase, but it's what Clang does, so we should match
   // it.
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func copy8() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC5copy8So5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
@@ -106,7 +106,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc(copyDuplicate) }}
   func makeDuplicate() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
@@ -123,7 +123,7 @@ class Hoozit : Gizmo {
 
   // Override the normal family conventions to make this non-consuming and
   // returning at +0.
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func initFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7initFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo
@@ -138,7 +138,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var typicalProperty: Gizmo
   // -- getter
@@ -190,7 +190,7 @@ class Hoozit : Gizmo {
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs'
 
   // NS_RETURNS_RETAINED getter by family (-copy)
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var copyProperty: Gizmo
   // -- getter
@@ -239,7 +239,7 @@ class Hoozit : Gizmo {
   // CHECK:   destroy_value [[ARG1]]
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs'
 
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var roProperty: Gizmo { return self }
   // -- getter
@@ -258,7 +258,7 @@ class Hoozit : Gizmo {
   // -- no setter
   // CHECK-NOT: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvsTo
 
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var rwProperty: Gizmo {
     get {
@@ -283,7 +283,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var copyRWProperty: Gizmo {
     get {
@@ -319,7 +319,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var initProperty: Gizmo
   // -- getter
@@ -349,13 +349,13 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var propComputed: Gizmo {
-    // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this getter}}
+    // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this getter}}
     // expected-note@+1 {{add attribute explicitly to silence this warning}} {{5-5=@objc(initPropComputedGetter) }}
     get { return self }
-    // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this setter}}
+    // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this setter}}
     // expected-note@+1 {{add attribute explicitly to silence this warning}} {{5-5=@objc(initPropComputedSetter:) }}
     set {}
   }
@@ -410,7 +410,7 @@ class Hoozit : Gizmo {
   }
 
   // Subscript
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this subscript}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this subscript}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   subscript (i: Int) -> Hoozit {
   // Getter
@@ -458,7 +458,7 @@ class Wotsit<T> : Gizmo {
   // CHECK-NEXT: }
   @objc(plain)
   func plain() { }
-  // expected-warning@-2 {{access note for fancy test suite changes the '@objc' name of this instance method to 'fancy', but source code specifies 'plain'; the access note will be ignored}}
+  // expected-remark@-2 {{access note for fancy test suite changes the '@objc' name of this instance method to 'fancy', but source code specifies 'plain'; the access note will be ignored}}
 
   func generic<U>(_ x: U) {}
 
@@ -505,9 +505,9 @@ class Wotsit<T> : Gizmo {
 extension Hoozit {
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC3intACSi_tcfcTo : $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
   convenience init(int i: Int) { self.init(bellsOn: i) }
-  // expected-warning@-1 {{access note for fancy test suite adds attribute 'objc' to this initializer}}
+  // expected-remark@-1 {{access note for fancy test suite adds attribute 'objc' to this initializer}}
   // expected-note@-2 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
-  // expected-warning@-3 {{access note for fancy test suite adds modifier 'dynamic' to this initializer}}
+  // expected-remark@-3 {{access note for fancy test suite adds modifier 'dynamic' to this initializer}}
   // expected-note@-4 {{add modifier explicitly to silence this warning}} {{3-3=dynamic }}
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC6doubleACSd_tcfC : $@convention(method) (Double, @thick Hoozit.Type) -> @owned Hoozit
@@ -517,7 +517,7 @@ extension Hoozit {
     other()
   }
 
-  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func foof() {}
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC4foofyyFTo : $@convention(objc_method) (Hoozit) -> () {

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 -access-notes %S/Inputs/objc_access_notes.accessnotes -verify | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 -access-notes-path %S/Inputs/objc_access_notes.accessnotes -verify | %FileCheck %s
 
 // Verify that the access notes are necessary for the test to pass.
 // RUN-X: not %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 | %FileCheck %s

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -352,9 +352,12 @@ class Hoozit : Gizmo {
   // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
   // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var propComputed: Gizmo {
-    // FIXME: Add a way to specify these names in an access note.
-    @objc(initPropComputedGetter) get { return self }
-    @objc(initPropComputedSetter:) set {}
+    // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this getter}}
+    // expected-note@+1 {{add attribute explicitly to silence this warning}} {{5-5=@objc(initPropComputedGetter) }}
+    get { return self }
+    // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this setter}}
+    // expected-note@+1 {{add attribute explicitly to silence this warning}} {{5-5=@objc(initPropComputedSetter:) }}
+    set {}
   }
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12propComputedSo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -107,7 +107,7 @@ class Hoozit : Gizmo {
 
   // NS_RETURNS_RETAINED by family (-copy)
   // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc(copyDuplicate) }}
   func makeDuplicate() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -8,7 +8,7 @@ import gizmo
 import ansible
 
 class Hoozit : Gizmo {
-  @objc func typical(_ x: Int, y: Gizmo) -> Gizmo { return y }
+  func typical(_ x: Int, y: Gizmo) -> Gizmo { return y }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtFTo : $@convention(objc_method) (Int, Gizmo, Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[X:%.*]] : $Int, [[Y:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
   // CHECK-NEXT:   [[Y_COPY:%.*]] = copy_value [[Y]]
@@ -17,12 +17,12 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   [[BORROWED_THIS_COPY:%.*]] = begin_borrow [[THIS_COPY]]
   // CHECK-NEXT:   // function_ref objc_thunks.Hoozit.typical
   // CHECK-NEXT:   [[NATIVE:%.*]] = function_ref @$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtF : $@convention(method) (Int, @guaranteed Gizmo, @guaranteed Hoozit) -> @owned Gizmo
-  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[X]], [[BORROWED_Y_COPY]], [[BORROWED_THIS_COPY]]) {{.*}} line:[[@LINE-9]]:14:auto_gen
+  // CHECK-NEXT:   [[RES:%.*]] = apply [[NATIVE]]([[X]], [[BORROWED_Y_COPY]], [[BORROWED_THIS_COPY]]) {{.*}} line:[[@LINE-9]]:8:auto_gen
   // CHECK-NEXT:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK-NEXT:   end_borrow [[BORROWED_Y_COPY]]
   // CHECK-NEXT:   destroy_value [[THIS_COPY]] : $Hoozit
   // CHECK-NEXT:   destroy_value [[Y_COPY]]
-  // CHECK-NEXT:   return [[RES]] : $Gizmo{{.*}} line:[[@LINE-14]]:14:auto_gen
+  // CHECK-NEXT:   return [[RES]] : $Gizmo{{.*}} line:[[@LINE-14]]:8:auto_gen
   // CHECK-NEXT: } // end sil function '$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtFTo'
 
   // NS_CONSUMES_SELF by inheritance
@@ -52,7 +52,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
-  @objc func copyFoo() -> Gizmo { return self }
+  func copyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7copyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
   // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
@@ -66,7 +66,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-mutableCopy)
-  @objc func mutableCopyFoo() -> Gizmo { return self }
+  func mutableCopyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC14mutableCopyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
   // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
@@ -82,7 +82,7 @@ class Hoozit : Gizmo {
   // NS_RETURNS_RETAINED by family (-copy). This is different from Swift's
   // normal notion of CamelCase, but it's what Clang does, so we should match
   // it.
-  @objc func copy8() -> Gizmo { return self }
+  func copy8() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC5copy8So5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
   // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
@@ -96,7 +96,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
-  @objc(copyDuplicate) func makeDuplicate() -> Gizmo { return self }
+  func makeDuplicate() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
   // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
@@ -111,7 +111,7 @@ class Hoozit : Gizmo {
 
   // Override the normal family conventions to make this non-consuming and
   // returning at +0.
-  @objc func initFoo() -> Gizmo { return self }
+  func initFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7initFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
   // CHECK-NEXT:   [[THIS_COPY:%.*]] = copy_value [[THIS]]
@@ -124,7 +124,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
-  @objc var typicalProperty: Gizmo
+  var typicalProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[SELF:%.*]] : @unowned $Hoozit):
@@ -158,7 +158,7 @@ class Hoozit : Gizmo {
   // CHECK:   [[RES:%.*]] = apply [[FR]]([[VALUE_COPY]], [[BORROWED_THIS_COPY]])
   // CHECK:   end_borrow [[BORROWED_THIS_COPY]]
   // CHECK:   destroy_value [[THIS_COPY]]
-  // CHECK:   return [[RES]] : $(), loc {{.*}}, scope {{.*}} // id: {{.*}} line:[[@LINE-34]]:13:auto_gen
+  // CHECK:   return [[RES]] : $(), loc {{.*}}, scope {{.*}} // id: {{.*}} line:[[@LINE-34]]:7:auto_gen
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvsTo'
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs
@@ -174,7 +174,7 @@ class Hoozit : Gizmo {
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs'
 
   // NS_RETURNS_RETAINED getter by family (-copy)
-  @objc var copyProperty: Gizmo
+  var copyProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo {
   // CHECK: bb0([[SELF:%.*]] : @unowned $Hoozit):
@@ -221,7 +221,7 @@ class Hoozit : Gizmo {
   // CHECK:   destroy_value [[ARG1]]
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs'
 
-  @objc var roProperty: Gizmo { return self }
+  var roProperty: Gizmo { return self }
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -238,7 +238,7 @@ class Hoozit : Gizmo {
   // -- no setter
   // CHECK-NOT: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvsTo
 
-  @objc var rwProperty: Gizmo {
+  var rwProperty: Gizmo {
     get {
       return self
     }
@@ -261,7 +261,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  @objc var copyRWProperty: Gizmo {
+  var copyRWProperty: Gizmo {
     get {
       return self
     }
@@ -295,7 +295,7 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  @objc var initProperty: Gizmo
+  var initProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12initPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -323,7 +323,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  @objc var propComputed: Gizmo {
+  var propComputed: Gizmo {
+    // FIXME: Add a way to specify these names in an access note.
     @objc(initPropComputedGetter) get { return self }
     @objc(initPropComputedSetter:) set {}
   }
@@ -378,7 +379,7 @@ class Hoozit : Gizmo {
   }
 
   // Subscript
-  @objc subscript (i: Int) -> Hoozit {
+  subscript (i: Int) -> Hoozit {
   // Getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitCyACSicigTo : $@convention(objc_method) (Int, Hoozit) -> @autoreleased Hoozit
   // CHECK: bb0([[I:%[0-9]+]] : $Int, [[SELF:%[0-9]+]] : @unowned $Hoozit):
@@ -422,7 +423,7 @@ class Wotsit<T> : Gizmo {
   // CHECK-NEXT: destroy_value [[SELF_COPY]] : $Wotsit<T>
   // CHECK-NEXT: return [[RESULT]] : $()
   // CHECK-NEXT: }
-  @objc func plain() { }
+  func plain() { }
 
   func generic<U>(_ x: U) {}
 
@@ -468,7 +469,7 @@ class Wotsit<T> : Gizmo {
 // Extension initializers, properties and methods need thunks too.
 extension Hoozit {
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC3intACSi_tcfcTo : $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
-  @objc dynamic convenience init(int i: Int) { self.init(bellsOn: i) }
+  convenience init(int i: Int) { self.init(bellsOn: i) }
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC6doubleACSd_tcfC : $@convention(method) (Double, @thick Hoozit.Type) -> @owned Hoozit
   convenience init(double d: Double) {
@@ -477,7 +478,7 @@ extension Hoozit {
     other()
   }
 
-  @objc func foof() {}
+  func foof() {}
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC4foofyyFTo : $@convention(objc_method) (Hoozit) -> () {
 
   var extensionProperty: Int { return 0 }
@@ -536,7 +537,7 @@ class DesignatedStubs : Gizmo {
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks15DesignatedStubsC7bellsOnACSgSi_tcfc
   // CHECK: string_literal utf8 "objc_thunks.DesignatedStubs"
   // CHECK: string_literal utf8 "init(bellsOn:)"
-  // CHECK: string_literal utf8 "{{.*}}objc_thunks.swift"
+  // CHECK: string_literal utf8 "{{.*}}objc_access_notes.swift"
   // CHECK: function_ref @$ss25_unimplementedInitializer9className04initD04file4line6columns5NeverOs12StaticStringV_A2JS2utF
   // CHECK: return
 

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -1,5 +1,7 @@
 
-// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 -access-notes %S/Inputs/objc_access_notes.accessnotes | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 -access-notes %S/Inputs/objc_access_notes.accessnotes -verify | %FileCheck %s
+
+// Verify that the access notes are necessary for the test to pass.
 // RUN-X: not %target-swift-emit-silgen -module-name objc_thunks -Xllvm -sil-full-demangle -Xllvm -sil-print-debuginfo -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -emit-verbose-sil -swift-version 5 | %FileCheck %s
 
 // REQUIRES: objc_interop
@@ -8,6 +10,8 @@ import gizmo
 import ansible
 
 class Hoozit : Gizmo {
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func typical(_ x: Int, y: Gizmo) -> Gizmo { return y }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtFTo : $@convention(objc_method) (Int, Gizmo, Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[X:%.*]] : $Int, [[Y:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
@@ -52,6 +56,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func copyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7copyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -66,6 +72,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-mutableCopy)
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func mutableCopyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC14mutableCopyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -82,6 +90,8 @@ class Hoozit : Gizmo {
   // NS_RETURNS_RETAINED by family (-copy). This is different from Swift's
   // normal notion of CamelCase, but it's what Clang does, so we should match
   // it.
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func copy8() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC5copy8So5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -96,6 +106,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func makeDuplicate() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -111,6 +123,8 @@ class Hoozit : Gizmo {
 
   // Override the normal family conventions to make this non-consuming and
   // returning at +0.
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func initFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7initFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -124,6 +138,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var typicalProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
@@ -174,6 +190,8 @@ class Hoozit : Gizmo {
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs'
 
   // NS_RETURNS_RETAINED getter by family (-copy)
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var copyProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo {
@@ -221,6 +239,8 @@ class Hoozit : Gizmo {
   // CHECK:   destroy_value [[ARG1]]
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs'
 
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var roProperty: Gizmo { return self }
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
@@ -238,6 +258,8 @@ class Hoozit : Gizmo {
   // -- no setter
   // CHECK-NOT: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvsTo
 
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var rwProperty: Gizmo {
     get {
       return self
@@ -261,6 +283,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var copyRWProperty: Gizmo {
     get {
       return self
@@ -295,6 +319,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var initProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12initPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
@@ -323,6 +349,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   var propComputed: Gizmo {
     // FIXME: Add a way to specify these names in an access note.
     @objc(initPropComputedGetter) get { return self }
@@ -379,6 +407,8 @@ class Hoozit : Gizmo {
   }
 
   // Subscript
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this subscript}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   subscript (i: Int) -> Hoozit {
   // Getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitCyACSicigTo : $@convention(objc_method) (Int, Hoozit) -> @autoreleased Hoozit
@@ -424,6 +454,8 @@ class Wotsit<T> : Gizmo {
   // CHECK-NEXT: return [[RESULT]] : $()
   // CHECK-NEXT: }
   func plain() { }
+  // expected-warning@-1 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@-2 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
 
   func generic<U>(_ x: U) {}
 
@@ -470,14 +502,20 @@ class Wotsit<T> : Gizmo {
 extension Hoozit {
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC3intACSi_tcfcTo : $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
   convenience init(int i: Int) { self.init(bellsOn: i) }
+  // expected-warning@-1 {{access note for fancy test suite adds attribute 'objc' to this initializer}}
+  // expected-note@-2 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-warning@-3 {{access note for fancy test suite adds modifier 'dynamic' to this initializer}}
+  // expected-note@-4 {{add modifier explicitly to silence this warning}} {{3-3=dynamic }}
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC6doubleACSd_tcfC : $@convention(method) (Double, @thick Hoozit.Type) -> @owned Hoozit
   convenience init(double d: Double) {
-    var x = X()
+    var x = X()       // expected-warning {{initialization of variable 'x' was never used}}
     self.init(int:Int(d))
     other()
   }
 
+  // expected-warning@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
+  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
   func foof() {}
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC4foofyyFTo : $@convention(objc_method) (Hoozit) -> () {
 

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -456,9 +456,9 @@ class Wotsit<T> : Gizmo {
   // CHECK-NEXT: destroy_value [[SELF_COPY]] : $Wotsit<T>
   // CHECK-NEXT: return [[RESULT]] : $()
   // CHECK-NEXT: }
+  @objc(plain)
   func plain() { }
-  // expected-warning@-1 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@-2 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-warning@-2 {{access note for fancy test suite changes the '@objc' name of this instance method to 'fancy', but source code specifies 'plain'; the access note will be ignored}}
 
   func generic<U>(_ x: U) {}
 

--- a/test/Sema/Inputs/bad.accessnotes
+++ b/test/Sema/Inputs/bad.accessnotes
@@ -1,1 +1,2 @@
 Colourless green ideas sleep furiously.
+# expected-warning@-1 {{ignored access notes file because it cannot be parsed: not a mapping}}

--- a/test/Sema/Inputs/bad.accessnotes
+++ b/test/Sema/Inputs/bad.accessnotes
@@ -1,0 +1,1 @@
+Colourless green ideas sleep furiously.

--- a/test/Sema/Inputs/extra.accessnotes
+++ b/test/Sema/Inputs/extra.accessnotes
@@ -1,0 +1,5 @@
+Reason: Access notes containing future, unknown syntax
+CorinthianLeather: 'rich'
+Notes:
+- Name: 'fn()'
+  CorinthianLeather: 'rich'

--- a/test/Sema/Inputs/extra.accessnotes
+++ b/test/Sema/Inputs/extra.accessnotes
@@ -1,5 +1,7 @@
 Reason: Access notes containing future, unknown syntax
 CorinthianLeather: 'rich'
+# expected-remark@-1 {{ignored invalid content in access notes file: unknown key 'CorinthianLeather'}}
 Notes:
 - Name: 'fn()'
   CorinthianLeather: 'rich'
+  # expected-remark@-1 {{ignored invalid content in access notes file: unknown key 'CorinthianLeather'}}

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/missing.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-MISSING %s
+// CHECK-MISSING: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/missing.accessnotes' will be ignored due to an error while loading them: No such file or directory{{$}}
+
+// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/bad.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-BAD %s
+// CHECK-BAD: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/bad.accessnotes' will be ignored due to an error while loading them: not a mapping at line 1, column 0{{$}}

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -3,3 +3,9 @@
 
 // RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/bad.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-BAD %s
 // CHECK-BAD: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/bad.accessnotes' will be ignored due to an error while loading them: not a mapping at line 1, column 0{{$}}
+
+// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/extra.accessnotes >%t.txt 2>&1 
+// RUN: %FileCheck --check-prefix=CHECK-EXTRA %s <%t.txt
+// RUN: %FileCheck --check-prefix=NEGATIVE-EXTRA %s <%t.txt
+// CHECK-EXTRA: <unknown>:0: remark: compiler ignored unknown key 'CorinthianLeather' in access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes'
+// NEGATIVE-EXTRA-NOT: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes' will be ignored due to an error while loading them

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/missing.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-MISSING --enable-windows-compatibility %s
+// RUN: %target-swift-frontend -typecheck -primary-file %/s -access-notes-path %/S/Inputs/missing.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-MISSING %s
 // CHECK-MISSING: <unknown>:0: warning: ignored access notes file at 'SOURCE_DIR/test/Sema/Inputs/missing.accessnotes' because it cannot be read: No such file or directory{{$}}
 
 // RUN: %target-typecheck-verify-swift -access-notes-path %S/Inputs/bad.accessnotes -verify-additional-file %S/Inputs/bad.accessnotes

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -1,14 +1,9 @@
 // RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/missing.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-MISSING --enable-windows-compatibility %s
-// CHECK-MISSING: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/missing.accessnotes' will be ignored due to an error while loading them: No such file or directory{{$}}
+// CHECK-MISSING: <unknown>:0: warning: ignored access notes file at 'SOURCE_DIR/test/Sema/Inputs/missing.accessnotes' because it cannot be read: No such file or directory{{$}}
 
-// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/bad.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-BAD --enable-windows-compatibility %s
-// CHECK-BAD: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/bad.accessnotes' will be ignored due to an error while loading them: not a mapping at line 1, column 0{{$}}
+// RUN: %target-typecheck-verify-swift -access-notes-path %S/Inputs/bad.accessnotes -verify-additional-file %S/Inputs/bad.accessnotes
 
-// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/extra.accessnotes >%t.txt 2>&1 
-// RUN: %FileCheck --check-prefix=CHECK-EXTRA --enable-windows-compatibility %s <%t.txt
-// RUN: %FileCheck --check-prefix=NEGATIVE-EXTRA --enable-windows-compatibility %s <%t.txt
-// CHECK-EXTRA: <unknown>:0: remark: compiler ignored unknown key 'CorinthianLeather' in access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes'
-// NEGATIVE-EXTRA-NOT: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes' will be ignored due to an error while loading them
+// RUN: %target-typecheck-verify-swift -access-notes-path %S/Inputs/extra.accessnotes -verify-additional-file %S/Inputs/extra.accessnotes
 
 // FIXME: Should diagnose multiple access notes for the same decl
 

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -9,3 +9,7 @@
 // RUN: %FileCheck --check-prefix=NEGATIVE-EXTRA %s <%t.txt
 // CHECK-EXTRA: <unknown>:0: remark: compiler ignored unknown key 'CorinthianLeather' in access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes'
 // NEGATIVE-EXTRA-NOT: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes' will be ignored due to an error while loading them
+
+// FIXME: Should diagnose multiple access notes for the same decl
+
+// FIXME: Should diagnose access notes that don't match a decl in the source code

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -1,12 +1,12 @@
-// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/missing.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-MISSING %s
+// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/missing.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-MISSING --enable-windows-compatibility %s
 // CHECK-MISSING: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/missing.accessnotes' will be ignored due to an error while loading them: No such file or directory{{$}}
 
-// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/bad.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-BAD %s
+// RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/bad.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-BAD --enable-windows-compatibility %s
 // CHECK-BAD: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/bad.accessnotes' will be ignored due to an error while loading them: not a mapping at line 1, column 0{{$}}
 
 // RUN: %target-swift-frontend -typecheck -primary-file %s -access-notes-path %S/Inputs/extra.accessnotes >%t.txt 2>&1 
-// RUN: %FileCheck --check-prefix=CHECK-EXTRA %s <%t.txt
-// RUN: %FileCheck --check-prefix=NEGATIVE-EXTRA %s <%t.txt
+// RUN: %FileCheck --check-prefix=CHECK-EXTRA --enable-windows-compatibility %s <%t.txt
+// RUN: %FileCheck --check-prefix=NEGATIVE-EXTRA --enable-windows-compatibility %s <%t.txt
 // CHECK-EXTRA: <unknown>:0: remark: compiler ignored unknown key 'CorinthianLeather' in access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes'
 // NEGATIVE-EXTRA-NOT: <unknown>:0: warning: access notes at 'SOURCE_DIR/test/Sema/Inputs/extra.accessnotes' will be ignored due to an error while loading them
 

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -typecheck -primary-file %/s -access-notes-path %/S/Inputs/missing.accessnotes 2>&1 | %FileCheck --check-prefix=CHECK-MISSING %s
-// CHECK-MISSING: <unknown>:0: warning: ignored access notes file at 'SOURCE_DIR/test/Sema/Inputs/missing.accessnotes' because it cannot be read: No such file or directory{{$}}
+// CHECK-MISSING: <unknown>:0: warning: ignored access notes file at 'SOURCE_DIR/test/Sema/Inputs/missing.accessnotes' because it cannot be read: {{[Nn]}}o such file or directory{{$}}
 
 // RUN: %target-typecheck-verify-swift -access-notes-path %S/Inputs/bad.accessnotes -verify-additional-file %S/Inputs/bad.accessnotes
 


### PR DESCRIPTION
Access notes are sidecar files that can be ingested while a module is being compiled to apply small tweaks to the declarations in the module. They're intended to be used in situations where a module needs to be built with additional internals exposed, but without editing its source code. To make sure the differences from the source code are obvious, the compiler diagnoses each change made by the access notes.

Currently, access notes can:

* Add or remove `@objc` attributes
* Set the selector for an `@objc` attribute
* Add or remove `dynamic` modifiers

In the future, they might gain other capabilities, such as increasing access levels, adding SPI groups, or enabling library evolution for a module.

Fixes rdar://71870054, rdar://71872830.

------

At the time of this PR's creation, this work is incomplete, but basically functions. I still need to write a more targeted set of tests, but I want to self-review the PR in its current state so I can identify other tasks I have to complete.