### PR TITLE
[AutoDiff] NFC: Clean up dead code.

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1231,41 +1231,6 @@ static ManagedValue emitBuiltinApplyTranspose(
       arity, throws, SGF, loc, substitutions, args, C);
 }
 
-static ManagedValue emitBuiltinDifferentiableFunction(
-    SILGenFunction &SGF, SILLocation loc, SubstitutionMap substitutions,
-    ArrayRef<ManagedValue> args, SGFContext C) {
-  assert(args.size() == 3);
-  auto origFn = args.front();
-  auto origType = origFn.getType().castTo<SILFunctionType>();
-  auto numResults =
-      origType->getNumResults() + origType->getNumIndirectMutatingParameters();
-  auto diffFn = SGF.B.createDifferentiableFunction(
-      loc,
-      IndexSubset::getDefault(SGF.getASTContext(), origType->getNumParameters(),
-                              /*includeAll*/ true),
-      IndexSubset::getDefault(SGF.getASTContext(), numResults,
-                              /*includeAll*/ true),
-      origFn.forward(SGF),
-      std::make_pair(args[1].forward(SGF), args[2].forward(SGF)));
-  return SGF.emitManagedRValueWithCleanup(diffFn);
-}
-
-static ManagedValue emitBuiltinLinearFunction(
-    SILGenFunction &SGF, SILLocation loc, SubstitutionMap substitutions,
-    ArrayRef<ManagedValue> args, SGFContext C) {
-  assert(args.size() == 2);
-  auto origFn = args.front();
-  auto origType = origFn.getType().castTo<SILFunctionType>();
-  auto linearFn = SGF.B.createLinearFunction(
-      loc,
-      IndexSubset::getDefault(
-          SGF.getASTContext(),
-          origType->getNumParameters(),
-          /*includeAll*/ true),
-      origFn.forward(SGF), args[1].forward(SGF));
-  return SGF.emitManagedRValueWithCleanup(linearFn);
-}
-
 /// Emit SIL for the named builtin: globalStringTablePointer. Unlike the default
 /// ownership convention for named builtins, which is to take (non-trivial)
 /// arguments as Owned, this builtin accepts owned as well as guaranteed


### PR DESCRIPTION
`emitBuiltinDifferentiableFunction()` and `emitBuiltinLinearFunction()` are unused.