### PR TITLE
[capture-promotion] Teach capture promotion how to diagnose concurrent function captures that it can not promote from by ref to by val

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -645,5 +645,15 @@ NOTE(box_to_stack_cannot_promote_box_to_stack_due_to_escape_location, none,
 
 WARNING(semantic_function_improper_nesting, none, "'@_semantics' function calls non-'@_semantics' function with nested '@_semantics' calls", ())
 
+// Capture promotion diagnostics
+WARNING(capturepromotion_concurrentcapture_mutation, none,
+        "'%0' mutated after capture by concurrent closure", (StringRef))
+NOTE(capturepromotion_concurrentcapture_closure_here, none,
+     "variable captured by concurrent closure", ())
+NOTE(capturepromotion_concurrentcapture_capturinguse_here, none,
+     "capturing use", ())
+NOTE(capturepromotion_variable_defined_here,none,
+     "variable defined here", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -565,6 +565,13 @@ public:
   /// Returns true if this SILType is a differentiable type.
   bool isDifferentiable(SILModule &M) const;
 
+  /// If this is a SILBoxType, return getSILBoxFieldType(). Otherwise, return
+  /// SILType().
+  ///
+  /// \p field Return the type of the ith field of the box. Default set to 0
+  /// since we only support one field today. This is just future proofing.
+  SILType getSILBoxFieldType(const SILFunction *f, unsigned field = 0);
+
   /// Returns the hash code for the SILType.
   llvm::hash_code getHashCode() const {
     return llvm::hash_combine(*this);

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -699,3 +699,11 @@ bool SILType::isEffectivelyExhaustiveEnumType(SILFunction *f) {
   return decl->isEffectivelyExhaustive(f->getModule().getSwiftModule(),
                                        f->getResilienceExpansion());
 }
+
+SILType SILType::getSILBoxFieldType(const SILFunction *f, unsigned field) {
+  auto *boxTy = getASTType()->getAs<SILBoxType>();
+  if (!boxTy)
+    return SILType();
+  return ::getSILBoxFieldType(f->getTypeExpansionContext(), boxTy,
+                              f->getModule().Types, field);
+}

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -60,12 +60,21 @@
 
 using namespace swift;
 
-typedef llvm::SmallSet<unsigned, 4> IndicesSet;
-typedef llvm::DenseMap<PartialApplyInst*, IndicesSet> PartialApplyIndicesMap;
-
 STATISTIC(NumCapturesPromoted, "Number of captures promoted");
 
 namespace {
+
+using IndicesSet = llvm::SmallSet<unsigned, 4>;
+using PartialApplyIndicesMap = llvm::DenseMap<PartialApplyInst *, IndicesSet>;
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//                           Reachability Utilites
+//===----------------------------------------------------------------------===//
+
+namespace {
+
 /// Transient reference to a block set within ReachabilityInfo.
 ///
 /// This is a bitset that conveniently flattens into a matrix allowing bit-wise
@@ -186,50 +195,6 @@ private:
 
 } // end anonymous namespace
 
-
-namespace {
-/// A SILCloner subclass which clones a closure function while converting
-/// one or more captures from 'inout' (by-reference) to by-value.
-class ClosureCloner : public SILClonerWithScopes<ClosureCloner> {
-public:
-  friend class SILInstructionVisitor<ClosureCloner>;
-  friend class SILCloner<ClosureCloner>;
-
-  ClosureCloner(SILOptFunctionBuilder &funcBuilder, SILFunction *orig,
-                IsSerialized_t serialized, StringRef clonedName,
-                IndicesSet &promotableIndices, ResilienceExpansion expansion);
-
-  void populateCloned();
-
-  SILFunction *getCloned() { return &getBuilder().getFunction(); }
-
-private:
-  static SILFunction *initCloned(SILOptFunctionBuilder &funcBuilder,
-                                 SILFunction *orig, IsSerialized_t serialized,
-                                 StringRef clonedName,
-                                 IndicesSet &promotableIndices,
-                                 ResilienceExpansion expansion);
-
-  SILValue getProjectBoxMappedVal(SILValue operandValue);
-
-  void visitDebugValueAddrInst(DebugValueAddrInst *inst);
-  void visitStrongReleaseInst(StrongReleaseInst *inst);
-  void visitDestroyValueInst(DestroyValueInst *inst);
-  void visitStructElementAddrInst(StructElementAddrInst *inst);
-  void visitLoadInst(LoadInst *inst);
-  void visitLoadBorrowInst(LoadBorrowInst *inst);
-  void visitProjectBoxInst(ProjectBoxInst *inst);
-  void visitBeginAccessInst(BeginAccessInst *inst);
-  void visitEndAccessInst(EndAccessInst *inst);
-
-  ResilienceExpansion resilienceExpansion;
-  SILFunction *origF;
-  IndicesSet &promotableIndices;
-  llvm::DenseMap<SILArgument *, SILValue> boxArgumentMap;
-  llvm::DenseMap<ProjectBoxInst *, SILValue> projectBoxArgumentMap;
-};
-} // end anonymous namespace
-
 /// Compute ReachabilityInfo so that it can answer queries about
 /// whether a given basic block in a function is reachable from another basic
 /// block in the function.
@@ -309,6 +274,62 @@ bool ReachabilityInfo::isReachable(SILBasicBlock *fromBlock,
   ReachingBlockSet fromSet(ti->second, matrix);
   return fromSet.test(fi->second);
 }
+
+//===----------------------------------------------------------------------===//
+//                               Closure Cloner
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// A SILCloner subclass which clones a closure function while converting
+/// one or more captures from 'inout' (by-reference) to by-value.
+class ClosureCloner : public SILClonerWithScopes<ClosureCloner> {
+public:
+  friend class SILInstructionVisitor<ClosureCloner>;
+  friend class SILCloner<ClosureCloner>;
+
+  ClosureCloner(SILOptFunctionBuilder &funcBuilder, SILFunction *orig,
+                IsSerialized_t serialized, StringRef clonedName,
+                IndicesSet &promotableIndices, ResilienceExpansion expansion);
+
+  void populateCloned();
+
+  SILFunction *getCloned() { return &getBuilder().getFunction(); }
+
+  /// Top level API for producing a cloned function using a closure cloner.
+  static SILFunction *
+  constructClonedFunction(SILOptFunctionBuilder &funcBuilder,
+                          PartialApplyInst *pai, FunctionRefInst *fri,
+                          IndicesSet &promotableIndices,
+                          ResilienceExpansion resilienceExpansion);
+
+private:
+  static SILFunction *initCloned(SILOptFunctionBuilder &funcBuilder,
+                                 SILFunction *orig, IsSerialized_t serialized,
+                                 StringRef clonedName,
+                                 IndicesSet &promotableIndices,
+                                 ResilienceExpansion expansion);
+
+  SILValue getProjectBoxMappedVal(SILValue operandValue);
+
+  void visitDebugValueAddrInst(DebugValueAddrInst *inst);
+  void visitStrongReleaseInst(StrongReleaseInst *inst);
+  void visitDestroyValueInst(DestroyValueInst *inst);
+  void visitStructElementAddrInst(StructElementAddrInst *inst);
+  void visitLoadInst(LoadInst *inst);
+  void visitLoadBorrowInst(LoadBorrowInst *inst);
+  void visitProjectBoxInst(ProjectBoxInst *inst);
+  void visitBeginAccessInst(BeginAccessInst *inst);
+  void visitEndAccessInst(EndAccessInst *inst);
+
+  ResilienceExpansion resilienceExpansion;
+  SILFunction *origF;
+  IndicesSet &promotableIndices;
+  llvm::DenseMap<SILArgument *, SILValue> boxArgumentMap;
+  llvm::DenseMap<ProjectBoxInst *, SILValue> projectBoxArgumentMap;
+};
+
+} // end anonymous namespace
 
 ClosureCloner::ClosureCloner(SILOptFunctionBuilder &funcBuilder,
                              SILFunction *orig, IsSerialized_t serialized,
@@ -705,6 +726,63 @@ void ClosureCloner::visitLoadInst(LoadInst *li) {
   SILCloner<ClosureCloner>::visitLoadInst(li);
 }
 
+SILFunction *ClosureCloner::constructClonedFunction(
+    SILOptFunctionBuilder &funcBuilder, PartialApplyInst *pai,
+    FunctionRefInst *fri, IndicesSet &promotableIndices,
+    ResilienceExpansion resilienceExpansion) {
+  SILFunction *f = pai->getFunction();
+
+  // Create the Cloned Name for the function.
+  SILFunction *origF = fri->getReferencedFunctionOrNull();
+
+  IsSerialized_t isSerialized = IsNotSerialized;
+  if (f->isSerialized() && origF->isSerialized())
+    isSerialized = IsSerialized_t::IsSerializable;
+
+  auto clonedName = getSpecializedName(origF, isSerialized, promotableIndices);
+
+  // If we already have such a cloned function in the module then just use it.
+  if (auto *prevF = f->getModule().lookUpFunction(clonedName)) {
+    assert(prevF->isSerialized() == isSerialized);
+    return prevF;
+  }
+
+  // Otherwise, create a new clone.
+  ClosureCloner cloner(funcBuilder, origF, isSerialized, clonedName,
+                       promotableIndices, resilienceExpansion);
+  cloner.populateCloned();
+  return cloner.getCloned();
+}
+
+//===----------------------------------------------------------------------===//
+//                        EscapeMutationScanningState
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// The structure that we use to store information about escapes/mutations for
+/// both partial apply uses of our box /and/ project_box uses of our box.
+struct EscapeMutationScanningState {
+  /// The list of mutations that we found while checking for escapes.
+  SmallVector<Operand *, 8> accumulatedMutations;
+
+  /// The list of escapes that we found while checking for escapes.
+  SmallVector<Operand *, 8> accumulatedEscapes;
+
+  /// A flag that we use to ensure that we only ever see 1 project_box on an
+  /// alloc_box.
+  bool sawProjectBoxInst;
+
+  /// The global partial_apply -> index map.
+  llvm::DenseMap<PartialApplyInst *, unsigned> &globalIndexMap;
+};
+
+} // end anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//                       Partial Apply Box Use Analysis
+//===----------------------------------------------------------------------===//
+
 static SILArgument *getBoxFromIndex(SILFunction *f, unsigned index) {
   assert(f->isDefinition() && "Expected definition not external declaration!");
   auto &entry = f->front();
@@ -794,6 +872,84 @@ static bool getPartialApplyArgMutationsAndEscapes(
     accumulatedEscapes.push_back(incrementalEscapes.pop_back_val());
   return true;
 }
+
+bool isPartialApplyNonEscapingUser(Operand *currentOp, PartialApplyInst *pai,
+                                   EscapeMutationScanningState &state) {
+  LLVM_DEBUG(llvm::dbgs() << "    Found partial: " << *pai);
+
+  unsigned opNo = currentOp->getOperandNumber();
+  assert(opNo != 0 && "Alloc box used as callee of partial apply?");
+
+  // If we've already seen this partial apply, then it means the same alloc box
+  // is being captured twice by the same closure, which is odd and unexpected:
+  // bail instead of trying to handle this case.
+  if (state.globalIndexMap.count(pai)) {
+    // TODO: Is it correct to treat this like an escape? We are just currently
+    // flagging all failures as warnings.
+    LLVM_DEBUG(llvm::dbgs() << "        FAIL! Already seen.\n");
+    state.accumulatedEscapes.push_back(currentOp);
+    return false;
+  }
+
+  SILModule &mod = pai->getModule();
+  SILFunction *f = pai->getFunction();
+  auto closureType = pai->getType().castTo<SILFunctionType>();
+  SILFunctionConventions closureConv(closureType, mod);
+
+  // Calculate the index into the closure's argument list of the captured
+  // box pointer (the captured address is always the immediately following
+  // index so is not stored separately);
+  unsigned index = opNo - 1 + closureConv.getNumSILArguments();
+
+  auto *fn = pai->getReferencedFunctionOrNull();
+
+  // It is not safe to look at the content of dynamically replaceable functions
+  // since this pass looks at the content of Fn.
+  if (!fn || !fn->isDefinition() || fn->isDynamicallyReplaceable()) {
+    LLVM_DEBUG(llvm::dbgs() << "        FAIL! Not a direct function definition "
+                               "reference.\n");
+    state.accumulatedEscapes.push_back(currentOp);
+    return false;
+  }
+
+  SILArgument *boxArg = getBoxFromIndex(fn, index);
+
+  // For now, return false is the address argument is an address-only type,
+  // since we currently handle loadable types only.
+  // TODO: handle address-only types
+  // FIXME: Expansion
+  auto boxTy = boxArg->getType().castTo<SILBoxType>();
+  assert(boxTy->getLayout()->getFields().size() == 1 &&
+         "promoting compound box not implemented yet");
+  if (getSILBoxFieldType(TypeExpansionContext(*fn), boxTy, mod.Types, 0)
+          .isAddressOnly(*f)) {
+    LLVM_DEBUG(llvm::dbgs() << "        FAIL! Box is an address only "
+                               "argument!\n");
+    state.accumulatedEscapes.push_back(currentOp);
+    return false;
+  }
+
+  // Verify that this closure is known not to mutate the captured value; if
+  // it does, then conservatively refuse to promote any captures of this
+  // value.
+  if (getPartialApplyArgMutationsAndEscapes(boxArg, state.accumulatedMutations,
+                                            state.accumulatedEscapes)) {
+    LLVM_DEBUG(llvm::dbgs() << "        FAIL: Have a mutation or escape of a "
+                               "partial apply arg?!\n");
+    return false;
+  }
+
+  // Record the index and continue.
+  LLVM_DEBUG(llvm::dbgs()
+             << "        Partial apply does not escape, may be optimizable!\n");
+  LLVM_DEBUG(llvm::dbgs() << "        Index: " << index << "\n");
+  state.globalIndexMap.insert(std::make_pair(pai, index));
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
+//                     Project Box Escaping Use Analysis
+//===----------------------------------------------------------------------===//
 
 namespace {
 
@@ -963,25 +1119,6 @@ public:
 
 } // end anonymous namespace
 
-namespace {
-
-struct EscapeMutationScanningState {
-  /// The list of mutations that we found while checking for escapes.
-  SmallVector<Operand *, 8> accumulatedMutations;
-
-  /// The list of escapes that we found while checking for escapes.
-  SmallVector<Operand *, 8> accumulatedEscapes;
-
-  /// A flag that we use to ensure that we only ever see 1 project_box on an
-  /// alloc_box.
-  bool sawProjectBoxInst;
-
-  /// The global partial_apply -> index map.
-  llvm::DenseMap<PartialApplyInst *, unsigned> &globalIndexMap;
-};
-
-} // end anonymous namespace
-
 /// Given a use of an alloc_box instruction, return true if the use
 /// definitely does not allow the box to escape; also, if the use is an
 /// instruction which possibly mutates the contents of the box, then add it to
@@ -991,80 +1128,6 @@ static bool isNonEscapingUse(Operand *initialOp,
   return NonEscapingUserVisitor(initialOp, state.accumulatedMutations,
                                 state.accumulatedEscapes)
       .compute();
-}
-
-bool isPartialApplyNonEscapingUser(Operand *currentOp, PartialApplyInst *pai,
-                                   EscapeMutationScanningState &state) {
-  LLVM_DEBUG(llvm::dbgs() << "    Found partial: " << *pai);
-
-  unsigned opNo = currentOp->getOperandNumber();
-  assert(opNo != 0 && "Alloc box used as callee of partial apply?");
-
-  // If we've already seen this partial apply, then it means the same alloc box
-  // is being captured twice by the same closure, which is odd and unexpected:
-  // bail instead of trying to handle this case.
-  if (state.globalIndexMap.count(pai)) {
-    // TODO: Is it correct to treat this like an escape? We are just currently
-    // flagging all failures as warnings.
-    LLVM_DEBUG(llvm::dbgs() << "        FAIL! Already seen.\n");
-    state.accumulatedEscapes.push_back(currentOp);
-    return false;
-  }
-
-  SILModule &mod = pai->getModule();
-  SILFunction *f = pai->getFunction();
-  auto closureType = pai->getType().castTo<SILFunctionType>();
-  SILFunctionConventions closureConv(closureType, mod);
-
-  // Calculate the index into the closure's argument list of the captured
-  // box pointer (the captured address is always the immediately following
-  // index so is not stored separately);
-  unsigned index = opNo - 1 + closureConv.getNumSILArguments();
-
-  auto *fn = pai->getReferencedFunctionOrNull();
-
-  // It is not safe to look at the content of dynamically replaceable functions
-  // since this pass looks at the content of Fn.
-  if (!fn || !fn->isDefinition() || fn->isDynamicallyReplaceable()) {
-    LLVM_DEBUG(llvm::dbgs() << "        FAIL! Not a direct function definition "
-                          "reference.\n");
-    state.accumulatedEscapes.push_back(currentOp);
-    return false;
-  }
-
-  SILArgument *boxArg = getBoxFromIndex(fn, index);
-
-  // For now, return false is the address argument is an address-only type,
-  // since we currently handle loadable types only.
-  // TODO: handle address-only types
-  // FIXME: Expansion
-  auto boxTy = boxArg->getType().castTo<SILBoxType>();
-  assert(boxTy->getLayout()->getFields().size() == 1 &&
-         "promoting compound box not implemented yet");
-  if (getSILBoxFieldType(TypeExpansionContext(*fn), boxTy, mod.Types, 0)
-          .isAddressOnly(*f)) {
-    LLVM_DEBUG(llvm::dbgs() << "        FAIL! Box is an address only "
-                               "argument!\n");
-    state.accumulatedEscapes.push_back(currentOp);
-    return false;
-  }
-
-  // Verify that this closure is known not to mutate the captured value; if
-  // it does, then conservatively refuse to promote any captures of this
-  // value.
-  if (getPartialApplyArgMutationsAndEscapes(boxArg, state.accumulatedMutations,
-                                            state.accumulatedEscapes)) {
-    LLVM_DEBUG(llvm::dbgs() << "        FAIL: Have a mutation or escape of a "
-                               "partial apply arg?!\n");
-    return false;
-  }
-
-  // Record the index and continue.
-  LLVM_DEBUG(llvm::dbgs()
-             << "        Partial apply does not escape, may be optimizable!\n");
-  LLVM_DEBUG(llvm::dbgs() << "        Index: " << index << "\n");
-  state.globalIndexMap.insert(std::make_pair(pai, index));
-  return true;
 }
 
 static bool isProjectBoxNonEscapingUse(ProjectBoxInst *pbi,
@@ -1081,6 +1144,10 @@ static bool isProjectBoxNonEscapingUse(ProjectBoxInst *pbi,
 
   return true;
 }
+
+//===----------------------------------------------------------------------===//
+//                Top Level AllocBox Escape/Mutation Analysis
+//===----------------------------------------------------------------------===//
 
 static bool findEscapeOrMutationUses(Operand *op,
                                      EscapeMutationScanningState &state) {
@@ -1208,35 +1275,6 @@ examineAllocBoxInst(AllocBoxInst *abi, ReachabilityInfo &ri,
   return true;
 }
 
-static SILFunction *
-constructClonedFunction(SILOptFunctionBuilder &funcBuilder,
-                        PartialApplyInst *pai, FunctionRefInst *fri,
-                        IndicesSet &promotableIndices,
-                        ResilienceExpansion resilienceExpansion) {
-  SILFunction *f = pai->getFunction();
-
-  // Create the Cloned Name for the function.
-  SILFunction *origF = fri->getReferencedFunctionOrNull();
-
-  IsSerialized_t isSerialized = IsNotSerialized;
-  if (f->isSerialized() && origF->isSerialized())
-    isSerialized = IsSerialized_t::IsSerializable;
-
-  auto clonedName = getSpecializedName(origF, isSerialized, promotableIndices);
-
-  // If we already have such a cloned function in the module then just use it.
-  if (auto *prevF = f->getModule().lookUpFunction(clonedName)) {
-    assert(prevF->isSerialized() == isSerialized);
-    return prevF;
-  }
-
-  // Otherwise, create a new clone.
-  ClosureCloner cloner(funcBuilder, origF, isSerialized, clonedName,
-                       promotableIndices, resilienceExpansion);
-  cloner.populateCloned();
-  return cloner.getCloned();
-}
-
 /// For an alloc_box or iterated copy_value alloc_box, get or create the
 /// project_box for the copy or original alloc_box.
 ///
@@ -1280,6 +1318,10 @@ static SILValue getOrCreateProjectBoxHelper(SILValue partialOperand) {
   return b.createProjectBox(box->getLoc(), box, 0);
 }
 
+//===----------------------------------------------------------------------===//
+//         Top Level Processing of Partial Applies with AllocBox Args
+//===----------------------------------------------------------------------===//
+
 /// Change the base in mark_dependence.
 static void
 mapMarkDependenceArguments(SingleValueInstruction *root,
@@ -1316,7 +1358,7 @@ processPartialApplyInst(SILOptFunctionBuilder &funcBuilder,
   auto *fri = dyn_cast<FunctionRefInst>(pai->getCallee());
 
   // Clone the closure with the given promoted captures.
-  SILFunction *clonedFn = constructClonedFunction(
+  SILFunction *clonedFn = ClosureCloner::constructClonedFunction(
       funcBuilder, pai, fri, promotableIndices, f->getResilienceExpansion());
   worklist.push_back(clonedFn);
 
@@ -1441,6 +1483,10 @@ static void constructMapFromPartialApplyToPromotableIndices(
     }
   }
 }
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
 
 namespace {
 

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -43,12 +43,14 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-capture-promotion"
+
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/SIL/SILCloner.h"
-#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/TypeSubstCloner.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallSet.h"
@@ -716,16 +718,21 @@ static bool isNonMutatingLoad(SILInstruction *inst) {
   return li->getOwnershipQualifier() != LoadOwnershipQualifier::Take;
 }
 
-/// Given a partial_apply instruction and the argument index into its
-/// callee's argument list of a box argument (which is followed by an argument
-/// for the address of the box's contents), return true if the closure is known
-/// not to mutate the captured variable.
-static bool isNonMutatingCapture(SILArgument *boxArg) {
+/// Given a partial_apply instruction and the argument index into its callee's
+/// argument list of a box argument (which is followed by an argument for the
+/// address of the box's contents), return true if this box has mutating
+/// captures. Return false otherwise. All of the mutating captures that we find
+/// are placed into \p accumulatedMutatingUses.
+static bool getPartialApplyArgMutationsAndEscapes(
+    SILArgument *boxArg, SmallVectorImpl<Operand *> &accumulatedMutatingUses,
+    SmallVectorImpl<Operand *> &accumulatedEscapes) {
   SmallVector<ProjectBoxInst *, 2> projectBoxInsts;
 
   // Conservatively do not allow any use of the box argument other than a
   // strong_release or projection, since this is the pattern expected from
   // SILGen.
+  SmallVector<Operand *, 32> incrementalMutatingUses;
+  SmallVector<Operand *, 32> incrementalEscapes;
   for (auto *use : boxArg->getUses()) {
     if (isa<StrongReleaseInst>(use->getUser()) ||
         isa<DestroyValueInst>(use->getUser()))
@@ -736,7 +743,7 @@ static bool isNonMutatingCapture(SILArgument *boxArg) {
       continue;
     }
 
-    return false;
+    incrementalEscapes.push_back(use);
   }
 
   // Only allow loads of projections, either directly or via
@@ -745,33 +752,46 @@ static bool isNonMutatingCapture(SILArgument *boxArg) {
   // TODO: This seems overly limited.  Why not projections of tuples and other
   // stuff?  Also, why not recursive struct elements?  This should be a helper
   // function that mirrors isNonEscapingUse.
-  auto isAddrUseMutating = [](SILInstruction *addrInst) {
+  auto checkIfAddrUseMutating = [&](Operand *addrUse) -> bool {
+    unsigned initSize = incrementalMutatingUses.size();
+    auto *addrInst = addrUse->getUser();
     if (auto *seai = dyn_cast<StructElementAddrInst>(addrInst)) {
-      return all_of(seai->getUses(), [](Operand *op) -> bool {
-        return isNonMutatingLoad(op->getUser());
-      });
+      for (auto *seaiUse : seai->getUses()) {
+        if (!isNonMutatingLoad(seaiUse->getUser())) {
+          incrementalMutatingUses.push_back(seaiUse);
+        }
+      }
+      return incrementalMutatingUses.size() != initSize;
     }
 
-    return isNonMutatingLoad(addrInst) || isa<DebugValueAddrInst>(addrInst) ||
-           isa<MarkFunctionEscapeInst>(addrInst) ||
-           isa<EndAccessInst>(addrInst);
+    if (isNonMutatingLoad(addrInst) || isa<DebugValueAddrInst>(addrInst) ||
+        isa<MarkFunctionEscapeInst>(addrInst) || isa<EndAccessInst>(addrInst)) {
+      return false;
+    }
+
+    incrementalMutatingUses.push_back(addrUse);
+    return true;
   };
 
   for (auto *pbi : projectBoxInsts) {
     for (auto *use : pbi->getUses()) {
       if (auto *bai = dyn_cast<BeginAccessInst>(use->getUser())) {
         for (auto *accessUseOper : bai->getUses()) {
-          if (!isAddrUseMutating(accessUseOper->getUser()))
-            return false;
+          checkIfAddrUseMutating(accessUseOper);
         }
         continue;
       }
 
-      if (!isAddrUseMutating(use->getUser()))
-        return false;
+      checkIfAddrUseMutating(use);
     }
   }
 
+  if (incrementalMutatingUses.empty() && incrementalEscapes.empty())
+    return false;
+  while (!incrementalMutatingUses.empty())
+    accumulatedMutatingUses.push_back(incrementalMutatingUses.pop_back_val());
+  while (!incrementalEscapes.empty())
+    accumulatedEscapes.push_back(incrementalEscapes.pop_back_val());
   return true;
 }
 
@@ -779,15 +799,17 @@ namespace {
 
 class NonEscapingUserVisitor
     : public SILInstructionVisitor<NonEscapingUserVisitor, bool> {
-  llvm::SmallVector<Operand *, 32> worklist;
-  llvm::SmallVectorImpl<SILInstruction *> &foundMutations;
+  SmallVector<Operand *, 32> worklist;
+  SmallVectorImpl<Operand *> &accumulatedMutations;
+  SmallVectorImpl<Operand *> &accumulatedEscapes;
   NullablePtr<Operand> currentOp;
 
 public:
-  NonEscapingUserVisitor(
-      Operand *initialOperand,
-      llvm::SmallVectorImpl<SILInstruction *> &foundMutations)
-      : worklist(), foundMutations(foundMutations), currentOp() {
+  NonEscapingUserVisitor(Operand *initialOperand,
+                         SmallVectorImpl<Operand *> &accumulatedMutations,
+                         SmallVectorImpl<Operand *> &accumulatedEscapes)
+      : worklist(), accumulatedMutations(accumulatedMutations),
+        accumulatedEscapes(accumulatedEscapes), currentOp() {
     worklist.push_back(initialOperand);
   }
 
@@ -796,6 +818,15 @@ public:
   NonEscapingUserVisitor(NonEscapingUserVisitor &&) = delete;
   NonEscapingUserVisitor &operator=(NonEscapingUserVisitor &&) = delete;
 
+private:
+  void markCurrentOpAsMutation() {
+    accumulatedMutations.push_back(currentOp.get());
+  }
+  void markCurrentOpAsEscape() {
+    accumulatedEscapes.push_back(currentOp.get());
+  }
+
+public:
   bool compute() {
     while (!worklist.empty()) {
       currentOp = worklist.pop_back_val();
@@ -823,6 +854,7 @@ public:
   bool visitSILInstruction(SILInstruction *inst) {
     LLVM_DEBUG(llvm::dbgs()
                << "    FAIL! Have unknown escaping user: " << *inst);
+    markCurrentOpAsEscape();
     return false;
   }
 
@@ -838,7 +870,7 @@ public:
 #undef ALWAYS_NON_ESCAPING_INST
 
   bool visitDeallocBoxInst(DeallocBoxInst *dbi) {
-    foundMutations.push_back(dbi);
+    markCurrentOpAsMutation();
     return true;
   }
 
@@ -851,9 +883,10 @@ public:
     if (!convention.isIndirectConvention()) {
       LLVM_DEBUG(llvm::dbgs()
                  << "    FAIL! Found non indirect apply user: " << *ai);
+      markCurrentOpAsEscape();
       return false;
     }
-    foundMutations.push_back(ai);
+    markCurrentOpAsMutation();
     return true;
   }
 
@@ -876,7 +909,7 @@ public:
 #define RECURSIVE_INST_VISITOR(MUTATING, INST)                                 \
   bool visit##INST##Inst(INST##Inst *i) {                                      \
     if (bool(detail::MUTATING)) {                                              \
-      foundMutations.push_back(i);                                             \
+      markCurrentOpAsMutation();                                               \
     }                                                                          \
     addUsesToWorklist(i);                                                      \
     return true;                                                               \
@@ -903,25 +936,27 @@ public:
 
   bool visitCopyAddrInst(CopyAddrInst *cai) {
     if (currentOp.get()->getOperandNumber() == 1 || cai->isTakeOfSrc())
-      foundMutations.push_back(cai);
+      markCurrentOpAsMutation();
     return true;
   }
 
   bool visitStoreInst(StoreInst *si) {
     if (currentOp.get()->getOperandNumber() != 1) {
       LLVM_DEBUG(llvm::dbgs() << "    FAIL! Found store of pointer: " << *si);
+      markCurrentOpAsEscape();
       return false;
     }
-    foundMutations.push_back(si);
+    markCurrentOpAsMutation();
     return true;
   }
 
   bool visitAssignInst(AssignInst *ai) {
     if (currentOp.get()->getOperandNumber() != 1) {
       LLVM_DEBUG(llvm::dbgs() << "    FAIL! Found store of pointer: " << *ai);
+      markCurrentOpAsEscape();
       return false;
     }
-    foundMutations.push_back(ai);
+    markCurrentOpAsMutation();
     return true;
   }
 };
@@ -932,7 +967,10 @@ namespace {
 
 struct EscapeMutationScanningState {
   /// The list of mutations that we found while checking for escapes.
-  llvm::SmallVector<SILInstruction *, 8> foundMutations;
+  SmallVector<Operand *, 8> accumulatedMutations;
+
+  /// The list of escapes that we found while checking for escapes.
+  SmallVector<Operand *, 8> accumulatedEscapes;
 
   /// A flag that we use to ensure that we only ever see 1 project_box on an
   /// alloc_box.
@@ -950,7 +988,9 @@ struct EscapeMutationScanningState {
 /// the Mutations vector.
 static bool isNonEscapingUse(Operand *initialOp,
                              EscapeMutationScanningState &state) {
-  return NonEscapingUserVisitor(initialOp, state.foundMutations).compute();
+  return NonEscapingUserVisitor(initialOp, state.accumulatedMutations,
+                                state.accumulatedEscapes)
+      .compute();
 }
 
 bool isPartialApplyNonEscapingUser(Operand *currentOp, PartialApplyInst *pai,
@@ -960,11 +1000,14 @@ bool isPartialApplyNonEscapingUser(Operand *currentOp, PartialApplyInst *pai,
   unsigned opNo = currentOp->getOperandNumber();
   assert(opNo != 0 && "Alloc box used as callee of partial apply?");
 
-  // If we've already seen this partial apply, then it means the same alloc
-  // box is being captured twice by the same closure, which is odd and
-  // unexpected: bail instead of trying to handle this case.
+  // If we've already seen this partial apply, then it means the same alloc box
+  // is being captured twice by the same closure, which is odd and unexpected:
+  // bail instead of trying to handle this case.
   if (state.globalIndexMap.count(pai)) {
+    // TODO: Is it correct to treat this like an escape? We are just currently
+    // flagging all failures as warnings.
     LLVM_DEBUG(llvm::dbgs() << "        FAIL! Already seen.\n");
+    state.accumulatedEscapes.push_back(currentOp);
     return false;
   }
 
@@ -985,6 +1028,7 @@ bool isPartialApplyNonEscapingUser(Operand *currentOp, PartialApplyInst *pai,
   if (!fn || !fn->isDefinition() || fn->isDynamicallyReplaceable()) {
     LLVM_DEBUG(llvm::dbgs() << "        FAIL! Not a direct function definition "
                           "reference.\n");
+    state.accumulatedEscapes.push_back(currentOp);
     return false;
   }
 
@@ -1001,14 +1045,17 @@ bool isPartialApplyNonEscapingUser(Operand *currentOp, PartialApplyInst *pai,
           .isAddressOnly(*f)) {
     LLVM_DEBUG(llvm::dbgs() << "        FAIL! Box is an address only "
                                "argument!\n");
+    state.accumulatedEscapes.push_back(currentOp);
     return false;
   }
 
   // Verify that this closure is known not to mutate the captured value; if
   // it does, then conservatively refuse to promote any captures of this
   // value.
-  if (!isNonMutatingCapture(boxArg)) {
-    LLVM_DEBUG(llvm::dbgs() << "        FAIL: Have a mutating capture!\n");
+  if (getPartialApplyArgMutationsAndEscapes(boxArg, state.accumulatedMutations,
+                                            state.accumulatedEscapes)) {
+    LLVM_DEBUG(llvm::dbgs() << "        FAIL: Have a mutation or escape of a "
+                               "partial apply arg?!\n");
     return false;
   }
 
@@ -1035,12 +1082,12 @@ static bool isProjectBoxNonEscapingUse(ProjectBoxInst *pbi,
   return true;
 }
 
-static bool scanUsesForEscapesAndMutations(Operand *op,
-                                           EscapeMutationScanningState &state) {
+static bool findEscapeOrMutationUses(Operand *op,
+                                     EscapeMutationScanningState &state) {
   SILInstruction *user = op->getUser();
 
   if (auto *pai = dyn_cast<PartialApplyInst>(user)) {
-    return isPartialApplyNonEscapingUser(op, pai, state);
+    return !isPartialApplyNonEscapingUser(op, pai, state);
   }
 
   // A mark_dependence user on a partial_apply is safe.
@@ -1050,7 +1097,11 @@ static bool scanUsesForEscapesAndMutations(Operand *op,
       while ((mdi = dyn_cast<MarkDependenceInst>(parent))) {
         parent = mdi->getValue();
       }
-      return isa<PartialApplyInst>(parent);
+      if (isa<PartialApplyInst>(parent))
+        return false;
+      state.accumulatedEscapes.push_back(
+          &mdi->getOperandRef(MarkDependenceInst::Value));
+      return true;
     }
   }
 
@@ -1059,9 +1110,9 @@ static bool scanUsesForEscapesAndMutations(Operand *op,
     // can be seen since there is no code for reasoning about multiple
     // boxes. Just put in the restriction so we are consistent.
     if (state.sawProjectBoxInst)
-      return false;
+      return true;
     state.sawProjectBoxInst = true;
-    return isProjectBoxNonEscapingUse(pbi, state);
+    return !isProjectBoxNonEscapingUse(pbi, state);
   }
 
   // Given a top level copy value use or mark_uninitialized, check all of its
@@ -1072,10 +1123,11 @@ static bool scanUsesForEscapesAndMutations(Operand *op,
   // derived from a projection like instruction). In fact such a thing may not
   // even make any sense!
   if (isa<CopyValueInst>(user) || isa<MarkUninitializedInst>(user)) {
-    return all_of(cast<SingleValueInstruction>(user)->getUses(),
-                  [&state](Operand *userOp) -> bool {
-                    return scanUsesForEscapesAndMutations(userOp, state);
-                  });
+    bool foundSomeMutations = false;
+    for (auto *use : cast<SingleValueInstruction>(user)->getUses()) {
+      foundSomeMutations |= findEscapeOrMutationUses(use, state);
+    }
+    return foundSomeMutations;
   }
 
   // Verify that this use does not otherwise allow the alloc_box to
@@ -1091,14 +1143,20 @@ static bool
 examineAllocBoxInst(AllocBoxInst *abi, ReachabilityInfo &ri,
                     llvm::DenseMap<PartialApplyInst *, unsigned> &im) {
   LLVM_DEBUG(llvm::dbgs() << "Visiting alloc box: " << *abi);
-  EscapeMutationScanningState state{{}, false, im};
+  EscapeMutationScanningState state{{}, {}, false, im};
 
-  // Scan the box for interesting uses.
-  if (any_of(abi->getUses(), [&state](Operand *op) {
-        return !scanUsesForEscapesAndMutations(op, state);
-      })) {
+  // Scan the box for escaping or mutating uses.
+  for (auto *use : abi->getUses()) {
+    findEscapeOrMutationUses(use, state);
+  }
+
+  if (!state.accumulatedEscapes.empty()) {
     LLVM_DEBUG(llvm::dbgs()
-               << "Found an escaping use! Can not optimize this alloc box?!\n");
+               << "Found escaping uses! Can not optimize this alloc box?!\n");
+    while (!state.accumulatedEscapes.empty()) {
+      auto *escapingUse = state.accumulatedEscapes.pop_back_val();
+      LLVM_DEBUG(llvm::dbgs() << "Escaping use: " << *escapingUse->getUser());
+    }
     return false;
   }
 
@@ -1121,17 +1179,18 @@ examineAllocBoxInst(AllocBoxInst *abi, ReachabilityInfo &ri,
   LLVM_DEBUG(llvm::dbgs()
              << "Checking for any mutations that invalidate captures...\n");
   // Loop over all mutations to possibly invalidate captures.
-  for (auto *inst : state.foundMutations) {
+  for (auto *use : state.accumulatedMutations) {
     auto iter = im.begin();
     while (iter != im.end()) {
+      auto *user = use->getUser();
       auto *pai = iter->first;
       // The mutation invalidates a capture if it occurs in a block reachable
       // from the block the partial_apply is in, or if it is in the same
       // block is after the partial_apply.
-      if (ri.isReachable(pai->getParent(), inst->getParent()) ||
-          (pai->getParent() == inst->getParent() && isAfter(pai, inst))) {
+      if (ri.isReachable(pai->getParent(), user->getParent()) ||
+          (pai->getParent() == user->getParent() && isAfter(pai, user))) {
         LLVM_DEBUG(llvm::dbgs() << "    Invalidating: " << *pai);
-        LLVM_DEBUG(llvm::dbgs() << "    Because of user: " << *inst);
+        LLVM_DEBUG(llvm::dbgs() << "    Because of user: " << *user);
         auto prev = iter++;
         im.erase(prev);
         continue;

--- a/test/Concurrency/concurrentfunction_capturediagnostics.swift
+++ b/test/Concurrency/concurrentfunction_capturediagnostics.swift
@@ -1,0 +1,217 @@
+// RUN: %target-swift-frontend -enable-experimental-concurrency -verify -emit-sil %s -o - >/dev/null
+
+// REQUIRES: concurrency
+
+func f(_: @escaping @concurrent () -> Void) { }
+open class F {
+  func useConcurrent(_: @escaping @concurrent () -> Void) { }
+}
+
+extension Int {
+  mutating func addOne() {
+    self += 1
+  }
+}
+
+func inoutUserInt(_ t: inout Int) {}
+
+func testCaseTrivialValue() {
+  var i = 17
+  f {
+    print(i + 17)
+    print(i + 18)
+    print(i + 19)
+  }
+
+  i = 20
+  i += 21
+
+  // We only emit a warning here since we use the last write.
+  //
+  // TODO: Should we emit for all writes?
+  i.addOne() // expected-warning {{'i' mutated after capture by concurrent closure}}
+             // expected-note @-14 {{variable defined here}}
+             // expected-note @-14 {{variable captured by concurrent closure}}
+             // expected-note @-14 {{capturing use}}
+             // expected-note @-14 {{capturing use}}
+             // expected-note @-14 {{capturing use}}
+}
+
+func testCaseTrivialValue2() {
+  var i2 = 17
+  f {
+    print(i2 + 17)
+    print(i2 + 18)
+    print(i2 + 19)
+  }
+
+  i2 = 20
+  i2 += 21 // expected-warning {{'i2' mutated after capture by concurrent closure}}
+             // expected-note @-9 {{variable defined here}}
+             // expected-note @-9 {{variable captured by concurrent closure}}
+             // expected-note @-9 {{capturing use}}
+             // expected-note @-9 {{capturing use}}
+             // expected-note @-9 {{capturing use}}
+}
+
+func testCaseTrivialValue3() {
+  var i3 = 17
+  f {
+    print(i3 + 17)
+    print(i3 + 18)
+    print(i3 + 19)
+  }
+
+  i3 = 20 // expected-warning {{'i3' mutated after capture by concurrent closure}}
+          // expected-note @-8 {{variable defined here}}
+          // expected-note @-8 {{variable captured by concurrent closure}}
+          // expected-note @-8 {{capturing use}}
+          // expected-note @-8 {{capturing use}}
+          // expected-note @-8 {{capturing use}}
+}
+
+func testCaseTrivialValue4() {
+  var i4 = 17
+  f {
+    print(i4 + 17)
+    print(i4 + 18)
+    print(i4 + 19)
+  }
+
+  inoutUserInt(&i4) // expected-warning {{'i4' mutated after capture by concurrent closure}}
+                    // expected-note @-8 {{variable defined here}}
+                    // expected-note @-8 {{variable captured by concurrent closure}}
+                    // expected-note @-8 {{capturing use}}
+                    // expected-note @-8 {{capturing use}}
+                    // expected-note @-8 {{capturing use}}
+}
+
+class Klass {
+  var next: Klass? = nil
+}
+func inoutUserKlass(_ k: inout Klass) {}
+func inoutUserOptKlass(_ k: inout Klass?) {}
+
+func testCaseClass() {
+  var i = Klass()
+  f {
+    print(i)
+  }
+
+  i = Klass() // expected-warning {{'i' mutated after capture by concurrent closure}}
+              // expected-note @-6 {{variable defined here}}
+              // expected-note @-6 {{variable captured by concurrent closure}}
+              // expected-note @-6 {{capturing use}}
+}
+
+func testCaseClassInout() {
+  var i2 = Klass()
+  f {
+    print(i2)
+  }
+  inoutUserKlass(&i2) // expected-warning {{'i2' mutated after capture by concurrent closure}}
+                      // expected-note @-5 {{variable defined here}}
+                      // expected-note @-5 {{variable captured by concurrent closure}}
+                      // expected-note @-5 {{capturing use}}
+}
+
+func testCaseClassInoutField() {
+  var i2 = Klass()
+  i2 = Klass()
+  f {
+    print(i2)
+  }
+  // Since we are passing in .next inout and we are using a class this isn't a
+  // violation.
+  inoutUserOptKlass(&i2.next)
+}
+
+////////////////////////////
+// Non Trivial Value Type //
+////////////////////////////
+
+struct NonTrivialValueType {
+  var i: Int
+  var k: Klass? = nil
+
+  init(_ inputI: Int, _ inputKlass: Klass) {
+    self.i = inputI
+    self.k = inputKlass
+  }
+}
+
+func testCaseNonTrivialValue() {
+  var i = NonTrivialValueType(17, Klass())
+  f {
+    print(i.i + 17)
+    print(i.i + 18)
+    print(i.i + 19)
+  }
+
+  i.i = 20
+  i.i += 21
+
+  // We only emit a warning here since we use the last write.
+  //
+  // TODO: Should we emit for all writes?
+  i.i.addOne() // expected-warning {{'i' mutated after capture by concurrent closure}}
+               // expected-note @-14 {{variable defined here}}
+               // expected-note @-14 {{variable captured by concurrent closure}}
+               // expected-note @-14 {{capturing use}}
+               // expected-note @-14 {{capturing use}}
+               // expected-note @-14 {{capturing use}}
+}
+
+func testCaseNonTrivialValueInout() {
+  var i = NonTrivialValueType(17, Klass())
+  f {
+    print(i.i + 17)
+    print(i.k ?? "none")
+  }
+
+  // We only emit a warning here since we use the last write.
+  inoutUserOptKlass(&i.k) // expected-warning {{'i' mutated after capture by concurrent closure}}
+                          // expected-note @-8 {{variable defined here}}
+                          // expected-note @-8 {{variable captured by concurrent closure}}
+                          // expected-note @-8 {{capturing use}}
+                          // expected-note @-8 {{capturing use}}
+}
+
+protocol MyProt {
+  var i: Int { get set }
+  var k: Klass? { get set }
+}
+
+func testCaseAddressOnlyAllocBoxToStackable<T : MyProt>(i : T) {
+  var i2 = i
+  f {
+    print(i2.i + 17)
+    print(i2.k ?? "none")
+  }
+
+  // TODO: Make sure we emit these once we support address only types!
+  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by concurrent closure}}
+                           // xpected-note @-8 {{variable defined here}}
+                           // xpected-note @-8 {{variable captured by concurrent closure}}
+                           // xpected-note @-8 {{capturing use}}
+                           // xpected-note @-8 {{capturing use}}
+}
+
+// Alloc box to stack can't handle this test case, so show off a bit and make
+// sure we can emit a great diagnostic here!
+func testCaseAddressOnlyNoAllocBoxToStackable<T : MyProt>(i : T) {
+  let f2 = F()
+  var i2 = i
+  f2.useConcurrent {
+    print(i2.i + 17)
+    print(i2.k ?? "none")
+  }
+
+  // TODO: Make sure we emit these once we support address only types!
+  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by concurrent closure}}
+                           // xpected-note @-8 {{variable defined here}}
+                           // xpected-note @-8 {{variable captured by concurrent closure}}
+                           // xpected-note @-8 {{capturing use}}
+                           // xpected-note @-8 {{capturing use}}
+}
+

--- a/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
+++ b/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
@@ -1,0 +1,95 @@
+// RUN: %target-sil-opt -enable-experimental-concurrency %s
+
+// REQUIRES: concurrency
+
+// This test ensures that the SILVerifier does not enforce (yet) that concurrent
+// functions must have non-box parameters in canonical SIL for address only
+// types.
+
+sil_stage canonical
+
+import Builtin
+
+func f(_: @escaping @concurrent () -> ())
+
+@_hasMissingDesignatedInitializers open class F {
+  func useConcurrent(_: @escaping @concurrent () -> ())
+  @objc deinit
+  init()
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+class Klass {}
+
+/////////////////////////////////////////
+// Address Only Type Success (For Now) //
+/////////////////////////////////////////
+
+protocol MyProt {
+  var i: Int { get set }
+  var k: FakeOptional<Klass> { get set }
+}
+
+sil @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+sil @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+sil @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+sil @$s37concurrentfunction_capturediagnostics1FCfD : $@convention(method) (@owned F) -> ()
+
+// This is address only so we shouldn't crash.
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF : $@convention(thin) <T where T : MyProt> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  debug_value_addr %0 : $*T, let, name "i", argno 1 // id: %1
+  %2 = alloc_stack $F, var, name "f2"             // users: %34, %33, %7
+  %3 = metatype $@thick F.Type                    // user: %5
+  // function_ref F.__allocating_init()
+  %4 = function_ref @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+  %5 = apply %4(%3) : $@convention(method) (@thick F.Type) -> @owned F // users: %6, %7
+  %6 = copy_value %5 : $F                         // users: %11, %12
+  store %5 to [init] %2 : $*F                     // id: %7
+  %8 = alloc_box $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, var, name "i2" // users: %32, %14, %9
+  %9 = project_box %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, 0 // users: %24, %10
+  copy_addr %0 to [initialization] %9 : $*T       // id: %10
+  %11 = copy_value %6 : $F                        // users: %23, %18
+  destroy_value %6 : $F                           // id: %12
+  // function_ref closure #1 in testCaseAddressOnly2<A>(i:)
+  %13 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+  %14 = copy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // user: %15
+  %15 = partial_apply [callee_guaranteed] %13<T>(%14) : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // users: %17, %22
+  // function_ref F.useConcurrent(_:)
+  %16 = function_ref @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+  %17 = begin_borrow %15 : $@concurrent @callee_guaranteed () -> () // users: %20, %19
+  %18 = begin_borrow %11 : $F                     // users: %21, %19
+  %19 = apply %16(%17, %18) : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> ()
+  end_borrow %17 : $@concurrent @callee_guaranteed () -> () // id: %20
+  end_borrow %18 : $F                             // id: %21
+  destroy_value %15 : $@concurrent @callee_guaranteed () -> () // id: %22
+  destroy_value %11 : $F                          // id: %23
+  %24 = begin_access [modify] [dynamic] %9 : $*T  // users: %31, %26
+  %25 = witness_method $T, #MyProt.k!modify : <Self where Self : MyProt> (inout Self) -> () -> () : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // user: %26
+  (%26, %27) = begin_apply %25<T>(%24) : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // users: %29, %30
+  // function_ref inoutUserOptKlass(_:)
+  %28 = function_ref @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+  %29 = apply %28(%26) : $@convention(thin) (@inout FakeOptional<Klass>) -> ()
+  end_apply %27                                   // id: %30
+  end_access %24 : $*T                            // id: %31
+  destroy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // id: %32
+  destroy_addr %2 : $*F                           // id: %33
+  dealloc_stack %2 : $*F                          // id: %34
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF'
+
+sil_vtable [serialized] F {
+  #F.useConcurrent: (F) -> (@escaping @concurrent () -> ()) -> () : @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF	// F.useConcurrent(_:)
+  #F.init!allocator: (F.Type) -> () -> F : @$s37concurrentfunction_capturediagnostics1FCACycfC	// F.__allocating_init()
+  #F.deinit!deallocator: @$s37concurrentfunction_capturediagnostics1FCfD	// F.__deallocating_deinit
+}

--- a/test/SIL/concurrentclosure_capture_verify_canonical_loadable.sil
+++ b/test/SIL/concurrentclosure_capture_verify_canonical_loadable.sil
@@ -1,0 +1,61 @@
+// RUN: not --crash %target-sil-opt -enable-experimental-concurrency %s
+
+// REQUIRES: concurrency
+
+// This test ensures that the SILVerifier does enforce that concurrent functions
+// must have non-box parameters in canonical SIL for loadable types.
+
+sil_stage canonical
+
+import Builtin
+
+func f(_: @escaping @concurrent () -> ())
+
+@_hasMissingDesignatedInitializers open class F {
+  func useConcurrent(_: @escaping @concurrent () -> ())
+  @objc deinit
+  init()
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+class Klass {}
+
+////////////////////
+// Loadable Type  //
+////////////////////
+
+sil @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+sil @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+
+// testCaseTrivialValue()
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "i"      // users: %34, %8, %1
+  %1 = project_box %0 : ${ var Int }, 0           // users: %30, %26, %18, %9, %6
+  %2 = integer_literal $Builtin.IntLiteral, 17    // user: %5
+  %3 = metatype $@thin Int.Type                   // user: %5
+  // function_ref Int.init(_builtinIntegerLiteral:)
+  %4 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+  %5 = apply %4(%2, %3) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %6
+  store %5 to [trivial] %1 : $*Int                // id: %6
+  // function_ref closure #1 in testCaseTrivialValue()
+  %7 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+  %8 = copy_value %0 : ${ var Int }               // user: %10
+  %10 = partial_apply [callee_guaranteed] %7(%8) : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // users: %13, %12
+  // function_ref f(_:)
+  %11 = function_ref @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> () // user: %12
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+  destroy_value %10 : $@concurrent @callee_guaranteed () -> () // id: %13
+  destroy_value %0 : ${ var Int }
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF'

--- a/test/SIL/concurrentclosure_capture_verify_raw.sil
+++ b/test/SIL/concurrentclosure_capture_verify_raw.sil
@@ -1,0 +1,128 @@
+// RUN: %target-sil-opt -enable-experimental-concurrency %s
+
+// REQUIRES: concurrency
+
+// This test ensures that the SILVerifier does not enforce that concurrent
+// functions must have non-box parameters in raw SIL.
+
+sil_stage raw
+
+import Builtin
+
+func f(_: @escaping @concurrent () -> ())
+
+@_hasMissingDesignatedInitializers open class F {
+  func useConcurrent(_: @escaping @concurrent () -> ())
+  @objc deinit
+  init()
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+class Klass {}
+
+////////////////////
+// Loadable Type  //
+////////////////////
+
+sil @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+sil @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+
+// testCaseTrivialValue()
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "i"      // users: %34, %8, %1
+  %1 = project_box %0 : ${ var Int }, 0           // users: %30, %26, %18, %9, %6
+  %2 = integer_literal $Builtin.IntLiteral, 17    // user: %5
+  %3 = metatype $@thin Int.Type                   // user: %5
+  // function_ref Int.init(_builtinIntegerLiteral:)
+  %4 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+  %5 = apply %4(%2, %3) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %6
+  store %5 to [trivial] %1 : $*Int                // id: %6
+  // function_ref closure #1 in testCaseTrivialValue()
+  %7 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+  %8 = copy_value %0 : ${ var Int }               // user: %10
+  mark_function_escape %1 : $*Int                 // id: %9
+  %10 = partial_apply [callee_guaranteed] %7(%8) : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // users: %13, %12
+  // function_ref f(_:)
+  %11 = function_ref @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> () // user: %12
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+  destroy_value %10 : $@concurrent @callee_guaranteed () -> () // id: %13
+  destroy_value %0 : ${ var Int }
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF'
+
+
+/////////////////////////////////////////
+// Address Only Type Success (For Now) //
+/////////////////////////////////////////
+
+protocol MyProt {
+  var i: Int { get set }
+  var k: FakeOptional<Klass> { get set }
+}
+
+sil @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+sil @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+sil @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+sil @$s37concurrentfunction_capturediagnostics1FCfD : $@convention(method) (@owned F) -> ()
+
+// This is address only so we shouldn't crash.
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF : $@convention(thin) <T where T : MyProt> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  debug_value_addr %0 : $*T, let, name "i", argno 1 // id: %1
+  %2 = alloc_stack $F, var, name "f2"             // users: %34, %33, %7
+  %3 = metatype $@thick F.Type                    // user: %5
+  // function_ref F.__allocating_init()
+  %4 = function_ref @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+  %5 = apply %4(%3) : $@convention(method) (@thick F.Type) -> @owned F // users: %6, %7
+  %6 = copy_value %5 : $F                         // users: %11, %12
+  store %5 to [init] %2 : $*F                     // id: %7
+  %8 = alloc_box $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, var, name "i2" // users: %32, %14, %9
+  %9 = project_box %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, 0 // users: %24, %10
+  copy_addr %0 to [initialization] %9 : $*T       // id: %10
+  %11 = copy_value %6 : $F                        // users: %23, %18
+  destroy_value %6 : $F                           // id: %12
+  // function_ref closure #1 in testCaseAddressOnly2<A>(i:)
+  %13 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+  %14 = copy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // user: %15
+  %15 = partial_apply [callee_guaranteed] %13<T>(%14) : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // users: %17, %22
+  // function_ref F.useConcurrent(_:)
+  %16 = function_ref @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+  %17 = begin_borrow %15 : $@concurrent @callee_guaranteed () -> () // users: %20, %19
+  %18 = begin_borrow %11 : $F                     // users: %21, %19
+  %19 = apply %16(%17, %18) : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> ()
+  end_borrow %17 : $@concurrent @callee_guaranteed () -> () // id: %20
+  end_borrow %18 : $F                             // id: %21
+  destroy_value %15 : $@concurrent @callee_guaranteed () -> () // id: %22
+  destroy_value %11 : $F                          // id: %23
+  %24 = begin_access [modify] [dynamic] %9 : $*T  // users: %31, %26
+  %25 = witness_method $T, #MyProt.k!modify : <Self where Self : MyProt> (inout Self) -> () -> () : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // user: %26
+  (%26, %27) = begin_apply %25<T>(%24) : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // users: %29, %30
+  // function_ref inoutUserOptKlass(_:)
+  %28 = function_ref @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+  %29 = apply %28(%26) : $@convention(thin) (@inout FakeOptional<Klass>) -> ()
+  end_apply %27                                   // id: %30
+  end_access %24 : $*T                            // id: %31
+  destroy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // id: %32
+  destroy_addr %2 : $*F                           // id: %33
+  dealloc_stack %2 : $*F                          // id: %34
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF'
+
+sil_vtable [serialized] F {
+  #F.useConcurrent: (F) -> (@escaping @concurrent () -> ()) -> () : @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF	// F.useConcurrent(_:)
+  #F.init!allocator: (F.Type) -> () -> F : @$s37concurrentfunction_capturediagnostics1FCACycfC	// F.__allocating_init()
+  #F.deinit!deallocator: @$s37concurrentfunction_capturediagnostics1FCfD	// F.__deallocating_deinit
+}


### PR DESCRIPTION
In a subsequent commit, I am going to use this to emit a warning if this fails
for captures by concurrent functions.