### PR TITLE
Centralize and document low-level OSSA utilities

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -75,6 +75,66 @@ inline bool isForwardingConsume(SILValue value) {
   return canOpcodeForwardOwnedValues(value);
 }
 
+/// Find all "use points" of a guaranteed value within its enclosing borrow
+/// scope (without looking through reborrows). To find the use points of the
+/// extended borrow scope, after looking through reborrows, use
+/// findExtendedTransitiveGuaranteedUses() instead.
+///
+/// Accumulate results in \p usePoints. This avoids the need for separate
+/// worklist and result vectors. Existing vector elements are ignored.
+///
+/// "Use points" are the relevant points for determining lifetime. They are
+/// determined differently depending on each of these two cases:
+///
+/// 1. If \p guaranteedValue introduces a borrow scope (begin_borrow,
+/// load_borrow, or phi), then its only use points are the scope-ending uses,
+/// and this function returns true. This is, in fact, equivalent to calling
+/// BorrowedValue::visitLocalScopeEndingUses(). Any scope-ending uses that are
+/// reborrows are recorded as use points without following the reborrowed
+/// uses. The \p visitReborrow callback can be used to transitively process
+/// reborrows to discover the extended lifetime. Reborrows may be recursive, so
+/// this will require checking membership in a working set. Nested borrow scope
+/// are irrelevant to the parent scope's lifetime. They are not considered use
+/// points, and reborrows within those nested scope are not visited by \p
+/// visitReborrow.
+///
+/// 2. If \p guaranteedValue does not introduce a borrow scope (it is not a
+/// valid BorrowedValue), then its uses are discovered transitively by looking
+/// through forwarding operations. If any use is a PointerEscape, then this
+/// returns false without adding more uses--the guaranteed values lifetime is
+/// indeterminite. If a use introduces a nested borrow scope, it creates use
+/// points where the "extended" borrow scope ends. An extended borrow
+/// scope is found by looking through any reborrows that end the nested
+/// scope. Other uses within nested borrow scopes are ignored.
+bool findTransitiveGuaranteedUses(SILValue guaranteedValue,
+                                  SmallVectorImpl<Operand *> &usePoints,
+                                  function_ref<void(Operand *)> visitReborrow);
+
+/// Find all "use points" of guaranteed value across its extended borrow scope
+/// (looking through reborrows). The "use points" are the relevant points for
+/// determining lifetime.
+///
+/// Accumulate results in \p usePoints. This avoids the need for separate
+/// worklist and result vectors. Existing vector elements are ignored.
+///
+/// "Use points" are the relevant points for determining lifetime. They are
+/// determined differently depending on each of these two cases:
+///
+/// 1. If \p guaranteedValue introduces a borrow scope (begin_borrow,
+/// load_borrow, or phi), then its only use points are the extended scope-ending
+/// uses, and this function returns true. This is, in fact, equivalent to
+/// calling BorrowedValue::visitExtendedLocalScopeEndingUses().
+///
+/// 2. If \p guaranteedValue does not introduce a borrow scope (it is not a
+/// valid BorrowedValue), then its uses are discovered transitively by looking
+/// through forwarding operations. Only a BorrowedValue can have its lifetime
+/// extended by a reborrow; therefore, in this case, the algorithm is equivalent
+/// to findTransitiveGuaranteedUses(). See those comments for more detail.
+bool findExtendedTransitiveGuaranteedUses(
+  SILValue guaranteedValue,
+  SmallVectorImpl<Operand *> &usePoints);
+
+/// An operand that forwards ownership to one or more results.
 class ForwardingOperand {
   Operand *use = nullptr;
 
@@ -216,16 +276,21 @@ struct BorrowingOperand {
   /// over a region of code instead of just for a single instruction, visit
   /// those uses.
   ///
-  /// Returns true if all visitor invocations returns true. Exits early if a
-  /// visitor returns false.
+  /// Returns false and early exits if the visitor \p func returns false.
   ///
-  /// Example: An apply performs an instantaneous recursive borrow of a
-  /// guaranteed value but a begin_apply borrows the value over the entire
-  /// region of code corresponding to the coroutine.
+  /// For an instantaneous borrow, such as apply, this visits no uses. For
+  /// begin_apply it visits the end_apply uses. For borrow introducers, it
+  /// visits the end of the introduced borrow scope.
+  bool visitScopeEndingUses(function_ref<bool(Operand *)> func) const;
+
+  /// Visit the scope ending operands of the extended scope, after transitively
+  /// searching through reborrows. These uses might not be dominated by this
+  /// BorrowingOperand.
   ///
-  /// NOTE: Return false from func to stop iterating. Returns false if the
-  /// closure requested to stop early.
-  bool visitLocalEndScopeUses(function_ref<bool(Operand *)> func) const;
+  /// Returns false and early exits if the visitor \p func returns false.
+  ///
+  /// Note: this does not visit the intermediate reborrows.
+  bool visitExtendedScopeEndingUses(function_ref<bool(Operand *)> func) const;
 
   /// Returns true if this borrow scope operand consumes guaranteed
   /// values and produces a new scope afterwards.
@@ -247,10 +312,12 @@ struct BorrowingOperand {
     llvm_unreachable("Covered switch isn't covered?!");
   }
 
-  /// Is the result of this instruction also a borrow introducer?
+  /// Return true if the user instruction introduces a borrow scope? This is
+  /// true for both reborrows and nested borrows.
   ///
-  /// TODO: This needs a better name.
-  bool areAnyUserResultsBorrowIntroducers() const {
+  /// If true, the visitBorrowIntroducingUserResults() can be called to acquire
+  /// each BorrowedValue that introduces a new borrow scopes.
+  bool hasBorrowIntroducingUser() const {
     // TODO: Can we derive this by running a borrow introducer check ourselves?
     switch (kind) {
     case BorrowingOperandKind::Invalid:
@@ -267,24 +334,19 @@ struct BorrowingOperand {
     llvm_unreachable("Covered switch isn't covered?!");
   }
 
-  /// Visit all of the results of the operand's user instruction that are
-  /// consuming uses.
-  void visitUserResultConsumingUses(function_ref<void(Operand *)> visitor) const;
-
   /// Visit all of the "results" of the user of this operand that are borrow
   /// scope introducers for the specific scope that this borrow scope operand
   /// summarizes.
-  void
-  visitBorrowIntroducingUserResults(function_ref<void(BorrowedValue)> visitor) const;
-
-  /// Passes to visitor all of the consuming uses of this use's using
-  /// instruction.
   ///
-  /// This enables one to walk the def-use chain of guaranteed phis for a single
-  /// guaranteed scope by using a worklist and checking if any of the operands
-  /// are BorrowScopeOperands.
-  void visitConsumingUsesOfBorrowIntroducingUserResults(
-      function_ref<void(Operand *)> visitor) const;
+  /// Precondition: hasBorrowIntroducingUser() is true
+  ///
+  /// Returns false and early exits if \p visitor returns false.
+  bool visitBorrowIntroducingUserResults(
+      function_ref<bool(BorrowedValue)> visitor) const;
+
+  /// If this operand's user has a single borrowed value result return a
+  /// valid BorrowedValue instance.
+  BorrowedValue getBorrowIntroducingUserResult();
 
   /// Compute the implicit uses that this borrowing operand "injects" into the
   /// set of its operands uses.
@@ -398,22 +460,32 @@ struct InteriorPointerOperand;
 /// guaranteed results are borrow introducers. In practice this means that
 /// borrow introducers can not have guaranteed results that are not creating a
 /// new borrow scope. No such instructions exist today.
+///
+/// This provides utilities for visiting the end of the borrow scope introduced
+/// by this value. The scope ending uses are always dominated by this value and
+/// jointly post-dominate this value (see visitLocalScopeEndingUses()). The
+/// extended scope, including reborrows has end points that are not dominated by
+/// this value but still jointly post-dominate (see
+/// visitExtendedLocalScopeEndingUses()).
 struct BorrowedValue {
   SILValue value;
-  BorrowedValueKind kind;
+  BorrowedValueKind kind = BorrowedValueKind::Invalid;
 
-  BorrowedValue() : value(), kind(BorrowedValueKind::Invalid) {}
+  BorrowedValue() = default;
+
+  /// If \p value is a borrow introducer construct a valid BorrowedValue.
+  BorrowedValue(SILValue value) {
+    kind = BorrowedValueKind::get(value);
+    if (!kind)
+      return;
+    this->value = value;
+  }
 
   /// If value is a borrow introducer return it after doing some checks.
   ///
   /// This is the only way to construct a BorrowScopeIntroducingValue. We make
   /// the primary constructor private for this reason.
-  static BorrowedValue get(SILValue value) {
-    auto kind = BorrowedValueKind::get(value);
-    if (!kind)
-      return {nullptr, kind};
-    return {value, kind};
-  }
+  static BorrowedValue get(SILValue value) { return BorrowedValue(value); }
 
   operator bool() const { return kind != BorrowedValueKind::Invalid && value; }
 
@@ -430,6 +502,8 @@ struct BorrowedValue {
   /// instructions and pass them individually to visitor. Asserts if this is
   /// called with a scope that is not local.
   ///
+  /// Returns false and early exist if \p visitor returns false.
+  ///
   /// The intention is that this method can be used instead of
   /// BorrowScopeIntroducingValue::getLocalScopeEndingUses() to avoid
   /// introducing an intermediate array when one needs to transform the
@@ -437,7 +511,7 @@ struct BorrowedValue {
   ///
   /// NOTE: To determine if a scope is a local scope, call
   /// BorrowScopeIntoducingValue::isLocalScope().
-  void visitLocalScopeEndingUses(function_ref<void(Operand *)> visitor) const;
+  bool visitLocalScopeEndingUses(function_ref<bool(Operand *)> visitor) const;
 
   bool isLocalScope() const { return kind.isLocalScope(); }
 
@@ -451,9 +525,10 @@ struct BorrowedValue {
                           DeadEndBlocks &deadEndBlocks) const;
 
   /// Given a local borrow scope introducer, visit all non-forwarding consuming
-  /// users. This means that this looks through guaranteed block arguments.
-  bool visitLocalScopeTransitiveEndingUses(
-      function_ref<void(Operand *)> visitor) const;
+  /// users. This means that this looks through guaranteed block arguments. \p
+  /// visitor is *not* called on Reborrows, only on final scope ending uses.
+  bool visitExtendedLocalScopeEndingUses(
+      function_ref<bool(Operand *)> visitor) const;
 
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
@@ -632,14 +707,15 @@ struct InteriorPointerOperand {
   /// Return the end scope of all borrow introducers of the parent value of this
   /// projection. Returns true if we were able to find all borrow introducing
   /// values.
-  bool visitBaseValueScopeEndingUses(function_ref<void(Operand *)> func) const {
+  bool visitBaseValueScopeEndingUses(function_ref<bool(Operand *)> func) const {
     SmallVector<BorrowedValue, 4> introducers;
     if (!getAllBorrowIntroducingValues(operand->get(), introducers))
       return false;
     for (const auto &introducer : introducers) {
       if (!introducer.isLocalScope())
         continue;
-      introducer.visitLocalScopeEndingUses(func);
+      if (!introducer.visitLocalScopeEndingUses(func))
+        return false;
     }
     return true;
   }

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -473,19 +473,12 @@ struct BorrowedValue {
 
   BorrowedValue() = default;
 
-  /// If \p value is a borrow introducer construct a valid BorrowedValue.
-  BorrowedValue(SILValue value) {
+  /// If value is a borrow introducer, create a valid BorrowedValue.
+  explicit BorrowedValue(SILValue value) {
     kind = BorrowedValueKind::get(value);
-    if (!kind)
-      return;
-    this->value = value;
+    if (kind)
+      this->value = value;
   }
-
-  /// If value is a borrow introducer return it after doing some checks.
-  ///
-  /// This is the only way to construct a BorrowScopeIntroducingValue. We make
-  /// the primary constructor private for this reason.
-  static BorrowedValue get(SILValue value) { return BorrowedValue(value); }
 
   operator bool() const { return kind != BorrowedValueKind::Invalid && value; }
 
@@ -567,12 +560,6 @@ struct BorrowedValue {
   SILValue operator->() const { return value; }
   SILValue operator*() { return value; }
   SILValue operator*() const { return value; }
-
-private:
-  /// Internal constructor for failable static constructor. Please do not expand
-  /// its usage since it assumes the code passed in is well formed.
-  BorrowedValue(SILValue value, BorrowedValueKind kind)
-      : value(value), kind(kind) {}
 };
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -414,13 +414,13 @@ bool BorrowingOperand::visitBorrowIntroducingUserResults(
   case BorrowingOperandKind::Yield:
     llvm_unreachable("Never has borrow introducer results!");
   case BorrowingOperandKind::BeginBorrow: {
-    auto value = BorrowedValue::get(cast<BeginBorrowInst>(op->getUser()));
+    auto value = BorrowedValue(cast<BeginBorrowInst>(op->getUser()));
     assert(value);
     return visitor(value);
   }
   case BorrowingOperandKind::Branch: {
     auto *bi = cast<BranchInst>(op->getUser());
-    auto value = BorrowedValue::get(
+    auto value = BorrowedValue(
         bi->getDestBB()->getArgument(op->getOperandNumber()));
     assert(value && "guaranteed-to-unowned conversion not allowed on branches");
     return visitor(value);
@@ -820,7 +820,7 @@ bool swift::getAllBorrowIntroducingValues(SILValue inputValue,
     SILValue value = worklist.pop_back_val();
 
     // First check if v is an introducer. If so, stash it and continue.
-    if (auto scopeIntroducer = BorrowedValue::get(value)) {
+    if (auto scopeIntroducer = BorrowedValue(value)) {
       out.push_back(scopeIntroducer);
       continue;
     }
@@ -868,7 +868,7 @@ BorrowedValue swift::getSingleBorrowIntroducingValue(SILValue inputValue) {
   while (true) {
     // First check if our initial value is an introducer. If we have one, just
     // return it.
-    if (auto scopeIntroducer = BorrowedValue::get(currentValue)) {
+    if (auto scopeIntroducer = BorrowedValue(currentValue)) {
       return scopeIntroducer;
     }
 

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Basic/SmallPtrSetVector.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/LinearLifetimeChecker.h"
 #include "swift/SIL/Projection.h"
@@ -143,6 +144,167 @@ bool swift::canOpcodeForwardOwnedValues(Operand *use) {
 }
 
 //===----------------------------------------------------------------------===//
+//                 Guaranteed Use-Point (Lifetime) Discovery
+//===----------------------------------------------------------------------===//
+
+// Find all use points of \p guaranteedValue within its borrow scope where \p
+// guaranteedValue is not itself a BorrowedValue (it does not introduce a borrow
+// scope). This means there is no need to consider reborrows, and all uses are
+// naturally dominated by \p guaranteedValue. On the other hand, if a
+// PointerEscape is found, then no assumption can be made about \p
+// guaranteedValue's lifetime. Therefore the use points are incomplete and this
+// returns false.
+//
+// Accumulate results in \p usePoints, ignoring existing elements.
+//
+// Skip over nested borrow scopes. Their scope-ending instructions are their use
+// points. Transitively find all nested scope-ending instructions by looking
+// through nested reborrows. Nested reborrows are not use points and \p
+// visitReborrow is not called for them.
+static bool
+findInnerTransitiveGuaranteedUses(SILValue guaranteedValue,
+                                  SmallVectorImpl<Operand *> &usePoints) {
+  // Push the value's immediate uses.
+  unsigned firstOffset = usePoints.size();
+  for (Operand *use : guaranteedValue->getUses()) {
+    if (use->getOperandOwnership() != OperandOwnership::NonUse)
+      usePoints.push_back(use);
+  }
+
+  // --- Transitively follow forwarded uses and look for escapes.
+
+  // TODO: Remove this SmallPtrSet if destructures are changed to be represented
+  // as reborrows. Currently it forwards multiple results! This means that
+  // usePoints could grow exponentially without a membership check. It's fine to
+  // do this membership check locally in this function (within a borrow
+  // scope). It isn't needed for the immediate uses, only the transitive uses.
+  SmallPtrSet<Operand *, 16> visitedUses;
+  auto pushUse = [&](Operand *use) {
+    if (use->getOperandOwnership() != OperandOwnership::NonUse) {
+      if (visitedUses.insert(use).second)
+        usePoints.push_back(use);
+    }
+    return true;
+  };
+
+  // usePoints grows in this loop.
+  for (unsigned i = firstOffset; i < usePoints.size(); ++i) {
+    Operand *use = usePoints[i];
+    switch (use->getOperandOwnership()) {
+    case OperandOwnership::NonUse:
+    case OperandOwnership::TrivialUse:
+    case OperandOwnership::ForwardingConsume:
+    case OperandOwnership::DestroyingConsume:
+    case OperandOwnership::Reborrow:
+      llvm_unreachable("this operand cannot handle an inner guaranteed use");
+
+    case OperandOwnership::ForwardingUnowned:
+    case OperandOwnership::PointerEscape:
+      return false;
+
+    case OperandOwnership::InstantaneousUse:
+    case OperandOwnership::UnownedInstantaneousUse:
+    case OperandOwnership::BitwiseEscape:
+    // An end_borrow may be pushed as a use when processing a nested borrow.
+    case OperandOwnership::EndBorrow:
+      break;
+
+    case OperandOwnership::InteriorPointer:
+      // If our base guaranteed value does not have any consuming uses (consider
+      // function arguments), we need to be sure to include interior pointer
+      // operands since we may not get a use from a end_scope instruction.
+      if (!InteriorPointerOperand(use).findTransitiveUses(usePoints)) {
+        return false;
+      }
+      break;
+
+    case OperandOwnership::ForwardingBorrow:
+      ForwardingOperand(use).visitForwardedValues(
+          [&](SILValue transitiveValue) {
+            // Do not include transitive uses with 'none' ownership
+            if (transitiveValue.getOwnershipKind() == OwnershipKind::None)
+              return true;
+            for (auto *transitiveUse : transitiveValue->getUses()) {
+              pushUse(transitiveUse);
+            }
+            return true;
+          });
+      break;
+
+    case OperandOwnership::Borrow:
+      BorrowingOperand(use).visitExtendedScopeEndingUses(pushUse);
+    }
+  }
+  return true;
+}
+
+// Find all use points of \p guaranteedValue within its borrow scope. All use
+// points will be dominated by \p guaranteedValue.
+//
+// Record (non-nested) reborrows as uses and call \p visitReborrow.
+//
+// BorrowedValues (which introduce a borrow scope) are fundamentally different
+// than "inner" guaranteed values. Their only use points are their scope-ending
+// uses. There is no need to transitively process uses. However, unlike inner
+// guaranteed values, they can have reborrows. To transitively process
+// reborrows, use findExtendedTransitiveBorrowedUses.
+bool swift::findTransitiveGuaranteedUses(
+    SILValue guaranteedValue, SmallVectorImpl<Operand *> &usePoints,
+    function_ref<void(Operand *)> visitReborrow) {
+
+  // Handle local borrow introducers without following uses.
+  // SILFunctionArguments are *not* borrow introducers in this context--we're
+  // trying to find lifetime of values within a function.
+  if (auto borrowedValue = BorrowedValue(guaranteedValue)) {
+    if (borrowedValue.isLocalScope()) {
+      borrowedValue.visitLocalScopeEndingUses([&](Operand *scopeEnd) {
+        // Initially push the reborrow as a use point. visitReborrow may pop it
+        // if it only wants to compute the extended lifetime's use points.
+        usePoints.push_back(scopeEnd);
+        if (scopeEnd->getOperandOwnership() == OperandOwnership::Reborrow)
+          visitReborrow(scopeEnd);
+        return true;
+      });
+    }
+    return true;
+  }
+  return findInnerTransitiveGuaranteedUses(guaranteedValue, usePoints);
+}
+
+// Find all use points of \p guaranteedValue within its borrow scope. If the
+// guaranteed value introduces a borrow scope, then this includes the extended
+// borrow scope by following reborrows.
+bool swift::
+findExtendedTransitiveGuaranteedUses(SILValue guaranteedValue,
+                                     SmallVectorImpl<Operand *> &usePoints) {
+  // Multiple paths may reach the same reborrows, and reborrow may even be
+  // recursive, so the working set requires a membership check.
+  SmallPtrSetVector<SILValue, 4> reborrows;
+  auto visitReborrow = [&](Operand *reborrow) {
+    // Pop the reborrow. It should not appear in the use points of the
+    // extend lifetime.
+    assert(reborrow == usePoints.back());
+    usePoints.pop_back();
+    auto borrowedPhi =
+      BorrowingOperand(reborrow).getBorrowIntroducingUserResult();
+    reborrows.insert(borrowedPhi.value);
+  };
+  if (!findTransitiveGuaranteedUses(guaranteedValue, usePoints, visitReborrow))
+    return false;
+
+  // For guaranteed values that do not introduce a borrow scope, reborrows will
+  // be empty at this point.
+  for (unsigned idx = 0; idx < reborrows.size(); ++idx) {
+    bool result =
+      findTransitiveGuaranteedUses(reborrows[idx], usePoints, visitReborrow);
+    // It is impossible to find a Pointer escape while traversing reborrows.
+    assert(result && "visiting reborrows always succeeds");
+    (void)result;
+  }
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
 //                           Borrowing Operand
 //===----------------------------------------------------------------------===//
 
@@ -191,7 +353,7 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
   return os;
 }
 
-bool BorrowingOperand::visitLocalEndScopeUses(
+bool BorrowingOperand::visitScopeEndingUses(
     function_ref<bool(Operand *)> func) const {
   switch (kind) {
   case BorrowingOperandKind::Invalid:
@@ -227,12 +389,22 @@ bool BorrowingOperand::visitLocalEndScopeUses(
     return true;
   }
   }
-
   llvm_unreachable("Covered switch isn't covered");
 }
 
-void BorrowingOperand::visitBorrowIntroducingUserResults(
-    function_ref<void(BorrowedValue)> visitor) const {
+bool BorrowingOperand::visitExtendedScopeEndingUses(
+    function_ref<bool(Operand *)> func) const {
+  if (hasBorrowIntroducingUser()) {
+    return visitBorrowIntroducingUserResults(
+        [func](BorrowedValue borrowedValue) {
+          return borrowedValue.visitExtendedLocalScopeEndingUses(func);
+        });
+  }
+  return visitScopeEndingUses(func);
+}
+
+bool BorrowingOperand::visitBorrowIntroducingUserResults(
+    function_ref<bool(BorrowedValue)> visitor) const {
   switch (kind) {
   case BorrowingOperandKind::Invalid:
     llvm_unreachable("Using invalid case");
@@ -248,72 +420,38 @@ void BorrowingOperand::visitBorrowIntroducingUserResults(
   }
   case BorrowingOperandKind::Branch: {
     auto *bi = cast<BranchInst>(op->getUser());
-    for (auto *succBlock : bi->getSuccessorBlocks()) {
-      auto value =
-          BorrowedValue::get(succBlock->getArgument(op->getOperandNumber()));
-      assert(value);
-      visitor(value);
-    }
-    return;
+    auto value = BorrowedValue::get(
+        bi->getDestBB()->getArgument(op->getOperandNumber()));
+    assert(value && "guaranteed-to-unowned conversion not allowed on branches");
+    return visitor(value);
   }
   }
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
-void BorrowingOperand::visitConsumingUsesOfBorrowIntroducingUserResults(
-    function_ref<void(Operand *)> func) const {
-  // First visit all of the results of our user that are borrow introducing
-  // values.
-  visitBorrowIntroducingUserResults([&](BorrowedValue value) {
-    // Visit the scope ending instructions of this value. If any of them are
-    // consuming borrow scope operands, visit the consuming uses of the
-    // results or successor arguments.
-    //
-    // This enables one to walk the def-use chain of guaranteed phis for a
-    // single guaranteed scope.
-    value.visitLocalScopeEndingUses([&](Operand *valueUser) {
-      if (auto subBorrowScopeOp = BorrowingOperand::get(valueUser)) {
-        if (subBorrowScopeOp.isReborrow()) {
-          subBorrowScopeOp.visitUserResultConsumingUses(func);
-          return;
-        }
-      }
+BorrowedValue BorrowingOperand::getBorrowIntroducingUserResult() {
+  switch (kind) {
+  case BorrowingOperandKind::Invalid:
+  case BorrowingOperandKind::Apply:
+  case BorrowingOperandKind::TryApply:
+  case BorrowingOperandKind::BeginApply:
+  case BorrowingOperandKind::Yield:
+    return BorrowedValue();
 
-      // Otherwise, if we don't have a borrow scope operand that consumes
-      // guaranteed values, just visit value user.
-      func(valueUser);
-    });
-  });
-}
+  case BorrowingOperandKind::BeginBorrow:
+    return BorrowedValue(cast<BeginBorrowInst>(op->getUser()));
 
-void BorrowingOperand::visitUserResultConsumingUses(
-    function_ref<void(Operand *)> visitor) const {
-  auto *ti = dyn_cast<TermInst>(op->getUser());
-  if (!ti) {
-    for (SILValue result : op->getUser()->getResults()) {
-      for (auto *use : result->getUses()) {
-        if (use->isLifetimeEnding()) {
-          visitor(use);
-        }
-      }
-    }
-    return;
+  case BorrowingOperandKind::Branch: {
+    auto *bi = cast<BranchInst>(op->getUser());
+    return BorrowedValue(bi->getDestBB()->getArgument(op->getOperandNumber()));
   }
-
-  for (auto *succBlock : ti->getSuccessorBlocks()) {
-    auto *arg = succBlock->getArgument(op->getOperandNumber());
-    for (auto *use : arg->getUses()) {
-      if (use->isLifetimeEnding()) {
-        visitor(use);
-      }
-    }
   }
 }
 
 void BorrowingOperand::getImplicitUses(
     SmallVectorImpl<Operand *> &foundUses,
     std::function<void(Operand *)> *errorFunction) const {
-  visitLocalEndScopeUses([&](Operand *op) {
+  visitScopeEndingUses([&](Operand *op) {
     foundUses.push_back(op);
     return true;
   });
@@ -371,8 +509,8 @@ void BorrowedValue::getLocalScopeEndingInstructions(
   llvm_unreachable("Covered switch isn't covered?!");
 }
 
-void BorrowedValue::visitLocalScopeEndingUses(
-    function_ref<void(Operand *)> visitor) const {
+bool BorrowedValue::visitLocalScopeEndingUses(
+    function_ref<bool(Operand *)> visitor) const {
   assert(isLocalScope() && "Should only call this given a local scope");
   switch (kind) {
   case BorrowedValueKind::Invalid:
@@ -384,10 +522,11 @@ void BorrowedValue::visitLocalScopeEndingUses(
   case BorrowedValueKind::Phi:
     for (auto *use : value->getUses()) {
       if (use->isLifetimeEnding()) {
-        visitor(use);
+        if (!visitor(use))
+          return false;
       }
     }
-    return;
+    return true;
   }
   llvm_unreachable("Covered switch isn't covered?!");
 }
@@ -422,53 +561,43 @@ bool BorrowedValue::areUsesWithinScope(
 
   // Otherwise, gather up our local scope ending instructions, looking through
   // guaranteed phi nodes.
-  visitLocalScopeTransitiveEndingUses(
-      [&scratchSpace](Operand *op) { scratchSpace.emplace_back(op); });
+  visitExtendedLocalScopeEndingUses([&scratchSpace](Operand *op) {
+    scratchSpace.emplace_back(op);
+    return true;
+  });
 
   LinearLifetimeChecker checker(deadEndBlocks);
   return checker.validateLifetime(value, scratchSpace, uses);
 }
 
-bool BorrowedValue::visitLocalScopeTransitiveEndingUses(
-    function_ref<void(Operand *)> visitor) const {
+// The visitor \p func is only called on final scope-ending uses, not reborrows.
+bool BorrowedValue::visitExtendedLocalScopeEndingUses(
+    function_ref<bool(Operand *)> func) const {
   assert(isLocalScope());
 
-  SmallVector<Operand *, 32> worklist;
-  SmallPtrSet<Operand *, 16> beenInWorklist;
-  for (auto *use : value->getUses()) {
-    if (!use->isLifetimeEnding())
-      continue;
-    worklist.push_back(use);
-    beenInWorklist.insert(use);
-  }
+  SmallPtrSetVector<SILValue, 4> reborrows;
 
-  bool foundError = false;
-  while (!worklist.empty()) {
-    auto *op = worklist.pop_back_val();
-    assert(op->isLifetimeEnding() && "Expected only consuming uses");
-
-    // See if we have a borrow scope operand. If we do not, then we know we are
-    // a final consumer of our borrow scope introducer. Visit it and continue.
-    auto scopeOperand = BorrowingOperand::get(op);
-    if (!scopeOperand) {
-      visitor(op);
-      continue;
-    }
-
-    scopeOperand.visitConsumingUsesOfBorrowIntroducingUserResults(
-        [&](Operand *op) {
-          assert(op->isLifetimeEnding() && "Expected only consuming uses");
-          // Make sure we haven't visited this consuming operand yet. If we
-          // have, signal an error and bail without re-visiting the operand.
-          if (!beenInWorklist.insert(op).second) {
-            foundError = true;
-            return;
-          }
-          worklist.push_back(op);
+  auto visitEnd = [&](Operand *scopeEndingUse) {
+    if (scopeEndingUse->getOperandOwnership() == OperandOwnership::Reborrow) {
+      BorrowingOperand(scopeEndingUse).visitBorrowIntroducingUserResults(
+        [&](BorrowedValue borrowedValue) {
+          reborrows.insert(borrowedValue.value);
+          return true;
         });
-  }
+      return true;
+    }
+    return func(scopeEndingUse);
+  };
 
-  return foundError;
+  if (!visitLocalScopeEndingUses(visitEnd))
+    return false;
+
+  // reborrows grows in this loop.
+  for (unsigned idx = 0; idx < reborrows.size(); ++idx) {
+    if (!BorrowedValue(reborrows[idx]).visitLocalScopeEndingUses(visitEnd))
+      return false;
+  }
+  return true;
 }
 
 bool BorrowedValue::visitInteriorPointerOperands(

--- a/lib/SIL/Verifier/ReborrowVerifier.cpp
+++ b/lib/SIL/Verifier/ReborrowVerifier.cpp
@@ -41,7 +41,7 @@ void ReborrowVerifier::verifyReborrows(BorrowingOperand initialScopedOperand,
                                        SILValue value) {
   SmallVector<std::tuple<Operand *, SILValue>, 4> worklist;
   // Initialize the worklist with borrow lifetime ending uses
-  initialScopedOperand.visitLocalEndScopeUses([&](Operand *op) {
+  initialScopedOperand.visitScopeEndingUses([&](Operand *op) {
     worklist.emplace_back(op, value);
     return true;
   });
@@ -88,6 +88,7 @@ void ReborrowVerifier::verifyReborrows(BorrowingOperand initialScopedOperand,
       scopedValue.visitLocalScopeEndingUses([&](Operand *op) {
         addVisitedOp(op, newBaseVal);
         worklist.emplace_back(op, newBaseVal);
+        return true;
       });
     }
   }

--- a/lib/SIL/Verifier/ReborrowVerifier.cpp
+++ b/lib/SIL/Verifier/ReborrowVerifier.cpp
@@ -83,7 +83,7 @@ void ReborrowVerifier::verifyReborrows(BorrowingOperand initialScopedOperand,
 
       // Find the scope ending uses of the guaranteed phi arg and add it to the
       // worklist.
-      auto scopedValue = BorrowedValue::get(phiArg);
+      auto scopedValue = BorrowedValue(phiArg);
       assert(scopedValue);
       scopedValue.visitLocalScopeEndingUses([&](Operand *op) {
         addVisitedOp(op, newBaseVal);

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -475,7 +475,7 @@ static bool tryJoinIfDestroyConsumingUseInSameBlock(
     // singleConsumingUse (the original forwarded use) and the destroy_value. In
     // such a case, we must bail!
     if (auto operand = BorrowingOperand::get(use))
-      if (!operand.visitLocalEndScopeUses([&](Operand *endScopeUse) {
+      if (!operand.visitScopeEndingUses([&](Operand *endScopeUse) {
             // Return false if we did see the relevant end scope instruction
             // in the block. That means that we are going to exit early and
             // return false.

--- a/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
@@ -241,7 +241,7 @@ public:
     // borrow it's based on.
     SmallVector<Operand *, 4> endScopeInsts;
     value.visitLocalScopeEndingUses(
-        [&](Operand *use) { endScopeInsts.push_back(use); });
+      [&](Operand *use) { endScopeInsts.push_back(use); return true; });
 
     LinearLifetimeChecker checker(ctx.getDeadEndBlocks());
 

--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -76,13 +76,13 @@ SILValue CanonicalizeOSSALifetime::getCanonicalCopiedDef(SILValue v) {
       case BorrowedValueKind::SILFunctionArgument:
         return def;
       case BorrowedValueKind::BeginBorrow: {
-        bool localScope = true;
-        // TODO: visitLocalScopeEndingUses should have an early exit.
-        borrowedVal.visitLocalScopeEndingUses([&](Operand *endBorrow) {
-          if (endBorrow->getUser()->getParent() != def->getParentBlock())
-            localScope = false;
-        });
-        if (localScope) {
+        // TODO: Remove this call to visitLocalScopeEndingUses and the
+        // same-block check once computeBorrowLiveness supports multiple blocks.
+        auto *defBB = def->getParentBlock();
+        if (borrowedVal.visitLocalScopeEndingUses(
+              [&](Operand *endBorrow) {
+                return endBorrow->getUser()->getParent() == defBB;
+              })) {
           return def;
         }
         break;
@@ -144,6 +144,7 @@ bool CanonicalizeOSSALifetime::computeBorrowLiveness() {
   }
   borrowedVal.visitLocalScopeEndingUses([this](Operand *use) {
     liveness.updateForUse(use->getUser(), /*lifetimeEnding*/ true);
+    return true;
   });
 
   // TODO: Fix getCanonicalCopiedDef to allow multi-block borrows and remove
@@ -247,7 +248,7 @@ bool CanonicalizeOSSALifetime::consolidateBorrowScope() {
         recordOuterUse(use);
         // For borrows, record the scope-ending instructions in addition to the
         // borrow instruction as an outer use point.
-        borrowOper.visitLocalEndScopeUses([&](Operand *endBorrow) {
+        borrowOper.visitScopeEndingUses([&](Operand *endBorrow) {
           if (!isUserInLiveOutBlock(endBorrow->getUser())) {
             outerUseInsts.insert(endBorrow->getUser());
           }
@@ -286,7 +287,7 @@ bool CanonicalizeOSSALifetime::consolidateBorrowScope() {
       }
       // For sub-borrows also check that the scope-ending instructions are
       // within the scope.
-      if (borrowOper.visitLocalEndScopeUses([&](Operand *endBorrow) {
+      if (borrowOper.visitScopeEndingUses([&](Operand *endBorrow) {
             return !outerUseInsts.count(endBorrow->getUser());
           })) {
         continue;
@@ -387,7 +388,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
       case OperandOwnership::Borrow:
         // An entire borrow scope is considered a single use that occurs at the
         // point of the end_borrow.
-        BorrowingOperand(use).visitLocalEndScopeUses([this](Operand *end) {
+        BorrowingOperand(use).visitScopeEndingUses([this](Operand *end) {
           liveness.updateForUse(end->getUser(), /*lifetimeEnding*/ false);
           return true;
         });

--- a/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalOSSALifetime.cpp
@@ -67,7 +67,7 @@ SILValue CanonicalizeOSSALifetime::getCanonicalCopiedDef(SILValue v) {
       v = def;
       continue;
     }
-    if (auto borrowedVal = BorrowedValue::get(def)) {
+    if (auto borrowedVal = BorrowedValue(def)) {
       // Any def's that aren't filtered out here must be handled by
       // computeBorrowLiveness.
       switch (borrowedVal.kind) {
@@ -121,7 +121,7 @@ llvm::cl::opt<bool>
                          llvm::cl::desc("Enable rewriting borrow scopes"));
 
 bool CanonicalizeOSSALifetime::computeBorrowLiveness() {
-  auto borrowedVal = BorrowedValue::get(currentDef);
+  auto borrowedVal = BorrowedValue(currentDef);
   if (!borrowedVal) {
     return false;
   }
@@ -261,8 +261,7 @@ bool CanonicalizeOSSALifetime::consolidateBorrowScope() {
 
   auto *beginBorrow = cast<BeginBorrowInst>(currentDef);
   SmallVector<SILInstruction *, 1> scopeEndingInst;
-  BorrowedValue::get(beginBorrow)
-      .getLocalScopeEndingInstructions(scopeEndingInst);
+  BorrowedValue(beginBorrow).getLocalScopeEndingInstructions(scopeEndingInst);
   assert(scopeEndingInst.size() == 1 && "expected single-block borrow");
   // Remove outer uses that occur before the end of the borrow scope by
   // forward iterating from begin_borrow to end_borrow.

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -99,95 +99,13 @@ insertOwnedBaseValueAlongBranchEdge(BranchInst *bi, SILValue innerCopy,
   return phiArg;
 }
 
-static bool findTransitiveBorrowedUses(
-    SmallVectorImpl<Operand *> &usePoints,
-    SmallVectorImpl<std::pair<SILBasicBlock *, unsigned>> &reborrowPoints,
-    unsigned firstOffset = 0) {
-  // NOTE: Use points resizes in this loop so usePoints.size() may be
-  // different every time.
-  for (unsigned i = firstOffset; i < usePoints.size(); ++i) {
-    Operand *use = usePoints[i];
-    switch (use->getOperandOwnership()) {
-    case OperandOwnership::NonUse:
-    case OperandOwnership::TrivialUse:
-    case OperandOwnership::ForwardingConsume:
-    case OperandOwnership::DestroyingConsume:
-      llvm_unreachable("this operand cannot handle a guaranteed use");
-
-    case OperandOwnership::ForwardingUnowned:
-    case OperandOwnership::PointerEscape:
-      return false;
-
-    case OperandOwnership::InstantaneousUse:
-    case OperandOwnership::UnownedInstantaneousUse:
-    case OperandOwnership::BitwiseEscape:
-    case OperandOwnership::EndBorrow:
-    case OperandOwnership::Reborrow:
-      break;
-
-    case OperandOwnership::InteriorPointer:
-      // If our base guaranteed value does not have any consuming uses (consider
-      // function arguments), we need to be sure to include interior pointer
-      // operands since we may not get a use from a end_scope instruction.
-      if (!InteriorPointerOperand(use).findTransitiveUses(usePoints)) {
-        return false;
-      }
-      break;
-
-    case OperandOwnership::ForwardingBorrow:
-      ForwardingOperand(use).visitForwardedValues(
-        [&](SILValue transitiveValue) {
-          // Do not include transitive uses with 'none' ownership
-          if (transitiveValue.getOwnershipKind() == OwnershipKind::None)
-            return true;
-          for (auto *transitiveUse : transitiveValue->getUses()) {
-            if (transitiveUse->getOperandOwnership()
-                != OperandOwnership::NonUse) {
-              usePoints.push_back(transitiveUse);
-            }
-          }
-          return true;
-        });
-      break;
-
-    case OperandOwnership::Borrow:
-      // Try to grab additional end scope instructions to find more liveness
-      // info. Stash any reborrow uses so that we can eliminate the reborrow
-      // before we are done processing.
-      BorrowingOperand(use).visitLocalEndScopeUses(
-        [&](Operand *scopeEndingUse) {
-          if (auto scopeEndingBorrowingOp = BorrowingOperand(scopeEndingUse)) {
-            if (scopeEndingBorrowingOp.isReborrow()) {
-              auto *branch = scopeEndingUse->getUser();
-              reborrowPoints.push_back(
-                  {branch->getParent(), scopeEndingUse->getOperandNumber()});
-              return true;
-            }
-          }
-          usePoints.push_back(scopeEndingUse);
-          return true;
-        });
-    }
-  }
-  return true;
-}
-
-static bool findTransitiveBorrowedUses(
-    SILValue value, SmallVectorImpl<Operand *> &usePoints,
-    SmallVectorImpl<std::pair<SILBasicBlock *, unsigned>> &reborrowPoints) {
-  assert(value.getOwnershipKind() == OwnershipKind::Guaranteed);
-
-  unsigned firstOffset = usePoints.size();
-  for (Operand *use : value->getUses()) {
-    if (use->getOperandOwnership() != OperandOwnership::NonUse)
-      usePoints.push_back(use);
-  }
-  return findTransitiveBorrowedUses(usePoints, reborrowPoints, firstOffset);
-}
+//===----------------------------------------------------------------------===//
+//                      Ownership RAUW Helper Functions
+//===----------------------------------------------------------------------===//
 
 // Determine whether it is valid to replace \p oldValue with \p newValue by
-// directly checking ownership requirements. This does not determine whether the
-// scope of the newValue can be fully extended.
+// directly checking ownership requirements. This does not determine whether
+// the scope of the newValue can be fully extended.
 static bool hasValidRAUWOwnership(SILValue oldValue, SILValue newValue) {
   auto newOwnershipKind = newValue.getOwnershipKind();
 
@@ -244,14 +162,40 @@ static bool canFixUpOwnershipForRAUW(SILValue oldValue, SILValue newValue,
   if (!hasValidRAUWOwnership(oldValue, newValue))
     return false;
 
-  if (oldValue.getOwnershipKind() == OwnershipKind::Guaranteed) {
-    // Check that the old lifetime can be extended and record the necessary
-    // book-keeping in the OwnershipFixupContext.
-    if (!findTransitiveBorrowedUses(oldValue, context.transitiveBorrowedUses,
-                                    context.recursiveReborrows)) {
-      context.clear();
-      return false;
-    }
+  if (oldValue.getOwnershipKind() != OwnershipKind::Guaranteed)
+    return true;
+
+  // Check that the old lifetime can be extended and record the necessary
+  // book-keeping in the OwnershipFixupContext.
+  context.clear();
+
+  // Note: The following code is the same logic as
+  // findExtendedTransitiveGuaranteedUses(), but it handles the reborrows
+  // itself to maintain book-keeping. This is intended to be moved into a
+  // different utility in a follow-up commit.
+  SmallSetVector<SILValue, 4> reborrows;
+  auto visitReborrow = [&](Operand *endScope) {
+    auto borrowingOper = BorrowingOperand(endScope);
+    assert(borrowingOper.isReborrow());
+    // TODO: if non-phi reborrows even exist, handle them using a separate
+    // SILValue list since we don't want to refer directly to phi SILValues.
+    reborrows.insert(borrowingOper.getBorrowIntroducingUserResult().value);
+    auto *branch = endScope->getUser();
+    context.recursiveReborrows.push_back(
+      {branch->getParent(), endScope->getOperandNumber()});
+  };
+  if (!findTransitiveGuaranteedUses(oldValue, context.transitiveBorrowedUses,
+                                    visitReborrow))
+    return false;
+
+  for (unsigned idx = 0; idx < reborrows.size(); ++idx) {
+    bool result =
+      findTransitiveGuaranteedUses(reborrows[idx],
+                                   context.transitiveBorrowedUses,
+                                   visitReborrow);
+    // It is impossible to find a Pointer escape while traversing reborrows.
+    assert(result && "visiting reborrows always succeeds");
+    (void)result;
   }
   return true;
 }

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -734,7 +734,7 @@ SILBasicBlock::iterator OwnershipRAUWUtility::handleGuaranteed() {
   //    this formulation is that it ensures that we are always working with a
   //    non-dominating copy value, allowing us to force our borrowing value to
   //    need a base phi argument (the one of our choosing).
-  if (auto oldValueBorrowedVal = BorrowedValue::get(oldValue)) {
+  if (auto oldValueBorrowedVal = BorrowedValue(oldValue)) {
     SmallVector<std::pair<SILBasicBlock *, unsigned>, 8> foundReborrows;
     if (oldValueBorrowedVal.gatherReborrows(foundReborrows)) {
       rewriteReborrows(newBorrowedValue, foundReborrows, ctx.callbacks);


### PR DESCRIPTION
...for handling borrow scopes:

- find[Extended]TransitiveGuaranteedUses

- BorrowingOperand::visit[Extended]ScopeEndingUses

- BorrowedValue BorrowingOperand::getBorrowIntroducingUserResult()

And document the logic.

Mostly NFC in this commit, but more RAUW cases should be correctly
handled now.

Particularly, ensure that we can cleanly handle all manner of
reborrows. This is necessary to ensure both CanonicalizeOSSA and
replace-all-uses higher-level utilities handle all cases.

This generalizes some of the logic in CanonicalizeOSSA so it can be
shared by other high-level OSSA utilities.

These utilities extend the fundamental BorrowingOperand and
BorrowedValue functionality that has been designed recently. It builds
on and replaces a mix of piece-meal functionality that was needed
during bootstrapping. These APIs are now consistent with the more
recently designed code. It should be obvious what they mean and how to
use them, should be very hard to use them incorrectly, and should be
as efficient as possible, since they're fundamental to other
higher-level utilities.

Most importantly, there were several very subtle correctness issues
that were not handled cleanly in a centralized way. There are now a
mix of higher-level utilities trying to use this underlying
functionality, but it was hard to tell if all those higher-level
utilities were covering all the subtle cases:

- checking for PointerEscapes everywhere we need to

- the differences between uses of borrow introducers and other
  guaranteed values

- handling the uses of nested borrow scopes

- transitively handling reborrows

- the difference between nested and top-level reborrows

- forwarding destructures (which can cause exponential explosion)

In short, I was fundamentally confused and getting things wrong before
designing these utilities.
