### PR TITLE
[pmo] Teach pmo to ignore debug instruction uses.

### DIFF
--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -438,6 +438,10 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
     if (isSanitizerInstrumentation(User))
       continue;
 
+    // We don't care about debug instructions.
+    if (User->isDebugInstruction())
+      continue;
+
     // Otherwise, the use is something complicated, it escapes.
     Uses.emplace_back(User, PMOUseKind::Escape);
   }

--- a/test/SILOptimizer/predictable_memaccess_opts.sil
+++ b/test/SILOptimizer/predictable_memaccess_opts.sil
@@ -1935,3 +1935,71 @@ bbEnd:
   return %9999 : $()
 }
 
+class Foo {}
+struct MyInt {
+  var _value: Builtin.Int64
+}
+struct Baz {
+  var x: MyInt
+  var b: Builtin.NativeObject
+}
+sil @foo_method : $@convention(method) (@guaranteed Foo) -> MyInt
+
+// We promote all loads below.
+//
+// CHECK: sil [ossa] @promote_loads_despite_debug_uses : $@convention(thin) (MyInt, @guaranteed Foo, @guaranteed Baz) -> MyInt {
+// CHECK-NOT: load
+// CHECK: alloc_stack
+// CHECK-NOT: load
+// CHECK: alloc_stack
+// CHECK-NOT: load
+// CHECK: alloc_stack
+// CHECK-NOT: load
+// CHECK: alloc_stack
+// CHECK-NOT: load
+// CHECK: } // end sil function 'promote_loads_despite_debug_uses'
+sil [ossa] @promote_loads_despite_debug_uses : $@convention(thin) (MyInt, @guaranteed Foo, @guaranteed Baz) -> MyInt {
+bb0(%0 : $MyInt, %1 : @guaranteed $Foo, %2 : @guaranteed $Baz):
+  %3 = alloc_stack $MyInt
+  store %0 to [trivial] %3 : $*MyInt
+  %5 = alloc_stack $Foo
+  %6 = copy_value %1 : $Foo
+  store %6 to [init] %5 : $*Foo
+  %8 = alloc_stack $Baz
+  %9 = copy_value %2 : $Baz
+  store %9 to [init] %8 : $*Baz
+  debug_value_addr %3 : $*MyInt, var, name "x", argno 1
+  debug_value_addr %5 : $*Foo, var, name "y", argno 2
+  debug_value_addr %8 : $*Baz, var, name "z", argno 3
+  %14 = load [trivial] %3 : $*MyInt
+  %15 = load [copy] %5 : $*Foo
+
+  %16 = function_ref @foo_method : $@convention(method) (@guaranteed Foo) -> MyInt
+  %17 = begin_borrow %15 : $Foo
+  %18 = apply %16(%17) : $@convention(method) (@guaranteed Foo) -> MyInt
+  end_borrow %17 : $Foo
+  destroy_value %15 : $Foo
+  %21 = struct_extract %14 : $MyInt, #MyInt._value
+  %22 = struct_extract %18 : $MyInt, #MyInt._value
+  %23 = integer_literal $Builtin.Int1, -1
+  %24 = builtin "sadd_with_overflow_Int64"(%21 : $Builtin.Int64, %22 : $Builtin.Int64, %23 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  (%25, %26) = destructure_tuple %24 : $(Builtin.Int64, Builtin.Int1)
+  cond_fail %26 : $Builtin.Int1, "arithmetic overflow"
+  %28 = struct $MyInt (%25 : $Builtin.Int64)
+  %29 = struct_element_addr %8 : $*Baz, #Baz.x
+  %30 = load [trivial] %29 : $*MyInt
+  %31 = struct_extract %28 : $MyInt, #MyInt._value
+  %32 = struct_extract %30 : $MyInt, #MyInt._value
+  %33 = integer_literal $Builtin.Int1, -1
+  %34 = builtin "sadd_with_overflow_Int64"(%31 : $Builtin.Int64, %32 : $Builtin.Int64, %33 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  (%35, %36) = destructure_tuple %34 : $(Builtin.Int64, Builtin.Int1)
+  cond_fail %36 : $Builtin.Int1, "arithmetic overflow"
+  %38 = struct $MyInt (%35 : $Builtin.Int64)
+  destroy_addr %8 : $*Baz
+  dealloc_stack %8 : $*Baz
+  destroy_addr %5 : $*Foo
+  dealloc_stack %5 : $*Foo
+  destroy_addr %3 : $*MyInt
+  dealloc_stack %3 : $*MyInt
+  return %38 : $MyInt
+} // end sil function '$s27capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n'

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -1340,3 +1340,65 @@ bb5:
 bbEnd(%8 : @owned $Optional<Builtin.NativeObject>):
   return %8 : $Optional<Builtin.NativeObject>
 }
+
+class Foo {}
+struct MyInt {
+  var _value: Builtin.Int64
+}
+struct Baz {
+  var x: MyInt
+  var b: Builtin.NativeObject
+}
+sil @foo_method : $@convention(method) (@guaranteed Foo) -> MyInt
+
+// We completely eliminate the alloc_stack here since the alloc_stack are not
+// viewed as user code by dead allocation elimination.
+//
+// CHECK: sil [ossa] @promote_loads_despite_debug_uses : $@convention(thin) (MyInt, @guaranteed Foo, @guaranteed Baz) -> MyInt {
+// CHECK-NOT: alloc_stack
+// CHECK: } // end sil function 'promote_loads_despite_debug_uses'
+sil [ossa] @promote_loads_despite_debug_uses : $@convention(thin) (MyInt, @guaranteed Foo, @guaranteed Baz) -> MyInt {
+bb0(%0 : $MyInt, %1 : @guaranteed $Foo, %2 : @guaranteed $Baz):
+  %3 = alloc_stack $MyInt
+  store %0 to [trivial] %3 : $*MyInt
+  %5 = alloc_stack $Foo
+  %6 = copy_value %1 : $Foo
+  store %6 to [init] %5 : $*Foo
+  %8 = alloc_stack $Baz
+  %9 = copy_value %2 : $Baz
+  store %9 to [init] %8 : $*Baz
+  debug_value_addr %3 : $*MyInt, var, name "x", argno 1
+  debug_value_addr %5 : $*Foo, var, name "y", argno 2
+  debug_value_addr %8 : $*Baz, var, name "z", argno 3
+  %14 = load [trivial] %3 : $*MyInt
+  %15 = load [copy] %5 : $*Foo
+
+  %16 = function_ref @foo_method : $@convention(method) (@guaranteed Foo) -> MyInt
+  %17 = begin_borrow %15 : $Foo
+  %18 = apply %16(%17) : $@convention(method) (@guaranteed Foo) -> MyInt
+  end_borrow %17 : $Foo
+  destroy_value %15 : $Foo
+  %21 = struct_extract %14 : $MyInt, #MyInt._value
+  %22 = struct_extract %18 : $MyInt, #MyInt._value
+  %23 = integer_literal $Builtin.Int1, -1
+  %24 = builtin "sadd_with_overflow_Int64"(%21 : $Builtin.Int64, %22 : $Builtin.Int64, %23 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  (%25, %26) = destructure_tuple %24 : $(Builtin.Int64, Builtin.Int1)
+  cond_fail %26 : $Builtin.Int1, "arithmetic overflow"
+  %28 = struct $MyInt (%25 : $Builtin.Int64)
+  %29 = struct_element_addr %8 : $*Baz, #Baz.x
+  %30 = load [trivial] %29 : $*MyInt
+  %31 = struct_extract %28 : $MyInt, #MyInt._value
+  %32 = struct_extract %30 : $MyInt, #MyInt._value
+  %33 = integer_literal $Builtin.Int1, -1
+  %34 = builtin "sadd_with_overflow_Int64"(%31 : $Builtin.Int64, %32 : $Builtin.Int64, %33 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  (%35, %36) = destructure_tuple %34 : $(Builtin.Int64, Builtin.Int1)
+  cond_fail %36 : $Builtin.Int1, "arithmetic overflow"
+  %38 = struct $MyInt (%35 : $Builtin.Int64)
+  destroy_addr %8 : $*Baz
+  dealloc_stack %8 : $*Baz
+  destroy_addr %5 : $*Foo
+  dealloc_stack %5 : $*Foo
+  destroy_addr %3 : $*MyInt
+  dealloc_stack %3 : $*MyInt
+  return %38 : $MyInt
+} // end sil function '$s27capture_promotion_ownership05test_a1_B0SiycyFSiycfU_Tf2iii_n'


### PR DESCRIPTION
Just noticed this while trying to figure out why a change I was trying to make
in capture promotion wasn't optimizing loads away.