### PR TITLE
[clang-format] Change the clang-format style to always break on template declarations.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: LLVM
+AlwaysBreakTemplateDeclarations: Yes


### PR DESCRIPTION
Specifically, I am changin about is called BreakTemplateDeclarationsStyle from
BTDS_No (the current value) to BTDS_Yes. The two differences are:

```
BTDS_No (in configuration: No) Do not force break before declaration. PenaltyBreakTemplateDeclaration is taken into account.
template <typename T> T foo() {
}
template <typename T> T foo(int aaaaaaaaaaaaaaaaaaaaa,
                            int bbbbbbbbbbbbbbbbbbbbb) {
}
```

```
BTDS_Yes (in configuration: Yes) Always break after template declaration.
template <typename T>
T foo() {
}
template <typename T>
T foo(int aaaaaaaaaaaaaaaaaaaaa,
      int bbbbbbbbbbbbbbbbbbbbb) {
}
```

If one looks at the code base, most templates already look like BTDS_Yes except
for instances where clang-format performed it. Change the clang-format style to
stop this from happening incrementally.
