### PR TITLE
Fix typo in AttributeNodes.py

### DIFF
--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -277,7 +277,7 @@ ATTRIBUTE_NODES = [
     Node('DifferentiabilityParamList', kind='SyntaxCollection',
          element='DifferentiabilityParam'),
 
-    # differentiability-param -> ('self' | identifer | integer-literal) ','?
+    # differentiability-param -> ('self' | identifier | integer-literal) ','?
     Node('DifferentiabilityParam', kind='Syntax',
          description='''
          A differentiability parameter: either the "self" identifier, a function


### PR DESCRIPTION
identifer -> identifier