### PR TITLE
[Test] XFAIL witness-layout-opts-irgen.swift on iOS simulators.

### DIFF
--- a/test/Interop/Cxx/value-witness-table/witness-layout-opts-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/witness-layout-opts-irgen.swift
@@ -7,6 +7,9 @@
 // to test them in the same file.
 // XFAIL: OS=windows-msvc
 
+// Failing on i386 simulator, disable for now. rdar://73829982
+// XFAIL: DARWIN_SIMULATOR=ios
+
 import WitnessLayoutOpts
 
 protocol Dummy { }


### PR DESCRIPTION
@zoecarver This test started failing overnight, looks like from one of your commits here: https://ci.swift.org/job/oss-swift-pr-test/16338/changes#detail. Have a look, and if you have a fix, please re-enable the test.