### PR TITLE
swift-api-extract to generate JSON API information

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -132,6 +132,7 @@ ERROR(cannot_emit_ir_skipping_function_bodies,none,
 WARNING(emit_reference_dependencies_without_primary_file,none,
         "ignoring -emit-reference-dependencies (requires -primary-file)", ())
 
+ERROR(error_module_name_required,none, "-module-name is required", ())
 ERROR(error_bad_module_name,none,
       "module name \"%0\" is not a valid identifier"
       "%select{|; use -module-name flag to specify an alternate name}1",

--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -41,6 +41,10 @@ namespace swift {
 class FileUnit;
 class ModuleDecl;
 
+namespace apigen {
+class API;
+} // end namespace apigen
+
 class TBDGenDescriptor final {
   using FileOrModule = llvm::PointerUnion<FileUnit *, ModuleDecl *>;
   FileOrModule Input;
@@ -118,6 +122,21 @@ private:
   // Evaluation.
   std::vector<std::string>
   evaluate(Evaluator &evaluator, TBDGenDescriptor desc) const;
+};
+
+/// Retrieve API information for a file or module.
+class APIGenRequest
+    : public SimpleRequest<APIGenRequest,
+                           apigen::API(TBDGenDescriptor),
+                           RequestFlags::Uncached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  apigen::API evaluate(Evaluator &evaluator, TBDGenDescriptor desc) const;
 };
 
 /// Describes the origin of a particular symbol, including the stage of

--- a/include/swift/AST/TBDGenTypeIDZone.def
+++ b/include/swift/AST/TBDGenTypeIDZone.def
@@ -22,3 +22,5 @@ SWIFT_REQUEST(TBDGen, PublicSymbolsRequest,
 SWIFT_REQUEST(TBDGen, SymbolSourceMapRequest,
               SymbolSourceMap(TBDGenDescriptor),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TBDGen, APIGenRequest, apigen::API(TBDGenDescriptor), Uncached,
+              NoLocationInfo)

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -166,7 +166,8 @@ public:
     Batch,           // swiftc
     AutolinkExtract, // swift-autolink-extract
     SwiftIndent,     // swift-indent
-    SymbolGraph      // swift-symbolgraph
+    SymbolGraph,     // swift-symbolgraph
+    APIExtract       // swift-api-extract
   };
 
   class InputInfoMap;

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -37,6 +37,7 @@ namespace options {
     ArgumentIsPath = (1 << 12),
     ModuleInterfaceOption = (1 << 13),
     SupplementaryOutput = (1 << 14),
+    SwiftAPIExtractOption = (1 << 15),
   };
 
   enum ID {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -55,6 +55,9 @@ def ModuleInterfaceOption : OptionFlag;
 // for a supplementary output. E.g., `-emit-module` and `-emit-module-path`.
 def SupplementaryOutput : OptionFlag;
 
+// The option should be accepted by swift-api-extract.
+def SwiftAPIExtractOption : OptionFlag;
+
 /////////
 // Options
 
@@ -169,7 +172,8 @@ def driver_mode : Joined<["--"], "driver-mode=">, Flags<[HelpHidden]>,
   HelpText<"Set the driver mode to either 'swift' or 'swiftc'">;
 
 def help : Flag<["-", "--"], "help">,
-  Flags<[FrontendOption, AutolinkExtractOption, ModuleWrapOption, SwiftIndentOption]>,
+  Flags<[FrontendOption, AutolinkExtractOption, ModuleWrapOption,
+         SwiftIndentOption, SwiftAPIExtractOption]>,
   HelpText<"Display available options">;
 def h : Flag<["-"], "h">, Alias<help>;
 def help_hidden : Flag<["-", "--"], "help-hidden">,
@@ -191,16 +195,17 @@ def _DASH_DASH : Option<["--"], "", KIND_REMAINING_ARGS>,
 
 def o : JoinedOrSeparate<["-"], "o">,
   Flags<[FrontendOption, AutolinkExtractOption, ModuleWrapOption,
-         NoInteractiveOption, SwiftIndentOption, ArgumentIsPath]>,
+         NoInteractiveOption, SwiftIndentOption, ArgumentIsPath,
+         SwiftAPIExtractOption]>,
   HelpText<"Write output to <file>">, MetaVarName<"<file>">;
 
 def j : JoinedOrSeparate<["-"], "j">, Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Number of commands to execute in parallel">, MetaVarName<"<n>">;
 
-def sdk : Separate<["-"], "sdk">, Flags<[FrontendOption, ArgumentIsPath]>,
+def sdk : Separate<["-"], "sdk">, Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
   HelpText<"Compile against <sdk>">, MetaVarName<"<sdk>">;
 
-def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, ModuleInterfaceOption]>,
+def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption]>,
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
@@ -217,16 +222,16 @@ def tools_directory : Separate<["-"], "tools-directory">,
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
 
-def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption, ArgumentIsPath]>,
+def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
   HelpText<"Add directory to framework search path">;
 def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<F>;
 
 def Fsystem : Separate<["-"], "Fsystem">,
-  Flags<[FrontendOption, ArgumentIsPath]>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
   HelpText<"Add directory to system framework search path">;
 
-def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption, ArgumentIsPath]>,
+def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
   HelpText<"Add directory to the import search path">;
 def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<I>;
@@ -372,7 +377,7 @@ def localization_path : Separate<["-"], "localization-path">,
   MetaVarName<"<path>">;
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption]>,
   HelpText<"Specifies the Clang module cache path">;
 
 def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
@@ -393,7 +398,7 @@ def define_availability : Separate<["-"], "define-availability">,
   MetaVarName<"<macro>">;
 
 def module_name : Separate<["-"], "module-name">,
-  Flags<[FrontendOption, ModuleInterfaceOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption]>,
   HelpText<"Name of the module to build">;
 def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
   Alias<module_name>;
@@ -663,7 +668,7 @@ def framework : Separate<["-"], "framework">, Group<linker_option_Group>,
   HelpText<"Specifies a framework which should be linked against">;
 
 def L : JoinedOrSeparate<["-"], "L">, Group<linker_option_Group>,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption]>,
   HelpText<"Add directory to library link search path">;
 def L_EQ : Joined<["-"], "L=">, Group<linker_option_Group>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
@@ -1027,7 +1032,7 @@ def resource_dir : Separate<["-"], "resource-dir">,
   HelpText<"The directory that holds the compiler resource files">;
 
 def target : Separate<["-"], "target">,
-  Flags<[FrontendOption, ModuleWrapOption, ModuleInterfaceOption]>,
+  Flags<[FrontendOption, ModuleWrapOption, ModuleInterfaceOption, SwiftAPIExtractOption]>,
   HelpText<"Generate code for the given target <triple>, such as x86_64-apple-macos10.9">, MetaVarName<"<triple>">;
 def target_legacy_spelling : Joined<["--"], "target=">,
   Flags<[FrontendOption]>, Alias<target>;
@@ -1146,7 +1151,7 @@ def working_directory_EQ : Joined<["-"], "working-directory=">,
 // VFS
 
 def vfsoverlay : JoinedOrSeparate<["-"], "vfsoverlay">,
-  Flags<[FrontendOption, ArgumentIsPath]>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
   HelpText<"Add directory to VFS overlay file">;
 def vfsoverlay_EQ : Joined<["-"], "vfsoverlay=">,
   Alias<vfsoverlay>;
@@ -1176,5 +1181,9 @@ def emit_symbol_graph_dir : Separate<["-"], "emit-symbol-graph-dir">,
          ArgumentIsPath, SupplementaryOutput, HelpHidden]>,
   HelpText<"Emit a symbol graph to directory <dir>">,
   MetaVarName<"<dir>">;
+
+// Swift API Extraction only options
+def pretty_print: Flag<["-"], "pretty-print">, Flags<[SwiftAPIExtractOption]>,
+  HelpText<"Pretty-print the output JSON">;
 
 include "FrontendOptions.td"

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -99,6 +99,8 @@ std::vector<std::string> getPublicSymbols(TBDGenDescriptor desc);
 void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
                   const TBDGenOptions &opts);
 
+void writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os, bool PrettyPrint);
+
 } // end namespace swift
 
 #endif

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -102,6 +102,7 @@ void Driver::parseDriverKind(ArrayRef<const char *> Args) {
   .Case("swift-autolink-extract", DriverKind::AutolinkExtract)
   .Case("swift-indent", DriverKind::SwiftIndent)
   .Case("swift-symbolgraph-extract", DriverKind::SymbolGraph)
+  .Case("swift-api-extract", DriverKind::APIExtract)
   .Default(None);
   
   if (Kind.hasValue())
@@ -3467,6 +3468,7 @@ void Driver::printHelp(bool ShowHidden) const {
   case DriverKind::AutolinkExtract:
   case DriverKind::SwiftIndent:
   case DriverKind::SymbolGraph:
+  case DriverKind::APIExtract:
     ExcludedFlagsBitmask |= options::NoBatchOption;
     break;
   }

--- a/lib/TBDGen/APIGen.cpp
+++ b/lib/TBDGen/APIGen.cpp
@@ -1,0 +1,173 @@
+//===--- APIGen.cpp - Swift API Generation --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements the entrypoints into API file generation.
+//
+//===----------------------------------------------------------------------===//
+
+
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "APIGen.h"
+
+namespace swift {
+namespace apigen {
+
+void API::addSymbol(llvm::StringRef symbol, APILoc loc, APILinkage linkage,
+                    APIFlags flags, APIAccess access,
+                    APIAvailability availability) {
+  globals.emplace_back(symbol, loc, linkage, flags, access, GVKind::Function,
+                       availability);
+}
+
+ObjCInterfaceRecord *API::addObjCClass(llvm::StringRef name, APILinkage linkage,
+                                       APILoc loc, APIAccess access,
+                                       APIAvailability availability,
+                                       llvm::StringRef superClassName) {
+  interfaces.emplace_back(name, linkage, loc, access, availability,
+                          superClassName);
+  return &interfaces.back();
+}
+
+void API::addObjCMethod(ObjCInterfaceRecord *cls, llvm::StringRef name,
+                        APILoc loc, APIAccess access, bool isInstanceMethod,
+                        bool isOptional, APIAvailability availability) {
+  cls->methods.emplace_back(name, loc, access, isInstanceMethod, isOptional,
+                            availability);
+}
+
+static void serialize(llvm::json::OStream &OS, APIAccess access) {
+  switch (access) {
+  case APIAccess::Public:
+    OS.attribute("access", "public");
+    break;
+  case APIAccess::Private:
+    OS.attribute("access", "private");
+    break;
+  case APIAccess::Project:
+    OS.attribute("access", "project");
+    break;
+  case APIAccess::Unknown:
+    break;
+  }
+}
+
+static void serialize(llvm::json::OStream &OS, APIAvailability availability) {
+  if (availability.empty())
+    return;
+  if (!availability.introduced.empty())
+    OS.attribute("introduced", availability.introduced);
+  if (!availability.obsoleted.empty())
+    OS.attribute("obsoleted", availability.obsoleted);
+  if (availability.unavailable)
+    OS.attribute("unavailable", availability.unavailable);
+}
+
+static void serialize(llvm::json::OStream &OS, APILinkage linkage) {
+  switch (linkage) {
+  case APILinkage::Exported:
+    OS.attribute("linkage", "exported");
+    break;
+  case APILinkage::Reexported:
+    OS.attribute("linkage", "re-exported");
+    break;
+  case APILinkage::Internal:
+    OS.attribute("linkage", "internal");
+    break;
+  case APILinkage::External:
+    OS.attribute("linkage", "external");
+    break;
+  case APILinkage::Unknown:
+    // do nothing;
+    break;
+  }
+}
+
+static void serialize(llvm::json::OStream &OS, APILoc loc) {
+  OS.attribute("file", loc.getFilename());
+}
+
+static void serialize(llvm::json::OStream &OS, const GlobalRecord &record) {
+  OS.object([&]() {
+    OS.attribute("name", record.name);
+    serialize(OS, record.access);
+    serialize(OS, record.loc);
+    serialize(OS, record.linkage);
+    serialize(OS, record.availability);
+  });
+}
+
+static void serialize(llvm::json::OStream &OS, const ObjCMethodRecord &record) {
+  OS.object([&]() {
+    OS.attribute("name", record.name);
+    serialize(OS, record.access);
+    serialize(OS, record.loc);
+    serialize(OS, record.linkage);
+    serialize(OS, record.availability);
+    if (record.isOptional)
+      OS.attribute("optional", record.isOptional);
+  });
+}
+
+static void serialize(llvm::json::OStream &OS,
+                      const ObjCInterfaceRecord &record) {
+  OS.object([&]() {
+    OS.attribute("name", record.name);
+    serialize(OS, record.access);
+    serialize(OS, record.loc);
+    serialize(OS, record.linkage);
+    serialize(OS, record.availability);
+    OS.attribute("super", record.superClassName);
+    OS.attributeArray("instanceMethods", [&]() {
+      for (auto &method : record.methods) {
+        if (method.isInstanceMethod)
+          serialize(OS, method);
+      }
+    });
+    OS.attributeArray("classMethods", [&]() {
+      for (auto &method : record.methods) {
+        if (!method.isInstanceMethod)
+          serialize(OS, method);
+      }
+    });
+  });
+}
+
+static bool sortAPIRecords(const APIRecord &base, const APIRecord &compare) {
+  return base.name < compare.name;
+}
+
+void API::writeAPIJSONFile(llvm::raw_ostream &os, bool PrettyPrint) {
+  unsigned indentSize = PrettyPrint ? 2 : 0;
+  llvm::json::OStream JSON(os, indentSize);
+
+  // FIXME: only write PublicSDKContentRoot now.
+  JSON.object([&]() {
+    JSON.attribute("target", target.str());
+    JSON.attributeArray("globals", [&]() {
+      llvm::sort(globals, sortAPIRecords);
+      for (const auto &g : globals)
+        serialize(JSON, g);
+    });
+    JSON.attributeArray("interfaces", [&]() {
+      llvm::sort(interfaces, sortAPIRecords);
+      for (const auto &i : interfaces)
+        serialize(JSON, i);
+    });
+    JSON.attribute("version", "1.0");
+  });
+}
+
+} // end namespace apigen
+} // end namespace swift

--- a/lib/TBDGen/APIGen.h
+++ b/lib/TBDGen/APIGen.h
@@ -1,0 +1,184 @@
+//===--- APIGen.h - Public interface to APIGen ------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_APIGEN_APIGEN_H
+#define SWIFT_APIGEN_APIGEN_H
+
+#include "llvm/ADT/BitmaskEnum.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/Triple.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace swift {
+namespace apigen {
+LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
+enum class APIAccess : uint8_t {
+  Unknown = 0, // No information about access.
+  Project = 1, // APIs available within the project.
+  Private = 2, // Private unstable APIs.
+  Public  = 3, // Public stable APIs.
+};
+
+enum class APILinkage : uint8_t {
+  Unknown    = 0, // Unknown.
+  Internal   = 1, // API is internal.
+  External   = 2, // External interface used.
+  Reexported = 3, // API is re-exported.
+  Exported   = 4, // API is exported.
+};
+
+enum class APIFlags : uint8_t {
+  None             = 0,
+  ThreadLocalValue = 1U << 0,
+  WeakDefined      = 1U << 1,
+  WeakReferenced   = 1U << 2,
+  LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/WeakReferenced)
+};
+
+class APILoc {
+public:
+  APILoc() = default;
+  APILoc(std::string file, unsigned line, unsigned col)
+      : file(file), line(line), col(col) {}
+
+  llvm::StringRef getFilename() const { return file; }
+  unsigned getLine() const { return line; }
+  unsigned getColumn() const { return col; }
+
+private:
+  std::string file;
+  unsigned line;
+  unsigned col;
+};
+
+struct APIAvailability {
+  std::string introduced;
+  std::string obsoleted;
+  bool unavailable = false;
+
+  bool empty() {
+    return introduced.empty() && obsoleted.empty() && !unavailable;
+  }
+};
+
+struct APIRecord {
+  std::string name;
+  APILoc loc;
+  APILinkage linkage;
+  APIFlags flags;
+  APIAccess access;
+  APIAvailability availability;
+
+  APIRecord(llvm::StringRef name, APILoc loc, APILinkage linkage,
+            APIFlags flags, APIAccess access, APIAvailability availability)
+      : name(name.str()), loc(loc), linkage(linkage), flags(flags),
+        access(access), availability(availability) {}
+
+  bool isWeakDefined() const {
+    return (flags & APIFlags::WeakDefined) == APIFlags::WeakDefined;
+  }
+
+  bool isWeakReferenced() const {
+    return (flags & APIFlags::WeakReferenced) == APIFlags::WeakReferenced;
+  }
+
+  bool isThreadLocalValue() const {
+    return (flags & APIFlags::ThreadLocalValue) == APIFlags::ThreadLocalValue;
+  }
+
+  bool isExternal() const { return linkage == APILinkage::External; }
+  bool isExported() const { return linkage >= APILinkage::Reexported; }
+  bool isReexported() const { return linkage == APILinkage::Reexported; }
+};
+
+enum class GVKind : uint8_t {
+  Unknown = 0,
+  Variable = 1,
+  Function = 2,
+};
+
+struct GlobalRecord : APIRecord {
+  GVKind kind;
+
+  GlobalRecord(llvm::StringRef name, APILoc loc, APILinkage linkage,
+               APIFlags flags, APIAccess access, GVKind kind,
+               APIAvailability availability)
+      : APIRecord(name, loc, linkage, flags, access, availability), kind(kind) {
+  }
+};
+
+struct ObjCMethodRecord : APIRecord {
+  bool isInstanceMethod;
+  bool isOptional;
+
+  ObjCMethodRecord(llvm::StringRef name, APILoc loc, APIAccess access,
+                   bool isInstanceMethod, bool isOptional,
+                   APIAvailability availability)
+      : APIRecord(name, loc, APILinkage::Unknown, APIFlags::None, access,
+                  availability),
+        isInstanceMethod(isInstanceMethod), isOptional(isOptional) {}
+};
+
+struct ObjCContainerRecord : APIRecord {
+  std::vector<ObjCMethodRecord> methods;
+
+  ObjCContainerRecord(llvm::StringRef name, APILinkage linkage, APILoc loc,
+                      APIAccess access, const APIAvailability &availability)
+      : APIRecord(name, loc, linkage, APIFlags::None, access, availability) {}
+};
+
+struct ObjCInterfaceRecord : ObjCContainerRecord {
+  std::string superClassName;
+  ObjCInterfaceRecord(llvm::StringRef name, APILinkage linkage, APILoc loc,
+                      APIAccess access, APIAvailability availability,
+                      llvm::StringRef superClassName)
+      : ObjCContainerRecord(name, linkage, loc, access, availability),
+        superClassName(superClassName.str()) {}
+};
+
+class API {
+public:
+  API(const llvm::Triple &triple) : target(triple) {}
+  const llvm::Triple &getTarget() const { return target; }
+
+  void addSymbol(llvm::StringRef symbol, APILoc loc, APILinkage linkage,
+                 APIFlags flags, APIAccess access,
+                 APIAvailability availability);
+
+  ObjCInterfaceRecord *addObjCClass(llvm::StringRef name, APILinkage linkage,
+                                    APILoc loc, APIAccess access,
+                                    APIAvailability availability,
+                                    llvm::StringRef superClassName);
+
+  void addObjCMethod(ObjCInterfaceRecord *cls, llvm::StringRef name, APILoc loc,
+                     APIAccess access, bool isInstanceMethod, bool isOptional,
+                     APIAvailability availability);
+
+  void writeAPIJSONFile(llvm::raw_ostream &os, bool PrettyPrint = false);
+
+private:
+  const llvm::Triple target;
+
+  std::vector<GlobalRecord> globals;
+  std::vector<ObjCInterfaceRecord> interfaces;
+};
+
+} // end namespace apigen
+} // end namespace swift
+
+#endif

--- a/lib/TBDGen/CMakeLists.txt
+++ b/lib/TBDGen/CMakeLists.txt
@@ -1,10 +1,11 @@
 set_swift_llvm_is_available()
 add_swift_host_library(swiftTBDGen STATIC
+  APIGen.cpp
   TBDGen.cpp
   TBDGenRequests.cpp
   LLVM_LINK_COMPONENTS
     demangle
-    TextAPI 
+    TextAPI
 )
 target_link_libraries(swiftTBDGen PRIVATE
   swiftAST

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -47,9 +47,11 @@
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/TextAPI/MachO/InterfaceFile.h"
+#include "llvm/TextAPI/MachO/Symbol.h"
 #include "llvm/TextAPI/MachO/TextAPIReader.h"
 #include "llvm/TextAPI/MachO/TextAPIWriter.h"
 
+#include "APIGen.h"
 #include "TBDGenVisitor.h"
 
 using namespace swift;
@@ -64,10 +66,9 @@ static bool isGlobalOrStaticVar(VarDecl *VD) {
 }
 
 TBDGenVisitor::TBDGenVisitor(const TBDGenDescriptor &desc,
-                             SymbolCallbackFn symbolCallback)
+                             APIRecorder &recorder)
     : TBDGenVisitor(desc.getTarget(), desc.getDataLayout(),
-                    desc.getParentModule(), desc.getOptions(),
-                    symbolCallback) {}
+                    desc.getParentModule(), desc.getOptions(), recorder) {}
 
 void TBDGenVisitor::addSymbolInternal(StringRef name, SymbolKind kind,
                                       SymbolSource source) {
@@ -82,7 +83,7 @@ void TBDGenVisitor::addSymbolInternal(StringRef name, SymbolKind kind,
     }
   }
 #endif
-  SymbolCallback(name, kind, source);
+  recorder.addSymbol(name, kind, source);
 }
 
 static std::vector<OriginallyDefinedInAttr::ActiveVersion>
@@ -900,6 +901,7 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
       SmallString<128> buffer;
       addSymbol(CD->getObjCRuntimeName(buffer), SymbolSource::forUnknown(),
                 SymbolKind::ObjectiveCClass);
+      recorder.addObjCInterface(CD);
     }
   }
 
@@ -930,10 +932,11 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
     TBDGenVisitor &TBD;
     ClassDecl *CD;
     bool FirstTime = true;
+    APIRecorder &recorder;
 
   public:
-    VTableVisitor(TBDGenVisitor &TBD, ClassDecl *CD)
-        : TBD(TBD), CD(CD) {}
+    VTableVisitor(TBDGenVisitor &TBD, ClassDecl *CD, APIRecorder &recorder)
+        : TBD(TBD), CD(CD), recorder(recorder) {}
 
     void addMethod(SILDeclRef method) {
       assert(method.getDecl()->getDeclContext() == CD);
@@ -951,9 +954,30 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
       }
 
       TBD.addMethodDescriptor(method);
+
+      if (auto methodOrCtorOrDtor = method.getDecl()) {
+        // Skip non objc compatible methods or non-public methods.
+        if (!methodOrCtorOrDtor->isObjC() ||
+            methodOrCtorOrDtor->getFormalAccess() != AccessLevel::Public)
+          return;
+
+        // only handle FuncDecl here. Initializers are handled in
+        // visitConstructorDecl.
+        if (isa<FuncDecl>(methodOrCtorOrDtor))
+          recorder.addObjCMethod(CD, method);
+      }
     }
 
-    void addMethodOverride(SILDeclRef baseRef, SILDeclRef derivedRef) {}
+    void addMethodOverride(SILDeclRef baseRef, SILDeclRef derivedRef) {
+      if (auto methodOrCtorOrDtor = derivedRef.getDecl()) {
+        if (!methodOrCtorOrDtor->isObjC() ||
+            methodOrCtorOrDtor->getFormalAccess() != AccessLevel::Public)
+          return;
+
+        if (isa<FuncDecl>(methodOrCtorOrDtor))
+          recorder.addObjCMethod(CD, derivedRef);
+      }
+    }
 
     void addPlaceholder(MissingMemberDecl *) {}
 
@@ -962,7 +986,7 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
     }
   };
 
-  VTableVisitor(*this, CD).doIt();
+  VTableVisitor(*this, CD, recorder).doIt();
 }
 
 void TBDGenVisitor::visitConstructorDecl(ConstructorDecl *CD) {
@@ -971,7 +995,12 @@ void TBDGenVisitor::visitConstructorDecl(ConstructorDecl *CD) {
     // default ValueDecl handling gives the allocating one, so we have to
     // manually include the non-allocating one.
     addSymbol(SILDeclRef(CD, SILDeclRef::Kind::Initializer));
+    if (auto parentClass = CD->getParent()->getSelfClassDecl()) {
+      if (parentClass->isObjC() || CD->isObjC())
+        recorder.addObjCMethod(parentClass, SILDeclRef(CD));
+    }
   }
+
   visitAbstractFunctionDecl(CD);
 }
 
@@ -1264,8 +1293,8 @@ TBDFile GenerateTBDRequest::evaluate(Evaluator &evaluator,
   auto addSymbol = [&](StringRef symbol, SymbolKind kind, SymbolSource source) {
     file.addSymbol(kind, symbol, targets);
   };
-
-  TBDGenVisitor visitor(desc, addSymbol);
+  SimpleAPIRecorder recorder(addSymbol);
+  TBDGenVisitor visitor(desc, recorder);
   visitor.visit(desc);
   return file;
 }
@@ -1278,8 +1307,8 @@ PublicSymbolsRequest::evaluate(Evaluator &evaluator,
     if (kind == SymbolKind::GlobalSymbol)
       symbols.push_back(symbol.str());
   };
-
-  TBDGenVisitor visitor(desc, addSymbol);
+  SimpleAPIRecorder recorder(addSymbol);
+  TBDGenVisitor visitor(desc, recorder);
   visitor.visit(desc);
   return symbols;
 }
@@ -1297,6 +1326,137 @@ void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
                  "YAML writing should be error-free");
 }
 
+class APIGenRecorder final : public APIRecorder {
+public:
+  APIGenRecorder(apigen::API &api, ModuleDecl *module)
+      : api(api), module(module) {
+    const auto &MainFile = module->getMainFile(FileUnitKind::SerializedAST);
+    moduleLoc = apigen::APILoc(MainFile.getModuleDefiningPath().str(), 0, 0);
+  }
+  ~APIGenRecorder() {}
+
+  void addSymbol(StringRef symbol, SymbolKind kind,
+                 SymbolSource source) override {
+    if (kind != SymbolKind::GlobalSymbol)
+      return;
+
+    apigen::APIAvailability availability;
+    if (source.kind == SymbolSource::Kind::SIL) {
+      auto ref = source.getSILDeclRef();
+      if (auto *decl = ref.getDecl())
+        availability = getAvailability(decl);
+    }
+
+    api.addSymbol(symbol, moduleLoc, apigen::APILinkage::Exported,
+                  apigen::APIFlags::None, apigen::APIAccess::Public,
+                  availability);
+  }
+
+  void addObjCInterface(const ClassDecl *decl) override {
+    addOrGetObjCInterface(decl);
+  }
+
+  void addObjCMethod(const ClassDecl *cls,
+                     SILDeclRef method) override {
+    SmallString<128> buffer;
+    StringRef name = getSelectorName(method, buffer);
+    apigen::APIAvailability availability;
+    bool isInstanceMethod = true;
+    if (auto *decl = method.getDecl()) {
+      availability = getAvailability(decl);
+      if (decl->getDescriptiveKind() == DescriptiveDeclKind::ClassMethod)
+        isInstanceMethod = false;
+    }
+
+    auto *clsRecord = addOrGetObjCInterface(cls);
+    api.addObjCMethod(clsRecord, name, moduleLoc, apigen::APIAccess::Public,
+                      isInstanceMethod, false, availability);
+  }
+
+private:
+  apigen::APIAvailability getAvailability(const Decl *decl) {
+    bool unavailable = false;
+    std::string introduced, obsoleted;
+    auto platform = targetPlatform(module->getASTContext().LangOpts);
+    for (auto *attr : decl->getAttrs()) {
+      if (auto *ava = dyn_cast<AvailableAttr>(attr)) {
+        if (ava->isUnconditionallyUnavailable())
+          unavailable = true;
+        if (ava->Platform == platform) {
+          if (ava->Introduced)
+            introduced = ava->Introduced->getAsString();
+          if (ava->Obsoleted)
+            obsoleted = ava->Obsoleted->getAsString();
+        }
+      }
+    }
+    return {introduced, obsoleted, unavailable};
+  }
+
+  StringRef getSelectorName(SILDeclRef method, SmallString<128> &buffer) {
+    auto methodOrCtorOrDtor = method.getDecl();
+    if (methodOrCtorOrDtor) {
+      if (auto *method = dyn_cast<FuncDecl>(methodOrCtorOrDtor))
+        return method->getObjCSelector().getString(buffer);
+      else if (auto *ctor = dyn_cast<ConstructorDecl>(methodOrCtorOrDtor))
+        return ctor->getObjCSelector().getString(buffer);
+      else if (isa<DestructorDecl>(methodOrCtorOrDtor))
+        return "dealloc";
+    }
+    llvm_unreachable("cannot get selector name from decl");
+  }
+
+  apigen::ObjCInterfaceRecord *addOrGetObjCInterface(const ClassDecl *decl) {
+    auto entry = classMap.find(decl);
+    if (entry != classMap.end())
+      return entry->second;
+
+    SmallString<128> nameBuffer;
+    auto name = decl->getObjCRuntimeName(nameBuffer);
+    StringRef superCls;
+    SmallString<128> buffer;
+    if (auto *super = decl->getSuperclassDecl())
+      superCls = super->getObjCRuntimeName(buffer);
+    apigen::APIAvailability availability = getAvailability(decl);
+    apigen::APIAccess access = decl->getFormalAccess() == AccessLevel::Public
+                                   ? apigen::APIAccess::Public
+                                   : apigen::APIAccess::Private;
+    apigen::APILinkage linkage = decl->isObjC() ? apigen::APILinkage::Exported
+                                                : apigen::APILinkage::Internal;
+    auto cls = api.addObjCClass(name, linkage, moduleLoc, access, availability,
+                                superCls);
+    classMap.try_emplace(decl, cls);
+    return cls;
+  }
+
+  apigen::API &api;
+  ModuleDecl *module;
+  apigen::APILoc moduleLoc;
+
+  llvm::DenseMap<const ClassDecl*, apigen::ObjCInterfaceRecord*> classMap;
+};
+
+apigen::API APIGenRequest::evaluate(Evaluator &evaluator,
+                                    TBDGenDescriptor desc) const {
+  auto *M = desc.getParentModule();
+  apigen::API api(M->getASTContext().LangOpts.Target);
+  APIGenRecorder recorder(api, M);
+
+  TBDGenVisitor visitor(desc, recorder);
+  visitor.visit(desc);
+
+  return api;
+}
+
+void swift::writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os,
+                             bool PrettyPrint) {
+  TBDGenOptions opts;
+  auto &evaluator = M->getASTContext().evaluator;
+  auto desc = TBDGenDescriptor::forModule(M, opts);
+  auto api = llvm::cantFail(evaluator(APIGenRequest{desc}));
+  api.writeAPIJSONFile(os, PrettyPrint);
+}
+
 SymbolSourceMap SymbolSourceMapRequest::evaluate(Evaluator &evaluator,
                                                  TBDGenDescriptor desc) const {
   using Map = SymbolSourceMap::Storage;
@@ -1306,7 +1466,8 @@ SymbolSourceMap SymbolSourceMapRequest::evaluate(Evaluator &evaluator,
     symbolSources.insert({symbol, source});
   };
 
-  TBDGenVisitor visitor(desc, addSymbol);
+  SimpleAPIRecorder recorder(addSymbol);
+  TBDGenVisitor visitor(desc, recorder);
   visitor.visit(desc);
 
   // FIXME: Once the evaluator supports returning a reference to a cached value

--- a/lib/TBDGen/TBDGenRequests.cpp
+++ b/lib/TBDGen/TBDGenRequests.cpp
@@ -21,6 +21,8 @@
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/TextAPI/MachO/InterfaceFile.h"
 
+#include "APIGen.h"
+
 using namespace swift;
 
 namespace swift {

--- a/lib/TBDGen/TBDGenVisitor.h
+++ b/lib/TBDGen/TBDGenVisitor.h
@@ -61,6 +61,32 @@ struct InstallNameStore {
   void remark(ASTContext &Ctx, StringRef ModuleName) const;
 };
 
+/// A set of callbacks for recording APIs.
+class APIRecorder {
+public:
+  virtual ~APIRecorder() {}
+
+  virtual void addSymbol(StringRef name, llvm::MachO::SymbolKind kind,
+                         SymbolSource source) {}
+  virtual void addObjCInterface(const ClassDecl *decl) {}
+  virtual void addObjCMethod(const ClassDecl *cls, SILDeclRef method) {}
+};
+
+class SimpleAPIRecorder final : public APIRecorder {
+public:
+  using SymbolCallbackFn = llvm::function_ref<void(
+      StringRef, llvm::MachO::SymbolKind, SymbolSource)>;
+
+  SimpleAPIRecorder(SymbolCallbackFn func) : func(func) {}
+
+  void addSymbol(StringRef symbol, llvm::MachO::SymbolKind kind,
+                 SymbolSource source) override {
+    func(symbol, kind, source);
+  }
+private:
+  SymbolCallbackFn func;
+};
+
 class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
 #ifndef NDEBUG
   /// Tracks the symbols emitted to ensure we don't emit any duplicates.
@@ -71,12 +97,9 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
   UniversalLinkageInfo UniversalLinkInfo;
   ModuleDecl *SwiftModule;
   const TBDGenOptions &Opts;
+  APIRecorder &recorder;
 
   using SymbolKind = llvm::MachO::SymbolKind;
-  using SymbolCallbackFn =
-      llvm::function_ref<void(StringRef, SymbolKind, SymbolSource)>;
-
-  SymbolCallbackFn SymbolCallback;
 
   /// A set of original function and derivative configuration pairs for which
   /// derivative symbols have been emitted.
@@ -145,15 +168,15 @@ class TBDGenVisitor : public ASTVisitor<TBDGenVisitor> {
 public:
   TBDGenVisitor(const llvm::Triple &target, const llvm::DataLayout &dataLayout,
                 ModuleDecl *swiftModule, const TBDGenOptions &opts,
-                SymbolCallbackFn symbolCallback)
+                APIRecorder &recorder)
       : DataLayout(dataLayout),
         UniversalLinkInfo(target, opts.HasMultipleIGMs, /*forcePublic*/ false),
-        SwiftModule(swiftModule), Opts(opts), SymbolCallback(symbolCallback),
+        SwiftModule(swiftModule), Opts(opts), recorder(recorder),
         previousInstallNameMap(parsePreviousModuleInstallNameMap()) {}
 
   /// Create a new visitor using the target and layout information from a
   /// TBDGenDescriptor.
-  TBDGenVisitor(const TBDGenDescriptor &desc, SymbolCallbackFn symbolCallback);
+  TBDGenVisitor(const TBDGenDescriptor &desc, APIRecorder &recorder);
 
   ~TBDGenVisitor() { assert(DeclStack.empty()); }
   void addMainIfNecessary(FileUnit *file) {

--- a/test/APIJSON/access.swift
+++ b/test/APIJSON/access.swift
@@ -1,0 +1,24 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Apple Swift version 5.3
+// swift-module-flags: -target x86_64-apple-macos11.0 -enable-objc-interop -enable-library-evolution -module-name MyModule
+
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/MyModule.swiftinterface
+// RUN: %target-swift-api-extract -target x86_64-apple-macos11.0 -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+
+public func publicFunction()
+internal func internalFunction()
+fileprivate func filePrivateFunction()
+private func privateFunction()
+
+// CHECK:        "target":
+// CHECK-NEXT:   "globals": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule14publicFunctionyyF",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "interfaces": []

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -1,0 +1,432 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+
+import Foundation
+
+@available(macOS 10.13, *)
+public class Test : NSObject {
+  @objc public func method1() {}
+  @objc public class func method2() {}
+  public func nonObjc() {}
+}
+
+@available(macOS 10.13, *)
+public class Derived : Test {
+  @objc public override func method1() {}
+  public override func nonObjc() {}
+}
+
+// Not derived from NSObject. ObjC metadata is still emitted but not exported.
+// Ignore those metadata for now.
+public class Test2 {}
+
+// Test initializers.
+public class Test3 : NSObject {
+  @objc public override init() {}
+  @objc public init(fromInt number: Int) {}
+  @objc public convenience init(_ number: Float) {
+    self.init()
+  }
+}
+
+@available(macOS 10.13, *)
+public func myFunction() -> Int {
+  return 0
+}
+
+@available(macOS, obsoleted: 10.9)
+public func myFunction1() {}
+
+@available(*, unavailable)
+public func myFunction2() {}
+
+// CHECK:      "target"
+// CHECK-NEXT: "globals": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule10myFunctionSiyF",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule11myFunction1yyF",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "obsoleted": "10.9"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule11myFunction2yyF",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "unavailable": true
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestC7method1yyFTj",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestC7method1yyFTq",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestC7method2yyFZTj",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestC7method2yyFZTq",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestC7nonObjcyyFTj",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestC7nonObjcyyFTq",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCACycfC",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCACycfc",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCMa",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCMn",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCMo",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCMu",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCN",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule4TestCfD",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test2CMa",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test2CMm",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test2CMn",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test2CMo",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test2CN",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test2CfD",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test2Cfd",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3C7fromIntACSi_tcfC",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3C7fromIntACSi_tcfCTj",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3C7fromIntACSi_tcfCTq",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3C7fromIntACSi_tcfc",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CACycfC",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CACycfc",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CMa",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CMn",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CMo",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CMu",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CN",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CfD",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CyACSfcfC",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule5Test3CyACSfcfc",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule7DerivedCACycfC",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule7DerivedCACycfc",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule7DerivedCMa",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule7DerivedCMn",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule7DerivedCMo",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule7DerivedCN",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_$s8MyModule7DerivedCfD",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_OBJC_CLASS_$__TtC8MyModule4Test",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_OBJC_CLASS_$__TtC8MyModule5Test3",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_OBJC_CLASS_$__TtC8MyModule7Derived",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_OBJC_METACLASS_$__TtC8MyModule4Test",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_OBJC_METACLASS_$__TtC8MyModule5Test3",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_OBJC_METACLASS_$__TtC8MyModule7Derived",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],
+// CHECK-NEXT: "interfaces": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_TtC8MyModule4Test",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13",
+// CHECK-NEXT:     "super": "NSObject",
+// CHECK-NEXT:     "instanceMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "init",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "method1",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "classMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "method2",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_TtC8MyModule5Test3",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "super": "NSObject",
+// CHECK-NEXT:     "instanceMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "init",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "initFromInt:",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "init:",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "classMethods": []
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_TtC8MyModule7Derived",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "exported",
+// CHECK-NEXT:     "introduced": "10.13",
+// CHECK-NEXT:     "super": "_TtC8MyModule4Test",
+// CHECK-NEXT:     "instanceMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "init",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "method1",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "classMethods": []
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],
+// CHECK-NEXT: "version": "1.0"

--- a/test/APIJSON/non-objc-class.swift
+++ b/test/APIJSON/non-objc-class.swift
@@ -1,0 +1,95 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+
+import Foundation
+
+// Need objc data for objc compatible methods.
+public class NonObjC {
+  @objc public init() {}
+  @objc public func testMethod() {}
+}
+
+public class NonObjC1 {
+  @objc public func testMethod() {}
+}
+
+public class NonObjC2 {
+  @objc public func testMethod() {}
+  public init() {}
+}
+
+public class NonObjC3 {
+  @objc public init() {}
+  public init(fromInt: Int) {}
+}
+
+// CHECK:      "interfaces": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_TtC8MyModule7NonObjC",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "internal",
+// CHECK-NEXT:     "super": "",
+// CHECK-NEXT:     "instanceMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "init",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "testMethod",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "classMethods": []
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_TtC8MyModule8NonObjC1",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "internal",
+// CHECK-NEXT:     "super": "",
+// CHECK-NEXT:     "instanceMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "testMethod",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "classMethods": []
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_TtC8MyModule8NonObjC2",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "internal",
+// CHECK-NEXT:     "super": "",
+// CHECK-NEXT:     "instanceMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "testMethod",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "classMethods": []
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "name": "_TtC8MyModule8NonObjC3",
+// CHECK-NEXT:     "access": "public",
+// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:     "linkage": "internal",
+// CHECK-NEXT:     "super": "",
+// CHECK-NEXT:     "instanceMethods": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "name": "init",
+// CHECK-NEXT:         "access": "public",
+// CHECK-NEXT:         "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "classMethods": []
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -1,0 +1,93 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+
+import Foundation
+
+@_spi(Experimental) public func newUnprovenFunc() {}
+@_spi(Experimental) public class MyClass : NSObject {
+  public func spiMethod() {}
+}
+
+public class MyClass2 : NSObject {
+  @_spi(Experimental) public func spiMethod() {}
+}
+
+// CHECK:      {
+// CHECK-NEXT:   "target":
+// CHECK-NEXT:   "globals": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CACycfC",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CACycfc",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMa",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMn",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CMo",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CN",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule0A6Class2CfD",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule8MyClass2",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_OBJC_METACLASS_$__TtC8MyModule8MyClass2",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "interfaces": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_TtC8MyModule8MyClass2",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "super": "NSObject",
+// CHECK-NEXT:       "instanceMethods": [
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "name": "init",
+// CHECK-NEXT:           "access": "public",
+// CHECK-NEXT:           "file": "/@input/MyModule.swiftinterface"
+// CHECK-NEXT:         }
+// CHECK-NEXT:       ],
+// CHECK-NEXT:       "classMethods": []
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "version": "1.0"
+// CHECK-NEXT: }

--- a/test/APIJSON/struct.swift
+++ b/test/APIJSON/struct.swift
@@ -1,0 +1,52 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+
+// Struct has no objc data.
+@available(macOS 10.13, *)
+public struct TestStruct {
+  public init() {}
+
+  @available(macOS 10.14, *)
+  public func testMethod() {}
+}
+
+// CHECK:      {
+// CHECK-NEXT:   "target":
+// CHECK-NEXT:   "globals": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule10TestStructV10testMethodyyF",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "introduced": "10.14"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule10TestStructVACycfC",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule10TestStructVMa",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule10TestStructVMn",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule10TestStructVN",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "interfaces": [],
+// CHECK-NEXT:   "version": "1.0"
+// CHECK-NEXT: }

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -288,6 +288,7 @@ config.swift_reflection_dump = inferSwiftBinary('swift-reflection-dump')
 config.swift_remoteast_test = inferSwiftBinary('swift-remoteast-test')
 config.swift_indent = inferSwiftBinary('swift-indent')
 config.swift_symbolgraph_extract = inferSwiftBinary('swift-symbolgraph-extract')
+config.swift_api_extract = inferSwiftBinary('swift-api-extract')
 config.clang = inferSwiftBinary('clang')
 config.llvm_link = inferSwiftBinary('llvm-link')
 config.swift_llvm_opt = inferSwiftBinary('swift-llvm-opt')
@@ -1074,6 +1075,9 @@ if run_vendor == 'apple':
     config.target_swift_symbolgraph_extract = (
         "%s %s %s" %
         (xcrun_prefix, config.swift_symbolgraph_extract, target_options))
+    config.target_swift_api_extract = (
+        "%s %s -sdk %r" %
+        (config.swift_api_extract, target_options, config.variant_sdk))
     config.target_swift_ide_test = (
         "%s %s %s %s" %
         (xcrun_prefix, config.swift_ide_test, target_options, ccp_opt))
@@ -1184,6 +1188,10 @@ elif run_os in ['windows-msvc']:
             ('%r -target %s %s' % (config.swift_symbolgraph_extract,             \
                                          config.variant_triple,                  \
                                          mcp_opt))
+    config.target_swift_api_extract =                                            \
+            ('%r -target %s -sdk %r' % (config.swift_api_extract,                \
+                                         config.variant_sdk,                     \
+                                         config.variant_triple))
     config.target_swift_ide_test =                                               \
             ('%r -target %s %s %s %s' % (config.swift_ide_test,                  \
                                          config.variant_triple,                  \
@@ -1295,6 +1303,9 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     config.target_swift_symbolgraph_extract = (
         '%s -target %s %s' %
         (config.swift_symbolgraph_extract, config.variant_triple, mcp_opt))
+    config.target_swift_api_extract = (
+        '%s -target %s -sdk %r' %
+        (config.swift_api_extract, config.variant_triple, config.variant_sdk))
     config.target_swift_ide_test = (
         '%s -target %s %s %s %s' %
         (config.swift_ide_test, config.variant_triple, resource_dir_opt,
@@ -1971,6 +1982,7 @@ config.substitutions.append(('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
 config.substitutions.append(('%target-swift-ide-test', "%s -swift-version %s" % (config.target_swift_ide_test, swift_version)))
 
 config.substitutions.append(('%target-swift-symbolgraph-extract', config.target_swift_symbolgraph_extract))
+config.substitutions.append(('%target-swift-api-extract', config.target_swift_api_extract))
 
 if not hasattr(config, 'target_swift_reflection_test'):
     config.target_swift_reflection_test = inferSwiftBinary(swift_reflection_test_name)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -4,6 +4,7 @@ add_swift_host_tool(swift-frontend
   modulewrap_main.cpp
   swift_indent_main.cpp
   swift_symbolgraph_extract_main.cpp
+  swift_api_extract_main.cpp
   SWIFT_COMPONENT compiler
 )
 target_link_libraries(swift-frontend
@@ -35,12 +36,18 @@ swift_create_post_build_symlink(swift-frontend
 
 swift_create_post_build_symlink(swift-frontend
   SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+  DESTINATION "swift-api-extract${CMAKE_EXECUTABLE_SUFFIX}"
+  WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+
+swift_create_post_build_symlink(swift-frontend
+  SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
   DESTINATION "swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
 add_swift_tool_symlink(swift swift-frontend compiler)
 add_swift_tool_symlink(swiftc swift-frontend compiler)
 add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler)
+add_swift_tool_symlink(swift-api-extract swift-frontend compiler)
 add_swift_tool_symlink(swift-autolink-extract swift-frontend autolink-driver)
 add_swift_tool_symlink(swift-indent swift-frontend editor-integration)
 
@@ -57,6 +64,9 @@ swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc${CMAKE_E
                            DESTINATION "bin"
                            COMPONENT compiler)
 swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-symbolgraph-extract${CMAKE_EXECUTABLE_SUFFIX}"
+                           DESTINATION "bin"
+                           COMPONENT compiler)
+swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-extract${CMAKE_EXECUTABLE_SUFFIX}"
                            DESTINATION "bin"
                            COMPONENT compiler)
 add_dependencies(autolink-driver swift-frontend)

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -75,6 +75,10 @@ extern int swift_indent_main(ArrayRef<const char *> Args, const char *Argv0,
 extern int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv0,
 void *MainAddr);
 
+/// Run 'swift-api-extract'
+extern int swift_api_extract_main(ArrayRef<const char *> Args,
+                                  const char *Argv0, void *MainAddr);
+
 /// Determine if the given invocation should run as a "subcommand".
 ///
 /// Examples of "subcommands" are 'swift build' or 'swift test', which are
@@ -230,6 +234,10 @@ static int run_driver(StringRef ExecName,
       argv[0], (void *)(intptr_t)getExecutablePath);
   case Driver::DriverKind::SymbolGraph:
       return swift_symbolgraph_extract_main(TheDriver.getArgsWithoutProgramNameAndDriverMode(argv), argv[0], (void *)(intptr_t)getExecutablePath);
+  case Driver::DriverKind::APIExtract:
+    return swift_api_extract_main(
+        TheDriver.getArgsWithoutProgramNameAndDriverMode(argv), argv[0],
+        (void *)(intptr_t)getExecutablePath);
   default:
     break;
   }

--- a/tools/driver/swift_api_extract_main.cpp
+++ b/tools/driver/swift_api_extract_main.cpp
@@ -1,0 +1,242 @@
+//===--- swift_api_extract_main.cpp - Swift module API extract tool -------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Extracts APIs from a .swiftmodule file.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/LLVMInitialize.h"
+#include "swift/Basic/Version.h"
+#include "swift/Frontend/Frontend.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/Option/Options.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+#include <system_error>
+
+using namespace swift;
+using namespace llvm::opt;
+
+class SwiftAPIExtractInvocation {
+private:
+  CompilerInvocation Invocation;
+  CompilerInstance Instance;
+  PrintingDiagnosticConsumer PDC;
+  std::string MainExecutablePath;
+  std::string OutputFilename = "-";
+  std::string InputModulePath;
+  std::string InputModuleName;
+  bool PrettyPrint = false;
+
+public:
+  SwiftAPIExtractInvocation(const std::string &ExecPath)
+      : MainExecutablePath(ExecPath) {
+    Instance.addDiagnosticConsumer(&PDC);
+  }
+
+  int parseArgs(ArrayRef<const char *> Args) {
+    using namespace options;
+    auto &Diags = Instance.getDiags();
+
+    std::unique_ptr<llvm::opt::OptTable> Table = createSwiftOptTable();
+    unsigned MissingIndex;
+    unsigned MissingCount;
+    llvm::opt::InputArgList ParsedArgs = Table->ParseArgs(
+        Args, MissingIndex, MissingCount, SwiftAPIExtractOption);
+    if (MissingCount) {
+      Diags.diagnose(SourceLoc(), diag::error_missing_arg_value,
+                     ParsedArgs.getArgString(MissingIndex), MissingCount);
+      return 1;
+    }
+
+    if (ParsedArgs.getLastArg(OPT_help)) {
+      std::string ExecutableName =
+          llvm::sys::path::stem(MainExecutablePath).str();
+      Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+                       "Swift API Extract", options::SwiftAPIExtractOption, 0,
+                       /*ShowAllAliases*/ false);
+      return 1;
+    }
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_module_name))
+      InputModuleName = A->getValue();
+    else {
+      Diags.diagnose(SourceLoc(), diag::error_module_name_required);
+      return 1;
+    }
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_INPUT))
+      InputModulePath = A->getValue();
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_o))
+      OutputFilename = A->getValue();
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_target))
+      Invocation.setTargetTriple(A->getValue());
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_swift_version)) {
+      bool isValid = false;
+      if (auto Version = version::Version::parseVersionString(
+              A->getValue(), SourceLoc(), nullptr)) {
+        if (auto Effective = Version.getValue().getEffectiveLanguageVersion()) {
+          Invocation.getLangOptions().EffectiveLanguageVersion = *Effective;
+          isValid = true;
+        }
+      }
+      if (!isValid) {
+        Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                       A->getAsString(ParsedArgs), A->getValue());
+        return 1;
+      }
+    }
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_sdk))
+      Invocation.setSDKPath(A->getValue());
+
+    std::vector<SearchPathOptions::FrameworkSearchPath> FrameworkSearchPaths;
+    for (auto *A : ParsedArgs.filtered(OPT_F))
+      FrameworkSearchPaths.emplace_back(A->getValue(), /*isSystem*/ false);
+
+    for (auto *A : ParsedArgs.filtered(OPT_Fsystem))
+      FrameworkSearchPaths.emplace_back(A->getValue(), /*isSystem*/ true);
+    Invocation.setFrameworkSearchPaths(FrameworkSearchPaths);
+
+    std::vector<std::string> LibrarySearchPaths;
+    for (auto *A : ParsedArgs.filtered(OPT_L))
+      LibrarySearchPaths.push_back(A->getValue());
+    Invocation.getSearchPathOptions().LibrarySearchPaths = LibrarySearchPaths;
+
+    std::vector<std::string> ImportSearchPaths;
+    if (!InputModulePath.empty()) {
+      // FIXME: this needs to move to tapi.
+      // Create an overlay of in memory file system of everything inside the
+      // input swiftmodule.
+      // The input module is mapped to "/@input" to avoid finding duplicated
+      // dependency modules in case there are other modules next to the input
+      // module.
+      llvm::vfs::YAMLVFSWriter VFSWriter;
+      SmallString<256> Prefix("/@input");
+      llvm::sys::path::append(Prefix,
+                              llvm::sys::path::filename(InputModulePath));
+      std::error_code EC;
+      if (llvm::sys::fs::is_directory(InputModulePath)) {
+        for (llvm::sys::fs::recursive_directory_iterator F(InputModulePath, EC),
+             FE;
+             F != FE; F.increment(EC)) {
+          if (EC) {
+            Diags.diagnose(SourceLoc(), diag::cannot_open_file, F->path(),
+                           EC.message());
+            return 1;
+          }
+          SmallString<256> MappedPath(Prefix);
+          StringRef RelativePath(F->path());
+          RelativePath.consume_front(InputModulePath);
+          llvm::sys::path::append(MappedPath, RelativePath);
+          VFSWriter.addFileMapping(MappedPath, F->path());
+        }
+      } else
+        VFSWriter.addFileMapping(Prefix, InputModulePath);
+
+      SmallString<256> VFSMapFile;
+      EC = llvm::sys::fs::createTemporaryFile("vfsmap", "map", VFSMapFile);
+      if (EC) {
+        Diags.diagnose(SourceLoc(), diag::cannot_open_file, VFSMapFile,
+                       EC.message());
+        return 1;
+      }
+      llvm::raw_fd_ostream SS(VFSMapFile, EC);
+      if (EC) {
+        Diags.diagnose(SourceLoc(), diag::cannot_open_file, VFSMapFile,
+                       EC.message());
+        return 1;
+      }
+      VFSWriter.write(SS);
+      Invocation.getSearchPathOptions().VFSOverlayFiles.push_back(
+          VFSMapFile.str().str());
+      // Put the scanning module in the beginning of the import search path.
+      ImportSearchPaths.push_back("/@input");
+    }
+    for (auto *A : ParsedArgs.filtered(OPT_I))
+      ImportSearchPaths.push_back(A->getValue());
+    Invocation.setImportSearchPaths(ImportSearchPaths);
+
+    for (auto *A : ParsedArgs.filtered(OPT_vfsoverlay))
+      Invocation.getSearchPathOptions().VFSOverlayFiles.push_back(
+          A->getValue());
+
+    if (ParsedArgs.hasArg(OPT_pretty_print))
+      PrettyPrint = true;
+
+    if (auto *A = ParsedArgs.getLastArg(OPT_module_cache_path))
+      Invocation.setClangModuleCachePath(A->getValue());
+
+    Invocation.setMainExecutablePath(MainExecutablePath);
+    Invocation.setModuleName("swift_api_extract");
+    Invocation.getLangOptions().EnableObjCInterop =
+        llvm::Triple(Invocation.getTargetTriple()).isOSDarwin();
+    Invocation.getLangOptions().DebuggerSupport = true;
+    Invocation.getFrontendOptions().EnableLibraryEvolution = true;
+    Invocation.setDefaultPrebuiltCacheIfNecessary();
+
+    return 0;
+  }
+
+  int extractAPI() {
+    if (Instance.setup(Invocation)) {
+      llvm::outs() << "Failed to setup compiler instance\n";
+      return 1;
+    }
+
+    auto *M = Instance.getASTContext().getModuleByName(InputModuleName);
+    if (!M) {
+      Instance.getDiags().diagnose(SourceLoc(), diag::unknown_swift_module_name,
+                                   InputModuleName);
+      return 1;
+    }
+
+    if (OutputFilename == "-") {
+      writeAPIJSONFile(M, llvm::outs(), PrettyPrint);
+      return 0;
+    }
+
+    std::error_code EC;
+    llvm::raw_fd_ostream OS(OutputFilename, EC);
+    if (EC) {
+      Instance.getDiags().diagnose(SourceLoc(), diag::cannot_open_file,
+                                   OutputFilename, EC.message());
+      return 1;
+    }
+
+    writeAPIJSONFile(M, OS, PrettyPrint);
+    return 0;
+  }
+};
+
+int swift_api_extract_main(ArrayRef<const char *> Args, const char *Argv0,
+                           void *MainAddr) {
+  INITIALIZE_LLVM();
+
+  SwiftAPIExtractInvocation Invocation(
+      llvm::sys::fs::getMainExecutable(Argv0, MainAddr));
+
+  if (Invocation.parseArgs(Args) != 0)
+    return EXIT_FAILURE;
+
+  if (Invocation.extractAPI() != 0)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add a new swift-frontend driver option that extract APIs in the swift
module and print in JSON format. This is to allow tooling to understand
and process swift APIs without the need to be a swift compiler or
understand swift module/AST.

<!-- What's in this pull request? -->
Create a swift driver option that based on TBDGen but provide more information about swift APIs in both swift/objc/etc. in JSON format. The output can be easily consumed by other tools and scripts to reason about APIs in the swift module.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
rdar://69600000

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
