### PR TITLE
[Tests] Disable process-stats-dir.py related tests

### DIFF
--- a/test/Driver/pipe_round_robin.swift.gyb
+++ b/test/Driver/pipe_round_robin.swift.gyb
@@ -1,5 +1,6 @@
 // Windows doesn't track/use read() and poll()
 // UNSUPPORTED: windows
+// REQUIRES: rdar73834542
 // RUN: %empty-directory(%t/manyfuncs)
 // RUN: %empty-directory(%t/stats)
 //

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
 // RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t

--- a/test/Misc/stats_dir_failure_count.swift
+++ b/test/Misc/stats_dir_failure_count.swift
@@ -1,4 +1,5 @@
 // Check that a failed process-tree emits nonzero failure counters
+// REQUIRES: rdar73834542
 // RUN: %empty-directory(%t)
 // RUN: echo zzz >%t/other.swift
 // RUN: not %target-swiftc_driver -continue-building-after-errors -D BROKEN -j 2 -typecheck -stats-output-dir %t %s %t/other.swift

--- a/test/Misc/stats_dir_instructions.swift
+++ b/test/Misc/stats_dir_instructions.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: rdar73834542
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s
 // RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t

--- a/test/Misc/stats_dir_long_path_name.swift
+++ b/test/Misc/stats_dir_long_path_name.swift
@@ -1,4 +1,5 @@
 // REQUIRES: OS=macosx
+// REQUIRES: rdar73834542
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents
 // RUN: cp %s %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift

--- a/test/Misc/stats_dir_plausible_maxrss.swift
+++ b/test/Misc/stats_dir_plausible_maxrss.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: %empty-directory(%t)
 // RUN: touch %t/main.swift
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %t/main.swift

--- a/test/NameLookup/named_lazy_member_loading_anyobject.swift
+++ b/test/NameLookup/named_lazy_member_loading_anyobject.swift
@@ -1,5 +1,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
+// REQUIRES: rdar73834542
 //
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers %s -verify
 

--- a/test/NameLookup/named_lazy_member_loading_objc_category.swift
+++ b/test/NameLookup/named_lazy_member_loading_objc_category.swift
@@ -1,5 +1,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache

--- a/test/NameLookup/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameLookup/named_lazy_member_loading_objc_interface.swift
@@ -1,5 +1,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache

--- a/test/NameLookup/named_lazy_member_loading_objc_protocol.swift
+++ b/test/NameLookup/named_lazy_member_loading_objc_protocol.swift
@@ -1,5 +1,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache

--- a/test/NameLookup/named_lazy_member_loading_protocol_mirroring.swift
+++ b/test/NameLookup/named_lazy_member_loading_protocol_mirroring.swift
@@ -1,5 +1,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache

--- a/test/NameLookup/named_lazy_member_loading_swift_class.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_class.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_class_type.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_class_type.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_derived_class.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_derived_class.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_derived_class_type.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_derived_class_type.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_enum.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_enum.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_proto.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_proto.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_struct.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_struct.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_struct_ext.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_struct_ext.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/NameLookup/named_lazy_member_loading_swift_struct_ext_mem.swift
+++ b/test/NameLookup/named_lazy_member_loading_swift_struct_ext_mem.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables

--- a/test/SILOptimizer/hello-world.swift
+++ b/test/SILOptimizer/hello-world.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar73834542
 // RUN: rm -rf %t && mkdir -p %t/stats
 // RUN: %target-swift-frontend -emit-sil -stats-output-dir %t/stats %s -o /dev/null
 // RUN: %{python} %utils/process-stats-dir.py --evaluate 'NumSILGenFunctions < 10' %t/stats

--- a/validation-test/compiler_scale/parse_array_nested.swift.gyb
+++ b/validation-test/compiler_scale/parse_array_nested.swift.gyb
@@ -1,5 +1,7 @@
 // RUN: %scale-test -parse --begin 0 --end 10 --step 1 --select NumASTBytes %s
 
+// REQUIRES: rdar73834542
+
  %for i in range(1, N + 1):
  [
  %end


### PR DESCRIPTION
Disable a series of tests failing in https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch_tools-R_stdlib-RD_test-simulator/13/ with errors like `name 'NumDriverPipeReads' is not defined`.