### PR TITLE
Disable Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift on arm64e the 2nd

### DIFF
--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 // This tests output needs to be updated for arm64.
-// XFAIL: arm64e
+// XFAIL: CPU=arm64e
 
 import CustomDestructor
 


### PR DESCRIPTION
The previous PR missed the `CPU=` part.

rdar://73755064
