### PR TITLE
[Async CC] Put extra sources before unfulfilled requirements.

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3058,20 +3058,6 @@ NecessaryBindings NecessaryBindings::computeBindings(
   // Figure out what we're actually required to pass:
   PolymorphicConvention convention(IGM, origType, considerParameterSources);
 
-  //  - unfulfilled requirements
-  convention.enumerateUnfulfilledRequirements(
-                                        [&](GenericRequirement requirement) {
-    CanType type = requirement.TypeParameter.subst(subs)->getCanonicalType();
-
-    if (requirement.Protocol) {
-      auto conf = subs.lookupConformance(requirement.TypeParameter,
-                                         requirement.Protocol);
-      bindings.addProtocolConformance(type, conf);
-    } else {
-      bindings.addTypeMetadata(type);
-    }
-  });
-
   //   - extra sources
   for (auto &source : convention.getSources()) {
     switch (source.getKind()) {
@@ -3097,6 +3083,20 @@ NecessaryBindings NecessaryBindings::computeBindings(
     }
     llvm_unreachable("bad source kind");
   }
+
+  //  - unfulfilled requirements
+  convention.enumerateUnfulfilledRequirements(
+                                        [&](GenericRequirement requirement) {
+    CanType type = requirement.TypeParameter.subst(subs)->getCanonicalType();
+
+    if (requirement.Protocol) {
+      auto conf = subs.lookupConformance(requirement.TypeParameter,
+                                         requirement.Protocol);
+      bindings.addProtocolConformance(type, conf);
+    } else {
+      bindings.addTypeMetadata(type);
+    }
+  });
 
   return bindings;
 }

--- a/test/IRGen/async/run-call-struct-instance_generic-mutating-generic_1-to-generic_1.swift
+++ b/test/IRGen/async/run-call-struct-instance_generic-mutating-generic_1-to-generic_1.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -emit-ir -parse-as-library -module-name main | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -parse-as-library -module-name main -o %t/main %target-rpath(%t) 
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import _Concurrency
+
+struct G<T> {
+  // CHECK-LL: @"$s4main1GV19theMutatingFunctionyqd__qd__YlFTu" = hidden global %swift.async_func_pointer
+  // CHECK-LL: define hidden swiftcc void @"$s4main1GV19theMutatingFunctionyqd__qd__YlF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}} {
+  mutating func theMutatingFunction<U>(_ u: U) async -> U {
+    return u
+  }
+}
+
+func theMutatingCaller<T, U>(_ g: inout G<T>, _ u: U) async -> U {
+  return await g.theMutatingFunction(u)
+}
+
+@main struct Main {
+  static func main() async {
+    var g = G<Int>()
+    let i = await theMutatingCaller(&g, 3)
+    // CHECK: 3
+    print(i)
+  }
+}


### PR DESCRIPTION
EmitPolymorphicArguments puts the extra sources before the unfulfilled requirements into the explosion.  The NecessaryBindings instance must have the type parameters in the same order.  Previously, though, they were added after enumerating unfulfilled requirements.  Here, they are added _before_ enumerating, matching the ordering of EmitPolymorphicArguments.

rdar://73742483