### PR TITLE
[Parse] Fix hash accumulation in decl member parsing

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4764,6 +4764,10 @@ bool Parser::parseMemberDeclList(SourceLoc &LBLoc, SourceLoc &RBLoc,
     return true;
   }
 
+  // Record '{' '}' to the current hash, nothing else.
+  recordTokenHash("}");
+  llvm::SaveAndRestore<Optional<StableHasher>> T(CurrentTokenHash, None);
+
   bool HasOperatorDeclarations;
   bool HasNestedClassDeclarations;
 
@@ -4808,12 +4812,12 @@ Parser::parseDeclList(SourceLoc LBLoc, SourceLoc &RBLoc, Diag<> ErrorDiag,
                       ParseDeclOptions Options, IterableDeclContext *IDC,
                       bool &hadError) {
 
-  // If we're hashing the type body separately, record the curly braces but
-  // nothing inside for the interface hash.
+  // Hash the type body separately.
   llvm::SaveAndRestore<Optional<StableHasher>> MemberHashingScope{
       CurrentTokenHash, StableHasher::defaultHasher()};
+
+  // Record '{' which has been consumed in callers.
   recordTokenHash("{");
-  recordTokenHash("}");
 
   std::vector<Decl *> decls;
   ParserStatus Status;

--- a/test/InterfaceHash/delayedparsing.swift
+++ b/test/InterfaceHash/delayedparsing.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift 2> %t/a.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift 2> %t/b.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/a.swift -experimental-skip-all-function-bodies 2> %t/c.hash
+// RUN: %target-swift-frontend -dump-interface-hash -primary-file %t/b.swift -experimental-skip-all-function-bodies 2> %t/d.hash
+// RUN: cmp %t/a.hash %t/b.hash
+// RUN: cmp %t/a.hash %t/c.hash
+// RUN: cmp %t/a.hash %t/d.hash
+
+// Make sure "interface hash" doesn't change after modifying type members, and 
+
+// BEGIN a.swift
+class C {
+  func foo() {}
+}
+
+// BEGIN b.swift
+class C {
+  func foo() {}
+  func bar() {}
+}

--- a/test/Serialization/sourceinfo.swift
+++ b/test/Serialization/sourceinfo.swift
@@ -7,4 +7,4 @@ import MyModule
 // RUN: %target-swift-ide-test -print-module-metadata -module-to-print MyModule -enable-swiftsourceinfo -I %t/Modules -source-filename %s | %FileCheck %s
 
 // CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File1.swift; hash=9da710e9b2de1fff2915639236b8929c; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=35
-// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File2.swift; hash=4ce628834bb98fd822ac840ea341de26; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=57
+// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File2.swift; hash=22b75a7717318d48f7a979906f35195e; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=57


### PR DESCRIPTION
For example, given:
```swift
  class C: P {
    func foo() { return 1 }
  }
```
For the outer context (i.e. source file), the interface should be `class C : P { }`. For the member list, it's `{ func foo ( ) { } }`. This must be the same regardless delayed parsing is enabled or not.


(Delayed parsing for primary file is enabled since https://github.com/apple/swift/pull/35441)