### PR TITLE
Correct the Location of a Protocol Requirement Fixit

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2814,7 +2814,7 @@ static void finishProtocolStorageImplInfo(AbstractStorageDecl *storage,
   if (auto *var = dyn_cast<VarDecl>(storage)) {
     SourceLoc typeLoc;
     if (auto *repr = var->getTypeReprOrParentPatternTypeRepr())
-      typeLoc = repr->getLoc();
+      typeLoc = repr->getEndLoc();
     
     if (info.hasStorage()) {
       // Protocols cannot have stored properties.

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -516,11 +516,15 @@ protocol LetThereBeCrash {
   let x: Int
   // expected-error@-1 {{protocols cannot require properties to be immutable; declare read-only properties by using 'var' with a '{ get }' specifier}} {{13-13= { get \}}}
   // expected-note@-2 {{declared here}}
+  let xs: [Int]
+  // expected-error@-1 {{protocols cannot require properties to be immutable; declare read-only properties by using 'var' with a '{ get }' specifier}} {{3-6=var}} {{16-16= { get \}}}
+  // expected-note@-2 {{declared here}}
 }
 
 extension LetThereBeCrash {
-  init() { x = 1 }
+  init() { x = 1; xs = [] }
   // expected-error@-1 {{'let' property 'x' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+  // expected-error@-2 {{'let' property 'xs' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
 }
 
 // SR-11412


### PR DESCRIPTION
The old fixit mistakenly used getLoc() instead of getEndLoc() on the
type repr, which for simple identifiers will do the right thing. For
compound ones like `[T]`, it instead points inside of the repr
which leads to nonsensical fixes like [ { get }T]

rdar://73632764