### PR TITLE
[CSBindings] New binding formed by join operation should refer to con…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -597,7 +597,10 @@ bool PotentialBindings::addPotentialBinding(PotentialBinding binding,
             Type::join(existingBinding->BindingType, binding.BindingType);
 
         if (join && isAcceptableJoin(*join)) {
-          joined.push_back(existingBinding->withType(*join));
+          // Result of the join has to use new binding because it refers
+          // to the constraint that triggered the join that replaced the
+          // existing binding.
+          joined.push_back(binding.withType(*join));
           // Remove existing binding from the set.
           // It has to be re-introduced later, since its type has been changed.
           existingBinding = Bindings.erase(existingBinding);

--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -120,3 +120,14 @@ func rdar37241221(_ a: C?, _ b: D?) {
   let inferred = [a!, b]
   expectEqualType(type(of: array_c_opt).self, type(of: inferred).self)
 }
+
+extension FixedWidthInteger {
+  public static func test_nonstale_join_result<Other: BinaryInteger>(_ lhs: inout Self, _ rhs: Other) {
+    let shift = rhs < -Self.bitWidth ? -Self.bitWidth
+               : rhs > Self.bitWidth ? Self.bitWidth
+               : Int(rhs) // `shift` is `Int`
+
+    func accepts_int(_: Int) {}
+    accepts_int(shift) // Ok
+  }
+}


### PR DESCRIPTION
…straint that triggered join

Using existing binding with updated type would result in incorrect
behavior in incremental mode since when "originating" (new) constraint
gets retracted it would leave a stale binding behind.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
