### PR TITLE
[NFC] Correct contributor name (again)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,7 +9,10 @@ Ankit Aggarwal <ankit_aggarwal@apple.com> <ankit.spd@gmail.com>
 Argyrios Kyrtzidis <kyrtzidis@apple.com> <akyrtzi@gmail.com>
 Arsen Gasparyan <to.arsen.gasparyan@gmail.com> <frootloops@users.noreply.github.com>
 Ashley Garland <acgarland@apple.com> <dfarler@apple.com>
-Becca Royal-Gordon <beccadax@apple.com> <broyalgordon@apple.com> <becca@beccadax.com> <brentdax@apple.com> <brent@brentdax.com>
+Becca Royal-Gordon <beccadax@apple.com> <broyalgordon@apple.com>
+Becca Royal-Gordon <beccadax@apple.com> <becca@beccadax.com>
+Becca Royal-Gordon <beccadax@apple.com> <brentdax@apple.com>
+Becca Royal-Gordon <beccadax@apple.com> <brent@brentdax.com>
 Ben Cohen <ben_cohen@apple.com>
 Ben Cohen <ben_cohen@apple.com> <airspeedswift@users.noreply.github.com>
 Ben Cohen <ben_cohen@apple.com> <ben@airspeedvelocity.net>


### PR DESCRIPTION
It appears that the .mailmap syntax only recognizes two email addresses per line, not N addresses. Correct this mistake.

h/t @benrimmington 