### PR TITLE
[CSBindings] Literal coverage checking should account for type variab…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -538,11 +538,13 @@ PotentialBindings::isLiteralCoveredBy(const LiteralRequirement &literal,
     break;
   }
 
-  if (type->isTypeVariableOrMember() || type->isHole())
-    return std::make_pair(false, Type());
-
   bool requiresUnwrap = false;
   do {
+    // Conformance check on type variable would always return true,
+    // but type variable can't cover anything until it's bound.
+    if (type->isTypeVariableOrMember() || type->isHole())
+      return std::make_pair(false, Type());
+
     if (literal.isCoveredBy(type, CS.DC)) {
       return std::make_pair(true, requiresUnwrap ? type : binding.BindingType);
     }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -782,8 +782,8 @@ func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
   // ?? should have higher precedence than logical operators like || and comparisons.
   if cond || (a ?? 42 > 0) {}  // Ok.
   if (cond || a) ?? 42 > 0 {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
-  // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-  // expected-error@-2 {{cannot convert value of type 'Bool' to expected argument type 'Int'}}
+  // expected-error@-1 {{binary operator '>' cannot be applied to operands of type 'Bool' and 'Int'}}  expected-note@-1 {{overloads for '>' exist with these partially matching parameter list}}
+  // expected-error@-2 {{binary operator '??' cannot be applied to operands of type 'Bool' and 'Int'}}
   if (cond || a) ?? (42 > 0) {}  // expected-error {{cannot be used as a boolean}} {{15-15=(}} {{16-16= != nil)}}
 
   if cond || a ?? 42 > 0 {}    // Parses as the first one, not the others.


### PR DESCRIPTION
…le/hole embedded in optional

Currently `isLiteralCoveredBy` only checks for top-level type variable or hole.

That check has to be sunk down so it could be used after optionality is stripped
away (when possible), otherwise bindings like `$T0?` are (incorrectly) determined
to cover literal requirements (because conformance check always succeeds when
attempted on a type variable).


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
