### PR TITLE
[complete-test] Add options for performance testing

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -10,12 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/AST/Decl.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
-#include "swift/AST/Decl.h"
-#include "swift/AST/Expr.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/FileSystem.h"

--- a/tools/SourceKit/tools/complete-test/CMakeLists.txt
+++ b/tools/SourceKit/tools/complete-test/CMakeLists.txt
@@ -3,9 +3,9 @@ add_sourcekit_executable(complete-test
   LLVM_LINK_COMPONENTS option coverage lto
 )
 if(SWIFT_SOURCEKIT_USE_INPROC_LIBRARY)
-  target_link_libraries(complete-test PRIVATE sourcekitdInProc)
+  target_link_libraries(complete-test PRIVATE sourcekitdInProc swiftBasic)
 else()
-  target_link_libraries(complete-test PRIVATE sourcekitd)
+  target_link_libraries(complete-test PRIVATE sourcekitd swiftBasic)
 endif()
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(complete-test PRIVATE


### PR DESCRIPTION
This adds two changes to complete-test
1. Ability to perform multiple completions by specifying multiple `-tok` parameters.
2. Ability to measure the time spent performing the completions using a `-stats-output-dir` parameter.

The stats output file looks as follows. The `time.swift-completetest.complete_test_invocation-Validation.swift-na-na-Onone` entries measure how long the entire `complete-test` invocation took, which is probably less useful but auto-generated by `UnifiedStatsReporter`, which I didn’t want to fiddle around with too much.

```json
{
	"time.swift.complete-request.MEMBER_FAST.wall": 1.4068841934204102e-02,
	"time.swift.complete-request.MEMBER_FAST.user": 1.2606000000000117e-02,
	"time.swift.complete-request.MEMBER_FAST.sys": 1.4890000000000181e-03,
	"time.swift.complete-request.MEMBER.wall": 1.9094991683959961e-01,
	"time.swift.complete-request.MEMBER.user": 1.5148800000000007e-01,
	"time.swift.complete-request.MEMBER.sys": 3.9364000000000010e-02,
	"time.swift.complete-request.GLOBAL_TYPE_2_FAST.wall": 1.0192823410034180e-01,
	"time.swift.complete-request.GLOBAL_TYPE_2_FAST.user": 6.0383999999999993e-02,
	"time.swift.complete-request.GLOBAL_TYPE_2_FAST.sys": 4.0125999999999995e-02,
	"time.swift.complete-request.GLOBAL_TYPE_2.wall": 1.1122202873229980e-01,
	"time.swift.complete-request.GLOBAL_TYPE_2.user": 6.5863999999999923e-02,
	"time.swift.complete-request.GLOBAL_TYPE_2.sys": 4.3583999999999984e-02,
	"time.swift.complete-request.GLOBAL_TYPE_FAST.wall": 1.4530825614929199e-01,
	"time.swift.complete-request.GLOBAL_TYPE_FAST.user": 7.9532999999999854e-02,
	"time.swift.complete-request.GLOBAL_TYPE_FAST.sys": 6.1341000000000007e-02,
	"time.swift.complete-request.GLOBAL_TYPE.wall": 1.2794480323791504e+00,
	"time.swift.complete-request.GLOBAL_TYPE.user": 1.1115800000000000e+00,
	"time.swift.complete-request.GLOBAL_TYPE.sys": 1.6348500000000002e-01,
	"time.swift-completetest.complete_test_invocation-Validation.swift-na-na-Onone.wall": 1.8632860183715820e+00,
	"time.swift-completetest.complete_test_invocation-Validation.swift-na-na-Onone.user": 1.5013159999999999e+00,
	"time.swift-completetest.complete_test_invocation-Validation.swift-na-na-Onone.sys": 3.4988199999999997e-01
}
```