### PR TITLE
[Docs] Fix testing target suffixes

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -199,16 +199,16 @@ For every target above, there are variants for different optimizations:
 * the target with ``-optimize`` suffix (e.g., ``check-swift-optimize``) -- runs
   execution tests in ``-O`` mode.  This target will only run tests marked as
   ``executable_test``.
-* the target with ``-optimize-unchecked`` suffix (e.g.,
-  ``check-swift-optimize-unchecked``) -- runs execution tests in
+* the target with ``-optimize_unchecked`` suffix (e.g.,
+  ``check-swift-optimize_unchecked``) -- runs execution tests in
   ``-Ounchecked`` mode. This target will only run tests marked as
   ``executable_test``.
-* the target with ``-executable`` suffix (e.g.,
-  ``check-swift-executable-iphoneos-arm64``) -- runs tests marked with
+* the target with ``-only_executable`` suffix (e.g.,
+  ``check-swift-only_executable-iphoneos-arm64``) -- runs tests marked with
   ``executable_test`` in ``-Onone`` mode.
-* the target with ``-non-executable`` suffix (e.g.,
-  ``check-swift-non-executable-iphoneos-arm64``) -- runs tests not marked with
-  ``executable_test`` in ``-Onone`` mode.
+* the target with ``-only_non_executable`` suffix (e.g.,
+  ``check-swift-only_non_executable-iphoneos-arm64``) -- runs tests not marked
+  with ``executable_test`` in ``-Onone`` mode.
 
 ### Writing tests
 


### PR DESCRIPTION
The underlying change happened almost five years ago: 457f2b901caad14e2085ea0fe2c9b116b5df3520.