### PR TITLE
SourceKit: add test for attributed imports in generated interfaces

### DIFF
--- a/test/IDE/print_attributed_imports.swift
+++ b/test/IDE/print_attributed_imports.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+
+// RUN: echo 'public func module1() {}' >> %t/module1.swift
+// RUN: echo 'public func module2() {}' >> %t/module2.swift
+// RUN: %target-swift-frontend -emit-module -module-name Module1 -o %t %t/module1.swift
+// RUN: %target-swift-frontend -emit-module -module-name Module2 -o %t %t/module2.swift
+
+// RUN: %target-swift-frontend -I %t -emit-module -o %t/AttrImports.swiftmodule %S/print_attributed_imports.swift
+// RUN: %target-swift-ide-test -I %t -print-module -source-filename %s -module-to-print=AttrImports | %FileCheck %s
+
+@_exported import Module1
+@_implementationOnly import Module2
+
+// CHECK: import Module1
+// CHECK-NOT: import Module2


### PR DESCRIPTION
This PR adds a separate test for printing imports with attributes `@_exported`/`@_implementationOnly` in the generated interfaces.
It doesn't cover `@_private` imports, since those are currently printed, and require more effort to hide.

This is a follow-up to https://github.com/apple/swift/pull/35575.