### PR TITLE
[Runtime] Support precomputed protocol conformances in the shared cache.

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -47,4 +47,12 @@ VARIABLE(SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE, bool, false,
 VARIABLE(SWIFT_DEBUG_ENABLE_COW_CHECKS, bool, false,
          "Enable internal checks for copy-on-write operations.")
 
+#if defined(__APPLE__) && defined(__MACH__)
+
+VARIABLE(SWIFT_DEBUG_VALIDATE_SHARED_CACHE_PROTOCOL_CONFORMANCES, bool, false,
+         "Validate shared cache protocol conformance results against the "
+         "lists of conformances in the shared cache images.")
+
+#endif
+
 #undef VARIABLE

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -14,11 +14,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/StringExtras.h"
+#include "swift/ABI/TypeIdentity.h"
 #include "swift/Basic/Lazy.h"
+#include "swift/Basic/STLExtras.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Runtime/Bincompat.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Concurrent.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Basic/Unreachable.h"
@@ -28,6 +32,21 @@
 #include "Private.h"
 
 #include <vector>
+
+#if __has_include(<mach-o/dyld_priv.h>)
+#include <mach-o/dyld_priv.h>
+#define DYLD_EXPECTED_SWIFT_OPTIMIZATIONS_VERSION 1u
+#endif
+
+// Set this to 1 to enable logging of calls to the dyld shared cache conformance
+// table
+#if 0
+#define SHARED_CACHE_LOG(fmt, ...)                                             \
+  fprintf(stderr, "PROTOCOL CONFORMANCE: " fmt "\n", __VA_ARGS__)
+#define SHARED_CACHE_LOG_ENABLED 1
+#else
+#define SHARED_CACHE_LOG(fmt, ...) (void)0
+#endif
 
 using namespace swift;
 
@@ -185,6 +204,17 @@ ProtocolConformanceDescriptor::getWitnessTable(const Metadata *type) const {
 namespace {
   struct ConformanceSection {
     const ProtocolConformanceRecord *Begin, *End;
+
+    ConformanceSection(const ProtocolConformanceRecord *begin,
+                       const ProtocolConformanceRecord *end)
+        : Begin(begin), End(end) {}
+
+    ConformanceSection(const void *ptr, uintptr_t size) {
+      auto bytes = reinterpret_cast<const char *>(ptr);
+      Begin = reinterpret_cast<const ProtocolConformanceRecord *>(ptr);
+      End = reinterpret_cast<const ProtocolConformanceRecord *>(bytes + size);
+    }
+
     const ProtocolConformanceRecord *begin() const {
       return Begin;
     }
@@ -242,9 +272,47 @@ struct ConformanceState {
   ConcurrentReadableArray<ConformanceSection> SectionsToScan;
   bool scanSectionsBackwards;
 
+#if DYLD_FIND_PROTOCOL_CONFORMANCE_DEFINED
+  uintptr_t dyldSharedCacheStart;
+  uintptr_t dyldSharedCacheEnd;
+  bool hasOverriddenImage;
+  bool validateSharedCacheResults;
+
+  // Only populated when validateSharedCacheResults is enabled.
+  ConcurrentReadableArray<ConformanceSection> SharedCacheSections;
+
+  bool inSharedCache(const void *ptr) {
+    auto uintPtr = reinterpret_cast<uintptr_t>(ptr);
+    return dyldSharedCacheStart <= uintPtr && uintPtr < dyldSharedCacheEnd;
+  }
+#endif
+
   ConformanceState() {
     scanSectionsBackwards =
         runtime::bincompat::workaroundProtocolConformanceReverseIteration();
+
+#if DYLD_FIND_PROTOCOL_CONFORMANCE_DEFINED
+    if (_dyld_swift_optimizations_version() ==
+        DYLD_EXPECTED_SWIFT_OPTIMIZATIONS_VERSION) {
+      size_t length;
+      dyldSharedCacheStart = (uintptr_t)_dyld_get_shared_cache_range(&length);
+      dyldSharedCacheEnd =
+          dyldSharedCacheStart ? dyldSharedCacheStart + length : 0;
+      validateSharedCacheResults = runtime::environment::
+          SWIFT_DEBUG_VALIDATE_SHARED_CACHE_PROTOCOL_CONFORMANCES();
+      SHARED_CACHE_LOG("Shared cache range is %#lx-%#lx", dyldSharedCacheStart,
+                       dyldSharedCacheEnd);
+    } else {
+      SHARED_CACHE_LOG("Disabling shared cache optimizations due to unknown "
+                       "optimizations version %u",
+                       _dyld_swift_optimizations_version());
+      dyldSharedCacheStart = 0;
+      dyldSharedCacheEnd = 0;
+    }
+#endif
+
+    // This must run last, as it triggers callbacks that require
+    // ConformanceState to be set up.
     initializeProtocolConformanceLookup();
   }
 
@@ -305,11 +373,9 @@ static Lazy<ConformanceState> Conformances;
 const void * const swift::_swift_debug_protocolConformanceStatePointer =
   &Conformances;
 
-static void
-_registerProtocolConformances(ConformanceState &C,
-                              const ProtocolConformanceRecord *begin,
-                              const ProtocolConformanceRecord *end) {
-  C.SectionsToScan.push_back(ConformanceSection{begin, end});
+static void _registerProtocolConformances(ConformanceState &C,
+                                          ConformanceSection section) {
+  C.SectionsToScan.push_back(section);
 
   // Blow away the conformances cache to get rid of any negative entries that
   // may now be obsolete.
@@ -321,17 +387,43 @@ void swift::addImageProtocolConformanceBlockCallbackUnsafe(
   assert(conformancesSize % sizeof(ProtocolConformanceRecord) == 0 &&
          "conformances section not a multiple of ProtocolConformanceRecord");
 
-  // If we have a section, enqueue the conformances for lookup.
-  auto conformanceBytes = reinterpret_cast<const char *>(conformances);
-  auto recordsBegin
-    = reinterpret_cast<const ProtocolConformanceRecord*>(conformances);
-  auto recordsEnd
-    = reinterpret_cast<const ProtocolConformanceRecord*>
-                                          (conformanceBytes + conformancesSize);
-  
   // Conformance cache should always be sufficiently initialized by this point.
-  _registerProtocolConformances(Conformances.unsafeGetAlreadyInitialized(),
-                                recordsBegin, recordsEnd);
+  auto &C = Conformances.unsafeGetAlreadyInitialized();
+
+#if DYLD_FIND_PROTOCOL_CONFORMANCE_DEFINED
+  // If any image in the shared cache is overridden, we need to scan all
+  // conformance sections in the shared cache. The pre-built table does NOT work
+  // if the protocol, type, or descriptor are in overridden images. Example:
+  //
+  // libX.dylib: struct S {}
+  // libY.dylib: protocol P {}
+  // libZ.dylib: extension S: P {}
+  //
+  // If libX or libY are overridden, then dyld will not return the S: P
+  // conformance from libZ. But that conformance still exists and we must still
+  // return it! Therefore we must scan libZ (and all other dylibs) even though
+  // it is not overridden.
+  if (!dyld_shared_cache_some_image_overridden()) {
+    // Sections in the shared cache are ignored in favor of the shared cache's
+    // pre-built tables.
+    if (C.inSharedCache(conformances)) {
+      SHARED_CACHE_LOG("Skipping conformances section %p in the shared cache",
+                       conformances);
+      if (C.validateSharedCacheResults)
+        C.SharedCacheSections.push_back(
+            ConformanceSection{conformances, conformancesSize});
+      return;
+    } else {
+      SHARED_CACHE_LOG(
+          "Adding conformances section %p outside the shared cache",
+          conformances);
+    }
+  }
+#endif
+
+  // If we have a section, enqueue the conformances for lookup.
+  _registerProtocolConformances(
+      C, ConformanceSection{conformances, conformancesSize});
 }
 
 void swift::addImageProtocolConformanceBlockCallback(
@@ -345,7 +437,7 @@ void
 swift::swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
                                           const ProtocolConformanceRecord *end){
   auto &C = Conformances.get();
-  _registerProtocolConformances(C, begin, end);
+  _registerProtocolConformances(C, ConformanceSection{begin, end});
 }
 
 /// Search for a conformance descriptor in the ConformanceCache.
@@ -371,6 +463,36 @@ searchInConformanceCache(const Metadata *type,
 
   // We did not find a cache entry.
   return {false, nullptr};
+}
+
+/// Get the appropriate context descriptor for a type. If the descriptor is a
+/// foreign type descriptor, also return its identity string.
+static std::pair<const ContextDescriptor *, llvm::StringRef>
+getContextDescriptor(const Metadata *conformingType) {
+  const auto *description = conformingType->getTypeContextDescriptor();
+  if (description) {
+    if (description->hasForeignMetadataInitialization()) {
+      auto identity = ParsedTypeIdentity::parse(description).FullIdentity;
+      return {description, identity};
+    }
+    return {description, {}};
+  }
+
+  // Handle single-protocol existential types for self-conformance.
+  auto *existentialType = dyn_cast<ExistentialTypeMetadata>(conformingType);
+  if (existentialType == nullptr ||
+      existentialType->getProtocols().size() != 1 ||
+      existentialType->getSuperclassConstraint() != nullptr)
+    return {nullptr, {}};
+
+  auto proto = existentialType->getProtocols()[0];
+
+#if SWIFT_OBJC_INTEROP
+  if (proto.isObjC())
+    return {nullptr, {}};
+#endif
+
+  return {proto.getSwiftProtocol(), {}};
 }
 
 namespace {
@@ -399,29 +521,6 @@ namespace {
       }
     }
 
-    const ContextDescriptor *
-    getContextDescriptor(const Metadata *conformingType) const {
-      const auto *description = conformingType->getTypeContextDescriptor();
-      if (description)
-        return description;
-
-      // Handle single-protocol existential types for self-conformance.
-      auto *existentialType = dyn_cast<ExistentialTypeMetadata>(conformingType);
-      if (existentialType == nullptr ||
-          existentialType->getProtocols().size() != 1 ||
-          existentialType->getSuperclassConstraint() != nullptr)
-        return nullptr;
-
-      auto proto = existentialType->getProtocols()[0];
-
-#if SWIFT_OBJC_INTEROP
-      if (proto.isObjC())
-        return nullptr;
-#endif
-
-      return proto.getSwiftProtocol();
-    }
-
     /// Whether the conforming type exactly matches the conformance candidate.
     bool matches(const Metadata *conformingType) const {
       // Check whether the types match.
@@ -430,7 +529,8 @@ namespace {
 
       // Check whether the nominal type descriptors match.
       if (!candidateIsMetadata) {
-        const auto *description = getContextDescriptor(conformingType);
+        const auto *description = std::get<const ContextDescriptor *>(
+            getContextDescriptor(conformingType));
         auto candidateDescription =
           static_cast<const ContextDescriptor *>(candidate);
         if (description && equalContexts(description, candidateDescription))
@@ -458,17 +558,212 @@ namespace {
   };
 }
 
+static void validateSharedCacheResults(
+    ConformanceState &C, const Metadata *type,
+    const ProtocolDescriptor *protocol,
+    const WitnessTable *dyldCachedWitnessTable,
+    const ProtocolConformanceDescriptor *dyldCachedConformanceDescriptor) {
+#if DYLD_FIND_PROTOCOL_CONFORMANCE_DEFINED
+  if (!C.validateSharedCacheResults)
+    return;
+
+  llvm::SmallVector<const ProtocolConformanceDescriptor *, 8> conformances;
+  for (auto &section : C.SharedCacheSections.snapshot()) {
+    for (const auto &record : section) {
+      auto &descriptor = *record.get();
+      if (descriptor.getProtocol() != protocol)
+        continue;
+
+      ConformanceCandidate candidate(descriptor);
+      if (candidate.getMatchingType(type))
+        conformances.push_back(&descriptor);
+    }
+  }
+
+  auto conformancesString = [&]() -> std::string {
+    std::string result = "";
+    for (auto *conformance : conformances) {
+      if (!result.empty())
+        result += ", ";
+      result += "0x";
+      result += llvm::utohexstr(reinterpret_cast<uint64_t>(conformance));
+    }
+    return result;
+  };
+
+  if (dyldCachedConformanceDescriptor) {
+    if (!std::find(conformances.begin(), conformances.end(),
+                   dyldCachedConformanceDescriptor)) {
+      auto typeName = swift_getTypeName(type, true);
+      swift::fatalError(
+          0,
+          "Checking conformance of %.*s %p to %s %p - dyld cached conformance "
+          "descriptor %p not found in conformance records: (%s)\n",
+          (int)typeName.length, typeName.data, type, protocol->Name.get(),
+          protocol, dyldCachedConformanceDescriptor,
+          conformancesString().c_str());
+    }
+  } else {
+    if (!conformances.empty()) {
+      auto typeName = swift_getTypeName(type, true);
+      swift::fatalError(
+          0,
+          "Checking conformance of %.*s %p to %s %p - dyld found no "
+          "conformance descriptor, but matching descriptors exist: (%s)\n",
+          (int)typeName.length, typeName.data, type, protocol->Name.get(),
+          protocol, conformancesString().c_str());
+    }
+  }
+#endif
+}
+
+/// Query the shared cache for a protocol conformance, if supported. The return
+/// value is a tuple consisting of the found witness table (if any), the found
+/// conformance descriptor (if any), and a bool that's true if a failure is
+/// definitive.
+static std::tuple<const WitnessTable *, const ProtocolConformanceDescriptor *,
+                  bool>
+findSharedCacheConformance(ConformanceState &C, const Metadata *type,
+                           const ProtocolDescriptor *protocol) {
+#if DYLD_FIND_PROTOCOL_CONFORMANCE_DEFINED
+  const ContextDescriptor *description;
+  llvm::StringRef foreignTypeIdentity;
+  std::tie(description, foreignTypeIdentity) = getContextDescriptor(type);
+
+  // dyld expects the ObjC class, if any, as the second parameter.
+  auto objcClassMetadata = swift_getObjCClassFromMetadataConditional(type);
+#if SHARED_CACHE_LOG_ENABLED
+  auto typeName = swift_getTypeName(type, true);
+  SHARED_CACHE_LOG("Looking up conformance of %.*s to %s", (int)typeName.length,
+                   typeName.data, protocol->Name.get());
+#endif
+  _dyld_protocol_conformance_result dyldResult;
+  if (!foreignTypeIdentity.empty()) {
+    SHARED_CACHE_LOG(
+        "_dyld_find_foreign_type_protocol_conformance(%p, %.*s, %zu)", protocol,
+        (int)foreignTypeIdentity.size(), foreignTypeIdentity.data(),
+        foreignTypeIdentity.size());
+    dyldResult = _dyld_find_foreign_type_protocol_conformance(
+        protocol, foreignTypeIdentity.data(), foreignTypeIdentity.size());
+  } else {
+    SHARED_CACHE_LOG("_dyld_find_protocol_conformance(%p, %p, %p)", protocol,
+                     objcClassMetadata, description);
+    dyldResult = _dyld_find_protocol_conformance(protocol, objcClassMetadata,
+                                                 description);
+  }
+  switch (dyldResult.kind) {
+  case _dyld_protocol_conformance_result_kind_found_descriptor: {
+    auto *conformanceDescriptor =
+        reinterpret_cast<const ProtocolConformanceDescriptor *>(
+            dyldResult.value);
+
+    assert(conformanceDescriptor->getProtocol() == protocol);
+    assert(ConformanceCandidate{*conformanceDescriptor}.getMatchingType(type));
+
+    if (conformanceDescriptor->getGenericWitnessTable()) {
+      SHARED_CACHE_LOG(
+          "Found generic conformance descriptor %p for %s in shared "
+          "cache, continuing",
+          conformanceDescriptor, protocol->Name.get());
+      return std::make_tuple(nullptr, conformanceDescriptor, false);
+    } else {
+      // When there are no generics, we can retrieve the witness table cheaply,
+      // so do it up front.
+      SHARED_CACHE_LOG("Found conformance descriptor %p for %s in shared cache",
+                       conformanceDescriptor, protocol->Name.get());
+      auto *witnessTable = conformanceDescriptor->getWitnessTable(type);
+      return std::make_tuple(witnessTable, conformanceDescriptor, false);
+    }
+    break;
+  }
+  case _dyld_protocol_conformance_result_kind_found_witness_table:
+    // If we found a witness table then we're done.
+    SHARED_CACHE_LOG(
+        "Found witness table %p for conformance to %s in shared cache",
+        dyldResult.value, protocol->Name.get());
+    return std::make_tuple(reinterpret_cast<const WitnessTable *>(dyldResult.value), nullptr,
+            false);
+  case _dyld_protocol_conformance_result_kind_not_found:
+    // If nothing is found, then we'll proceed with checking the runtime's
+    // caches and scanning conformance records.
+    SHARED_CACHE_LOG("Conformance to %s not found in shared cache",
+                     protocol->Name.get());
+    return std::make_tuple(nullptr, nullptr, false);
+    break;
+  case _dyld_protocol_conformance_result_kind_definitive_failure:
+    // This type is known not to conform to this protocol. Return failure
+    // without any further checks.
+    SHARED_CACHE_LOG("Found definitive failure for %s in shared cache",
+                     protocol->Name.get());
+    return std::make_tuple(nullptr, nullptr, true);
+  default:
+    // Other values may be added. Consider them equivalent to not_found until
+    // we implement code to handle them.
+    SHARED_CACHE_LOG(
+        "Unknown result kind %lu from _dyld_find_protocol_conformance()",
+        (unsigned long)dyldResult.kind);
+    return std::make_tuple(nullptr, nullptr, false);
+  }
+#else
+  return std::make_tuple(nullptr, nullptr, false);
+#endif
+}
+
 static const WitnessTable *
 swift_conformsToProtocolImpl(const Metadata *const type,
                              const ProtocolDescriptor *protocol) {
   auto &C = Conformances.get();
 
+  const WitnessTable *dyldCachedWitnessTable = nullptr;
+  const ProtocolConformanceDescriptor *dyldCachedConformanceDescriptor =
+      nullptr;
+
+  // Search the shared cache tables for a conformance for this type, and for
+  // superclasses (if it's a class).
+  const Metadata *dyldSearchType = type;
+  do {
+    bool definitiveFailure;
+    std::tie(dyldCachedWitnessTable, dyldCachedConformanceDescriptor,
+             definitiveFailure) =
+        findSharedCacheConformance(C, dyldSearchType, protocol);
+
+    if (definitiveFailure)
+      return nullptr;
+
+    dyldSearchType = _swift_class_getSuperclass(dyldSearchType);
+  } while (dyldSearchType && !dyldCachedWitnessTable &&
+           !dyldCachedConformanceDescriptor);
+
+  validateSharedCacheResults(C, type, protocol, dyldCachedWitnessTable,
+                             dyldCachedConformanceDescriptor);
+
+  // Return a cached result if we got a witness table. We can't do this if
+  // scanSectionsBackwards is set, since a scanned conformance can override a
+  // cached result in that case.
+  if (!C.scanSectionsBackwards)
+    if (dyldCachedWitnessTable)
+      return dyldCachedWitnessTable;
+
   // See if we have an authoritative cached conformance. The
   // ConcurrentReadableHashMap data structure allows us to search the map
   // concurrently without locking.
   auto found = searchInConformanceCache(type, protocol);
-  if (found.first)
+  if (found.first) {
+    // An authoritative negative result can be overridden by a result from dyld.
+    if (!found.second) {
+      if (dyldCachedWitnessTable)
+        return dyldCachedWitnessTable;
+    }
     return found.second;
+  }
+
+  if (dyldCachedConformanceDescriptor) {
+    auto witness = dyldCachedConformanceDescriptor->getWitnessTable(type);
+    C.cacheResult(type, protocol, witness, /*always cache*/ 0);
+    SHARED_CACHE_LOG("Caching generic conformance to %s found in shared cache",
+                     protocol->Name.get());
+    return witness;
+  }
 
   // Scan conformance records.
   llvm::SmallDenseMap<const Metadata *, const WitnessTable *> foundWitnesses;
@@ -524,6 +819,11 @@ swift_conformsToProtocolImpl(const Metadata *const type,
   if (searchType != type)
     C.cacheResult(type, protocol, foundWitness, snapshot.count());
 
+  // A negative result can be overridden by a result from dyld.
+  if (foundWitness) {
+    if (dyldCachedWitnessTable)
+      return dyldCachedWitnessTable;
+  }
   return foundWitness;
 }
 


### PR DESCRIPTION
When available, take advantage of precomputed protocol conformances in the shared cache on Darwin platforms to accelerate conformance lookups and cut down on memory usage.

We consult the precomputed conformances before doing the runtime's standard conformance lookup. When a conformance is precomputed, this avoids the slow linear scan of all loaded conformances for the first access, and it avoids the memory cost of storing the conformance in the cache.

When the shared cache has no images overridden (the normal case), then we can also skip scanning conformances in the shared cache in all circumstances, because the precomputed conformances will always cover those results. This greatly speeds up the slow linear scan for the initial lookup of anything that doesn't have a conformance in the shared cache, including lookups with conformances in apps or app frameworks, and negative lookups.

A validation mode is available by setting the `SWIFT_DEBUG_VALIDATE_SHARED_CACHE_PROTOCOL_CONFORMANCES` environment variable. When enabled, results from the precomputed conformances are compared with the results from a slow scan of the conformances in the shared cache. This extremely slow, but good at catching bugs in the system.

When the calls for precomputed conformances are unavailable, the new code is omitted and we remain in the same situation as before, with the runtime performing all lookups by scanning conformance sections in all loaded Swift images.

rdar://71128983