### PR TITLE
Fixes for OSSA DCE

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1009,6 +1009,12 @@ void findTransitiveReborrowBaseValuePairs(
     BorrowingOperand initialScopeOperand, SILValue origBaseValue,
     function_ref<void(SILPhiArgument *, SILValue)> visitReborrowBaseValuePair);
 
+/// Given a begin_borrow visit all end_borrow users of the borrow or its
+/// reborrows.
+void visitTransitiveEndBorrows(
+    BeginBorrowInst *borrowInst,
+    function_ref<void(EndBorrowInst *)> visitEndBorrow);
+
 } // namespace swift
 
 #endif

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -998,6 +998,17 @@ bool getAllOwnedValueIntroducers(SILValue value,
 
 OwnedValueIntroducer getSingleOwnedValueIntroducer(SILValue value);
 
+using BaseValueSet = SmallPtrSet<SILValue, 8>;
+
+/// Starting from \p initialScopeOperand, find all reborrows and their
+/// corresponding base values, and run the visitor function \p
+/// visitReborrowBaseValuePair on them.
+///  Note that a reborrow phi, can have different base values based on different
+/// control flow paths.
+void findTransitiveReborrowBaseValuePairs(
+    BorrowingOperand initialScopeOperand, SILValue origBaseValue,
+    function_ref<void(SILPhiArgument *, SILValue)> visitReborrowBaseValuePair);
+
 } // namespace swift
 
 #endif

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1245,3 +1245,55 @@ bool ForwardingOperand::visitForwardedValues(
     return visitor(args[0]);
   });
 }
+
+void swift::findTransitiveReborrowBaseValuePairs(
+    BorrowingOperand initialScopedOperand, SILValue origBaseValue,
+    function_ref<void(SILPhiArgument *, SILValue)> visitReborrowBaseValuePair) {
+  // We need a SetVector to make sure we don't revisit the same reborrow operand
+  // again.
+  SmallSetVector<std::tuple<Operand *, SILValue>, 4> worklist;
+
+  // Populate the worklist with reborrow and the base value
+  initialScopedOperand.visitScopeEndingUses([&](Operand *op) {
+    if (op->getOperandOwnership() == OperandOwnership::Reborrow) {
+      worklist.insert(std::make_tuple(op, origBaseValue));
+    }
+    return true;
+  });
+
+  // Size of worklist changes in this loop
+  for (unsigned idx = 0; idx < worklist.size(); idx++) {
+    Operand *reborrowOp;
+    SILValue baseValue;
+    std::tie(reborrowOp, baseValue) = worklist[idx];
+
+    BorrowingOperand borrowingOperand(reborrowOp);
+    assert(borrowingOperand.isReborrow());
+
+    auto *branchInst = cast<BranchInst>(reborrowOp->getUser());
+    auto *succBlock = branchInst->getDestBB();
+    auto *phiArg = cast<SILPhiArgument>(
+        succBlock->getArgument(reborrowOp->getOperandNumber()));
+
+    SILValue newBaseVal = baseValue;
+    // If the previous base value was also passed as a phi arg, that will be
+    // the new base value.
+    for (auto *arg : succBlock->getArguments()) {
+      if (arg->getIncomingPhiValue(branchInst->getParent()) == baseValue) {
+        newBaseVal = arg;
+        break;
+      }
+    }
+
+    // Call the visitor function
+    visitReborrowBaseValuePair(phiArg, newBaseVal);
+
+    BorrowedValue scopedValue(phiArg);
+    scopedValue.visitLocalScopeEndingUses([&](Operand *op) {
+      if (op->getOperandOwnership() == OperandOwnership::Reborrow) {
+        worklist.insert(std::make_tuple(op, newBaseVal));
+      }
+      return true;
+    });
+  }
+}

--- a/lib/SIL/Verifier/ReborrowVerifier.cpp
+++ b/lib/SIL/Verifier/ReborrowVerifier.cpp
@@ -39,57 +39,18 @@ bool ReborrowVerifier::verifyReborrowLifetime(SILPhiArgument *phiArg,
 
 void ReborrowVerifier::verifyReborrows(BorrowingOperand initialScopedOperand,
                                        SILValue value) {
-  SmallVector<std::tuple<Operand *, SILValue>, 4> worklist;
-  // Initialize the worklist with borrow lifetime ending uses
-  initialScopedOperand.visitScopeEndingUses([&](Operand *op) {
-    worklist.emplace_back(op, value);
-    return true;
-  });
-
-  while (!worklist.empty()) {
-    Operand *borrowLifetimeEndOp;
-    SILValue baseVal;
-    std::tie(borrowLifetimeEndOp, baseVal) = worklist.pop_back_val();
-    auto *borrowLifetimeEndUser = borrowLifetimeEndOp->getUser();
-
-    auto borrowingOperand = BorrowingOperand::get(borrowLifetimeEndOp);
-    if (!borrowingOperand || !borrowingOperand.isReborrow())
-      continue;
-
-    if (isVisitedOp(borrowLifetimeEndOp, baseVal))
-      continue;
-
-    // Process reborrow
-    auto *branchInst = cast<BranchInst>(borrowLifetimeEndUser);
-    for (auto *succBlock : branchInst->getSuccessorBlocks()) {
-      auto *phiArg = cast<SILPhiArgument>(
-          succBlock->getArgument(borrowLifetimeEndOp->getOperandNumber()));
-      assert(phiArg->getOwnershipKind() == OwnershipKind::Guaranteed);
-
-      SILValue newBaseVal = baseVal;
-      // If the previous base value was also passed as a phi arg, that will be
-      // the new base value.
-      for (auto *arg : succBlock->getArguments()) {
-        if (arg->getIncomingPhiValue(branchInst->getParent()) == baseVal) {
-          newBaseVal = arg;
-          break;
-        }
-      }
-
-      if (isVisitedPhiArg(phiArg, newBaseVal))
-        continue;
-      addVisitedPhiArg(phiArg, newBaseVal);
-      verifyReborrowLifetime(phiArg, newBaseVal);
-
-      // Find the scope ending uses of the guaranteed phi arg and add it to the
-      // worklist.
-      auto scopedValue = BorrowedValue(phiArg);
-      assert(scopedValue);
-      scopedValue.visitLocalScopeEndingUses([&](Operand *op) {
-        addVisitedOp(op, newBaseVal);
-        worklist.emplace_back(op, newBaseVal);
-        return true;
-      });
+  auto visitReborrowBaseValuePair = [&](SILPhiArgument *phiArg,
+                                        SILValue baseValue) {
+    // If the (phiArg, baseValue) pair was not visited before, verify the
+    // lifetime.
+    auto it = reborrowToBaseValuesMap.find(phiArg);
+    if (it == reborrowToBaseValuesMap.end() ||
+        it->second.find(baseValue) == it->second.end()) {
+      reborrowToBaseValuesMap[phiArg].insert(baseValue);
+      verifyReborrowLifetime(phiArg, baseValue);
     }
-  }
+  };
+  // For every unique reborrow/base value pair, verify the lifetime
+  findTransitiveReborrowBaseValuePairs(initialScopedOperand, value,
+                                       visitReborrowBaseValuePair);
 }

--- a/test/SIL/ownership-verifier/arguments.sil
+++ b/test/SIL/ownership-verifier/arguments.sil
@@ -687,8 +687,7 @@ bb3:
 // CHECK: Non Consuming User:   br bb2(%5 : $Builtin.NativeObject, %8 : $Builtin.NativeObject)
 // CHECK: Block: bb4
 // CHECK-LABEL: Error#: 1. End Error in Function: 'simple_loop_carry_over_consume'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'simple_loop_carry_over_consume'
+// Some more errors are emitted
 sil [ossa] @simple_loop_carry_over_consume : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -218,6 +218,21 @@ bb3(%2 : @owned $Klass):
   return %res : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dce_deadcopy7 :
+// CHECK-NOT: load [copy]
+// CHECK-LABEL: } // end sil function 'dce_deadcopy7'
+sil [ossa] @dce_deadcopy7 : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = load [copy] %0 : $*Klass
+  br bb1(%1 : $Klass)
+
+bb1(%2 : @owned $Klass):
+  destroy_value %2 : $Klass
+  destroy_addr %0 : $*Klass
+  %res = tuple ()
+  return %res : $()
+}
+
 // CHECK-LABEL: sil [ossa] @dce_destructure1 :
 // CHECK: bb0(%0 : {{.*}})
 // CHECK-NEXT: destroy_value %0

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -339,3 +339,86 @@ bb4:
   return %res : $()
 }
 
+struct TestStruct {
+  var val:Klass
+  var index:Int
+}
+
+// CHECK-LABEL: sil [ossa] @dce_destructurenotfullydead :
+// CHECK-NOT: copy_value
+// CHECK-LABEL: } // end sil function 'dce_destructurenotfullydead'
+sil [ossa] @dce_destructurenotfullydead : $@convention(thin) (@owned TestStruct) -> Int {
+bb0(%0 : @owned $TestStruct):
+  %stk = alloc_stack $TestStruct
+  store %0 to [init] %stk : $*TestStruct
+  %copy = load [take] %stk : $*TestStruct
+  (%2, %3) = destructure_struct %copy : $TestStruct
+  %4 = struct $TestStruct (%2 : $Klass, %3 : $Int)
+  destroy_value %4 : $TestStruct
+  dealloc_stack %stk : $*TestStruct
+  return %3 : $Int
+}
+
+// CHECK-LABEL: sil [ossa] @dce_borrowlifetime1 :
+// CHECK: bb1([[ARG1:%.*]] : @owned $NonTrivialStruct, [[ARG2:%.*]] : @guaranteed $NonTrivialStruct):
+// CHECK-LABEL: } // end sil function 'dce_borrowlifetime1'
+sil [ossa] @dce_borrowlifetime1 : $@convention(thin) (@guaranteed NonTrivialStruct) -> @owned NonTrivialStruct {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %copy = copy_value %0 : $NonTrivialStruct
+  %borrow = begin_borrow %copy : $NonTrivialStruct
+  br bb1(%copy : $NonTrivialStruct, %borrow : $NonTrivialStruct)
+
+bb1(%copy2 : @owned $NonTrivialStruct, %borrow2 : @guaranteed $NonTrivialStruct):
+  %newcopy = copy_value %borrow2 : $NonTrivialStruct
+  end_borrow %borrow2 : $NonTrivialStruct
+  destroy_value %copy2 : $NonTrivialStruct
+  return %newcopy : $NonTrivialStruct
+}
+
+// CHECK-LABEL: sil [ossa] @infinite_loop :
+// CHECK-NOT: copy_value
+// CHECK-LABEL: } // end sil function 'infinite_loop'
+sil [ossa] @infinite_loop : $@convention(thin) (@guaranteed NonTrivialStruct, @guaranteed NonTrivialStruct) -> () {
+bb0(%0 : @guaranteed $NonTrivialStruct, %1 : @guaranteed $NonTrivialStruct):
+  cond_br undef, bb1, bb4
+
+bb1:
+  %copy0 = copy_value %0 : $NonTrivialStruct
+  %borrow0 = begin_borrow %copy0 : $NonTrivialStruct
+  br bb3(%borrow0 : $NonTrivialStruct, %copy0 : $NonTrivialStruct)
+
+bb3(%newborrow : @guaranteed $NonTrivialStruct, %newowned : @owned $NonTrivialStruct):
+  br bb3(%newborrow : $NonTrivialStruct, %newowned : $NonTrivialStruct)
+
+bb4:
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_reborrow_with_different_basevalues :
+// CHECK: bb3([[ARG1:%.*]] : @guaranteed $NonTrivialStruct, [[ARG2:%.*]] : @owned $NonTrivialStruct, [[ARG3:%.*]] : @owned $NonTrivialStruct):
+// CHECK-LABEL: } // end sil function 'dce_reborrow_with_different_basevalues'
+sil [ossa] @dce_reborrow_with_different_basevalues : $@convention(thin) (@guaranteed NonTrivialStruct, @guaranteed NonTrivialStruct) -> @owned NonTrivialStruct {
+bb0(%0 : @guaranteed $NonTrivialStruct, %1 : @guaranteed $NonTrivialStruct):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy0a = copy_value %0 : $NonTrivialStruct
+  %borrow0a = begin_borrow %copy0a : $NonTrivialStruct
+  %copy1a = copy_value %1 : $NonTrivialStruct
+  br bb3(%borrow0a : $NonTrivialStruct, %copy0a : $NonTrivialStruct, %copy1a : $NonTrivialStruct)
+
+bb2:
+  %copy1b = copy_value %1 : $NonTrivialStruct
+  %borrow0b = begin_borrow %copy1b : $NonTrivialStruct
+  %copy0b = copy_value %0 : $NonTrivialStruct
+  br bb3(%borrow0b : $NonTrivialStruct, %copy0b : $NonTrivialStruct, %copy1b : $NonTrivialStruct)
+
+bb3(%newborrow : @guaranteed $NonTrivialStruct, %newowned1 : @owned $NonTrivialStruct, %newowned2 : @owned $NonTrivialStruct):
+  %res = copy_value %newborrow : $NonTrivialStruct
+  end_borrow %newborrow : $NonTrivialStruct
+  destroy_value %newowned1 : $NonTrivialStruct
+  destroy_value %newowned2 : $NonTrivialStruct
+  return %res : $NonTrivialStruct
+}
+

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -375,6 +375,91 @@ bb1(%copy2 : @owned $NonTrivialStruct, %borrow2 : @guaranteed $NonTrivialStruct)
   return %newcopy : $NonTrivialStruct
 }
 
+// CHECK-LABEL: sil [ossa] @dce_borrowlifetime2 :
+// CHECK: bb1:
+// CHECK-LABEL: } // end sil function 'dce_borrowlifetime2'
+sil [ossa] @dce_borrowlifetime2 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %copy = copy_value %0 : $Klass
+  %borrow = begin_borrow %copy : $Klass
+  %2 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = apply %2(%borrow) : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %2(%copy) : $@convention(thin) (@guaranteed Klass) -> ()
+  br bb1(%copy : $Klass, %borrow : $Klass)
+
+bb1(%copy2 : @owned $Klass, %borrow2 : @guaranteed $Klass):
+  end_borrow %borrow2 : $Klass
+  destroy_value %copy2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_borrowlifetime3 :
+// CHECK: bb1:
+// CHECK-LABEL: } // end sil function 'dce_borrowlifetime3'
+sil [ossa] @dce_borrowlifetime3 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %copy = copy_value %0 : $Klass
+  %borrow = begin_borrow %copy : $Klass
+  %2 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = apply %2(%borrow) : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %2(%copy) : $@convention(thin) (@guaranteed Klass) -> ()
+  br bb1(%borrow : $Klass, %copy : $Klass)
+
+bb1(%borrow2 : @guaranteed $Klass, %copy2 : @owned $Klass):
+  end_borrow %borrow2 : $Klass
+  destroy_value %copy2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_borrowlifetime4 :
+// CHECK: bb1:
+// CHECK-LABEL: } // end sil function 'dce_borrowlifetime4'
+sil [ossa] @dce_borrowlifetime4 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %copy = copy_value %0 : $Klass
+  %borrow = begin_borrow %copy : $Klass
+  %2 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = apply %2(%borrow) : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %2(%copy) : $@convention(thin) (@guaranteed Klass) -> ()
+  br bb1(%borrow : $Klass)
+
+bb1(%borrow2 : @guaranteed $Klass):
+  end_borrow %borrow2 : $Klass
+  br bb2(%copy : $Klass)
+
+bb2(%copy2 : @owned $Klass):
+  destroy_value %copy2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_borrowlifetime5 :
+// CHECK: bb1:
+// CHECK-LABEL: } // end sil function 'dce_borrowlifetime5'
+sil [ossa] @dce_borrowlifetime5 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %copy1 = copy_value %0 : $Klass
+  %copy2 = copy_value %0 : $Klass
+  %borrow1 = begin_borrow %copy1 : $Klass
+  %borrow2 = begin_borrow %copy2 : $Klass
+  %2 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = apply %2(%borrow1) : $@convention(thin) (@guaranteed Klass) -> ()
+  %4 = apply %2(%borrow2) : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %2(%copy1) : $@convention(thin) (@guaranteed Klass) -> ()
+  %6 = apply %2(%copy2) : $@convention(thin) (@guaranteed Klass) -> ()
+  br bb1(%copy1 : $Klass, %borrow1 : $Klass, %borrow2 : $Klass)
+
+bb1(%newcopy : @owned $Klass, %newborrow1 : @guaranteed $Klass, %newborrow2 : @guaranteed $Klass):
+  end_borrow %newborrow1 : $Klass
+  end_borrow %newborrow2 : $Klass
+  destroy_value %newcopy : $Klass
+  destroy_value %copy2 : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
 // CHECK-LABEL: sil [ossa] @infinite_loop :
 // CHECK-NOT: copy_value
 // CHECK-LABEL: } // end sil function 'infinite_loop'

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -456,6 +456,57 @@ bb1(%newcopy : @owned $Klass, %newborrow1 : @guaranteed $Klass, %newborrow2 : @g
   end_borrow %newborrow2 : $Klass
   destroy_value %newcopy : $Klass
   destroy_value %copy2 : $Klass
+   %res = tuple ()
+  return %res : $()
+}
+
+// Nested borrows are currently not optimized in DCE
+sil [ossa] @dce_nestedborrowlifetime1 : $@convention(thin) (@guaranteed NonTrivialStruct) -> @owned NonTrivialStruct {
+bb0(%0 : @guaranteed $NonTrivialStruct):
+  %borrowo = begin_borrow %0 : $NonTrivialStruct
+  %borrow = begin_borrow %borrowo : $NonTrivialStruct
+  br bb1(%borrowo : $NonTrivialStruct, %borrow : $NonTrivialStruct)
+
+bb1(%newborrowo : @guaranteed $NonTrivialStruct, %borrow2 : @guaranteed $NonTrivialStruct):
+  %newcopy = copy_value %borrow2 : $NonTrivialStruct
+  end_borrow %borrow2 : $NonTrivialStruct
+  end_borrow %newborrowo : $NonTrivialStruct
+  return %newcopy : $NonTrivialStruct
+}
+
+sil [ossa] @dce_nestedborrowlifetime2 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %borrowo = begin_borrow %0 : $Klass
+  %borrow = begin_borrow %borrowo : $Klass
+  %2 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = apply %2(%borrow) : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %2(%borrowo) : $@convention(thin) (@guaranteed Klass) -> ()
+  br bb1(%borrowo : $Klass, %borrow : $Klass)
+
+bb1(%newborrow : @guaranteed $Klass, %borrow2 : @guaranteed $Klass):
+  end_borrow %borrow2 : $Klass
+  end_borrow %newborrow : $Klass
+  %res = tuple ()
+  return %res : $()
+}
+
+// This test shows it is non trivial to find the insert point of an outer reborrow.
+// Here %newborrowo and %newborrowi are both dead phis.
+// First end_borrow for the incoming value of %newborrowi is added
+// It is non straight forward to find the insert pt for the end_borrow of the incoming value of %newborrowo
+// This may not be important once CanonicalizeOSSALifetime supports rewrite of multi-block borrows. 
+sil [ossa] @dce_nestedborrowlifetime3 : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %borrowo = begin_borrow %0 : $Klass
+  %borrow = begin_borrow %borrowo : $Klass
+  %2 = function_ref @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
+  %3 = apply %2(%borrow) : $@convention(thin) (@guaranteed Klass) -> ()
+  %5 = apply %2(%borrowo) : $@convention(thin) (@guaranteed Klass) -> ()
+  br bb1(%borrow : $Klass, %borrowo : $Klass)
+
+bb1(%newborrowi : @guaranteed $Klass, %newborrowo : @guaranteed $Klass):
+  end_borrow %newborrowi : $Klass
+  end_borrow %newborrowo : $Klass
   %res = tuple ()
   return %res : $()
 }

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -13,6 +13,11 @@ struct NonTrivialStruct {
   var val:Klass
 }
 
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
 sil [ossa] @$testtryapplyklassgen : $@convention(thin) () -> (@owned Klass, @error Error)
 sil [ossa] @$use_klass1 : $@convention(thin) (@owned Klass) -> ()
 sil [ossa] @$use_klass2 : $@convention(thin) (@guaranteed Klass) -> ()
@@ -556,5 +561,53 @@ bb3(%newborrow : @guaranteed $NonTrivialStruct, %newowned1 : @owned $NonTrivialS
   destroy_value %newowned1 : $NonTrivialStruct
   destroy_value %newowned2 : $NonTrivialStruct
   return %res : $NonTrivialStruct
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadterm1 :
+// CHECK-NOT: switch_enum
+// CHECK-LABEL: } // end sil function 'dce_deadterm1'
+sil [ossa] @dce_deadterm1 : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $FakeOptional<Builtin.NativeObject>):
+  %0a = alloc_stack $FakeOptional<Builtin.NativeObject>
+  store %0 to [init] %0a : $*FakeOptional<Builtin.NativeObject>
+  %1 = load [take] %0a : $*FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  dealloc_stack %0a : $*FakeOptional<Builtin.NativeObject>
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @dce_deadterm2 :
+// CHECK-NOT: load [copy]
+// CHECK-NOT: switch_enum
+// CHECK-LABEL: } // end sil function 'dce_deadterm2'
+sil [ossa] @dce_deadterm2 : $@convention(thin) (@owned FakeOptional<Builtin.NativeObject>) -> () {
+bb0(%0 : @owned $FakeOptional<Builtin.NativeObject>):
+  %0a = alloc_stack $FakeOptional<Builtin.NativeObject>
+  store %0 to [init] %0a : $*FakeOptional<Builtin.NativeObject>
+  %1 = load [copy] %0a : $*FakeOptional<Builtin.NativeObject>
+  switch_enum %1 : $FakeOptional<Builtin.NativeObject>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%2 : @owned $Builtin.NativeObject):
+  destroy_value %2 : $Builtin.NativeObject
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  destroy_addr %0a :  $*FakeOptional<Builtin.NativeObject>
+  dealloc_stack %0a : $*FakeOptional<Builtin.NativeObject>
+  %9999 = tuple()
+  return %9999 : $()
 }
 


### PR DESCRIPTION
This PR consists of fixes and minor improvements for OSSA DCE. Individual commits contain more details.

The main change in the PR is adding reborrow dependencies in DCE.
    
A reborrow's base value may change if the base value is also passed as  an operand on a branch. Record reborrow dependencies so that we can mark the base value as live, if the reborrow was also live. This ensures we do not insert destroy_value on the base value prematurely before the lifetime of the reborrow ends.

Example :  

```
bb0(%0 : @guaranteed $NonTrivialStruct):
  %copy = copy_value %0 : $NonTrivialStruct
  %borrow = begin_borrow %copy : $NonTrivialStruct
  br bb1(%copy : $NonTrivialStruct, %borrow : $NonTrivialStruct)

bb1(%copy2 : @owned $NonTrivialStruct, %borrow2 : @guaranteed $NonTrivialStruct):
  %newcopy = copy_value %borrow2 : $NonTrivialStruct
  end_borrow %borrow2 : $NonTrivialStruct
  destroy_value %copy2 : $NonTrivialStruct
  return %newcopy : $NonTrivialStruct
```

Here %copy2 is the new base value of %borrow2. And both are dead, so can be DCE'ed. Tracking reborrow dependencies will make sure we insert the end_borrow of the incoming value before we insert the destroy_value of the incoming value.

