### PR TITLE
[concurrency][Part 2] Fix async objc protocol conformance bugs

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -851,6 +851,14 @@ public:
   /// Retrieve the Objective-C requirements in this protocol that have the
   /// given Objective-C method key.
   ArrayRef<AbstractFunctionDecl *> getObjCRequirements(ObjCMethodKey key);
+
+  /// @returns a non-null requirement if the given requirement is part of a
+  /// group of ObjC requirements that share the same ObjC method key.
+  /// The first such requirement that the predicate function returns true for
+  /// is the requirement required by this function. Otherwise, nullptr is
+  /// returned.
+  ValueDecl *getObjCRequirementSibling(ValueDecl *requirement,
+                    llvm::function_ref<bool(AbstractFunctionDecl *)>predicate);
 };
 
 /// Captures the state needed to infer associated types.

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -22,7 +22,7 @@ extension C2 {
 // a version of C2 that requires both sync and async methods (differing only by
 // completion handler) in ObjC, is not possible to conform to with 'async' in
 // a Swift protocol
-class C3 : NSObject, RequiredObserver {} // expected-error {{type 'C3' does not conform to protocol 'RequiredObserver'}}
+class C3 : NSObject, RequiredObserver {}
 extension C3 {
   func hello() -> Bool { true } // expected-note {{'hello()' previously declared here}}
   func hello() async -> Bool { true } // expected-error {{invalid redeclaration of 'hello()'}}
@@ -33,6 +33,12 @@ class C4 : NSObject, RequiredObserver {}
 extension C4 {
   func hello() -> Bool { true }
   func hello(_ completion : @escaping (Bool) -> Void) -> Void { completion(true) }
+}
+
+protocol Club : ObjCClub {}
+
+class ConformsToSync : NSObject, Club {
+  func activate( completion: @escaping ( Error? ) -> Void ) { }
 }
 
 ///////

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -97,6 +97,12 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 - (void)rollWithCompletionHandler: (void (^)(void))completionHandler;
 @end
 
+typedef void ( ^ObjCErrorHandler )( NSError * _Nullable inError );
+
+@protocol ObjCClub
+- (void) activateWithCompletion:(ObjCErrorHandler) inCompletion;
+@end
+
 #define MAGIC_NUMBER 42
 
 #pragma clang assume_nonnull end


### PR DESCRIPTION
A continuation of https://github.com/apple/swift/pull/35662

TODOs:

- ~Fix unusual note that claims a protocol's requirements are not satisfied (rdar://73641790).~ **The conformance diagnostic should not be encountered at all.**
    - ~Make an error also be emitted alongside this missing witness note.~
    - ~Determine whether an error should have been encountered at all.~
- [x] Fix a conformance serialization issue that might be related to the unusual note (rdar://73326224).