### PR TITLE
SILGen: Unwrap optional async callback arguments if imported return is unbridged and not optional

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -315,6 +315,14 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
                                        // FIXME: pass down formal type
                                        destBuf->getType().getASTType(),
                                        destBuf->getType().getObjectType());
+          // Force-unwrap an argument that comes to us as Optional if it's
+          // formally non-optional in the return.
+          if (bridgedArg.getType().getOptionalObjectType()
+              && !destBuf->getType().getOptionalObjectType()) {
+            bridgedArg = SGF.emitPreconditionOptionalHasValue(loc,
+                                                             bridgedArg,
+                                                             /*implicit*/ true);
+          }
           bridgedArg.forwardInto(SGF, loc, destBuf);
         };
 

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -51,6 +51,8 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 // rdar://72604599
 - (void)stopRecordingWithHandler:(nullable void (^)(NSObject *_Nullable_result x, NSError *_Nullable error))handler __attribute__((swift_async_name("stopRecording()"))) __attribute__((swift_async(not_swift_private, 1)));
 
+// rdar://73798726
+- (void)getSomeObjectWithCompletionHandler:(nullable void (^)(NSObject *_Nullable x, NSError *_Nullable error))handler;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -60,6 +60,7 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: String = try await slowServer.doSomethingDangerousNullably("foo")
 
   let _: NSObject? = try await slowServer.stopRecording()
+  let _: NSObject = try await slowServer.someObject()
 }
 
 // CHECK: sil{{.*}}@[[INT_COMPLETION_BLOCK]]


### PR DESCRIPTION
The bridging code handles optional wrapping and unwrapping, but in cases where a nullable completion
callback argument did not need bridging, it would get short circuited out of the bridging code, and
did not get unwrapped. Fixes rdar://73798726