### PR TITLE
[sil-combine] Fix optimization of COWBufferRead for ownership

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -533,7 +533,7 @@ struct BorrowedValue {
   /// we were able to understand all uses and thus guarantee we found all
   /// interior pointer uses. Returns false otherwise.
   bool visitInteriorPointerOperands(
-      function_ref<void(const InteriorPointerOperand &)> func) const;
+      function_ref<void(InteriorPointerOperand)> func) const;
 
   /// Visit all immediate uses of this borrowed value and if any of them are
   /// reborrows, place them in BorrowingOperand form into \p

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -601,7 +601,7 @@ bool BorrowedValue::visitExtendedLocalScopeEndingUses(
 }
 
 bool BorrowedValue::visitInteriorPointerOperands(
-    function_ref<void(const InteriorPointerOperand &)> func) const {
+    function_ref<void(InteriorPointerOperand)> func) const {
   SmallVector<Operand *, 32> worklist(value->getUses());
   while (!worklist.empty()) {
     auto *op = worklist.pop_back_val();

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -312,6 +312,8 @@ public:
   SILInstruction *optimizeBuiltinIsConcrete(BuiltinInst *I);
 
   SILInstruction *optimizeBuiltinCOWBufferForReading(BuiltinInst *BI);
+  SILInstruction *optimizeBuiltinCOWBufferForReadingNonOSSA(BuiltinInst *BI);
+  SILInstruction *optimizeBuiltinCOWBufferForReadingOSSA(BuiltinInst *BI);
 
   // Optimize the "trunc_N1_M2" builtin. if N1 is a result of "zext_M1_*" and
   // the following holds true: N1 > M1 and M2>= M1

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-combine"
+
 #include "SILCombiner.h"
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/DynamicCasts.h"
@@ -22,6 +23,7 @@
 #include "swift/SILOptimizer/Analysis/ValueTracking.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -112,6 +114,92 @@ SILInstruction *SILCombiner::optimizeBuiltinIsConcrete(BuiltinInst *BI) {
 /// Replace
 /// \code
 ///   %b = builtin "COWBufferForReading" %r
+///   %bb = begin_borrow %b
+///   %a = ref_element_addr %bb
+///   ... use %a ...
+///   end_borrow %bb
+/// \endcode
+/// with
+/// \code
+///   %bb = begin_borrow %r
+///   %a = ref_element_addr [immutable] %r
+///   ... use %b ...
+///   end_borrow %bb
+/// \endcode
+/// The same for ref_tail_addr.
+SILInstruction *
+SILCombiner::optimizeBuiltinCOWBufferForReadingOSSA(BuiltinInst *bi) {
+  SmallVector<BorrowedValue, 32> accumulatedBorrowedValues;
+
+  // A helper that performs our main loop to look through uses. It ensures
+  // that we do not need to fill up the useWorklist on the first iteration.
+  for (auto *use : bi->getUses()) {
+    // See if we have a borrowing operand that we can find a local borrowed
+    // value for. In such a case, we stash that borrowed value so that we can
+    // use it to find interior pointer operands.
+    if (auto operand = BorrowingOperand(use)) {
+      if (operand.isReborrow())
+        return nullptr;
+      operand.visitBorrowIntroducingUserResults([&](BorrowedValue bv) {
+        accumulatedBorrowedValues.push_back(bv);
+        return true;
+      });
+      continue;
+    }
+
+    // Otherwise, look for instructions that we know are uses that we can
+    // ignore.
+    auto *user = use->getUser();
+
+    // Debug instructions are safe.
+    if (user->isDebugInstruction())
+      continue;
+
+    // copy_value, destroy_value are safe due to our checking of the
+    // instruction use list for safety.
+    if (isa<DestroyValueInst>(user) || isa<CopyValueInst>(user))
+      continue;
+
+    // An instruction we don't understand, bail.
+    return nullptr;
+  }
+
+  // Now that we know that we have a case we support, use our stashed
+  // BorrowedValues to find all interior pointer operands into this copy of our
+  // COWBuffer and mark them as immutable.
+  //
+  // NOTE: We currently only use nested int ptr operands instead of extended int
+  // ptr operands since we do not want to look through reborrows and thus lose
+  // dominance.
+  while (!accumulatedBorrowedValues.empty()) {
+    auto bv = accumulatedBorrowedValues.pop_back_val();
+    bv.visitNestedInteriorPointerOperands(
+        [&](InteriorPointerOperand intPtrOperand) {
+          switch (intPtrOperand.kind) {
+          case InteriorPointerOperandKind::Invalid:
+            llvm_unreachable("Invalid int pointer kind?!");
+          case InteriorPointerOperandKind::RefElementAddr:
+            cast<RefElementAddrInst>(intPtrOperand->getUser())->setImmutable();
+            return;
+          case InteriorPointerOperandKind::RefTailAddr:
+            cast<RefTailAddrInst>(intPtrOperand->getUser())->setImmutable();
+            return;
+          case InteriorPointerOperandKind::OpenExistentialBox:
+            // Can not mark this immutable.
+            return;
+          }
+        });
+  }
+
+  OwnershipRAUWHelper helper(ownershipFixupContext, bi, bi->getOperand(0));
+  assert(helper && "COWBufferForReading always has an owned arg/owned result");
+  helper.perform();
+  return nullptr;
+}
+
+/// Replace
+/// \code
+///   %b = builtin "COWBufferForReading" %r
 ///   %a = ref_element_addr %b
 /// \endcode
 /// with
@@ -119,23 +207,24 @@ SILInstruction *SILCombiner::optimizeBuiltinIsConcrete(BuiltinInst *BI) {
 ///   %a = ref_element_addr [immutable] %r
 /// \endcode
 /// The same for ref_tail_addr.
-SILInstruction *SILCombiner::optimizeBuiltinCOWBufferForReading(BuiltinInst *BI) {
-  auto useIter = BI->use_begin();
-  while (useIter != BI->use_end()) {
+SILInstruction *
+SILCombiner::optimizeBuiltinCOWBufferForReadingNonOSSA(BuiltinInst *bi) {
+  auto useIter = bi->use_begin();
+  while (useIter != bi->use_end()) {
     auto nextIter = std::next(useIter);
     SILInstruction *user = useIter->getUser();
-    SILValue ref = BI->getOperand(0);
+    SILValue ref = bi->getOperand(0);
     switch (user->getKind()) {
       case SILInstructionKind::RefElementAddrInst: {
-        auto *REAI = cast<RefElementAddrInst>(user);
-        REAI->setOperand(ref);
-        REAI->setImmutable();
+        auto *reai = cast<RefElementAddrInst>(user);
+        reai->setOperand(ref);
+        reai->setImmutable();
         break;
       }
       case SILInstructionKind::RefTailAddrInst: {
-        auto *RTAI = cast<RefTailAddrInst>(user);
-        RTAI->setOperand(ref);
-        RTAI->setImmutable();
+        auto *rtai = cast<RefTailAddrInst>(user);
+        rtai->setOperand(ref);
+        rtai->setImmutable();
         break;
       }
     case SILInstructionKind::DestroyValueInst:
@@ -151,9 +240,16 @@ SILInstruction *SILCombiner::optimizeBuiltinCOWBufferForReading(BuiltinInst *BI)
   }
 
   // If there are unknown users, keep the builtin, and IRGen will handle it.
-  if (BI->use_empty())
-    return eraseInstFromFunction(*BI);
+  if (bi->use_empty())
+    return eraseInstFromFunction(*bi);
   return nullptr;
+}
+
+SILInstruction *
+SILCombiner::optimizeBuiltinCOWBufferForReading(BuiltinInst *BI) {
+  if (hasOwnership())
+    return optimizeBuiltinCOWBufferForReadingOSSA(BI);
+  return optimizeBuiltinCOWBufferForReadingNonOSSA(BI);
 }
 
 static unsigned getTypeWidth(SILType Ty) {

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -7,6 +7,7 @@ sil_stage canonical
 
 import Builtin
 import Swift
+import SwiftShims
 
 class Klass {}
 
@@ -4663,3 +4664,100 @@ bb1(%2a : @guaranteed $Builtin.NativeObject):
   return %3 : $Builtin.NativeObject
 }
 
+// CHECK-LABEL: sil [ossa] @cowbuffer_reading_immutable_1 : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> Int {
+// CHECK: ref_element_addr [immutable]
+// CHECK: } // end sil function 'cowbuffer_reading_immutable_1'
+sil [ossa] @cowbuffer_reading_immutable_1 : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> Int {
+bb0(%0 : @guaranteed $_ContiguousArrayBuffer<Element>):
+  %3 = struct_extract %0 : $_ContiguousArrayBuffer<Element>, #_ContiguousArrayBuffer._storage
+  %4 = copy_value %3 : $__ContiguousArrayStorageBase
+  %5 = builtin "COWBufferForReading"<__ContiguousArrayStorageBase>(%4 : $__ContiguousArrayStorageBase) : $__ContiguousArrayStorageBase
+  %6 = begin_borrow %5 : $__ContiguousArrayStorageBase
+  %7 = ref_element_addr %6 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %8 = load [trivial] %7 : $*_ArrayBody
+  debug_value %8 : $_ArrayBody, let, name "self", argno 1
+  %10 = struct_extract %8 : $_ArrayBody, #_ArrayBody._storage
+  %11 = struct_extract %10 : $_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %12 = struct_extract %11 : $Int, #Int._value
+  %13 = builtin "assumeNonNegative_Int64"(%12 : $Builtin.Int64) : $Builtin.Int64
+  %14 = struct $Int (%13 : $Builtin.Int64)
+  end_borrow %6 : $__ContiguousArrayStorageBase
+  destroy_value %5 : $__ContiguousArrayStorageBase
+  return %14 : $Int
+}
+
+// CHECK-LABEL: sil [ossa] @cowbuffer_reading_no_crash_derived_borrow : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> Int {
+// CHECK: ref_element_addr [immutable]
+// CHECK: ref_tail_addr [immutable]
+// CHECK: } // end sil function 'cowbuffer_reading_no_crash_derived_borrow'
+sil [ossa] @cowbuffer_reading_no_crash_derived_borrow : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> Int {
+bb0(%0 : @guaranteed $_ContiguousArrayBuffer<Element>):
+  %3 = struct_extract %0 : $_ContiguousArrayBuffer<Element>, #_ContiguousArrayBuffer._storage
+  %4 = copy_value %3 : $__ContiguousArrayStorageBase
+  %5 = builtin "COWBufferForReading"<__ContiguousArrayStorageBase>(%4 : $__ContiguousArrayStorageBase) : $__ContiguousArrayStorageBase
+  %6 = begin_borrow %5 : $__ContiguousArrayStorageBase
+  %6b = begin_borrow %6 : $__ContiguousArrayStorageBase
+  %7 = ref_element_addr %6b : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %8 = load [trivial] %7 : $*_ArrayBody
+  debug_value %8 : $_ArrayBody, let, name "self", argno 1
+  %10 = struct_extract %8 : $_ArrayBody, #_ArrayBody._storage
+  %11 = struct_extract %10 : $_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %12 = struct_extract %11 : $Int, #Int._value
+  end_borrow %6b : $__ContiguousArrayStorageBase
+  %6c = begin_borrow %6 : $__ContiguousArrayStorageBase
+  %7b = ref_tail_addr %6c : $__ContiguousArrayStorageBase, $Element
+  // This is evil! I am doing it just for this test!
+  %7c = unchecked_addr_cast %7b : $*Element to $*Builtin.Int64
+  %12b = load [trivial] %7c : $*Builtin.Int64
+  end_borrow %6c : $__ContiguousArrayStorageBase
+  end_borrow %6 : $__ContiguousArrayStorageBase
+  destroy_value %5 : $__ContiguousArrayStorageBase
+  %12c = builtin "and_Int64"(%12 : $Builtin.Int64, %12b : $Builtin.Int64) : $Builtin.Int64
+  %13 = builtin "assumeNonNegative_Int64"(%12c : $Builtin.Int64) : $Builtin.Int64
+  %14 = struct $Int (%13 : $Builtin.Int64)
+  return %14 : $Int
+}
+
+// CHECK-LABEL: sil [ossa] @cowbuffer_reading_no_lookthrough_reborrow : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> Int {
+// CHECK-NOT: ref_element_addr [immutable]
+// CHECK-NOT: ref_tail_addr [immutable]
+// CHECK: ref_element_addr %
+// CHECK-NOT: ref_element_addr [immutable]
+// CHECK-NOT: ref_tail_addr [immutable]
+// CHECK: ref_tail_addr %
+// CHECK-NOT: ref_element_addr [immutable]
+// CHECK-NOT: ref_tail_addr [immutable]
+// CHECK: } // end sil function 'cowbuffer_reading_no_lookthrough_reborrow'
+sil [ossa] @cowbuffer_reading_no_lookthrough_reborrow : $@convention(method) <Element> (@guaranteed _ContiguousArrayBuffer<Element>) -> Int {
+bb0(%0 : @guaranteed $_ContiguousArrayBuffer<Element>):
+  %3 = struct_extract %0 : $_ContiguousArrayBuffer<Element>, #_ContiguousArrayBuffer._storage
+  %4 = copy_value %3 : $__ContiguousArrayStorageBase
+  %5 = builtin "COWBufferForReading"<__ContiguousArrayStorageBase>(%4 : $__ContiguousArrayStorageBase) : $__ContiguousArrayStorageBase
+  %6 = begin_borrow %5 : $__ContiguousArrayStorageBase
+  %6bb = begin_borrow %6 : $__ContiguousArrayStorageBase
+  br bb1(%6bb : $__ContiguousArrayStorageBase)
+
+bb1(%6b : @guaranteed $__ContiguousArrayStorageBase):
+  %7 = ref_element_addr %6b : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %8 = load [trivial] %7 : $*_ArrayBody
+  debug_value %8 : $_ArrayBody, let, name "self", argno 1
+  %10 = struct_extract %8 : $_ArrayBody, #_ArrayBody._storage
+  %11 = struct_extract %10 : $_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %12 = struct_extract %11 : $Int, #Int._value
+  end_borrow %6b : $__ContiguousArrayStorageBase
+  %6cb = begin_borrow %6 : $__ContiguousArrayStorageBase
+  br bb2(%6cb : $__ContiguousArrayStorageBase)
+
+bb2(%6c : @guaranteed $__ContiguousArrayStorageBase):
+  %7b = ref_tail_addr %6c : $__ContiguousArrayStorageBase, $Element
+  // This is evil! I am doing it just for this test!
+  %7c = unchecked_addr_cast %7b : $*Element to $*Builtin.Int64
+  %12b = load [trivial] %7c : $*Builtin.Int64
+  end_borrow %6c : $__ContiguousArrayStorageBase
+  end_borrow %6 : $__ContiguousArrayStorageBase
+  destroy_value %5 : $__ContiguousArrayStorageBase
+  %12c = builtin "and_Int64"(%12 : $Builtin.Int64, %12b : $Builtin.Int64) : $Builtin.Int64
+  %13 = builtin "assumeNonNegative_Int64"(%12c : $Builtin.Int64) : $Builtin.Int64
+  %14 = struct $Int (%13 : $Builtin.Int64)
+  return %14 : $Int
+}


### PR DESCRIPTION
Got to use the interior pointer functionality to simplify the algorithm/make it safer.