### PR TITLE
[ConstraintSystem] Tweak the generic operator partition heuristic.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2135,7 +2135,9 @@ void ConstraintSystem::partitionGenericOperators(ArrayRef<Constraint *> constrai
   // overload choices first.
   for (auto arg : argFnType->getParams()) {
     auto argType = arg.getPlainType();
-    if (!argType || argType->hasTypeVariable())
+    argType = getFixedTypeRecursive(argType, /*wantRValue=*/true);
+
+    if (argType->isTypeVariableOrMember())
       continue;
 
     if (conformsToKnownProtocol(DC, argType, KnownProtocolKind::AdditiveArithmetic)) {


### PR DESCRIPTION
Before checking if an argument type to an applied disjunction conforms to a known protocol, grab its fixed type. This helps in cases where the argument type is a type variable, but the solver has already bound the type variable to a conforming type, e.g. `Array`. For example:

```swift
protocol P {}

struct S1: P {}
struct S2: P {}

func test(arr1: [S1], arr2: [S2]) -> [P] {
  return arr1.map { $0 as P } + arr2.map { $0 as P }
}
```

When the solver gets to the generic operator overload partition for `+`, it knows to attempt the `Sequence` overloads first because it already knows the result of `.map` is an array (and `map` is bound first because there are fewer overloads).

I haven't added a test because this case still doesn't scale well, but this fix mitigates the impact of changing overload binding order from https://github.com/apple/swift/pull/35025. Cases like this only happened to compile before because the solver happened to attempt `Array.+` first.

Resolves: rdar://73892488