### PR TITLE
Sema: Fix inherited designated init synthesis when there's a 'where' clause but no new generic parameters [5.4]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -424,51 +424,53 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
       moduleDecl, superclassDecl);
 
   GenericSignature genericSig;
-
-  // Inheriting initializers that have their own generic parameters
   auto *genericParams = superclassCtor->getGenericParams();
-  if (genericParams) {
+
+  auto superclassCtorSig = superclassCtor->getGenericSignature();
+  auto superclassSig = superclassDecl->getGenericSignature();
+
+  if (superclassCtorSig.getPointer() != superclassSig.getPointer()) {
     SmallVector<GenericTypeParamDecl *, 4> newParams;
+    SmallVector<GenericTypeParamType *, 1> newParamTypes;
 
-    // First, clone the superclass constructor's generic parameter list,
-    // but change the depth of the generic parameters to be one greater
-    // than the depth of the subclass.
-    unsigned depth = 0;
-    if (auto genericSig = classDecl->getGenericSignature())
-      depth = genericSig->getGenericParams().back()->getDepth() + 1;
+    // Inheriting initializers that have their own generic parameters
+    if (genericParams) {
+      // First, clone the superclass constructor's generic parameter list,
+      // but change the depth of the generic parameters to be one greater
+      // than the depth of the subclass.
+      unsigned depth = 0;
+      if (auto genericSig = classDecl->getGenericSignature())
+        depth = genericSig->getGenericParams().back()->getDepth() + 1;
 
-    for (auto *param : genericParams->getParams()) {
-      auto *newParam = new (ctx) GenericTypeParamDecl(classDecl,
-                                                      param->getName(),
-                                                      SourceLoc(),
-                                                      depth,
-                                                      param->getIndex());
-      newParams.push_back(newParam);
+      for (auto *param : genericParams->getParams()) {
+        auto *newParam = new (ctx) GenericTypeParamDecl(classDecl,
+                                                        param->getName(),
+                                                        SourceLoc(),
+                                                        depth,
+                                                        param->getIndex());
+        newParams.push_back(newParam);
+      }
+
+      // We don't have to clone the requirements, because they're not
+      // used for anything.
+      genericParams = GenericParamList::create(ctx,
+                                               SourceLoc(),
+                                               newParams,
+                                               SourceLoc(),
+                                               ArrayRef<RequirementRepr>(),
+                                               SourceLoc());
+
+      // Add the generic parameter types.
+      for (auto *newParam : newParams) {
+        newParamTypes.push_back(
+            newParam->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
+      }
     }
-
-    // We don't have to clone the requirements, because they're not
-    // used for anything.
-    genericParams = GenericParamList::create(ctx,
-                                             SourceLoc(),
-                                             newParams,
-                                             SourceLoc(),
-                                             ArrayRef<RequirementRepr>(),
-                                             SourceLoc());
 
     // Build a generic signature for the derived class initializer.
-
-    // Add the generic parameters.
-    SmallVector<GenericTypeParamType *, 1> newParamTypes;
-    for (auto *newParam : newParams) {
-      newParamTypes.push_back(
-          newParam->getDeclaredInterfaceType()->castTo<GenericTypeParamType>());
-    }
-
-    auto superclassSig = superclassCtor->getGenericSignature();
-
     unsigned superclassDepth = 0;
-    if (auto genericSig = superclassDecl->getGenericSignature())
-      superclassDepth = genericSig->getGenericParams().back()->getDepth() + 1;
+    if (superclassSig)
+      superclassDepth = superclassSig->getGenericParams().back()->getDepth() + 1;
 
     // We're going to be substituting the requirements of the base class
     // initializer to form the requirements of the derived class initializer.
@@ -490,13 +492,13 @@ configureGenericDesignatedInitOverride(ASTContext &ctx,
     };
 
     SmallVector<Requirement, 2> requirements;
-    for (auto reqt : superclassSig->getRequirements())
+    for (auto reqt : superclassCtorSig->getRequirements())
       if (auto substReqt = reqt.subst(substFn, lookupConformanceFn))
         requirements.push_back(*substReqt);
 
     // Now form the substitution map that will be used to remap parameter
     // types.
-    subMap = SubstitutionMap::get(superclassSig,
+    subMap = SubstitutionMap::get(superclassCtorSig,
                                   substFn, lookupConformanceFn);
 
     genericSig = evaluateOrDefault(

--- a/test/SILGen/designated_init_inheritance_with_where_clause.swift
+++ b/test/SILGen/designated_init_inheritance_with_where_clause.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen -primary-file %s | %FileCheck %s
+
+public protocol Ungulate {}
+public protocol Domesticated {}
+
+public class Horse<U: Ungulate> {
+  // CHECK-LABEL: sil [serialized] [exact_self_class] [ossa] @$s45designated_init_inheritance_with_where_clause5HorseCACyxGycfC : $@convention(method) <U where U : Ungulate> (@thick Horse<U>.Type) -> @owned Horse<U> {
+  // CHECK-LABEL: sil [ossa] @$s45designated_init_inheritance_with_where_clause5HorseCACyxGycfc : $@convention(method) <U where U : Ungulate> (@owned Horse<U>) -> @owned Horse<U> {
+  public init() { }
+
+  // CHECK-LABEL: sil [serialized] [exact_self_class] [ossa] @$s45designated_init_inheritance_with_where_clause5HorseCACyxGycAA12DomesticatedRzrlufC : $@convention(method) <U where U : Domesticated, U : Ungulate> (@thick Horse<U>.Type) -> @owned Horse<U> {
+  // CHECK-LABEL: sil [ossa] @$s45designated_init_inheritance_with_where_clause5HorseCACyxGycAA12DomesticatedRzrlufc : $@convention(method) <U where U : Domesticated, U : Ungulate> (@owned Horse<U>) -> @owned Horse<U> {
+  public init() where U: Domesticated { }
+}
+
+public class Pony<U : Ungulate> : Horse<U> {
+  // CHECK-LABEL: sil [serialized] [exact_self_class] [ossa] @$s45designated_init_inheritance_with_where_clause4PonyCACyxGycfC : $@convention(method) <U where U : Ungulate> (@thick Pony<U>.Type) -> @owned Pony<U> {
+  // CHECK-LABEL: sil [ossa] @$s45designated_init_inheritance_with_where_clause4PonyCACyxGycfc : $@convention(method) <U where U : Ungulate> (@owned Pony<U>) -> @owned Pony<U> {
+
+  // CHECK-LABEL: sil [serialized] [exact_self_class] [ossa] @$s45designated_init_inheritance_with_where_clause4PonyCACyxGycAA12DomesticatedRzrlufC : $@convention(method) <U where U : Domesticated, U : Ungulate> (@thick Pony<U>.Type) -> @owned Pony<U> {
+  // CHECK-LABEL: sil [ossa] @$s45designated_init_inheritance_with_where_clause4PonyCACyxGycAA12DomesticatedRzrlufc : $@convention(method) <U where U : Domesticated, U : Ungulate> (@owned Pony<U>) -> @owned Pony<U> {
+}


### PR DESCRIPTION
SE-0267 allows where clauses on declarations without their own generic
parameters, which means we can longer assume that if getGenericParams()
returns nullptr on a constructor, then the constructor has the same
generic signature as its parent class.

Instead, explicitly compare the superclass constructor's generic
signature with that of the superclass, and if they don't match,
compute a new generic signature for the override.

Fixes https://bugs.swift.org/browse/SR-14118 / rdar://73764827.