### PR TITLE
Sema: Tweak assertion in CustomAttrTypeRequest to allow generic typealiases [5.4]

### DIFF
--- a/test/decl/var/property_wrapper_generic_aliases.swift
+++ b/test/decl/var/property_wrapper_generic_aliases.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://bugs.swift.org/browse/SR-14143
+
+@propertyWrapper
+struct SomeLongFooName<Holder, T> {
+  var wrappedValue: T
+  
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+
+struct Bar {
+  typealias Foo<T> = SomeLongFooName<Self, T>
+  
+  @Foo var baz: Bool = false
+}

--- a/test/decl/var/property_wrapper_generic_aliases_invalid.swift
+++ b/test/decl/var/property_wrapper_generic_aliases_invalid.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+
+@propertyWrapper
+struct SomeStruct<T> {
+  var wrappedValue: T 
+    
+  init(wrappedValue: T) { 
+    self.wrappedValue = wrappedValue
+  } 
+}
+
+typealias Invalid1<T> = (T) -> ()
+typealias Invalid2<T> = SomeStruct<T>.Type
+typealias Invalid3 = SomeStruct<Bool>.Type
+
+struct Bar {
+  @Invalid1 var badWrapper1: Bool = false // expected-error {{unknown attribute 'Invalid1'}}
+  @Invalid2 var badWrapper2: Bool = false // expected-error {{unknown attribute 'Invalid2'}}
+  @Invalid3 var badWrapper3: Bool = false // expected-error {{unknown attribute 'Invalid3'}}
+}


### PR DESCRIPTION
If the typealias here is generic, we return an UnboundGenericType
where getAnyNominal() returns nullptr. This would fail by returning
an ErrorType to the caller without diagnosing anything.

This was a regression after some recent refactoring to remove code
duplication and some TypeLoc usages, because one of the copies of
this code did not have this check, so it happened to work for
property wrappers.

Relax the check by looking through a TypeAliasDecl explicitly.
I believe we can't end up here anyway, because if the type was
not a nominal we would fail earlier in CustomAttrNominalRequest, and
we wouldn't attempt to compute the type of the property wrapper at
all. However it's better to keep the assertion in place just in case.

Fixes https://bugs.swift.org/browse/SR-14143 / rdar://problem/73888684.