### PR TITLE
Add "marker" protocols, indicated by @_marker.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -68,6 +68,14 @@ protected:
   std::function<bool (SymbolicReferent)> CanSymbolicReference;
   
   bool canSymbolicReference(SymbolicReferent referent) {
+    // Marker protocols cannot ever be symbolically referenced.
+    if (auto nominal = referent.dyn_cast<const NominalTypeDecl *>()) {
+      if (auto proto = dyn_cast<ProtocolDecl>(nominal)) {
+        if (proto->isMarkerProtocol())
+          return false;
+      }
+    }
+
     return AllowSymbolicReferences
       && (!CanSymbolicReference || CanSymbolicReference(referent));
   }

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -606,6 +606,12 @@ SIMPLE_DECL_ATTR(concurrent, Concurrent,
   APIBreakingToAdd | APIBreakingToRemove,
   107)
 
+SIMPLE_DECL_ATTR(_marker, Marker,
+  OnProtocol | UserInaccessible |
+  ABIBreakingToAdd | ABIBreakingToRemove |
+  APIBreakingToAdd | APIBreakingToRemove,
+  108)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4162,6 +4162,10 @@ public:
   ProtocolRethrowsRequirementList getRethrowingRequirements() const;
   bool isRethrowingProtocol() const;
 
+  /// Determine whether this is a "marker" protocol, meaning that is indicates
+  /// semantics but has no corresponding witness table.
+  bool isMarkerProtocol() const;
+
 private:
   void computeKnownProtocolKind() const;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5582,6 +5582,17 @@ NOTE(result_builder_missing_build_limited_availability, none,
         "this behavior is deprecated", ())
 
 //------------------------------------------------------------------------------
+// MARK: marker protocol diagnostics
+//------------------------------------------------------------------------------
+ERROR(marker_protocol_requirement, none,
+      "marker protocol %0 cannot have any requirements", (DeclName))
+ERROR(marker_protocol_inherit_nonmarker, none,
+      "marker protocol %0 cannot inherit non-marker protocol %1",
+      (DeclName, DeclName))
+ERROR(marker_protocol_value,none,
+      "marker protocol %0 can only be used in generic constraints", (DeclName))
+
+//------------------------------------------------------------------------------
 // MARK: differentiable programming diagnostics
 //------------------------------------------------------------------------------
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -813,6 +813,9 @@ public:
 
   /// True if a protocol uses witness tables for dynamic dispatch.
   static bool protocolRequiresWitnessTable(ProtocolDecl *P) {
+    if (P->isMarkerProtocol())
+      return false;
+
     return swift::protocolRequiresWitnessTable(getProtocolDispatchStrategy(P));
   }
   

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4601,6 +4601,10 @@ ProtocolDecl::ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc,
     setTrailingWhereClause(TrailingWhere);
 }
 
+bool ProtocolDecl::isMarkerProtocol() const {
+  return getAttrs().hasAttribute<MarkerAttr>();
+}
+
 ArrayRef<ProtocolDecl *> ProtocolDecl::getInheritedProtocols() const {
   auto *mutThis = const_cast<ProtocolDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5243,6 +5243,11 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
     case RequirementKind::Conformance: {
       auto protocol = requirement.getSecondType()->castTo<ProtocolType>()
         ->getDecl();
+
+      // Marker protocols do not record generic requirements at all.
+      if (protocol->isMarkerProtocol())
+        break;
+
       bool needsWitnessTable =
         Lowering::TypeConverter::protocolRequiresWitnessTable(protocol);
       auto flags = GenericRequirementFlags(GenericRequirementKind::Protocol,

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5150,6 +5150,10 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
 void IRGenModule::emitProtocolDecl(ProtocolDecl *protocol) {
   PrettyStackTraceDecl stackTraceRAII("emitting metadata for", protocol);
 
+  // Marker protocols are never emitted.
+  if (protocol->isMarkerProtocol())
+    return;
+
   // Emit remote reflection metadata for the protocol.
   emitFieldDescriptor(protocol);
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1534,6 +1534,7 @@ namespace  {
     UNINTERESTING_ATTR(Concurrent)
 
     UNINTERESTING_ATTR(AtRethrows)
+    UNINTERESTING_ATTR(Marker)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3918,6 +3918,12 @@ public:
                            proto->getName());
         T->setInvalid();
       }
+      if (proto->isMarkerProtocol()) {
+        Ctx.Diags.diagnose(comp->getNameLoc(),
+                           diag::marker_protocol_value,
+                           proto->getName());
+        T->setInvalid();
+      }
     } else if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(comp->getBoundDecl())) {
       auto type = Type(alias->getDeclaredInterfaceType()->getDesugaredType());
       type.findIf([&](Type type) -> bool {
@@ -3927,6 +3933,14 @@ public:
           auto layout = type->getExistentialLayout();
           for (auto *proto : layout.getProtocols()) {
             auto *protoDecl = proto->getDecl();
+
+            if (protoDecl->isMarkerProtocol()) {
+              Ctx.Diags.diagnose(comp->getNameLoc(),
+                                 diag::marker_protocol_value,
+                                 protoDecl->getName());
+              T->setInvalid();
+              continue;
+            }
 
             if (protoDecl->existentialTypeSupported())
               continue;

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -1037,7 +1037,7 @@ static bool isValidProtocolMemberForTBDGen(const Decl *D) {
 #endif
 
 void TBDGenVisitor::visitProtocolDecl(ProtocolDecl *PD) {
-  if (!PD->isObjC()) {
+  if (!PD->isObjC() && !PD->isMarkerProtocol()) {
     addSymbol(LinkEntity::forProtocolDescriptor(PD));
 
     struct WitnessVisitor : public SILWitnessVisitor<WitnessVisitor> {

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -13,7 +13,7 @@ extension Int: P { }
 extension Array: P where Element: P { }
 
 // Note: no witness tables
-// CHECK: define swiftcc void @"$s15marker_protocol7genericyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T)
+// CHECK: swiftcc void @"$s15marker_protocol7genericyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T)
 public func generic<T: P>(_: T) { }
 
 public func testGeneric(i: Int, array: [Int]) {

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -5,7 +5,6 @@
 
 // CHECK-NOT: $s15marker_protocol1PP
 // CHECK-NOT: $s15marker_protocol1PMp
-// CHECK-NOT: "\01l_protocols"
 
 @_marker public protocol P { }
 
@@ -20,3 +19,5 @@ public func testGeneric(i: Int, array: [Int]) {
   generic(i)
   generic(array)
 }
+
+public protocol Q: P { }

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -o - | %FileCheck %s
+
+// Marker protocols should have no ABI impact at all, so this source file checks
+// for the absence of symbols related to marker protocols.
+
+// CHECK-NOT: $s15marker_protocol1PP
+// CHECK-NOT: $s15marker_protocol1PMp
+// CHECK-NOT: "\01l_protocols"
+
+@_marker public protocol P { }
+
+extension Int: P { }
+extension Array: P where Element: P { }
+
+// Note: no witness tables
+// CHECK: define swiftcc void @"$s15marker_protocol7genericyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T)
+public func generic<T: P>(_: T) { }
+
+public func testGeneric(i: Int, array: [Int]) {
+  generic(i)
+  generic(array)
+}

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -1,0 +1,51 @@
+// RUN: %target-typecheck-verify-swift
+
+// Marker protocol definition
+@_marker protocol P1 {
+  func f() // expected-error{{marker protocol 'P1' cannot have any requirements}}
+}
+
+@_marker protocol P2 {
+  associatedtype AT // expected-error{{marker protocol 'P2' cannot have any requirements}}
+}
+
+@_marker protocol P3 {
+  typealias A = Int
+}
+
+protocol P4 { } // expected-note{{'P4' declared here}}
+
+@_marker protocol P5: P4 { } // expected-error{{marker protocol 'P5' cannot inherit non-marker protocol 'P4'}}
+
+// Legitimate uses of marker protocols.
+extension P3 {
+  func f() { }
+}
+
+extension Int: P3 { }
+extension Array: P3 where Element: P3 { } // expected-note{{requirement from conditional conformance of '[Double]' to 'P3'}}
+
+protocol P6: P3 { } // okay
+@_marker protocol P7: P3 { } // okay
+
+func genericOk<T: P3>(_: T) { }
+
+func testGenericOk(i: Int, arr: [Int], nope: [Double]) {
+  genericOk(i)
+  genericOk(arr)
+  genericOk(nope) // expected-error{{global function 'genericOk' requires that 'Double' conform to 'P3'}}
+}
+
+// Incorrect uses of marker protocols in types.
+func testNotOkay(a: Any) {
+  var mp1: P3 = 17 // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+  _ = mp1
+  mp1 = 17
+
+  if let mp2 = a as? P3 { _ = mp2 } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+  if let mp3 = a as? AnyObject & P3 { _ = mp3 } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+  if a is AnyObject & P3 { } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+
+  func inner(p3: P3) { } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+}
+


### PR DESCRIPTION
A marker protocol is a protocol with no requirements and with no ABI
footprint. They can be used to indicate semantics, only, and one can
never have values of a marker protocol type.

We still mangle marker protocols when they are used as generic
requirements, because they are a distinguishing characteristic for
overloading, but "no ABI footprint" means no protocol descriptors,
conformance descriptors, or dynamic discovery of any kind.