### PR TITLE
[libSyntax] Store the token's text in the SyntaxArena

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -150,7 +150,7 @@ typedef unsigned SyntaxNodeId;
 ///
 /// This is implementation detail - do not expose it in public API.
 class RawSyntax final
-    : private llvm::TrailingObjects<RawSyntax, RC<RawSyntax>, OwnedString> {
+    : private llvm::TrailingObjects<RawSyntax, RC<RawSyntax>> {
   friend TrailingObjects;
 
   /// The ID that shall be used for the next node that is created and does not
@@ -198,15 +198,13 @@ class RawSyntax final
       /// The kind of token this "token" node represents.
       unsigned TokenKind : 16;
       StringRef LeadingTrivia;
+      StringRef TokenText;
       StringRef TrailingTrivia;
     } Token;
   } Bits;
 
   size_t numTrailingObjects(OverloadToken<RC<RawSyntax>>) const {
     return isToken() ? 0 : Bits.Layout.NumChildren;
-  }
-  size_t numTrailingObjects(OverloadToken<OwnedString>) const {
-    return isToken() ? 1 : 0;
   }
 
   /// Constructor for creating layout nodes.
@@ -223,7 +221,7 @@ class RawSyntax final
   /// underlying storage.
   /// If \p NodeId is \c None, the next free NodeId is used, if it is passed,
   /// the caller needs to assure that the NodeId has not been used yet.
-  RawSyntax(tok TokKind, OwnedString Text, size_t TextLength,
+  RawSyntax(tok TokKind, StringRef Text, size_t TextLength,
             StringRef LeadingTrivia, StringRef TrailingTrivia,
             SourcePresence Presence, const RC<SyntaxArena> &Arena,
             llvm::Optional<SyntaxNodeId> NodeId);
@@ -286,7 +284,7 @@ public:
   }
 
   /// Make a raw "token" syntax node.
-  static RC<RawSyntax> make(tok TokKind, OwnedString Text, size_t TextLength,
+  static RC<RawSyntax> make(tok TokKind, StringRef Text, size_t TextLength,
                             StringRef LeadingTrivia, StringRef TrailingTrivia,
                             SourcePresence Presence,
                             const RC<SyntaxArena> &Arena = SyntaxArena::make(),
@@ -294,7 +292,7 @@ public:
 
   /// Make a raw "token" syntax node that was allocated in \p Arena.
   static RC<RawSyntax>
-  makeAndCalcLength(tok TokKind, OwnedString Text, StringRef LeadingTrivia,
+  makeAndCalcLength(tok TokKind, StringRef Text, StringRef LeadingTrivia,
                     StringRef TrailingTrivia, SourcePresence Presence,
                     const RC<SyntaxArena> &Arena = SyntaxArena::make(),
                     llvm::Optional<SyntaxNodeId> NodeId = llvm::None) {
@@ -316,7 +314,7 @@ public:
 
   /// Make a missing raw "token" syntax node.
   static RC<RawSyntax>
-  missing(tok TokKind, OwnedString Text,
+  missing(tok TokKind, StringRef Text,
           const RC<SyntaxArena> &Arena = SyntaxArena::make()) {
     return make(TokKind, Text, /*TextLength=*/0, {}, {},
                 SourcePresence::Missing, Arena);
@@ -390,16 +388,12 @@ public:
     return static_cast<tok>(Bits.Token.TokenKind);
   }
 
-  /// Return the text of the token as an \c OwnedString. Keeping a reference to
-  /// this string will keep it alive even if the syntax node gets freed.
-  OwnedString getOwnedTokenText() const {
-    assert(isToken());
-    return *getTrailingObjects<OwnedString>();
-  }
-
   /// Return the text of the token as a reference. The referenced buffer may
   /// disappear when the syntax node gets freed.
-  StringRef getTokenText() const { return getOwnedTokenText().str(); }
+  StringRef getTokenText() const {
+    assert(isToken());
+    return Bits.Token.TokenText;
+  }
 
   /// Return the unparsed leading trivia of the token.
   StringRef getLeadingTrivia() const {
@@ -434,17 +428,15 @@ public:
   /// Return a new token like this one, but with the given leading
   /// trivia instead.
   RC<RawSyntax> withLeadingTrivia(StringRef NewLeadingTrivia) const {
-    return makeAndCalcLength(getTokenKind(), getOwnedTokenText(),
-                             NewLeadingTrivia, getTrailingTrivia(),
-                             getPresence());
+    return makeAndCalcLength(getTokenKind(), getTokenText(), NewLeadingTrivia,
+                             getTrailingTrivia(), getPresence());
   }
 
   /// Return a new token like this one, but with the given trailing
   /// trivia instead.
   RC<RawSyntax> withTrailingTrivia(StringRef NewTrailingTrivia) const {
-    return makeAndCalcLength(getTokenKind(), getOwnedTokenText(),
-                             getLeadingTrivia(), NewTrailingTrivia,
-                             getPresence());
+    return makeAndCalcLength(getTokenKind(), getTokenText(), getLeadingTrivia(),
+                             NewTrailingTrivia, getPresence());
   }
 
   /// @}
@@ -503,7 +495,7 @@ public:
   /// Dump this piece of syntax recursively.
   void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
 
-  static void Profile(llvm::FoldingSetNodeID &ID, tok TokKind, OwnedString Text,
+  static void Profile(llvm::FoldingSetNodeID &ID, tok TokKind, StringRef Text,
                       StringRef LeadingTrivia, StringRef TrailingTrivia);
 };
 

--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -163,8 +163,8 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
       in.mapRequired("id", nodeIdString);
       unsigned nodeId = std::atoi(nodeIdString.data());
       value = swift::RawSyntax::makeAndCalcLength(
-          tokenKind, swift::OwnedString::makeRefCounted(text), leadingTrivia,
-          trailingTrivia, presence, swift::SyntaxArena::make(), nodeId);
+          tokenKind, text, leadingTrivia, trailingTrivia, presence,
+          swift::SyntaxArena::make(), nodeId);
     } else {
       swift::SyntaxKind kind;
       in.mapRequired("kind", kind);

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -46,7 +46,7 @@ class SyntaxArena;
 struct SyntaxFactory {
   /// Make any kind of token.
   static TokenSyntax makeToken(tok Kind,
-      OwnedString Text, StringRef LeadingTrivia, StringRef TrailingTrivia,
+      StringRef Text, StringRef LeadingTrivia, StringRef TrailingTrivia,
       SourcePresence Presence,
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );
@@ -108,7 +108,7 @@ struct SyntaxFactory {
             StringRef TrailingTrivia,
       const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   else:
-  static TokenSyntax make${token.name}(OwnedString Text,
+  static TokenSyntax make${token.name}(StringRef Text,
             StringRef LeadingTrivia, StringRef TrailingTrivia,
       const RC<SyntaxArena> &Arena = SyntaxArena::make());
 %   end
@@ -139,7 +139,7 @@ struct SyntaxFactory {
 
   /// Creates a TypeIdentifierSyntax with the provided name and leading/trailing
   /// trivia.
-  static TypeSyntax makeTypeIdentifier(OwnedString TypeName,
+  static TypeSyntax makeTypeIdentifier(StringRef TypeName,
       StringRef LeadingTrivia = {}, StringRef TrailingTrivia = {},
       const RC<SyntaxArena> &Arena = SyntaxArena::make()
   );

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -35,7 +35,7 @@ protected:
 public:
   TokenSyntax(const SyntaxData Data) : Syntax(Data) {}
 
-  static TokenSyntax missingToken(const tok Kind, OwnedString Text) {
+  static TokenSyntax missingToken(const tok Kind, StringRef Text) {
     return makeRoot<TokenSyntax>(RawSyntax::missing(Kind, Text));
   }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -336,12 +336,11 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
       /*SplitTokens=*/ArrayRef<Token>(),
       [&](const Token &Tok, StringRef LeadingTrivia, StringRef TrailingTrivia) {
         CharSourceRange TokRange = Tok.getRange();
-        auto Text = OwnedString::makeRefCounted(Tok.getRawText());
         size_t TextLength = LeadingTrivia.size() + TokRange.getByteLength() +
                             TrailingTrivia.size();
-        auto ThisToken =
-            RawSyntax::make(Tok.getKind(), Text, TextLength, LeadingTrivia,
-                            TrailingTrivia, SourcePresence::Present);
+        auto ThisToken = RawSyntax::make(
+            Tok.getKind(), Tok.getRawText(), TextLength, LeadingTrivia,
+            TrailingTrivia, SourcePresence::Present);
 
         auto ThisTokenPos =
             RunningPos.advancedBy(ThisToken->getLeadingTriviaLength());

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -139,7 +139,7 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
                           getTrailingObjects<RC<RawSyntax>>());
 }
 
-RawSyntax::RawSyntax(tok TokKind, OwnedString Text, size_t TextLength,
+RawSyntax::RawSyntax(tok TokKind, StringRef Text, size_t TextLength,
                      StringRef LeadingTrivia, StringRef TrailingTrivia,
                      SourcePresence Presence, const RC<SyntaxArena> &Arena,
                      llvm::Optional<unsigned> NodeId)
@@ -147,6 +147,7 @@ RawSyntax::RawSyntax(tok TokKind, OwnedString Text, size_t TextLength,
       RefCount(0) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
   copyToArenaIfNecessary(LeadingTrivia, Arena);
+  copyToArenaIfNecessary(Text, Arena);
   copyToArenaIfNecessary(TrailingTrivia, Arena);
 
   if (NodeId.hasValue()) {
@@ -156,19 +157,13 @@ RawSyntax::RawSyntax(tok TokKind, OwnedString Text, size_t TextLength,
     this->NodeId = NextFreeNodeId++;
   }
   Bits.Token.TokenKind = unsigned(TokKind);
-  // FIXME: Copy the backing storage of the string into the arena
   Bits.Token.LeadingTrivia = LeadingTrivia;
+  Bits.Token.TokenText = Text;
   Bits.Token.TrailingTrivia = TrailingTrivia;
-
-  // Initialize token text.
-  ::new (static_cast<void *>(getTrailingObjects<OwnedString>()))
-      OwnedString(Text);
 }
 
 RawSyntax::~RawSyntax() {
-  if (isToken()) {
-    getTrailingObjects<OwnedString>()->~OwnedString();
-  } else {
+  if (!isToken()) {
     for (auto &child : getLayout())
       child.~RC<RawSyntax>();
   }
@@ -179,19 +174,19 @@ RC<RawSyntax> RawSyntax::make(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
                               const RC<SyntaxArena> &Arena,
                               llvm::Optional<unsigned> NodeId) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
-  auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString>(Layout.size(), 0);
+  auto size = totalSizeToAlloc<RC<RawSyntax>>(Layout.size());
   void *data = Arena->Allocate(size, alignof(RawSyntax));
   return RC<RawSyntax>(
       new (data) RawSyntax(Kind, Layout, TextLength, Presence, Arena, NodeId));
 }
 
-RC<RawSyntax> RawSyntax::make(tok TokKind, OwnedString Text, size_t TextLength,
+RC<RawSyntax> RawSyntax::make(tok TokKind, StringRef Text, size_t TextLength,
                               StringRef LeadingTrivia, StringRef TrailingTrivia,
                               SourcePresence Presence,
                               const RC<SyntaxArena> &Arena,
                               llvm::Optional<unsigned> NodeId) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
-  auto size = totalSizeToAlloc<RC<RawSyntax>, OwnedString>(0, 1);
+  auto size = totalSizeToAlloc<RC<RawSyntax>>(0);
   void *data = Arena->Allocate(size, alignof(RawSyntax));
   return RC<RawSyntax>(new (data)
                            RawSyntax(TokKind, Text, TextLength, LeadingTrivia,
@@ -306,9 +301,8 @@ void RawSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   OS << ')';
 }
 
-void RawSyntax::Profile(llvm::FoldingSetNodeID &ID, tok TokKind,
-                        OwnedString Text, StringRef LeadingTrivia,
-                        StringRef TrailingTrivia) {
+void RawSyntax::Profile(llvm::FoldingSetNodeID &ID, tok TokKind, StringRef Text,
+                        StringRef LeadingTrivia, StringRef TrailingTrivia) {
   ID.AddInteger(unsigned(TokKind));
   ID.AddInteger(LeadingTrivia.size());
   ID.AddInteger(TrailingTrivia.size());
@@ -320,7 +314,7 @@ void RawSyntax::Profile(llvm::FoldingSetNodeID &ID, tok TokKind,
 #include "swift/Syntax/TokenKinds.def"
     break;
   default:
-    ID.AddString(Text.str());
+    ID.AddString(Text);
     break;
   }
   ID.AddString(LeadingTrivia);

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -38,7 +38,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-TokenSyntax SyntaxFactory::makeToken(tok Kind, OwnedString Text,
+TokenSyntax SyntaxFactory::makeToken(tok Kind, StringRef Text,
                                      StringRef LeadingTrivia,
                                      StringRef TrailingTrivia,
                                      SourcePresence Presence,
@@ -239,29 +239,24 @@ SyntaxFactory::makeBlank${node.syntax_kind}(const RC<SyntaxArena> &Arena) {
   SyntaxFactory::make${token.name}Keyword(StringRef LeadingTrivia,
                                           StringRef TrailingTrivia,
                                           const RC<SyntaxArena> &Arena) {
-    return makeToken(tok::${token.kind},
-                     OwnedString::makeUnowned("${token.text}"),
-                     LeadingTrivia, TrailingTrivia,
-                     SourcePresence::Present, Arena);
+    return makeToken(tok::${token.kind}, "${token.text}", LeadingTrivia,
+                     TrailingTrivia, SourcePresence::Present, Arena);
   }
 %   elif token.text:
   TokenSyntax
   SyntaxFactory::make${token.name}Token(StringRef LeadingTrivia,
                                         StringRef TrailingTrivia,
                                         const RC<SyntaxArena> &Arena) {
-    return makeToken(tok::${token.kind},
-                     OwnedString::makeUnowned("${token.text}"),
-                     LeadingTrivia, TrailingTrivia,
-                     SourcePresence::Present, Arena);
+    return makeToken(tok::${token.kind}, "${token.text}", LeadingTrivia,
+                     TrailingTrivia, SourcePresence::Present, Arena);
   }
 %   else:
   TokenSyntax
-  SyntaxFactory::make${token.name}(OwnedString Text,
+  SyntaxFactory::make${token.name}(StringRef Text,
                                    StringRef LeadingTrivia,
                                    StringRef TrailingTrivia,
                                    const RC<SyntaxArena> &Arena) {
-    return makeToken(tok::${token.kind}, Text,
-                     LeadingTrivia, TrailingTrivia,
+    return makeToken(tok::${token.kind}, Text, LeadingTrivia, TrailingTrivia,
                      SourcePresence::Present, Arena);
   }
 %   end
@@ -299,7 +294,7 @@ SyntaxFactory::makeGenericParameter(TokenSyntax Name,
   return makeGenericParameter(None, Name, None, None, TrailingComma, Arena);
 }
 
-TypeSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
+TypeSyntax SyntaxFactory::makeTypeIdentifier(StringRef TypeName,
                                              StringRef LeadingTrivia,
                                              StringRef TrailingTrivia,
                                              const RC<SyntaxArena> &Arena) {
@@ -311,35 +306,30 @@ TypeSyntax SyntaxFactory::makeTypeIdentifier(OwnedString TypeName,
 TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(StringRef LeadingTrivia,
                                                 StringRef TrailingTrivia,
                                                 const RC<SyntaxArena> &Arena) {
-  return makeTypeIdentifier(OwnedString::makeUnowned("Any"), LeadingTrivia,
-                            TrailingTrivia, Arena);
+  return makeTypeIdentifier("Any", LeadingTrivia, TrailingTrivia, Arena);
 }
 
 TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(StringRef LeadingTrivia,
                                                  StringRef TrailingTrivia,
                                                  const RC<SyntaxArena> &Arena) {
-  return makeTypeIdentifier(OwnedString::makeUnowned("Self"),
-                            LeadingTrivia, TrailingTrivia, Arena);
+  return makeTypeIdentifier("Self", LeadingTrivia, TrailingTrivia, Arena);
 }
 
 TokenSyntax SyntaxFactory::makeTypeToken(StringRef LeadingTrivia,
                                          StringRef TrailingTrivia,
                                          const RC<SyntaxArena> &Arena) {
-  return makeIdentifier(OwnedString::makeUnowned("Type"),
-                        LeadingTrivia, TrailingTrivia, Arena);
+  return makeIdentifier("Type", LeadingTrivia, TrailingTrivia, Arena);
 }
 
 TokenSyntax SyntaxFactory::makeProtocolToken(StringRef LeadingTrivia,
                                              StringRef TrailingTrivia,
                                              const RC<SyntaxArena> &Arena) {
-  return makeIdentifier(OwnedString::makeUnowned("Protocol"),
-                        LeadingTrivia, TrailingTrivia, Arena);
+  return makeIdentifier("Protocol", LeadingTrivia, TrailingTrivia, Arena);
 }
 
 TokenSyntax SyntaxFactory::makeEqualityOperator(StringRef LeadingTrivia,
                                                 StringRef TrailingTrivia,
                                                 const RC<SyntaxArena> &Arena) {
-  return makeToken(tok::oper_binary_spaced, OwnedString::makeUnowned("=="),
-                   LeadingTrivia, TrailingTrivia, SourcePresence::Present,
-                   Arena);
+  return makeToken(tok::oper_binary_spaced, "==", LeadingTrivia, TrailingTrivia, 
+                   SourcePresence::Present, Arena);
 }

--- a/lib/SyntaxParse/RawSyntaxTokenCache.cpp
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.cpp
@@ -40,7 +40,7 @@ static bool shouldCacheNode(tok TokKind, size_t TextSize,
 }
 
 RC<RawSyntax> RawSyntaxTokenCache::getToken(RC<SyntaxArena> &Arena, tok TokKind,
-                                            size_t TextLength, OwnedString Text,
+                                            size_t TextLength, StringRef Text,
                                             StringRef LeadingTrivia,
                                             StringRef TrailingTrivia) {
   // Determine whether this token is worth to cache.

--- a/lib/SyntaxParse/RawSyntaxTokenCache.h
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.h
@@ -62,7 +62,7 @@ class RawSyntaxTokenCache {
 
 public:
   RC<syntax::RawSyntax> getToken(RC<syntax::SyntaxArena> &Arena, tok TokKind,
-                                 size_t TextLength, OwnedString Text,
+                                 size_t TextLength, StringRef Text,
                                  StringRef LeadingTrivia,
                                  StringRef TrailingTrivia);
 

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -135,9 +135,8 @@ OpaqueSyntaxNode SyntaxTreeCreator::recordToken(tok tokenKind,
   StringRef trailingTriviaText = ArenaSourceBuffer.substr(
       trailingTriviaStartOffset, trailingTrivia.size());
 
-  auto ownedText = OwnedString::makeRefCounted(tokenText);
   auto raw =
-      TokenCache->getToken(Arena, tokenKind, range.getByteLength(), ownedText,
+      TokenCache->getToken(Arena, tokenKind, range.getByteLength(), tokenText,
                            leadingTriviaText, trailingTriviaText);
   OpaqueSyntaxNode opaqueN = raw.get();
   raw.resetWithoutRelease();
@@ -146,8 +145,7 @@ OpaqueSyntaxNode SyntaxTreeCreator::recordToken(tok tokenKind,
 
 OpaqueSyntaxNode
 SyntaxTreeCreator::recordMissingToken(tok kind, SourceLoc loc) {
-  auto ownedText = OwnedString::makeRefCounted(getTokenText(kind));
-  auto raw = RawSyntax::missing(kind, ownedText, Arena);
+  auto raw = RawSyntax::missing(kind, getTokenText(kind), Arena);
   OpaqueSyntaxNode opaqueN = raw.get();
   raw.resetWithoutRelease();
   return opaqueN;

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -38,7 +38,7 @@ def make_missing_child(child):
         tok_kind = token.kind if token else "unknown"
         tok_text = token.text if token else ""
         return \
-            'RawSyntax::missing(tok::%s, OwnedString::makeUnowned("%s"))' % \
+            'RawSyntax::missing(tok::%s, "%s")' % \
             (tok_kind, tok_text)
     else:
         missing_kind = "Unknown" if child.syntax_kind == "Syntax" \


### PR DESCRIPTION
This PR contains commits from https://github.com/apple/swift/pull/35649

------------------

Do the same thing that we are already doing for trivia: Since `RawSyntax` nodes always live inside a `SyntaxArena`, we don't need to tail-allocate an `OwnedString` to store the token's text. Instead we can just copy it to the `SyntaxArena`. If we copy the entire source buffer to the syntax arena at the start of parsing, this means that no more copies are required later on. Plus we also avoid ref-counting the `OwnedString` which should also increase performance.

### Performance checklist (performed on my local machine)
- [x] No regression during compilation
- [x] No regression during code completion
- [x] No regression during SwiftSyntax parsing