### PR TITLE
DeadObjectElimination: delete dead arrays for which the "destroyArray" builtin is inlined.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -821,6 +821,10 @@ public:
   /// access, thus not within an access scope.
   static AccessPath computeInScope(SILValue address);
 
+  /// Creates an AccessPass, which identifies the first tail-element of the
+  /// object \p rootReference.
+  static AccessPath forTailStorage(SILValue rootReference);
+
   // Encode a dynamic index_addr as an UnknownOffset.
   static constexpr int UnknownOffset = std::numeric_limits<int>::min() >> 1;
 
@@ -983,6 +987,12 @@ public:
   collectUses(SmallVectorImpl<Operand *> &uses, AccessUseType useTy,
               SILFunction *function,
               unsigned useLimit = std::numeric_limits<unsigned>::max()) const;
+
+  /// Returns a new AccessPass, identical to this AccessPath, except that the
+  /// offset is replaced with \p newOffset.
+  AccessPath withOffset(int newOffset) const {
+    return AccessPath(storage, pathNode, newOffset);
+  }
 
   void printPath(raw_ostream &os) const;
   void print(raw_ostream &os) const;

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -943,7 +943,8 @@ public:
 
   bool operator==(AccessPath other) const {
     return
-      storage.hasIdenticalBase(other.storage) && pathNode == other.pathNode;
+      storage.hasIdenticalBase(other.storage) && pathNode == other.pathNode &&
+      offset == other.offset;
   }
   bool operator!=(AccessPath other) const { return !(*this == other); }
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -763,6 +763,13 @@ AccessedStorage AccessedStorage::computeInScope(SILValue sourceAddress) {
 //                              MARK: AccessPath
 //===----------------------------------------------------------------------===//
 
+AccessPath AccessPath::forTailStorage(SILValue rootReference) {
+  return AccessPath(
+    AccessedStorage::forClass(rootReference, AccessedStorage::TailIndex),
+    PathNode(rootReference->getModule()->getIndexTrieRoot()),
+    /*offset*/ 0);
+}
+
 bool AccessPath::contains(AccessPath subPath) const {
   if (!isValid() || !subPath.isValid()) {
     return false;

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -2,6 +2,7 @@
 
 import Swift
 import Builtin
+import SwiftShims
 
 //////////
 // Data //
@@ -19,6 +20,11 @@ class Kl {}
 class NontrivialDestructor {
   @_hasStorage var p : Kl 
   @_hasStorage var i : Int 
+  init()
+}
+
+class ArrayStorage {
+  @_hasStorage var bodyField : Kl 
   init()
 }
 
@@ -441,6 +447,199 @@ bb0(%0 : $X):
   inject_enum_addr %3 : $*Optional<P>, #Optional.some!enumelt
   destroy_addr %3 : $*Optional<P>
   dealloc_stack %3 : $*Optional<P>
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @remove_dead_array_with_destroy_simple
+// CHECK-NOT:   alloc_ref
+// CHECK-NOT:   dealloc_ref
+// CHECK:       strong_release %0 : $Kl
+// CHECK-NEXT:  strong_release %0 : $Kl
+// CHECK-NEXT:  tuple
+// CHECK-NEXT:  return
+// CHECK:      } // end sil function 'remove_dead_array_with_destroy_simple'
+sil @remove_dead_array_with_destroy_simple : $@convention(thin) (@owned Kl) -> () {
+bb0(%0 : $Kl):
+  %3 = integer_literal $Builtin.Word, 2
+  %4 = alloc_ref [tail_elems $Kl * %3 : $Builtin.Word] $ArrayStorage
+  %11 = ref_tail_addr %4 : $ArrayStorage, $Kl
+  store %0 to %11 : $*Kl
+  %27 = integer_literal $Builtin.Word, 1
+  %28 = index_addr %11 : $*Kl, %27 : $Builtin.Word
+  retain_value %0 : $Kl
+  store %0 to %28 : $*Kl
+  set_deallocating %4 : $ArrayStorage
+  %65 = address_to_pointer %11 : $*Kl to $Builtin.RawPointer
+  %66 = metatype $@thick Kl.Type
+  %67 = builtin "destroyArray"<Kl>(%66 : $@thick Kl.Type, %65 : $Builtin.RawPointer, %3 : $Builtin.Word) : $()
+  dealloc_ref %4 : $ArrayStorage
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @remove_dead_array_with_destroy_complex
+// CHECK-NOT:   alloc_ref
+// CHECK-NOT:   dealloc_ref
+// CHECK:       release_value %0 : $String
+// CHECK-NEXT:  release_value %0 : $String
+// CHECK-NEXT:  tuple
+// CHECK-NEXT:  return
+// CHECK:      } // end sil function 'remove_dead_array_with_destroy_complex'
+sil @remove_dead_array_with_destroy_complex : $@convention(thin) (@guaranteed String, Int, UInt) -> () {
+bb0(%0 : $String, %1 : $Int, %2 : $UInt):
+  %3 = integer_literal $Builtin.Word, 2
+  %4 = alloc_ref [stack] [tail_elems $(Int, String) * %3 : $Builtin.Word] $_ContiguousArrayStorage<(Int, String)>
+  %5 = upcast %4 : $_ContiguousArrayStorage<(Int, String)> to $__ContiguousArrayStorageBase
+  %6 = struct $_SwiftArrayBodyStorage (%1 : $Int, %2 : $UInt)
+  %7 = struct $_ArrayBody (%6 : $_SwiftArrayBodyStorage)
+  %9 = ref_element_addr %5 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  store %7 to %9 : $*_ArrayBody
+  %11 = ref_tail_addr %5 : $__ContiguousArrayStorageBase, $(Int, String)
+  %12 = tuple_element_addr %11 : $*(Int, String), 0
+  %13 = tuple_element_addr %11 : $*(Int, String), 1
+  retain_value %0 : $String
+  store %1 to %12 : $*Int
+  store %0 to %13 : $*String
+  %27 = integer_literal $Builtin.Word, 1
+  %28 = index_addr %11 : $*(Int, String), %27 : $Builtin.Word
+  %29 = tuple_element_addr %28 : $*(Int, String), 0
+  %30 = tuple_element_addr %28 : $*(Int, String), 1
+  retain_value %0 : $String
+  store %1 to %29 : $*Int
+  store %0 to %30 : $*String
+  set_deallocating %4 : $_ContiguousArrayStorage<(Int, String)>
+  %64 = ref_tail_addr %4 : $_ContiguousArrayStorage<(Int, String)>, $(Int, String)
+  %65 = address_to_pointer %64 : $*(Int, String) to $Builtin.RawPointer
+  %66 = metatype $@thick (Int, String).Type
+  %67 = builtin "destroyArray"<(Int, String)>(%66 : $@thick (Int, String).Type, %65 : $Builtin.RawPointer, %3 : $Builtin.Word) : $()
+  fix_lifetime %4 : $_ContiguousArrayStorage<(Int, String)>
+  dealloc_ref %4 : $_ContiguousArrayStorage<(Int, String)>
+  dealloc_ref [stack] %4 : $_ContiguousArrayStorage<(Int, String)>
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @dont_remove_dead_array_overlapping_stores
+// CHECK:   alloc_ref
+// CHECK:   dealloc_ref
+// CHECK: } // end sil function 'dont_remove_dead_array_overlapping_stores'
+sil @dont_remove_dead_array_overlapping_stores : $@convention(thin) (@owned Kl) -> () {
+bb0(%0 : $Kl):
+  %3 = integer_literal $Builtin.Word, 2
+  %4 = alloc_ref [tail_elems $Kl * %3 : $Builtin.Word] $ArrayStorage
+  %11 = ref_tail_addr %4 : $ArrayStorage, $Kl
+  %27 = integer_literal $Builtin.Word, 1
+  %28 = index_addr %11 : $*Kl, %27 : $Builtin.Word
+  retain_value %0 : $Kl
+  store %0 to %28 : $*Kl
+  store %0 to %11 : $*Kl
+  %30 = index_addr %11 : $*Kl, %27 : $Builtin.Word
+  retain_value %0 : $Kl
+  store %0 to %30 : $*Kl // Overwrites the first store
+  set_deallocating %4 : $ArrayStorage
+  %65 = address_to_pointer %11 : $*Kl to $Builtin.RawPointer
+  %66 = metatype $@thick Kl.Type
+  %67 = builtin "destroyArray"<Kl>(%66 : $@thick Kl.Type, %65 : $Builtin.RawPointer, %3 : $Builtin.Word) : $()
+  dealloc_ref %4 : $ArrayStorage
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @dont_remove_dead_array_store_to_body
+// CHECK:   alloc_ref
+// CHECK:   dealloc_ref
+// CHECK: } // end sil function 'dont_remove_dead_array_store_to_body'
+sil @dont_remove_dead_array_store_to_body : $@convention(thin) (@owned Kl) -> () {
+bb0(%0 : $Kl):
+  %3 = integer_literal $Builtin.Word, 2
+  %4 = alloc_ref [tail_elems $Kl * %3 : $Builtin.Word] $ArrayStorage
+  %5 = ref_element_addr %4 : $ArrayStorage, #ArrayStorage.bodyField
+  %11 = ref_tail_addr %4 : $ArrayStorage, $Kl
+  store %0 to %5 : $*Kl // Store non-trivial type to body of ArrayStorage
+  %27 = integer_literal $Builtin.Word, 1
+  %28 = index_addr %11 : $*Kl, %27 : $Builtin.Word
+  retain_value %0 : $Kl
+  store %0 to %28 : $*Kl
+  set_deallocating %4 : $ArrayStorage
+  %65 = address_to_pointer %11 : $*Kl to $Builtin.RawPointer
+  %66 = metatype $@thick Kl.Type
+  %67 = builtin "destroyArray"<Kl>(%66 : $@thick Kl.Type, %65 : $Builtin.RawPointer, %3 : $Builtin.Word) : $()
+  dealloc_ref %4 : $ArrayStorage
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @dont_remove_dead_array_out_of_bounds_store
+// CHECK:   alloc_ref
+// CHECK:   dealloc_ref
+// CHECK: } // end sil function 'dont_remove_dead_array_out_of_bounds_store'
+sil @dont_remove_dead_array_out_of_bounds_store: $@convention(thin) (@owned Kl) -> () {
+bb0(%0 : $Kl):
+  %2 = integer_literal $Builtin.Word, 1
+  %3 = integer_literal $Builtin.Word, 2
+  %4 = alloc_ref [tail_elems $Kl * %3 : $Builtin.Word] $ArrayStorage
+  %11 = ref_tail_addr %4 : $ArrayStorage, $Kl
+  store %0 to %11 : $*Kl
+  %28 = index_addr %11 : $*Kl, %2 : $Builtin.Word // out-of-bounds store
+  retain_value %0 : $Kl
+  store %0 to %28 : $*Kl
+  set_deallocating %4 : $ArrayStorage
+  %65 = address_to_pointer %11 : $*Kl to $Builtin.RawPointer
+  %66 = metatype $@thick Kl.Type
+  %67 = builtin "destroyArray"<Kl>(%66 : $@thick Kl.Type, %65 : $Builtin.RawPointer, %2 : $Builtin.Word) : $()
+  dealloc_ref %4 : $ArrayStorage
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @dont_remove_dead_array_unknown_bounds
+// CHECK:   alloc_ref
+// CHECK:   dealloc_ref
+// CHECK: } // end sil function 'dont_remove_dead_array_unknown_bounds'
+sil @dont_remove_dead_array_unknown_bounds : $@convention(thin) (@owned Kl, Builtin.Word) -> () {
+bb0(%0 : $Kl, %1 : $Builtin.Word):
+  %3 = integer_literal $Builtin.Word, 2
+  %4 = alloc_ref [tail_elems $Kl * %3 : $Builtin.Word] $ArrayStorage
+  %11 = ref_tail_addr %4 : $ArrayStorage, $Kl
+  store %0 to %11 : $*Kl
+  %27 = integer_literal $Builtin.Word, 1
+  %28 = index_addr %11 : $*Kl, %27 : $Builtin.Word
+  retain_value %0 : $Kl
+  store %0 to %28 : $*Kl
+  set_deallocating %4 : $ArrayStorage
+  %65 = address_to_pointer %11 : $*Kl to $Builtin.RawPointer
+  %66 = metatype $@thick Kl.Type
+  %67 = builtin "destroyArray"<Kl>(%66 : $@thick Kl.Type, %65 : $Builtin.RawPointer, %1 : $Builtin.Word) : $()
+  dealloc_ref %4 : $ArrayStorage
+  %10 = tuple ()
+  return %10 : $()
+}
+
+// CHECK-LABEL: sil @dont_remove_dead_array_wrong_blocks
+// CHECK:   alloc_ref
+// CHECK:   dealloc_ref
+// CHECK: } // end sil function 'dont_remove_dead_array_wrong_blocks'
+sil @dont_remove_dead_array_wrong_blocks : $@convention(thin) (@owned Kl) -> () {
+bb0(%0 : $Kl):
+  %3 = integer_literal $Builtin.Word, 2
+  %4 = alloc_ref [tail_elems $Kl * %3 : $Builtin.Word] $ArrayStorage
+  %11 = ref_tail_addr %4 : $ArrayStorage, $Kl
+  cond_br undef, bb1, bb2
+bb1:
+  store %0 to %11 : $*Kl
+  br bb3
+bb2:
+  %27 = integer_literal $Builtin.Word, 1
+  %28 = index_addr %11 : $*Kl, %27 : $Builtin.Word
+  store %0 to %28 : $*Kl
+  br bb3
+bb3:
+  set_deallocating %4 : $ArrayStorage
+  %65 = address_to_pointer %11 : $*Kl to $Builtin.RawPointer
+  %66 = metatype $@thick Kl.Type
+  %67 = builtin "destroyArray"<Kl>(%66 : $@thick Kl.Type, %65 : $Builtin.RawPointer, %3 : $Builtin.Word) : $()
+  dealloc_ref %4 : $ArrayStorage
   %10 = tuple ()
   return %10 : $()
 }

--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -51,3 +51,26 @@ func testDeadArrayElimWithFixLifetimeUse() {
 func testDeadArrayElimWithAddressOnlyValues<T>(x: T, y: T) {
   _ = [x, y]
 }
+
+// CHECK-LABEL: sil hidden @$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF
+// CHECK:      bb0(%0 : $String):
+// CHECK-NEXT:   debug_value {{.*}} name "stringParameter"
+// CHECK-NEXT:   integer_literal $Builtin.Int{{[0-9]+}}, 21
+// CHECK-NEXT:   struct $Int
+// CHECK-NEXT:   return
+// CHECK:      } // end sil function '$s15dead_array_elim31testDeadArrayAfterOptimizationsySiSSF'
+func testDeadArrayAfterOptimizations(_ stringParameter: String) -> Int {
+  var sum = 0
+  for x in [(1, "hello"),
+            (2, "a larger string which does not fit into a small string"),
+            (3, stringParameter),
+            (4, "hello"),
+            (5, "hello"),
+            (6, "hello"),
+            ] {
+    sum += x.0
+  }
+  return sum
+}
+
+

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3825,6 +3825,36 @@ bb0(%0 : $Builtin.Int64):
   return %2 : $Builtin.BridgeObject
 }
 
+struct MyStringObj {
+  @_hasStorage var a: UInt64
+  @_hasStorage var b: Builtin.BridgeObject
+}
+
+struct MyStringGuts {
+  @_hasStorage var o: MyStringObj
+}
+
+struct MyString {
+  @_hasStorage var g: MyStringGuts
+}
+
+// CHECK-LABEL: sil @optimize_arc_with_value_to_bridge_object2
+// CHECK:      bb0(%0 : $UInt64):
+// CHECK-NEXT:   tuple
+// CHECK-NEXT:   return
+// CHECK:      } // end sil function 'optimize_arc_with_value_to_bridge_object2'
+sil @optimize_arc_with_value_to_bridge_object2 : $@convention(thin) (UInt64) -> () {
+bb0(%0 : $UInt64):
+  %1 = integer_literal $Builtin.Int64, -1945555039024054272
+  %2 = value_to_bridge_object %1 : $Builtin.Int64
+  %3 = struct $MyStringObj (%0 : $UInt64, %2 : $Builtin.BridgeObject)
+  %4 = struct $MyStringGuts (%3 : $MyStringObj)
+  %5 = struct $MyString (%4 : $MyStringGuts)
+  release_value %5 : $MyString
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // CHECK-LABEL: sil @optimize_stringObject_bit_operations
 // CHECK:      bb0:
 // CHECK-NEXT:   %0 = integer_literal $Builtin.Int64, 4611686018427387904


### PR DESCRIPTION
This is needed for non-OSSA SIL: in case we see a destroyArray builtin, we can safely remove the otherwise dead array.
This optimization kicks in later in the pipeline, after array semantics are already inlined (for early SIL, DeadObjectElimination can remove arrays based on semantics).

rdar://73569282
https://bugs.swift.org/browse/SR-14100