### PR TITLE
Fold Incremental External Dependency Nodes Into External Dependency Nodes

### DIFF
--- a/include/swift/Basic/ReferenceDependencyKeys.h
+++ b/include/swift/Basic/ReferenceDependencyKeys.h
@@ -53,7 +53,6 @@ enum class NodeKind {
   dynamicLookup,
   externalDepend,
   sourceFileProvide,
-  incrementalExternalDepend,
   /// For iterating through the NodeKinds.
   kindCount
 };
@@ -64,7 +63,7 @@ const std::string NodeKindNames[]{
     "topLevel",          "nominal",
     "potentialMember",   "member",
     "dynamicLookup",     "externalDepend",
-    "sourceFileProvide", "incrementalExternalDepend"};
+    "sourceFileProvide"};
 } // end namespace fine_grained_dependencies
 } // end namespace swift
 

--- a/include/swift/Driver/FineGrainedDependencyDriverGraph.h
+++ b/include/swift/Driver/FineGrainedDependencyDriverGraph.h
@@ -170,7 +170,6 @@ class ModuleDepGraph {
 
   // Supports requests from the driver to getExternalDependencies.
   std::unordered_set<std::string> externalDependencies;
-  std::unordered_set<std::string> incrementalExternalDependencies;
 
   /// Keyed by swiftdeps filename, so we can get back to Jobs.
   std::unordered_map<std::string, const driver::Job *> jobsBySwiftDeps;
@@ -515,22 +514,12 @@ public:
   std::vector<const driver::Job *>
   findExternallyDependentUntracedJobs(StringRef externalDependency);
 
-  /// Find jobs that were previously not known to need compilation but that
-  /// depend on \c incrementalExternalDependency.
-  ///
-  /// This code path should only act as a fallback to the status-quo behavior.
-  /// Otherwise it acts to pessimize the behavior of cross-module incremental
-  /// builds.
-  std::vector<const driver::Job *>
-  findIncrementalExternallyDependentUntracedJobs(StringRef externalDependency);
-
   //============================================================================
   // MARK: ModuleDepGraph - External dependencies
   //============================================================================
 
 public:
   std::vector<StringRef> getExternalDependencies() const;
-  std::vector<StringRef> getIncrementalExternalDependencies() const;
 
   void forEachUntracedJobDirectlyDependentOnExternalSwiftDeps(
       StringRef externalDependency, function_ref<void(const driver::Job *)> fn);

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -240,7 +240,6 @@ std::string DependencyKey::humanReadableName() const {
   switch (kind) {
   case NodeKind::member:
     return demangleTypeAsContext(context) + "." + name;
-  case NodeKind::incrementalExternalDepend:
   case NodeKind::externalDepend:
   case NodeKind::sourceFileProvide:
     return llvm::sys::path::filename(name).str();
@@ -271,12 +270,9 @@ raw_ostream &fine_grained_dependencies::operator<<(raw_ostream &out,
 bool DependencyKey::verify() const {
   assert((getKind() != NodeKind::externalDepend || isInterface()) &&
          "All external dependencies must be interfaces.");
-  assert((getKind() != NodeKind::incrementalExternalDepend || isInterface()) &&
-         "All incremental external dependencies must be interfaces.");
   switch (getKind()) {
   case NodeKind::topLevel:
   case NodeKind::dynamicLookup:
-  case NodeKind::incrementalExternalDepend:
   case NodeKind::externalDepend:
   case NodeKind::sourceFileProvide:
     assert(context.empty() && !name.empty() && "Must only have a name");
@@ -307,7 +303,6 @@ void DependencyKey::verifyNodeKindNames() {
       CHECK_NAME(potentialMember)
       CHECK_NAME(member)
       CHECK_NAME(dynamicLookup)
-      CHECK_NAME(incrementalExternalDepend)
       CHECK_NAME(externalDepend)
       CHECK_NAME(sourceFileProvide)
     case NodeKind::kindCount:

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -491,8 +491,8 @@ public:
 
   void enumerateExternalUses(UseEnumerator enumerator) {
     for (const auto &id : depTracker.getIncrementalDependencies()) {
-      enumerateUse<NodeKind::incrementalExternalDepend>(enumerator, id.path,
-                                                        id.fingerprint);
+      enumerateUse<NodeKind::externalDepend>(enumerator, id.path,
+                                             id.fingerprint);
     }
     for (StringRef s : depTracker.getDependencies()) {
       enumerateUse<NodeKind::externalDepend>(enumerator, s, None);
@@ -503,8 +503,7 @@ private:
   template <NodeKind kind>
   void enumerateUse(UseEnumerator createDefUse, StringRef name,
                     Optional<Fingerprint> maybeFP) {
-    static_assert(kind == NodeKind::incrementalExternalDepend ||
-                      kind == NodeKind::externalDepend,
+    static_assert(kind == NodeKind::externalDepend,
                   "Not a kind of external dependency!");
     createDefUse(DependencyKey(kind, DeclAspect::interface, "", name.str()),
                  sourceFileImplementation, maybeFP);

--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -109,8 +109,6 @@ void ScalarEnumerationTraits<swift::fine_grained_dependencies::NodeKind>::
   io.enumCase(value, "member", NodeKind::member);
   io.enumCase(value, "dynamicLookup", NodeKind::dynamicLookup);
   io.enumCase(value, "externalDepend", NodeKind::externalDepend);
-  io.enumCase(value, "incrementalExternalDepend",
-              NodeKind::incrementalExternalDepend);
   io.enumCase(value, "sourceFileProvide", NodeKind::sourceFileProvide);
 }
 

--- a/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
+++ b/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
@@ -143,7 +143,6 @@ UnitTestSourceFileDepGraphFactory::singleNameIsContext(const NodeKind kind) {
     return true;
   case NodeKind::topLevel:
   case NodeKind::dynamicLookup:
-  case NodeKind::incrementalExternalDepend:
   case NodeKind::externalDepend:
   case NodeKind::sourceFileProvide:
     return false;


### PR DESCRIPTION
Remove this distinction without a difference. Originally, the thought
was to
1) Isolate the cross-module build infrastructure
2) Provide a signal to the driver that a dependency had swiftdeps info in it

But the driver need only notice swiftmodule files as external
dependencies and try to extract that information if it can to divine the
signal it needs. Additionally, we can give it fingerprints as priors to
let it know there might be incremental info to be had.