### PR TITLE
[ConstraintSystem] Tweak disjunction selection

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -686,6 +686,11 @@ public:
     });
   }
 
+  /// Returns the number of resolved argument types for an applied disjunction
+  /// constriant. This is always zero for disjunctions that do not represent
+  /// an applied overload.
+  unsigned countResolvedArgumentTypes(ConstraintSystem &cs) const;
+
   /// Determine if this constraint represents explicit conversion,
   /// e.g. coercion constraint "as X" which forms a disjunction.
   bool isExplicitConversion() const;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4983,7 +4983,7 @@ public:
 
   // If the given constraint is an applied disjunction, get the argument function
   // that the disjunction is applied to.
-  const FunctionType *getAppliedDisjunctionArgumentFunction(Constraint *disjunction) {
+  const FunctionType *getAppliedDisjunctionArgumentFunction(const Constraint *disjunction) {
     assert(disjunction->getKind() == ConstraintKind::Disjunction);
     return AppliedDisjunctions[disjunction->getLocator()];
   }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2293,20 +2293,27 @@ Constraint *ConstraintSystem::selectDisjunction() {
           return first->countActiveNestedConstraints() < second->countActiveNestedConstraints();
 
         if (firstFavored == secondFavored) {
-          // Look for additional choices to favor
+          // Look for additional choices that are "favored"
           SmallVector<unsigned, 4> firstExisting;
           SmallVector<unsigned, 4> secondExisting;
 
           existingOperatorBindingsForDisjunction(*cs, first->getNestedConstraints(), firstExisting);
-          firstFavored = firstExisting.size() ? firstExisting.size() : first->countActiveNestedConstraints();
+          firstFavored += firstExisting.size();
           existingOperatorBindingsForDisjunction(*cs, second->getNestedConstraints(), secondExisting);
-          secondFavored = secondExisting.size() ? secondExisting.size() : second->countActiveNestedConstraints();
-
-          return firstFavored < secondFavored;
+          secondFavored += secondExisting.size();
         }
 
         firstFavored = firstFavored ? firstFavored : first->countActiveNestedConstraints();
         secondFavored = secondFavored ? secondFavored : second->countActiveNestedConstraints();
+
+        // Everything else equal, choose the disjunction with the greatest
+        // number of resoved argument types. The number of resolved argument
+        // types is always zero for disjunctions that don't represent applied
+        // overloads.
+        if (firstFavored == secondFavored) {
+          return first->countResolvedArgumentTypes(*this) > second->countResolvedArgumentTypes(*this);
+        }
+
         return firstFavored < secondFavored;
       });
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -606,6 +606,17 @@ gatherReferencedTypeVars(Constraint *constraint,
   }
 }
 
+unsigned Constraint::countResolvedArgumentTypes(ConstraintSystem &cs) const {
+  auto *argumentFuncType = cs.getAppliedDisjunctionArgumentFunction(this);
+  if (!argumentFuncType)
+    return 0;
+
+  return llvm::count_if(argumentFuncType->getParams(), [&](const AnyFunctionType::Param arg) {
+    auto argType = cs.getFixedTypeRecursive(arg.getPlainType(), /*wantRValue=*/true);
+    return !argType->isTypeVariableOrMember();
+  });
+}
+
 bool Constraint::isExplicitConversion() const {
   assert(Kind == ConstraintKind::Disjunction);
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar73892556.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar73892556.gyb
@@ -1,0 +1,9 @@
+// RUN: %scale-test --begin 10 --end 20 --step 1 --select NumLeafScopes %s
+// REQUIRES: asserts,no_asan
+
+func test(_ arr: [Int]) -> [Int] {
+%for i in range(0, N):
+  arr +
+%end
+  (arr.isEmpty ? arr : [Int]())
+}


### PR DESCRIPTION
Consider the number of resolved argument types for applied overloads when selecting a disjunction to attempt.

Previously, in cases where the same operator is chained together several times, the solver would always pick the last one to try first. Instead, the solver should pick the overload that it has the most information about. This helps in situations like this:

```swift
let array: [Int]
_ = array + array + ... + array + <some expression whose type won't be bound until later>
```

Note: Disjunction selection based on favoring should also be changed, but it breaks some things so I'm leaving it alone for now.

Resolves: rdar://73892556
