### PR TITLE
[5.4][CodeCompletion][Sema] Don't filter out any viable solutions when solving for code completion

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2784,7 +2784,7 @@ private:
   void
   filterSolutions(SmallVectorImpl<Solution> &solutions,
                   bool minimize = false) {
-    if (solutions.size() < 2)
+    if (solutions.size() < 2 || isForCodeCompletion())
       return;
 
     if (auto best = findBestSolution(solutions, minimize)) {

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -46,6 +46,8 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_ERROR | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_FIXME | %FileCheck %s --check-prefix=NORESULTS
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=REGULAR_MULTICLOSURE_APPLIED | %FileCheck %s --check-prefix=POINT_MEMBER
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=BEST_SOLUTION_FILTER | %FileCheck %s --check-prefix=BEST_SOLUTION_FILTER
+// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=BEST_SOLUTION_FILTER2 | %FileCheck %s --check-prefix=BEST_SOLUTION_FILTER
 
 
 struct A {
@@ -438,3 +440,23 @@ takesClosureOfPoint { p in
     if p.#^REGULAR_MULTICLOSURE_APPLIED^# {}
   }
 }
+
+enum Enum123 {
+    case enumElem
+}
+struct Struct123: Equatable {
+    var structMem = Enum123.enumElem
+}
+func testNoBestSolutionFilter() {
+  let a = Struct123();
+  let b = [Struct123]().first(where: { $0 == a && 1 + 90 * 5 / 8 == 45 * -10 })?.structMem != .#^BEST_SOLUTION_FILTER^#
+  let c = min(10.3, 10 / 10.4) < 6 + 5 / (10 - 3) ? true : Optional(a)?.structMem != .#^BEST_SOLUTION_FILTER2^#
+}
+
+// BEST_SOLUTION_FILTER: Begin completions
+// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: enumElem[#Enum123#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Enum123#})[#(into: inout Hasher) -> Void#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#Enum123?#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<Enum123>#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#Enum123#})[#Optional<Enum123>#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER: End completions


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/35535 for 5.4

- **Explanation**: When type checking expressions there are sometimes multiple viable solutions. The constraint solver has some logic to pick a “best” solution in these cases and filter out the rest (e.g. choosing a more-specialized non-generic function or operator overload over purely generic one). This makes sense during regular compilation, but failing to consider the removed solutions made us miss valid code completion results that once inserted into the code would have made those solutions become the "best" solution. In the code below, for example, we would fail to suggest the members of Optional and MyEnum, instead just offering static members of Int:

   ```
   enum MyEnum { case first, second }
   func foo(a: Int, b: Int)-> Int { return 42 }
   func foo<T:Equatable>(a: T, b: T) -> MyEnum? { return nil }

   foo(a: 42, b: 4) != .<COMPLETE-HERE> 
   ```
   This patch resolves this issue by not filtering out any viable solutions when solving for code completion.
- **Scope of issue**: This can cause us to offer only a small subset of valid code completions in expressions involving multiple components and generic overloads.
- **Origination**: Introduced when code completion was switched over to use the new solver-based implementation.
- **Risk**: Low. The change only affects the behavior of code completion – not the compiler – and is small.
- **Testing**: Added a regression test for this case, checked it had no noticeable impact on code completion performance in small and complex expressions, and the existing regression tests pass. 
- **Reviewer**: Pavel Yaskevich (@xedin) reviewed on the main branch PR

Resolves rdar://problem/73282163