### PR TITLE
IRGen: Only emit PragmaCommentDecls if building for Windows, or LTO is enabled

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "IRGenModule.h"
+#include "swift/AST/IRGenOptions.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclGroup.h"
@@ -145,14 +146,20 @@ IRGenModule::getAddrOfClangGlobalDecl(clang::GlobalDecl global,
 }
 
 void IRGenModule::finalizeClangCodeGen() {
-  // Ensure that code is emitted for any `PragmaCommentDecl`s. (These are
-  // always guaranteed to be directly below the TranslationUnitDecl.)
-  // In Clang, this happens automatically during the Sema phase, but here we
-  // need to take care of it manually because our Clang CodeGenerator is not
-  // attached to Clang Sema as an ASTConsumer.
-  for (const auto *D : ClangASTContext->getTranslationUnitDecl()->decls()) {
-    if (const auto *PCD = dyn_cast<clang::PragmaCommentDecl>(D)) {
-      emitClangDecl(PCD);
+  // FIXME: We try to avoid looking for PragmaCommentDecls unless we need to,
+  // since clang::DeclContext::decls_begin() can trigger expensive
+  // de-serialization.
+  if (Triple.isWindowsMSVCEnvironment() || Triple.isWindowsItaniumEnvironment() ||
+      IRGen.Opts.LLVMLTOKind != IRGenLLVMLTOKind::None) {
+    // Ensure that code is emitted for any `PragmaCommentDecl`s. (These are
+    // always guaranteed to be directly below the TranslationUnitDecl.)
+    // In Clang, this happens automatically during the Sema phase, but here we
+    // need to take care of it manually because our Clang CodeGenerator is not
+    // attached to Clang Sema as an ASTConsumer.
+    for (const auto *D : ClangASTContext->getTranslationUnitDecl()->decls()) {
+      if (const auto *PCD = dyn_cast<clang::PragmaCommentDecl>(D)) {
+        emitClangDecl(PCD);
+      }
     }
   }
 


### PR DESCRIPTION
`clang::DeclContext::decls_begin()` deserializes all the pre-compiled headers
imported into the current translation unit, which is expensive.

Workaround this by disabling the emission of PragmaCommentDecls unless we're
building for a Windows target, or LTO is enabled.

A better fix would be to serialize a separate index for PragmaCommentDecls
so that they can be deserialized without deserializing everything else.
I filed rdar://problem/74036099 to track the longer-term fix.

Fixes rdar://problem/73951264.