### PR TITLE
Frontend: allow retrying expanding response files in argument lists

### DIFF
--- a/include/swift/Driver/FrontendUtil.h
+++ b/include/swift/Driver/FrontendUtil.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/StringSaver.h"
 
 #include <memory>
 
@@ -23,6 +24,11 @@ namespace swift {
 class DiagnosticEngine;
 
 namespace driver {
+/// Expand response files in the argument list with retrying.
+/// This function is a wrapper of lvm::cl::ExpandResponseFiles. It will
+/// retry calling the function if the previous expansion failed.
+void ExpandResponseFilesWithRetry(llvm::StringSaver &Saver,
+                                  llvm::SmallVectorImpl<const char *> &Args);
 
 /// Generates the list of arguments that would be passed to the compiler
 /// frontend from the given driver arguments.

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -26,6 +26,20 @@
 using namespace swift;
 using namespace swift::driver;
 
+void swift::driver::ExpandResponseFilesWithRetry(llvm::StringSaver &Saver,
+                                llvm::SmallVectorImpl<const char *> &Args) {
+  const unsigned MAX_COUNT = 30;
+  for (unsigned I = 0; I != MAX_COUNT; ++I) {
+    if (llvm::cl::ExpandResponseFiles(Saver,
+        llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()
+          ? llvm::cl::TokenizeWindowsCommandLine
+          : llvm::cl::TokenizeGNUCommandLine,
+        Args)) {
+      return;
+    }
+  }
+}
+
 bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
     ArrayRef<const char *> Argv, DiagnosticEngine &Diags,
     llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action,
@@ -52,12 +66,7 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
   // Expand any file list args.
   llvm::BumpPtrAllocator Allocator;
   llvm::StringSaver Saver(Allocator);
-  llvm::cl::ExpandResponseFiles(
-      Saver,
-      llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()
-          ? llvm::cl::TokenizeWindowsCommandLine
-          : llvm::cl::TokenizeGNUCommandLine,
-      Args);
+  ExpandResponseFilesWithRetry(Saver, Args);
 
   // Force the driver into batch mode by specifying "swiftc" as the name.
   Driver TheDriver("swiftc", "swiftc", Args, Diags);

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -281,12 +281,7 @@ int main(int argc_, const char **argv_) {
   SmallVector<const char *, 256> ExpandedArgs(&argv_[0], &argv_[argc_]);
   llvm::BumpPtrAllocator Allocator;
   llvm::StringSaver Saver(Allocator);
-  llvm::cl::ExpandResponseFiles(
-      Saver,
-      llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()
-          ? llvm::cl::TokenizeWindowsCommandLine
-          : llvm::cl::TokenizeGNUCommandLine,
-      ExpandedArgs);
+  swift::driver::ExpandResponseFilesWithRetry(Saver, ExpandedArgs);
 
   // Initialize the stack trace using the parsed argument vector with expanded
   // response files.


### PR DESCRIPTION
We've seen bad file descriptor errors in certain build environments (rdar://73157185) and retrying
opening those files seems to be a walk-around. In this change, we allow the
compiler to retry expanding response files in argument lists.

rdar://73892564
