### PR TITLE
Ban @objc Methods that Introduce Constraints on Contextually Generic Methods

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4690,6 +4690,9 @@ ERROR(objc_invalid_on_static_subscript,none,
 ERROR(objc_invalid_with_generic_params,none,
       "%0 cannot be %" OBJC_ATTR_SELECT "1 because it has generic parameters",
       (DescriptiveDeclKind, unsigned))
+ERROR(objc_invalid_with_generic_requirements,none,
+      "%0 cannot be %" OBJC_ATTR_SELECT "1 because it has a 'where' clause",
+      (DescriptiveDeclKind, unsigned))
 ERROR(objc_convention_invalid,none,
       "%0 is not representable in Objective-C, so it cannot be used"
       " with '@convention(%1)'", (Type, StringRef))

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -327,6 +327,17 @@ static bool checkObjCWithGenericParams(const ValueDecl *VD, ObjCReason Reason) {
     return true;
   }
 
+  if (GC->getTrailingWhereClause()) {
+    // Diagnose this problem, if asked to.
+    if (Diagnose) {
+      VD->diagnose(diag::objc_invalid_with_generic_requirements,
+                   VD->getDescriptiveKind(), getObjCDiagnosticAttrKind(Reason));
+      describeObjCReason(VD, Reason);
+    }
+
+    return true;
+  }
+
   return false;
 }
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -413,6 +413,11 @@ class GenericContext3<T> {
   }
 }
 
+class GenericContext4<T> {
+  @objc
+  func foo() where T: Hashable { } // expected-error {{instance method cannot be marked @objc because it has a 'where' clause}}
+}
+
 @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class ConcreteSubclassOfGeneric : GenericContext3<Int> {}
 


### PR DESCRIPTION
SE-0267 makes this legal in Swift, but these constraints are
unrepresentable in Objective-C and often lead to blow-ups in SILGen when
we construct invalid SIL signatures.

rdar://71845752