### PR TITLE
IRGen: repair the windows build of Foundation

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1570,6 +1570,16 @@ bool IRGenModule::finalize() {
     DebugInfo->finalize();
   cleanupClangCodeGenMetadata();
 
+  // Clean up DSOLocal & DLLImport attributes, they cannot be applied together.
+  // The imported declarations are marked as DSO local by default.
+  for (auto &GV : Module.globals())
+    if (GV.hasDLLImportStorageClass())
+      GV.setDSOLocal(false);
+
+  for (auto &F : Module.functions())
+    if (F.hasDLLImportStorageClass())
+      F.setDSOLocal(false);
+
   return true;
 }
 


### PR DESCRIPTION
Foundation imports `free`, importing it as `dllimport dso_local` which
is not permitted.  Clean up the IRGen to ensure that the two are not
emitted together.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
