### PR TITLE
[sourcekitd-test] Add option to count the number of instructions executed during a request

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -70,6 +70,10 @@ class Stmt;
 class TypeRepr;
 struct FingerprintAndMembers;
 
+/// Get the number of instructions executed since this process was launched.
+/// Returns 0 if the number of instructions executed could not be determined.
+uint64_t getInstructionsExecuted();
+
 // There are a handful of cases where the swift compiler can introduce
 // counter-measurement noise via nondeterminism, especially via
 // parallelism; inhibiting all such cases reliably using existing avenues

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -10,12 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/AST/Decl.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
-#include "swift/AST/Decl.h"
-#include "swift/AST/Expr.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/FileSystem.h"
@@ -57,6 +54,16 @@ bool environmentVariableRequestedMaximumDeterminism() {
   if (const char *S = ::getenv("SWIFTC_MAXIMUM_DETERMINISM"))
     return (S[0] != '\0');
   return false;
+}
+
+uint64_t getInstructionsExecuted() {
+#if defined(HAVE_PROC_PID_RUSAGE) && defined(RUSAGE_INFO_V4)
+  struct rusage_info_v4 ru;
+  if (proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru) == 0) {
+    return ru.ri_instructions;
+  }
+#endif
+  return 0;
 }
 
 static std::string
@@ -510,12 +517,9 @@ FrontendStatsTracer::~FrontendStatsTracer()
 // associated fields in the provided AlwaysOnFrontendCounters.
 void updateProcessWideFrontendCounters(
     UnifiedStatsReporter::AlwaysOnFrontendCounters &C) {
-#if defined(HAVE_PROC_PID_RUSAGE) && defined(RUSAGE_INFO_V4)
-  struct rusage_info_v4 ru;
-  if (0 == proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&ru)) {
-    C.NumInstructionsExecuted = ru.ri_instructions;
+  if (auto instrExecuted = getInstructionsExecuted()) {
+    C.NumInstructionsExecuted = instrExecuted;
   }
-#endif
 
 #if defined(HAVE_MALLOC_ZONE_STATISTICS) && defined(HAVE_MALLOC_MALLOC_H)
   // On Darwin we have a lifetime max that's maintained by malloc we can

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -130,6 +130,9 @@ def cancel_on_subsequent_request_EQ : Joined<["-"], "cancel-on-subsequent-reques
 def time_request : Flag<["-"], "time-request">,
   HelpText<"Print the time taken to process the request">;
 
+def time_request_instr : Flag<["-"], "time-request-instr">,
+  HelpText<"If -time-request is specified, also print the number of instructions executed during the request. Note that this only gives meaningful results if using the in process sourcekitd since sourcekitd-test cannot measure the number of instructions exectuted by the XPC service.">;
+
 def repeat_request : Separate<["-"], "repeat-request">,
   HelpText<"Repeat the request n times">, MetaVarName<"<n>">;
 def repeat_request_EQ : Joined<["-"], "repeat-request=">, Alias<repeat_request>;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -345,6 +345,10 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       timeRequest = true;
       break;
 
+    case OPT_time_request_instr:
+      timeRequestInstr = true;
+      break;
+
     case OPT_repeat_request:
       if (StringRef(InputArg->getValue()).getAsInteger(10, repeatRequest)) {
         llvm::errs() << "error: expected integer for 'cancel-on-subsequent-request'\n";

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -112,6 +112,7 @@ struct TestOptions {
   bool CollectActionables = false;
   bool isAsyncRequest = false;
   bool timeRequest = false;
+  bool timeRequestInstr = false;
   llvm::Optional<bool> OptimizeForIde;
   bool SuppressDefaultConfigRequest = false;
   llvm::Optional<unsigned> CompletionCheckDependencyInterval;


### PR DESCRIPTION
The number of instructions executed gives a pretty stable measurement that's a good proxy for the time an operation took.

To use this in `sourcekitd-test`, we need to use an in-process `sourcekitd` (since `sourcekitd-test` cannot by itself inspect the instruction counter) of an XPC service.

I'm putting this behind an additional flag for now because whoever uses it, should do so deliberately and understand the limitation that this counter only gives meaningful results when used together with an in-process `sourcekitd`.