### PR TITLE
[Sema] Corrections for for-await-in syntax to prevent specific bad code-gen scenarios and improve diagnostics

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2295,6 +2295,13 @@ FunctionType::ExtInfo ConstraintSystem::closureEffects(ClosureExpr *expr) {
         return { false, stmt };
       }
 
+      if (auto forEach = dyn_cast<ForEachStmt>(stmt)) {
+        if (forEach->getTryLoc().isValid()) {
+          FoundThrow = true;
+          return { false, nullptr };
+        }
+      }
+
       return { true, stmt };
     }
 
@@ -2330,6 +2337,17 @@ FunctionType::ExtInfo ConstraintSystem::closureEffects(ClosureExpr *expr) {
         return false;
 
       return true;
+    }
+
+    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override { 
+      if (auto forEach = dyn_cast<ForEachStmt>(stmt)) {
+        if (forEach->getAwaitLoc().isValid()) {
+          FoundAsync = true;
+          return { false, nullptr };
+        }
+      }
+
+      return { true, stmt };
     }
 
   public:

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -592,17 +592,9 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
   // check to see if the sequence expr is throwing (and async), if so require 
   // the stmt to have a try loc
   if (stmt->getAwaitLoc().isValid()) {
-    auto Ty = sequence->getType();
-    if (Ty.isNull()) { 
-      auto DRE = dyn_cast<DeclRefExpr>(sequence);
-      if (DRE) {
-        Ty = DRE->getDecl()->getInterfaceType();
-      }
-      if (Ty.isNull()) {
-        return failed();
-      }
-    }
-    
+    // fetch the sequence out of the statement
+    // else wise the value is potentially unresolved
+    auto Ty = stmt->getSequence()->getType();
     auto module = dc->getParentModule();
     auto conformanceRef = module->lookupConformance(Ty, sequenceProto);
     

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2096,6 +2096,12 @@ private:
                         Classification::forThrow(PotentialThrowReason::forThrow(),
                                                  /*async*/false));
     }
+    if (S->getAwaitLoc().isValid() && 
+        !Flags.has(ContextFlags::HasAnyAsyncSite)) {
+      if (!CurContext.handlesAsync()) {
+        CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, S);
+      }
+    }
     return ShouldRecurse;
   }
 };

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -528,6 +528,13 @@ public:
       }
 
       if (classifiedAsThrows) {
+        // multiple passes can occur, so ensure that any sub-expressions of this
+        // call are marked as throws to mimic the closure variant.
+        if (auto subExpr = dyn_cast<ApplyExpr>(E->getFn())) {
+          if (!subExpr->isThrowsSet()) {
+            subExpr->setThrows(true);
+          }
+        }
         return Classification::forRethrowingOnly(
           PotentialThrowReason::forRethrowsConformance(E), isAsync);
       }

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+// expected-note@+1{{add 'async' to function 'missingAsync' to make it asynchronous}}
+func missingAsync<T : AsyncSequence>(_ seq: T) throws { 
+  for try await _ in seq { } // expected-error{{'async' in a function that does not support concurrency}}
+}
+
+func missingThrows<T : AsyncSequence>(_ seq: T) async {
+  for try await _ in seq { } // expected-error{{error is not handled because the enclosing function is not declared 'throws'}}
+}
+
+func executeAsync(_ work: () async -> Void) { }
+func execute(_ work: () -> Void) { }
+
+func missingThrowingInBlock<T : AsyncSequence>(_ seq: T) { 
+  executeAsync { // expected-error{{invalid conversion from throwing function of type '() async throws -> Void' to non-throwing function type '() async -> Void'}}
+    for try await _ in seq { }
+  }
+}
+
+func missingTryInBlock<T : AsyncSequence>(_ seq: T) { 
+  executeAsync { 
+    for await _ in seq { } // expected-error{{call can throw, but the error is not handled}}
+  }
+}
+
+func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) { 
+  execute { // expected-error{{invalid conversion from 'async' function of type '() async -> Void' to synchronous function type '() -> Void'}}
+    do { 
+      for try await _ in seq { }
+    } catch { }
+  }
+}

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -32,3 +32,26 @@ func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) {
     } catch { }
   }
 }
+
+func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
+  var it = seq.makeAsyncIterator()
+  // expected-note@+2{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+  // expected-error@+1{{call can throw, but it is not marked with 'try' and the error is not handled}}
+  let _ = await it.next()
+}
+
+struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
+  typealias Element = Int
+  typealias AsyncIterator = Self
+  mutating func next() async throws -> Int? {
+    return nil
+  }
+
+  func makeAsyncIterator() -> Self { return self }
+}
+
+func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
+  var it = seq.makeAsyncIterator()
+  // expected-error@+1{{call can throw, but it is not marked with 'try' and the error is not handled}}
+  let _ = await it.next()
+}


### PR DESCRIPTION
SILGen verification crash when no other async functions are called in a function body not marked as async when a for-await-in syntax is used. This corrects the diagnostics to ensure that the type check effects sees the proper async call that the for-await-in syntax infers.

for-await-in syntax was missing a diagnistic hint for inserting a try when the protocol conformance of the sequence shows a potential of throwing. (also there was a superfluous check for the nominal type in that type check (which was removed).

for-await-in syntax and for-try-await-in syntax did not infer async or throwing to closure constraints, both were added to properly identify the asyncy-ness/throwy-ness of the iteration.

Resolves:
rdar://73952786
rdar://73883058
rdar://73953266
rdar://73995416
rdar://74008250