### PR TITLE
Avoid false FileDependnecies among Implicitly-built Swift and Clang modules

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1292,18 +1292,28 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // required by sourcekitd.
   subClangImporterOpts.DetailedPreprocessingRecord =
     clangImporterOpts.DetailedPreprocessingRecord;
+
   // We need to add these extra clang flags because explict module building
   // related flags are all there: -fno-implicit-modules, -fmodule-map-file=,
   // and -fmodule-file=.
   // If we don't add these flags, the interface will be built with implicit
   // PCMs.
-  subClangImporterOpts.ExtraArgs = clangImporterOpts.ExtraArgs;
-  for (auto arg: subClangImporterOpts.ExtraArgs) {
-    GenericArgs.push_back("-Xcc");
-    GenericArgs.push_back(ArgSaver.save(arg));
+  // FIXME: With Implicit Module Builds, if sub-invocations inherit `-fmodule-map-file=` options,
+  // those modulemaps become File dependencies of all downstream PCMs and their depending Swift
+  // modules, triggering unnecessary re-builds. We work around this by only inheriting these options
+  // when building with explicit modules. While this problem will not manifest with Explicit Modules
+  // (which do not use the ClangImporter to build PCMs), we may still need a better way to
+  // decide which options must be inherited here.
+  if (LoaderOpts.disableImplicitSwiftModule) {
+    subClangImporterOpts.ExtraArgs = clangImporterOpts.ExtraArgs;
+    for (auto arg : subClangImporterOpts.ExtraArgs) {
+      GenericArgs.push_back("-Xcc");
+      GenericArgs.push_back(ArgSaver.save(arg));
+    }
   }
 
-  // Tell the genericSubInvocation to serialize dependency hashes if asked to do so.
+  // Tell the genericSubInvocation to serialize dependency hashes if asked to do
+  // so.
   auto &frontendOpts = genericSubInvocation.getFrontendOptions();
   frontendOpts.SerializeModuleInterfaceDependencyHashes =
     serializeDependencyHashes;

--- a/test/ModuleInterface/Inputs/implicit-options-inheritance/CIMod.h
+++ b/test/ModuleInterface/Inputs/implicit-options-inheritance/CIMod.h
@@ -1,0 +1,1 @@
+void funcCI(void);

--- a/test/ModuleInterface/Inputs/implicit-options-inheritance/SIMod.swiftinterface
+++ b/test/ModuleInterface/Inputs/implicit-options-inheritance/SIMod.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enforce-exclusivity=checked -module-name SIMod 
+import CIMod
+

--- a/test/ModuleInterface/Inputs/implicit-options-inheritance/module.modulemap
+++ b/test/ModuleInterface/Inputs/implicit-options-inheritance/module.modulemap
@@ -1,0 +1,4 @@
+module CIMod {
+  header "CIMod.h"
+  export *
+}

--- a/test/ModuleInterface/Inputs/implicit-options-inheritance/test-dummy.modulemap
+++ b/test/ModuleInterface/Inputs/implicit-options-inheritance/test-dummy.modulemap
@@ -1,0 +1,4 @@
+module Dummy {
+  header "Dummy.h"
+  export *
+}

--- a/test/ModuleInterface/no-implicit-extra-clang-opts.swift
+++ b/test/ModuleInterface/no-implicit-extra-clang-opts.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ModuleCache)
+
+import SIMod
+
+// Step 0: Copy relevant files into the temp dir which will serve as the search path
+// RUN: cp %S/Inputs/implicit-options-inheritance/module.modulemap %t/module.modulemap
+// RUN: cp %S/Inputs/implicit-options-inheritance/CIMod.h %t/CIMod.h
+// RUN: cp %S/Inputs/implicit-options-inheritance/SIMod.swiftinterface %t/SIMod.swiftinterface
+
+// Step 1: Build this file, causing an implicit build of SIMod and CIMod into the module cache.
+// Pass in a clang arg pointing it to a modulemap that has nothing to do with downstream modules and is not on the search path.
+
+// RUN: %target-swift-frontend -emit-module -module-name no-implicit-extra-clang-maps -o %t/no-implicit-extra-clang-maps.swiftmodule %s -I %t -Xcc -fmodule-map-file=%S/Inputs/implicit-options-inheritance/test-dummy.modulemap -module-cache-path %t/ModuleCache
+
+// Step 2: Touch the dummy modulemap we passed in with `-Xcc -fmodule-map-file` above.
+// RUN: touch %S/Inputs/implicit-options-inheritance/test-dummy.modulemap
+
+// Step 3: Re-build this file, and ensure we are not re-building SIMod due to a dependency on the dummy file
+// RUN: %target-swift-frontend -emit-module -module-name no-implicit-extra-clang-maps -o %t/no-implicit-extra-clang-maps.swiftmodule %s -I %t -Xcc -fmodule-map-file=%S/Inputs/implicit-options-inheritance/test-dummy.modulemap -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild 2>&1 | %FileCheck -allow-empty %s
+
+// Step 4: Ensure that SIMod was not re-built
+// CHECK-NOT: remark: rebuilding module 'SIMod' from interface
+// CHECK-NOT: note: cached module is out of date
+// CHECK-NOT: note: dependency is out of date


### PR DESCRIPTION
This is a cherry-pick of a bug-fix submitted in: https://github.com/apple/swift/pull/35749

`InterfaceSubContextDelegateImpl` causes sub-instances to inherit `-fmodule-map-file=` options.
Those Module Maps become file dependencies of all downstream PCMs and their depending Swift modules, even though they really aren't.
This causes frequent re-builds of the Module Cache contents when seemingly-unrelated files are touched.

Explicit Module Builds rely on these options for building Swift Interface files, so for now we just disable inheritance of these options in Implicit Module builds.

