### PR TITLE
Ensure that delayed diagnostics in protocol conformance checking are emitted.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -986,7 +986,13 @@ public:
 
   /// Check whether current context has any errors associated with
   /// ill-formed protocol conformances which haven't been produced yet.
-  bool hasDelayedConformanceErrors() const;
+  ///
+  /// @param conformance if non-null, will check only for errors specific to the
+  /// provided conformance. Otherwise, checks for _any_ errors.
+  ///
+  /// @returns true iff there are any delayed diagnostic errors
+  bool hasDelayedConformanceErrors(
+                  NormalProtocolConformance const* conformance = nullptr) const;
 
   /// Add a delayed diagnostic produced while type-checking a
   /// particular protocol conformance.
@@ -996,7 +1002,7 @@ public:
   /// Retrieve the delayed-conformance diagnostic callbacks for the
   /// given normal protocol conformance.
   std::vector<DelayedConformanceDiag>
-  takeDelayedConformanceDiags(NormalProtocolConformance *conformance);
+  takeDelayedConformanceDiags(NormalProtocolConformance const* conformance);
 
   /// Add delayed missing witnesses for the given normal protocol conformance.
   void addDelayedMissingWitnesses(

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -815,6 +815,8 @@ public:
                      llvm::SetVector<MissingWitness> &GlobalMissingWitnesses,
                      bool suppressDiagnostics = true);
 
+  ~ConformanceChecker();
+
   /// Resolve all of the type witnesses.
   void resolveTypeWitnesses();
 

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -22,7 +22,7 @@ extension C2 {
 // a version of C2 that requires both sync and async methods (differing only by
 // completion handler) in ObjC, is not possible to conform to with 'async' in
 // a Swift protocol
-class C3 : NSObject, RequiredObserver {}
+class C3 : NSObject, RequiredObserver {} // expected-error {{type 'C3' does not conform to protocol 'RequiredObserver'}}
 extension C3 {
   func hello() -> Bool { true } // expected-note {{'hello()' previously declared here}}
   func hello() async -> Bool { true } // expected-error {{invalid redeclaration of 'hello()'}}


### PR DESCRIPTION
It was recently discovered that some delayed conformance error diagnostics are not being emitted by the `MultiConformanceChecker`. While the desire to even have this delayed diagnostics infrastructure is ripe for debate, for now I think it would be good make the `MultiConformanceChecker` and `ConformanceChecker` destructors more robust by ensuring that they check for lost diagnostics. 

For `MultiConformanceChecker` we now try to force-flush delayed diagnostics if one of its `ConformanceChecker`s has not already complained. I also added an assert in `ConformanceChecker` to identify obviously-forgotten diagnostics.

As a result, this PR fixes one missing "does not conform to protocol" error diagnostic that was not being emitted.

Fixes rdar://73641790