### PR TITLE
GSB: Optimize PotentialArchetype::getDependentType()

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1042,8 +1042,6 @@ ERROR(expected_else_after_guard,PointsToFirstBadToken,
       "expected 'else' after 'guard' condition", ())
 ERROR(expected_lbrace_after_guard,PointsToFirstBadToken,
       "expected '{' after 'guard' else", ())
-ERROR(bound_var_guard_body,none,
-      "variable declared in 'guard' condition is not usable in its body", ())
 
 // While Statement
 ERROR(expected_condition_while,PointsToFirstBadToken,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1477,30 +1477,16 @@ struct GenericSignatureBuilder::Constraint {
 };
 
 class GenericSignatureBuilder::PotentialArchetype {
-  /// The parent of this potential archetype (for a nested type) or the
-  /// ASTContext in which the potential archetype resides.
-  llvm::PointerUnion<PotentialArchetype*, ASTContext*> parentOrContext;
-
-  /// The identifier describing this particular archetype.
-  ///
-  /// \c parentOrBuilder determines whether we have a nested type vs. a root.
-  union PAIdentifier {
-    /// The associated type for a resolved nested type.
-    AssociatedTypeDecl *assocType;
-
-    /// The generic parameter key for a root.
-    GenericParamKey genericParam;
-
-    PAIdentifier(AssociatedTypeDecl *assocType) : assocType(assocType) {}
-
-    PAIdentifier(GenericParamKey genericParam) : genericParam(genericParam) { }
-  } identifier;
+  /// The parent of this potential archetype, for a nested type.
+  PotentialArchetype* parent;
 
   /// The representative of the equivalence class of potential archetypes
   /// to which this potential archetype belongs, or (for the representative)
   /// the equivalence class itself.
   mutable llvm::PointerUnion<PotentialArchetype *, EquivalenceClass *>
     representativeOrEquivClass;
+
+  mutable CanType depType;
 
   /// A stored nested type.
   struct StoredNestedType {
@@ -1539,7 +1525,7 @@ class GenericSignatureBuilder::PotentialArchetype {
   PotentialArchetype(PotentialArchetype *parent, AssociatedTypeDecl *assocType);
 
   /// Construct a new potential archetype for a generic parameter.
-  PotentialArchetype(ASTContext &ctx, GenericParamKey genericParam);
+  explicit PotentialArchetype(GenericTypeParamType *genericParam);
 
 public:
   /// Retrieve the representative for this archetype, performing
@@ -1558,42 +1544,17 @@ public:
   /// Retrieve the parent of this potential archetype, which will be non-null
   /// when this potential archetype is an associated type.
   PotentialArchetype *getParent() const { 
-    return parentOrContext.dyn_cast<PotentialArchetype *>();
+    return parent;
   }
 
   /// Retrieve the type declaration to which this nested type was resolved.
   AssociatedTypeDecl *getResolvedType() const {
-    assert(getParent() && "Not an associated type");
-    return identifier.assocType;
+    return cast<DependentMemberType>(depType)->getAssocType();
   }
 
   /// Determine whether this is a generic parameter.
   bool isGenericParam() const {
-    return parentOrContext.is<ASTContext *>();
-  }
-
-  /// Retrieve the generic parameter key for a potential archetype that
-  /// represents this potential archetype.
-  ///
-  /// \pre \c isGenericParam()
-  GenericParamKey getGenericParamKey() const {
-    assert(isGenericParam() && "Not a generic parameter");
-    return identifier.genericParam;
-  }
-
-  /// Retrieve the generic parameter key for the generic parameter at the
-  /// root of this potential archetype.
-  GenericParamKey getRootGenericParamKey() const {
-    if (auto parent = getParent())
-      return parent->getRootGenericParamKey();
-
-    return getGenericParamKey();
-  }
-
-  /// Retrieve the name of a nested potential archetype.
-  Identifier getNestedName() const {
-    assert(getParent() && "Not a nested type");
-    return identifier.assocType->getName();
+    return parent == nullptr;
   }
 
   /// Retrieve the set of nested types.
@@ -1645,10 +1606,16 @@ public:
 
   /// Retrieve the dependent type that describes this potential
   /// archetype.
+  CanType getDependentType() const {
+    return depType;
+  }
+
+  /// Retrieve the dependent type that describes this potential
+  /// archetype.
   ///
   /// \param genericParams The set of generic parameters to use in the resulting
   /// dependent type.
-  Type getDependentType(TypeArrayView<GenericTypeParamType> genericParams)const;
+  Type getDependentType(TypeArrayView<GenericTypeParamType> genericParams) const;
 
   /// True if the potential archetype has been bound by a concrete type
   /// constraint.
@@ -1658,9 +1625,6 @@ public:
 
     return false;
   }
-
-  /// Retrieve the AST context in which this potential archetype resides.
-  ASTContext &getASTContext() const;
 
   SWIFT_DEBUG_DUMP;
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -160,8 +160,8 @@ public:
     /// Describes a component within the graph of same-type constraints within
     /// the equivalence class that is held together by derived constraints.
     struct DerivedSameTypeComponent {
-      /// The potential archetype that acts as the anchor for this component.
-      UnresolvedType anchor;
+      /// The type that acts as the anchor for this component.
+      Type type;
 
       /// The (best) requirement source within the component that makes the
       /// potential archetypes in this component equivalent to the concrete

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5659,8 +5659,7 @@ public:
   }
 };
 BEGIN_CAN_TYPE_WRAPPER(DependentMemberType, Type)
-  static CanDependentMemberType get(CanType base, AssociatedTypeDecl *assocType,
-                                    const ASTContext &C) {
+  static CanDependentMemberType get(CanType base, AssociatedTypeDecl *assocType) {
     return CanDependentMemberType(DependentMemberType::get(base, assocType));
   }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5266,18 +5266,6 @@ static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
   auto genericParams = builder.getGenericParams();
   auto existingMembers = equivClass->members;
   for (auto pa : existingMembers) {
-    // Make sure that there are only associated types that chain up to the
-    // parent.
-    bool foundNonAssociatedType = false;
-    for (auto currentPA = pa; auto parentPA = currentPA->getParent();
-         currentPA = parentPA){
-      if (!currentPA->getResolvedType()) {
-        foundNonAssociatedType = true;
-        break;
-      }
-    }
-    if (foundNonAssociatedType) continue;
-
     auto dependentType = pa->getDependentType(genericParams);
     for (const auto &conforms : equivClass->conformsTo) {
       auto proto = conforms.first;

--- a/lib/AST/GenericSignatureBuilderImpl.h
+++ b/lib/AST/GenericSignatureBuilderImpl.h
@@ -45,6 +45,10 @@ public:
   }
 
   /// Retrieve the dependent type.
+  CanType getDependentType() const;
+
+  /// Retrieve the dependent type, possibly sugared with the builder's generic
+  /// parameters.
   Type getDependentType(GenericSignatureBuilder &builder) const;
 
   /// Retrieve the concrete type, or a null type if this result doesn't store


### PR DESCRIPTION
We were spending a lot of time in DependentMemberType::get(), via PotentialArchetype::getDependentType(), which is a recursive walk from the root to the leaf. We can reduce this cost with two changes:

- DerivedSameTypeComponent doesn't need to store a `PotentialArchetype *` at all, only a `Type`.
- PotentialArchetype's representation can be changed to just store the canonical dependent type directly, instead of a union of `GenericParamKey` with `AssociatedTypeDecl *`.

We still have to rebuild `DependentMemberType` to "re-sugar" them with the right generic parameter name. While this is important when the type is ultimately meant for user consumption, there are many places where we do it unnecessarily. Fixing those is the next step here.

On this incredibly silly benchmark, an asserts build is now twice as fast as without this change, from ~8 seconds to 4:

```
public protocol P1 {
  associatedtype A
  associatedtype B
  associatedtype C
  associatedtype D
}

public protocol P2 {
  associatedtype A : P1
  associatedtype B : P1
  associatedtype C : P1
  associatedtype D : P1
}

public protocol P3 {
  associatedtype A : P2
  associatedtype B : P2
  associatedtype C : P2
  associatedtype D : P2
}

public protocol P4 {
  associatedtype A : P3
  associatedtype B : P3
  associatedtype C : P3
  associatedtype D : P3
}

public protocol P5 {
  associatedtype A : P4
  associatedtype B : P4
  associatedtype C : P4
  associatedtype D : P4
}

public protocol P6 {
  associatedtype A : P5
  associatedtype B : P5
  associatedtype C : P5
  associatedtype D : P5
}

public protocol P7 {
  associatedtype A : P6
  associatedtype B : P6
  associatedtype C : P6
  associatedtype D : P6
}

public protocol P8 {
  associatedtype A : P7
  associatedtype B : P7
  associatedtype C : P7
  associatedtype D : P7
}

public protocol P9 {
  associatedtype A : P8
  associatedtype B : P8
  associatedtype C : P8
  associatedtype D : P8
}

public protocol P10 {
  associatedtype A : P9
  associatedtype B : P9
  associatedtype C : P9
  associatedtype D : P9
}
```