### PR TITLE
[capture-promotion] Emit a warning when the pass fails to promote a capture of a concurrent function to a by value capture instead of by ref capture.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -645,5 +645,15 @@ NOTE(box_to_stack_cannot_promote_box_to_stack_due_to_escape_location, none,
 
 WARNING(semantic_function_improper_nesting, none, "'@_semantics' function calls non-'@_semantics' function with nested '@_semantics' calls", ())
 
+// Capture promotion diagnostics
+WARNING(capturepromotion_concurrentcapture_mutation, none,
+        "'%0' mutated after capture by concurrent closure", (StringRef))
+NOTE(capturepromotion_concurrentcapture_closure_here, none,
+     "variable captured by concurrent closure", ())
+NOTE(capturepromotion_concurrentcapture_capturinguse_here, none,
+     "capturing use", ())
+NOTE(capturepromotion_variable_defined_here,none,
+     "variable defined here", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -565,6 +565,13 @@ public:
   /// Returns true if this SILType is a differentiable type.
   bool isDifferentiable(SILModule &M) const;
 
+  /// If this is a SILBoxType, return getSILBoxFieldType(). Otherwise, return
+  /// SILType().
+  ///
+  /// \p field Return the type of the ith field of the box. Default set to 0
+  /// since we only support one field today. This is just future proofing.
+  SILType getSILBoxFieldType(const SILFunction *f, unsigned field = 0);
+
   /// Returns the hash code for the SILType.
   llvm::hash_code getHashCode() const {
     return llvm::hash_combine(*this);

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -699,3 +699,11 @@ bool SILType::isEffectivelyExhaustiveEnumType(SILFunction *f) {
   return decl->isEffectivelyExhaustive(f->getModule().getSwiftModule(),
                                        f->getResilienceExpansion());
 }
+
+SILType SILType::getSILBoxFieldType(const SILFunction *f, unsigned field) {
+  auto *boxTy = getASTType()->getAs<SILBoxType>();
+  if (!boxTy)
+    return SILType();
+  return ::getSILBoxFieldType(f->getTypeExpansionContext(), boxTy,
+                              f->getModule().Types, field);
+}

--- a/test/Concurrency/concurrentfunction_capturediagnostics.swift
+++ b/test/Concurrency/concurrentfunction_capturediagnostics.swift
@@ -1,0 +1,221 @@
+// RUN: %target-swift-frontend -enable-experimental-concurrency -verify -emit-sil %s -o - >/dev/null
+
+// REQUIRES: concurrency
+
+func f(_: @escaping @concurrent () -> Void) { }
+open class F {
+  func useConcurrent(_: @escaping @concurrent () -> Void) { }
+}
+
+extension Int {
+  mutating func addOne() {
+    self += 1
+  }
+}
+
+func inoutUserInt(_ t: inout Int) {}
+
+func testCaseTrivialValue() {
+  var i = 17
+  f {
+    print(i + 17)
+    print(i + 18)
+    print(i + 19)
+  }
+
+  i = 20
+  i += 21
+
+  // We only emit a warning here since we use the last write.
+  //
+  // TODO: Should we emit for all writes?
+  i.addOne() // expected-warning {{'i' mutated after capture by concurrent closure}}
+             // expected-note @-14 {{variable defined here}}
+             // expected-note @-14 {{variable captured by concurrent closure}}
+             // expected-note @-14 {{capturing use}}
+             // expected-note @-14 {{capturing use}}
+             // expected-note @-14 {{capturing use}}
+}
+
+func testCaseTrivialValue2() {
+  var i2 = 17
+  f {
+    print(i2 + 17)
+    print(i2 + 18)
+    print(i2 + 19)
+  }
+
+  i2 = 20
+  i2 += 21 // expected-warning {{'i2' mutated after capture by concurrent closure}}
+             // expected-note @-9 {{variable defined here}}
+             // expected-note @-9 {{variable captured by concurrent closure}}
+             // expected-note @-9 {{capturing use}}
+             // expected-note @-9 {{capturing use}}
+             // expected-note @-9 {{capturing use}}
+}
+
+func testCaseTrivialValue3() {
+  var i3 = 17
+  f {
+    print(i3 + 17)
+    print(i3 + 18)
+    print(i3 + 19)
+  }
+
+  i3 = 20 // expected-warning {{'i3' mutated after capture by concurrent closure}}
+          // expected-note @-8 {{variable defined here}}
+          // expected-note @-8 {{variable captured by concurrent closure}}
+          // expected-note @-8 {{capturing use}}
+          // expected-note @-8 {{capturing use}}
+          // expected-note @-8 {{capturing use}}
+}
+
+func testCaseTrivialValue4() {
+  var i4 = 17
+  f {
+    print(i4 + 17)
+    print(i4 + 18)
+    print(i4 + 19)
+  }
+
+  inoutUserInt(&i4) // expected-warning {{'i4' mutated after capture by concurrent closure}}
+                    // expected-note @-8 {{variable defined here}}
+                    // expected-note @-8 {{variable captured by concurrent closure}}
+                    // expected-note @-8 {{capturing use}}
+                    // expected-note @-8 {{capturing use}}
+                    // expected-note @-8 {{capturing use}}
+}
+
+class Klass {
+  var next: Klass? = nil
+}
+func inoutUserKlass(_ k: inout Klass) {}
+func inoutUserOptKlass(_ k: inout Klass?) {}
+
+func testCaseClass() {
+  var i = Klass()
+  f {
+    print(i)
+  }
+
+  i = Klass() // expected-warning {{'i' mutated after capture by concurrent closure}}
+              // expected-note @-6 {{variable defined here}}
+              // expected-note @-6 {{variable captured by concurrent closure}}
+              // expected-note @-6 {{capturing use}}
+}
+
+func testCaseClassInout() {
+  var i2 = Klass()
+  f {
+    print(i2)
+  }
+  inoutUserKlass(&i2) // expected-warning {{'i2' mutated after capture by concurrent closure}}
+                      // expected-note @-5 {{variable defined here}}
+                      // expected-note @-5 {{variable captured by concurrent closure}}
+                      // expected-note @-5 {{capturing use}}
+}
+
+func testCaseClassInoutField() {
+  var i2 = Klass()
+  i2 = Klass()
+  f {
+    print(i2)
+  }
+  // Since we are passing in .next inout and we are using a class this isn't a
+  // violation.
+  inoutUserOptKlass(&i2.next)
+}
+
+////////////////////////////
+// Non Trivial Value Type //
+////////////////////////////
+
+struct NonTrivialValueType {
+  var i: Int
+  var k: Klass? = nil
+
+  init(_ inputI: Int, _ inputKlass: Klass) {
+    self.i = inputI
+    self.k = inputKlass
+  }
+}
+
+func testCaseNonTrivialValue() {
+  var i = NonTrivialValueType(17, Klass())
+  f {
+    // Currently emits a typechecker level error due to some sort of bug in the type checker.
+//    print(i.i + 17)
+//    print(i.i + 18)
+//    print(i.i + 19)
+  }
+
+  i.i = 20
+  i.i += 21
+
+  // We only emit a warning here since we use the last write.
+  //
+  // TODO: Should we emit for all writes?
+  i.i.addOne() // xpected-warning {{'i' mutated after capture by concurrent closure}}
+               // xpected-note @-14 {{variable defined here}}
+               // xpected-note @-14 {{variable captured by concurrent closure}}
+               // xpected-note @-14 {{capturing use}}
+               // xpected-note @-14 {{capturing use}}
+               // xpected-note @-14 {{capturing use}}
+}
+
+func testCaseNonTrivialValueInout() {
+  var i = NonTrivialValueType(17, Klass())
+  f {
+    // Currently emits a typechecker level error due to some sort of bug in the type checker.
+//    print(i.i + 17)
+//    print(i.k ?? "none")
+  }
+
+  // We only emit a warning here since we use the last write.
+  inoutUserOptKlass(&i.k) // xpected-warning {{'i' mutated after capture by concurrent closure}}
+                          // xpected-note @-8 {{variable defined here}}
+                          // xpected-note @-8 {{variable captured by concurrent closure}}
+                          // xpected-note @-8 {{capturing use}}
+                          // xpected-note @-8 {{capturing use}}
+}
+
+protocol MyProt {
+  var i: Int { get set }
+  var k: Klass? { get set }
+}
+
+func testCaseAddressOnlyAllocBoxToStackable<T : MyProt>(i : T) {
+  var i2 = i
+  f {
+    // Currently emits an error due to some sort of bug in the type checker.
+//    print(i2.i + 17)
+//    print(i2.k ?? "none")
+  }
+
+  // TODO: Make sure we emit these once we support address only types!
+  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by concurrent closure}}
+                           // xpected-note @-8 {{variable defined here}}
+                           // xpected-note @-8 {{variable captured by concurrent closure}}
+                           // xpected-note @-8 {{capturing use}}
+                           // xpected-note @-8 {{capturing use}}
+}
+
+// Alloc box to stack can't handle this test case, so show off a bit and make
+// sure we can emit a great diagnostic here!
+func testCaseAddressOnlyNoAllocBoxToStackable<T : MyProt>(i : T) {
+  let f2 = F()
+  var i2 = i
+  f2.useConcurrent {
+    // Currently emits a typechecker level error due to some sort of bug in the type checker.
+//    print(i2.i + 17)
+//    print(i2.k ?? "none")
+  }
+
+  // TODO: Make sure we emit these once we support address only types!
+  inoutUserOptKlass(&i2.k) // xpected-warning {{'i2' mutated after capture by concurrent closure}}
+                           // xpected-note @-8 {{variable defined here}}
+                           // xpected-note @-8 {{variable captured by concurrent closure}}
+                           // xpected-note @-8 {{capturing use}}
+                           // xpected-note @-8 {{capturing use}}
+}
+

--- a/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
+++ b/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
@@ -1,0 +1,95 @@
+// RUN: %target-sil-opt -enable-experimental-concurrency %s
+
+// REQUIRES: concurrency
+
+// This test ensures that the SILVerifier does not enforce (yet) that concurrent
+// functions must have non-box parameters in canonical SIL for address only
+// types.
+
+sil_stage canonical
+
+import Builtin
+
+func f(_: @escaping @concurrent () -> ())
+
+@_hasMissingDesignatedInitializers
+class F {
+  func useConcurrent(_: @escaping @concurrent () -> ())
+  init()
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+class Klass {}
+
+/////////////////////////////////////////
+// Address Only Type Success (For Now) //
+/////////////////////////////////////////
+
+protocol MyProt {
+  var i: Int { get set }
+  var k: FakeOptional<Klass> { get set }
+}
+
+sil @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+sil @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+sil @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+sil @$s37concurrentfunction_capturediagnostics1FCfD : $@convention(method) (@owned F) -> ()
+
+// This is address only so we shouldn't crash.
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF : $@convention(thin) <T where T : MyProt> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  debug_value_addr %0 : $*T, let, name "i", argno 1 // id: %1
+  %2 = alloc_stack $F, var, name "f2"             // users: %34, %33, %7
+  %3 = metatype $@thick F.Type                    // user: %5
+  // function_ref F.__allocating_init()
+  %4 = function_ref @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+  %5 = apply %4(%3) : $@convention(method) (@thick F.Type) -> @owned F // users: %6, %7
+  %6 = copy_value %5 : $F                         // users: %11, %12
+  store %5 to [init] %2 : $*F                     // id: %7
+  %8 = alloc_box $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, var, name "i2" // users: %32, %14, %9
+  %9 = project_box %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, 0 // users: %24, %10
+  copy_addr %0 to [initialization] %9 : $*T       // id: %10
+  %11 = copy_value %6 : $F                        // users: %23, %18
+  destroy_value %6 : $F                           // id: %12
+  // function_ref closure #1 in testCaseAddressOnly2<A>(i:)
+  %13 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+  %14 = copy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // user: %15
+  %15 = partial_apply [callee_guaranteed] %13<T>(%14) : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // users: %17, %22
+  // function_ref F.useConcurrent(_:)
+  %16 = function_ref @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+  %17 = begin_borrow %15 : $@concurrent @callee_guaranteed () -> () // users: %20, %19
+  %18 = begin_borrow %11 : $F                     // users: %21, %19
+  %19 = apply %16(%17, %18) : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> ()
+  end_borrow %17 : $@concurrent @callee_guaranteed () -> () // id: %20
+  end_borrow %18 : $F                             // id: %21
+  destroy_value %15 : $@concurrent @callee_guaranteed () -> () // id: %22
+  destroy_value %11 : $F                          // id: %23
+  %24 = begin_access [modify] [dynamic] %9 : $*T  // users: %31, %26
+  %25 = witness_method $T, #MyProt.k!modify : <Self where Self : MyProt> (inout Self) -> () -> () : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // user: %26
+  (%26, %27) = begin_apply %25<T>(%24) : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // users: %29, %30
+  // function_ref inoutUserOptKlass(_:)
+  %28 = function_ref @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+  %29 = apply %28(%26) : $@convention(thin) (@inout FakeOptional<Klass>) -> ()
+  end_apply %27                                   // id: %30
+  end_access %24 : $*T                            // id: %31
+  destroy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // id: %32
+  destroy_addr %2 : $*F                           // id: %33
+  dealloc_stack %2 : $*F                          // id: %34
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF'
+
+sil_vtable [serialized] F {
+  #F.useConcurrent: (F) -> (@escaping @concurrent () -> ()) -> () : @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF	// F.useConcurrent(_:)
+  #F.init!allocator: (F.Type) -> () -> F : @$s37concurrentfunction_capturediagnostics1FCACycfC	// F.__allocating_init()
+  #F.deinit!deallocator: @$s37concurrentfunction_capturediagnostics1FCfD	// F.__deallocating_deinit
+}

--- a/test/SIL/concurrentclosure_capture_verify_canonical_loadable.sil
+++ b/test/SIL/concurrentclosure_capture_verify_canonical_loadable.sil
@@ -1,0 +1,61 @@
+// RUN: not --crash %target-sil-opt -enable-experimental-concurrency %s
+
+// REQUIRES: concurrency
+
+// This test ensures that the SILVerifier does enforce that concurrent functions
+// must have non-box parameters in canonical SIL for loadable types.
+
+sil_stage canonical
+
+import Builtin
+
+func f(_: @escaping @concurrent () -> ())
+
+@_hasMissingDesignatedInitializers
+class F {
+  func useConcurrent(_: @escaping @concurrent () -> ())
+  init()
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+class Klass {}
+
+////////////////////
+// Loadable Type  //
+////////////////////
+
+sil @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+sil @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+
+// testCaseTrivialValue()
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "i"      // users: %34, %8, %1
+  %1 = project_box %0 : ${ var Int }, 0           // users: %30, %26, %18, %9, %6
+  %2 = integer_literal $Builtin.IntLiteral, 17    // user: %5
+  %3 = metatype $@thin Int.Type                   // user: %5
+  // function_ref Int.init(_builtinIntegerLiteral:)
+  %4 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+  %5 = apply %4(%2, %3) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %6
+  store %5 to [trivial] %1 : $*Int                // id: %6
+  // function_ref closure #1 in testCaseTrivialValue()
+  %7 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+  %8 = copy_value %0 : ${ var Int }               // user: %10
+  %10 = partial_apply [callee_guaranteed] %7(%8) : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // users: %13, %12
+  // function_ref f(_:)
+  %11 = function_ref @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> () // user: %12
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+  destroy_value %10 : $@concurrent @callee_guaranteed () -> () // id: %13
+  destroy_value %0 : ${ var Int }
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF'

--- a/test/SIL/concurrentclosure_capture_verify_raw.sil
+++ b/test/SIL/concurrentclosure_capture_verify_raw.sil
@@ -1,0 +1,128 @@
+// RUN: %target-sil-opt -enable-experimental-concurrency %s
+
+// REQUIRES: concurrency
+
+// This test ensures that the SILVerifier does not enforce that concurrent
+// functions must have non-box parameters in raw SIL.
+
+sil_stage raw
+
+import Builtin
+
+func f(_: @escaping @concurrent () -> ())
+
+@_hasMissingDesignatedInitializers
+class F {
+  func useConcurrent(_: @escaping @concurrent () -> ())
+  init()
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+class Klass {}
+
+////////////////////
+// Loadable Type  //
+////////////////////
+
+sil @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+sil @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+
+// testCaseTrivialValue()
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ var Int }, var, name "i"      // users: %34, %8, %1
+  %1 = project_box %0 : ${ var Int }, 0           // users: %30, %26, %18, %9, %6
+  %2 = integer_literal $Builtin.IntLiteral, 17    // user: %5
+  %3 = metatype $@thin Int.Type                   // user: %5
+  // function_ref Int.init(_builtinIntegerLiteral:)
+  %4 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %5
+  %5 = apply %4(%2, %3) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %6
+  store %5 to [trivial] %1 : $*Int                // id: %6
+  // function_ref closure #1 in testCaseTrivialValue()
+  %7 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyFyyJcfU_ : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // user: %10
+  %8 = copy_value %0 : ${ var Int }               // user: %10
+  mark_function_escape %1 : $*Int                 // id: %9
+  %10 = partial_apply [callee_guaranteed] %7(%8) : $@convention(thin) @concurrent (@guaranteed { var Int }) -> () // users: %13, %12
+  // function_ref f(_:)
+  %11 = function_ref @$s37concurrentfunction_capturediagnostics1fyyyyJcF : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> () // user: %12
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed @concurrent @callee_guaranteed () -> ()) -> ()
+  destroy_value %10 : $@concurrent @callee_guaranteed () -> () // id: %13
+  destroy_value %0 : ${ var Int }
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseTrivialValueyyF'
+
+
+/////////////////////////////////////////
+// Address Only Type Success (For Now) //
+/////////////////////////////////////////
+
+protocol MyProt {
+  var i: Int { get set }
+  var k: FakeOptional<Klass> { get set }
+}
+
+sil @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+sil @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+sil @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+sil @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+sil @$s37concurrentfunction_capturediagnostics1FCfD : $@convention(method) (@owned F) -> ()
+
+// This is address only so we shouldn't crash.
+sil hidden [ossa] @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF : $@convention(thin) <T where T : MyProt> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  debug_value_addr %0 : $*T, let, name "i", argno 1 // id: %1
+  %2 = alloc_stack $F, var, name "f2"             // users: %34, %33, %7
+  %3 = metatype $@thick F.Type                    // user: %5
+  // function_ref F.__allocating_init()
+  %4 = function_ref @$s37concurrentfunction_capturediagnostics1FCACycfC : $@convention(method) (@thick F.Type) -> @owned F // user: %5
+  %5 = apply %4(%3) : $@convention(method) (@thick F.Type) -> @owned F // users: %6, %7
+  %6 = copy_value %5 : $F                         // users: %11, %12
+  store %5 to [init] %2 : $*F                     // id: %7
+  %8 = alloc_box $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, var, name "i2" // users: %32, %14, %9
+  %9 = project_box %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, 0 // users: %24, %10
+  copy_addr %0 to [initialization] %9 : $*T       // id: %10
+  %11 = copy_value %6 : $F                        // users: %23, %18
+  destroy_value %6 : $F                           // id: %12
+  // function_ref closure #1 in testCaseAddressOnly2<A>(i:)
+  %13 = function_ref @$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlFyyJcfU_ : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // user: %15
+  %14 = copy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // user: %15
+  %15 = partial_apply [callee_guaranteed] %13<T>(%14) : $@convention(thin) @concurrent <τ_0_0 where τ_0_0 : MyProt> (@guaranteed <τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <τ_0_0>) -> () // users: %17, %22
+  // function_ref F.useConcurrent(_:)
+  %16 = function_ref @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> () // user: %19
+  %17 = begin_borrow %15 : $@concurrent @callee_guaranteed () -> () // users: %20, %19
+  %18 = begin_borrow %11 : $F                     // users: %21, %19
+  %19 = apply %16(%17, %18) : $@convention(method) (@guaranteed @concurrent @callee_guaranteed () -> (), @guaranteed F) -> ()
+  end_borrow %17 : $@concurrent @callee_guaranteed () -> () // id: %20
+  end_borrow %18 : $F                             // id: %21
+  destroy_value %15 : $@concurrent @callee_guaranteed () -> () // id: %22
+  destroy_value %11 : $F                          // id: %23
+  %24 = begin_access [modify] [dynamic] %9 : $*T  // users: %31, %26
+  %25 = witness_method $T, #MyProt.k!modify : <Self where Self : MyProt> (inout Self) -> () -> () : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // user: %26
+  (%26, %27) = begin_apply %25<T>(%24) : $@yield_once @convention(witness_method: MyProt) <τ_0_0 where τ_0_0 : MyProt> (@inout τ_0_0) -> @yields @inout FakeOptional<Klass> // users: %29, %30
+  // function_ref inoutUserOptKlass(_:)
+  %28 = function_ref @$s37concurrentfunction_capturediagnostics17inoutUserOptKlassyyAA0F0CSgzF : $@convention(thin) (@inout FakeOptional<Klass>) -> () // user: %29
+  %29 = apply %28(%26) : $@convention(thin) (@inout FakeOptional<Klass>) -> ()
+  end_apply %27                                   // id: %30
+  end_access %24 : $*T                            // id: %31
+  destroy_value %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T> // id: %32
+  destroy_addr %2 : $*F                           // id: %33
+  dealloc_stack %2 : $*F                          // id: %34
+  %35 = tuple ()                                  // user: %36
+  return %35 : $()                                // id: %36
+} // end sil function '$s37concurrentfunction_capturediagnostics20testCaseAddressOnly21iyx_tAA6MyProtRzlF'
+
+sil_vtable [serialized] F {
+  #F.useConcurrent: (F) -> (@escaping @concurrent () -> ()) -> () : @$s37concurrentfunction_capturediagnostics1FC13useConcurrentyyyyJcF	// F.useConcurrent(_:)
+  #F.init!allocator: (F.Type) -> () -> F : @$s37concurrentfunction_capturediagnostics1FCACycfC	// F.__allocating_init()
+  #F.deinit!deallocator: @$s37concurrentfunction_capturediagnostics1FCfD	// F.__deallocating_deinit
+}


### PR DESCRIPTION
I also added a SILVerifier check that once we are in canonical SIL all
concurrent functions that are partial applied are banned from having Box
arguments.

I have not added support yet for this for address only types, so we do not crash
on that yet.

----

NOTE: The non trivial test case in this I disabled temporarily pending @dgregor looking at it for a type checker bug potentially.