### PR TITLE
[Driver] Don't check input file existence if a -vfsoverlay arg is present.

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1284,6 +1284,7 @@ void Driver::buildInputs(const ToolChain &TC,
                          const DerivedArgList &Args,
                          InputFileList &Inputs) const {
   llvm::DenseMap<StringRef, StringRef> SourceFileNames;
+  bool HasVFS = Args.hasArg(options::OPT_vfsoverlay);
 
   for (Arg *A : Args) {
     if (A->getOption().getKind() == Option::InputClass) {
@@ -1305,7 +1306,7 @@ void Driver::buildInputs(const ToolChain &TC,
         }
       }
 
-      if (checkInputExistence(*this, Args, Diags, Value))
+      if (HasVFS || checkInputExistence(*this, Args, Diags, Value))
         Inputs.push_back(std::make_pair(Ty, A));
 
       if (Ty == file_types::TY_Swift) {

--- a/test/Driver/vfs.swift
+++ b/test/Driver/vfs.swift
@@ -7,3 +7,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -c -vfsoverlay overlay1.yaml -vfsoverlay overlay2.yaml -vfsoverlay overlay3.yaml %s | %FileCheck --check-prefix=CHECK-MULTIPLE %s
 
 // CHECK-MULTIPLE: bin{{/|\\\\}}swift{{(-frontend|c)?(\.exe)?"?}} -frontend{{.*}}-c{{.*}}-vfsoverlay overlay1.yaml -vfsoverlay overlay2.yaml -vfsoverlay overlay3.yaml
+
+// Verifies that input paths are not rejected prematurely when -vfsoverlay is present as they may exist on the vfs (which the frontend accounts for) even if they don't exist on the real file system.
+// RUN: not %swiftc_driver -driver-print-jobs -c %t/file-not-on-the-real-filesystem.swift
+// RUN: %swiftc_driver -driver-print-jobs -c -vfsoverlay overlay1.yaml %t/file-not-on-the-real-filesystem.swift


### PR DESCRIPTION
Unlike the frontend, the driver doesn't account for any VFS overlays set up by the -vfsoverlay option when processing its input files. It also errors if any of those input files don't exist on the file system. This makes it impossible to use a file that only exists in the VFS as input to the driver, even though the same file would be handled without issue by the frontend.

If the file doesn't exist even accounting for the VFS the frontend still emits a missing file diagnostic, so this change just updates the driver to suppress the existence check for inputs when a -vfsoverlay option is present.

Resolves rdar://problem/72485443