### PR TITLE
SILOptimizer: allow function pointers in static globals and static global arrays.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -201,6 +201,8 @@ public:
   bool isInsertingIntoGlobal() const { return F == nullptr; }
 
   TypeExpansionContext getTypeExpansionContext() const {
+    if (!F)
+      return TypeExpansionContext::minimal();
     return TypeExpansionContext(getFunction());
   }
 
@@ -1027,7 +1029,7 @@ public:
                                              SILType Ty,
                                              bool WithoutActuallyEscaping) {
     return insert(ConvertFunctionInst::create(getSILDebugLocation(Loc), Op, Ty,
-                                              getFunction(), C.OpenedArchetypes,
+                                              getModule(), F, C.OpenedArchetypes,
                                               WithoutActuallyEscaping));
   }
 
@@ -1157,7 +1159,7 @@ public:
   ThinToThickFunctionInst *createThinToThickFunction(SILLocation Loc,
                                                      SILValue Op, SILType Ty) {
     return insert(ThinToThickFunctionInst::create(
-        getSILDebugLocation(Loc), Op, Ty, getFunction(), C.OpenedArchetypes));
+        getSILDebugLocation(Loc), Op, Ty, getModule(), F, C.OpenedArchetypes));
   }
 
   ThickToObjCMetatypeInst *createThickToObjCMetatype(SILLocation Loc,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -967,7 +967,7 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitFunctionRefInst(FunctionRefInst *Inst) {
   SILFunction *OpFunction =
-      getOpFunction(Inst->getInitiallyReferencedFunction());
+      getOpFunction(Inst->getReferencedFunction());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createFunctionRef(
                                     getOpLocation(Inst->getLoc()), OpFunction));

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -128,6 +128,10 @@ public:
   SILLinkage getLinkage() const { return SILLinkage(Linkage); }
   void setLinkage(SILLinkage linkage) { Linkage = unsigned(linkage); }
 
+  /// Returns true if the linkage of the SILFunction indicates that the global
+  /// might be referenced from outside the current compilation unit.
+  bool isPossiblyUsedExternally() const;
+
   /// Get this global variable's serialized attribute.
   IsSerialized_t isSerialized() const;
   void setSerialized(IsSerialized_t isSerialized);

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4815,7 +4815,7 @@ class ConvertFunctionInst final
 
   static ConvertFunctionInst *create(SILDebugLocation DebugLoc,
                                      SILValue Operand, SILType Ty,
-                                     SILFunction &F,
+                                     SILModule &Mod, SILFunction *F,
                                      SILOpenedArchetypesState &OpenedArchetypes,
                                      bool WithoutActuallyEscaping);
 
@@ -5165,8 +5165,8 @@ class ThinToThickFunctionInst final
             Operand.getOwnershipKind()) {}
 
   static ThinToThickFunctionInst *
-  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
-         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty, SILModule &Mod,
+         SILFunction *F, SILOpenedArchetypesState &OpenedArchetypes);
 
 public:
   /// Return the callee of the thin_to_thick_function.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2756,9 +2756,9 @@ public:
 };
 
 class FunctionRefBaseInst : public LiteralInst {
+protected:
   SILFunction *f;
 
-protected:
   FunctionRefBaseInst(SILInstructionKind Kind, SILDebugLocation DebugLoc,
                       SILFunction *F, TypeExpansionContext context);
 
@@ -2819,6 +2819,9 @@ class FunctionRefInst : public FunctionRefBaseInst {
                   TypeExpansionContext context);
 
 public:
+  /// Return the referenced function.
+  SILFunction *getReferencedFunction() const { return f; }
+
   static bool classof(SILNodePointer node) {
     return node->getKind() == SILNodeKind::FunctionRefInst;
   }

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -69,7 +69,7 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
 
       if (!Cloner.Inlining) {
         FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(AI.getCallee());
-        if (FRI && FRI->getInitiallyReferencedFunction() == AI.getFunction() &&
+        if (FRI && FRI->getReferencedFunction() == AI.getFunction() &&
             Subs == Cloner.SubsMap) {
           // Handle recursions by replacing the apply to the callee with an
           // apply to the newly specialized function, but only if substitutions

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -140,8 +140,8 @@ PASS(DCE, "dce",
      "Dead Code Elimination")
 PASS(DeadArgSignatureOpt, "dead-arg-signature-opt",
      "Dead Argument Elimination via Function Specialization")
-PASS(DeadFunctionElimination, "sil-deadfuncelim",
-     "Dead Function Elimination")
+PASS(DeadFunctionAndGlobalElimination, "sil-deadfuncelim",
+     "Dead Function and Global Variable Elimination")
 PASS(DeadObjectElimination, "deadobject-elim",
      "Dead Object Elimination for Classes with Trivial Destruction")
 PASS(DefiniteInitialization, "definite-init",
@@ -220,8 +220,8 @@ PASS(LICM, "licm",
      "Loop Invariant Code Motion")
 PASS(LateCodeMotion, "late-codemotion",
      "Late Code Motion with Release Hoisting")
-PASS(LateDeadFunctionElimination, "late-deadfuncelim",
-     "Late Dead Function Elimination")
+PASS(LateDeadFunctionAndGlobalElimination, "late-deadfuncelim",
+     "Late Dead Function and Global Elimination")
 PASS(LateInliner, "late-inline",
      "Late Function Inlining")
 PASS(LoopCanonicalizer, "loop-canonicalizer",

--- a/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/BasicBlockOptUtils.h
@@ -320,7 +320,9 @@ public:
   /// Add \p InitVal and all its operands (transitively) for cloning.
   ///
   /// Note: all init values must are added, before calling clone().
-  void add(SILInstruction *initVal);
+  /// Returns false if cloning is not possible, e.g. if we would end up cloning
+  /// a reference to a private function into a function which is serialized.
+  bool add(SILInstruction *initVal);
 
   /// Clone \p InitVal and all its operands into the initializer of the
   /// SILGlobalVariable.
@@ -332,7 +334,9 @@ public:
   static void appendToInitializer(SILGlobalVariable *gVar,
                                   SingleValueInstruction *initVal) {
     StaticInitCloner cloner(gVar);
-    cloner.add(initVal);
+    bool success = cloner.add(initVal);
+    (void)success;
+    assert(success && "adding initVal cannot fail for a global variable");
     cloner.clone(initVal);
   }
 

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -22,6 +22,7 @@
 #include "GenTuple.h"
 #include "TypeInfo.h"
 #include "StructLayout.h"
+#include "Callee.h"
 #include "swift/Basic/Range.h"
 #include "swift/SIL/SILModule.h"
 
@@ -109,11 +110,67 @@ llvm::Constant *irgen::emitAddrOfConstantString(IRGenModule &IGM,
   llvm_unreachable("bad string encoding");
 }
 
-static llvm::Constant *emitConstantValue(IRGenModule &IGM, SILValue operand) {
+namespace {
+
+/// Fill in the missing values for padding.
+void insertPadding(SmallVectorImpl<llvm::Constant *> &Elements,
+                   llvm::StructType *sTy) {
+  // fill in any gaps, which are the explicit padding that swiftc inserts.
+  for (unsigned i = 0, e = Elements.size(); i != e; ++i) {
+    auto &elt = Elements[i];
+    if (elt == nullptr) {
+      auto *eltTy = sTy->getElementType(i);
+      assert(eltTy->isArrayTy() &&
+             eltTy->getArrayElementType()->isIntegerTy(8) &&
+             "Unexpected non-byte-array type for constant struct padding");
+      elt = llvm::UndefValue::get(eltTy);
+    }
+  }
+}
+
+template <typename InstTy, typename NextIndexFunc>
+llvm::Constant *emitConstantStructOrTuple(IRGenModule &IGM, InstTy inst,
+                                          NextIndexFunc nextIndex) {
+  auto type = inst->getType();
+  auto *sTy = cast<llvm::StructType>(IGM.getTypeInfo(type).getStorageType());
+
+  SmallVector<llvm::Constant *, 32> elts(sTy->getNumElements(), nullptr);
+
+  // run over the Swift initializers, putting them into the struct as
+  // appropriate.
+  for (unsigned i = 0, e = inst->getElements().size(); i != e; ++i) {
+    auto operand = inst->getOperand(i);
+    Optional<unsigned> index = nextIndex(IGM, type, i);
+    if (index.hasValue()) {
+      assert(elts[index.getValue()] == nullptr &&
+             "Unexpected constant struct field overlap");
+
+      elts[index.getValue()] = emitConstantValue(IGM, operand);
+    }
+  }
+  insertPadding(elts, sTy);
+  return llvm::ConstantStruct::get(sTy, elts);
+}
+} // end anonymous namespace
+
+llvm::Constant *irgen::emitConstantValue(IRGenModule &IGM, SILValue operand) {
   if (auto *SI = dyn_cast<StructInst>(operand)) {
-    return emitConstantStruct(IGM, SI);
+    // The only way to get a struct's stored properties (which we need to map to
+    // their physical/LLVM index) is to iterate over the properties
+    // progressively. Fortunately the iteration order matches the order of
+    // operands in a StructInst.
+    auto StoredProperties = SI->getStructDecl()->getStoredProperties();
+    auto Iter = StoredProperties.begin();
+
+    return emitConstantStructOrTuple(
+        IGM, SI, [&Iter](IRGenModule &IGM, SILType Type, unsigned _i) mutable {
+          (void)_i;
+          auto *FD = *Iter++;
+          return irgen::getPhysicalStructFieldIndex(IGM, Type, FD);
+        });
   } else if (auto *TI = dyn_cast<TupleInst>(operand)) {
-    return emitConstantTuple(IGM, TI);
+    return emitConstantStructOrTuple(IGM, TI,
+                                     irgen::getPhysicalTupleElementStructIndex);
   } else if (auto *ILI = dyn_cast<IntegerLiteralInst>(operand)) {
     return emitConstantInt(IGM, ILI);
   } else if (auto *FLI = dyn_cast<FloatLiteralInst>(operand)) {
@@ -162,70 +219,6 @@ static llvm::Constant *emitConstantValue(IRGenModule &IGM, SILValue operand) {
   } else {
     llvm_unreachable("Unsupported SILInstruction in static initializer!");
   }
-}
-
-namespace {
-
-/// Fill in the missing values for padding.
-void insertPadding(SmallVectorImpl<llvm::Constant *> &Elements,
-                   llvm::StructType *sTy) {
-  // fill in any gaps, which are the explicit padding that swiftc inserts.
-  for (unsigned i = 0, e = Elements.size(); i != e; ++i) {
-    auto &elt = Elements[i];
-    if (elt == nullptr) {
-      auto *eltTy = sTy->getElementType(i);
-      assert(eltTy->isArrayTy() &&
-             eltTy->getArrayElementType()->isIntegerTy(8) &&
-             "Unexpected non-byte-array type for constant struct padding");
-      elt = llvm::UndefValue::get(eltTy);
-    }
-  }
-}
-
-template <typename InstTy, typename NextIndexFunc>
-llvm::Constant *emitConstantStructOrTuple(IRGenModule &IGM, InstTy inst,
-                                          NextIndexFunc nextIndex) {
-  auto type = inst->getType();
-  auto *sTy = cast<llvm::StructType>(IGM.getTypeInfo(type).getStorageType());
-
-  SmallVector<llvm::Constant *, 32> elts(sTy->getNumElements(), nullptr);
-
-  // run over the Swift initializers, putting them into the struct as
-  // appropriate.
-  for (unsigned i = 0, e = inst->getElements().size(); i != e; ++i) {
-    auto operand = inst->getOperand(i);
-    Optional<unsigned> index = nextIndex(IGM, type, i);
-    if (index.hasValue()) {
-      assert(elts[index.getValue()] == nullptr &&
-             "Unexpected constant struct field overlap");
-
-      elts[index.getValue()] = emitConstantValue(IGM, operand);
-    }
-  }
-  insertPadding(elts, sTy);
-  return llvm::ConstantStruct::get(sTy, elts);
-}
-} // end anonymous namespace
-
-llvm::Constant *irgen::emitConstantStruct(IRGenModule &IGM, StructInst *SI) {
-  // The only way to get a struct's stored properties (which we need to map to
-  // their physical/LLVM index) is to iterate over the properties
-  // progressively. Fortunately the iteration order matches the order of
-  // operands in a StructInst.
-  auto StoredProperties = SI->getStructDecl()->getStoredProperties();
-  auto Iter = StoredProperties.begin();
-
-  return emitConstantStructOrTuple(
-      IGM, SI, [&Iter](IRGenModule &IGM, SILType Type, unsigned _i) mutable {
-        (void)_i;
-        auto *FD = *Iter++;
-        return irgen::getPhysicalStructFieldIndex(IGM, Type, FD);
-      });
-}
-
-llvm::Constant *irgen::emitConstantTuple(IRGenModule &IGM, TupleInst *TI) {
-  return emitConstantStructOrTuple(IGM, TI,
-                                   irgen::getPhysicalTupleElementStructIndex);
 }
 
 llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,

--- a/lib/IRGen/GenConstant.h
+++ b/lib/IRGen/GenConstant.h
@@ -37,11 +37,8 @@ llvm::Constant *emitConstantFP(IRGenModule &IGM, FloatLiteralInst *FLI);
 llvm::Constant *emitAddrOfConstantString(IRGenModule &IGM,
                                          StringLiteralInst *SLI);
 
-/// Construct a struct literal from a StructInst containing constant values.
-llvm::Constant *emitConstantStruct(IRGenModule &IGM, StructInst *SI);
-
-/// Construct a struct literal from a TupleInst containing constant values.
-llvm::Constant *emitConstantTuple(IRGenModule &IGM, TupleInst *TI);
+/// Construct a constant from a SILValue containing constant values.
+llvm::Constant *emitConstantValue(IRGenModule &IGM, SILValue value);
 
 /// Construct an object (with a HeapObject header) from an ObjectInst
 /// containing constant values.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6414,17 +6414,8 @@ void IRGenModule::emitSILStaticInitializers() {
       continue;
     }
 
-    // Set the IR global's initializer to the constant for this SIL
-    // struct.
-    if (auto *SI = dyn_cast<StructInst>(InitValue)) {
-      IRGlobal->setInitializer(emitConstantStruct(*this, SI));
-      continue;
-    }
-
-    // Set the IR global's initializer to the constant for this SIL
-    // tuple.
-    auto *TI = cast<TupleInst>(InitValue);
-    IRGlobal->setInitializer(emitConstantTuple(*this, TI));
+    IRGlobal->setInitializer(
+      emitConstantValue(*this, cast<SingleValueInstruction>(InitValue)));
   }
 }
 

--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -175,7 +175,7 @@ void SILLinkerVisitor::visitPartialApplyInst(PartialApplyInst *PAI) {
 }
 
 void SILLinkerVisitor::visitFunctionRefInst(FunctionRefInst *FRI) {
-  maybeAddFunctionToWorklist(FRI->getInitiallyReferencedFunction());
+  maybeAddFunctionToWorklist(FRI->getReferencedFunction());
 }
 
 void SILLinkerVisitor::visitDynamicFunctionRefInst(

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -62,6 +62,11 @@ SILGlobalVariable::~SILGlobalVariable() {
   StaticInitializerBlock.clearStaticInitializerBlock(Module);
 }
 
+bool SILGlobalVariable::isPossiblyUsedExternally() const {
+  SILLinkage linkage = getLinkage();
+  return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
+}
+
 /// Get this global variable's fragile attribute.
 IsSerialized_t SILGlobalVariable::isSerialized() const {
   return Serialized ? IsSerialized : IsNotSerialized;

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -170,12 +170,19 @@ bool SILGlobalVariable::isValidStaticInitializerInst(const SILInstruction *I,
           return false;
       }
       return false;
+    case SILInstructionKind::FunctionRefInst:
+      // TODO: support async function pointers in static globals.
+      if (cast<FunctionRefInst>(I)->getReferencedFunction()->isAsync())
+        return false;
+      return true;
     case SILInstructionKind::StructInst:
     case SILInstructionKind::TupleInst:
     case SILInstructionKind::IntegerLiteralInst:
     case SILInstructionKind::FloatLiteralInst:
     case SILInstructionKind::ObjectInst:
     case SILInstructionKind::ValueToBridgeObjectInst:
+    case SILInstructionKind::ConvertFunctionInst:
+    case SILInstructionKind::ThinToThickFunctionInst:
       return true;
     default:
       return false;
@@ -310,13 +317,7 @@ swift::getVariableOfStaticInitializer(SILFunction *InitFunc,
       if (HasStore || SI->getDest() != SGA)
         return nullptr;
       HasStore = true;
-      SILValue value = SI->getSrc();
-
-      // We only handle StructInst and TupleInst being stored to a
-      // global variable for now.
-      if (!isa<StructInst>(value) && !isa<TupleInst>(value))
-        return nullptr;
-      InitVal = cast<SingleValueInstruction>(value);
+      InitVal = cast<SingleValueInstruction>(SI->getSrc());
     } else if (!SILGlobalVariable::isValidStaticInitializerInst(&I,
                                                              I.getModule())) {
       return nullptr;

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -241,7 +241,7 @@ SILFunction *swift::getCalleeOfOnceCall(BuiltinInst *BI) {
          "Expected C function representation!");
 
   if (auto *FR = dyn_cast<FunctionRefInst>(Callee))
-    return FR->getReferencedFunctionOrNull();
+    return FR->getReferencedFunction();
 
   return nullptr;
 }

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -475,8 +475,7 @@ namespace {
 
     bool visitFunctionRefInst(const FunctionRefInst *RHS) {
       auto *X = cast<FunctionRefInst>(LHS);
-      return X->getInitiallyReferencedFunction() ==
-             RHS->getInitiallyReferencedFunction();
+      return X->getReferencedFunction() == RHS->getReferencedFunction();
     }
     bool visitDynamicFunctionRefInst(const DynamicFunctionRefInst *RHS) {
       auto *X = cast<DynamicFunctionRefInst>(LHS);

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2317,12 +2317,14 @@ UpcastInst *UpcastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
 
 ThinToThickFunctionInst *
 ThinToThickFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
-                                SILType Ty, SILFunction &F,
+                                SILType Ty, SILModule &Mod, SILFunction *F,
                                 SILOpenedArchetypesState &OpenedArchetypes) {
-  SILModule &Mod = F.getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
-  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
-                               Ty.getASTType());
+  if (F) {
+    assert(&F->getModule() == &Mod);
+    collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, *F,
+                                 Ty.getASTType());
+  }
   unsigned size =
     totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(ThinToThickFunctionInst));
@@ -2346,12 +2348,15 @@ PointerToThinFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
 }
 
 ConvertFunctionInst *ConvertFunctionInst::create(
-    SILDebugLocation DebugLoc, SILValue Operand, SILType Ty, SILFunction &F,
+    SILDebugLocation DebugLoc, SILValue Operand, SILType Ty, SILModule &Mod,
+    SILFunction *F,
     SILOpenedArchetypesState &OpenedArchetypes, bool WithoutActuallyEscaping) {
-  SILModule &Mod = F.getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
-  collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
-                               Ty.getASTType());
+  if (F) {
+    assert(&F->getModule() == &Mod);
+    collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, *F,
+                                 Ty.getASTType());
+  }
   unsigned size =
     totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(ConvertFunctionInst));
@@ -2362,14 +2367,14 @@ ConvertFunctionInst *ConvertFunctionInst::create(
   //
   // *NOTE* We purposely do not use an early return here to ensure that in
   // builds without assertions this whole if statement is optimized out.
-  if (F.getModule().getStage() != SILStage::Lowered) {
+  if (Mod.getStage() != SILStage::Lowered) {
     // Make sure we are not performing ABI-incompatible conversions.
     CanSILFunctionType opTI =
         CFI->getOperand()->getType().castTo<SILFunctionType>();
     (void)opTI;
     CanSILFunctionType resTI = CFI->getType().castTo<SILFunctionType>();
     (void)resTI;
-    assert(opTI->isABICompatibleWith(resTI, F).isCompatible() &&
+    assert((!F || opTI->isABICompatibleWith(resTI, *F).isCompatible()) &&
            "Can not convert in between ABI incompatible function types");
   }
   return CFI;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -957,7 +957,7 @@ public:
   void print(const SILInstruction *I) {
     if (auto *FRI = dyn_cast<FunctionRefInst>(I))
       *this << "  // function_ref "
-            << demangleSymbol(FRI->getInitiallyReferencedFunction()->getName())
+            << demangleSymbol(FRI->getReferencedFunction()->getName())
             << "\n";
     else if (auto *FRI = dyn_cast<DynamicFunctionRefInst>(I))
       *this << "  // dynamic_function_ref "
@@ -1270,7 +1270,7 @@ public:
   }
 
   void visitFunctionRefInst(FunctionRefInst *FRI) {
-    FRI->getInitiallyReferencedFunction()->printName(PrintState.OS);
+    FRI->getReferencedFunction()->printName(PrintState.OS);
     *this << " : " << FRI->getType();
   }
   void visitDynamicFunctionRefInst(DynamicFunctionRefInst *FRI) {

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -66,7 +66,7 @@ ArrayCallKind swift::getArraySemanticsKind(SILFunction *f) {
 static ParameterConvention
 getSelfParameterConvention(ApplyInst *SemanticsCall) {
   FunctionRefInst *FRI = cast<FunctionRefInst>(SemanticsCall->getCallee());
-  SILFunction *F = FRI->getInitiallyReferencedFunction();
+  SILFunction *F = FRI->getReferencedFunction();
   auto FnTy = F->getLoweredFunctionType();
 
   return FnTy->getSelfParameter().getConvention();
@@ -78,7 +78,7 @@ bool swift::ArraySemanticsCall::isValidSignature() {
   assert(SemanticsCall && getKind() != ArrayCallKind::kNone &&
          "Need an array semantic call");
   FunctionRefInst *FRI = cast<FunctionRefInst>(SemanticsCall->getCallee());
-  SILFunction *F = FRI->getInitiallyReferencedFunction();
+  SILFunction *F = FRI->getReferencedFunction();
   auto FnTy = F->getLoweredFunctionType();
   auto &Mod = F->getModule();
 
@@ -203,7 +203,7 @@ ArrayCallKind swift::ArraySemanticsCall::getKind() const {
     return ArrayCallKind::kNone;
 
   auto F = cast<FunctionRefInst>(SemanticsCall->getCallee())
-               ->getInitiallyReferencedFunction();
+               ->getReferencedFunction();
 
   return getArraySemanticsKind(F);
 }

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -256,7 +256,7 @@ CalleeList CalleeCache::getCalleeListForCalleeKind(SILValue Callee) const {
 
   case ValueKind::FunctionRefInst:
     return CalleeList(
-        cast<FunctionRefInst>(Callee)->getInitiallyReferencedFunction());
+        cast<FunctionRefInst>(Callee)->getReferencedFunction());
 
   case ValueKind::DynamicFunctionRefInst:
   case ValueKind::PreviousDynamicFunctionRefInst:

--- a/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DifferentiableActivityAnalysis.cpp
@@ -29,7 +29,7 @@ using namespace swift::autodiff;
 
 static bool isWithoutDerivative(SILValue v) {
   if (auto *fnRef = dyn_cast<FunctionRefInst>(v))
-    return fnRef->getReferencedFunctionOrNull()->hasSemanticsAttr(
+    return fnRef->getReferencedFunction()->hasSemanticsAttr(
         "autodiff.nonvarying");
   return false;
 }

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -852,7 +852,7 @@ getOrCreateSubsetParametersThunkForDerivativeFunction(
   StringRef origName;
   if (auto *origFnRef =
           peerThroughFunctionConversions<FunctionRefInst>(origFnOperand)) {
-    origName = origFnRef->getInitiallyReferencedFunction()->getName();
+    origName = origFnRef->getReferencedFunction()->getName();
   } else if (auto *origMethodInst =
                  peerThroughFunctionConversions<MethodInst>(origFnOperand)) {
     origName = origMethodInst->getMember()
@@ -905,7 +905,7 @@ getOrCreateSubsetParametersThunkForDerivativeFunction(
   SILValue assocRef;
   if (auto *derivativeFnRef =
           peerThroughFunctionConversions<FunctionRefInst>(derivativeFn)) {
-    auto *assoc = derivativeFnRef->getReferencedFunctionOrNull();
+    auto *assoc = derivativeFnRef->getReferencedFunction();
     assocRef = builder.createFunctionRef(loc, assoc);
   } else if (auto *assocMethodInst =
                  peerThroughFunctionConversions<WitnessMethodInst>(

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -184,18 +184,15 @@ public:
   CallSiteDescriptor &operator=(CallSiteDescriptor &&) =default;
 
   SILFunction *getApplyCallee() const {
-    return cast<FunctionRefInst>(AI.getCallee())
-        ->getInitiallyReferencedFunction();
+    return cast<FunctionRefInst>(AI.getCallee())->getReferencedFunction();
   }
 
   SILFunction *getClosureCallee() const {
     if (auto *PAI = dyn_cast<PartialApplyInst>(getClosure()))
-      return cast<FunctionRefInst>(PAI->getCallee())
-          ->getInitiallyReferencedFunction();
+      return cast<FunctionRefInst>(PAI->getCallee())->getReferencedFunction();
 
     auto *TTTFI = cast<ThinToThickFunctionInst>(getClosure());
-    return cast<FunctionRefInst>(TTTFI->getCallee())
-        ->getInitiallyReferencedFunction();
+    return cast<FunctionRefInst>(TTTFI->getCallee())->getReferencedFunction();
   }
 
   bool closureHasRefSemanticContext() const {
@@ -565,8 +562,7 @@ static bool isSupportedClosure(const SILInstruction *Closure) {
     // Bail if any of the arguments are passed by address and
     // are not @inout.
     // This is a temporary limitation.
-    auto ClosureCallee = FRI->getReferencedFunctionOrNull();
-    assert(ClosureCallee);
+    auto ClosureCallee = FRI->getReferencedFunction();
     auto ClosureCalleeConv = ClosureCallee->getConventions();
     unsigned ClosureArgIdx =
         ClosureCalleeConv.getNumSILArguments() - PAI->getNumArguments();

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -334,7 +334,7 @@ protected:
           MethodInfo *mi = getMethodInfo(funcDecl, /*isWitnessTable*/ false);
           ensureAliveClassMethod(mi, dyn_cast<FuncDecl>(funcDecl), MethodCl);
         } else if (auto *FRI = dyn_cast<FunctionRefInst>(&I)) {
-          ensureAlive(FRI->getInitiallyReferencedFunction());
+          ensureAlive(FRI->getReferencedFunction());
         } else if (auto *FRI = dyn_cast<DynamicFunctionRefInst>(&I)) {
           ensureAlive(FRI->getInitiallyReferencedFunction());
         } else if (auto *FRI = dyn_cast<PreviousDynamicFunctionRefInst>(&I)) {

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -27,6 +27,7 @@
 using namespace swift;
 
 STATISTIC(NumDeadFunc, "Number of dead functions eliminated");
+STATISTIC(NumDeadGlobals, "Number of dead global variables eliminated");
 
 namespace {
 
@@ -115,11 +116,6 @@ protected:
     if (F->getRepresentation() == SILFunctionTypeRepresentation::ObjCMethod)
       return true;
 
-    // Global initializers are always emitted into the defining module and
-    // their bodies are never SIL serialized.
-    if (F->isGlobalInit())
-      return true;
-
     return false;
   }
 
@@ -143,6 +139,11 @@ protected:
   /// Returns true if a witness table is marked as alive.
   bool isAlive(SILWitnessTable *WT) {
     return AliveFunctionsAndTables.count(WT) != 0;
+  }
+
+  /// Returns true if a global variable is marked as alive.
+  bool isAlive(SILGlobalVariable *global) {
+    return AliveFunctionsAndTables.count(global) != 0;
   }
 
   /// Marks a function as alive.
@@ -204,6 +205,16 @@ protected:
     }
   }
 
+  /// Marks the \p global and all functions, which are referenced from its
+  /// initializer as alive.
+  void makeAlive(SILGlobalVariable *global) {
+    AliveFunctionsAndTables.insert(global);
+    for (const SILInstruction &initInst : *global) {
+      if (auto *fRef = dyn_cast<FunctionRefInst>(&initInst))
+        ensureAlive(fRef->getReferencedFunction());
+    }
+  }
+
   /// Marks the declarations referenced by a key path pattern as alive if they
   /// aren't yet.
   void
@@ -237,6 +248,12 @@ protected:
   void ensureAlive(SILFunction *F) {
     if (!isAlive(F))
       makeAlive(F);
+  }
+
+  /// Marks a global variable as alive if it is not alive yet.
+  void ensureAlive(SILGlobalVariable *global) {
+    if (!isAlive(global))
+      makeAlive(global);
   }
 
   /// Marks a witness table as alive if it is not alive yet.
@@ -342,6 +359,10 @@ protected:
         } else if (auto *KPI = dyn_cast<KeyPathInst>(&I)) {
           for (auto &component : KPI->getPattern()->getComponents())
             ensureKeyPathComponentIsAlive(component);
+        } else if (auto *GA = dyn_cast<GlobalAddrInst>(&I)) {
+          ensureAlive(GA->getReferencedGlobal());
+        } else if (auto *GV = dyn_cast<GlobalValueInst>(&I)) {
+          ensureAlive(GV->getReferencedGlobal());
         }
       }
     }
@@ -406,6 +427,11 @@ protected:
                                 << F.getName() << "\n");
         ensureAlive(&F);
       }
+    }
+    
+    for (SILGlobalVariable &global : Module->getSILGlobals()) {
+      if (global.isPossiblyUsedExternally())
+        ensureAlive(&global);
     }
   }
 
@@ -675,11 +701,19 @@ public:
 
     // First drop all references so that we don't get problems with non-zero
     // reference counts of dead functions.
-    std::vector<SILFunction *> DeadFunctions;
+    llvm::SmallVector<SILFunction *, 16> DeadFunctions;
+    llvm::SmallVector<SILGlobalVariable *, 16> DeadGlobals;
     for (SILFunction &F : *Module) {
       if (!isAlive(&F)) {
         F.dropAllReferences();
         DeadFunctions.push_back(&F);
+      }
+    }
+    
+    for (SILGlobalVariable &global : Module->getSILGlobals()) {
+      if (!isAlive(&global)) {
+        global.dropAllReferences();
+        DeadGlobals.push_back(&global);
       }
     }
 
@@ -706,6 +740,11 @@ public:
       DFEPass->notifyWillDeleteFunction(F);
       Module->eraseFunction(F);
     }
+    for (SILGlobalVariable *deadGlobal : DeadGlobals) {
+      ++NumDeadGlobals;
+      Module->eraseGlobalVariable(deadGlobal);
+    }
+    
     if (changedTables)
       DFEPass->invalidateFunctionTables();
   }

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -388,7 +388,8 @@ replaceLoadsByKnownValue(SILFunction *InitF, SILGlobalVariable *SILG,
     StaticInitCloner cloner(initCall);
     SmallVector<SILInstruction *, 8> insertedInsts;
     cloner.setTrackingList(&insertedInsts);
-    cloner.add(initVal);
+    if (!cloner.add(initVal))
+      continue;
 
     // Replace all loads from the addressor with the initial value of the global.
     replaceLoadsFromGlobal(initCall, initVal, cloner);
@@ -693,7 +694,8 @@ void SILGlobalOpt::optimizeGlobalAccess(SILGlobalVariable *SILG,
       continue;
 
     StaticInitCloner cloner(globalAddr);
-    cloner.add(initVal);
+    if (!cloner.add(initVal))
+      continue;
 
     // Replace all loads from the addressor with the initial value of the global.
     replaceLoadsFromGlobal(globalAddr, initVal, cloner);

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -539,7 +539,7 @@ SILFunction *ClosureCloner::constructClonedFunction(
   SILFunction *f = pai->getFunction();
 
   // Create the Cloned Name for the function.
-  SILFunction *origF = fri->getReferencedFunctionOrNull();
+  SILFunction *origF = fri->getReferencedFunction();
 
   IsSerialized_t isSerialized = IsNotSerialized;
   if (f->isSerialized() && origF->isSerialized())

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -416,7 +416,7 @@ static SILValue reapplyFunctionConversion(
     // `differentiable_function` of the function-typed thunk argument.
     auto isReabstractionThunkCallee = [&]() -> bool {
       auto *fri = dyn_cast<FunctionRefInst>(oldFunc);
-      return fri && fri->getReferencedFunctionOrNull()->isThunk() ==
+      return fri && fri->getReferencedFunction()->isThunk() ==
                         IsReabstractionThunk;
     };
     if (isReabstractionThunkCallee()) {
@@ -513,8 +513,7 @@ emitDerivativeFunctionReference(
   if (auto *originalFRI =
           peerThroughFunctionConversions<FunctionRefInst>(original)) {
     auto loc = originalFRI->getLoc();
-    auto *originalFn = originalFRI->getReferencedFunctionOrNull();
-    assert(originalFn);
+    auto *originalFn = originalFRI->getReferencedFunction();
     auto originalFnTy = originalFn->getLoweredFunctionType();
     auto *desiredParameterIndices = desiredConfig.parameterIndices;
     auto *desiredResultIndices = desiredConfig.resultIndices;
@@ -1005,7 +1004,7 @@ static SILValue promoteCurryThunkApplicationToDifferentiableFunction(
   auto *thunkRef = dyn_cast<FunctionRefInst>(ai->getCallee());
   if (!thunkRef)
     return nullptr;
-  auto *thunk = thunkRef->getReferencedFunctionOrNull();
+  auto *thunk = thunkRef->getReferencedFunction();
   auto thunkTy = thunk->getLoweredFunctionType();
   auto thunkResult = thunkTy->getSingleResult();
   auto resultFnTy = thunkResult.getInterfaceType()->getAs<SILFunctionType>();

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -741,7 +741,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
   if (!FRI)
     return nullptr;
 
-  SILFunction *CalleeFunction = FRI->getReferencedFunctionOrNull();
+  SILFunction *CalleeFunction = FRI->getReferencedFunction();
 
   switch (CalleeFunction->getRepresentation()) {
   case SILFunctionTypeRepresentation::Thick:

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -451,7 +451,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
 
   // Get rid of apparently dead functions as soon as possible so that
   // we do not spend time optimizing them.
-  P.addDeadFunctionElimination();
+  P.addDeadFunctionAndGlobalElimination();
 
   // Cleanup after SILGen: remove trivial copies to temporaries.
   P.addTempRValueOpt();
@@ -525,7 +525,7 @@ static void addHighLevelFunctionPipeline(SILPassPipelinePlan &P) {
 // one round of module passes.
 static void addHighLevelModulePipeline(SILPassPipelinePlan &P) {
   P.startPipeline("HighLevel,Module+StackPromote");
-  P.addDeadFunctionElimination();
+  P.addDeadFunctionAndGlobalElimination();
   P.addPerformanceSILLinker();
   P.addDeadObjectElimination();
   P.addGlobalPropertyOpt();
@@ -572,7 +572,7 @@ static void addMidLevelFunctionPipeline(SILPassPipelinePlan &P) {
 
 static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("ClosureSpecialize");
-  P.addDeadFunctionElimination();
+  P.addDeadFunctionAndGlobalElimination();
   P.addDeadStoreElimination();
   P.addDeadObjectElimination();
 
@@ -639,7 +639,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   // Delete dead code and drop the bodies of shared functions.
   // Also, remove externally available witness tables. They are not needed
   // anymore after the last devirtualizer run.
-  P.addLateDeadFunctionElimination();
+  P.addLateDeadFunctionAndGlobalElimination();
 
   // Perform the final lowering transformations.
   P.addCodeSinking();

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1422,7 +1422,7 @@ static bool knowHowToEmitReferenceCountInsts(ApplyInst *Call) {
   FunctionRefInst *FRI = dyn_cast<FunctionRefInst>(Call->getCallee());
   if (!FRI)
     return false;
-  SILFunction *F = FRI->getReferencedFunctionOrNull();
+  SILFunction *F = FRI->getReferencedFunction();
   auto FnTy = F->getLoweredFunctionType();
 
   // Look at the result type.
@@ -1445,7 +1445,7 @@ static bool knowHowToEmitReferenceCountInsts(ApplyInst *Call) {
 /// Add reference counting operations equal to the effect of the call.
 static void emitMatchingRCAdjustmentsForCall(ApplyInst *Call, SILValue OnX) {
   FunctionRefInst *FRI = cast<FunctionRefInst>(Call->getCallee());
-  SILFunction *F = FRI->getReferencedFunctionOrNull();
+  SILFunction *F = FRI->getReferencedFunction();
   auto FnTy = F->getLoweredFunctionType();
   assert(FnTy->getNumResults() == 1);
   auto ResultInfo = FnTy->getResults()[0];

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -959,8 +959,9 @@ SILInstruction *SILCombiner::visitLoadInst(LoadInst *LI) {
   // globals, which can occur with cross-module optimization.
   if (SingleValueInstruction *initVal = getValueFromStaticLet(LI->getOperand())) {
     StaticInitCloner cloner(LI);
-    cloner.add(initVal);
-    return cloner.clone(initVal);
+    if (cloner.add(initVal)) {
+      return cloner.clone(initVal);
+    }
   }
 
   // If we have a load [copy] whose only non-debug users are destroy_value, just

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -888,7 +888,7 @@ specializeApplySite(SILOptFunctionBuilder &FuncBuilder, ApplySite Apply,
                     AllocBoxToStackState &pass) {
   auto *FRI = cast<FunctionRefInst>(Apply.getCallee());
   assert(FRI && "Expected a direct ApplySite");
-  auto *F = FRI->getReferencedFunctionOrNull();
+  auto *F = FRI->getReferencedFunction();
   assert(F && "Expected a referenced function!");
 
   IsSerialized_t Serialized = IsNotSerialized;

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -144,8 +144,7 @@ public:
   }
 
   hash_code visitFunctionRefInst(FunctionRefInst *X) {
-    return llvm::hash_combine(X->getKind(),
-                              X->getInitiallyReferencedFunction());
+    return llvm::hash_combine(X->getKind(), X->getReferencedFunction());
   }
 
   hash_code visitGlobalAddrInst(GlobalAddrInst *X) {

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -485,7 +485,7 @@ static bool matchSwitch(SwitchInfo &SI, SILInstruction *Inst,
 
   // Check that we call the _unconditionallyBridgeFromObjectiveC witness.
   auto NativeType = Apply->getType().getASTType();
-  auto *BridgeFun = FunRef->getInitiallyReferencedFunction();
+  auto *BridgeFun = FunRef->getReferencedFunction();
   auto *SwiftModule = BridgeFun->getModule().getSwiftModule();
   // Not every type conforms to the ObjectiveCBridgeable protocol in such a case
   // getBridgeFromObjectiveC returns SILDeclRef().
@@ -821,7 +821,7 @@ BridgedArgument BridgedArgument::match(unsigned ArgIdx, SILValue Arg,
 
   // Make sure we are calling the actual bridge witness.
   auto NativeType = BridgedValue->getType().getASTType();
-  auto *BridgeFun = FunRef->getInitiallyReferencedFunction();
+  auto *BridgeFun = FunRef->getReferencedFunction();
   auto *SwiftModule = BridgeFun->getModule().getSwiftModule();
   // Not every type conforms to the ObjectiveCBridgeable protocol in such a case
   // getBridgeToObjectiveC returns SILDeclRef().

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -127,7 +127,7 @@ class BugReducerTester : public SILFunctionTransform {
         }
 
         auto *FRI = dyn_cast<FunctionRefInst>(FAS.getCallee());
-        if (!FRI || !FRI->getInitiallyReferencedFunction()->getName().equals(
+        if (!FRI || !FRI->getReferencedFunction()->getName().equals(
                         FunctionTarget)) {
           ++II;
           continue;

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -287,7 +287,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
     return SymbolicValue::getString(sli->getValue(), evaluator.getAllocator());
 
   if (auto *fri = dyn_cast<FunctionRefInst>(value))
-    return SymbolicValue::getFunction(fri->getInitiallyReferencedFunction());
+    return SymbolicValue::getFunction(fri->getReferencedFunction());
 
   // If we have a reference to a metatype, constant fold any substitutable
   // types.

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2521,7 +2521,7 @@ void swift::trySpecializeApplyOfGeneric(
   assert(Apply.hasSubstitutions() && "Expected an apply with substitutions!");
   auto *F = Apply.getFunction();
   auto *RefF =
-      cast<FunctionRefInst>(Apply.getCallee())->getReferencedFunctionOrNull();
+      cast<FunctionRefInst>(Apply.getCallee())->getReferencedFunction();
 
   LLVM_DEBUG(llvm::dbgs() << "\n\n*** ApplyInst in function " << F->getName()
                           << ":\n";

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -603,17 +603,8 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
 
       // If we have a function ref inst, we need to especially drop its function
       // argument so that it gets a proper ref decrement.
-      auto *fri = dyn_cast<FunctionRefInst>(inst);
-      if (fri && fri->getInitiallyReferencedFunction())
+      if (auto *fri = dyn_cast<FunctionRefBaseInst>(inst))
         fri->dropReferencedFunction();
-
-      auto *dfri = dyn_cast<DynamicFunctionRefInst>(inst);
-      if (dfri && dfri->getInitiallyReferencedFunction())
-        dfri->dropReferencedFunction();
-
-      auto *pfri = dyn_cast<PreviousDynamicFunctionRefInst>(inst);
-      if (pfri && pfri->getInitiallyReferencedFunction())
-        pfri->dropReferencedFunction();
     }
 
     for (auto inst : deadInsts) {

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -182,12 +182,12 @@ FunctionSignatureSpecializationMangler::mangleClosureProp(SILInstruction *Inst) 
   // restriction is removed, the assert here will fire.
   if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(Inst)) {
     auto *FRI = cast<FunctionRefInst>(TTTFI->getCallee());
-    appendIdentifier(FRI->getInitiallyReferencedFunction()->getName());
+    appendIdentifier(FRI->getReferencedFunction()->getName());
     return;
   }
   auto *PAI = cast<PartialApplyInst>(Inst);
   auto *FRI = cast<FunctionRefInst>(PAI->getCallee());
-  appendIdentifier(FRI->getInitiallyReferencedFunction()->getName());
+  appendIdentifier(FRI->getReferencedFunction()->getName());
 
   // Then we mangle the types of the arguments that the partial apply is
   // specializing.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1416,7 +1416,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     // Use SILOneOperandLayout to specify the function type and the function
     // name (IdentifierID).
     const FunctionRefInst *FRI = cast<FunctionRefInst>(&SI);
-    SILFunction *ReferencedFunction = FRI->getInitiallyReferencedFunction();
+    SILFunction *ReferencedFunction = FRI->getReferencedFunction();
     unsigned abbrCode = SILAbbrCodes[SILOneOperandLayout::Code];
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned)SI.getKind(), 0,

--- a/test/SILOptimizer/dead_function_elimination.swift
+++ b/test/SILOptimizer/dead_function_elimination.swift
@@ -168,11 +168,29 @@ internal func donotEliminate() {
   return
 }
 
+func callingGlobalFuncPtr() {
+  GFStr.globalFuncPtr()
+}
+
+func aliveReferencedFunc() {
+}
+
+struct GFStr {
+  static var globalFuncPtr: () -> () = callingGlobalFuncPtr
+  static var aliveFuncPtr: () -> () = aliveReferencedFunc
+}
+
+public func keepPtrAlive() {
+  GFStr.aliveFuncPtr()
+}
+
 // CHECK-NOT: sil {{.*}}inCycleA
 // CHECK-NOT: sil {{.*}}inCycleB
 // CHECK-NOT: sil {{.*}}DeadMethod
 // CHECK-NOT: sil {{.*}}DeadWitness
 // CHECK-NOT: sil {{.*}}publicClassMethod
+// CHECK-NOT: sil {{.*}}callingGlobalFuncPtr
+// CHECK-NOT: sil_global {{.*}}globalFuncPtr
 
 // CHECK-TESTING: sil {{.*}}inCycleA
 // CHECK-TESTING: sil {{.*}}inCycleB
@@ -180,7 +198,9 @@ internal func donotEliminate() {
 // CHECK-TESTING: sil {{.*}}publicClassMethod
 // CHECK-TESTING: sil {{.*}}DeadWitness
 
+// CHECK-LABEL: sil_global hidden @$s25dead_function_elimination5GFStrV12aliveFuncPtryycvpZ
 // CHECK-LABEL: @$s25dead_function_elimination14donotEliminateyyF
+// CHECK-LABEL: sil @$s25dead_function_elimination12keepPtrAliveyyF
 
 // CHECK-LABEL: sil_vtable Base
 // CHECK: aliveMethod

--- a/test/SILOptimizer/existential_specializer_indirect_class.sil
+++ b/test/SILOptimizer/existential_specializer_indirect_class.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -O -wmo -enable-sil-verify-all -sil-disable-pass=DeadFunctionElimination %s | %FileCheck %s
+// RUN: %target-sil-opt -O -wmo -enable-sil-verify-all -sil-disable-pass=DeadFunctionAndGlobalElimination %s | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/SILOptimizer/remove_unused_func.sil
+++ b/test/SILOptimizer/remove_unused_func.sil
@@ -1,3 +1,4 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-deadfuncelim | %FileCheck --check-prefix=KEEP %s
 // RUN: %target-sil-opt -enable-sil-verify-all %s -sil-deadfuncelim | %FileCheck %s
 
 sil_stage canonical
@@ -6,7 +7,7 @@ import Builtin
 import Swift
 
 // This function needs to be removed.
-// CHECK-NOT: @remove_me
+// KEEP-NOT: @remove_me
 
 sil private @remove_me : $@convention(thin) (Builtin.Int64) -> Builtin.Int64 {
 bb0(%0 : $Builtin.Int64):
@@ -15,3 +16,32 @@ bb0(%0 : $Builtin.Int64):
   %4 = tuple_extract %3 : $(Builtin.Int64, Builtin.Int1), 0
   return %4: $Builtin.Int64
 }
+
+sil_global @globalFunctionPointer : $@callee_guaranteed () -> () = {
+  %0 = function_ref @alivePrivateFunc : $@convention(thin) () -> ()
+  %initval = thin_to_thick_function %0 : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+}
+
+// CHECK-LABEL: sil private @alivePrivateFunc
+sil private @alivePrivateFunc : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+}
+
+// KEEP-NOT: @privateFunctionPointer
+sil_global private @privateFunctionPointer : $@callee_guaranteed () -> () = {
+  %0 = function_ref @deadPrivateFunc : $@convention(thin) () -> ()
+  %initval = thin_to_thick_function %0 : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+}
+
+// KEEP-NOT: @deadPrivateFunc
+sil private @deadPrivateFunc : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @privateFunctionPointer : $*@callee_guaranteed () -> ()
+  %1 = load %0 : $*@callee_guaranteed () -> ()
+  %2 = apply %1() : $@callee_guaranteed () -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -4497,6 +4497,31 @@ bb0:
   return %1 : $Int64
 }
 
+sil private [ossa] @somePrivateFunction : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 27
+  %1 = struct $Int64 (%0 : $Builtin.Int64)
+  return %1 : $Int64
+}
+
+sil_global [let] @pointerToSomePrivateFunction : $@callee_guaranteed () -> Int64 = {
+  %0 = function_ref @somePrivateFunction: $@convention(thin) () -> Int64
+  %initval = thin_to_thick_function %0 : $@convention(thin) () -> Int64 to $@callee_guaranteed () -> Int64
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @dontInlinePrivateFunctionRefIntoSerializedFunction
+// CHECK:         [[GA:%[0-9]+]] = global_addr
+// CHECK:         [[L:%[0-9]+]] = load [copy] [[GA]]
+// CHECK:         return [[L]]
+// CHECK:       } // end sil function 'dontInlinePrivateFunctionRefIntoSerializedFunction'
+sil [serialized] [ossa] @dontInlinePrivateFunctionRefIntoSerializedFunction : $@convention(thin) () -> @owned @callee_guaranteed () -> Int64 {
+bb0:
+  %0 = global_addr @pointerToSomePrivateFunction : $*@callee_guaranteed () -> Int64
+  %1 = load [copy] %0 : $*@callee_guaranteed () -> Int64
+  return %1 : $@callee_guaranteed () -> Int64
+}
+
+
 // Check for disabled optimization of unchecked_bitwise_cast to unchecked_ref_cast in ossa
 // This test can be optimized when ossa is supported in the SILCombine for unchecked_bitwise_cast
 // CHECK-LABEL: sil [ossa] @refcast :

--- a/test/SILOptimizer/sil_combine_protocol_conf.swift
+++ b/test/SILOptimizer/sil_combine_protocol_conf.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -O -wmo -emit-sil -Xllvm -sil-disable-pass=DeadFunctionElimination | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -wmo -emit-sil | %FileCheck %s
 
 // case 1: class protocol -- should optimize
 internal protocol SomeProtocol : class {
@@ -95,7 +95,7 @@ internal class Klass2: MultipleConformanceProtocol {
 }
 
 
-internal class Other {
+public class Other {
    let x:SomeProtocol
    let y:SomeNonClassProtocol
    let z:DerivedProtocol
@@ -113,7 +113,7 @@ internal class Other {
      self.s = s;
    }
 
-// CHECK-LABEL: sil hidden [noinline] @$s25sil_combine_protocol_conf5OtherC11doWorkClassSiyF : $@convention(method) (@guaranteed Other) -> Int {
+// CHECK-LABEL: sil [noinline] @$s25sil_combine_protocol_conf5OtherC11doWorkClassSiyF : $@convention(method) (@guaranteed Other) -> Int {
 // CHECK: bb0
 // CHECK: debug_value
 // CHECK: integer_literal
@@ -162,7 +162,7 @@ internal class Other {
 // CHECK: struct 
 // CHECK: return
 // CHECK: } // end sil function '$s25sil_combine_protocol_conf5OtherC11doWorkClassSiyF'
-   @inline(never) func doWorkClass () ->Int {
+   @inline(never) public func doWorkClass () ->Int {
       return self.x.foo(x:self.x) // optimize
              + self.y.bar(x:self.y) // optimize
              + self.z.foo() // do not optimize
@@ -221,7 +221,7 @@ struct GenericOuter<T> {
   }
 }
 
-internal class OtherClass {
+public class OtherClass {
   var arg1: PropProtocol
   var arg2: GenericPropProtocol
   var arg3: NestedPropProtocol
@@ -234,7 +234,7 @@ internal class OtherClass {
      self.arg4 = arg4
   }
 
-// CHECK-LABEL: sil hidden [noinline] @$s25sil_combine_protocol_conf10OtherClassC12doWorkStructSiyF : $@convention(method) (@guaranteed OtherClass) -> Int {
+// CHECK-LABEL: sil [noinline] @$s25sil_combine_protocol_conf10OtherClassC12doWorkStructSiyF : $@convention(method) (@guaranteed OtherClass) -> Int {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK: debug_value
 // CHECK: [[R1:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg1
@@ -279,7 +279,7 @@ internal class OtherClass {
 // CHECK: struct
 // CHECK: return
 // CHECK: } // end sil function '$s25sil_combine_protocol_conf10OtherClassC12doWorkStructSiyF'
-  @inline(never) func doWorkStruct () -> Int{
+  @inline(never) public func doWorkStruct () -> Int{
     return self.arg1.val  // optimize
            + self.arg2.val  // do not optimize
            + self.arg3.val  // optimize
@@ -322,7 +322,7 @@ internal enum AGenericEnum<T> : AGenericProtocol {
   }
 }
 
-internal class OtherKlass {
+public class OtherKlass {
   var arg1: AProtocol
   var arg2: AGenericProtocol
 
@@ -331,7 +331,7 @@ internal class OtherKlass {
      self.arg2 = arg2
   }
 
-// CHECK-LABEL: sil hidden [noinline] @$s25sil_combine_protocol_conf10OtherKlassC10doWorkEnumSiyF : $@convention(method) (@guaranteed OtherKlass) -> Int {
+// CHECK-LABEL: sil [noinline] @$s25sil_combine_protocol_conf10OtherKlassC10doWorkEnumSiyF : $@convention(method) (@guaranteed OtherKlass) -> Int {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK: debug_value
 // CHECK: integer_literal
@@ -350,7 +350,7 @@ internal class OtherKlass {
 // CHECK: struct
 // CHECK: return
 // CHECK: } // end sil function '$s25sil_combine_protocol_conf10OtherKlassC10doWorkEnumSiyF'
-  @inline(never) func doWorkEnum() -> Int {
+  @inline(never) public func doWorkEnum() -> Int {
     return self.arg1.val  // optimize
            + self.arg2.val // do not optimize
   }


### PR DESCRIPTION
For example, generate a static global for the array literal in:
```
func foo(_ i: Int) -> Int { ... }
func bar(_ i: Int) -> Int { ... }

func returnFunctionArray() -> [(Int) -> Int] {
  return [foo, bar]
}
```
rdar://73570149
https://bugs.swift.org/browse/SR-14101

This PR also contains an improvement of DeadFunctionElimination: it now can also remove dead global variables.
Handling function references in global initializers is required in DeadFunctionElimination anyway. It was only a small addition to implement dead global variable elimination in the same change.

rdar://32956923