### PR TITLE
[Docs] Remove UnicodeScalar from ABI/Mangling.rst

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -453,7 +453,6 @@ Types
   KNOWN-TYPE-KIND ::= 'a'                    // Swift.Array
   KNOWN-TYPE-KIND ::= 'B'                    // Swift.BinaryFloatingPoint
   KNOWN-TYPE-KIND ::= 'b'                    // Swift.Bool
-  KNOWN-TYPE-KIND ::= 'c'                    // Swift.UnicodeScalar
   KNOWN-TYPE-KIND ::= 'D'                    // Swift.Dictionary
   KNOWN-TYPE-KIND ::= 'd'                    // Swift.Float64
   KNOWN-TYPE-KIND ::= 'E'                    // Swift.Encodable


### PR DESCRIPTION
Follow-up to: apple/swift@9e7dfad38428f1d453131994d7eb0af5db7bcb3a