### PR TITLE
Define an earliest insertion point

### DIFF
--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -285,8 +285,6 @@ void IRGenThunk::emit() {
   GenericContextScope scope(IGF.IGM, origTy->getInvocationGenericSignature());
 
   if (isAsync) {
-    IGF.setupAsync();
-
     auto entity = LinkEntity::forDispatchThunk(declRef);
     emitAsyncFunctionEntry(IGF, *asyncLayout, entity);
     emitAsyncFunctionPointer(IGF.IGM, IGF.CurFn, entity,

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -346,6 +346,20 @@ private:
   llvm::Instruction *AllocaIP;
   const SILDebugScope *DbgScope;
 
+  /// The insertion point where we should but instructions we would normally put
+  /// at the beginning of the function. LLVM's coroutine lowering really does
+  /// not like it if we put instructions with side-effectrs before the
+  /// coro.begin.
+  llvm::Instruction *EarliestIP;
+
+public:
+  void setEarliestInsertionPoint(llvm::Instruction *inst) { EarliestIP = inst; }
+  /// Returns the first insertion point before which we should insert
+  /// instructions which have side-effects.
+  llvm::Instruction *getEarliestInsertionPoint() const {
+    return EarliestIP;
+  }
+
 //--- Reference-counting methods -----------------------------------------------
 public:
   // Returns the default atomicity of the module.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -680,6 +680,9 @@ public:
       return;
 
     llvm::IRBuilder<> ZeroInitBuilder(AI->getNextNode());
+    ZeroInitBuilder.SetInsertPoint(
+        getEarliestInsertionPoint()->getParent(),
+        getEarliestInsertionPoint()->getIterator());
 
     // No debug location is how LLVM marks prologue instructions.
     ZeroInitBuilder.SetCurrentDebugLocation(nullptr);
@@ -1507,8 +1510,6 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
     IGM.createReplaceableProlog(*this, f);
   }
 
-  if (f->getLoweredFunctionType()->isAsync())
-    setupAsync();
 }
 
 IRGenSILFunction::~IRGenSILFunction() {
@@ -1705,10 +1706,6 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
                                    witnessMetadata);
   }
 
-  // Bind the error result by popping it off the parameter list.
-  if (funcTy->hasErrorResult()) {
-    IGF.setCallerErrorResultSlot(emission->getCallerErrorResultArgument());
-  }
   // The coroutine context should be the first parameter.
   switch (funcTy->getCoroutineKind()) {
   case SILCoroutineKind::None:
@@ -1725,6 +1722,11 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
     emitAsyncFunctionEntry(IGF,
                            getAsyncContextLayout(IGF.IGM, IGF.CurSILFn),
                            LinkEntity::forSILFunction(IGF.CurSILFn));
+  }
+
+  // Bind the error result by popping it off the parameter list.
+  if (funcTy->hasErrorResult()) {
+    IGF.setCallerErrorResultSlot(emission->getCallerErrorResultArgument());
   }
 
   SILFunctionConventions conv(funcTy, IGF.getSILModule());

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -14,6 +14,12 @@ final actor MyActor {
 // CHECK-LABEL: define{{.*}} void @test_simple(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
 // CHECK: [[TASK_LOC:%[0-9]+]] = alloca %swift.task*
 // CHECK: [[CTX:%[0-9]+]] = bitcast %swift.context* %2
+// Make sure the stores happen after the coro.begin. LLVM coro lowering prefers
+// it this way.
+// CHECK: coro.begin
+// CHECK: store %swift.task* %0
+// CHECK: store %swift.executor* %1
+// CHECK: store %swift.context* %2
 // CHECK-32: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, %swift.error*, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 5
 // CHECK-64: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error*, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 6
 // CHECK: [[ACTOR:%[0-9]+]] = load %T4test7MyActorC*, %T4test7MyActorC** [[ACTOR_ADDR]]


### PR DESCRIPTION
This is to deal with the fact that LLVM's coroutine lowering can't handle
instructions with side-effects well that are inserted before the coro.begin.