### PR TITLE
[IRGen] Use coro.end.async to return from an async function

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4738,8 +4738,24 @@ void irgen::emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &asyncLayout,
   Args.push_back(IGF.getAsyncTask());
   Args.push_back(IGF.getAsyncExecutor());
   Args.push_back(IGF.getAsyncContext());
-  auto call = IGF.Builder.CreateCall(fnPtr, Args);
-  call->setTailCall();
+
+  // Setup the coro.end.async intrinsic call.
+  auto &Builder = IGF.Builder;
+  auto mustTailCallFn = IGF.createAsyncDispatchFn(fnPtr,Args);
+  auto handle = IGF.getCoroutineHandle();
+  auto rawFnPtr =
+      Builder.CreateBitOrPointerCast(fnPtr.getRawPointer(), IGF.IGM.Int8PtrTy);
+
+  SmallVector<llvm::Value*, 8> arguments;
+  arguments.push_back(handle);
+  arguments.push_back(/*is unwind*/Builder.getFalse());
+  arguments.push_back(mustTailCallFn);
+  arguments.push_back(rawFnPtr);
+  for (auto *arg: Args)
+    arguments.push_back(arg);
+
+  Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_end_async, arguments);
+  Builder.CreateUnreachable();
 }
 
 FunctionPointer

--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -346,7 +346,6 @@ void IRGenThunk::emit() {
 
   if (isAsync) {
     emitAsyncReturn(IGF, *asyncLayout, origTy);
-    IGF.emitCoroutineOrAsyncExit();
     return;
   }
 

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -84,7 +84,7 @@ bb0:
 // CHECK:  br label %coro.end
 
 // CHECK: coro.end:
-// CHECK:   call i1 @llvm.coro.end(
+// CHECK:   call i1 (i8*, i1, ...) @llvm.coro.end.async(
 // CHECK:   unreachable
 
 // CHECK: await.async.maybe.resume:

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -30,6 +30,10 @@ final actor class MyActor {
 // CHECK: [[CAST_ACTOR:%[0-9]+]] = bitcast %T4test7MyActorC* [[ACTOR]] to %swift.executor*
 // CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async(i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
 // CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async(i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[SIGNED_RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
+// CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.task*, %swift.executor*, %swift.context*)* {{.*}} to i8*
+// CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.task*, %swift.executor*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
+// CHECK: unreachable
+
 sil @test_simple : $@convention(method) @async (@guaranteed MyActor) -> () {
 bb0(%0 : $MyActor):
   hop_to_executor %0 : $MyActor
@@ -44,6 +48,13 @@ bb0(%0 : $MyActor):
 // CHECK:    store %swift.context* %4, %swift.context** [[CTXT_ADDR]]
 // CHECK:    tail call swiftcc void @swift_task_switch(%swift.task* %2, %swift.executor* %3, %swift.executor* %1)
 // CHECK:    ret void
+
+// CHECK: define{{.*}} void @[[TAIL_CALL_FUNC]](i8* %0, %swift.task* %1, %swift.executor* %2, %swift.context* %3)
+// CHECK:   %4 = bitcast i8* %0 to void (%swift.task*, %swift.executor*, %swift.context*)*
+// CHECK:   tail call swiftcc void %4(%swift.task* %1, %swift.executor* %2, %swift.context* swiftasync %3)
+// CHECK:   ret void
+// CHECK: }
+
 
 sil_vtable MyActor {
 }

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -405,7 +405,7 @@ bb0(%x : $*SwiftClassPair):
 sil public_external @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swiftcc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.70"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
 sil @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in_guaranteed SwiftClassPair) -> () {
 bb0(%x : $*SwiftClassPair):

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -101,7 +101,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_forwarder_parameter(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swiftcc void @"$s7takingQTA.19"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swiftcc void @"$s7takingQTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
 sil public @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> () {
 bb0(%0 : $*τ_0_1):

--- a/test/IRGen/async/unreachable.swift
+++ b/test/IRGen/async/unreachable.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -enable-experimental-concurrency -disable-llvm-optzns -disable-swift-specific-llvm-optzns | %FileCheck %s
 // REQUIRES: concurrency
 
-// CHECK: call i1 @llvm.coro.end
+// CHECK: call i1 (i8*, i1, ...) @llvm.coro.end.async
 func foo() async -> Never {
   await bar()
   fatalError()
 }
 
-// CHECK: call i1 @llvm.coro.end
+// CHECK: call i1 (i8*, i1, ...) @llvm.coro.end.async
 func bar() async -> Never {
   await foo()
   fatalError()


### PR DESCRIPTION
The `coro.end.async` intrinsic allow specifying a function that is to be
tail called as the last thing before returning.

LLVM lowering will inline the `must-tail-call` function argument to
`coro.end.async`. This `must-tail-call` function can contain a
`musttail` call.

```
define @my_must_tail_call_func(void (*)(i64) %fnptr, i64 %args) {
  call musttail void %fnptr(i64 %args)
  ret void
}

define @async_func() {
  ...
  coro.end.async(..., @my_must_tail_call_func, %return_continuation, i64 %args)
  unreachable
}
```