### PR TITLE
Change 'actor class' to 'actor'

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -570,6 +570,7 @@ SIMPLE_DECL_ATTR(asyncHandler, AsyncHandler,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   101)
 
+// TODO: Remove this once we don't need to support 'actor' as a modifier
 CONTEXTUAL_SIMPLE_DECL_ATTR(actor, Actor,
   DeclModifier | OnClass | ConcurrencyOnly |
   ABIBreakingToAdd | ABIBreakingToRemove |

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -546,7 +546,7 @@ protected:
     NumRequirementsInSignature : 16
   );
 
-  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+1+2+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+1+2+1+1+1+1+1+1,
     /// Whether this class inherits its superclass's convenience initializers.
     InheritsSuperclassInits : 1,
     ComputedInheritsSuperclassInits : 1,
@@ -562,7 +562,10 @@ protected:
 
     /// Whether instances of this class are incompatible
     /// with weak and unowned references.
-    IsIncompatibleWithWeakReferences : 1
+    IsIncompatibleWithWeakReferences : 1,
+
+    /// Set when the class represents an actor
+    IsActor : 1
   );
 
   SWIFT_INLINE_BITFIELD(
@@ -3589,7 +3592,8 @@ class ClassDecl final : public NominalTypeDecl {
 public:
   ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
             ArrayRef<TypeLoc> Inherited,
-            GenericParamList *GenericParams, DeclContext *DC);
+            GenericParamList *GenericParams, DeclContext *DC,
+            bool isActor);
 
   SourceLoc getStartLoc() const { return ClassLoc; }
   SourceRange getSourceRange() const {
@@ -3688,6 +3692,9 @@ public:
   /// Whether the class is known to be a *root* default actor,
   /// i.e. the first class in its hierarchy that is a default actor.
   bool isRootDefaultActor() const;
+
+  /// Whether the class was explicitly declared with the `actor` keyword.
+  bool isExplicitActor() const { return Bits.ClassDecl.IsActor; }
 
   /// Does this class explicitly declare any of the methods that
   /// would prevent it from being a default actor?

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2832,8 +2832,13 @@ void PrintAST::visitClassDecl(ClassDecl *decl) {
     printSourceRange(CharSourceRange(Ctx.SourceMgr, decl->getStartLoc(),
                               decl->getBraces().Start.getAdvancedLoc(-1)), Ctx);
   } else {
-    if (!Options.SkipIntroducerKeywords)
-      Printer << tok::kw_class << " ";
+    if (!Options.SkipIntroducerKeywords) {
+      if (decl->isExplicitActor()) {
+        Printer.printKeyword("actor", Options, " ");
+      } else {
+        Printer << tok::kw_class << " ";
+      }
+    }
     printContextIfNeeded(decl);
     recordDeclLoc(decl,
       [&]{

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4093,7 +4093,8 @@ VarDecl *NominalTypeDecl::getGlobalActorInstance() const {
 
 ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
                      ArrayRef<TypeLoc> Inherited,
-                     GenericParamList *GenericParams, DeclContext *Parent)
+                     GenericParamList *GenericParams, DeclContext *Parent,
+                     bool isActor)
   : NominalTypeDecl(DeclKind::Class, Parent, Name, NameLoc, Inherited,
                     GenericParams),
     ClassLoc(ClassLoc) {
@@ -4105,6 +4106,7 @@ ClassDecl::ClassDecl(SourceLoc ClassLoc, Identifier Name, SourceLoc NameLoc,
   Bits.ClassDecl.HasMissingVTableEntries = 0;
   Bits.ClassDecl.ComputedHasMissingVTableEntries = 0;
   Bits.ClassDecl.IsIncompatibleWithWeakReferences = 0;
+  Bits.ClassDecl.IsActor = isActor;
 }
 
 bool ClassDecl::hasResilientMetadata() const {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5146,7 +5146,8 @@ namespace {
                                                         AccessLevel::Public,
                                                         SourceLoc(), name,
                                                         SourceLoc(), None,
-                                                        nullptr, dc);
+                                                        nullptr, dc,
+                                                        /*isActor*/false);
         Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
         result->setSuperclass(Type());
         result->setAddedImplicitInitializers(); // suppress all initializers
@@ -5236,7 +5237,8 @@ namespace {
       // Create the class declaration and record it.
       auto result = Impl.createDeclWithClangNode<ClassDecl>(
           decl, access, Impl.importSourceLoc(decl->getBeginLoc()), name,
-          Impl.importSourceLoc(decl->getLocation()), None, nullptr, dc);
+          Impl.importSourceLoc(decl->getLocation()), None, nullptr, dc,
+          /*isActor*/false);
 
       // Import generic arguments, if any.
       if (auto gpImportResult = importObjCGenericParams(decl, dc)) {
@@ -5695,7 +5697,7 @@ SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
 
   auto theClass = Impl.createDeclWithClangNode<ClassDecl>(
       decl, AccessLevel::Public, SourceLoc(), className, SourceLoc(), None,
-      nullptr, dc);
+      nullptr, dc, /*isActor*/false);
   theClass->setSuperclass(superclass);
   theClass->setAddedImplicitInitializers(); // suppress all initializers
   theClass->setHasMissingVTableEntries(false);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2415,7 +2415,8 @@ ClassDecl *IRGenModule::getObjCRuntimeBaseClass(Identifier name,
   auto SwiftRootClass = new (Context) ClassDecl(SourceLoc(), name, SourceLoc(),
                                            ArrayRef<TypeLoc>(),
                                            /*generics*/ nullptr,
-                                           Context.TheBuiltinModule);
+                                           Context.TheBuiltinModule,
+                                           /*isActor*/false);
   SwiftRootClass->setIsObjC(Context.LangOpts.EnableObjCInterop);
   SwiftRootClass->getAttrs().add(ObjCAttr::createNullary(Context, objcName,
     /*isNameImplicit=*/true));

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3584,6 +3584,7 @@ public:
     IdentifierID nameID;
     DeclContextID contextID;
     bool isImplicit, isObjC;
+    bool isExplicitActorDecl;
     bool inheritsSuperclassInitializers;
     bool hasMissingDesignatedInits;
     GenericSignatureID genericSigID;
@@ -3593,6 +3594,7 @@ public:
     ArrayRef<uint64_t> rawInheritedAndDependencyIDs;
     decls_block::ClassLayout::readRecord(scratch, nameID, contextID,
                                          isImplicit, isObjC,
+                                         isExplicitActorDecl,
                                          inheritsSuperclassInitializers,
                                          hasMissingDesignatedInits,
                                          genericSigID, superclassID,
@@ -3621,7 +3623,8 @@ public:
       return declOrOffset;
 
     auto theClass = MF.createDecl<ClassDecl>(SourceLoc(), name, SourceLoc(),
-                                             None, genericParams, DC);
+                                             None, genericParams, DC,
+                                             isExplicitActorDecl);
     declOrOffset = theClass;
 
     theClass->setGenericSignature(MF.getGenericSignature(genericSigID));

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 594; // @differentiable(reverse) attr
+const uint16_t SWIFTMODULE_VERSION_MINOR = 595; // Adding Actor class decls
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1208,6 +1208,7 @@ namespace decls_block {
     DeclContextIDField,     // context decl
     BCFixed<1>,             // implicit?
     BCFixed<1>,             // explicitly objc?
+    BCFixed<1>,             // Explicitly actor?
     BCFixed<1>,             // inherits convenience initializers from its superclass?
     BCFixed<1>,             // has missing designated initializers?
     GenericSignatureIDField, // generic environment

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3397,6 +3397,7 @@ public:
                             contextID.getOpaqueValue(),
                             theClass->isImplicit(),
                             theClass->isObjC(),
+                            theClass->isExplicitActor(),
                             mutableClass->inheritsSuperclassInitializers(),
                             mutableClass->hasMissingDesignatedInitializers(),
                             S.addGenericSignatureRef(

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -48,7 +48,7 @@ fileprivate func _registerMainActor(actor: AnyObject)
 @globalActor public final class MainActor {
   public static let shared = _Impl()
   
-  public actor class _Impl {
+  public actor _Impl {
     init() { _registerMainActor(actor: self) }
   }
 }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -71,7 +71,7 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
 // Check import of attributes
 func globalAsync() async { }
 
-actor class MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
+actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
   func syncMethod() { } // expected-note 2{{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
 
   func independentMethod() {

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -13,7 +13,7 @@ import Darwin
 import Glibc
 #endif
 
-actor class Counter {
+actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
 

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -26,7 +26,7 @@ func checkIfMainQueue(expectedAnswer expected: Bool) -> Bool {
   return true
 }
 
-actor class A {
+actor A {
   func onCorrectQueue(_ count : Int) -> Int {
     if checkIfMainQueue(expectedAnswer: false) {
       print("on actor instance's queue")

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-actor class BankAccount {
+actor BankAccount {
 
   private var curBalance : Int
 
@@ -61,7 +61,7 @@ actor class BankAccount {
     _ = deposit(withdraw(deposit(withdraw(balance()))))
   }
 
-} // end actor class
+} // end actor
 
 func someAsyncFunc() async {
   let deposit1 = 120, deposit2 = 45
@@ -136,7 +136,7 @@ func regularFunc() {
 }
 
 
-actor class TestActor {}
+actor TestActor {}
 
 @globalActor
 struct BananaActor {
@@ -189,7 +189,7 @@ func blender(_ peeler : () -> Void) {
 ///////////
 // check various curried applications to ensure we mark the right expression.
 
-actor class Calculator {
+actor Calculator {
   func addCurried(_ x : Int) -> ((Int) -> Int) { 
     return { (_ y : Int) in x + y }
   }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -22,7 +22,7 @@ struct Point {
   }
 }
 
-actor class TestActor {
+actor TestActor {
   // expected-note@+1{{mutable state is only available within the actor instance}}
   var position = Point(x: 0, y: 0)
   var nextPosition = Point(x: 0, y: 1)
@@ -122,7 +122,7 @@ extension TestActor {
 }
 
 // Check implicit async testing
-actor class DifferentActor {
+actor DifferentActor {
   func modify(_ state: inout Int) {}
 }
 
@@ -144,7 +144,7 @@ extension TestActor {
   }
 }
 
-actor class MyActor {
+actor MyActor {
   var points: [Point] = []
   var int: Int = 0
   var maybeInt: Int?

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -17,7 +17,7 @@ func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
 // ----------------------------------------------------------------------
 // Actor state isolation restrictions
 // ----------------------------------------------------------------------
-actor class MySuperActor {
+actor MySuperActor {
   var superState: Int = 25 // expected-note {{mutable state is only available within the actor instance}}
 
   func superMethod() { } // expected-note 3 {{calls to instance method 'superMethod()' from outside of its actor context are implicitly asynchronous}}
@@ -28,7 +28,7 @@ actor class MySuperActor {
   }
 }
 
-actor class MyActor: MySuperActor {
+actor MyActor: MySuperActor {
   let immutable: Int = 17
   var text: [String] = [] // expected-note 10{{mutable state is only available within the actor instance}}
 
@@ -199,7 +199,7 @@ extension MyActor {
 // ----------------------------------------------------------------------
 // Global actor isolation restrictions
 // ----------------------------------------------------------------------
-actor class SomeActor { }
+actor SomeActor { }
 
 @globalActor
 struct SomeGlobalActor {
@@ -395,7 +395,7 @@ func checkLocalFunctions() async {
 // Lazy properties with initializers referencing 'self'
 // ----------------------------------------------------------------------
 
-actor class LazyActor {
+actor LazyActor {
     var v: Int = 0
     // expected-note@-1 6 {{mutable state is only available within the actor instance}}
 
@@ -450,7 +450,7 @@ extension SomeClassInActor.ID {
 // ----------------------------------------------------------------------
 // Initializers
 // ----------------------------------------------------------------------
-actor class SomeActorWithInits {
+actor SomeActorWithInits {
   var mutableState: Int = 17
   var otherMutableState: Int
 

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -6,7 +6,7 @@ import Foundation
 
 func g(_ selector: Selector) -> Int { }
 
-actor class A {
+actor A {
   func selectors() {
     _ = #selector(type(of: self).f) // expected-error{{argument of '#selector' refers to instance method 'f()' that is not exposed to Objective-C}}
     _ = #selector(type(of: self).g) // expected-error{{argument of '#selector' refers to instance method 'g()' that is not exposed to Objective-C}}

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-actor class MyActor {
+actor MyActor {
   let immutable: Int = 17
   var text: [String] = []
 

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -7,7 +7,7 @@ func acceptEscapingClosure<T>(_: @escaping () -> T) { }
 func acceptAsyncClosure<T>(_: () async -> T) { }
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
 
-actor class MyActor {
+actor MyActor {
   func method() async -> String { "" }
 }
 
@@ -36,7 +36,7 @@ extension MyActor {
   }
 }
 
-actor class SomeActor { }
+actor SomeActor { }
 
 @globalActor
 struct SomeGlobalActor {

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -7,13 +7,13 @@ class NotConcurrent { }
 // ConcurrentValue restriction on actor operations
 // ----------------------------------------------------------------------
 
-actor class A1 {
+actor A1 {
   let localLet: NotConcurrent = NotConcurrent()
   func synchronous() -> NotConcurrent? { nil }
   func asynchronous(_: NotConcurrent?) async { }
 }
 
-actor class A2 {
+actor A2 {
   var localVar: NotConcurrent
 
   init(value: NotConcurrent) {
@@ -46,7 +46,7 @@ extension A1 {
 // ----------------------------------------------------------------------
 // ConcurrentValue restriction on global actor operations
 // ----------------------------------------------------------------------
-actor class TestActor {}
+actor TestActor {}
 
 @globalActor
 struct SomeGlobalActor {

--- a/test/Concurrency/default_actor_definit.swift
+++ b/test/Concurrency/default_actor_definit.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil %s -enable-experimental-concurrency | %FileCheck %s
 // REQUIRES: concurrency
 
-actor class A {
+actor A {
   var x: String = "Hello"
   var y: String = "World"
 }
@@ -9,7 +9,7 @@ actor class A {
 // CHECK:         builtin "initializeDefaultActor"(%0 : $A) : $()
 // CHECK-LABEL: end sil function '$s21default_actor_definit1ACACycfc'
 
-actor class B {
+actor B {
   var x: String
   var y: String
 
@@ -22,7 +22,7 @@ actor class B {
 // CHECK:         builtin "initializeDefaultActor"(%0 : $B) : $()
 // CHECK-LABEL: end sil function '$s21default_actor_definit1BCACycfc'
 
-actor class C {
+actor C {
   var x: String
   var y: Int
 

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -3,7 +3,7 @@
 
 // provides coverage for rdar://71548470
 
-actor class TestActor {}
+actor TestActor {}
 
 @globalActor
 struct SomeGlobalActor {
@@ -14,7 +14,7 @@ struct SomeGlobalActor {
 @SomeGlobalActor func syncGlobActorFn() { }
 @SomeGlobalActor func asyncGlobalActFn() async { }
 
-actor class Alex {
+actor Alex {
   @SomeGlobalActor let const_memb = 20
   @SomeGlobalActor var mut_memb = 30 // expected-note 2 {{mutable state is only available within the actor instance}}
   @SomeGlobalActor func method() {} // expected-note 2 {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-actor class SomeActor { }
+actor SomeActor { }
 
 @globalActor
 struct SomeGlobalActor {
@@ -140,7 +140,7 @@ class C6: P2, P3 {
 // ----------------------------------------------------------------------
 // Global actor checking for overrides
 // ----------------------------------------------------------------------
-actor class GenericSuper<T> {
+actor GenericSuper<T> {
   @GenericGlobalActor<T> func method() { }
 
   @GenericGlobalActor<T> func method2() { } // expected-note {{overridden declaration is here}}
@@ -149,7 +149,7 @@ actor class GenericSuper<T> {
   @GenericGlobalActor<T> func method5() { }
 }
 
-actor class GenericSub<T> : GenericSuper<[T]> {
+actor GenericSub<T> : GenericSuper<[T]> {
   override func method() { }  // expected-note{{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
   @GenericGlobalActor<T> override func method2() { } // expected-error{{global actor 'GenericGlobalActor<T>'-isolated instance method 'method2()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}

--- a/test/IRGen/actor_class.swift
+++ b/test/IRGen/actor_class.swift
@@ -37,7 +37,7 @@
 // CHECK-SAME: i16 1, i16 12, i32 2, i32 6,
 // CHECK-SAME: @"symbolic BD"
 
-public actor class MyClass {
+public actor MyClass {
   public var x: Int
   public init() { self.x = 0 }
 }
@@ -60,7 +60,7 @@ public actor class MyClass {
 // CHECK: swift_defaultActor_destroy
 // CHECK-LABEL: ret
 
-public actor class Exchanger<T> {
+public actor Exchanger<T> {
   public var value: T
 
   public init(value: T) { self.value = value }

--- a/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
@@ -7,19 +7,19 @@ import _Concurrency
 
 // CHECK: @_METACLASS_DATA__TtC37actor_class_forbid_objc_assoc_objects5Actor = internal constant { {{.*}} } { i32 [[METAFLAGS:1153]],
 // CHECK: @_DATA__TtC37actor_class_forbid_objc_assoc_objects5Actor = internal constant { {{.*}} } { i32 [[OBJECTFLAGS:1152|1216]],
-final actor class Actor {
+final actor Actor {
 }
 
 // CHECK: @_METACLASS_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor2 = internal constant { {{.*}} } { i32 [[METAFLAGS]],
 // CHECK: @_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor2 = internal constant { {{.*}} } { i32 [[OBJECTFLAGS]],
-actor class Actor2 {
+actor Actor2 {
 }
 
 // CHECK: @_METACLASS_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor3 = internal constant { {{.*}} } { i32 [[METAFLAGS]],
 // CHECK: @_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor3 = internal constant { {{.*}} } { i32 [[OBJECTFLAGS]],
 class Actor3 : Actor2 {}
 
-actor class GenericActor<T> {
+actor GenericActor<T> {
     var state: T
     init(state: T) { self.state = state }
 }

--- a/test/IRGen/actor_class_objc.swift
+++ b/test/IRGen/actor_class_objc.swift
@@ -32,7 +32,7 @@ import Foundation
 // CHECK-64-SAME: i64 96,
 // CHECK-32-SAME: i32 48,
 
-public actor class MyClass: NSObject {
+public actor MyClass: NSObject {
   public var x: Int
   public override init() { self.x = 0 }
 }

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -8,7 +8,7 @@ import Builtin
 import Swift
 import _Concurrency
 
-final actor class MyActor {
+final actor MyActor {
 }
 
 // CHECK-LABEL: define{{.*}} void @test_simple(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)

--- a/test/IRGen/async/run-switch-executor.swift
+++ b/test/IRGen/async/run-switch-executor.swift
@@ -16,7 +16,7 @@
 // Currently this test just checks if nothing crashes.
 // TODO: also check if the current executor is the correct one.
 
-final actor class MyActor {
+final actor MyActor {
   var p: Int
 
   @inline(never)

--- a/test/IRGen/ptrauth-actor.swift
+++ b/test/IRGen/ptrauth-actor.swift
@@ -8,11 +8,11 @@
 import Swift
 import _Concurrency
 
-public actor class A1 {
+public actor A1 {
   var x: Int = 17
 }
 
-open actor class A3<T>: Actor {
+open actor A3<T>: Actor {
   open func f() { }
 }
 

--- a/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
@@ -15,7 +15,7 @@ defer { runAllTests() }
 var Tests = TestSuite("Actor.AssocObject")
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-final actor class Actor {
+final actor Actor {
 }
 
 if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
@@ -29,7 +29,7 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 }
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-actor class Actor2 {
+actor Actor2 {
 }
 
 if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
@@ -85,7 +85,7 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 }
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-actor class Actor5<T> {
+actor Actor5<T> {
   var state: T
   init(state: T) { self.state = state }
 }
@@ -153,7 +153,7 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 }
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-actor class ActorNSObjectSubKlass : NSObject {}
+actor ActorNSObjectSubKlass : NSObject {}
 
 if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   Tests.test("no crash when inherit from nsobject")
@@ -164,7 +164,7 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 }
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-actor class ActorNSObjectSubKlassGeneric<T> : NSObject {
+actor ActorNSObjectSubKlassGeneric<T> : NSObject {
   var state: T
   init(state: T) { self.state = state }
 }

--- a/test/Interpreter/actor_subclass_metatypes.swift
+++ b/test/Interpreter/actor_subclass_metatypes.swift
@@ -14,7 +14,7 @@ defer { runAllTests() }
 
 var Tests = TestSuite("Actor.SubClass.Metatype")
 
-actor class Actor5<T> {
+actor Actor5<T> {
   var state: T
   init(state: T) { self.state = state }
 }

--- a/test/ModuleInterface/Inputs/MeowActor.swift
+++ b/test/ModuleInterface/Inputs/MeowActor.swift
@@ -1,7 +1,7 @@
 @globalActor public final class MeowActor {
   public static let shared = _Impl()
   
-  public actor class _Impl {
+  public actor _Impl {
     @actorIndependent
     public func enqueue(partialTask: PartialAsyncTask) {
       // DOES NOTHING! :)

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -6,8 +6,8 @@
 
 // REQUIRES: concurrency
 
-// CHECK: actor public class SomeActor
-public actor class SomeActor {
+// CHECK: public actor SomeActor
+public actor SomeActor {
   @actorIndependent func maine() { }
 }
 
@@ -36,8 +36,8 @@ public class C2 { }
 // CHECK: @{{(Test.)?}}SomeGlobalActor public class C2
 public class C3: C2 { }
 
-// CHECK: actor public class SomeSubActor
+// CHECK: public actor SomeSubActor
 // CHECK-NEXT: @actorIndependent public func maine()
-public actor class SomeSubActor: SomeActor {
+public actor SomeSubActor: SomeActor {
   override public func maine() { }
 }

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -5,21 +5,24 @@
 // REQUIRES: concurrency
 
 /// This test ensures that, when generating a swiftinterface file,
-/// the actor class decl itself is what may conform to the Actor protocol,
+/// the actor decl itself is what may conform to the Actor protocol,
 /// and not via some extension. The requirement is due to the unique
 /// optimizations applied to the implementation of actors.
 
 // CHECK-EXTENSION-NOT: extension {{.+}} : _Concurrency.Actor
 
-// CHECK: actor public class PlainActorClass {
-public actor class PlainActorClass {
+// CHECK: public actor PlainActorClass {
+public actor PlainActorClass {
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
 
-// CHECK: actor public class ExplicitActorClass : _Concurrency.Actor {
-public actor class ExplicitActorClass : Actor {
+// CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
+public actor ExplicitActorClass : Actor {
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
+
+// CHECK: public actor EmptyActor {
+public actor EmptyActor {}
 
 // CHECK: actor public class EmptyActorClass {
 public actor class EmptyActorClass {}
@@ -29,8 +32,8 @@ public protocol Cat : Actor {
   func mew()
 }
 
-// CHECK: actor public class HouseCat : Library.Cat {
-public actor class HouseCat : Cat {
+// CHECK: public actor HouseCat : Library.Cat {
+public actor HouseCat : Cat {
   @asyncHandler public func mew() {}
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
@@ -40,8 +43,8 @@ public protocol ToothyMouth {
   func chew()
 }
 
-// CHECK: actor public class Lion : Library.ToothyMouth, _Concurrency.Actor {
-public actor class Lion : ToothyMouth, Actor {
+// CHECK: public actor Lion : Library.ToothyMouth, _Concurrency.Actor {
+public actor Lion : ToothyMouth, Actor {
   @asyncHandler public func chew() {}
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }

--- a/test/SIL/Parser/concurrency.sil
+++ b/test/SIL/Parser/concurrency.sil
@@ -6,7 +6,7 @@ sil_stage raw // CHECK: sil_stage raw
 import Builtin
 import Swift
 
-actor class Actor { }
+actor Actor { }
 
 // CHECK-LABEL: sil @test_hop_to_executor
 sil @test_hop_to_executor : $@convention(thin) (@guaranteed Actor) -> () {

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -2,7 +2,7 @@
 // REQUIRES: concurrency
 
 
-actor class MyActor {
+actor MyActor {
 
   private var p: Int
 
@@ -119,14 +119,14 @@ func testGenericGlobalActorWithGetter() async {
 }
 
 
-actor class RedActorImpl {
+actor RedActorImpl {
   // CHECK-LABEL: sil hidden [ossa] @$s4test12RedActorImplC5helloyySiF : $@convention(method) (Int, @guaranteed RedActorImpl) -> () {
   // CHECK-NOT: hop_to_executor
   // CHECK: } // end sil function '$s4test12RedActorImplC5helloyySiF'
   func hello(_ x : Int) {}
 }
 
-actor class BlueActorImpl {
+actor BlueActorImpl {
 // CHECK-LABEL: sil hidden [ossa] @$s4test13BlueActorImplC4poke6personyAA03RedcD0C_tYF : $@convention(method) @async (@guaranteed RedActorImpl, @guaranteed BlueActorImpl) -> () {
 // CHECK:       bb0([[RED:%[0-9]+]] : @guaranteed $RedActorImpl, [[BLUE:%[0-9]+]] : @guaranteed $BlueActorImpl):
 // CHECK:         hop_to_executor [[BLUE]] : $BlueActorImpl

--- a/test/SILGen/synthesized_conformance_actor.swift
+++ b/test/SILGen/synthesized_conformance_actor.swift
@@ -5,7 +5,7 @@ public protocol DefaultInit {
   init()
 }
 
-public actor class A1<T: DefaultInit> {
+public actor A1<T: DefaultInit> {
   var x: Int = 17
   var y: T = T()
 
@@ -14,7 +14,7 @@ public actor class A1<T: DefaultInit> {
 
 extension Int: DefaultInit { }
 
-public actor class A2 {
+public actor A2 {
   func f() { }
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -7,7 +7,7 @@ sil_stage canonical
 import Builtin
 import Swift
 
-actor class MyActor {
+actor MyActor {
   @_hasStorage private var p: Int { get set }
 }
 

--- a/test/Serialization/Inputs/def_concurrency.sil
+++ b/test/Serialization/Inputs/def_concurrency.sil
@@ -3,7 +3,7 @@ sil_stage raw // CHECK: sil_stage canonical
 import Builtin
 import Swift
 
-actor class Act { }
+actor Act { }
 
 @_transparent public func serialize_all() {
 }

--- a/test/Serialization/attr-actorindependent.swift
+++ b/test/Serialization/attr-actorindependent.swift
@@ -13,7 +13,7 @@
 
 // look for correct annotation after first deserialization's module print:
 
-// MODULE-CHECK:      actor class UnsafeCounter {
+// MODULE-CHECK:      actor UnsafeCounter {
 // MODULE-CHECK-NEXT:   @actorIndependent(unsafe) func enqueue(partialTask: PartialAsyncTask)
 // MODULE-CHECK-NEXT:   @actorIndependent(unsafe) var storage: Int
 // MODULE-CHECK-NEXT:   @actorIndependent var count: Int
@@ -28,7 +28,7 @@
 // BC-CHECK: <ActorIndependent_DECL_ATTR abbrevid={{[0-9]+}} op0=0/>
 
 
-actor class UnsafeCounter {
+actor UnsafeCounter {
 
   @actorIndependent(unsafe)
   private var storage : Int = 0

--- a/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
@@ -1,9 +1,17 @@
 // BEGIN MyModule.swift
-public actor class MyActor {
+public actor MyActor {
   public func asyncFunc(fn: () async -> Void) async throws {}
 }
 
 func test(act: MyActor) async throws {
+    try await act.asyncFunc {}
+}
+
+public actor class MyActorClass {
+  public func asyncFunc(fn: () async -> Void) async throws {}
+}
+
+func test(act: MyActorClass) async throws {
     try await act.asyncFunc {}
 }
 
@@ -22,13 +30,19 @@ func test(act: MyActor) async throws {
 // RUN: %empty-directory(%t/Modules)
 // RUN: %target-swift-frontend -emit-module -o %t/Modules/MyModule.swiftmodule -module-name MyModule %t/MyModule.swift -enable-experimental-concurrency 
 
-// RUN: %sourcekitd-test -req=cursor -pos=1:20 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=ACTOR %s
+// RUN: %sourcekitd-test -req=cursor -pos=1:15 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=ACTOR %s
 // RUN: %sourcekitd-test -req=cursor -pos=2:15 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=FUNC %s
 // RUN: %sourcekitd-test -req=cursor -pos=5:16 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=ACTOR %s
 // RUN: %sourcekitd-test -req=cursor -pos=6:19  %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=FUNC %s
 
-// ACTOR: <Declaration>public actor class MyActor</Declaration>
-// ACTOR: <decl.class><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>actor</syntaxtype.keyword> <syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>MyActor</decl.name></decl.class>
+// RUN: %sourcekitd-test -req=cursor -pos=9:20  %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=CLASSACTOR %s
+// RUN: %sourcekitd-test -req=cursor -pos=13:16  %t/MyModule.swift -- %t/MyModule.swift -target %target-triple -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=CLASSACTOR %s
+
+// ACTOR: <Declaration>public actor MyActor</Declaration>
+// ACTOR: <decl.class><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>actor</syntaxtype.keyword> <decl.name>MyActor</decl.name></decl.class>
+
+// CLASSACTOR: <Declaration>public actor class MyActorClass</Declaration>
+// CLASSACTOR: <decl.class><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>actor</syntaxtype.keyword> <syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>MyActorClass</decl.name></decl.class>
 
 // FUNC: <Declaration>public func asyncFunc(fn: () async -&gt; <Type usr="s:s4Voida">Void</Type>) async throws</Declaration>
 // FUNC: <decl.function.method.instance><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>asyncFunc</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>fn</decl.var.parameter.argument_label>: <decl.var.parameter.type>() <syntaxtype.keyword>async</syntaxtype.keyword> -&gt; <decl.function.returntype><ref.typealias usr="s:s4Voida">Void</ref.typealias></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>async</syntaxtype.keyword> <syntaxtype.keyword>throws</syntaxtype.keyword></decl.function.method.instance>
@@ -36,12 +50,8 @@ func test(act: MyActor) async throws {
 // RUN: %sourcekitd-test -req=cursor -pos=3:16 %t/App.swift -- %t/App.swift -target %target-triple -I %t/Modules -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=ACTOR_XMOD %s
 // RUN: %sourcekitd-test -req=cursor -pos=4:19 %t/App.swift -- %t/App.swift -target %target-triple -I %t/Modules -Xfrontend -enable-experimental-concurrency | %FileCheck -check-prefix=FUNC_XMOD %s
 
-// ACTOR_XMOD: <Declaration>actor class MyActor</Declaration>
-// ACTOR_XMOD: <decl.class><syntaxtype.keyword>actor</syntaxtype.keyword> <syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>MyActor</decl.name></decl.class>
+// ACTOR_XMOD: <Declaration>actor MyActor</Declaration>
+// ACTOR_XMOD: <decl.class><syntaxtype.keyword>actor</syntaxtype.keyword> <decl.name>MyActor</decl.name></decl.class>
 
 // FUNC_XMOD: <Declaration>func asyncFunc(fn: () async -&gt; <Type usr="s:s4Voida">Void</Type>) async throws</Declaration>
 // FUNC_XMOD: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>asyncFunc</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>fn</decl.var.parameter.argument_label>: <decl.var.parameter.type>() <syntaxtype.keyword>async</syntaxtype.keyword> -&gt; <decl.function.returntype><ref.typealias usr="s:s4Voida">Void</ref.typealias></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>async</syntaxtype.keyword> <syntaxtype.keyword>throws</syntaxtype.keyword></decl.function.method.instance>
-
-
-
-

--- a/test/attr/actorindependent.swift
+++ b/test/attr/actorindependent.swift
@@ -39,7 +39,7 @@ class C {
   func f() { }
 }
 
-actor class A {
+actor A {
   var property: Int = 5
 
   // expected-error@+1{{'@actorIndependent' can not be applied to stored properties}}
@@ -80,7 +80,7 @@ actor class A {
   @actorIndependent static func staticFunc() { }
 }
 
-actor class FromProperty {
+actor FromProperty {
   // expected-note@+3{{mutable state is only available within the actor instance}}
   // expected-note@+2{{mutable state is only available within the actor instance}}
   // expected-note@+1{{mutable state is only available within the actor instance}}

--- a/test/attr/actorindependent_unsafe.swift
+++ b/test/attr/actorindependent_unsafe.swift
@@ -8,7 +8,7 @@
 
 //////////////////////////
 // 1 -- basic unsafe methods / properties accessing var member without annotation
-actor class Actor1 {
+actor Actor1 {
   var counter : Int = 42
   
   @actorIndependent(unsafe)
@@ -27,7 +27,7 @@ let _ = a1.computedProp == a1.computedProp
 
 //////////////////////////
 // 2 -- more unsafe methods / properties accessing var member without annotation
-actor class WeatherActor1 {
+actor WeatherActor1 {
   var tempCelsius : Double = 5.0
   
   var tempFahrenheit : Double { 
@@ -73,7 +73,7 @@ wa1.tempCelsiusUnsafe2 = wa1.tempCelsiusUnsafe2 + 2
 
 //////////////////////////
 // 3 -- basic actorIndependent accessing actorIndependent(unsafe) member
-actor class Actor2 {
+actor Actor2 {
   
   @actorIndependent(unsafe)
   var counter : Int = 42
@@ -94,7 +94,7 @@ let _ = a2.computedProp
 
 //////////////////////////
 // 4 -- more actorIndependent accessing actorIndependent(unsafe) member
-actor class WeatherActor2 {
+actor WeatherActor2 {
   @actorIndependent(unsafe)
   var tempCelsius : Double = 5.0
   
@@ -135,7 +135,7 @@ wa2.tempCelsiusUnsafe2 = wa2.tempCelsiusUnsafe2 + 2
 
 //////////////////////////
 // 5 -- even more actorIndependent accessing actorIndependent(unsafe) member
-actor class WeatherActor3 {
+actor WeatherActor3 {
   
   @actorIndependent(unsafe)
   var tempCelsius : Double = 5.0
@@ -183,7 +183,7 @@ wa3.tempCelsius -= 1
 //////////////////////////
 // 6 -- accesses to static members
 
-actor class Actor3 {
+actor Actor3 {
   @actorIndependent(unsafe)
   static var pi : Double = 3.0
 
@@ -205,14 +205,14 @@ let _ = Actor3.pi + Actor3.e
 @actorIndependent(unsafe)
 var time = 1.12
 
-actor class Actor4 {
+actor Actor4 {
   var currentTime : Double {
     get { time }
     set { time = newValue }
   }
 }
 
-actor class SomeActor { }
+actor SomeActor { }
 
 @globalActor
 struct SomeGlobalActor {

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -37,7 +37,7 @@ func asyncHandlerBad4(result: inout Int) { }
 func asyncHandlerBad5(result: () -> Int) { }
 // expected-error@-1{{non-escaping closure parameter is not allowed in '@asyncHandler' function}}
 
-actor class X {
+actor X {
   @asyncHandler func asyncHandlerMethod() { }
 
   @asyncHandler init() { }

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -23,10 +23,10 @@ class MyClass {
   // expected-error@-1{{asynchronous method returning 'Self' cannot be '@objc'}}
 }
 
-// Actor class exporting Objective-C entry points.
+// actor exporting Objective-C entry points.
 
-// CHECK: class MyActor
-actor class MyActor {
+// CHECK: actor MyActor
+actor MyActor {
   // CHECK: @objc func doBigJob() async -> Int
   // CHECK-DUMP: func_decl{{.*}}doBigJob{{.*}}foreign_async=@convention(block) (Int) -> (),completion_handler_param=0
   @objc func doBigJob() async -> Int { return 0 }
@@ -47,5 +47,13 @@ actor class MyActor {
   @objc @actorIndependent func synchronousGood() { }
 }
 
-// CHECK: @objc actor class MyObjCActor
-@objc actor class MyObjCActor: NSObject { }
+// CHECK: actor class MyActor2
+actor class MyActor2 { }
+// expected-warning@-1{{'actor class' has been renamed to 'actor'}}{{7-13=}}
+
+// CHECK: @objc actor MyObjCActor
+@objc actor MyObjCActor: NSObject { }
+
+// CHECK: @objc actor class MyObjCActor2
+@objc actor class MyObjCActor2: NSObject {}
+// expected-warning@-1{{'actor class' has been renamed to 'actor'}}{{13-19=}}

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify %s -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-actor class SomeActor { }
+actor SomeActor { }
 
 // -----------------------------------------------------------------------
 // @globalActor attribute itself.
@@ -83,7 +83,7 @@ class SomeClass {
 
 @GA1 typealias Integer = Int // expected-error{{type alias cannot have a global actor}}
 
-@GA1 actor class ActorInTooManyPlaces { } // expected-error{{actor class 'ActorInTooManyPlaces' cannot have a global actor}}
+@GA1 actor ActorInTooManyPlaces { } // expected-error{{actor class 'ActorInTooManyPlaces' cannot have a global actor}}
 
 @GA1 @OtherGlobalActor func twoGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('OtherGlobalActor' and 'GA1')}}
 

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -2,12 +2,26 @@
 
 // REQUIRES: concurrency
 
-actor class MyActor { }
+actor MyActor { }
 
 class MyActorSubclass1: MyActor { }
 
-actor class MyActorSubclass2: MyActor { }
+actor MyActorSubclass2: MyActor { }
+
+// expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{7-13=}}
+actor class MyActorClass { }
 
 class NonActor { }
 
-actor class NonActorSubclass : NonActor { } // expected-error{{actor class cannot inherit from non-actor class 'NonActor'}}
+actor NonActorSubclass : NonActor { } // expected-error{{actor class cannot inherit from non-actor class 'NonActor'}}
+
+// expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{14-20=}}
+public actor class BobHope {}
+// expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{14-19=actor}}{{1-7=}}
+actor public class BarbraStreisand {}
+// expected-warning@+2{{'actor class' has been renamed to 'actor'}}{{14-21=}}
+// expected-error@+1{{'actor' may only be used on 'class' declarations}}
+public actor struct JulieAndrews {}
+// expected-warning@+2{{'actor class' has been renamed to 'actor'}}{{14-18=actor}}{{1-7=}}
+// expected-error@+1{{'actor' may only be used on 'class' declarations}}
+actor public enum TomHanks {}

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -6,7 +6,7 @@ protocol AsyncProtocol {
   func asyncMethod() async -> Int
 }
 
-actor class MyActor {
+actor MyActor {
 }
 
 // Actors conforming to asynchronous program.
@@ -31,7 +31,7 @@ protocol SyncProtocol {
 }
 
 
-actor class OtherActor: SyncProtocol {
+actor OtherActor: SyncProtocol {
   var propertyB: Int = 17
   // expected-error@-1{{actor-isolated property 'propertyB' cannot be used to satisfy a protocol requirement}}
 

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-actor class SomeActor { }
+actor SomeActor { }
 
 @globalActor
 struct GlobalActor {

--- a/test/decl/protocol/conforms/objc_async.swift
+++ b/test/decl/protocol/conforms/objc_async.swift
@@ -54,7 +54,7 @@ extension C5: ConcurrentProtocol {
 }
 
 // Global actors.
-actor class SomeActor { }
+actor SomeActor { }
 
 @globalActor
 struct SomeGlobalActor {

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -1,38 +1,38 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-// Synthesis of for actor classes.
+// Synthesis of for actores.
 
-actor class A1 {
+actor A1 {
   var x: Int = 17
 }
 
-actor class A2: Actor {
+actor A2: Actor {
   var x: Int = 17
 }
 
-actor class A3<T>: Actor {
+actor A3<T>: Actor {
   var x: Int = 17
 }
 
-actor class A4: A1 {
+actor A4: A1 {
 }
 
-actor class A5: A2 {
+actor A5: A2 {
 }
 
-actor class A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
+actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
   // expected-note@-1{{'A6' inherits conformance to protocol 'Actor' from superclass here}}
 }
 
 // Explicitly satisfying the requirement.
 
-actor class A7 {
+actor A7 {
   // Okay: satisfy the requirement explicitly
   @actorIndependent func enqueue(partialTask: PartialAsyncTask) { }
 }
 
-// A non-actor class can conform to the Actor protocol, if it does it properly.
+// A non-actor can conform to the Actor protocol, if it does it properly.
 class C1: Actor {
   func enqueue(partialTask: PartialAsyncTask) { }
 }
@@ -40,7 +40,7 @@ class C1: Actor {
 // Bad actors, that incorrectly try to satisfy the various requirements.
 
 // Method that is not usable as a witness.
-actor class BA1 {
+actor BA1 {
   func enqueue(partialTask: PartialAsyncTask) { } // expected-error{{actor-isolated instance method 'enqueue(partialTask:)' cannot be used to satisfy a protocol requirement}}
   //expected-note@-1{{add '@asyncHandler' to function 'enqueue(partialTask:)' to create an implicit asynchronous context}}{{3-3=@asyncHandler }}
   //expected-note@-2{{add '@actorIndependent' to 'enqueue(partialTask:)' to make this instance method independent of the actor}}{{3-3=@actorIndependent }}
@@ -48,14 +48,14 @@ actor class BA1 {
 
 // Method that isn't part of the main class definition cannot be used to
 // satisfy the requirement, because then it would not have a vtable slot.
-actor class BA2 { }
+actor BA2 { }
 
 extension BA2 {
   // expected-error@+1{{'enqueue(partialTask:)' can only be implemented in the definition of actor class 'BA2'}}
   @actorIndependent func enqueue(partialTask: PartialAsyncTask) { }
 }
 
-// No synthesis for non-actor classes.
+// No synthesis for non-actores.
 class C2: Actor { // expected-error{{type 'C2' does not conform to protocol 'Actor'}}
 }
 

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -55,14 +55,28 @@ public:
   TestContext(ShouldDeclareOptionalTypes optionals = DoNotDeclareOptionalTypes);
 
   template <typename Nominal>
-  Nominal *makeNominal(StringRef name,
-                       GenericParamList *genericParams = nullptr) {
+  typename std::enable_if<!std::is_same<Nominal, swift::ClassDecl>::value,
+                          Nominal *>::type
+  makeNominal(StringRef name, GenericParamList *genericParams = nullptr) {
     auto result = new (Ctx) Nominal(SourceLoc(), Ctx.getIdentifier(name),
                                     SourceLoc(), /*inherited*/{},
                                     genericParams, FileForLookups);
     result->setAccess(AccessLevel::Internal);
     return result;
   }
+
+  template <typename Nominal>
+  typename std::enable_if<std::is_same<Nominal, swift::ClassDecl>::value,
+                          swift::ClassDecl *>::type
+  makeNominal(StringRef name, GenericParamList *genericParams = nullptr) {
+    auto result = new (Ctx) ClassDecl(SourceLoc(), Ctx.getIdentifier(name),
+                                      SourceLoc(), /*inherited*/{},
+                                      genericParams, FileForLookups,
+                                      /*isActor*/false);
+    result->setAccess(AccessLevel::Internal);
+    return result;
+  }
+
 };
 
 } // end namespace unittest

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -197,7 +197,7 @@ DECL_NODES = [
          ]),
 
     # class-declaration -> attributes? access-level-modifier?
-    #                      'class' class-name
+    #                      ('class' | 'actor') class-name
     #                      generic-parameter-clause?
     #                      type-inheritance-clause?
     #                      generic-where-clause?
@@ -210,7 +210,8 @@ DECL_NODES = [
                    collection_element_name='Attribute', is_optional=True),
              Child('Modifiers', kind='ModifierList',
                    collection_element_name='Modifier', is_optional=True),
-             Child('ClassKeyword', kind='ClassToken'),
+             Child('ClassOrActorKeyword', kind='Token',
+                    token_choices=['ClassToken', 'ContextualKeywordToken']),
              Child('Identifier', kind='IdentifierToken'),
              Child('GenericParameterClause', kind='GenericParameterClause',
                    is_optional=True),


### PR DESCRIPTION
We've decided to go with calling actor classes `actor` instead of `actor class`.
We still want to be able to parse in `actor class` and recommend the correct fix-its to make it just `actor`. This is a little challenging since we parse other modifiers in any order, so `actor public class Foo` and `public actor class Foo` were both totally parsable. We still need to be able to do that, which makes this change less pleasant.

Furthermore, we want to make it a contextual keyword instead of an actual keyword so that we avoid breaking as much source. This also adds to the complexity.

I will update the diagnostics to refer to `actor` later.

Resolves: rdar://73728503