### PR TITLE
Harden `isKindOfClass:` check

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -554,7 +554,7 @@ isKindOfClass(HeapObject *object, Class cls) {
   IMP NSProxyLookupMethod = SWIFT_LAZY_CONSTANT(getNSProxyLookupMethod());
   // People sometimes fail to override `methodSignatureForSelector:` in their
   // NSProxy subclasses, which causes `isKindOfClass:` to crash.  Avoid that...
-  Class objectClass = object_getClass(object);
+  Class objectClass = object_getClass((id)object);
   IMP objectLookupMethod = class_getMethodImplementation(objectClass, @selector(methodSignatureForSelector:));
   if (objectLookupMethod == NSProxyLookupMethod) {
     return false;

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -542,6 +542,28 @@ swift::_swift_stdlib_bridgeErrorToNSError(SwiftError *errorObject) {
 
 extern "C" const ProtocolDescriptor PROTOCOL_DESCR_SYM(s5Error);
 
+static Method
+getNSProxyLookupMethod() {
+  Class NSProxyClass = objc_lookUpClass("NSProxy");
+  Method NSProxyLookupMethod = class_getInstanceMethod(NSProxyClass, @selector(methodSignatureForSelector:));
+}
+
+// A safer alternative to calling `isKindOfClass:` directly.
+static bool
+isKindOfClass(HeapObject *object, Class cls) {
+  Method NSProxyLookupMethod = SWIFT_LAZY_CONSTANT(getNSProxyLookupMethod());
+
+  // People sometimes fail to override `methodSignatureForSelector:` in their
+  // NSProxy subclasses, which causes `isKindOfClass:` to crash.  Avoid that...
+  Method objectLookupMethod = object_getObjectMethod(object, @selector(methodSignatureForSelector:));
+  if (objectLookupMethod == NSProxyLookupMethod) {
+    return false;
+  }
+  
+  return [reinterpret_cast<id>(object) isKindOfClass: cls];
+}
+
+
 bool
 swift::tryDynamicCastNSErrorObjectToValue(HeapObject *object,
                                           OpaqueValue *dest,
@@ -550,8 +572,7 @@ swift::tryDynamicCastNSErrorObjectToValue(HeapObject *object,
   Class NSErrorClass = getNSErrorClass();
 
   // The object must be an NSError subclass.
-  if (isObjCTaggedPointerOrNull(object) ||
-      ![reinterpret_cast<id>(object) isKindOfClass: NSErrorClass])
+  if (isObjCTaggedPointerOrNull(object) || !isKindOfClass(object, NSErrorClass))
     return false;
 
   id srcInstance = reinterpret_cast<id>(object);


### PR DESCRIPTION
We've seen some Obj-C NSProxy subclass implementations that are broken and will
crash if you send them a standard `isKindOfClass:` message.  This came out because
the casting machinery is now more aggressive about trying different casting options which
means some of these broken objects are being queried in new ways.

This adds an additional check before calling `isKindOfClass:` to verify that
this object is not using the default NSProxy selector routing.  If it is,
we just assume it's not whatever class is being tested for since we cannot
do anything better.

Resolves rdar://73799124