### PR TITLE
Introduce checking for language features via "#if $FeatureName"

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -1,0 +1,41 @@
+//===--- Features.def - Swift Features Metaprogramming ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for macro-metaprogramming with language
+// features.
+//
+//
+// FEATURE(FeatureName, SENumber, Description, Option)
+//
+//   The FEATURE macro describes each named feature that is introduced in
+//   Swift. It allows Swift code to check for a particular feature with
+//   "#if $FeatureName" in source code.
+//
+//     FeatureName: The name given to this feature to be used in source code,
+//       e.g., AsyncAwait.
+//     SENumber: The number assigned to this feature in the Swift Evolution
+//       process, or 0 if there isn't one.
+//     Description: A string literal describing the feature.
+//     Option: either a reference to a language option in the form
+//       "langOpts.<option name>" or "true" to indicate that it's always
+//       enabled.
+//===----------------------------------------------------------------------===//
+
+#ifndef LANGUAGE_FEATURE
+#  error define LANGUAGE_FEATURE before including Features.def
+#endif
+
+LANGUAGE_FEATURE(StaticAssert, 0, "#assert", langOpts.EnableExperimentalStaticAssert)
+LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
+LANGUAGE_FEATURE(Actors, 0, "actors", langOpts.EnableExperimentalConcurrency)
+
+#undef LANGUAGE_FEATURE

--- a/test/Parse/features.swift
+++ b/test/Parse/features.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend -typecheck %s 2>&1 | %FileCheck --check-prefix=CHECK-WITHOUT %s 
+// RUN: %target-typecheck-verify-swift -enable-experimental-static-assert
+
+#if compiler(>=5.3) && $StaticAssert
+#assert(true)
+#else
+// CHECK-WITHOUT: cannot find 'complete' in scope
+complete junk
+#endif


### PR DESCRIPTION
Introduce some basic support for defining specific language features
that can be checked by name, e.g.,

    #if $AsyncAwait
    // use the feature
    #endif

For backward compatibility with older compilers, to actually prevent
the parser from parsing, one will have to do a Swift compiler version
check, even though the version number doesn't matter. For example:

    #if compiler(>=5.3) && $AsyncAwait
    // use the feature
    #endif
