### PR TITLE
Allow 'lazy' local variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ Swift Next
   }
   ```
 
+* The 'lazy' keyword now works in local contexts, making the following valid:
+
+  ```swift
+  func test(useIt: Bool) {
+    lazy var result = getPotentiallyExpensiveResult()
+    if useIt {
+      doIt(result)
+    }
+  }
+  ```
+
 Swift 5.4
 ---------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ Swift Next
 Swift 5.4
 ---------
 
+* Property wrappers now work in local contexts, making the following valid:
+
+  ```swift
+  @propertyWrapper
+  struct Wrapper<T> {
+    var wrappedValue: T
+  }
+
+  func test() {
+    @Wrapper var value = 10
+  }
+  ```
+
 * [SR-10069][]:
 
   Function overloading now works in local contexts, making the following valid:

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3076,20 +3076,18 @@ ERROR(attr_MainType_without_main,none,
 ERROR(lazy_not_on_let,none,
       "'lazy' cannot be used on a let", ())
 ERROR(lazy_not_on_computed,none,
-      "'lazy' must not be used on a computed property", ())
+      "'lazy' cannot be used on a computed property", ())
 
 ERROR(lazy_on_already_lazy_global,none,
-      "'lazy' must not be used on an already-lazy global", ())
+      "'lazy' cannot be used on an already-lazy global", ())
 ERROR(lazy_not_in_protocol,none,
-      "'lazy' isn't allowed on a protocol requirement", ())
+      "'lazy' cannot be used on a protocol requirement", ())
 ERROR(lazy_requires_initializer,none,
       "lazy properties must have an initializer", ())
 
 ERROR(lazy_requires_single_var,none,
       "'lazy' cannot destructure an initializer", ())
 
-ERROR(lazy_must_be_property,none,
-      "lazy is only valid for members of a struct or class", ())
 ERROR(lazy_not_strong,none,
       "lazy properties cannot be %0", (ReferenceOwnership))
 ERROR(lazy_var_storage_access,none,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5936,16 +5936,18 @@ void VarDecl::visitAuxiliaryDecls(llvm::function_ref<void(VarDecl *)> visit) con
   if (getDeclContext()->isTypeContext())
     return;
 
-  // Avoid request evaluator overhead in the common case where there's
-  // no wrapper.
-  if (!getAttrs().hasAttribute<CustomAttr>())
-    return;
+  if (getAttrs().hasAttribute<LazyAttr>()) {
+    if (auto *backingVar = getLazyStorageProperty())
+      visit(backingVar);
+  }
 
-  if (auto *backingVar = getPropertyWrapperBackingProperty())
-    visit(backingVar);
+  if (getAttrs().hasAttribute<CustomAttr>()) {
+    if (auto *backingVar = getPropertyWrapperBackingProperty())
+      visit(backingVar);
 
-  if (auto *projectionVar = getPropertyWrapperProjectionVar())
-    visit(projectionVar);
+    if (auto *projectionVar = getPropertyWrapperProjectionVar())
+      visit(projectionVar);
+  }
 }
 
 VarDecl *VarDecl::getLazyStorageProperty() const {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2790,6 +2790,14 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
             collectFunctionCaptures(accessor);
         };
 
+        // 'Lazy' properties don't fit into the below categorization,
+        // and they have a synthesized getter, not a parsed one.
+        if (capturedVar->getAttrs().hasAttribute<LazyAttr>()) {
+          if (auto *getter = capturedVar->getSynthesizedAccessor(
+                AccessorKind::Get))
+            collectFunctionCaptures(getter);
+        }
+
         if (!capture.isDirect()) {
           auto impl = capturedVar->getImplInfo();
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1227,14 +1227,15 @@ void SILGenFunction::visitVarDecl(VarDecl *D) {
     auto wrapperInfo = D->getPropertyWrapperBackingPropertyInfo();
     if (wrapperInfo && wrapperInfo.initializeFromOriginal)
       SGM.emitPropertyWrapperBackingInitializer(D);
-
-    D->visitAuxiliaryDecls([&](VarDecl *var) {
-      if (auto *patternBinding = var->getParentPatternBinding())
-        visitPatternBindingDecl(patternBinding);
-
-      visit(var);
-    });
   }
+
+  // Emit lazy and property wrapper backing storage.
+  D->visitAuxiliaryDecls([&](VarDecl *var) {
+    if (auto *patternBinding = var->getParentPatternBinding())
+      visitPatternBindingDecl(patternBinding);
+
+    visit(var);
+  });
 
   // Emit the variable's accessors.
   D->visitEmittedAccessors([&](AccessorDecl *accessor) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -867,14 +867,8 @@ void AttributeChecker::visitLazyAttr(LazyAttr *attr) {
 
   // 'lazy' is not allowed on a global variable or on a static property (which
   // are already lazily initialized).
-  // TODO: we can't currently support lazy properties on non-type-contexts.
-  if (VD->isStatic() ||
-      (varDC->isModuleScopeContext() &&
-       !varDC->getParentSourceFile()->isScriptMode())) {
+  if (VD->isStatic() || varDC->isModuleScopeContext())
     diagnoseAndRemoveAttr(attr, diag::lazy_on_already_lazy_global);
-  } else if (!VD->getDeclContext()->isTypeContext()) {
-    diagnoseAndRemoveAttr(attr, diag::lazy_must_be_property);
-  }
 }
 
 bool AttributeChecker::visitAbstractAccessControlAttr(

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1330,7 +1330,8 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
 
   // Recontextualize any closure declcontexts nested in the initializer to
   // realize that they are in the getter function.
-  Get->getImplicitSelfDecl()->setDeclContext(Get);
+  if (Get->hasImplicitSelfDecl())
+    Get->getImplicitSelfDecl()->setDeclContext(Get);
 
   InitValue->walk(RecontextualizeClosures(Get));
 

--- a/test/SILGen/lazy_locals.swift
+++ b/test/SILGen/lazy_locals.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-emit-silgen -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+// CHECK-LABEL: sil hidden [ossa] @$s11lazy_locals6simpleSiyF : $@convention(thin) () -> Int {
+func simple() -> Int {
+  lazy var x = 123
+  return x
+}
+
+// CHECK-LABEL: sil private [lazy_getter] [noinline] [ossa] @$s11lazy_locals6simpleSiyF1xL_Sivg : $@convention(thin) (@guaranteed { var Optional<Int> }) -> Int {
+
+// CHECK-LABEL: sil hidden [ossa] @$s11lazy_locals8captures1xS2i_tF : $@convention(thin) (Int) -> Int {
+func captures(x: Int) -> Int {
+  let y = x * x
+  lazy var z = x + y
+  let fn = { z }
+  return fn()
+}
+
+// CHECK-LABEL: sil private [lazy_getter] [noinline] [ossa] @$s11lazy_locals8captures1xS2i_tF1zL_Sivg : $@convention(thin) (@guaranteed { var Optional<Int> }, Int, Int) -> Int {
+// CHECK-LABEL: sil private [ossa] @$s11lazy_locals8captures1xS2i_tFSiycfU_ : $@convention(thin) (@guaranteed { var Optional<Int> }, Int, Int) -> Int {
+
+// CHECK-LABEL: sil hidden [ossa] @$s11lazy_locals6assignSiyF : $@convention(thin) () -> Int {
+func assign() -> Int {
+  lazy var z = 123
+  z = 321
+  return z
+}
+
+// CHECK-LABEL: sil private [lazy_getter] [noinline] [ossa] @$s11lazy_locals6assignSiyF1zL_Sivg : $@convention(thin) (@guaranteed { var Optional<Int> }) -> Int {
+// CHECK-LABEL: sil private [ossa] @$s11lazy_locals6assignSiyF1zL_Sivs : $@convention(thin) (Int, @guaranteed { var Optional<Int> }) -> () {
+
+// CHECK-LABEL: sil hidden [ossa] @$s11lazy_locals7generic1xxx_tlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
+func generic<T>(x: T) -> T {
+  lazy var z = x
+  return z
+}
+
+// CHECK-LABEL: sil private [lazy_getter] [noinline] [ossa] @$s11lazy_locals7generic1xxx_tlF1zL_xvg : $@convention(thin) <T> (@guaranteed <τ_0_0> { var Optional<τ_0_0> } <T>, @in_guaranteed T) -> @out T {

--- a/test/decl/var/lazy_properties.swift
+++ b/test/decl/var/lazy_properties.swift
@@ -2,18 +2,18 @@
 
 lazy func lazy_func() {} // expected-error {{'lazy' may only be used on 'var' declarations}} {{1-6=}}
 
-lazy var b = 42  // expected-error {{'lazy' must not be used on an already-lazy global}} {{1-6=}}
+lazy var b = 42  // expected-error {{'lazy' cannot be used on an already-lazy global}} {{1-6=}}
 
 struct S {
-  lazy static var lazy_global = 42 // expected-error {{'lazy' must not be used on an already-lazy global}} {{3-8=}}
+  lazy static var lazy_global = 42 // expected-error {{'lazy' cannot be used on an already-lazy global}} {{3-8=}}
 }
 
 protocol SomeProtocol {
-  lazy var x : Int  // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
+  lazy var x : Int  // expected-error {{'lazy' cannot be used on a protocol requirement}} {{3-8=}}
   // expected-error@-1 {{property in protocol must have explicit { get } or { get set } specifier}} {{19-19= { get <#set#> \}}}
   // expected-error@-2 {{lazy properties must have an initializer}}
-  lazy var y : Int { get } // expected-error {{'lazy' isn't allowed on a protocol requirement}} {{3-8=}}
-  // expected-error@-1 {{'lazy' must not be used on a computed property}}
+  lazy var y : Int { get } // expected-error {{'lazy' cannot be used on a protocol requirement}} {{3-8=}}
+  // expected-error@-1 {{'lazy' cannot be used on a computed property}}
   // expected-error@-2 {{lazy properties must have an initializer}}
 }
 
@@ -24,7 +24,7 @@ class TestClass {
 
   lazy let b = 42  // expected-error {{'lazy' cannot be used on a let}} {{3-8=}}
 
-  lazy var c : Int { return 42 } // expected-error {{'lazy' must not be used on a computed property}} {{3-8=}}
+  lazy var c : Int { return 42 } // expected-error {{'lazy' cannot be used on a computed property}} {{3-8=}}
   // expected-error@-1 {{lazy properties must have an initializer}}
 
   lazy var d : Int  // expected-error {{lazy properties must have an initializer}} {{3-8=}}
@@ -55,7 +55,7 @@ class TestClass {
   }
 
   init() {
-    lazy var localvar = 42  // expected-error {{lazy is only valid for members of a struct or class}} {{5-10=}}
+    lazy var localvar = 42 // Okay
     localvar += 1
     _ = localvar
   }


### PR DESCRIPTION
Thanks to the changes that @hborla did to support local property wrappers, getting local `lazy` working only took a couple of tweaks. I added an entry to the CHANGELOG about this, as well as another entry for local property wrappers.