### PR TITLE
[validation] Fix some portability test issues.

### DIFF
--- a/utils/rth
+++ b/utils/rth
@@ -83,6 +83,9 @@ class ResilienceTest(object):
     def is_windows_host(self):
         return self.triple.split('-')[2] == 'windows'
 
+    def is_openbsd_host(self):
+        return self.triple.split('-')[2].startswith('openbsd')
+
     def compile_library(self):
         for config in self.config_dir_map:
             lib_file = self.lib_prefix + self.lib_name + self.lib_suffix
@@ -198,6 +201,9 @@ class ResilienceTest(object):
                 # drives library searching on Windows
                 os.chdir(self.config_dir_map[config1])
             else:
+                if self.is_openbsd_host():
+                    compiler_flags.extend([
+                        '-Xlinker', '-z', '-Xlinker', 'origin'])
                 compiler_flags.extend([
                     '-Xlinker', '-rpath', '-Xlinker',
                     os.path.join(rpath_origin,

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(first)) %S/Inputs/dsohandle-first.swift -emit-module -module-name first
 // RUN: %target-build-swift-dylib(%t/%target-library-name(second)) %S/Inputs/dsohandle-second.swift -emit-module -module-name second
-// RUN: %target-build-swift -I %t -L %t -lfirst -lsecond %s -o %t/main
+// RUN: %target-build-swift -I %t -L %t -lfirst -lsecond %s -o %t/main %target-rpath(%t)
 // RUN: %target-codesign %t/main %t/%target-library-name(first) %t/%target-library-name(second)
 // RUN: %target-run %t/main %t/%target-library-name(first) %t/%target-library-name(second)
 

--- a/validation-test/stdlib/HashingRandomization.swift
+++ b/validation-test/stdlib/HashingRandomization.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -disable-access-control -module-name main %s -o %t/hash
 // RUN: %target-codesign %t/hash
-// RUN: env -u %env-SWIFT_DETERMINISTIC_HASHING %target-run %t/hash > %t/nondeterministic.log
-// RUN: env -u %env-SWIFT_DETERMINISTIC_HASHING %target-run %t/hash >> %t/nondeterministic.log
+// RUN: env %env-SWIFT_DETERMINISTIC_HASHING='' %target-run %t/hash > %t/nondeterministic.log
+// RUN: env %env-SWIFT_DETERMINISTIC_HASHING='' %target-run %t/hash >> %t/nondeterministic.log
 // RUN: %FileCheck --check-prefixes=RANDOM %s < %t/nondeterministic.log
 // RUN: env %env-SWIFT_DETERMINISTIC_HASHING=1 %target-run %t/hash > %t/deterministic.log
 // RUN: env %env-SWIFT_DETERMINISTIC_HASHING=1 %target-run %t/hash >> %t/deterministic.log


### PR DESCRIPTION
Here we fix a few portability issues affecting running the validation tests on OpenBSD. The remaining failures will be dealt with separately.

1. In the `rth` tool, ensure `-z origin` is specified to the linker when
   using `$ORIGIN`, as required on this platform.

2. Explicitly set the rpath in the `dsohandle-multi-module` execution
   test, since the test uses built dynamic libraries during the test.

3. Erase the environment variable instead of using `env -u`, the latter
   of which is not portable.