### PR TITLE
[tools] Fix invocation of execv.

### DIFF
--- a/stdlib/tools/swift-reflection-test/swift-reflection-test.c
+++ b/stdlib/tools/swift-reflection-test/swift-reflection-test.c
@@ -643,8 +643,15 @@ int doDumpHeapInstance(const char *BinaryFilename) {
       close(PipeMemoryReader_getParentReadFD(&Pipe));
       dup2(PipeMemoryReader_getChildReadFD(&Pipe), STDIN_FILENO);
       dup2(PipeMemoryReader_getChildWriteFD(&Pipe), STDOUT_FILENO);
-      _execv(BinaryFilename, NULL);
-      exit(EXIT_SUCCESS);
+
+      char *const argv[] = {strdup(BinaryFilename), NULL};
+      int r = _execv(BinaryFilename, argv);
+      int status = EXIT_SUCCESS;
+      if (r == -1) {
+        perror("child process");
+        status = EXIT_FAILURE;
+      }
+      exit(status);
     }
     default: { // Parent
       close(PipeMemoryReader_getChildReadFD(&Pipe));


### PR DESCRIPTION
If execv fails, then there is no valid indication of what failed. This
may manifest itself as an unexpected EOF in `collectBytesFromPipe` when
in fact this is a problem with `execv`. Check the return status and be
noisy if the exec fails.

Now, on other platforms, it may not be a runtime error to call
`execv(..., NULL)`, despite the manual pages and standards requesting
that a valid array be passed. Furthermore, other platforms may require
that argv[0] be populated, and with a valid executable name.

Ensuring that these conditions are fulfilled is more correct, and
permits the Reflection validation tests to successfully run and pass on
OpenBSD.