### PR TITLE
[DRAFT][partial-spec] Turn off partial generic specialization on the stdlib/foundation

### DIFF
--- a/stdlib/public/Darwin/Foundation/CMakeLists.txt
+++ b/stdlib/public/Darwin/Foundation/CMakeLists.txt
@@ -80,7 +80,7 @@ add_swift_target_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES
   GYB_SOURCES
     NSValue.swift.gyb
 
-  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "-Xllvm" "-sil-partial-specialization" "${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}"
+  SWIFT_COMPILE_FLAGS "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}" "-Xllvm" "-sil-inline-generics" "${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}"
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS_OSX Darwin CoreGraphics Dispatch CoreFoundation ObjectiveC # auto-updated

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -277,7 +277,6 @@ option(SWIFT_CHECK_ESSENTIAL_STDLIB
 
 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
   list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
-  list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-partial-specialization")
 endif()
 if(SWIFT_STDLIB_ENABLE_STDLIBCORE_EXCLUSIVITY_CHECKING)
   list(APPEND swift_stdlib_compile_flags "-enforce-exclusivity=checked")


### PR DESCRIPTION
The reason why I am doing this is that we only have it enabled on the
stdlib/foundation. This causes it to not have the same test coverage that other
forms of inlining since those forms of inlining run anywhere.

I recently just hit a bug due to this so I was curious how much bang we are
getting for this.
