### PR TITLE
[android][test] XFAIL memory-layout-silgen in Android ARMv7

### DIFF
--- a/test/Interop/Cxx/class/memory-layout-silgen.swift
+++ b/test/Interop/Cxx/class/memory-layout-silgen.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swiftxx-frontend -I %S/Inputs -emit-ir -o - %s | %FileCheck %s
 
-// UNSUPPORTED: OS=linux-android
+// XFAIL: OS=linux-android
+// XFAIL: OS=linux-androideabi
 
 import MemoryLayout
 


### PR DESCRIPTION
Change the original UNSUPPORTED to XFAIL, to get signal if the test
starts working.

PR #35707 should allow this test to work properly.

/cc @buttaface 