### PR TITLE
[Docs] Add some initial user-facing driver documentation to ship in the toolchain

### DIFF
--- a/userdocs/CMakeLists.txt
+++ b/userdocs/CMakeLists.txt
@@ -1,3 +1,6 @@
 swift_install_in_component(DIRECTORY diagnostics
                            DESTINATION "share/doc/swift"
                            COMPONENT compiler)
+swift_install_in_component(DIRECTORY driver
+                           DESTINATION "share/doc/swift"
+                           COMPONENT compiler)

--- a/userdocs/driver/immediate-mode.md
+++ b/userdocs/driver/immediate-mode.md
@@ -1,0 +1,5 @@
+# Immediate Mode
+
+Single-file Swift programs and scripts can be run immediately using `swift /path/to/file.swift`. Any arguments which come before the input file will be processed by `swift`, and any arguments which follow it will be processed as arguments of the program. For example, `swift -warnings-as-errors myscript.swift foo bar` will treat warnings as errors while interpreting `myscript.swift` with arguments `foo` and `bar`.
+
+On Unix platforms, it's also possible to treat a `.swift` file as an executable which can be run directly. To do so, add a "shebang" line starting with `#!/usr/bin/swift` at the top of the file and grant it executable permissions.

--- a/userdocs/driver/repl.md
+++ b/userdocs/driver/repl.md
@@ -1,0 +1,9 @@
+# REPL Mode
+
+The Swift REPL (Read-Eval-Print Loop) makes it easy to quickly run individual statements and expressions with instant feedback. To launch the REPL, run `swift` without providing any input files.
+
+The REPL will evaluate any Swift code typed at the prompt and display the result immediately. You can press TAB at any time for code completion suggestions, and the up and down arrow keys can be used to access the REPL session's history. To run a swift script in the current REPL session, type `<` followed by its path.
+
+Each REPL session is also a full-featured LLDB debugging session. Any line starting with `:` will be interpreted as an LLDB command. For a complete listing of LLDB commands, type `:help`.
+
+To exit the REPL, type `:quit` or use CTRL-D.


### PR DESCRIPTION
The new documentation will live at usr/share/doc/swift/driver.

For now, this just includes a basic description of how to use the immediate and REPL modes. Some ideas for future topics include batch mode, `-incremental`, WMO, and output file maps

The plan is to copy Go's help tool and expose these via `swift help`. Something like this:

<img width="598" alt="image" src="https://user-images.githubusercontent.com/1946221/107167114-d7a17800-696c-11eb-8168-d17cb5e06f96.png">