### PR TITLE
[cxx-interop] Fix class template instantiation.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3738,13 +3738,6 @@ namespace {
       if (isSpecializationDepthGreaterThan(def, 8))
         return nullptr;
 
-      // FIXME: This will instantiate all members of the specialization (and detect
-      // instantiation failures in them), which can be more than is necessary
-      // and is more than what Clang does. As a result we reject some C++
-      // programs that Clang accepts.
-      Impl.getClangSema().InstantiateClassTemplateSpecializationMembers(
-          def->getLocation(), def, clang::TSK_ExplicitInstantiationDefinition);
-
       return VisitCXXRecordDecl(def);
     }
 

--- a/test/Interop/Cxx/templates/Inputs/class-template-instantiation-errors.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-instantiation-errors.h
@@ -14,9 +14,21 @@ struct IntWrapper {
 
 template<class T>
 struct CannotBeInstantianted {
-  void willFailInstantiating(T t) {
-    t.doesNotExist();
-  }
+  T value;
+
+  CannotBeInstantianted(char, T value) { value.doesNotExist(); }
+  CannotBeInstantianted(char, char) { memberWrongType(); }
+  CannotBeInstantianted(T value) : value(value) {}
+
+  void callsMethodWithError() { memberWrongType(); }
+
+  void memberWrongType() { value.doesNotExist(); }
+
+  void argWrongType(T t) { t.doesNotExist(); }
+
+  int getOne() { return 1; }
+  int incValue() { return value.value + getOne(); }
+  int incValue(T t) { return t.value + getOne(); }
 };
 
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_INSTANTIATION_ERRORS_H

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker-calls-method-with-error.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker-calls-method-with-error.swift
@@ -1,0 +1,10 @@
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+
+import ClassTemplateInstantiationErrors
+
+// CHECK: error: no member named 'doesNotExist' in 'IntWrapper'
+// CHECK: note: in instantiation of member function 'CannotBeInstantianted<IntWrapper>::memberWrongType' requested here
+public func test() {
+  var y = CannotBeInstantianted<IntWrapper>(IntWrapper())
+  y.callsMethodWithError()
+}

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker-constructor-calls-method-with-error.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker-constructor-calls-method-with-error.swift
@@ -1,0 +1,10 @@
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+
+import ClassTemplateInstantiationErrors
+
+// CHECK: error: no member named 'doesNotExist' in 'IntWrapper'
+// CHECK: note: in instantiation of member function 'CannotBeInstantianted<IntWrapper>::memberWrongType' requested here
+public func test() {
+  var x = CannotBeInstantianted<IntWrapper>(CChar(0), CChar(0))
+  x.incValue() // This is just to make sure "x" isn't removed.
+}

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 
@@ -7,8 +7,17 @@ func swiftTemplateArgNotSupported() {
   var _ = MagicWrapper<Optional>(t: "asdf")
 }
 
-// CHECK: class-template-instantiation-errors.h:18:7: error: no member named 'doesNotExist' in 'IntWrapper'
-// CHECK: class-template-instantiation-errors.h:16:8: note: in instantiation of member function 'CannotBeInstantianted<IntWrapper>::willFailInstantiating' requested here
-func clangErrorReportedOnInstantiation() {
-    var _ = CannotBeInstantianted<IntWrapper>()
+// CHECK: error: no member named 'doesNotExist' in 'IntWrapper'
+// CHECK: note: in instantiation of member function 'CannotBeInstantianted<IntWrapper>::CannotBeInstantianted' requested here
+
+// CHECK: error: no member named 'doesNotExist' in 'IntWrapper'
+// CHECK: note: in instantiation of member function 'CannotBeInstantianted<IntWrapper>::memberWrongType' requested here
+
+// CHECK: error: no member named 'doesNotExist' in 'IntWrapper'
+// CHECK: note: in instantiation of member function 'CannotBeInstantianted<IntWrapper>::argWrongType' requested here
+public func clangErrorReportedOnInstantiation() {
+  _ = CannotBeInstantianted<IntWrapper>(CChar(0), IntWrapper())
+  var z = CannotBeInstantianted<IntWrapper>(IntWrapper())
+  z.memberWrongType()
+  z.argWrongType(IntWrapper())
 }

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+
+import ClassTemplateInstantiationErrors
+
+// CHECK-LABEL: define {{.*}}void @"$s4main23instantiateValidMembersyyF"()
+// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueEv|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
+// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueES0_|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHUIntWrapper@@@Z"}}(%struct.CannotBeInstantianted* {{.*}}, {{i32|i64|\[1 x i32\]}}
+// CHECK: ret void
+
+// CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueEv|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
+// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
+// CHECK: ret i32
+
+// CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueES0_|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHUIntWrapper@@@Z"}}(%struct.CannotBeInstantianted* {{.*}}, {{i32|i64|\[1 x i32\]}}
+// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
+// CHECK: ret i32
+
+// CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
+// CHECK: ret i32 1
+public func instantiateValidMembers() {
+  var x = CannotBeInstantianted<IntWrapper>(IntWrapper(value: 41))
+  x.incValue()
+  var y = CannotBeInstantianted<IntWrapper>(IntWrapper(value: 0))
+  y.incValue(IntWrapper(value: 41))
+}

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import ClassTemplateInstantiationErrors
+import StdlibUnittest
+
+var TemplatesTestSuite = TestSuite("Template with uninstantiatable members")
+
+TemplatesTestSuite.test("Calls valid member") {
+  var x = CannotBeInstantianted<IntWrapper>(IntWrapper(value: 41))
+  expectEqual(x.incValue(), 42)
+}
+
+TemplatesTestSuite.test("Calls valid member on arg") {
+  var x = CannotBeInstantianted<IntWrapper>(IntWrapper(value: 0))
+  expectEqual(x.incValue(IntWrapper(value: 41)), 42)
+}
+
+runAllTests()


### PR DESCRIPTION
Lazily instantiate class template members. This means we no longer reject some programs that clang accepts, such as the following:

```
template<class T> struct Foo { 
  void fail(T value) { value.fail(); } 
};
using Bar = Foo<int>;
```

The above program will not error so long as `Bar::fail` isn't called. (Previously, we'd fail to import `Bar`.)