### PR TITLE
[AutoDiff] Fix DI verification failure with trampoline blocks in VJP.

### DIFF
--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -218,6 +218,7 @@ public:
   }
 
   void visitReturnInst(ReturnInst *ri) {
+    Builder.setCurrentDebugScope(getOpScope(ri->getDebugScope()));
     auto loc = ri->getOperand().getLoc();
     // Build pullback struct value for original block.
     auto *origExit = ri->getParent();
@@ -291,6 +292,7 @@ public:
   }
 
   void visitBranchInst(BranchInst *bi) {
+    Builder.setCurrentDebugScope(getOpScope(bi->getDebugScope()));
     // Build pullback struct value for original block.
     // Build predecessor enum value for destination block.
     auto *origBB = bi->getParent();
@@ -310,6 +312,7 @@ public:
   }
 
   void visitCondBranchInst(CondBranchInst *cbi) {
+    Builder.setCurrentDebugScope(getOpScope(cbi->getDebugScope()));
     // Build pullback struct value for original block.
     auto *pbStructVal = buildPullbackValueStructValue(cbi);
     // Create a new `cond_br` instruction.
@@ -320,6 +323,7 @@ public:
   }
 
   void visitSwitchEnumTermInst(SwitchEnumTermInst inst) {
+    Builder.setCurrentDebugScope(getOpScope(inst->getDebugScope()));
     // Build pullback struct value for original block.
     auto *pbStructVal = buildPullbackValueStructValue(*inst);
 
@@ -360,6 +364,7 @@ public:
   }
 
   void visitCheckedCastBranchInst(CheckedCastBranchInst *ccbi) {
+    Builder.setCurrentDebugScope(getOpScope(ccbi->getDebugScope()));
     // Build pullback struct value for original block.
     auto *pbStructVal = buildPullbackValueStructValue(ccbi);
     // Create a new `checked_cast_branch` instruction.
@@ -373,6 +378,7 @@ public:
   }
 
   void visitCheckedCastValueBranchInst(CheckedCastValueBranchInst *ccvbi) {
+    Builder.setCurrentDebugScope(getOpScope(ccvbi->getDebugScope()));
     // Build pullback struct value for original block.
     auto *pbStructVal = buildPullbackValueStructValue(ccvbi);
     // Create a new `checked_cast_value_branch` instruction.
@@ -386,6 +392,7 @@ public:
   }
 
   void visitCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *ccabi) {
+    Builder.setCurrentDebugScope(getOpScope(ccabi->getDebugScope()));
     // Build pullback struct value for original block.
     auto *pbStructVal = buildPullbackValueStructValue(ccabi);
     // Create a new `checked_cast_addr_branch` instruction.
@@ -437,6 +444,7 @@ public:
       return;
     }
 
+    Builder.setCurrentDebugScope(getOpScope(ai->getDebugScope()));
     auto loc = ai->getLoc();
     auto &builder = getBuilder();
     auto origCallee = getOpValue(ai->getCallee());
@@ -698,6 +706,7 @@ public:
   }
 
   void visitTryApplyInst(TryApplyInst *tai) {
+    Builder.setCurrentDebugScope(getOpScope(tai->getDebugScope()));
     // Build pullback struct value for original block.
     auto *pbStructVal = buildPullbackValueStructValue(tai);
     // Create a new `try_apply` instruction.
@@ -1008,6 +1017,7 @@ SILBasicBlock *VJPCloner::Implementation::createTrampolineBasicBlock(
   // In the trampoline block, build predecessor enum value for VJP successor
   // block and branch to it.
   SILBuilder trampolineBuilder(trampolineBB);
+  trampolineBuilder.setCurrentDebugScope(getOpScope(termInst->getDebugScope()));
   auto *origBB = termInst->getParent();
   auto *succEnumVal =
       buildPredecessorEnumValue(trampolineBuilder, origBB, succBB, pbStructVal);
@@ -1032,7 +1042,6 @@ VJPCloner::Implementation::buildPullbackValueStructValue(TermInst *termInst) {
     auto *predEnumArg = vjpBB->getArguments().back();
     bbPullbackValues.insert(bbPullbackValues.begin(), predEnumArg);
   }
-  getBuilder().setCurrentDebugScope(getOpScope(termInst->getDebugScope()));
   return getBuilder().createStruct(loc, structLoweredTy, bbPullbackValues);
 }
 

--- a/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
@@ -1,0 +1,12 @@
+// RUN: %target-build-swift %s
+// RUN: %target-swift-frontend -c -g -Xllvm -verify-di-holes=true %s
+
+// rdar://74087329 (DI verification failure with trampoline blocks in VJP)
+
+import _Differentiation
+
+func foo(x: Float?) -> Float {
+   _ = withoutDerivative(at: x ?? 0)
+   return 0
+}
+gradient(at: 0, in: foo)


### PR DESCRIPTION
- Set the builder's debug scope to the remapped debug scope in the overriden visiters.
- In trampoline blocks where we build predecessor enums, make the trampoline builder inherit the original terminator's remapped debug scope.

Resolves rdar://74087329.