### PR TITLE
PassManager: simplify the options to print intermediate SIL.

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -212,47 +212,31 @@ Often it is not sufficient to dump the SIL at the beginning or end of
 the optimization pipeline. The SILPassManager supports useful options
 to dump the SIL also between pass runs.
 
-The SILPassManager's SIL dumping options vary along two orthogonal
-functional axes:
+A short (non-exhaustive) list of SIL printing options:
 
-1. Options that control if functions/modules are printed.
-2. Options that filter what is printed at those points.
+* `-Xllvm '-sil-print-function=SWIFT_MANGLED_NAME'`: Print the specified
+  function after each pass which modifies the function. Note that for module
+  passes, the function is printed if the pass changed _any_ function (the
+  pass manager doesn't know which functions a module pass has changed).
+  Multiple functions can be specified as a comma separated list.
 
-One generally always specifies an option of type 1 and optionally adds
-an option of type 2 to filter the output.
+* `-Xllvm '-sil-print-functions=NAME'`: Like `-sil-print-function`, except that
+  functions are selected if NAME is _contained_ in their mangled names.
 
-A short (non-exhaustive) list of type 1 options:
+* `-Xllvm -sil-print-all`: Print all functions when ever a function pass
+  modifies a function and print the entire module if a module pass modifies
+  the SILModule.
 
-* `-Xllvm -sil-print-all`: Print functions/modules when ever a
-  function pass modifies a function and Print the entire module
-  (modulo filtering) if a module pass modifies a SILModule.
+* `-Xllvm -sil-print-around=$PASS_NAME`: Print the SIL before and after a pass
+  with name `$PASS_NAME` runs on a function or module.
+  By default it prints the whole module. To print only specific functions, add
+  `-sil-print-function` and/or `-sil-print-functions`.
 
-A short (non-exhaustive) list of type 2 options:
+* `-Xllvm -sil-print-before=$PASS_NAME`: Like `-sil-print-around`, but prints
+  the SIL only _before_ the specfied pass runs.
 
-* `-Xllvm -sil-print-around=$PASS_NAME`: Print a function/module
-  before and after a function pass with name `$PASS_NAME` runs on a
-  function/module or dump a module before a module pass with name
-  `$PASS_NAME` runs on a module.
-
-* `-Xllvm -sil-print-before=$PASS_NAME`: Print a function/module
-  before a function pass with name `$PASS_NAME` runs on a
-  function/module or dump a module before a module pass with name
-  `$PASS_NAME` runs on a module. NOTE: This happens even without
-  sil-print-all set!
-
-* `-Xllvm -sil-print-after=$PASS_NAME`: Print a function/module
-  after a function pass with name `$PASS_NAME` runs on a
-  function/module or dump a module before a module pass with name
-  `$PASS_NAME` runs on a module.
-
-* `-Xllvm '-sil-print-only-function=SWIFT_MANGLED_NAME'`: When ever
-  one would print a function/module, only print the given function.
-
-These options together allow one to visualize how a
-SILFunction/SILModule is optimized by the optimizer as each
-optimization pass runs easily via formulations like:
-
-    swiftc -Xllvm '-sil-print-only-function=$myMainFunction' -Xllvm -sil-print-all
+* `-Xllvm -sil-print-after=$PASS_NAME`: Like `-sil-print-around`, but prints
+  the SIL only _after_ the specfied pass did run.
 
 NOTE: This may emit a lot of text to stderr, so be sure to pipe the
 output to a file.
@@ -586,11 +570,11 @@ it's quite easy to do this manually:
 
 2. Get the SIL before and after the bad optimization.
 
-  a. Add the compiler options
-     `-Xllvm -sil-print-all -Xllvm -sil-print-only-function='<function>'`
+  a. Add the compiler option
+     `-Xllvm -sil-print-function='<function>'`
      where `<function>` is the function name (including the preceding `$`).
      For example:
-     `-Xllvm -sil-print-all -Xllvm -sil-print-only-function='$s4test6testityS2iF'`.
+     `-Xllvm -sil-print-function='$s4test6testityS2iF'`.
      Again, the output can be large, so it's best to redirect stderr to a file.
   b. From the output, copy the SIL of the function *before* the bad
      run into a separate file and the SIL *after* the bad run into a file.

--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -primary-file %s -Onone -emit-sil -Xllvm \
 // RUN:   -sil-print-after=raw-sil-inst-lowering -Xllvm \
-// RUN:   -sil-print-only-functions=$s3del1MC4fromAcA12WithDelegate_p_tKcfc \
+// RUN:   -sil-print-functions=$s3del1MC4fromAcA12WithDelegate_p_tKcfc \
 // RUN:   -Xllvm -sil-print-debuginfo -o /dev/null -module-name del 2>&1 | %FileCheck %s
 
 public protocol DelegateA {}

--- a/test/SILOptimizer/di-conditional-destroy-scope.swift
+++ b/test/SILOptimizer/di-conditional-destroy-scope.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil %s -Onone -Xllvm \
 // RUN:   -sil-print-after=raw-sil-inst-lowering -Xllvm \
-// RUN:   -sil-print-only-functions=$s2fs36RecursibleDirectoryContentsGeneratorC4path10fileSystemAcA12AbsolutePathV_AA04FileH0_ptKc33_F8B132991B28208F48606E87DC165393Llfc \
+// RUN:   -sil-print-functions=$s2fs36RecursibleDirectoryContentsGeneratorC4path10fileSystemAcA12AbsolutePathV_AA04FileH0_ptKc33_F8B132991B28208F48606E87DC165393Llfc \
 // RUN:   -Xllvm -sil-print-debuginfo -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop

--- a/test/SILOptimizer/stack-nesting-wrong-scope.swift
+++ b/test/SILOptimizer/stack-nesting-wrong-scope.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-sil %s -Onone -Xllvm \
 // RUN:   -sil-print-after=allocbox-to-stack -Xllvm \
-// RUN:   -sil-print-only-functions=$s3red19ThrowAddrOnlyStructV016throwsOptionalToG0ACyxGSgSi_tcfC \
+// RUN:   -sil-print-functions=$s3red19ThrowAddrOnlyStructV016throwsOptionalToG0ACyxGSgSi_tcfC \
 // RUN:   -Xllvm -sil-print-debuginfo -o %t -module-name red 2>&1 | %FileCheck %s
 
 // CHECK: bb{{[0-9]+}}(%{{[0-9]+}} : @owned $Error):

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -58,8 +58,8 @@ _swift_complete()
       -sil-print-pass-name \
       -sil-print-pass-time \
       -sil-opt-pass-count \
-      -sil-print-only-function \
-      -sil-print-only-functions \
+      -sil-print-function \
+      -sil-print-functions \
       -sil-print-before \
       -sil-print-after \
       -sil-print-around \


### PR DESCRIPTION
* rename `-sil-print-only-function` to `-sil-print-function` and `-sil-print-only-functions` to `-sil-print-functions`
* to print a single function, don't require `-Xllvm -sil-print-all`. It's now sufficient to use `-Xllvm -sil-print-function=<f>`
