### PR TITLE
Fix a couple of crash-on-invalid situations with local variables defined inside result builders  [5.4]

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -268,14 +268,27 @@ protected:
   }
 
   void visitPatternBindingDecl(PatternBindingDecl *patternBinding) {
-    // If any of the entries lacks an initializer, don't handle this node.
-    if (!llvm::all_of(range(patternBinding->getNumPatternEntries()),
-                      [&](unsigned index) {
-            return patternBinding->isExplicitlyInitialized(index);
-        })) {
-      if (!unhandledNode)
-        unhandledNode = patternBinding;
-      return;
+    // Enforce some restrictions on local variables inside a result builder.
+    for (unsigned i : range(patternBinding->getNumPatternEntries())) {
+      // The pattern binding must have an initial value expression.
+      if (!patternBinding->isExplicitlyInitialized(i)) {
+        if (!unhandledNode)
+          unhandledNode = patternBinding;
+        return;
+      }
+
+      // Each variable bound by the pattern must be stored, and cannot
+      // have observers.
+      SmallVector<VarDecl *, 8> variables;
+      patternBinding->getPattern(i)->collectVariables(variables);
+
+      for (auto *var : variables) {
+        if (!var->getImplInfo().isSimpleStored()) {
+          if (!unhandledNode)
+            unhandledNode = patternBinding;
+          return;
+        }
+      }
     }
 
     // If there is a constraint system, generate constraints for the pattern

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -288,6 +288,9 @@ protected:
             unhandledNode = patternBinding;
           return;
         }
+
+        // Also check for invalid attributes.
+        TypeChecker::checkDeclAttributes(var);
       }
     }
 

--- a/test/Constraints/result_builder_invalid_vars.swift
+++ b/test/Constraints/result_builder_invalid_vars.swift
@@ -43,3 +43,9 @@ dummy {
   @Wrapper var wrappedVar: Int = 123 // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
   ()
 }
+
+dummy {
+  @resultBuilder var attributedVar: Int = 123 // expected-error {{@resultBuilder' attribute cannot be applied to this declaration}}
+  // expected-warning@-1 {{variable 'attributedVar' was never used; consider replacing with '_' or removing it}}
+  ()
+}

--- a/test/Constraints/result_builder_invalid_vars.swift
+++ b/test/Constraints/result_builder_invalid_vars.swift
@@ -1,0 +1,45 @@
+// RUN: %target-typecheck-verify-swift
+
+@resultBuilder
+struct DummyBuilder { // expected-note 5 {{struct 'DummyBuilder' declared here}}
+  static func buildBlock<T>(_ t: T) -> T {
+    return t
+  }
+}
+
+func dummy<T>(@DummyBuilder _: () -> T) {}
+
+dummy {
+  var computedVar: Int { return 123 } // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  ()
+}
+
+dummy {
+  lazy var lazyVar: Int = 123 // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  ()
+}
+
+dummy {
+  var observedVar: Int = 123 { // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+    didSet {}
+  }
+
+  ()
+}
+
+dummy {
+  var observedVar: Int = 123 { // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+    willSet {}
+  }
+
+  ()
+}
+
+@propertyWrapper struct Wrapper {
+  var wrappedValue: Int
+}
+
+dummy {
+  @Wrapper var wrappedVar: Int = 123 // expected-error {{closure containing a declaration cannot be used with result builder 'DummyBuilder'}}
+  ()
+}


### PR DESCRIPTION
5.4 cherry-pick of https://github.com/apple/swift/pull/35812.

Fixes rdar://problem/73545981.