### PR TITLE
[ownership] Change store_borrow to be an interior pointer and update interior pointer formalism to use it.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -618,10 +618,11 @@ BorrowedValue getSingleBorrowIntroducingValue(SILValue inputValue);
 class InteriorPointerOperandKind {
 public:
   enum Kind : uint8_t {
-    Invalid=0,
+    Invalid = 0,
     RefElementAddr,
     RefTailAddr,
     OpenExistentialBox,
+    StoreBorrow,
   };
 
 private:
@@ -648,6 +649,8 @@ public:
       return Kind::RefTailAddr;
     case SILInstructionKind::OpenExistentialBoxInst:
       return Kind::OpenExistentialBox;
+    case SILInstructionKind::StoreBorrowInst:
+      return Kind::StoreBorrow;
     }
   }
 
@@ -664,6 +667,8 @@ public:
       return Kind::RefTailAddr;
     case ValueKind::OpenExistentialBoxInst:
       return Kind::OpenExistentialBox;
+    case ValueKind::StoreBorrowInst:
+      return Kind::StoreBorrow;
     }
   }
 
@@ -714,7 +719,8 @@ struct InteriorPointerOperand {
       return {};
     case InteriorPointerOperandKind::RefElementAddr:
     case InteriorPointerOperandKind::RefTailAddr:
-    case InteriorPointerOperandKind::OpenExistentialBox: {
+    case InteriorPointerOperandKind::OpenExistentialBox:
+    case InteriorPointerOperandKind::StoreBorrow: {
       // Ok, we have a valid instruction. Return the relevant operand.
       auto *op =
           &cast<SingleValueInstruction>(resultValue)->getAllOperands()[0];
@@ -754,6 +760,8 @@ struct InteriorPointerOperand {
       return cast<RefTailAddrInst>(operand->getUser());
     case InteriorPointerOperandKind::OpenExistentialBox:
       return cast<OpenExistentialBoxInst>(operand->getUser());
+    case InteriorPointerOperandKind::StoreBorrow:
+      return cast<StoreBorrowInst>(operand->getUser());
     }
     llvm_unreachable("Covered switch isn't covered?!");
   }

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -391,7 +391,7 @@ OperandOwnership OperandOwnershipClassifier::visitBranchInst(BranchInst *bi) {
 OperandOwnership
 OperandOwnershipClassifier::visitStoreBorrowInst(StoreBorrowInst *i) {
   if (getValue() == i->getSrc()) {
-    return OperandOwnership::ForwardingBorrow;
+    return OperandOwnership::InteriorPointer;
   }
   return OperandOwnership::TrivialUse;
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -185,6 +185,7 @@ SILCombiner::optimizeBuiltinCOWBufferForReadingOSSA(BuiltinInst *bi) {
             cast<RefTailAddrInst>(intPtrOperand->getUser())->setImmutable();
             return;
           case InteriorPointerOperandKind::OpenExistentialBox:
+          case InteriorPointerOperandKind::StoreBorrow:
             // Can not mark this immutable.
             return;
           }


### PR DESCRIPTION
For those who are unaware, a store_borrow is an instruction that is needed so
that we can without adding ARC traffic materialize a guaranteed object value
into memory so we can pass it as an in_guaranteed argument. It has not had its
model completely implemented due to time. I am going to add some information
about it in this commit message for others.

From a model semantic perspective, a store_borrow is meant to allow for a
guaranteed value to be materialized into memory safely for a scoped region of
time and be able to guarantee that:

1. The guaranteed value that was stored is always live.
2. The memory is never written to within that region.

The natural way to model this type of guaranteeing behavior from an object to an
address is via a safe interior pointer formulation and thus with that in mind I
made it so that store_borrow returned an address that was an interior pointer of
the guaranteed value. Sadly, we have not changed the compiler yet to use this
effectively since we in store_borrow code paths generally just use the input
address. That being said, in this PR I begin to move us toward this world by
making store_borrow's src operand an InteriorPointerOperand. This means that we
will require the borrowed value to be alive at all use points of the
store_borrow result. That will not have a large effect today but I am going to
loop back around and extend that.

There is additional work here that I wish to accomplish in the future is that I
would like to define an end_store_borrow instruction to explicitly end the scope
in which there is a condition on the borrow. Then we would require that the
memory we are using to for sure never be written to in that region and maybe
additionally try to give some sort of guarantee around exclusivity (consider if
we made it so that we could only store_borrow into an alloc_stack with certain
conditions). Not sure about the last one yet. But philosophically since we are
using this to just handle reabstraction suggests we can do something more
constrained.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
