### PR TITLE
[Concurrency] Add `*Continuation.resume()` for continuations returning `Void`.

### DIFF
--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -162,6 +162,7 @@ extension CheckedContinuation where T == Void {
   /// After `resume` enqueues the task, control is immediately returned to
   /// the caller. The task will continue executing when its executor is
   /// able to reschedule it.
+  @inlinable
   public func resume() {
     self.resume(returning: ())
   }
@@ -271,6 +272,7 @@ extension CheckedThrowingContinuation where T == Void {
   /// After `resume` enqueues the task, control is immediately returned to
   /// the caller. The task will continue executing when its executor is
   /// able to reschedule it.
+  @inlinable
   public func resume() {
     self.resume(returning: ())
   }

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -151,6 +151,22 @@ public struct CheckedContinuation<T> {
   }
 }
 
+extension CheckedContinuation where T == Void {
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// A continuation must be resumed exactly once. If the continuation has
+  /// already been resumed through this object, then the attempt to resume
+  /// the continuation again will trap.
+  ///
+  /// After `resume` enqueues the task, control is immediately returned to
+  /// the caller. The task will continue executing when its executor is
+  /// able to reschedule it.
+  public func resume() {
+    self.resume(returning: ())
+  }
+}
+
 public func withCheckedContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T>) -> Void
@@ -241,6 +257,22 @@ public struct CheckedThrowingContinuation<T> {
     } else {
       fatalError("SWIFT TASK CONTINUATION MISUSE: \(canary.function) tried to resume its continuation more than once, throwing \(x)!\n")
     }
+  }
+}
+
+extension CheckedThrowingContinuation where T == Void {
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// A continuation must be resumed exactly once. If the continuation has
+  /// already been resumed through this object, then the attempt to resume
+  /// the continuation again will trap.
+  ///
+  /// After `resume` enqueues the task, control is immediately returned to
+  /// the caller. The task will continue executing when its executor is
+  /// able to reschedule it.
+  public func resume() {
+    self.resume(returning: ())
   }
 }
 

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -35,6 +35,7 @@ public struct UnsafeContinuation<T> {
 }
 
 extension UnsafeContinuation where T == Void {
+  @inlinable
   public func resume() {
       self.resume(returning: ())
   }
@@ -65,6 +66,7 @@ public struct UnsafeThrowingContinuation<T> {
 }
 
 extension UnsafeThrowingContinuation where T == Void {
+  @inlinable
   public func resume() {
       self.resume(returning: ())
   }

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -37,7 +37,7 @@ public struct UnsafeContinuation<T> {
 extension UnsafeContinuation where T == Void {
   @inlinable
   public func resume() {
-      self.resume(returning: ())
+    self.resume(returning: ())
   }
 }
 
@@ -68,7 +68,7 @@ public struct UnsafeThrowingContinuation<T> {
 extension UnsafeThrowingContinuation where T == Void {
   @inlinable
   public func resume() {
-      self.resume(returning: ())
+    self.resume(returning: ())
   }
 }
 

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -34,6 +34,12 @@ public struct UnsafeContinuation<T> {
   public func resume(returning value: __owned T)
 }
 
+extension UnsafeContinuation where T == Void {
+  public func resume() {
+      self.resume(returning: ())
+  }
+}
+
 @frozen
 public struct UnsafeThrowingContinuation<T> {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
@@ -55,6 +61,12 @@ public struct UnsafeThrowingContinuation<T> {
       case .failure(let err):
         self.resume(throwing: err)
     }
+  }
+}
+
+extension UnsafeThrowingContinuation where T == Void {
+  public func resume() {
+      self.resume(returning: ())
   }
 }
 


### PR DESCRIPTION
This change implements the changes proposed in swift-evolution PR [#1264](https://github.com/apple/swift-evolution/pull/1264).
Existing test coverage should be sufficient here since the added function
simply calls into the existing `resume(returning:)` function.

This change resolves rdar://74031110.
