### PR TITLE
Some Cleanup Of Overriding Diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2455,8 +2455,8 @@ NOTE(overridden_near_match_here,none,
       (DescriptiveDeclKind, DeclName))
 ERROR(override_decl_extension,none,
       "%select{|non-@objc}0 %2 %3 %select{"
-      "is declared in extension of %4 and cannot be overriden|"
-      "declared in %4 cannot be overriden from extension}1", 
+      "is declared in extension of %4 and cannot be overridden|"
+      "declared in %4 cannot be overridden from extension}1", 
       (bool, bool, DescriptiveDeclKind, DeclName, DeclName))
 NOTE(overridden_here,none,
      "overridden declaration is here", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5402,8 +5402,8 @@ ERROR(override_nsobject_hashvalue_error,none,
       "did you mean to override 'NSObject.hash'?", ())
 
 ERROR(override_nsobject_hash_error,none,
-      "`NSObject.hash(into:)` is not overridable; "
-      "subclasses can customize hashing by overriding the `hash` property", ())
+      "'NSObject.hash(into:)' is not overridable; "
+      "did you mean to override 'NSObject.hash'?", ())
 
 WARNING(hashvalue_implementation,none,
         "'Hashable.hashValue' is deprecated as a protocol requirement; "

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1009,7 +1009,7 @@ static void checkOverrideAccessControl(ValueDecl *baseDecl, ValueDecl *decl,
       !baseHasOpenAccess &&
       baseDecl->getModuleContext() != decl->getModuleContext() &&
       !isa<ConstructorDecl>(decl)) {
-    // NSObject.hashValue and NSObject.hash(into:) is not overridable;
+    // NSObject.hashValue and NSObject.hash(into:) are not overridable;
     // one should override NSObject.hash instead.
     if (isNSObjectHashValue(baseDecl)) {
       diags.diagnose(decl, diag::override_nsobject_hashvalue_error)
@@ -1811,7 +1811,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
       (isa<ExtensionDecl>(base->getDeclContext()) ||
        isa<ExtensionDecl>(override->getDeclContext())) &&
       !base->isObjC()) {
-    // Suppress this diagnostic for overrides of a non-open NSObject.Hashable
+    // Suppress this diagnostic for overrides of non-open NSObject.Hashable
     // interfaces; these are diagnosed elsewhere. An error message complaining
     // about extensions would be misleading in this case; the correct fix is to
     // override NSObject.hash instead.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1012,10 +1012,12 @@ static void checkOverrideAccessControl(ValueDecl *baseDecl, ValueDecl *decl,
     // NSObject.hashValue and NSObject.hash(into:) are not overridable;
     // one should override NSObject.hash instead.
     if (isNSObjectHashValue(baseDecl)) {
-      diags.diagnose(decl, diag::override_nsobject_hashvalue_error)
+      decl->diagnose(diag::override_nsobject_hashvalue_error)
         .fixItReplace(SourceRange(decl->getNameLoc()), "hash");
     } else if (isNSObjectHashMethod(baseDecl)) {
-      diags.diagnose(decl, diag::override_nsobject_hash_error);
+      decl->diagnose(diag::override_nsobject_hash_error)
+        .fixItReplace(cast<FuncDecl>(decl)->getFuncLoc(), getTokenText(tok::kw_var))
+        .fixItReplace(cast<FuncDecl>(decl)->getParameters()->getSourceRange(), ": Int");
     } else {
       diags.diagnose(decl, diag::override_of_non_open,
                      decl->getDescriptiveKind());

--- a/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
@@ -231,7 +231,7 @@ extension NSObject : Equatable, Hashable {
   ///
   /// NSObject implements this by feeding `self.hash` to the hasher.
   ///
-  /// 'NSObject.hash(into:)' is not overridable; subclasses can customize
+  /// `NSObject.hash(into:)` is not overridable; subclasses can customize
   /// hashing by overriding the `hash` property.
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.hash)

--- a/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/Darwin/ObjectiveC/ObjectiveC.swift
@@ -231,7 +231,7 @@ extension NSObject : Equatable, Hashable {
   ///
   /// NSObject implements this by feeding `self.hash` to the hasher.
   ///
-  /// `NSObject.hash(into:)` is not overridable; subclasses can customize
+  /// 'NSObject.hash(into:)' is not overridable; subclasses can customize
   /// hashing by overriding the `hash` property.
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.hash)

--- a/test/ClangImporter/objc-cross-module-override.swift
+++ b/test/ClangImporter/objc-cross-module-override.swift
@@ -11,7 +11,7 @@
 import ImageInitializers
 
 final class MyImage : Image {
-  // CHECK: non-@objc initializer 'init(imageLiteralResourceName:)' is declared in extension of 'Image' and cannot be overriden
+  // CHECK: non-@objc initializer 'init(imageLiteralResourceName:)' is declared in extension of 'Image' and cannot be overridden
   // Make sure we aren't emitting a fixit into the extant module...
   // CHECK-NOT: add '@objc' to make this declaration overridable
   // CHECK: ImageInitializers.Image:{{.*}}: note: overridden declaration is here

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -116,7 +116,7 @@ class MyHashableNSObject: NSObject {
   }
 
   override func hash(into hasher: inout Hasher) {
-    // expected-error@-1 {{`NSObject.hash(into:)` is not overridable; subclasses can customize hashing by overriding the `hash` property}}
+    // expected-error@-1 {{'NSObject.hash(into:)' is not overridable; did you mean to override 'NSObject.hash'?}}
   }
 }
 

--- a/test/ClangImporter/objc_override.swift
+++ b/test/ClangImporter/objc_override.swift
@@ -116,7 +116,7 @@ class MyHashableNSObject: NSObject {
   }
 
   override func hash(into hasher: inout Hasher) {
-    // expected-error@-1 {{'NSObject.hash(into:)' is not overridable; did you mean to override 'NSObject.hash'?}}
+    // expected-error@-1 {{'NSObject.hash(into:)' is not overridable; did you mean to override 'NSObject.hash'?}} {{12-16=var}} {{21-48=: Int}}
   }
 }
 

--- a/test/attr/attr_objc_override.swift
+++ b/test/attr/attr_objc_override.swift
@@ -29,11 +29,11 @@ class B : A {
     get { return self }  // expected-error{{subscript getter with Objective-C selector 'objectForKeyedSubscript:' conflicts with subscript getter from superclass 'A'}}
   }
 
-  override func foo() { } // expected-error{{non-@objc instance method 'foo()' is declared in extension of 'A' and cannot be overriden}}
+  override func foo() { } // expected-error{{non-@objc instance method 'foo()' is declared in extension of 'A' and cannot be overridden}}
 
-  override func wibble(_: SwiftStruct) { } // expected-error{{instance method 'wibble' is declared in extension of 'A' and cannot be overriden}}
+  override func wibble(_: SwiftStruct) { } // expected-error{{instance method 'wibble' is declared in extension of 'A' and cannot be overridden}}
 }
 
 extension B {
-  override func bar() { } // expected-error{{non-@objc instance method 'bar()' declared in 'A' cannot be overriden from extension}}
+  override func bar() { } // expected-error{{non-@objc instance method 'bar()' declared in 'A' cannot be overridden from extension}}
 }

--- a/test/decl/func/static_func.swift
+++ b/test/decl/func/static_func.swift
@@ -83,8 +83,8 @@ class C_Derived : C {
   override class func f2() {}
   class override func f3() {}
 
-  override class func ef2() {} // expected-error {{cannot be overriden}}
-  class override func ef3() {} // expected-error {{cannot be overriden}}
+  override class func ef2() {} // expected-error {{cannot be overridden}}
+  class override func ef3() {} // expected-error {{cannot be overridden}}
   override static func f7() {} // expected-error {{static method overrides a 'final' class method}}
 }
 
@@ -98,11 +98,11 @@ class C_Derived3 : C {
 }
 
 extension C_Derived {
-  override class func f4() {} // expected-error {{cannot be overriden}}
-  class override func f5() {} // expected-error {{cannot be overriden}}
+  override class func f4() {} // expected-error {{cannot be overridden}}
+  class override func f5() {} // expected-error {{cannot be overridden}}
 
-  override class func ef4() {} // expected-error {{cannot be overriden}}
-  class override func ef5() {} // expected-error {{cannot be overriden}}
+  override class func ef4() {} // expected-error {{cannot be overridden}}
+  class override func ef5() {} // expected-error {{cannot be overridden}}
 }
 
 protocol P { // expected-note{{extended type declared here}}

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -47,7 +47,7 @@ extension B {
   override func f4D() -> ObjCClassB { }
 
   func f5() { }  // expected-error{{overri}}
-  func f6() -> A { }  // expected-error{{instance method 'f6()' is declared in extension of 'A' and cannot be overriden}}
+  func f6() -> A { }  // expected-error{{instance method 'f6()' is declared in extension of 'A' and cannot be overridden}}
 
   @objc override func f7() { }
   @objc override func f8() -> ObjCClassA { }

--- a/test/decl/init/basic_init.swift
+++ b/test/decl/init/basic_init.swift
@@ -25,7 +25,7 @@ class InitSubclass: InitClass {}
 // expected-note@-1{{'init(baz:)' previously overridden here}}
 // expected-note@-2{{'init(bar:)' previously overridden here}}
 extension InitSubclass {
-  convenience init(arg: Bool) {} // expected-error{{non-@objc initializer 'init(arg:)' declared in 'InitClass' cannot be overriden from extension}}
+  convenience init(arg: Bool) {} // expected-error{{non-@objc initializer 'init(arg:)' declared in 'InitClass' cannot be overridden from extension}}
   convenience override init(baz: Int) {}
   // expected-error@-1 {{'init(baz:)' has already been overridden}}
   // expected-error@-2 {{cannot override a non-dynamic class declaration from an extension}}

--- a/test/stdlib/NSObject-hashing.swift
+++ b/test/stdlib/NSObject-hashing.swift
@@ -12,6 +12,6 @@ class Foo: NSObject {
   }
 
   override func hash(into hasher: inout Hasher) {
-    // expected-error@-1 {{'NSObject.hash(into:)' is not overridable; did you mean to override 'NSObject.hash'?}}
+    // expected-error@-1 {{'NSObject.hash(into:)' is not overridable; did you mean to override 'NSObject.hash'?}} {{12-16=var}} {{21-48=: Int}}
   }
 }

--- a/test/stdlib/NSObject-hashing.swift
+++ b/test/stdlib/NSObject-hashing.swift
@@ -12,6 +12,6 @@ class Foo: NSObject {
   }
 
   override func hash(into hasher: inout Hasher) {
-    // expected-error@-1 {{`NSObject.hash(into:)` is not overridable; subclasses can customize hashing by overriding the `hash` property}}
+    // expected-error@-1 {{'NSObject.hash(into:)' is not overridable; did you mean to override 'NSObject.hash'?}}
   }
 }


### PR DESCRIPTION
- Correct some mistakes in grammar and style noticed by @xwu 
- Introduce a fixit to write mistaken overrides of `NSObject.hash(into:)` as overrides of `NSObject.hash`