### PR TITLE
[CSBindings] NFC: Couple minor incrementality adjustments

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -413,11 +413,7 @@ struct PotentialBindings {
 
   /// Add a potential binding to the list of bindings,
   /// coalescing supertype bounds when we are able to compute the meet.
-  ///
-  /// \returns true if this binding has been added to the set,
-  /// false otherwise (e.g. because binding with this type is
-  /// already in the set).
-  bool addPotentialBinding(PotentialBinding binding, bool allowJoinMeet = true);
+  void addPotentialBinding(PotentialBinding binding, bool allowJoinMeet = true);
 
   /// Check if this binding is viable for inclusion in the set.
   bool isViable(PotentialBinding &binding) const;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -608,12 +608,12 @@ PotentialBindings::isLiteralCoveredBy(const LiteralRequirement &literal,
   } while (true);
 }
 
-bool PotentialBindings::addPotentialBinding(PotentialBinding binding,
+void PotentialBindings::addPotentialBinding(PotentialBinding binding,
                                             bool allowJoinMeet) {
   assert(!binding.BindingType->is<ErrorType>());
 
   if (Bindings.count(binding))
-    return false;
+    return;
 
   // If this is a non-defaulted supertype binding,
   // check whether we can combine it with another
@@ -652,7 +652,7 @@ bool PotentialBindings::addPotentialBinding(PotentialBinding binding,
     // If new binding has been joined with at least one of existing
     // bindings, there is no reason to include it into the set.
     if (!joined.empty())
-      return false;
+      return;
   }
 
   // If the type variable can't bind to an lvalue, make sure the
@@ -663,7 +663,7 @@ bool PotentialBindings::addPotentialBinding(PotentialBinding binding,
   }
 
   if (!isViable(binding))
-    return false;
+    return;
 
   // Check whether the given binding covers any of the literal protocols
   // associated with this type variable.
@@ -698,7 +698,7 @@ bool PotentialBindings::addPotentialBinding(PotentialBinding binding,
     }
   }
 
-  return Bindings.insert(std::move(binding));
+  Bindings.insert(std::move(binding));
 }
 
 void PotentialBindings::addLiteral(Constraint *constraint) {


### PR DESCRIPTION
- Filter out some of the constraints which can't delay hole propagation
- Attempt `Void` fallback for closure result only when other choices have failed
- Attempt l-value fallback for force unwrap only after r-value type failed

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
