### PR TITLE
Fix copy-propagation: bail-out on reborrows.

### DIFF
--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -9,6 +9,7 @@ sil_stage canonical
 import Builtin
 import Swift
 
+sil [ossa] @getOwnedC : $@convention(thin) () -> (@owned C)
 sil [ossa] @takeOwned : $@convention(thin) <T> (@in T) -> ()
 sil [ossa] @takeMultipleOwned : $@convention(thin) <T> (@in T, @in T) -> ()
 sil [ossa] @takeGuaranteed : $@convention(thin) <T> (@in_guaranteed T) -> ()
@@ -1458,17 +1459,18 @@ bb3:
 // with cross-block reborrows. Its lifetime must be extended past the
 // end_borrow of the phi.
 //
+// TODO: CanonicalizeOSSA currently bails out on reborrows.
+//
 // CHECK-LABEL: sil [ossa] @testSubReborrowExtension : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK: [[ALLOC:%.*]] = alloc_ref $C
-// CHECK: [[BORROW:%.*]] = begin_borrow %0 : $C
+// CHECK:   [[ALLOC:%.*]] = alloc_ref $C
+// CHECK:   [[CP:%.*]] = copy_value %0 : $C
+// CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
 // CHECK:   cond_br undef, bb1, bb2
 // CHECK: bb1:
-// CHECK:   [[CP1:%.*]] = copy_value %0 : $C
-// CHECK:   br bb3([[CP1]] : $C, [[BORROW]] : $C)
+// CHECK:   br bb3([[CP]] : $C, [[BORROW]] : $C)
 // CHECK: bb2:
-// CHECK:   [[CP2:%.*]] = copy_value %0 : $C
-// CHECK:   br bb3([[CP2]] : $C, [[BORROW]] : $C)
+// CHECK:   br bb3([[CP]] : $C, [[BORROW]] : $C)
 // CHECK: bb3([[OWNEDPHI:%.*]] : @owned $C, [[BORROWPHI:%.*]] @guaranteed $C
 // CHECK:   end_borrow [[BORROWPHI]]
 // CHECK:   destroy_value [[OWNEDPHI]] : $C
@@ -1627,4 +1629,43 @@ bb3(%borrowphi : @guaranteed $C):
   destroy_value %alloc : $C
   %99 = tuple ()
   return %99 : $()
+}
+
+// Test a reborrow of an owned-and-copied def that does not dominate
+// the extended borrow scope.
+//
+// CHECK-LABEL: sil [ossa] @testOwnedReborrow : $@convention(thin) (@owned C) -> () {
+// CHECK: bb1:
+// CHECK:   destroy_value %0 : $C
+// CHECK:   [[CALL:%.*]] = apply %{{.*}}() : $@convention(thin) () -> @owned C
+// CHECK:   [[COPY1:%.*]] = copy_value [[CALL]] : $C
+// CHECK:   begin_borrow [[COPY1]] : $C
+// CHECK:   destroy_value [[CALL]] : $C
+// CHECK:   br bb3(%{{.*}} : $C, [[COPY1]] : $C)
+// CHECK: bb2:
+// CHECK:   begin_borrow %0 : $C
+// CHECK:   br bb3(%{{.*}} : $C, %0 : $C)
+// CHECK: bb3(%{{.*}} : @guaranteed $C, [[COPYPHI:%.*]] : @owned $C):
+// CHECK:   end_borrow
+// CHECK:   destroy_value [[COPYPHI]] : $C
+// CHECK-LABEL: } // end sil function 'testOwnedReborrow'
+sil [ossa] @testOwnedReborrow : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  cond_br undef, bb1, bb2
+bb1:
+  destroy_value %0 : $C
+  %f = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %owned1 = apply %f() : $@convention(thin) () -> (@owned C)
+  %copy1 = copy_value %owned1 : $C
+  %borrow1 = begin_borrow %copy1 : $C
+  destroy_value %owned1 : $C
+  br bb3(%borrow1 : $C, %copy1 : $C)
+bb2:
+  %borrow2 = begin_borrow %0 : $C
+  br bb3(%borrow2 : $C, %0 : $C)
+bb3(%borrow3 : @guaranteed $C, %copy3 : @owned $C):
+  end_borrow %borrow3 : $C
+  destroy_value %copy3 : $C
+  %result = tuple ()
+  return %result : $()
 }


### PR DESCRIPTION
The simple logic for discovering pruned liveness and skipping over
nested borrow scopes assumed a dominating definition. This isn't the
case for arbitrary reborrows and would potentially lead to OSSA
verification errors.

Rather than add support to handle certain cases, bail-out on this
situation, which is rare enough that it isn't a priority to optimize
yet.

Noticed by inspection while working on the OSSA utilities.
