### PR TITLE
[Runtime] Fix race condition in protocol conformance lookups that caused false negatives.

### DIFF
--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -110,7 +110,7 @@ public:
 
     Fn(Context, Command::DestroyContext, nullptr);
     Fn = other.Fn;
-    Context = Fn(Context, Command::CopyContext, nullptr);
+    Context = Fn(other.Context, Command::CopyContext, nullptr);
 
     return *this;
   }
@@ -169,6 +169,8 @@ template <typename T> class TypeLookupErrorOr {
   TaggedUnion<T, TypeLookupError> Value;
 
 public:
+  TypeLookupErrorOr() : Value(TypeLookupError("freshly constructed error")) {}
+
   TypeLookupErrorOr(const T &t) : Value(t) {
     if (!t)
       Value = TypeLookupError("unknown error");

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -5006,7 +5006,7 @@ swift_getAssociatedTypeWitnessSlowImpl(
     Demangle::makeSymbolicMangledNameStringRef(mangledNameBase);
 
   // Demangle the associated type.
-  TypeLookupErrorOr<TypeInfo> result = TypeInfo();
+  TypeLookupErrorOr<TypeInfo> result;
   if (inProtocolContext) {
     // The protocol's Self is the only generic parameter that can occur in the
     // type.


### PR DESCRIPTION
In the uncached case, we'd scan conformances, cache them, then re-query the cache. This worked fine when the cache always grew, but now we clear the cache when loading new Swift images into the process. If that happens between the scan and the re-query, we lose the entry and return a false negative.

Instead, track what we've found in the scan in a separate local table, then query that after completing the scan.

While we're in there, fix a bug in `TypeLookupError` where `operator=` accidentally copied `this->Context` instead of `other.Context`. This caused the runtime to crash when trying to print error messages due to the false negative.

Add a no-parameter constructor to `TypeLookupErrorOr<>` to distinguish the case where it's being initialized with nothing from the case where it's being initialized with `nullptr`.

rdar://72865822