### PR TITLE
SIL: Pick default ARC convention for witness thunks based on the kind of the original decl.

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2486,7 +2486,7 @@ static CanSILFunctionType getNativeSILFunctionType(
   case SILFunctionType::Representation::Method:
   case SILFunctionType::Representation::Closure:
   case SILFunctionType::Representation::WitnessMethod: {
-    switch (constant ? constant->kind : SILDeclRef::Kind::Func) {
+    switch (origConstant ? origConstant->kind : SILDeclRef::Kind::Func) {
     case SILDeclRef::Kind::Initializer:
     case SILDeclRef::Kind::EnumElement:
       return getSILFunctionTypeForConventions(DefaultInitializerConventions());

--- a/test/SILGen/enum_witness_thunks.swift
+++ b/test/SILGen/enum_witness_thunks.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+class C {}
+
+protocol P {
+    static func c(_: C) -> Self
+}
+
+enum E: P {
+    case c(C)
+}
+
+// CHECK-LABEL: sil {{.*}} @$s19enum_witness_thunks1EOAA1PA2aDP1cyxAA1CCFZTW : $@convention(witness_method: P) (@guaranteed C, @thick E.Type) -> @out E
+// CHECK:         [[COPY:%.*]] = copy_value
+// CHECK:         apply {{.*}}([[COPY]]


### PR DESCRIPTION
Enum constructors take their arguments +1 by default, but they can now be used to satisfy protocol static member
requirements, which take arguments +0 by default. Type lowering would accidentally use the kind of the witness
to determine the conventions for the witness thunk, leading to a miscompile when the requirement is called through
the protocol. Fixes rdar://74117738.