### PR TITLE
[Module interface] Use features in module interface generation.

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -355,6 +355,10 @@ void getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
                              llvm::SmallVectorImpl<TypeLoc> &Results);
 
 StringRef getAccessorKindString(AccessorKind value);
+
+bool printCompatibilityFeatureChecksPre(ASTPrinter &printer, Decl *decl);
+void printCompatibilityFeatureChecksPost(ASTPrinter &printer);
+
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_ASTPRINTER_H

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -460,6 +460,10 @@ struct PrintOptions {
   /// Whether to print inheritance lists for types.
   bool PrintInherited = true;
 
+  /// Whether to print feature checks for compatibility with older Swift
+  /// compilers that might parse the result.
+  bool PrintCompatibilityFeatureChecks = false;
+
   /// \see ShouldQualifyNestedDeclarations
   enum class QualifyNestedDeclarations {
     Never,

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -1,0 +1,34 @@
+//===--- Feature.h - Helpers related to Swift features ----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_FEATURES_H
+#define SWIFT_BASIC_FEATURES_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+
+class LangOptions;
+  
+/// Enumeration describing all of the named features.
+enum class Feature {
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
+  FeatureName,
+  #include "swift/Basic/Features.def"
+};
+
+/// Determine the in-source name of the given feature.
+llvm::StringRef getFeatureName(Feature feature);
+
+}
+
+#endif // SWIFT_BASIC_FEATURES_H

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -14,11 +14,11 @@
 // features.
 //
 //
-// FEATURE(FeatureName, SENumber, Description, Option)
+// LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
 //
-//   The FEATURE macro describes each named feature that is introduced in
-//   Swift. It allows Swift code to check for a particular feature with
-//   "#if $FeatureName" in source code.
+//   The LANGUAGE_FEATURE macro describes each named feature that is
+//   introduced in Swift. It allows Swift code to check for a particular
+//   feature with "#if $FeatureName" in source code.
 //
 //     FeatureName: The name given to this feature to be used in source code,
 //       e.g., AsyncAwait.
@@ -36,6 +36,7 @@
 
 LANGUAGE_FEATURE(StaticAssert, 0, "#assert", langOpts.EnableExperimentalStaticAssert)
 LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
+LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
 LANGUAGE_FEATURE(Actors, 0, "actors", langOpts.EnableExperimentalConcurrency)
 
 #undef LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Comment.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/FileUnit.h"
 #include "swift/AST/GenericSignature.h"
@@ -36,6 +37,7 @@
 #include "swift/AST/TypeWalker.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Defer.h"
+#include "swift/Basic/Feature.h"
 #include "swift/Basic/PrimitiveParsing.h"
 #include "swift/Basic/QuotedString.h"
 #include "swift/Basic/STLExtras.h"
@@ -136,6 +138,9 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
 
   // We should print __consuming, __owned, etc for the module interface file.
   result.SkipUnderscoredKeywords = false;
+
+  // We should provide backward-compatible Swift interfaces when we can.
+  result.PrintCompatibilityFeatureChecks = true;
 
   result.FunctionBody = [](const ValueDecl *decl, ASTPrinter &printer) {
     auto AFD = dyn_cast<AbstractFunctionDecl>(decl);
@@ -955,9 +960,16 @@ public:
       }
     }
 
+    
     Printer.callPrintDeclPre(D, Options.BracketOptions);
 
+    bool haveFeatureChecks = Options.PrintCompatibilityFeatureChecks &&
+      printCompatibilityFeatureChecksPre(Printer, D);
+
     ASTVisitor::visit(D);
+
+    if (haveFeatureChecks)
+      printCompatibilityFeatureChecksPost(Printer);
 
     if (Synthesize) {
       Printer.setSynthesizedTarget({});
@@ -2255,6 +2267,11 @@ static void printExtendedTypeName(Type ExtendedType, ASTPrinter &Printer,
 
 void PrintAST::printSynthesizedExtension(Type ExtendedType,
                                          ExtensionDecl *ExtDecl) {
+    // Print compatibility features checks first, if we need them.
+    bool haveFeatureChecks = Options.PrintCompatibilityFeatureChecks &&
+      Options.BracketOptions.shouldOpenExtension(ExtDecl) &&
+      Options.BracketOptions.shouldCloseExtension(ExtDecl) &&
+      printCompatibilityFeatureChecksPre(Printer, ExtDecl);
 
   auto printRequirementsFrom = [&](ExtensionDecl *ED, bool &IsFirst) {
     auto Sig = ED->getGenericSignature();
@@ -2297,7 +2314,6 @@ void PrintAST::printSynthesizedExtension(Type ExtendedType,
     return true;
   };
 
-
   if (Options.BracketOptions.shouldOpenExtension(ExtDecl)) {
     printDocumentationComment(ExtDecl);
     printAttributes(ExtDecl);
@@ -2330,6 +2346,9 @@ void PrintAST::printSynthesizedExtension(Type ExtendedType,
                        Options.BracketOptions.shouldOpenExtension(ExtDecl),
                        Options.BracketOptions.shouldCloseExtension(ExtDecl));
   }
+
+  if (haveFeatureChecks)
+    printCompatibilityFeatureChecksPost(Printer);
 }
 
 void PrintAST::printExtension(ExtensionDecl *decl) {
@@ -2372,6 +2391,143 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
                        Options.BracketOptions.shouldCloseExtension(decl));
   }
 }
+
+/// Functions to determine which features a particular declaration uses. The
+/// usesFeatureNNN functions correspond to the features in Features.def.
+
+static bool usesFeatureStaticAssert(Decl *decl) {
+  return false;
+}
+
+static bool usesFeatureAsyncAwait(Decl *decl) {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    if (func->hasAsync())
+      return true;
+  }
+
+  return false;
+}
+
+static bool usesFeatureMarkerProtocol(Decl *decl) {
+  if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
+    if (proto->isMarkerProtocol())
+      return true;
+  }
+
+  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
+    for (const auto &req: ext->getGenericRequirements()) {
+      if (req.getKind() == RequirementKind::Conformance &&
+          req.getSecondType()->castTo<ProtocolType>()->getDecl()
+              ->isMarkerProtocol())
+        return true;
+    }
+
+    for (const auto &inherited : ext->getInherited()) {
+      if (auto inheritedType = inherited.getType()) {
+        if (inheritedType->isExistentialType()) {
+          auto layout = inheritedType->getExistentialLayout();
+          for (ProtocolType *protoTy : layout.getProtocols()) {
+            if (protoTy->getDecl()->isMarkerProtocol())
+              return true;
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+static bool usesFeatureActors(Decl *decl) {
+  if (auto classDecl = dyn_cast<ClassDecl>(decl)) {
+    if (classDecl->isActor())
+      return true;
+  }
+
+  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
+    if (auto classDecl = ext->getSelfClassDecl())
+      if (classDecl->isActor())
+        return true;
+  }
+
+  return false;
+}
+
+/// Determine the set of "new" features used on a given declaration.
+///
+/// Note: right now, all features we check for are "new". At some point, we'll
+/// want a baseline version.
+static std::vector<Feature> getFeaturesUsed(Decl *decl) {
+  std::vector<Feature> features;
+  
+  // Only type- and module-scope declarations have any features to speak of.
+  auto dc = decl->getDeclContext();
+  if (!dc->isTypeContext() && !dc->isModuleScopeContext())
+    return features;
+
+  // Go through each of the features, checking whether the declaration uses that
+  // feature. This also ensures that the resulting set is in sorted order.
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)  \
+  if (usesFeature##FeatureName(decl))                                 \
+    features.push_back(Feature::FeatureName);
+#include "swift/Basic/Features.def"
+  
+  return features;
+}
+
+/// Get the set of features that are uniquely used by this declaration, and are
+/// not part of the enclosing context.
+static std::vector<Feature> getUniqueFeaturesUsed(Decl *decl) {
+  auto features = getFeaturesUsed(decl);
+  if (features.empty())
+    return features;
+
+  auto enclosingDecl = decl->getDeclContext()->getAsDecl();
+  if (!enclosingDecl)
+    return features;
+
+  if (!isa<NominalTypeDecl>(enclosingDecl) &&
+      !isa<ExtensionDecl>(enclosingDecl))
+    return features;
+  
+  auto enclosingFeatures = getFeaturesUsed(enclosingDecl);
+  if (enclosingFeatures.empty())
+    return features;
+
+  // Remove any features from the enclosing context from this set of features so
+  // that we are left with a unique set.
+  std::vector<Feature> uniqueFeatures;
+  std::set_difference(
+      features.begin(), features.end(),
+      enclosingFeatures.begin(), enclosingFeatures.end(),
+      std::back_inserter(uniqueFeatures));
+  return uniqueFeatures;
+}
+
+
+bool swift::printCompatibilityFeatureChecksPre(
+    ASTPrinter &printer, Decl *decl) {
+  auto features = getUniqueFeaturesUsed(decl);
+  if (features.empty())
+    return false;
+
+  printer.printNewline();  
+  printer << "#if compiler(>=5.3) && ";
+  llvm::interleave(features.begin(), features.end(),
+    [&](Feature feature) {
+      printer << "$" << getFeatureName(feature);
+    },
+    [&] { printer << " && "; });
+  printer.printNewline();
+
+  return true;
+}
+
+void swift::printCompatibilityFeatureChecksPost(ASTPrinter &printer) {
+  printer.printNewline();
+  printer << "#endif\n";
+}
+
 
 void PrintAST::visitExtensionDecl(ExtensionDecl *decl) {
   if (Options.TransformContext &&
@@ -5213,11 +5369,20 @@ swift::getInheritedForPrinting(const Decl *decl, const PrintOptions &options,
   // Collect explicit inherited types.
   for (auto TL: inherited) {
     if (auto ty = TL.getType()) {
-      bool foundUnprintable = ty.findIf([&options](Type subTy) {
+      bool foundUnprintable = ty.findIf([&](Type subTy) {
         if (auto aliasTy = dyn_cast<TypeAliasType>(subTy.getPointer()))
           return !options.shouldPrint(aliasTy->getDecl());
-        if (auto NTD = subTy->getAnyNominal())
-          return !options.shouldPrint(NTD);
+        if (auto NTD = subTy->getAnyNominal()) {
+          if (!options.shouldPrint(NTD))
+            return true;
+
+          if (auto PD = dyn_cast<ProtocolDecl>(NTD)) {
+            // Marker protocols are unprintable on nominal types, but they're
+            // okay on extension declarations.
+            if (PD->isMarkerProtocol() && !isa<ExtensionDecl>(decl))
+              return true;
+          }
+        }
         return false;
       });
       if (foundUnprintable)

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/LangOptions.h"
+#include "swift/Basic/Feature.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/Range.h"
 #include "swift/Config.h"
@@ -374,4 +375,12 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   // in the common case.
 
   return { false, false };
+}
+
+llvm::StringRef swift::getFeatureName(Feature feature) {
+  switch (feature) {
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
+  case Feature::FeatureName: return #FeatureName;
+#include "swift/Basic/Features.def"
+  }
 }

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -248,6 +248,23 @@ class InheritedProtocolCollector {
     return cache.getValue();
   }
 
+  static bool canPrintProtocolTypeNormally(Type type, const Decl *D) {
+    if (!isPublicOrUsableFromInline(type))
+      return false;
+
+    // Extensions can print marker protocols.
+    if (isa<ExtensionDecl>(D))
+      return true;
+
+    ExistentialLayout layout = type->getExistentialLayout();
+    for (ProtocolType *protoTy : layout.getProtocols()) {
+      if (protoTy->getDecl()->isMarkerProtocol())
+        return false;
+    }
+
+    return true;
+  }
+  
   /// For each type in \p directlyInherited, classify the protocols it refers to
   /// as included for printing or not, and record them in the appropriate
   /// vectors.
@@ -259,7 +276,7 @@ class InheritedProtocolCollector {
       if (!inheritedTy || !inheritedTy->isExistentialType())
         continue;
 
-      bool canPrintNormally = isPublicOrUsableFromInline(inheritedTy);
+      bool canPrintNormally = canPrintProtocolTypeNormally(inheritedTy, D);
       ExistentialLayout layout = inheritedTy->getExistentialLayout();
       for (ProtocolType *protoTy : layout.getProtocols()) {
         if (canPrintNormally)
@@ -452,6 +469,14 @@ public:
             inherited->isSpecificProtocol(KnownProtocolKind::Actor))
           return TypeWalker::Action::Continue; 
 
+#if false
+        // If the protocol is a marker protocol, print it separately.
+        if (inherited->isMarkerProtocol()) {
+          protocolsToPrint.push_back({inherited, protoAndAvailability.second});
+          return TypeWalker::Action::SkipChildren;
+        }
+#endif
+
         if (inherited->isSPI() && !printOptions.PrintSPIs)
           return TypeWalker::Action::Continue;
 
@@ -471,6 +496,9 @@ public:
       StreamPrinter printer(out);
       ProtocolDecl *proto = protoAndAvailability.first;
 
+      bool haveFeatureChecks = printOptions.PrintCompatibilityFeatureChecks &&
+        printCompatibilityFeatureChecksPre(printer, proto);
+
       // FIXME: Shouldn't this be an implicit conversion?
       TinyPtrVector<const DeclAttribute *> attrs;
       attrs.insert(attrs.end(), protoAndAvailability.second.begin(),
@@ -485,7 +513,12 @@ public:
 
       proto->getDeclaredInterfaceType()->print(printer, printOptions);
 
-      printer << " {}\n";
+      printer << " {}";
+
+      if (haveFeatureChecks)
+        printCompatibilityFeatureChecksPost(printer);
+      else
+        printer << "\n";
     }
   }
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -252,8 +252,8 @@ class InheritedProtocolCollector {
     if (!isPublicOrUsableFromInline(type))
       return false;
 
-    // Extensions can print marker protocols.
-    if (isa<ExtensionDecl>(D))
+    // Extensions and protocols can print marker protocols.
+    if (isa<ExtensionDecl>(D) || isa<ProtocolDecl>(D))
       return true;
 
     ExistentialLayout layout = type->getExistentialLayout();

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -363,8 +363,9 @@ static bool printModuleInterfaceDecl(Decl *D,
               Opened |= ET.Ext->print(Printer, Options);
               if (ET.IsSynthesized)
                 Options.clearSynthesizedExtension();
-              if (Options.BracketOptions.shouldCloseExtension(ET.Ext))
+              if (Options.BracketOptions.shouldCloseExtension(ET.Ext)) {
                 Printer << "\n";
+              }
             }
           });
         Options.BracketOptions = BracketOptions();

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -module-name FeatureTest -emit-module-interface-path %t/FeatureTest.swiftinterface -enable-library-evolution -enable-experimental-concurrency %s
+// RUN: %FileCheck %s < %t/FeatureTest.swiftinterface --check-prefix CHECK
+
+// Make sure we can parse the file without concurrency enabled
+
+// CHECK: #if compiler(>=5.3) && $Actors
+// CHECK-NEXT: actor {{.*}} MyActor
+// CHECK: }
+// CHECK-NEXT: #endif
+public actor class MyActor {
+}
+
+// CHECK: #if compiler(>=5.3) && $Actors
+// CHECK-NEXT: extension MyActor
+public extension MyActor {
+  // CHECK-NOT: $Actors
+  // CHECK: testFunc
+  func testFunc() async { }
+  // CHECK: }
+  // CHECK-NEXT: #endif
+}
+
+// CHECK: #if compiler(>=5.3) && $AsyncAwait
+// CHECK-NEXT: globalAsync
+// CHECK-NEXT: #endif
+public func globalAsync() async { }
+
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: public protocol MP
+@_marker public protocol MP { }
+
+// CHECK: class OldSchool {
+public class OldSchool: MP {
+  // CHECK: #if compiler(>=5.3) && $AsyncAwait
+  // CHECK-NEXT: takeClass()
+  // CHECK-NEXT: #endif
+  public func takeClass() async { }
+}
+
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: extension Array : FeatureTest.MP where Element : FeatureTest.MP {
+extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: extension OldSchool : Swift.UnsafeConcurrentValue {
+extension OldSchool: UnsafeConcurrentValue { }
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: extension FeatureTest.MyActor : Swift.ConcurrentValue {}
+// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: extension FeatureTest.OldSchool : FeatureTest.MP {
+// CHECK-NEXT: #endif
+

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -63,6 +63,16 @@ extension OldSchool: UnsafeConcurrentValue { }
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
 
+// CHECK: #if compiler(>=5.3) && $AsyncAwait
+// CHECK-NEXT: func runSomethingSomewhere
+// CHECK-NEXT: #endif
+public func runSomethingSomewhere(body: () async -> Void) { }
+
+// CHECK: #if compiler(>=5.3) && $Actors
+// CHECK-NEXT: func stage
+// CHECK-NEXT: #endif
+public func stage(with actor: MyActor) { }
+
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
 // CHECK-NEXT: extension FeatureTest.MyActor : Swift.ConcurrentValue {}
 // CHECK-NEXT: #endif

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -31,6 +31,18 @@ public func globalAsync() async { }
 // CHECK-NEXT: public protocol MP
 @_marker public protocol MP { }
 
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: @_marker public protocol MP2 : FeatureTest.MP {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+@_marker public protocol MP2: MP { }
+
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: public protocol MP3
+// CHECK-NEXT: }
+public protocol MP3: MP { }
+// CHECK-NEXT: #endif
+
 // CHECK: class OldSchool {
 public class OldSchool: MP {
   // CHECK: #if compiler(>=5.3) && $AsyncAwait


### PR DESCRIPTION
When generating a module interface, emit `#if` around any declarations
that are tied to specific, named language features. This allows module
interfaces to be processed by older Swift compilers that do not
support these newer features, such as async/await or actors.

The amount of effort required to correctly handle a new kind of
feature varies somewhat drastically based on the feature itself. The
"simple" case is where a particular declaration can only exist if a
feature is available. For example, and `async` declaration is fairly
easy to handle; a `@_marker` protocol's conformances are not.

Fixes rdar://73326633.

Design credit to @beccadax, bugs are my own.