### PR TITLE
swift-driver test tweaks

### DIFF
--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -78,7 +78,7 @@
 // COMPLEX-DAG: -F /path/to/frameworks -Fsystem /path/to/systemframeworks -F /path/to/more/frameworks
 // COMPLEX-DAG: -I /path/to/headers -I path/to/more/headers
 // COMPLEX-DAG: -module-cache-path /tmp/modules
-// COMPLEX-DAG: -emit-reference-dependencies-path {{(.*(/|\\))?driver-compile[^ /]+}}.swiftdeps
+// COMPLEX-DAG: -emit-reference-dependencies-path {{(.*(/|\\))?driver-compile[^ /]*}}.swiftdeps
 // COMPLEX: -o {{.+}}.o
 
 

--- a/test/Driver/driver_migration.swift
+++ b/test/Driver/driver_migration.swift
@@ -1,4 +1,4 @@
 // RUN: %swiftc_driver -update-code -migrate-keep-objc-visibility -### %s 2>&1 | %FileCheck -check-prefix=CHECK-KEEP-OBJC %s
 
-// CHECK-KEEP-OBJC: -migrate-keep-objc-visibility
-// CHECK-KEEP-OBJC: -emit-remap-file-path {{.*}}.remap
+// CHECK-KEEP-OBJC-DAG: -migrate-keep-objc-visibility
+// CHECK-KEEP-OBJC-DAG: -emit-remap-file-path {{.*}}.remap

--- a/test/Driver/help.swift
+++ b/test/Driver/help.swift
@@ -1,3 +1,6 @@
+// REQUIRES: cplusplus_driver
+// swift-driver has swift-help with its own tests and the output has evolved.
+
 // Check that options printed with -help respect whether the driver is invoked
 // as 'swift' or as 'swiftc'.
 


### PR DESCRIPTION
- `-emit-reference-dependencies-path` allow temporary file without `-#####` postfix
- Fix test unnecessarily requiring arguments in a specific order
- Disable Driver/help.swift for swift-driver @owenv 