### PR TITLE
Remove ReadNone attribute from runtime functions

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -13,6 +13,9 @@
 // This file defines x-macros used for metaprogramming with the set of
 // runtime functions.
 //
+// Runtime functions that read from object arguments cannot be marked
+// ReadNone. Otherwise the objects may be freed before the runtime call.
+//
 //===----------------------------------------------------------------------===//
 
 /// FUNCTION(Id, Name, CC, Availability, ReturnTys, ArgTys, Attrs)
@@ -56,10 +59,11 @@ FUNCTION(DeallocBox, swift_deallocBox, C_CC, AlwaysAvailable,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
+// swift_projectBox reads object metadata so cannot be marked ReadNone.
 FUNCTION(ProjectBox, swift_projectBox, C_CC, AlwaysAvailable,
          RETURNS(OpaquePtrTy),
          ARGS(RefCountedPtrTy),
-         ATTRS(NoUnwind, ReadNone))
+         ATTRS(NoUnwind, ReadOnly, ArgMemOnly))
 
 FUNCTION(AllocEmptyBox, swift_allocEmptyBox, C_CC, AlwaysAvailable,
          RETURNS(RefCountedPtrTy),
@@ -795,11 +799,12 @@ FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata,
          ATTRS(NoUnwind, ReadNone))
 
 // Metadata *swift_getObjCClassFromObject(id object);
+// This reads object metadata so cannot be marked ReadNone.
 FUNCTION(GetObjCClassFromObject, swift_getObjCClassFromObject,
          C_CC, AlwaysAvailable,
          RETURNS(ObjCClassPtrTy),
          ARGS(ObjCPtrTy),
-         ATTRS(NoUnwind, ReadNone))
+         ATTRS(NoUnwind, ReadOnly, ArgMemOnly))
 
 // MetadataResponse swift_getTupleTypeMetadata(MetadataRequest request,
 //                                             TupleTypeFlags flags,

--- a/test/SILOptimizer/llvm_arc.sil
+++ b/test/SILOptimizer/llvm_arc.sil
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend -O -emit-ir %s | %FileCheck %s
+//
+// Test LLVM ARC Optimization
+
+// REQUIRES: objc_interop
+
+sil_stage canonical
+
+import Builtin
+
+typealias AnyObject = Builtin.AnyObject
+
+sil @getObject : $@convention(thin) <T where T : AnyObject> () -> T
+
+// Test swift_getObjCClassFromObject side-effects. It reads the object
+// argument. A release cannot be hoisted above it.
+//
+// CHECK-LABEL: define {{.*}}swiftcc %objc_class* @testGetObjCClassFromObjectSideEffect(%swift.type* %T)
+// CHECK:     entry:
+// CHECK-NEXT:  %0 = tail call swiftcc %objc_object* @getObject(%swift.type* %T)
+// CHECK-NEXT:  %.Type = tail call %objc_class* @swift_getObjCClassFromObject(%objc_object* %0)
+// CHECK-NEXT:  tail call void @swift_unknownObjectRelease(%objc_object* %0)
+// CHECK:       ret %objc_class* %.Type
+// CHECK:     }
+sil @testGetObjCClassFromObjectSideEffect : $@convention(thin) <T where T : AnyObject> () -> @objc_metatype T.Type {
+bb0:
+  %f = function_ref @getObject : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> () -> τ_0_0
+  %obj = apply %f<T>() : $@convention(thin) <τ_0_0 where τ_0_0 : AnyObject> () -> τ_0_0
+  %mt = value_metatype $@objc_metatype T.Type, %obj : $T
+  // Do not hoist this release.
+  strong_release %obj : $T
+  return %mt : $@objc_metatype T.Type
+}


### PR DESCRIPTION
The Swift compiler incorrectly sets the LLVM "ReadNone" attribute when
declaring swift_getObjCClassFromObject and swift_projectBox. This
means that the LLVM ARC optimizer will hoist ARC "release" operations
above these runtime calls. Since the implementation of the calls reads
the object, this causes a use-after-free crash.

This problem is easy to reproduce with
swift_getObjCClassFromObject. It was only exposed recently because the
SIL optimizer now shrinks object lifetimes, making it easier for LLVM
optimizations to kick in. It is difficult to expose the problem with
swift_projectBox, but the bug/fix is still obvious.

Fixes rdar://73820091: Use-after free application crash.

(cherry picked from commit 29b9e51cb654ecfd82c6907203821be0d57e9fed)

