### PR TITLE
Evaluator: Improve -debug-cycles output

### DIFF
--- a/docs/RequestEvaluator.md
+++ b/docs/RequestEvaluator.md
@@ -21,8 +21,6 @@ All existing requests inherit the [`SimpleRequest`](https://github.com/apple/swi
 
 Each request can issue other requests, also through the evaluator. The evaluator automatically tracks such dependencies (by keeping a stack of the currently-active request evaluations). This information is valuable for a few reasons. First, it can help with debugging both correctness and performance, allowing one to visualize the dependencies evaluated when compiling a program. The current protocol has both full-graph visualization (via GraphViz output) and dependencies-for-a-single-request visualization (via a tree-like dump). Second, it ensures that we can detect cyclic dependencies (e.g., a cyclic inheritance hierarchy) correctly, because they show up as cycles in the dependency graph, allowing for proper diagnostics (for the user) and recovery (in the compiler). Third, it can eventually be leveraged to enable better incremental compilation--providing the ability to discover what information affected a particular type-checking decision, and propagate the effects of a specific change through the dependency graph.
 
-The complete dependency graph formed by processing a source file can be visualized by passing the frontend option `-output-request-graphviz <filename>`. The dependency graph will be emitted using the [GraphViz](https://www.graphviz.org) format.
-
 The frontend option `-debug-cycles` will provide debugging output for any cycle detected while processing the given source files. For example, running the [`circular_inheritance.swift` test](https://github.com/apple/swift/blob/main/test/decl/class/circular_inheritance.swift) from the Swift repository using this flag, e.g.,
 
 ```

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -70,11 +70,37 @@ bool Evaluator::checkDependency(const ActiveRequest &request) {
 
 void Evaluator::diagnoseCycle(const ActiveRequest &request) {
   if (debugDumpCycles) {
-    llvm::errs() << "===CYCLE DETECTED===\n";
-    for (auto &req : activeRequests) {
-      simple_display(llvm::errs(), req);
-      llvm::errs() << "\n";
+    const auto printIndent = [](llvm::raw_ostream &OS, unsigned indent) {
+      OS.indent(indent);
+      OS << "`--";
+    };
+
+    unsigned indent = 1;
+    auto &OS = llvm::errs();
+
+    OS << "===CYCLE DETECTED===\n";
+    for (const auto &step : activeRequests) {
+      printIndent(OS, indent);
+      if (step == request) {
+        OS.changeColor(llvm::raw_ostream::GREEN);
+        simple_display(OS, step);
+        OS.resetColor();
+      } else {
+        simple_display(OS, step);
+      }
+      OS << "\n";
+      indent += 4;
     }
+
+    printIndent(OS, indent);
+    OS.changeColor(llvm::raw_ostream::GREEN);
+    simple_display(OS, request);
+
+    OS.changeColor(llvm::raw_ostream::RED);
+    OS << " (cyclic dependency)";
+    OS.resetColor();
+
+    OS << "\n";
   }
 
   request.diagnoseCycle(diags);

--- a/test/Frontend/debug-cycles.swift
+++ b/test/Frontend/debug-cycles.swift
@@ -1,0 +1,12 @@
+
+// RUN: not %target-swift-frontend -typecheck -debug-cycles %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --color=false
+
+class Outer2: Outer2.Inner {
+  class Inner {}
+}
+// CHECK:===CYCLE DETECTED===
+// CHECK-NEXT: `--TypeCheckSourceFileRequest({{.*}})
+// CHECK-NEXT:     `--[0;32mSuperclassDeclRequest({{.*}})[0m
+// CHECK-NEXT:         `--InheritedDeclsReferencedRequest({{.*}})
+// CHECK-NEXT:             `--QualifiedLookupRequest({{.*}})
+// CHECK-NEXT:                 `--[0;32mSuperclassDeclRequest({{.*}})[0;31m (cyclic dependency)[0m


### PR DESCRIPTION
This restores the tree dump structure as per [RequestEvaluator.md](https://github.com/apple/swift/blob/main/docs/RequestEvaluator.md) and deletes a paragraph about a removed flag therein. I also restored the coloring and chose to use it unconditionally since the output is only intended for debugging.