### PR TITLE
[5.4] SIL: Pick default ARC convention for enum case witness thunks based on the kind of the original decl.

### DIFF
--- a/test/SILGen/enum_witness_thunks.swift
+++ b/test/SILGen/enum_witness_thunks.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+class C {}
+
+protocol P {
+    static func c(_: C) -> Self
+}
+
+enum E: P {
+    case c(C)
+}
+
+// CHECK-LABEL: sil {{.*}} @$s19enum_witness_thunks1EOAA1PA2aDP1cyxAA1CCFZTW : $@convention(witness_method: P) (@guaranteed C, @thick E.Type) -> @out E
+// CHECK:         [[COPY:%.*]] = copy_value
+// CHECK:         apply {{.*}}([[COPY]]


### PR DESCRIPTION
Explanation: Enum constructors take their arguments +1 by default, but they can now be used to satisfy protocol static member requirements, which take arguments +0 by default. Type lowering would accidentally use the kind of the witness
to determine the conventions for the witness thunk, leading to a miscompile when the requirement is called through
the protocol. This differs from the [fix on main](https://github.com/apple/swift/pull/35838) in that the behavior change is contained to only cases where the witness is an enum constructor, to minimize behavior change. 

Issue: rdar://73855052

Scope: Fixes a miscompile.

Risk: Low. The fix in main has been narrowed to only change behavior in the case known to be affected by the bug.

Testing: Swift CI

