### PR TITLE
Fix a Simple Crash-On-Invalid For @_spi

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -147,6 +147,11 @@ static void maybeAddMemberwiseDefaultArg(ParamDecl *arg, VarDecl *var,
   if (var->isLet())
     return;
 
+  // If there's no parent pattern there's not enough structure to even perform
+  // this analysis. Just bail.
+  if (!var->getParentPattern())
+    return;
+
   // We can only provide default values for patterns binding a single variable.
   // i.e. var (a, b) = getSomeTuple() is not allowed.
   if (!var->getParentPattern()->getSingleVar())

--- a/validation-test/compiler_crashers_2_fixed/rdar74154023.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar74154023.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+public struct PeakMemoryUsage {
+  public let rawValue: UInt64
+
+  @_spi( init(rawValue: UInt64) {
+    self.rawValue = rawValue
+  }
+}


### PR DESCRIPTION
The parser attempts to recover here by producing a broken VarDecl with
no parent pattern. The DeclChecker sees this when trying to install
a default initializer in the linked regression test and crashes because
it tries to look into a null parent pattern.

rdar://74154023