### PR TITLE
Allow cross host compilation without stdlib build

### DIFF
--- a/utils/swift_build_support/swift_build_support/host_specific_configuration.py
+++ b/utils/swift_build_support/swift_build_support/host_specific_configuration.py
@@ -39,7 +39,15 @@ class HostSpecificConfiguration(object):
             # Otherwise, this is a host we are building as part of
             # cross-compiling, so we only need the target itself.
             stdlib_targets_to_configure = [host_target]
-            stdlib_targets_to_build = set(stdlib_targets_to_configure)
+            if (hasattr(args, 'stdlib_deployment_targets')):
+                # there are some build configs that expect
+                # not to be building the stdlib for the target
+                # since it will be provided by different means
+                stdlib_targets_to_build = set(
+                    stdlib_targets_to_configure).intersection(
+                    set(args.stdlib_deployment_targets))
+            else:
+                stdlib_targets_to_build = set(stdlib_targets_to_configure)
 
         if (hasattr(args, 'stdlib_deployment_targets') and
                 args.stdlib_deployment_targets == []):

--- a/utils/swift_build_support/tests/test_host_specific_configuration.py
+++ b/utils/swift_build_support/tests/test_host_specific_configuration.py
@@ -73,6 +73,34 @@ class ToolchainTestCase(unittest.TestCase):
         self.assertIn('swift-test-stdlib-iphoneos-arm64',
                       hsc.swift_stdlib_build_targets)
 
+    def test_should_configure_and_build_cross_compiling_with_stdlib_targets(self):
+        args = self.default_args()
+        args.build_ios_device = True
+        args.host_target = 'macosx-x86_64'
+        args.stdlib_deployment_targets = ['iphoneos-arm64']
+
+        hsc = HostSpecificConfiguration('iphoneos-arm64', args)
+
+        self.assertEqual(len(hsc.sdks_to_configure), 1)
+        self.assertIn('IOS', hsc.sdks_to_configure)
+
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 1)
+        self.assertIn('swift-test-stdlib-iphoneos-arm64',
+                      hsc.swift_stdlib_build_targets)
+
+    def test_should_only_configure_when_cross_compiling_different_stdlib_targets(self):
+        args = self.default_args()
+        args.build_ios_device = True
+        args.host_target = 'macosx-x86_64'
+        args.stdlib_deployment_targets = ['iphonesimulator-arm64']
+
+        hsc = HostSpecificConfiguration('iphoneos-arm64', args)
+
+        self.assertEqual(len(hsc.sdks_to_configure), 1)
+        self.assertIn('IOS', hsc.sdks_to_configure)
+
+        self.assertEqual(len(hsc.swift_stdlib_build_targets), 0)
+
     def generate_should_skip_building_platform(
             host_target, sdk_name, build_target, build_arg_name):
         def test(self):


### PR DESCRIPTION
This is to support certain build configuration which will provide the
stdlib/runtime for the cross target by a different mean.

Addresses rdar://74188174, rdar://74154062