### PR TITLE
[concurrency][nfc] more test coverage for ObjC async conformance

### DIFF
--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -72,6 +72,12 @@ class Rock : NSObject, Rollable {
   func roll() { roll(completionHandler: {}) }
 }
 
+// additional coverage for a situation where only an argument label differs, excluding the completion handler.
+final class Moon : LabellyProtocol {
+  func myMethod(_ value: Int, foo: Int) {}
+  func myMethod(_ value: Int, newFoo foo: Int, completion: @escaping (Error?) -> Void) {}
+}
+
 // Crash involving actor isolation checking.
 class C5 {
   @MainActor @objc var allOperations: [String] = []

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -103,6 +103,11 @@ typedef void ( ^ObjCErrorHandler )( NSError * _Nullable inError );
 - (void) activateWithCompletion:(ObjCErrorHandler) inCompletion;
 @end
 
+@protocol LabellyProtocol
+  - (void) myMethod:(NSInteger)value1 newFoo:(NSInteger)value2 completion:(ObjCErrorHandler)completion;
+  - (void) myMethod:(NSInteger)value1 foo:(NSInteger)value2;
+@end
+
 #define MAGIC_NUMBER 42
 
 #pragma clang assume_nonnull end


### PR DESCRIPTION
This adds regression test coverage for a situation related to rdar://73326085, but was just recently fixed in https://github.com/apple/swift/pull/35719