### PR TITLE
Sema: Fix enum case witness crash when the requirement does not specify accessors

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5663,6 +5663,11 @@ bool VarDecl::isSettable(const DeclContext *UseDC,
   if (!isLet())
     return supportsMutation();
 
+  // Static 'let's are always immutable.
+  if (isStatic()) {
+    return false;
+  }
+
   //
   // All the remaining logic handles the special cases where you can
   // assign a 'let'.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -658,7 +658,7 @@ swift::matchWitness(
     if (!cast<ValueDecl>(req)->isStatic())
       return RequirementMatch(witness, MatchKind::StaticNonStaticConflict);
     if (isa<VarDecl>(req) &&
-        cast<VarDecl>(req)->getParsedAccessor(AccessorKind::Set))
+        cast<VarDecl>(req)->isSettable(req->getDeclContext()))
       return RequirementMatch(witness, MatchKind::SettableConflict);
 
     decomposeFunctionType = enumCase->hasAssociatedValues();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -648,15 +648,21 @@ swift::matchWitness(
   } else if (isa<ConstructorDecl>(witness)) {
     decomposeFunctionType = true;
     ignoreReturnType = true;
-  } else if (isa<EnumElementDecl>(witness)) {
-    auto enumCase = cast<EnumElementDecl>(witness);
+  } else if (auto *enumCase = dyn_cast<EnumElementDecl>(witness)) {
+    // An enum case with associated values can satisfy only a
+    // method requirement.
     if (enumCase->hasAssociatedValues() && isa<VarDecl>(req))
       return RequirementMatch(witness, MatchKind::EnumCaseWithAssociatedValues);
-    auto isValid = isa<VarDecl>(req) || isa<FuncDecl>(req);
-    if (!isValid)
+
+    // An enum case can satisfy only a method or property requirement.
+    if (!isa<VarDecl>(req) && !isa<FuncDecl>(req))
       return RequirementMatch(witness, MatchKind::KindConflict);
-    if (!cast<ValueDecl>(req)->isStatic())
+
+    // An enum case can satisfy only a static requirement.
+    if (!req->isStatic())
       return RequirementMatch(witness, MatchKind::StaticNonStaticConflict);
+
+    // An enum case cannot satisfy a settable property requirement.
     if (isa<VarDecl>(req) &&
         cast<VarDecl>(req)->isSettable(req->getDeclContext()))
       return RequirementMatch(witness, MatchKind::SettableConflict);

--- a/test/decl/protocol/protocol_enum_witness.swift
+++ b/test/decl/protocol/protocol_enum_witness.swift
@@ -146,3 +146,10 @@ protocol MissingAccessorsVar {
 enum Bar14: MissingAccessorsVar { // OK
   case bar
 }
+
+protocol MissingAccessorsLet {
+  static let bar: Self // expected-error {{protocols cannot require properties to be immutable; declare read-only properties by using 'var' with a '{ get }' specifier}}
+}
+enum Bar15: MissingAccessorsLet { // OK
+  case bar
+}

--- a/test/decl/protocol/protocol_enum_witness.swift
+++ b/test/decl/protocol/protocol_enum_witness.swift
@@ -139,3 +139,10 @@ protocol ThrowingFactory {
 enum HorseFactory : ThrowingFactory {
   case horse(Int)
 }
+
+protocol MissingAccessorsVar {
+  static var bar: Self // expected-error {{property in protocol must have explicit { get } or { get set } specifier}}
+}
+enum Bar14: MissingAccessorsVar { // OK
+  case bar
+}


### PR DESCRIPTION
We were checking only for a parsed setter.
