### PR TITLE
Fix assertion failure when comparing reconstructed SILBoxTypes.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4314,16 +4314,29 @@ case TypeKind::Id:
   }
 
   case TypeKind::SILBox: {
+    bool changed = false;
+    auto boxTy = cast<SILBoxType>(base);
 #ifndef NDEBUG
     // This interface isn't suitable for updating the substitution map in a
     // generic SILBox.
-    auto boxTy = cast<SILBoxType>(base);
     for (Type type : boxTy->getSubstitutions().getReplacementTypes()) {
       assert(type->isEqual(type.transformRec(fn))
-             && "SILBoxType can't be transformed");
+             && "SILBoxType substitutions can't be transformed");
     }
 #endif
-    return base;
+    SmallVector<SILField, 4> newFields;
+    auto *l = boxTy->getLayout();
+    for (auto f : l->getFields()) {
+      auto fieldTy = f.getLoweredType();
+      auto transformed = fieldTy.transformRec(fn)->getCanonicalType();
+      changed |= fieldTy != transformed;
+      newFields.push_back(SILField(transformed, f.isMutable()));
+    }
+    boxTy = SILBoxType::get(Ptr->getASTContext(),
+                            SILLayout::get(Ptr->getASTContext(),
+                                           l->getGenericSignature(), newFields),
+                            boxTy->getSubstitutions());
+    return boxTy;
   }
   
   case TypeKind::SILFunction: {

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -637,8 +637,8 @@ bool SILType::isDifferentiable(SILModule &M) const {
 
 Type
 TypeBase::replaceSubstitutedSILFunctionTypesWithUnsubstituted(SILModule &M) const {
-  return Type(const_cast<TypeBase*>(this)).transform([&](Type t) -> Type {
-    if (auto f = t->getAs<SILFunctionType>()) {
+  return Type(const_cast<TypeBase *>(this)).transform([&](Type t) -> Type {
+    if (auto *f = t->getAs<SILFunctionType>()) {
       auto sft = f->getUnsubstitutedType(M);
       
       // Also eliminate substituted function types in the arguments, yields,


### PR DESCRIPTION
Substitutions in SILFunctionTypes are not handled by TypeDecoder, by adding
support for SILBoxTypes to replaceSubstitutedSILFunctionTypesWithUnsubstituted()
we can avoid an assertion failure when running the compatibility test suite.

rdar://74153042

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
