### PR TITLE
[Concurrency] Fix actor isolation and restrictions on initializers.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6986,7 +6986,7 @@ AbstractFunctionDecl::getObjCSelector(DeclName preferredName,
     }
 
     // For the first selector piece, attach either the first parameter,
-    // "withCompletionHandker", or "AndReturnError" to the base name,
+    // "withCompletionHandler", or "AndReturnError" to the base name,
     // if appropriate.
     auto firstPiece = baseName;
     llvm::SmallString<32> scratch;
@@ -7999,7 +7999,8 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
     return getActorIsolation(vd);
 
   if (auto *init = dyn_cast<PatternBindingInitializer>(dc)) {
-    if (auto *var = init->getBinding()->getSingleVar())
+    if (auto *var = init->getBinding()->getAnchoringVarDecl(
+            init->getBindingIndex()))
       return getActorIsolation(var);
   }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -446,3 +446,35 @@ extension SomeClassInActor.ID {
     object.inActor() // expected-error{{'async' in a function that does not support concurrency}}
   }
 }
+
+// ----------------------------------------------------------------------
+// Initializers
+// ----------------------------------------------------------------------
+actor class SomeActorWithInits {
+  var mutableState: Int = 17
+  var otherMutableState: Int
+
+  init() {
+    self.mutableState = 42
+    self.otherMutableState = 17
+
+    self.isolated()
+  }
+
+  func isolated() { }
+}
+
+@MainActor
+class SomeClassWithInits {
+  var mutableState: Int = 17
+  var otherMutableState: Int
+
+  init() {
+    self.mutableState = 42
+    self.otherMutableState = 17
+
+    self.isolated()
+  }
+
+  func isolated() { }
+}


### PR DESCRIPTION
Initializers are actor-isolated when they are part of an actor or have
a global actor. However, uses of actor initializers need to be treated
as cross-actor references so we proper `ConcurrentValue` checking for
values passed into the initializer.

Fixes rdar://74064751.
