### PR TITLE
[SourceKit][SymbolGraph] Add a 'parent_contexts' field the CursorInfo response

### DIFF
--- a/include/swift/SymbolGraphGen/PathComponent.h
+++ b/include/swift/SymbolGraphGen/PathComponent.h
@@ -1,0 +1,36 @@
+//===--- SymbolGraphPathComponent.h - Swift SymbolGraph Path Component ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYMBOLGRAPHGEN_PATHCOMPONENT_H
+#define SWIFT_SYMBOLGRAPHGEN_PATHCOMPONENT_H
+
+#include "llvm/ADT/SmallString.h"
+
+namespace swift {
+class ValueDecl;
+
+namespace symbolgraphgen {
+
+/// Summary information for a node along a path through a symbol graph.
+struct PathComponent {
+  /// The title of the corresponding symbol graph node.
+  SmallString<32> Title;
+  /// The kind of the corresponding symbol graph node.
+  StringRef Kind;
+  /// The swift decl associated with the corresponding symbol graph node.
+  const ValueDecl *VD;
+};
+
+} // end namespace symbolgraphgen
+} // end namespace swift
+
+#endif // SWIFT_SYMBOLGRAPHGEN_PATHCOMPONENT_H

--- a/include/swift/SymbolGraphGen/SymbolGraphGen.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphGen.h
@@ -16,6 +16,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/Type.h"
 #include "SymbolGraphOptions.h"
+#include "PathComponent.h"
 
 namespace swift {
 class ValueDecl;
@@ -25,14 +26,17 @@ namespace symbolgraphgen {
 /// Emit a Symbol Graph JSON file for a module.
 int emitSymbolGraphForModule(ModuleDecl *M, const SymbolGraphOptions &Options);
 
-/// Print a Symbol Graph containing a single node for the given decl.
+/// Print a Symbol Graph containing a single node for the given decl to \p OS.
+/// The \p ParentContexts out parameter will also be populated with information
+/// about each parent context of the given decl, from outermost to innermost.
 ///
-/// \returns \c EXIT_SUCCESS if the kind of the provided node is supported and
-/// its Symbo lGraph was printed, or \c EXIT_FAILURE otherwise.
+/// \returns \c EXIT_SUCCESS if the kind of the provided node is supported or
+/// \c EXIT_FAILURE otherwise.
 int printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
-                             bool InSynthesizedExtensions,
-                             const SymbolGraphOptions &Options,
-                             llvm::raw_ostream &OS);
+                            bool InSynthesizedExtension,
+                            const SymbolGraphOptions &Options,
+                            llvm::raw_ostream &OS,
+                            SmallVectorImpl<PathComponent> &ParentContexts);
 
 } // end namespace symbolgraphgen
 } // end namespace swift

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -44,70 +44,56 @@ void Symbol::serializeKind(StringRef Identifier, StringRef DisplayName,
   });
 }
 
-void Symbol::serializeKind(llvm::json::OStream &OS) const {
-  // supportsKind and serializeKind must agree.
+std::pair<StringRef, StringRef> Symbol::getKind(const ValueDecl *VD) const {
+  // Make sure supportsKind stays in sync with getKind.
   assert(Symbol::supportsKind(VD->getKind()) && "unsupported decl kind");
-
-  AttributeRAII A("kind", OS);
   switch (VD->getKind()) {
   case swift::DeclKind::Class:
-    serializeKind("swift.class", "Class", OS);
-    break;
+    return {"swift.class", "Class"};
   case swift::DeclKind::Struct:
-    serializeKind("swift.struct", "Structure", OS);
-    break;
+    return {"swift.struct", "Structure"};
   case swift::DeclKind::Enum:
-    serializeKind("swift.enum", "Enumeration", OS);
-    break;
+    return {"swift.enum", "Enumeration"};
   case swift::DeclKind::EnumElement:
-    serializeKind("swift.enum.case", "Case", OS);
-    break;
+    return {"swift.enum.case", "Case"};
   case swift::DeclKind::Protocol:
-    serializeKind("swift.protocol", "Protocol", OS);
-    break;
+    return {"swift.protocol", "Protocol"};
   case swift::DeclKind::Constructor:
-    serializeKind("swift.init", "Initializer", OS);
-    break;
+    return {"swift.init", "Initializer"};
   case swift::DeclKind::Destructor:
-    serializeKind("swift.deinit", "Deinitializer", OS);
-    break;
+    return {"swift.deinit", "Deinitializer"};
   case swift::DeclKind::Func:
-    if (VD->isOperator()) {
-      serializeKind("swift.func.op", "Operator", OS);
-    } else if (VD->isStatic()) {
-      serializeKind("swift.type.method", "Type Method", OS);
-    } else if (VD->getDeclContext()->getSelfNominalTypeDecl()){
-      serializeKind("swift.method", "Instance Method", OS);
-    } else {
-      serializeKind("swift.func", "Function", OS);
-    }
-    break;
+    if (VD->isOperator())
+      return {"swift.func.op", "Operator"};
+    if (VD->isStatic())
+      return {"swift.type.method", "Type Method"};
+    if (VD->getDeclContext()->getSelfNominalTypeDecl())
+      return {"swift.method", "Instance Method"};
+    return {"swift.func", "Function"};
   case swift::DeclKind::Var:
-    if (VD->isStatic()) {
-      serializeKind("swift.type.property", "Type Property", OS);
-    } else if (VD->getDeclContext()->getSelfNominalTypeDecl()) {
-      serializeKind("swift.property", "Instance Property", OS);
-    } else {
-      serializeKind("swift.var", "Global Variable", OS);
-    }
-    break;
+    if (VD->isStatic())
+      return {"swift.type.property", "Type Property"};
+    if (VD->getDeclContext()->getSelfNominalTypeDecl())
+      return {"swift.property", "Instance Property"};
+    return {"swift.var", "Global Variable"};
   case swift::DeclKind::Subscript:
-    if (VD->isStatic()) {
-      serializeKind("swift.type.subscript", "Type Subscript", OS);
-    } else {
-      serializeKind("swift.subscript", "Instance Subscript", OS);
-    }
-    break;
+    if (VD->isStatic())
+      return {"swift.type.subscript", "Type Subscript"};
+    return {"swift.subscript", "Instance Subscript"};
   case swift::DeclKind::TypeAlias:
-    serializeKind("swift.typealias", "Type Alias", OS);
-    break;
+    return {"swift.typealias", "Type Alias"};
   case swift::DeclKind::AssociatedType:
-    serializeKind("swift.associatedtype", "Associated Type", OS);
-    break;
+    return {"swift.associatedtype", "Associated Type"};
   default:
     llvm::errs() << "Unsupported kind: " << VD->getKindName(VD->getKind());
     llvm_unreachable("Unsupported declaration kind for symbol graph");
   }
+}
+
+void Symbol::serializeKind(llvm::json::OStream &OS) const {
+  AttributeRAII A("kind", OS);
+  std::pair<StringRef, StringRef> IDAndName = getKind(VD);
+  serializeKind(IDAndName.first, IDAndName.second, OS);
 }
 
 void Symbol::serializeIdentifier(llvm::json::OStream &OS) const {
@@ -121,17 +107,17 @@ void Symbol::serializeIdentifier(llvm::json::OStream &OS) const {
 
 void Symbol::serializePathComponents(llvm::json::OStream &OS) const {
   OS.attributeArray("pathComponents", [&](){
-    SmallVector<SmallString<32>, 8> PathComponents;
+    SmallVector<PathComponent, 8> PathComponents;
     getPathComponents(PathComponents);
     for (auto Component : PathComponents) {
-      OS.value(Component);
+      OS.value(Component.Title);
     }
   });
 }
 
 void Symbol::serializeNames(llvm::json::OStream &OS) const {
   OS.attributeObject("names", [&](){
-    SmallVector<SmallString<32>, 8> PathComponents;
+    SmallVector<PathComponent, 8> PathComponents;
     getPathComponents(PathComponents);
 
     if (isa<GenericTypeDecl>(VD)) {    
@@ -141,12 +127,12 @@ void Symbol::serializeNames(llvm::json::OStream &OS) const {
         if (It != PathComponents.begin()) {
           FullyQualifiedTitle.push_back('.');
         }
-        FullyQualifiedTitle.append(*It);
+        FullyQualifiedTitle.append(It->Title);
       }
       
       OS.attribute("title", FullyQualifiedTitle.str());
     } else {
-      OS.attribute("title", PathComponents.back());
+      OS.attribute("title", PathComponents.back().Title);
     }
 
     Graph->serializeNavigatorDeclarationFragments("navigator", *this, OS);
@@ -481,16 +467,27 @@ void Symbol::serialize(llvm::json::OStream &OS) const {
 }
 
 void
-Symbol::getPathComponents(SmallVectorImpl<SmallString<32>> &Components) const {
+Symbol::getPathComponents(SmallVectorImpl<PathComponent> &Components) const {
+  // Note: this is also used for sourcekit's cursor-info request, so can be
+  // called on local symbols too. For such symbols, the path contains all parent
+  // decl contexts that are currently representable in the symbol graph,
+  // skipping over the rest (e.g. containing closures and accessors).
 
   auto collectPathComponents = [&](const ValueDecl *Decl,
-                                   SmallVectorImpl<SmallString<32>> &DeclComponents) {
-    // Collect the spellings of the fully qualified identifier components.
+                                   SmallVectorImpl<PathComponent> &DeclComponents) {
+    // Collect the spellings, kinds, and decls of the fully qualified identifier
+    // components.
     while (Decl && !isa<ModuleDecl>(Decl)) {
       SmallString<32> Scratch;
       Decl->getName().getString(Scratch);
-      DeclComponents.push_back(Scratch);
-      if (const auto *DC = Decl->getDeclContext()) {
+      if (supportsKind(Decl->getKind()))
+        DeclComponents.push_back({Scratch, getKind(Decl).first, Decl});
+
+      // Find the next parent.
+      auto *DC = Decl->getDeclContext();
+      while (DC && DC->getContextKind() == DeclContextKind::AbstractClosureExpr)
+        DC = DC->getParent();
+      if (DC) {
         if (const auto *Nominal = DC->getSelfNominalTypeDecl()) {
           Decl = Nominal;
         } else {
@@ -508,7 +505,8 @@ Symbol::getPathComponents(SmallVectorImpl<SmallString<32>> &Components) const {
     // a protocol. Build a path as if it were defined in the base type.
     SmallString<32> LastPathComponent;
     VD->getName().getString(LastPathComponent);
-    Components.push_back(LastPathComponent);
+    if (supportsKind(VD->getKind()))
+      Components.push_back({LastPathComponent, getKind(VD).first, VD});
     collectPathComponents(BaseTypeDecl, Components);
   } else {
     // Otherwise, this is just a normal declaration, so we can build
@@ -521,13 +519,13 @@ Symbol::getPathComponents(SmallVectorImpl<SmallString<32>> &Components) const {
 }
 
 void Symbol::printPath(llvm::raw_ostream &OS) const {
-  SmallVector<SmallString<32>, 8> Components;
+  SmallVector<PathComponent, 8> Components;
   getPathComponents(Components);
   for (auto it = Components.begin(); it != Components.end(); ++it) {
     if (it != Components.begin()) {
       OS << '.';
     }
-    OS << it->str();
+    OS << it->Title.str();
   }
 }
 

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -18,6 +18,7 @@
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Markup/Markup.h"
+#include "swift/SymbolGraphGen/PathComponent.h"
 
 namespace swift {
 namespace symbolgraphgen {
@@ -33,6 +34,8 @@ class Symbol {
   const ValueDecl *VD;
   Type BaseType;
   const NominalTypeDecl *SynthesizedBaseTypeDecl;
+
+  std::pair<StringRef, StringRef> getKind(const ValueDecl *VD) const;
 
   void serializeKind(StringRef Identifier, StringRef DisplayName,
                      llvm::json::OStream &OS) const;
@@ -95,7 +98,7 @@ public:
     return SynthesizedBaseTypeDecl;
   }
 
-  void getPathComponents(SmallVectorImpl<SmallString<32>> &Components) const;
+  void getPathComponents(SmallVectorImpl<PathComponent> &Components) const;
 
   /// Print the symbol path to an output stream.
   void printPath(llvm::raw_ostream &OS) const;

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -104,7 +104,8 @@ int symbolgraphgen::
 printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
                         bool InSynthesizedExtension,
                         const SymbolGraphOptions &Options,
-                        llvm::raw_ostream &OS) {
+                        llvm::raw_ostream &OS,
+                        SmallVectorImpl<PathComponent> &ParentContexts) {
   if (!Symbol::supportsKind(D->getKind()))
     return EXIT_FAILURE;
 
@@ -119,6 +120,11 @@ printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
       : nullptr;
 
   Symbol MySym(&Graph, D, NTD, BaseTy);
+
+  MySym.getPathComponents(ParentContexts);
+  assert(!ParentContexts.empty() && "doesn't have node for MySym?");
+  ParentContexts.pop_back();
+
   Graph.recordNode(MySym);
   Graph.serialize(JOS);
   return EXIT_SUCCESS;

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_parents.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_parents.swift
@@ -1,0 +1,180 @@
+/// Something about variable global
+let global = 1
+
+/// Something about type Parent
+struct Parent {
+    /// Something about type Inner
+    struct Inner {
+        /// Something about variable innerMember
+        let innerMember = 1
+    }
+
+    /// Something about variable member
+    let member = 1
+    /// Something aboout method
+    func method() {}
+
+    func localContext() {
+        /// Something about type Local
+        struct Local {
+            // Something about variable localMember
+            let localMember = 1
+        }
+    }
+}
+
+/// Something about extension of Parent
+extension Parent {
+    /// Something about method extensionMethod
+    func extensionMethod()
+
+    /// Something about type ExtInner
+    struct ExtInner {
+        /// Something about variable extInnerMember
+        let extInnerMember = 10
+    }	
+}
+
+/// Something about extension of Inner
+extension Parent.Inner {
+    /// Something about method extensionOfInnerMethod
+    func extensionOfInnerMethod() {}
+
+    class DeepNested<T> {
+        /// Something about constructor deepNestedInit
+    	init(deepNestedInit: T) {}
+    }
+}
+
+/// Something about extension of DeepInner
+extension Parent.Inner.DeepNested<T> where T: Equatable {
+    ///	Something about method extensionOfDeepNestedMethod
+    func extensionOfDeepNestedMethod() {
+        /// Something about local deepNestedLocal
+        var deepNestedLocal = {
+            /// Something about InClosure
+            struct InClosure {}
+        }
+        var deepNestedComputed: Int {
+        	/// Something about InAccessor
+        	struct InAccessor {}
+        }
+    }
+}
+
+// 1) Global symbols have no parents, but do have a symbol graph.
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=2:5 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=GLOBAL %s
+// RUN:  %sourcekitd-test -req=cursor -pos=5:8 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=GLOBAL %s
+// RUN:  %sourcekitd-test -req=cursor -pos=27:11 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=GLOBAL %s
+// RUN:  %sourcekitd-test -req=cursor -pos=39:11 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=GLOBAL %s
+// RUN:  %sourcekitd-test -req=cursor -pos=50:11 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=GLOBAL %s
+//
+//
+// GLOBAL-NOT: PARENT CONTEXTS BEGIN
+// GLOBAL: SYMBOL GRAPH BEGIN
+// GLOBAL-NOT: PARENT CONTEXTS BEGIN
+
+
+// 2) Members within Parent and its extensions should list Parent as a parent
+//    context, and have a symbol graph.
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=7:12 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=PARENTMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=13:9 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=PARENTMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=15:10 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=PARENTMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=29:10 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=PARENTMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=32:12 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=PARENTMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=39:18 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=PARENTMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=50:18 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=PARENTMEMBER %s
+//
+//
+// PARENTMEMBER: SYMBOL GRAPH BEGIN
+// PARENTMEMBER: SYMBOL GRAPH END
+// PARENTMEMBER: PARENT CONTEXTS BEGIN
+// PARENTMEMBER-NEXT: Parent swift.struct s:27cursor_symbol_graph_parents6ParentV
+// PARENTMEMBER-NEXT: PARENT CONTEXTS END
+
+
+// 3) Members within Parent.Inner and its extensions should list both Inner and
+//    Parent as parent contexts, and have a symbol graph.
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=9:13 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=INNERMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=41:10 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=INNERMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=43:12 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=INNERMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=50:24 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=INNERMEMBER %s
+//
+// INNERMEMBER: SYMBOL GRAPH BEGIN
+// INNERMEMBER: SYMBOL GRAPH END
+// INNERMEMBER: PARENT CONTEXTS BEGIN
+// INNERMEMBER-NEXT: Parent swift.struct s:27cursor_symbol_graph_parents6ParentV
+// INNERMEMBER-NEXT: Inner swift.struct s:27cursor_symbol_graph_parents6ParentV5InnerV
+// INNERMEMBER-NEXT: PARENT CONTEXTS END
+
+
+// 4) Members within Parent.Inner.DeepNested and its extensions should list
+//    DeepNested, Inner, and Parent as parent contexts and have a symbol graph.
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=45:9 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=DEEPNESTEDMEMBER %s
+// RUN:  %sourcekitd-test -req=cursor -pos=52:10 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=DEEPNESTEDMEMBER %s
+//
+// DEEPNESTEDMEMBER: SYMBOL GRAPH BEGIN
+// DEEPNESTEDMEMBER: SYMBOL GRAPH END
+// DEEPNESTEDMEMBER: PARENT CONTEXTS BEGIN
+// DEEPNESTEDMEMBER-NEXT: Parent swift.struct s:27cursor_symbol_graph_parents6ParentV
+// DEEPNESTEDMEMBER-NEXT: Inner swift.struct s:27cursor_symbol_graph_parents6ParentV5InnerV
+// DEEPNESTEDMEMBER-NEXT: DeepNested swift.class s:27cursor_symbol_graph_parents6ParentV5InnerV10DeepNestedC
+// DEEPNESTEDMEMBER-NEXT: PARENT
+
+
+// 5) Members directly or indirectly within local contexts should show the
+//    local contexts as parents if they're representable in the symbol graph.
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=19:16 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=LOCAL %s
+//
+// LOCAL: PARENT CONTEXTS BEGIN
+// LOCAL-NEXT: Parent swift.struct s:27cursor_symbol_graph_parents6ParentV
+// LOCAL-NEXT: localContext() swift.method s:27cursor_symbol_graph_parents6ParentV12localContextyyF
+// LOCAL-NEXT: PARENT CONTEXTS END
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=21:17 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=TRANSITIVELOCAL %s
+//
+// TRANSITIVELOCAL: PARENT CONTEXTS BEGIN
+// TRANSITIVELOCAL-NEXT: Parent swift.struct s:27cursor_symbol_graph_parents6ParentV
+// TRANSITIVELOCAL-NEXT: localContext() swift.method s:27cursor_symbol_graph_parents6ParentV12localContextyyF
+// TRANSITIVELOCAL-NEXT: Local swift.struct s:27cursor_symbol_graph_parents6ParentV12localContextyyF5LocalL_V
+// TRANSITIVELOCAL-NEXT: PARENT CONTEXTS END
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=56:20 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=CLOSUREINLOCAL %s
+//
+// CLOSUREINLOCAL: SYMBOL GRAPH BEGIN
+// CLOSUREINLOCAL: "pathComponents": [
+// CLOSUREINLOCAL-NEXT:    "Parent"
+// CLOSUREINLOCAL-NEXT:    "Inner"
+// CLOSUREINLOCAL-NEXT:    "DeepNested"
+// CLOSUREINLOCAL-NEXT:    "extensionOfDeepNestedMethod()"
+// CLOSUREINLOCAL-NEXT:    "InClosure"
+// CLOSUREINLOCAL-NEXT: ],
+// CLOSUREINLOCAL: SYMBOL GRAPH END
+// CLOSUREINLOCAL: PARENT CONTEXTS BEGIN
+// CLOSUREINLOCAL-NEXT: Parent swift.struct s:27cursor_symbol_graph_parents6ParentV
+// CLOSUREINLOCAL-NEXT: Inner swift.struct s:27cursor_symbol_graph_parents6ParentV5InnerV
+// CLOSUREINLOCAL-NEXT: DeepNested swift.class s:27cursor_symbol_graph_parents6ParentV5InnerV10DeepNestedC
+// CLOSUREINLOCAL-NEXT: extensionOfDeepNestedMethod() swift.method s:27cursor_symbol_graph_parents6ParentV5InnerV10DeepNestedCAASQRzlE011extensionOfgH6MethodyyF
+// CLOSUREINLOCAL-NEXT: PARENT CONTEXTS END
+//
+// RUN:  %sourcekitd-test -req=cursor -pos=60:20 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple | %FileCheck -check-prefix=ACCESSORINLOCAL %s
+
+// ACCESSORINLOCAL: SYMBOL GRAPH BEGIN
+// ACCESSORINLOCAL: "pathComponents": [
+// ACCESSORINLOCAL-NEXT:    "Parent",
+// ACCESSORINLOCAL-NEXT:    "Inner",
+// ACCESSORINLOCAL-NEXT:    "DeepNested",
+// ACCESSORINLOCAL-NEXT:    "extensionOfDeepNestedMethod()",
+// ACCESSORINLOCAL-NEXT:    "InAccessor"
+// ACCESSORINLOCAL-NEXT: ],
+// ACCESSORINLOCAL: PARENT CONTEXTS BEGIN
+// ACCESSORINLOCAL-NEXT: Parent swift.struct s:27cursor_symbol_graph_parents6ParentV
+// ACCESSORINLOCAL-NEXT: Inner swift.struct s:27cursor_symbol_graph_parents6ParentV5InnerV
+// ACCESSORINLOCAL-NEXT: DeepNested swift.class s:27cursor_symbol_graph_parents6ParentV5InnerV10DeepNestedC
+// ACCESSORINLOCAL-NEXT: extensionOfDeepNestedMethod() swift.method s:27cursor_symbol_graph_parents6ParentV5InnerV10DeepNestedCAASQRzlE011extensionOfgH6MethodyyF
+// ACCESSORINLOCAL-NEXT: PARENT CONTEXTS END

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -376,6 +376,12 @@ struct RefactoringInfo {
   StringRef UnavailableReason;
 };
 
+struct ParentInfo {
+  StringRef Title;
+  StringRef KindName;
+  StringRef USR;
+};
+
 struct CursorInfoData {
   // If nonempty, a proper Info could not be resolved (and the rest of the Info
   // will be empty). Clients can potentially use this to show a diagnostic
@@ -419,6 +425,10 @@ struct CursorInfoData {
   ArrayRef<StringRef> ModuleGroupArray;
   /// All available actions on the code under cursor.
   ArrayRef<RefactoringInfo> AvailableActions;
+  /// Stores the Symbol Graph title, kind, and USR of the parent contexts of the
+  /// symbol under the cursor.
+  ArrayRef<ParentInfo> ParentContexts;
+
   bool IsSystem = false;
   llvm::Optional<unsigned> ParentNameOffset;
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -485,7 +485,7 @@ void SwiftLangSupport::printFullyAnnotatedSynthesizedDeclaration(
 }
 
 template <typename FnTy>
-void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
+static void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
   if (isa<ParamDecl>(VD))
     return; // Parameters don't have interesting related declarations.
 
@@ -834,7 +834,11 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   }
   unsigned DeclEnd = SS.size();
 
+
+  SmallVector<symbolgraphgen::PathComponent, 4> PathComponents;
+  SmallVector<ParentInfo, 4> Parents;
   unsigned SymbolGraphBegin = SS.size();
+  unsigned SymbolGraphEnd = SymbolGraphBegin;
   if (SymbolGraph) {
     symbolgraphgen::SymbolGraphOptions Options {
       "",
@@ -845,10 +849,18 @@ static bool passCursorInfoForDecl(SourceFile* SF,
     };
     llvm::raw_svector_ostream OS(SS);
     symbolgraphgen::printSymbolGraphForDecl(VD, BaseType,
-                                            InSynthesizedExtension,
-                                            Options, OS);
+                                            InSynthesizedExtension, Options, OS,
+                                            PathComponents);
+    SymbolGraphEnd = SS.size();
+
+    for (auto &Component: PathComponents) {
+      unsigned USRStart = SS.size();
+      if (SwiftLangSupport::printUSR(Component.VD, OS))
+        continue;
+      StringRef USR{SS.begin()+USRStart, SS.size() - USRStart};
+      Parents.push_back({Component.Title, Component.Kind, USR});
+    }
   }
-  unsigned SymbolGraphEnd = SS.size();
 
   unsigned FullDeclBegin = SS.size();
   {
@@ -1043,6 +1055,7 @@ static bool passCursorInfoForDecl(SourceFile* SF,
   Info.AvailableActions = llvm::makeArrayRef(RefactoringInfoBuffer);
   Info.ParentNameOffset = getParamParentNameOffset(VD, CursorLoc);
   Info.SymbolGraph = SymbolGraphJSON;
+  Info.ParentContexts = llvm::makeArrayRef(Parents);
   Receiver(RequestResult<CursorInfoData>::fromResult(Info));
   return true;
 }

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1608,6 +1608,25 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
     OverrideUSRs.push_back(sourcekitd_variant_dictionary_get_string(Entry, KeyUSR));
   }
 
+  struct ParentInfo {
+    const char *Title;
+    const char *Kind;
+    const char *USR;
+  };
+  std::vector<ParentInfo> Parents;
+  sourcekitd_variant_t ParentsObj =
+      sourcekitd_variant_dictionary_get_value(Info, KeyParentContexts);
+  for (unsigned i = 0, e = sourcekitd_variant_array_get_count(ParentsObj);
+       i != e; ++i) {
+    sourcekitd_variant_t Entry =
+        sourcekitd_variant_array_get_value(ParentsObj, i);
+    Parents.push_back({
+      sourcekitd_variant_dictionary_get_string(Entry, KeyName),
+      sourcekitd_variant_dictionary_get_string(Entry, KeyKind),
+      sourcekitd_variant_dictionary_get_string(Entry, KeyUSR)
+    });
+  }
+
   std::vector<const char *> GroupNames;
   sourcekitd_variant_t GroupObj =
     sourcekitd_variant_dictionary_get_value(Info, KeyModuleGroups);
@@ -1698,6 +1717,12 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
       OS << SymbolGraph;
     }
     OS << "\nSYMBOL GRAPH END\n";
+  }
+  if (!Parents.empty()) {
+    OS << "PARENT CONTEXTS BEGIN\n";
+    for (auto parent: Parents)
+      OS << parent.Title << " " << parent.Kind << " " << parent.USR << '\n';
+    OS << "PARENT CONTEXTS END\n";
   }
   OS << "OVERRIDES BEGIN\n";
   for (auto OverUSR : OverrideUSRs)

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1822,6 +1822,15 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
     Elem.set(KeyContainerTypeUsr, Info.ContainerTypeUSR);
   if (!Info.SymbolGraph.empty())
     Elem.set(KeySymbolGraph, Info.SymbolGraph);
+  if (!Info.ParentContexts.empty()) {
+    auto Parents = Elem.setArray(KeyParentContexts);
+    for (const auto &ParentTy: Info.ParentContexts) {
+      auto Parent = Parents.appendDictionary();
+      Parent.set(KeyName, ParentTy.Title);
+      Parent.set(KeyKind, ParentTy.KindName);
+      Parent.set(KeyUSR, ParentTy.USR);
+    }
+  }
 
   return Rec(RespBuilder.createResponse());
 }

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -160,6 +160,7 @@ UID_KEYS = [
     KEY('RetrieveRefactorActions', 'key.retrieve_refactor_actions'),
     KEY('SymbolGraph', 'key.symbol_graph'),
     KEY('RetrieveSymbolGraph', 'key.retrieve_symbol_graph'),
+    KEY('ParentContexts', 'key.parent_contexts'),
     KEY('ActionUID', 'key.actionuid'),
     KEY('ActionUnavailableReason', 'key.actionunavailablereason'),
     KEY('CompileID', 'key.compileid'),


### PR DESCRIPTION
When the SymbolGraph json is requested via `key.retrieve_symbol_graph: 1` this adds a new field in the response that lists all the parent contexts of the symbol under the cursor with their symbol graph kind and name, and their USR:
```
key.parent_contexts: [
  {
    key.kind: "swift.struct",
    key.name: "Parent",
    key.usr: "s:27cursor_symbol_graph_parents6ParentV"
  },
  ...
]
```
Resolves rdar://problem/73904365