### PR TITLE
[libSyntax] Create an unowned *Ref version of the syntax hierarchy

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -471,8 +471,20 @@ public:
     return getLayout()[Index];
   }
 
+  /// Get a child based on a particular node's "Cursor", indicating
+  /// the position of the terms in the production of the Swift grammar.
+  ///
+  /// The caller is responsible for making sure the \c RawSyntax that the
+  /// returned pointer points to, stays alive for the duration of the use by
+  /// e.g. keeping the \c SyntaxArena alive in which the child lives or keeping
+  /// \c this node alive, which maintains a strong reference to the child.
+  RawSyntax *getChildRef(CursorIndex Index) const {
+    return getLayout()[Index].get();
+  }
+
   /// Return the number of bytes this node takes when spelled out in the source
-  size_t getTextLength() { return Bits.Common.TextLength; }
+  /// including trivia.
+  size_t getTextLength() const { return Bits.Common.TextLength; }
 
   /// @}
 

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -40,7 +40,7 @@ struct SyntaxVisitor;
 class SourceFileSyntax;
 
 template <typename SyntaxNode> SyntaxNode makeRoot(RC<RawSyntax> Raw) {
-  auto Data = SyntaxData::make(AbsoluteRawSyntax::forRoot(Raw));
+  auto Data = SyntaxData(AbsoluteRawSyntax::forRoot(Raw), /*Parent=*/nullptr);
   return SyntaxNode(Data);
 }
 

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -38,6 +38,7 @@ namespace syntax {
 
 struct SyntaxVisitor;
 class SourceFileSyntax;
+class TokenSyntax;
 
 template <typename SyntaxNode> SyntaxNode makeRoot(RC<RawSyntax> Raw) {
   auto Data = SyntaxData(AbsoluteRawSyntax::forRoot(Raw), /*Parent=*/nullptr);
@@ -46,47 +47,133 @@ template <typename SyntaxNode> SyntaxNode makeRoot(RC<RawSyntax> Raw) {
 
 const auto NoParent = llvm::None;
 
+// MARK: - SyntaxRef
+
 /// The main handle for syntax nodes - subclasses contain all public
 /// structured editing APIs.
 ///
-/// Essentially, this is a wrapper around \c SyntaxData that provides
-/// convenience methods based on the node's kind.
-class Syntax {
-  friend struct SyntaxFactory;
-
+/// Essentially, this is a wrapper around \c SyntaxDataRef that provides
+/// convenience methods based on the node's kind. As such \c SyntaxRef can
+/// either be reference-counted or unowned. See the comment on \c SyntaxDataRef
+/// for more details.
+class SyntaxRef {
 protected:
-  SyntaxData Data;
+  SyntaxDataRef Data;
 
 public:
-  explicit Syntax(const SyntaxData Data) : Data(Data) {}
+  explicit SyntaxRef(const SyntaxDataRef &Data) : Data(Data) {}
 
-  virtual ~Syntax() {}
+  virtual ~SyntaxRef() {}
 
-  /// Get the kind of syntax.
-  SyntaxKind getKind() const;
+  // MARK: - Get underlying data
+
+  /// Get the Data for this Syntax node.
+  const SyntaxDataRef &getDataRef() const { return Data; }
 
   /// Get the shared raw syntax.
-  const RC<RawSyntax> &getRaw() const;
+  const RawSyntax *getRawRef() const { return getDataRef().getRawRef(); }
 
-  /// Get an ID for this node that is stable across incremental parses
-  SyntaxNodeId getId() const { return getRaw()->getId(); }
+  /// Get the kind of syntax.
+  SyntaxKind getKind() const { return getRawRef()->getKind(); }
 
-  /// Get the number of child nodes in this piece of syntax, not including
-  /// tokens.
-  size_t getNumChildren() const;
+  /// Get an ID for the \c RawSyntax node backing this \c Syntax which is
+  /// stable across incremental parses.
+  /// Note that this is different from the \c AbsoluteRawSyntax's \c NodeId,
+  /// which uniquely identifies this node in the tree, but is not stable across
+  /// incremental parses.
+  SyntaxNodeId getId() const { return getRawRef()->getId(); }
 
-  /// Get the Nth child of this piece of syntax.
-  llvm::Optional<Syntax> getChild(const size_t N) const;
+  /// Return the number of bytes this node takes when spelled out in the source
+  size_t getTextLength() const { return getRawRef()->getTextLength(); }
+
+  // MARK: Parents/children
+
+  /// Return the parent of this node, if it has one.
+  llvm::Optional<SyntaxRef> getParentRef() const {
+    if (auto ParentDataRef = getDataRef().getParentRef()) {
+      return SyntaxRef(*ParentDataRef);
+    } else {
+      return None;
+    }
+  }
+
+  /// Get the number of child nodes in this piece of syntax.
+  size_t getNumChildren() const { return getDataRef().getNumChildren(); }
+
+  /// Returns the child index of this node in its parent, if it has one,
+  /// otherwise 0.
+  CursorIndex getIndexInParent() const {
+    return getDataRef().getIndexInParent();
+  }
+
+  /// Get the \p N -th child of this piece of syntax.
+  llvm::Optional<SyntaxRef> getChildRef(const size_t N) const {
+    if (auto ChildData = getDataRef().getChildRef(N)) {
+      return SyntaxRef(*ChildData);
+    } else {
+      return None;
+    }
+  }
+
+  // MARK: Position
+
+  /// Get the offset at which the leading trivia of this node starts.
+  AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const {
+    return getDataRef().getAbsolutePositionBeforeLeadingTrivia();
+  }
+
+  /// Get the offset at which the actual content (i.e. non-triva) of this node
+  /// starts.
+  AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
+    return getDataRef().getAbsolutePositionAfterLeadingTrivia();
+  }
+
+  /// Get the offset at which the trailing trivia of this node starts.
+  AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const {
+    return getDataRef().getAbsoluteEndPositionBeforeTrailingTrivia();
+  }
+
+  /// Get the offset at which the trailing trivia of this node ends.
+  AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const {
+    return getDataRef().getAbsoluteEndPositionAfterTrailingTrivia();
+  }
+
+  // MARK: - Get node kind
+
+  /// Returns true if this syntax node represents a token.
+  bool isToken() const { return getRawRef()->isToken(); }
+
+  /// Returns true if this syntax node represents a statement.
+  bool isStmt() const { return getRawRef()->isStmt(); }
+
+  /// Returns true if this syntax node represents a declaration.
+  bool isDecl() const { return getRawRef()->isDecl(); }
+
+  /// Returns true if this syntax node represents an expression.
+  bool isExpr() const { return getRawRef()->isExpr(); }
+
+  /// Returns true if this syntax node represents a pattern.
+  bool isPattern() const { return getRawRef()->isPattern(); }
+
+  /// Returns true if this syntax node represents a type.
+  bool isType() const { return getRawRef()->isType(); }
+
+  /// Returns true if this syntax is of some "unknown" kind.
+  bool isUnknown() const { return getRawRef()->isUnknown(); }
+
+  /// Returns true if the node is "missing" in the source (i.e. it was
+  /// expected (or optional) but not written.
+  bool isMissing() const { return getRawRef()->isMissing(); }
+
+  /// Returns true if the node is "present" in the source.
+  bool isPresent() const { return getRawRef()->isPresent(); }
+
+  // MARK: Casting
 
   /// Returns true if the syntax node is of the given type.
   template <typename T>
   bool is() const {
     return T::classof(this);
-  }
-
-  /// Get the Data for this Syntax node.
-  const SyntaxData &getData() const {
-    return Data;
   }
 
   /// Cast this Syntax node to a more specific type, asserting it's of the
@@ -103,102 +190,116 @@ public:
   llvm::Optional<T> getAs() const {
     if (is<T>()) {
       return castTo<T>();
+    } else {
+      return None;
     }
-    return llvm::None;
-  }
-
-  /// Return the parent of this node, if it has one.
-  llvm::Optional<Syntax> getParent() const;
-
-  /// Returns the child index of this node in its parent,
-  /// if it has one, otherwise 0.
-  CursorIndex getIndexInParent() const { return getData().getIndexInParent(); }
-
-  /// Return the number of bytes this node takes when spelled out in the source
-  size_t getTextLength() const { return getRaw()->getTextLength(); }
-
-  /// Returns true if this syntax node represents a token.
-  bool isToken() const;
-
-  /// Returns true if this syntax node represents a statement.
-  bool isStmt() const;
-
-  /// Returns true if this syntax node represents a declaration.
-  bool isDecl() const;
-
-  /// Returns true if this syntax node represents an expression.
-  bool isExpr() const;
-
-  /// Returns true if this syntax node represents a pattern.
-  bool isPattern() const;
-
-  /// Returns true if this syntax node represents a type.
-  bool isType() const;
-
-  /// Returns true if this syntax is of some "unknown" kind.
-  bool isUnknown() const;
-
-  /// Returns true if the node is "missing" in the source (i.e. it was
-  /// expected (or optional) but not written.
-  bool isMissing() const;
-
-  /// Returns true if the node is "present" in the source.
-  bool isPresent() const;
-
-  /// Print the syntax node with full fidelity to the given output stream.
-  void print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts = SyntaxPrintOptions()) const;
-
-  /// Print a debug representation of the syntax node to the given output stream
-  /// and indentation level.
-  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
-
-  /// Print a debug representation of the syntax node to standard error.
-  SWIFT_DEBUG_DUMP;
-
-  bool hasSameIdentityAs(const Syntax &Other) const {
-    return Data.getAbsoluteRaw().getNodeId() ==
-           Other.Data.getAbsoluteRaw().getNodeId();
   }
 
   static bool kindof(SyntaxKind Kind) {
     return true;
   }
 
-  static bool classof(const Syntax *S) {
+  static bool classof(const SyntaxRef *S) {
     // Trivially true.
     return true;
   }
 
+  // MARK: - Miscellaneous
+
+  /// Print the syntax node with full fidelity to the given output stream.
+  void print(llvm::raw_ostream &OS,
+             SyntaxPrintOptions Opts = SyntaxPrintOptions()) const {
+    if (auto Raw = getRawRef()) {
+      Raw->print(OS, Opts);
+    }
+  }
+
+  /// Print a debug representation of the syntax node to the given output stream
+  /// and indentation level.
+  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const {
+    getRawRef()->dump(OS, Indent);
+  }
+
+  /// Print a debug representation of the syntax node to standard error.
+  SWIFT_DEBUG_DUMP { getRawRef()->dump(); }
+
+  bool hasSameIdentityAs(const SyntaxRef &Other) const {
+    return getDataRef().getAbsoluteRawRef().getNodeId() ==
+           Other.getDataRef().getAbsoluteRawRef().getNodeId();
+  }
+};
+
+// MARK: - Syntax
+
+/// A \c SyntaxRef that is guaranteed to always be reference-counted. See
+/// comment on \c SyntaxRef.
+class Syntax : public SyntaxRef {
+  friend struct SyntaxFactory;
+
+public:
+  explicit Syntax(const SyntaxData &Data) : SyntaxRef(Data) {}
+
+  virtual ~Syntax() {}
+
+  // MARK: - Get underlying data
+
+  /// Get the data for this Syntax node.
+  SyntaxData getData() const { return SyntaxData(getDataRef()); }
+
+  /// Get the shared raw syntax.
+  RC<RawSyntax> getRaw() const { return getData().getRaw(); }
+
+  /// Get the \p N -th child of this piece of syntax.
+  llvm::Optional<Syntax> getChild(const size_t N) const;
+
+  /// Get the first non-missing token in this node.
+  Optional<TokenSyntax> getFirstToken() const;
+
+  /// Get the last non-missing token in this node.
+  Optional<TokenSyntax> getLastToken() const;
+
+  /// Return the parent of this node, if it has one.
+  llvm::Optional<Syntax> getParent() const;
+
+  /// Get the node immediately before this current node that does contain a
+  /// non-missing token. Return \c None if we cannot find such node.
+  Optional<Syntax> getPreviousNode() const;
+
+  /// Get the node immediately after this node that does contain a
+  /// non-missing token. Return \c None if we cannot find such node.
+  Optional<Syntax> getNextNode() const;
+
+  // MARK: - Casting
+
+  /// Returns true if the syntax node is of the given type.
+  template <typename T>
+  bool is() const {
+    return T::classof(this);
+  }
+
+  /// Cast this Syntax node to a more specific type, asserting it's of the
+  /// right kind.
+  template <typename T>
+  T castTo() const {
+    assert(is<T>() && "castTo<T>() node of incompatible type!");
+    return T(getData());
+  }
+
+  /// If this Syntax node is of the right kind, cast and return it,
+  /// otherwise return None.
+  template <typename T>
+  llvm::Optional<T> getAs() const {
+    if (is<T>()) {
+      return castTo<T>();
+    } else {
+      return None;
+    }
+  }
+
+  // MARK: - Miscellaneous
+
   /// Recursively visit this node.
   void accept(SyntaxVisitor &Visitor);
-
-  /// Same as \c getAbsolutePositionAfterLeadingTrivia.
-  AbsoluteOffsetPosition getAbsolutePosition() const {
-    return getAbsolutePositionAfterLeadingTrivia();
-  }
-
-  /// Get the offset at which the leading trivia of this node starts.
-  AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const {
-    return Data.getAbsolutePositionBeforeLeadingTrivia();
-  }
-
-  /// Get the offset at which the actual content (i.e. non-triva) of this node
-  /// starts.
-  AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
-    return Data.getAbsolutePositionAfterLeadingTrivia();
-  }
-
-  /// Get the offset at which the trailing trivia of this node starts.
-  AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const {
-    return Data.getAbsoluteEndPositionBeforeTrailingTrivia();
-  }
-
-  /// Get the offset at which the trailing trivia of this node starts.
-  AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const {
-    return Data.getAbsoluteEndPositionAfterTrailingTrivia();
-  }
-
-  // TODO: hasSameStructureAs ?
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -64,7 +64,7 @@ private:
       List.push_back(Elt.getRaw());
     auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, List,
                                             SourcePresence::Present);
-    return SyntaxData::make(AbsoluteRawSyntax::forRoot(Raw));
+    return SyntaxData(AbsoluteRawSyntax::forRoot(Raw), /*Parent=*/nullptr);
   }
 
 public:

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -249,7 +249,7 @@ public:
   }
 
   /// Returns the raw syntax node for this syntax node.
-  const RC<RawSyntax> &getRaw() const { return getAbsoluteRaw().getRaw(); }
+  RC<RawSyntax> getRaw() const { return getAbsoluteRaw().getRaw(); }
 
   // MARK: - Retrieving related nodes
 

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -58,8 +58,8 @@ class ${node.name} ${qualifier} : public ${node.base_type} {
 %     end
 %     if node.requires_validation():
   void validate() const;
-%     end
 
+%     end
 public:
 %     if node.children:
   enum Cursor : uint32_t {
@@ -71,9 +71,9 @@ public:
 
   ${node.name}(const SyntaxData Data) : ${node.base_type}(Data) {
 %     if node.requires_validation():
-      this->validate();
+    this->validate();
 %     end
-    }
+  }
 
 %     for child in node.children:
 %       for line in dedented_lines(child.description):
@@ -110,11 +110,11 @@ public:
 %     end
 
   static bool kindof(SyntaxKind Kind) {
-%   if node.is_base():
+%     if node.is_base():
     return is${node.syntax_kind}Kind(Kind);
-%   else:
+%     else:
     return Kind == SyntaxKind::${node.syntax_kind};
-%   end
+%     end
   }
 
   static bool classof(const Syntax *S) {

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -35,6 +35,7 @@ namespace syntax {
 % for node in SYNTAX_NODES:
 %   if not node.is_syntax_collection():
 class ${node.name};
+class ${node.name}Ref;
 %   end
 % end
 
@@ -43,6 +44,9 @@ class ${node.name};
 using ${node.name} =
   SyntaxCollection<SyntaxKind::${node.syntax_kind},
                    ${node.collection_element_type}>;
+using ${node.name}Ref =
+  SyntaxCollectionRef<SyntaxKind::${node.syntax_kind},
+                      ${node.collection_element_type}Ref>;
 %   end
 % end
 
@@ -69,7 +73,7 @@ public:
   };
 %     end
 
-  ${node.name}(const SyntaxData Data) : ${node.base_type}(Data) {
+  ${node.name}(const SyntaxData &Data) : ${node.base_type}(Data) {
 %     if node.requires_validation():
     this->validate();
 %     end
@@ -109,6 +113,57 @@ public:
 
 %     end
 
+  static bool kindof(SyntaxKind Kind) {
+%     if node.is_base():
+    return is${node.syntax_kind}Kind(Kind);
+%     else:
+    return Kind == SyntaxKind::${node.syntax_kind};
+%     end
+  }
+
+  static bool classof(const Syntax *S) {
+    return kindof(S->getKind());
+  }
+};
+
+%     for line in dedented_lines(node.description):
+/// ${line}
+%     end
+///
+/// This node is an unsafe reference that requires parents to always outlive
+/// their child nodes. See doc comment on \c SyntaxDataRef for more details.
+class ${node.name}Ref ${qualifier} : public ${node.base_type}Ref {
+  friend class ${node.name}; // Non-Ref node is a friend to call validate.
+  
+%     if node.requires_validation():
+  void validate() const;
+
+%     end
+public:
+%     if node.children:
+  using Cursor = ${node.name}::Cursor; // Use same cursor as non-Ref node.
+%     end
+
+  ${node.name}Ref(const SyntaxDataRef &Data) : ${node.base_type}Ref(Data) {
+%     if node.requires_validation():
+    this->validate();
+%     end
+  }
+
+  /// Demote a ${node.name} node to a ${node.name}Ref node.
+  ${node.name}Ref(const ${node.name} &Node) : ${node.base_type}Ref(Node.getDataRef()) {}
+
+%     for child in node.children:
+%       for line in dedented_lines(child.description):
+  /// ${line}
+%       end
+%       if child.is_optional:
+  llvm::Optional<${child.type_name}Ref> get${child.name}() const;
+%       else:
+  ${child.type_name}Ref get${child.name}() const;
+%       end
+
+%     end
   static bool kindof(SyntaxKind Kind) {
 %     if node.is_base():
     return is${node.syntax_kind}Kind(Kind);

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -28,19 +28,20 @@ namespace swift {
 namespace syntax {
 
 class TokenSyntax final : public Syntax {
-protected:
   void validate() const {
     assert(getRaw()->isToken());
   }
 public:
-  TokenSyntax(const SyntaxData Data) : Syntax(Data) {}
+  TokenSyntax(const SyntaxData &Data) : Syntax(Data) {}
 
   static TokenSyntax missingToken(const tok Kind, OwnedString Text) {
     return makeRoot<TokenSyntax>(RawSyntax::missing(Kind, Text));
   }
 
   StringRef getLeadingTrivia() const { return getRaw()->getLeadingTrivia(); }
-  Trivia getLeadingTriviaPieces() const { return getRaw()->getLeadingTriviaPieces(); }
+  Trivia getLeadingTriviaPieces() const {
+    return getRaw()->getLeadingTriviaPieces();
+  }
 
   StringRef getTrailingTrivia() const { return getRaw()->getTrailingTrivia(); }
   Trivia getTrailingTriviaPieces() const {
@@ -57,27 +58,11 @@ public:
     return TokenSyntax(getData().replacingSelf(NewRaw));
   }
 
-  /* TODO: If we really need them.
-  bool isKeyword() const;
+  bool isMissing() const { return getRaw()->isMissing(); }
 
-  bool isPunctuation() const;
+  tok getTokenKind() const { return getRaw()->getTokenKind(); }
 
-  bool isOperator() const;
-
-  bool isLiteral() const;
-  */
-
-  bool isMissing() const {
-    return getRaw()->isMissing();
-  }
-
-  tok getTokenKind() const {
-    return getRaw()->getTokenKind();
-  }
-
-  StringRef getText() const {
-    return getRaw()->getTokenText();
-  }
+  StringRef getText() const { return getRaw()->getTokenText(); }
 
   StringRef getIdentifierText() const {
     StringRef text = getText();
@@ -88,13 +73,52 @@ public:
     return text;
   }
 
-  static bool kindof(SyntaxKind Kind) {
-    return isTokenKind(Kind);
+  static bool kindof(SyntaxKind Kind) { return isTokenKind(Kind); }
+
+  static bool classof(const Syntax *S) { return kindof(S->getKind()); }
+};
+
+/// \c TokenSyntaxRef duplicates some code from \c TokenSyntax. For all other
+/// nodes, this code is gyb-generated but since we don't generate \c TokenSyntax
+/// the easiest way is to just duplicate it.
+class TokenSyntaxRef final : public SyntaxRef {
+  void validate() const { assert(getRawRef()->isToken()); }
+
+public:
+  TokenSyntaxRef(const SyntaxDataRef &Data) : SyntaxRef(Data) {}
+
+  TokenSyntaxRef(const TokenSyntax &Token) : SyntaxRef(Token.getData()) {}
+
+  StringRef getLeadingTrivia() const { return getRawRef()->getLeadingTrivia(); }
+  Trivia getLeadingTriviaPieces() const {
+    return getRawRef()->getLeadingTriviaPieces();
   }
 
-  static bool classof(const Syntax *S) {
-    return kindof(S->getKind());
+  StringRef getTrailingTrivia() const {
+    return getRawRef()->getTrailingTrivia();
   }
+  Trivia getTrailingTriviaPieces() const {
+    return getRawRef()->getTrailingTriviaPieces();
+  }
+
+  bool isMissing() const { return getRawRef()->isMissing(); }
+
+  tok getTokenKind() const { return getRawRef()->getTokenKind(); }
+
+  StringRef getText() const { return getRawRef()->getTokenText(); }
+
+  StringRef getIdentifierText() const {
+    StringRef text = getText();
+    if (text.front() == '`') {
+      assert(text.back() == '`');
+      return text.slice(1, text.size() - 1);
+    }
+    return text;
+  }
+
+  static bool kindof(SyntaxKind Kind) { return isTokenKind(Kind); }
+
+  static bool classof(const SyntaxRef *S) { return kindof(S->getKind()); }
 };
 
 } // end namespace syntax

--- a/lib/Syntax/Syntax.cpp
+++ b/lib/Syntax/Syntax.cpp
@@ -17,63 +17,50 @@
 using namespace swift;
 using namespace swift::syntax;
 
-const RC<RawSyntax> &Syntax::getRaw() const { return Data.getRaw(); }
-
-SyntaxKind Syntax::getKind() const {
-  return getRaw()->getKind();
+llvm::Optional<Syntax> Syntax::getChild(const size_t N) const {
+  if (auto ChildData = getData().getChild(N)) {
+    return Syntax(*ChildData);
+  } else {
+    return None;
+  }
 }
 
-void Syntax::print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const {
-  if (auto Raw = getRaw())
-    Raw->print(OS, Opts);
+Optional<TokenSyntax> Syntax::getFirstToken() const {
+  if (auto Token = getData().getFirstToken()) {
+    return TokenSyntax(*Token);
+  } else {
+    return None;
+  }
 }
 
-void Syntax::dump() const {
-  getRaw()->dump();
-}
-
-void Syntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
-  getRaw()->dump(OS, 0);
-}
-
-bool Syntax::isType() const { return Data.isType(); }
-
-bool Syntax::isDecl() const { return Data.isDecl(); }
-
-bool Syntax::isStmt() const { return Data.isStmt(); }
-
-bool Syntax::isExpr() const { return Data.isExpr(); }
-
-bool Syntax::isToken() const {
-  return getRaw()->isToken();
-}
-
-bool Syntax::isPattern() const { return Data.isPattern(); }
-
-bool Syntax::isUnknown() const { return Data.isUnknown(); }
-
-bool Syntax::isPresent() const {
-  return getRaw()->isPresent();
-}
-
-bool Syntax::isMissing() const {
-  return getRaw()->isMissing();
+Optional<TokenSyntax> Syntax::getLastToken() const {
+  if (auto Token = getData().getLastToken()) {
+    return TokenSyntax(*Token);
+  } else {
+    return None;
+  }
 }
 
 llvm::Optional<Syntax> Syntax::getParent() const {
-  auto ParentData = getData().getParent();
-  if (!ParentData) {
+  if (auto ParentData = getData().getParent()) {
+    return Syntax(*ParentData);
+  } else {
     return None;
   }
-  return Syntax(*ParentData);
 }
 
-size_t Syntax::getNumChildren() const { return Data.getNumChildren(); }
-
-llvm::Optional<Syntax> Syntax::getChild(const size_t N) const {
-  auto ChildData = Data.getChild(N);
-  if (!ChildData) {
+Optional<Syntax> Syntax::getPreviousNode() const {
+  if (auto prev = getData().getPreviousNode()) {
+    return Syntax(*prev);
+  } else {
     return None;
   }
-  return Syntax(*ChildData);
+}
+
+Optional<Syntax> Syntax::getNextNode() const {
+  if (auto prev = getData().getNextNode()) {
+    return Syntax(*prev);
+  } else {
+    return None;
+  }
 }

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -15,31 +15,66 @@
 using namespace swift;
 using namespace swift::syntax;
 
-SyntaxData SyntaxData::make(AbsoluteRawSyntax AbsoluteRaw,
-                            const RC<RefCountedBox<SyntaxData>> &Parent) {
-  return SyntaxData(AbsoluteRaw, Parent);
+// MARK: - SyntaxDataRef
+
+Optional<SyntaxDataRef> SyntaxDataRef::getChildRef(
+    AbsoluteSyntaxPosition::IndexInParentType Index) const {
+  auto AbsoluteRaw = getAbsoluteRawRef().getChildRef(Index);
+  if (AbsoluteRaw) {
+    return SyntaxDataRef(*AbsoluteRaw, /*Parent=*/this);
+  } else {
+    return None;
+  }
 }
+
+AbsoluteOffsetPosition
+SyntaxDataRef::getAbsolutePositionBeforeLeadingTrivia() const {
+  return AbsoluteRaw.getPosition();
+}
+
+AbsoluteOffsetPosition
+SyntaxDataRef::getAbsolutePositionAfterLeadingTrivia() const {
+  if (auto FirstToken = getAbsoluteRawRef().getFirstTokenRef()) {
+    return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
+        FirstToken->getRawRef()->getLeadingTriviaLength());
+  } else {
+    return getAbsolutePositionBeforeLeadingTrivia();
+  }
+}
+
+AbsoluteOffsetPosition
+SyntaxDataRef::getAbsoluteEndPositionBeforeTrailingTrivia() const {
+  if (auto LastToken = getAbsoluteRawRef().getLastTokenRef()) {
+    return getAbsoluteEndPositionAfterTrailingTrivia().advancedBy(
+        -LastToken->getRawRef()->getTrailingTriviaLength());
+  } else {
+    return getAbsoluteEndPositionAfterTrailingTrivia();
+  }
+}
+
+AbsoluteOffsetPosition
+SyntaxDataRef::getAbsoluteEndPositionAfterTrailingTrivia() const {
+  return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
+      getRawRef()->getTextLength());
+}
+
+void SyntaxDataRef::dump(llvm::raw_ostream &OS) const {
+  getRawRef()->dump(OS, 0);
+  OS << '\n';
+}
+
+void SyntaxDataRef::dump() const { dump(llvm::errs()); }
+
+// MARK: - SyntaxData
 
 Optional<SyntaxData>
 SyntaxData::getChild(AbsoluteSyntaxPosition::IndexInParentType Index) const {
-  if (!getRaw()->getChild(Index)) {
+  auto AbsoluteRaw = getAbsoluteRaw().getChild(Index);
+  if (AbsoluteRaw) {
+    return SyntaxData(*AbsoluteRaw, /*Parent=*/*this);
+  } else {
     return None;
   }
-  AbsoluteSyntaxPosition Position =
-      AbsoluteRaw.getInfo().getPosition().advancedToFirstChild();
-  SyntaxIdentifier NodeId =
-      AbsoluteRaw.getInfo().getNodeId().advancedToFirstChild();
-
-  for (size_t I = 0; I < Index; ++I) {
-    Position = Position.advancedBy(getRaw()->getChild(I));
-    NodeId = NodeId.advancedBy(getRaw()->getChild(I));
-  }
-  AbsoluteSyntaxInfo Info(Position, NodeId);
-
-  const RC<RefCountedBox<SyntaxData>> RefCountedParent =
-      RefCountedBox<SyntaxData>::make(*this);
-  return SyntaxData(AbsoluteRawSyntax(getRaw()->getChild(Index), Info),
-                    RefCountedParent);
 }
 
 Optional<SyntaxData> SyntaxData::getPreviousNode() const {
@@ -47,11 +82,13 @@ Optional<SyntaxData> SyntaxData::getPreviousNode() const {
     if (hasParent()) {
       for (size_t I = N - 1; ; --I) {
         if (auto C = getParent()->getChild(I)) {
-          if (C->getRaw()->isPresent() && C->getFirstToken())
+          if (C->getRaw()->isPresent() && C->getFirstToken() != None) {
             return C;
+          }
         }
-        if (I == 0)
+        if (I == 0) {
           break;
+        }
       }
     }
   }
@@ -60,11 +97,12 @@ Optional<SyntaxData> SyntaxData::getPreviousNode() const {
 
 Optional<SyntaxData> SyntaxData::getNextNode() const {
   if (hasParent()) {
-    for (size_t I = getIndexInParent() + 1, N = getParent()->getNumChildren();
-         I != N; ++I) {
+    size_t NumChildren = getParent()->getNumChildren();
+    for (size_t I = getIndexInParent() + 1; I != NumChildren; ++I) {
       if (auto C = getParent()->getChild(I)) {
-        if (C->getRaw()->isPresent() && C->getFirstToken())
+        if (C->getRaw()->isPresent() && C->getFirstToken() != None) {
           return C;
+        }
       }
     }
     return getParent()->getNextNode();
@@ -73,17 +111,21 @@ Optional<SyntaxData> SyntaxData::getNextNode() const {
 }
 
 Optional<SyntaxData> SyntaxData::getFirstToken() const {
-  if (getRaw()->isToken()) {
+  /// getFirstToken and getLastToken cannot be implemented on SyntaxDataRef
+  /// because we might need to traverse through multiple nodes to reach the
+  /// first token. When returning this token, the parent nodes are being
+  /// discarded and thus its parent pointer would point to invalid memory.
+  if (getRawRef()->isToken() && !getRawRef()->isMissing()) {
     return *this;
   }
 
   for (size_t I = 0, E = getNumChildren(); I < E; ++I) {
     if (auto Child = getChild(I)) {
-      if (Child->getRaw()->isMissing())
+      if (Child->getRawRef()->isMissing()) {
         continue;
-      if (Child->getRaw()->isToken()) {
-        return Child;
-      } else if (auto Token = Child->getFirstToken()) {
+      }
+
+      if (auto Token = Child->getFirstToken()) {
         return Token;
       }
     }
@@ -92,7 +134,8 @@ Optional<SyntaxData> SyntaxData::getFirstToken() const {
 }
 
 Optional<SyntaxData> SyntaxData::getLastToken() const {
-  if (getRaw()->isToken() && !getRaw()->isMissing()) {
+  // Also see comment in getFirstToken.
+  if (getRawRef()->isToken() && !getRawRef()->isMissing()) {
     return *this;
   }
 
@@ -101,12 +144,11 @@ Optional<SyntaxData> SyntaxData::getLastToken() const {
   }
   for (int I = getNumChildren() - 1; I >= 0; --I) {
     if (auto Child = getChild(I)) {
-      if (Child->getRaw()->isMissing()) {
+      if (Child->getRawRef()->isMissing()) {
         continue;
       }
-      if (Child->getRaw()->isToken()) {
-        return Child;
-      } else if (auto Token = Child->getLastToken()) {
+
+      if (auto Token = Child->getLastToken()) {
         return Token;
       }
     }
@@ -114,53 +156,14 @@ Optional<SyntaxData> SyntaxData::getLastToken() const {
   return None;
 }
 
-AbsoluteOffsetPosition
-SyntaxData::getAbsolutePositionBeforeLeadingTrivia() const {
-  return AbsoluteRaw.getPosition();
-}
-
-AbsoluteOffsetPosition
-SyntaxData::getAbsolutePositionAfterLeadingTrivia() const {
-  if (auto FirstToken = getFirstToken()) {
-    return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
-        FirstToken->getRaw()->getLeadingTriviaLength());
-  } else {
-    return getAbsolutePositionBeforeLeadingTrivia();
-  }
-}
-
-AbsoluteOffsetPosition
-SyntaxData::getAbsoluteEndPositionBeforeTrailingTrivia() const {
-  if (auto LastToken = getLastToken()) {
-    return getAbsoluteEndPositionAfterTrailingTrivia().advancedBy(
-        -LastToken->getRaw()->getTrailingTriviaLength());
-  } else {
-    return getAbsoluteEndPositionAfterTrailingTrivia();
-  }
-}
-
-AbsoluteOffsetPosition
-SyntaxData::getAbsoluteEndPositionAfterTrailingTrivia() const {
-  return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
-      getRaw()->getTextLength());
-}
-
 SyntaxData SyntaxData::replacingSelf(const RC<RawSyntax> &NewRaw) const {
   if (hasParent()) {
     auto NewRoot = getParent()->replacingChild(NewRaw, getIndexInParent());
-    auto NewRootBox = RefCountedBox<SyntaxData>::make(NewRoot);
-    auto NewSelf = AbsoluteRaw.replacingSelf(
+    auto NewSelf = getAbsoluteRaw().replacingSelf(
         NewRaw, NewRoot.AbsoluteRaw.getNodeId().getRootId());
-    return SyntaxData(NewSelf, NewRootBox);
+    return SyntaxData(NewSelf, NewRoot);
   } else {
     auto NewSelf = AbsoluteRawSyntax::forRoot(NewRaw);
     return SyntaxData(NewSelf, /*Parent=*/nullptr);
   }
 }
-
-void SyntaxData::dump(llvm::raw_ostream &OS) const {
-  getRaw()->dump(OS, 0);
-  OS << '\n';
-}
-
-void SyntaxData::dump() const { dump(llvm::errs()); }

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -26,9 +26,9 @@ using namespace swift::syntax;
 
 % for node in SYNTAX_NODES:
 %   if node.requires_validation():
-void ${node.name}::validate() const {
+void ${node.name}Ref::validate() const {
 #ifndef NDEBUG
-  auto raw = Data.getRaw();
+  auto raw = Data.getRawRef();
   if (isMissing()) return;
   assert(raw->getLayout().size() == ${len(node.children)});
 %     for child in node.children:
@@ -55,15 +55,39 @@ void ${node.name}::validate() const {
 
 %   for child in node.children:
 %     if child.is_optional:
+llvm::Optional<${child.type_name}Ref> ${node.name}Ref::get${child.name}() const {
+  if (auto ChildData = getDataRef().getChildRef(Cursor::${child.name})) {
+    return ${child.type_name}Ref(*ChildData);
+  } else {
+    return None;
+  }
+}
+%     else:
+${child.type_name}Ref ${node.name}Ref::get${child.name}() const {
+  return ${child.type_name}Ref(*getDataRef().getChildRef(Cursor::${child.name}));
+}
+%     end
+%   end
+
+
+%   if node.requires_validation():
+void ${node.name}::validate() const {
+  ${node.name}Ref(*this).validate();
+}
+%   end
+
+%   for child in node.children:
+%     if child.is_optional:
 llvm::Optional<${child.type_name}> ${node.name}::get${child.name}() const {
-  auto ChildData = Data.getChild(Cursor::${child.name});
-  if (!ChildData)
-    return llvm::None;
-  return ${child.type_name}(*ChildData);
+  if (auto ChildData = getData().getChild(Cursor::${child.name})) {
+    return ${child.type_name}(*ChildData);
+  } else {
+    return None;
+  }
 }
 %     else:
 ${child.type_name} ${node.name}::get${child.name}() const {
-  return ${child.type_name}(*Data.getChild(Cursor::${child.name}));
+  return ${child.type_name}(*getData().getChild(Cursor::${child.name}));
 }
 %     end
 
@@ -81,7 +105,7 @@ ${node.name} ${node.name}::add${child_elt}(${child_elt_type} ${child_elt}) {
   else
     raw = RawSyntax::makeAndCalcLength(SyntaxKind::${child_node.syntax_kind},
       {${child_elt}.getRaw()}, SourcePresence::Present);
-  return ${node.name}(Data.replacingChild(raw, Cursor::${child.name}));
+  return ${node.name}(getData().replacingChild(raw, Cursor::${child.name}));
 }
 %     end
 
@@ -97,7 +121,7 @@ ${node.name} ${node.name}::with${child.name}(
     raw = ${make_missing_child(child)};
 % end
   }
-  return ${node.name}(Data.replacingChild(raw, Cursor::${child.name}));
+  return ${node.name}(getData().replacingChild(raw, Cursor::${child.name}));
 }
 
 %   end

--- a/lib/Syntax/UnknownSyntax.cpp
+++ b/lib/Syntax/UnknownSyntax.cpp
@@ -16,4 +16,4 @@
 using namespace swift;
 using namespace swift::syntax;
 
-void UnknownSyntax::validate() const { assert(Data.getRaw()->isUnknown()); }
+void UnknownSyntax::validate() const { assert(Data.getRawRef()->isUnknown()); }

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -62,8 +62,8 @@ class SyntaxVerifier: public SyntaxVisitor {
 
   template<class T>
   SourceLoc getSourceLoc(T Node) {
-    return SourceMgr.getLocForOffset(BufferID,
-      Node.getAbsolutePosition().getOffset());
+    return SourceMgr.getLocForOffset(
+        BufferID, Node.getAbsolutePositionAfterLeadingTrivia().getOffset());
   }
 public:
   SyntaxVerifier( SourceManager &SM, unsigned bufID, DiagnosticEngine &diags)

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -819,7 +819,7 @@ int dumpEOFSourceLoc(const char *MainExecutablePath,
     auto SF = info.SF;
     auto BufferId = *SF->getBufferID();
     auto Root = SF->getSyntaxRoot();
-    auto AbPos = Root.getEOFToken().getAbsolutePosition();
+    auto AbPos = Root.getEOFToken().getAbsolutePositionAfterLeadingTrivia();
 
     SourceManager &SourceMgr = SF->getASTContext().SourceMgr;
     auto StartLoc = SourceMgr.getLocForBufferStart(BufferId);


### PR DESCRIPTION
When walking the libSyntax tree, reference counting of syntax nodes has a significant performance impact. In some situations, the ref-counting is, however, not necessary because the caller can guarantee that all objects stay alive. For those cases, this PR adds a `*Ref` version of the syntax hierarchy. These `*Ref` nodes don't retain any of their data and instead rely on the caller to make the following gurantees:

- The `RawSyntax` stay alive. This can easily be accomplished by holding on to the `RawSyntax` node of the root which retains all of its children
- Parent `Syntax` nodes always outlive their children. If the `Syntax` nodes are allocated on the stack and the tree is walked top to bottom, this is also easily given.

### Performance checklist (performed on my local machine)
- [x] No regression during compilation
- [x] No regression during code completion
- [x] No regression during SwiftSyntax parsing