### PR TITLE
[libSyntax] Mark parameters that are always passed with move semantics as move-types

### DIFF
--- a/include/swift/Parse/ParsedSyntax.h
+++ b/include/swift/Parse/ParsedSyntax.h
@@ -26,7 +26,7 @@ public:
     : RawNode(std::move(rawNode)) {}
 
   const ParsedRawSyntaxNode &getRaw() const { return RawNode; }
-  ParsedRawSyntaxNode takeRaw() { return std::move(RawNode); }
+  ParsedRawSyntaxNode &&takeRaw() { return std::move(RawNode); }
   syntax::SyntaxKind getKind() const { return RawNode.getKind(); }
 
   /// Returns true if the syntax node is of the given type.

--- a/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxBuilders.h.gyb
@@ -51,7 +51,7 @@ public:
     : SPCtx(SPCtx) {}
 
 %     for child in node.children:
-  Parsed${node.name}Builder &use${child.name}(Parsed${child.type_name} ${child.name});
+  Parsed${node.name}Builder &use${child.name}(Parsed${child.type_name} &&${child.name});
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
 %         child_elt = child_node.collection_element_name

--- a/include/swift/Parse/ParsedSyntaxNodes.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxNodes.h.gyb
@@ -53,7 +53,7 @@ class Parsed${node.name} ${qualifier} : public Parsed${node.base_type} {
 %     end
 
 public:
-  explicit Parsed${node.name}(ParsedRawSyntaxNode rawNode)
+  explicit Parsed${node.name}(ParsedRawSyntaxNode &&rawNode)
     : Parsed${node.base_type}(std::move(rawNode)) {
   }
 

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -39,7 +39,7 @@ struct ParsedSyntaxRecorder {
 %         if child.is_optional:
 %            param_type = "Optional<%s>" % param_type
 %         end
-%         child_params.append("%s %s" % (param_type, child.name))
+%         child_params.append("%s &&%s" % (param_type, child.name))
 %     end
 %     child_params = ', '.join(child_params)
 private:

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -261,13 +261,13 @@ public:
   }
 
   /// Add RawSyntax to the parts.
-  void addRawSyntax(ParsedRawSyntaxNode Raw);
+  void addRawSyntax(ParsedRawSyntaxNode &&Raw);
 
   /// Add Token with Trivia to the parts.
   void addToken(Token &Tok, StringRef LeadingTrivia, StringRef TrailingTrivia);
 
   /// Add Syntax to the parts.
-  void addSyntax(ParsedSyntax Node);
+  void addSyntax(ParsedSyntax &&Node);
 
   template<typename SyntaxNode>
   llvm::Optional<SyntaxNode> popIf() {

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -38,7 +38,7 @@ using namespace swift::syntax;
 %         child_elt_name = child.name + 'Member'
 %       end
 Parsed${node.name}Builder &
-Parsed${node.name}Builder::use${child.name}(Parsed${child.type_name} ${child.name}) {
+Parsed${node.name}Builder::use${child.name}(Parsed${child.type_name} &&${child.name}) {
 %       if child_elt:
   assert(${child_elt_name}s.empty() && "use either 'use' function or 'add', not both");
 %       end

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -85,7 +85,7 @@ bool ParsedSyntaxRecorder::formExactLayoutFor(syntax::SyntaxKind Kind,
 %         param_type = "Parsed%s" % child.type_name
 %         if child.is_optional:
 %            param_type = "Optional<%s>" % param_type
-%         child_params.append("%s %s" % (param_type, child.name))
+%         child_params.append("%s &&%s" % (param_type, child.name))
 %         child_move_args.append("std::move(%s)" % (child.name))
 %     child_params = ', '.join(child_params)
 %     child_move_args = ', '.join(child_move_args)

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -186,7 +186,7 @@ SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
 }
 
 /// Add RawSyntax to the parts.
-void SyntaxParsingContext::addRawSyntax(ParsedRawSyntaxNode Raw) {
+void SyntaxParsingContext::addRawSyntax(ParsedRawSyntaxNode &&Raw) {
   getStorage().emplace_back(std::move(Raw));
 }
 
@@ -219,7 +219,7 @@ void SyntaxParsingContext::addToken(Token &Tok, StringRef LeadingTrivia,
 }
 
 /// Add Syntax to the parts.
-void SyntaxParsingContext::addSyntax(ParsedSyntax Node) {
+void SyntaxParsingContext::addSyntax(ParsedSyntax &&Node) {
   if (!Enabled)
     return;
   addRawSyntax(Node.takeRaw());


### PR DESCRIPTION
This should reduce the number of times these types are being copied. In any way, it seems clearer to mark parameters as a move-only-type if its memory contents are being moved out of it directly afterwards.