### PR TITLE
[libSyntax] Don't create deferred nodes for a libSyntax tree

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -40,6 +40,7 @@ class SyntaxParsingContext;
 /// there are instances that it's not clear what will be the final syntax node
 /// in the current parsing context.
 class ParsedRawSyntaxNode {
+  friend class ParsedRawSyntaxRecorder;
   enum class DataKind: uint8_t {
     Null,
     Recorded,
@@ -291,25 +292,6 @@ public:
   }
 
   //==========================================================================//
-
-  /// Form a deferred syntax layout node.
-  static ParsedRawSyntaxNode makeDeferred(syntax::SyntaxKind k,
-                        MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
-                                          SyntaxParsingContext &ctx);
-
-  /// Form a deferred token node.
-  static ParsedRawSyntaxNode makeDeferred(Token tok, StringRef leadingTrivia,
-                                          StringRef trailingTrivia,
-                                          SyntaxParsingContext &ctx);
-
-  /// Form a deferred missing token node.
-  static ParsedRawSyntaxNode makeDeferredMissing(tok tokKind, SourceLoc loc) {
-    auto raw = ParsedRawSyntaxNode(tokKind, loc, /*tokLength=*/0,
-                                   /*leadingTrivia=*/StringRef(),
-                                   /*trailingTrivia=*/StringRef());
-    raw.IsMissing = true;
-    return raw;
-  }
 
   /// Dump this piece of syntax recursively for debugging or testing.
   SWIFT_DEBUG_DUMP;

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -20,6 +20,7 @@
 #define SWIFT_PARSE_PARSEDRAWSYNTAXRECORDER_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Parse/ParsedRawSyntaxNode.h"
 #include <memory>
 
 namespace swift {
@@ -29,6 +30,7 @@ class ParsedRawSyntaxNode;
 struct ParsedTrivia;
 class ParsedTriviaPiece;
 class SyntaxParseActions;
+class SyntaxParsingContext;
 class SourceLoc;
 class Token;
 enum class tok;
@@ -66,6 +68,25 @@ public:
   /// if not missing.
   ParsedRawSyntaxNode recordEmptyRawSyntaxCollection(syntax::SyntaxKind kind,
                                                      SourceLoc loc);
+
+  /// Create a deferred layout node.
+  static ParsedRawSyntaxNode
+  makeDeferred(syntax::SyntaxKind k,
+               MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
+               SyntaxParsingContext &ctx);
+
+  /// Create a deferred token node.
+  static ParsedRawSyntaxNode makeDeferred(Token tok, StringRef leadingTrivia,
+                                          StringRef trailingTrivia);
+
+  /// Form a deferred missing token node.
+  static ParsedRawSyntaxNode makeDeferredMissing(tok tokKind, SourceLoc loc) {
+    auto raw = ParsedRawSyntaxNode(tokKind, loc, /*tokLength=*/0,
+                                   /*leadingTrivia=*/StringRef(),
+                                   /*trailingTrivia=*/StringRef());
+    raw.IsMissing = true;
+    return raw;
+  }
 
   void discardRecordedNode(ParsedRawSyntaxNode &node);
 

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -42,6 +42,10 @@ namespace syntax {
 class ParsedRawSyntaxRecorder final {
   std::shared_ptr<SyntaxParseActions> SPActions;
 
+  /// Assuming that \p node is a deferred layout or token node, record it and
+  /// return the recorded node.
+  ParsedRawSyntaxNode recordDeferredNode(const ParsedRawSyntaxNode &node);
+
 public:
   explicit ParsedRawSyntaxRecorder(std::shared_ptr<SyntaxParseActions> spActions)
     : SPActions(std::move(spActions)) {}
@@ -70,23 +74,22 @@ public:
                                                      SourceLoc loc);
 
   /// Create a deferred layout node.
-  static ParsedRawSyntaxNode
+  ParsedRawSyntaxNode
   makeDeferred(syntax::SyntaxKind k,
                MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
                SyntaxParsingContext &ctx);
 
   /// Create a deferred token node.
-  static ParsedRawSyntaxNode makeDeferred(Token tok, StringRef leadingTrivia,
-                                          StringRef trailingTrivia);
+  ParsedRawSyntaxNode makeDeferred(Token tok, StringRef leadingTrivia,
+                                   StringRef trailingTrivia);
 
   /// Form a deferred missing token node.
-  static ParsedRawSyntaxNode makeDeferredMissing(tok tokKind, SourceLoc loc) {
-    auto raw = ParsedRawSyntaxNode(tokKind, loc, /*tokLength=*/0,
-                                   /*leadingTrivia=*/StringRef(),
-                                   /*trailingTrivia=*/StringRef());
-    raw.IsMissing = true;
-    return raw;
-  }
+  ParsedRawSyntaxNode makeDeferredMissing(tok tokKind, SourceLoc loc);
+
+  /// For a deferred layout node \p parent, retrieve the deferred child node
+  /// at \p ChildIndex.
+  ParsedRawSyntaxNode getDeferredChild(const ParsedRawSyntaxNode &parent,
+                                       size_t ChildIndex) const;
 
   void discardRecordedNode(ParsedRawSyntaxNode &node);
 

--- a/include/swift/Parse/ParsedSyntax.h
+++ b/include/swift/Parse/ParsedSyntax.h
@@ -43,10 +43,6 @@ public:
     return T(std::move(RawNode));
   }
 
-  ParsedSyntax copyDeferred() const {
-    return ParsedSyntax { RawNode.copyDeferred() };
-  }
-
   static bool kindof(syntax::SyntaxKind Kind) {
     return true;
   }

--- a/include/swift/Parse/ParsedSyntaxNodes.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxNodes.h.gyb
@@ -62,9 +62,13 @@ public:
   /// ${line}
 %       end
 %       if child.is_optional:
-  llvm::Optional<Parsed${child.type_name}> getDeferred${child.name}();
+  llvm::Optional<Parsed${child.type_name}> getDeferred${child.name}(
+    const SyntaxParsingContext *SyntaxContext
+  );
 %       else:
-  Parsed${child.type_name} getDeferred${child.name}();
+  Parsed${child.type_name} getDeferred${child.name}(
+    const SyntaxParsingContext *SyntaxContext
+  );
 %       end
 %     end
 

--- a/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxRecorder.h.gyb
@@ -29,7 +29,7 @@ namespace swift {
 class ParsedRawSyntaxRecorder;
 class SyntaxParsingContext;
 
-struct ParsedSyntaxRecorder {
+struct ParsedSyntaxRecorder final {
 
 % for node in SYNTAX_NODES:
 %   if node.children:

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -19,6 +19,8 @@
 #define SWIFT_PARSE_SYNTAXPARSEACTIONS_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace swift {
 
@@ -39,6 +41,27 @@ class SyntaxParseActions {
   virtual void _anchor();
 
 public:
+  /// Data returned from \c getDeferredChild. This is enough data to construct
+  /// a \c ParsedRawSyntaxNode. We don't return \c ParsedRawSyntaxNodes from
+  /// \c getDeferredChild to maintain a clean dependency relationship of
+  /// \c ParsedRawSyntaxNode being on a higher level than \c SyntaxParseActions.
+  struct DeferredNodeInfo {
+    OpaqueSyntaxNode Data;
+    CharSourceRange Range;
+    syntax::SyntaxKind SyntaxKind;
+    tok TokenKind;
+    bool IsMissing;
+
+    DeferredNodeInfo()
+        : Data(nullptr), Range(), SyntaxKind(), TokenKind(), IsMissing(true) {}
+
+    DeferredNodeInfo(OpaqueSyntaxNode Data, CharSourceRange Range,
+                     syntax::SyntaxKind SyntaxKind, tok TokenKind,
+                     bool IsMissing)
+        : Data(Data), Range(Range), SyntaxKind(SyntaxKind),
+          TokenKind(TokenKind), IsMissing(IsMissing) {}
+  };
+
   virtual ~SyntaxParseActions() = default;
 
   virtual OpaqueSyntaxNode recordToken(tok tokenKind, StringRef leadingTrivia,
@@ -52,9 +75,48 @@ public:
   /// The provided \c elements are an exact layout appropriate for the syntax
   /// \c kind. Missing optional elements are represented with a null
   /// OpaqueSyntaxNode object.
-  virtual OpaqueSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                           ArrayRef<OpaqueSyntaxNode> elements,
-                                           CharSourceRange range) = 0;
+  virtual OpaqueSyntaxNode
+  recordRawSyntax(syntax::SyntaxKind kind,
+                  const SmallVector<OpaqueSyntaxNode, 4> &elements,
+                  CharSourceRange range) = 0;
+
+  /// Create a deferred token node that may or may not be recorded later using
+  /// \c recordDeferredToken. The \c SyntaxParseAction is responsible for
+  /// keeping the deferred token alive until it is destructed.
+  virtual OpaqueSyntaxNode makeDeferredToken(tok tokenKind,
+                                             StringRef leadingTrivia,
+                                             StringRef trailingTrivia,
+                                             CharSourceRange range,
+                                             bool isMissing) = 0;
+
+  /// Create a deferred layout node that may or may not be recorded later using
+  /// \c recordDeferredLayout. The \c SyntaxParseAction is responsible for
+  /// keeping the deferred token alive until it is destructed.
+  virtual OpaqueSyntaxNode
+  makeDeferredLayout(syntax::SyntaxKind k, CharSourceRange Range,
+                     bool IsMissing,
+                     const SmallVector<OpaqueSyntaxNode, 4> &children) = 0;
+
+  /// Record a deferred token node that was previously created using \c
+  /// makeDeferredToken. The deferred data will never be used again, so it can
+  /// be destroyed by this method. Note, however, that not all deferred nodes
+  /// will be recorded and that pending deferred nodes need to be freed
+  /// when the \c SyntaxParseActions is destructed.
+  virtual OpaqueSyntaxNode recordDeferredToken(OpaqueSyntaxNode deferred) = 0;
+  virtual OpaqueSyntaxNode recordDeferredLayout(OpaqueSyntaxNode deferred) = 0;
+
+  /// Since most data of \c ParsedRawSyntax is described as opaque data, the
+  /// \c ParsedRawSyntax node needs to reach out to the \c SyntaxParseAction
+  /// that created it, to retrieve children.
+  /// This methods returns all information needed to construct a \c
+  /// ParsedRawSyntaxNode of a child node. \p node is the parent node for which
+  /// the child at position \p ChildIndex should be retrieved. Furthmore, \p
+  /// node starts at \p ThisNodeLoc. This information is needed for the \c
+  /// SyntaxTreeCreator in which the \c RawSyntax nodes do not keep track of
+  /// their absolute position.
+  virtual DeferredNodeInfo getDeferredChild(OpaqueSyntaxNode node,
+                                            size_t ChildIndex,
+                                            SourceLoc ThisNodeLoc) = 0;
 
   /// Attempt to realize an opaque raw syntax node for a source file into a
   /// SourceFileSyntax node. This will return \c None if the parsing action

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -255,6 +255,9 @@ public:
   const SyntaxParsingContext *getRoot() const;
 
   ParsedRawSyntaxRecorder &getRecorder() { return getRootData()->Recorder; }
+  const ParsedRawSyntaxRecorder &getRecorder() const {
+    return getRootData()->Recorder;
+  }
 
   llvm::BumpPtrAllocator &getScratchAlloc() {
     return getRootData()->ScratchAlloc;

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -471,8 +471,20 @@ public:
     return getLayout()[Index];
   }
 
+  /// Get a child based on a particular node's "Cursor", indicating
+  /// the position of the terms in the production of the Swift grammar.
+  ///
+  /// The caller is responsible for making sure the \c RawSyntax that the
+  /// returned pointer points to, stays alive for the duration of the use by
+  /// e.g. keeping the \c SyntaxArena alive in which the child lives or keeping
+  /// \c this node alive, which maintains a strong reference to the child.
+  RawSyntax *getChildRef(CursorIndex Index) const {
+    return getLayout()[Index].get();
+  }
+
   /// Return the number of bytes this node takes when spelled out in the source
-  size_t getTextLength() { return Bits.Common.TextLength; }
+  /// including trivia.
+  size_t getTextLength() const { return Bits.Common.TextLength; }
 
   /// @}
 

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1242,7 +1242,7 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
 
   if (SyntaxContext->isEnabled()) {
     if (auto UPES = PatternCtx.popIf<ParsedUnresolvedPatternExprSyntax>()) {
-      PatternCtx.addSyntax(UPES->getDeferredPattern());
+      PatternCtx.addSyntax(UPES->getDeferredPattern(SyntaxContext));
     } else {
       PatternCtx.setCreateSyntax(SyntaxKind::ExpressionPattern);
     }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -403,9 +403,9 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       if (InputNode.is<ParsedTupleTypeSyntax>()) {
         auto TupleTypeNode = std::move(InputNode).castTo<ParsedTupleTypeSyntax>();
         // Decompose TupleTypeSyntax and repack into FunctionType.
-        auto LeftParen = TupleTypeNode.getDeferredLeftParen();
-        auto Arguments = TupleTypeNode.getDeferredElements();
-        auto RightParen = TupleTypeNode.getDeferredRightParen();
+        auto LeftParen = TupleTypeNode.getDeferredLeftParen(SyntaxContext);
+        auto Arguments = TupleTypeNode.getDeferredElements(SyntaxContext);
+        auto RightParen = TupleTypeNode.getDeferredRightParen(SyntaxContext);
         Builder
           .useLeftParen(std::move(LeftParen))
           .useArguments(std::move(Arguments))

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -17,6 +17,12 @@ using namespace swift;
 using namespace swift::syntax;
 using namespace llvm;
 
+ParsedRawSyntaxNode ParsedRawSyntaxNode::getDeferredChild(
+    size_t ChildIndex, const SyntaxParsingContext *SyntaxContext) const {
+  assert(isDeferredLayout());
+  return SyntaxContext->getRecorder().getDeferredChild(*this, ChildIndex);
+}
+
 void ParsedRawSyntaxNode::dump() const {
   dump(llvm::errs(), /*Indent*/ 0);
   llvm::errs() << '\n';
@@ -43,16 +49,15 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
     case DataKind::DeferredLayout:
       dumpSyntaxKind(OS, getKind());
       OS << " [deferred]";
-      for (const auto &child : getDeferredChildren()) {
-        OS << "\n";
-        child.dump(OS, Indent + 2);
-      }
+      OS << "<layout>";
       break;
     case DataKind::DeferredToken:
       dumpSyntaxKind(OS, getKind());
       OS << " [deferred] ";
       dumpTokenKind(OS, getTokenKind());
       break;
+    case DataKind::Destroyed:
+      OS << " [destroyed] ";
   }
   OS << ')';
 }

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -17,50 +17,6 @@ using namespace swift;
 using namespace swift::syntax;
 using namespace llvm;
 
-ParsedRawSyntaxNode
-ParsedRawSyntaxNode::makeDeferred(SyntaxKind k,
-                                  MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
-                                  SyntaxParsingContext &ctx) {
-  CharSourceRange range;
-  if (deferredNodes.empty()) {
-    return ParsedRawSyntaxNode(k, range, {});
-  }
-  ParsedRawSyntaxNode *newPtr =
-    ctx.getScratchAlloc().Allocate<ParsedRawSyntaxNode>(deferredNodes.size());
-
-#ifndef NDEBUG
-  ParsedRawSyntaxRecorder::verifyElementRanges(deferredNodes);
-#endif
-  auto ptr = newPtr;
-  for (auto &node : deferredNodes) {
-    // Cached range.
-    if (!node.isNull() && !node.isMissing()) {
-      auto nodeRange = node.getDeferredRange();
-      if (nodeRange.isValid()) {
-        if (range.isInvalid())
-          range = nodeRange;
-        else
-          range.widen(nodeRange);
-      }
-    }
-
-    // uninitialized move;
-    :: new (static_cast<void *>(ptr++)) ParsedRawSyntaxNode(std::move(node));
-  }
-  return ParsedRawSyntaxNode(k, range,
-                             makeMutableArrayRef(newPtr, deferredNodes.size()));
-}
-
-ParsedRawSyntaxNode
-ParsedRawSyntaxNode::makeDeferred(Token tok, StringRef leadingTrivia,
-                                  StringRef trailingTrivia,
-                                  SyntaxParsingContext &ctx) {
-  CharSourceRange tokRange = tok.getRange();
-  return ParsedRawSyntaxNode(tok.getKind(), tokRange.getStart(),
-                             tokRange.getByteLength(), leadingTrivia,
-                             trailingTrivia);
-}
-
 void ParsedRawSyntaxNode::dump() const {
   dump(llvm::errs(), /*Indent*/ 0);
   llvm::errs() << '\n';

--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -66,8 +66,9 @@ Parsed${node.name}Builder::record() {
 
 Parsed${node.name}
 Parsed${node.name}Builder::makeDeferred() {
+  auto &Rec = SPCtx.getRecorder();
   finishLayout(/*deferred=*/true);
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
+  auto raw = Rec.makeDeferred(SyntaxKind::${node.syntax_kind},
     Layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
@@ -91,7 +92,7 @@ void Parsed${node.name}Builder::finishLayout(bool deferred) {
 %     if child_elt:
   if (!${child_elt_name}s.empty()) {
     if (deferred) {
-      Layout[${idx}] = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${child_node.syntax_kind},
+      Layout[${idx}] = Rec.makeDeferred(SyntaxKind::${child_node.syntax_kind},
                           ${child_elt_name}s, SPCtx);
     } else {
       Layout[${idx}] = Rec.recordRawSyntax(SyntaxKind::${child_node.syntax_kind}, ${child_elt_name}s);
@@ -104,13 +105,13 @@ void Parsed${node.name}Builder::finishLayout(bool deferred) {
 %         token = child.main_token()
 %         tok_kind = token.kind if token else "unknown"
     if (deferred) {
-      Layout[${idx}] = ParsedRawSyntaxNode::makeDeferredMissing(tok::${tok_kind}, SourceLoc());
+      Layout[${idx}] = Rec.makeDeferredMissing(tok::${tok_kind}, SourceLoc());
     } else {
       Layout[${idx}] = Rec.recordMissingToken(tok::${tok_kind}, SourceLoc());
     }
 %       elif child_elt:
     if (deferred) {
-      Layout[${idx}] = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${child_node.syntax_kind}, {}, SPCtx);
+      Layout[${idx}] = Rec.makeDeferred(SyntaxKind::${child_node.syntax_kind}, {}, SPCtx);
     } else {
       Layout[${idx}] = Rec.recordRawSyntax(SyntaxKind::${child_node.syntax_kind}, {});
     }

--- a/lib/Parse/ParsedSyntaxNodes.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxNodes.cpp.gyb
@@ -27,15 +27,16 @@ using namespace swift::syntax;
 %   for child in node.children:
 %     if child.is_optional:
 Optional<Parsed${child.type_name}>
-Parsed${node.name}::getDeferred${child.name}() {
-  auto &RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
-  if (RawChild.isNull())
+Parsed${node.name}::getDeferred${child.name}(const SyntaxParsingContext *SyntaxContext) {
+  auto Child = getRaw().getDeferredChild(${node.name}::Cursor::${child.name}, SyntaxContext);
+  if (Child.isNull())
     return None;
-  return Parsed${child.type_name} {RawChild.copyDeferred()};
+  return Parsed${child.type_name}(std::move(Child));
 }
 %     else:
-Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}() {
-  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}].copyDeferred()};
+Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}(const SyntaxParsingContext *SyntaxContext) {
+  auto Child = getRaw().getDeferredChild(${node.name}::Cursor::${child.name}, SyntaxContext);
+  return Parsed${child.type_name}(std::move(Child));
 }
 %     end
 

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -98,7 +98,7 @@ ParsedSyntaxRecorder::record${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxN
 
 Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(MutableArrayRef<ParsedRawSyntaxNode> layout, SyntaxParsingContext &SPCtx) {
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
+  auto raw = SPCtx.getRecorder().makeDeferred(SyntaxKind::${node.syntax_kind}, layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
 
@@ -132,7 +132,7 @@ Parsed${node.name}
 ParsedSyntaxRecorder::defer${node.syntax_kind}(
     MutableArrayRef<ParsedRawSyntaxNode> layout,
     SyntaxParsingContext &SPCtx) {
-  auto raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind},
+  auto raw = SPCtx.getRecorder().makeDeferred(SyntaxKind::${node.syntax_kind},
                              layout, SPCtx);
   return Parsed${node.name}(std::move(raw));
 }
@@ -157,7 +157,7 @@ ParsedSyntaxRecorder::makeBlank${node.syntax_kind}(SourceLoc loc,
   ParsedRawSyntaxNode raw;
   if (SPCtx.shouldDefer()) {
     // FIXME: 'loc' is not preserved when capturing a deferred layout.
-    raw = ParsedRawSyntaxNode::makeDeferred(SyntaxKind::${node.syntax_kind}, {}, SPCtx);
+    raw = SPCtx.getRecorder().makeDeferred(SyntaxKind::${node.syntax_kind}, {}, SPCtx);
   } else {
     raw = SPCtx.getRecorder().recordEmptyRawSyntaxCollection(SyntaxKind::${node.syntax_kind}, loc);
   }

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -88,7 +88,7 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  auto length = foundNode.getRecordedRange().getByteLength();
+  auto length = foundNode.getRange().getByteLength();
   getStorage().push_back(std::move(foundNode));
   return length;
 }
@@ -329,7 +329,7 @@ OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
   // the root context.
   getStorage().clear();
 
-  return root.takeOpaqueNode();
+  return root.takeData();
 }
 
 void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -98,7 +98,7 @@ SyntaxParsingContext::makeUnknownSyntax(SyntaxKind Kind,
                                         MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   assert(isUnknownKind(Kind));
   if (shouldDefer())
-    return ParsedRawSyntaxNode::makeDeferred(Kind, Parts, *this);
+    return getRecorder().makeDeferred(Kind, Parts, *this);
   else
     return getRecorder().recordRawSyntax(Kind, Parts);
 }
@@ -112,7 +112,7 @@ SyntaxParsingContext::createSyntaxAs(SyntaxKind Kind,
   auto &rec = getRecorder();
   auto formNode = [&](SyntaxKind kind, MutableArrayRef<ParsedRawSyntaxNode> layout) {
     if (nodeCreateK == SyntaxNodeCreationKind::Deferred || shouldDefer()) {
-      rawNode = ParsedRawSyntaxNode::makeDeferred(kind, layout, *this);
+      rawNode = getRecorder().makeDeferred(kind, layout, *this);
     } else {
       rawNode = rec.recordRawSyntax(kind, layout);
     }
@@ -210,8 +210,7 @@ void SyntaxParsingContext::addToken(Token &Tok, StringRef LeadingTrivia,
 
   ParsedRawSyntaxNode raw;
   if (shouldDefer()) {
-    raw = ParsedRawSyntaxNode::makeDeferred(Tok, LeadingTrivia, TrailingTrivia,
-                                            *this);
+    raw = getRecorder().makeDeferred(Tok, LeadingTrivia, TrailingTrivia);
   } else {
     raw = getRecorder().recordToken(Tok, LeadingTrivia, TrailingTrivia);
   }
@@ -339,7 +338,7 @@ void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {
 
   ParsedRawSyntaxNode raw;
   if (shouldDefer())
-    raw = ParsedRawSyntaxNode::makeDeferredMissing(Kind, Loc);
+    raw = getRecorder().makeDeferredMissing(Kind, Loc);
   else
     raw = getRecorder().recordMissingToken(Kind, Loc);
   getStorage().push_back(std::move(raw));

--- a/test/Syntax/serialize_tupletype.swift.result
+++ b/test/Syntax/serialize_tupletype.swift.result
@@ -17,7 +17,7 @@
                 null,
                 null,
                 {
-                  "id": 18,
+                  "id": 1,
                   "tokenKind": {
                     "kind": "kw_typealias"
                   },
@@ -26,7 +26,7 @@
                   "presence": "Present"
                 },
                 {
-                  "id": 19,
+                  "id": 2,
                   "tokenKind": {
                     "kind": "identifier",
                     "text": "x"
@@ -37,11 +37,11 @@
                 },
                 null,
                 {
-                  "id": 17,
+                  "id": 19,
                   "kind": "TypeInitializerClause",
                   "layout": [
                     {
-                      "id": 1,
+                      "id": 3,
                       "tokenKind": {
                         "kind": "equal"
                       },
@@ -50,11 +50,11 @@
                       "presence": "Present"
                     },
                     {
-                      "id": 16,
+                      "id": 18,
                       "kind": "TupleType",
                       "layout": [
                         {
-                          "id": 2,
+                          "id": 4,
                           "tokenKind": {
                             "kind": "l_paren"
                           },
@@ -63,16 +63,16 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 14,
+                          "id": 16,
                           "kind": "TupleTypeElementList",
                           "layout": [
                             {
-                              "id": 9,
+                              "id": 11,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 3,
+                                  "id": 5,
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
@@ -81,7 +81,7 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 4,
+                                  "id": 6,
                                   "tokenKind": {
                                     "kind": "identifier",
                                     "text": "b"
@@ -91,7 +91,7 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 5,
+                                  "id": 7,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -100,11 +100,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 7,
+                                  "id": 9,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 6,
+                                      "id": 8,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "Int"
@@ -120,7 +120,7 @@
                                 null,
                                 null,
                                 {
-                                  "id": 8,
+                                  "id": 10,
                                   "tokenKind": {
                                     "kind": "comma"
                                   },
@@ -132,12 +132,12 @@
                               "presence": "Present"
                             },
                             {
-                              "id": 13,
+                              "id": 15,
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
                                 {
-                                  "id": 10,
+                                  "id": 12,
                                   "tokenKind": {
                                     "kind": "kw__"
                                   },
@@ -147,7 +147,7 @@
                                 },
                                 null,
                                 {
-                                  "id": 5,
+                                  "id": 7,
                                   "tokenKind": {
                                     "kind": "colon"
                                   },
@@ -156,11 +156,11 @@
                                   "presence": "Present"
                                 },
                                 {
-                                  "id": 12,
+                                  "id": 14,
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
                                     {
-                                      "id": 11,
+                                      "id": 13,
                                       "tokenKind": {
                                         "kind": "identifier",
                                         "text": "String"
@@ -183,7 +183,7 @@
                           "presence": "Present"
                         },
                         {
-                          "id": 15,
+                          "id": 17,
                           "tokenKind": {
                             "kind": "r_paren"
                           },


### PR DESCRIPTION
Push the logic for creating deferred ParsedRawSyntaxNodes down to the `SyntaxParseActions`. This allows us to handle deferred nodes more efficiently in the `SyntaxTreeCreator`, which creates the libSyntax tree. 

Instead of creating dedicated deferred nodes that are later converted into recorded `RawSyntax` nodes, we directly record the `RawSyntax` nodes. If the RawSyntax node is later requested to be recorded, we don't need to do anything, but can just return the same node.

While we are leaking a small number of `RawSyntax` nodes this way, we have a significant performance gain for libSyntax tree creation in deferred mode. This is particularly important for the libSyntax parser transition where the `SyntaxParsingContext` is always put into deferred mode to  discard all nodes after parsing, unless a SyntaxParseAction has been  explicitly requested.

### Performance checklist (performed on my local machine)
- [x] No regression during compilation
- [x] No regression during code completion
- [x] No regression during SwiftSyntax parsing