### PR TITLE
[libSyntax] Allow a thread to gain exclusive access to a SyntaxArena and its RawSyntax nodes

### DIFF
--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -52,6 +52,7 @@ ParseMembersRequest::evaluate(Evaluator &evaluator,
                               IterableDeclContext *idc) const {
   SourceFile *sf = idc->getAsGenericContext()->getParentSourceFile();
   ASTContext &ctx = idc->getDecl()->getASTContext();
+  WithExcluseiveSyntaxArenaAccessRAII exclusiveArena(ctx.getSyntaxArena());
   if (!sf) {
     // If there is no parent source file, this is a deserialized or synthesized
     // declaration context, in which case `getMembers()` has all of the members.
@@ -140,6 +141,7 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
                                                          SourceFile *SF) const {
   assert(SF);
   auto &ctx = SF->getASTContext();
+  WithExcluseiveSyntaxArenaAccessRAII exclusiveArena(ctx.getSyntaxArena());
   auto bufferID = SF->getBufferID();
 
   // If there's no buffer, there's nothing to parse.


### PR DESCRIPTION
Reference counting of RawSyntax nodes is thread-safe by default. However, always incrementing and decrementing the `RefCount` atomically has a significant cost that's not necessary if only a single thread
accesses the data. 
This PR adds a way to get exclusive access to a SyntaxArena and all RawSyntax nodes contained within. While a thread has exclusive access, all ref-counting operations needn't be atomic.
