### PR TITLE
driver: use a non-op front-end argument to indicate new driver is getting used

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -173,8 +173,5 @@ WARNING(warn_drv_darwin_sdk_invalid_settings, none,
     "SDK settings were ignored because 'SDKSettings.json' could not be parsed",
     ())
 
-REMARK(remark_forwarding_to_new_driver, none,
-       "new Swift driver at '%0' will be used", (StringRef))
-
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -793,4 +793,7 @@ def disable_ast_verifier : Flag<["-"], "disable-ast-verifier">,
            "disabled. NOTE: Can not be used if enable-ast-verifier is used "
            "as well">;
 
+def new_driver_path
+  : Separate<["-"], "new-driver-path">, MetaVarName<"<path>">,
+  HelpText<"Path of the new driver to be used">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -199,10 +199,15 @@ static int run_driver(StringRef ExecName,
       }
       subCommandArgs.insert(subCommandArgs.end(), argv.begin() + 1, argv.end());
 
+      // Push these non-op frontend arguments so the build log can indicate
+      // the new driver is used.
+      subCommandArgs.push_back("-Xfrontend");
+      subCommandArgs.push_back("-new-driver-path");
+      subCommandArgs.push_back("-Xfrontend");
+      subCommandArgs.push_back(NewDriverPath.c_str());
+
       // Execute the subcommand.
       subCommandArgs.push_back(nullptr);
-      Diags.diagnose(SourceLoc(), diag::remark_forwarding_to_new_driver,
-                     NewDriverPath);
       ExecuteInPlace(NewDriverPath.c_str(), subCommandArgs.data());
 
       // If we reach here then an error occurred (typically a missing path).


### PR DESCRIPTION
This could help avoiding emitting remarks.

rdar://73710910
