### PR TITLE
Fix unchecked access to SPI decls from indirect clients

### DIFF
--- a/lib/AST/ModuleNameLookup.cpp
+++ b/lib/AST/ModuleNameLookup.cpp
@@ -230,7 +230,7 @@ void ModuleNameLookup<LookupStrategy>::lookupInModule(
       if (import.importedModule == headerImportModule)
         continue;
 
-      visitImport(import, nullptr);
+      visitImport(import, moduleScopeContext);
     }
   }
 

--- a/test/SPI/reexported_spi.swift
+++ b/test/SPI/reexported_spi.swift
@@ -1,0 +1,31 @@
+/// Test @_spi and @_exported imports.
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -DLIB_A %s -module-name A -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend -emit-module -DLIB_B %s -module-name B -emit-module-path %t/B.swiftmodule -I %t
+// RUN: %target-swift-frontend -typecheck -DCLIENT_EXTERNAL %s -I %t -verify
+
+#if LIB_A
+
+@_spi(A) public func spiFunc() {}
+
+@_spi(A) public struct SPIStruct {
+    public init() {}
+}
+
+#elseif LIB_B
+
+@_exported import A
+@_spi(A) import A
+
+spiFunc() // OK
+let x = SPIStruct() // OK
+
+#elseif CLIENT_EXTERNAL
+
+import B
+
+spiFunc() // expected-error{{cannot find 'spiFunc' in scope}}
+let x = SPIStruct() // expected-error{{cannot find 'SPIStruct' in scope}}
+
+#endif


### PR DESCRIPTION
Fix an issue where a public import (`@_exported`) broke the SPI checks in clients.

Future work may support for `@_exported` to export the SPIs too.

rdar://70502938