### PR TITLE
[Runtime] Copy the value witness table pointer manually.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -392,6 +392,10 @@ static void swift_objc_classCopyFixupHandler(Class oldClass, Class newClass) {
   if (!oldClassMetadata->isTypeMetadata())
    return;
 
+  // Copy the value witness table pointer for pointer authentication.
+  auto newClassMetadata = reinterpret_cast<ClassMetadata *>(newClass);
+  newClassMetadata->setValueWitnesses(oldClassMetadata->getValueWitnesses());
+
  // Otherwise, re-sign v-table entries using the extra discriminators stored
  // in the v-table descriptor.
 


### PR DESCRIPTION
Fixes rdar://74136916.