### PR TITLE
Look Through Class-Bound Archetypes When Installing Semantic Members

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3202,6 +3202,17 @@ public:
   /// declaration, or \c nullptr if it doesn't have one.
   ConstructorDecl *getDefaultInitializer() const;
 
+  /// Force the synthesis of all members named \c member requiring semantic
+  /// analysis and install them in the member list of this nominal type.
+  ///
+  /// \Note The use of this method in the compiler signals an architectural
+  /// problem with the caller. Use \c TypeChecker::lookup* instead of
+  /// introducing new usages.
+  ///
+  /// FIXME: This method presents a problem with respect to the consistency
+  /// and idempotency of lookups in the compiler. If we instead had a model
+  /// where lookup requests would explicitly return semantic members or parsed
+  /// members this function could disappear.
   void synthesizeSemanticMembersIfNeeded(DeclName member);
 
   /// Retrieves the static 'shared' property of a global actor type, which

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -287,6 +287,13 @@ static void installSemanticMembersIfNeeded(Type type, DeclNameRef name) {
     }
   }
 
+  if (type->isExistentialType()) {
+    auto layout = type->getExistentialLayout();
+    if (auto super = layout.explicitSuperclass) {
+      type = super;
+    }
+  }
+
   if (auto *current = type->getAnyNominal()) {
     current->synthesizeSemanticMembersIfNeeded(name.getFullName());
   }

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -273,6 +273,25 @@ LookupResult TypeChecker::lookupUnqualified(DeclContext *dc, DeclNameRef name,
   return result;
 }
 
+// An unfortunate hack to kick the decl checker into adding semantic members to
+// the current type before we attempt a semantic lookup. The places this method
+// looks needs to be in sync with \c extractDirectlyReferencedNominalTypes.
+// See the note in \c synthesizeSemanticMembersIfNeeded about a better, more
+// just, and peaceful world.
+static void installSemanticMembersIfNeeded(Type type, DeclNameRef name) {
+  // Look-through class-bound archetypes to ensure we synthesize e.g.
+  // inherited constructors.
+  if (auto archetypeTy = type->getAs<ArchetypeType>()) {
+    if (auto super = archetypeTy->getSuperclass()) {
+      type = super;
+    }
+  }
+
+  if (auto *current = type->getAnyNominal()) {
+    current->synthesizeSemanticMembersIfNeeded(name.getFullName());
+  }
+}
+
 LookupResult
 TypeChecker::lookupUnqualifiedType(DeclContext *dc, DeclNameRef name,
                                    SourceLoc loc,
@@ -320,9 +339,7 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   subOptions &= ~NL_RemoveNonVisible;
 
   // Make sure we've resolved implicit members, if we need them.
-  if (auto *current = type->getAnyNominal()) {
-    current->synthesizeSemanticMembersIfNeeded(name.getFullName());
-  }
+  installSemanticMembersIfNeeded(type, name);
 
   LookupResultBuilder builder(result, dc, options);
   SmallVector<ValueDecl *, 4> lookupResults;
@@ -392,9 +409,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
     subOptions |= NL_IncludeUsableFromInline;
 
   // Make sure we've resolved implicit members, if we need them.
-  if (auto *current = type->getAnyNominal()) {
-    current->synthesizeSemanticMembersIfNeeded(name.getFullName());
-  }
+  installSemanticMembersIfNeeded(type, name);
 
   if (!dc->lookupQualified(type, name, subOptions, decls))
     return result;

--- a/test/decl/init/Inputs/inherited-init-multifile-other.swift
+++ b/test/decl/init/Inputs/inherited-init-multifile-other.swift
@@ -1,0 +1,5 @@
+class A {
+  required init(_ x: Int) {}
+}
+
+class B : A { }

--- a/test/decl/init/Inputs/inherited-init-multifile-other.swift
+++ b/test/decl/init/Inputs/inherited-init-multifile-other.swift
@@ -2,4 +2,7 @@ class A {
   required init(_ x: Int) {}
 }
 
-class B : A { }
+class B : A {}
+class C : A {}
+
+protocol P {}

--- a/test/decl/init/inherited-init-multifile.swift
+++ b/test/decl/init/inherited-init-multifile.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %s %S/Inputs/inherited-init-multifile-other.swift
+// RUN: %target-swift-frontend -typecheck -verify %s -primary-file %S/Inputs/inherited-init-multifile-other.swift
+
+func make<Result: B>(ofClass cls: Result.Type) -> Result {
+    return cls.init(1)
+}

--- a/test/decl/init/inherited-init-multifile.swift
+++ b/test/decl/init/inherited-init-multifile.swift
@@ -4,3 +4,7 @@
 func make<Result: B>(ofClass cls: Result.Type) -> Result {
     return cls.init(1)
 }
+
+func make(ofClass cls: (C & P).Type) -> C {
+    return cls.init(1)
+}


### PR DESCRIPTION
Before lookup was requestified, the entire lookup stack would
install semantic members. As this caused cycles in the lookup path, it
was refactored to instead only occur at the TypeChecker::lookup*
entrypoints. Unfortunately, these entrypoints were not kept in sync with
the stack building code in qualified lookup, so a case was missed:
class-bound archetypes. We need to synthesize semantic members for them
as well or we'll non-deterministically fail to find synthesizable
members in incremental mode.

rdar://74174749