### PR TITLE
[test] Disable these tests on OpenBSD like Linux.

### DIFF
--- a/test/Concurrency/Runtime/class_resilience.swift
+++ b/test/Concurrency/Runtime/class_resilience.swift
@@ -12,6 +12,7 @@
 // REQUIRES: concurrency
 // XFAIL: windows
 // XFAIL: linux
+// XFAIL: openbsd
 
 import StdlibUnittest
 import resilient_class

--- a/test/Concurrency/Runtime/protocol_resilience.swift
+++ b/test/Concurrency/Runtime/protocol_resilience.swift
@@ -12,6 +12,7 @@
 // REQUIRES: concurrency
 // XFAIL: windows
 // UNSUPPORTED: linux
+// UNSUPPORTED: openbsd
 
 import StdlibUnittest
 import resilient_protocol


### PR DESCRIPTION
These tests are causing linker errors. Presumably this is like #35782,
which suggests these tests should also be XFAIL or UNSUPPORTED on OpenBSD
as well.