### PR TITLE
SILGen: Fix assertion failure when accessing a property with a __consuming getter

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4266,10 +4266,11 @@ bool SILGenModule::shouldEmitSelfAsRValue(FuncDecl *fn, CanType selfType) {
 
 bool SILGenModule::isNonMutatingSelfIndirect(SILDeclRef methodRef) {
   auto method = methodRef.getFuncDecl();
-  assert(method->getDeclContext()->isTypeContext());
-  assert(method->isNonMutating());
   if (method->isStatic())
     return false;
+
+  assert(method->getDeclContext()->isTypeContext());
+  assert(method->isNonMutating() || method->isConsuming());
 
   auto fnType = M.Types.getConstantFunctionType(TypeExpansionContext::minimal(),
                                                 methodRef);

--- a/test/SILGen/value_ownership.swift
+++ b/test/SILGen/value_ownership.swift
@@ -57,3 +57,31 @@ struct Witness: OwnershipProto {
 
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP17elidedPropertyGetSSvgTW :
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s15value_ownership7WitnessVAA14OwnershipProtoA2aDP19explicitPropertyGetSSvgTW :
+
+// Check that references to a consuming getter are lowered properly.
+
+func blackHole<T>(_: T) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s15value_ownership25useConsumingGetterGenericyyxAA14OwnershipProtoRzlF : $@convention(thin) <T where T : OwnershipProto> (@in_guaranteed T) -> () {
+func useConsumingGetterGeneric<T : OwnershipProto>(_ t: T) {
+// CHECK:       [[FN:%.*]] = witness_method $T, #OwnershipProto.explicitPropertyGet!getter : <Self where Self : OwnershipProto> (__owned Self) -> () -> String : $@convention(witness_method: OwnershipProto) <τ_0_0 where τ_0_0 : OwnershipProto> (@in τ_0_0) -> @owned String
+// CHECK-NEXT:  apply [[FN]]<T>({{%.*}}) : $@convention(witness_method: OwnershipProto) <τ_0_0 where τ_0_0 : OwnershipProto> (@in τ_0_0) -> @owned String
+
+  blackHole(t.explicitPropertyGet)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s15value_ownership29useConsumingGetterExistentialyyAA14OwnershipProto_pF : $@convention(thin) (@in_guaranteed OwnershipProto) -> () {
+func useConsumingGetterExistential(_ e: OwnershipProto) {
+// CHECK:      [[FN:%.*]] = witness_method $@opened("{{.*}}") OwnershipProto, #OwnershipProto.explicitPropertyGet!getter : <Self where Self : OwnershipProto> (__owned Self) -> () -> String, %2 : $*@opened("{{.*}}") OwnershipProto : $@convention(witness_method: OwnershipProto) <τ_0_0 where τ_0_0 : OwnershipProto> (@in τ_0_0) -> @owned String
+// CHECK-NEXT: apply [[FN]]<@opened("{{.*}}") OwnershipProto>({{%.*}}) : $@convention(witness_method: OwnershipProto) <τ_0_0 where τ_0_0 : OwnershipProto> (@in τ_0_0) -> @owned String
+
+  blackHole(e.explicitPropertyGet)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s15value_ownership26useConsumingGetterConcreteyyAA7WitnessVF : $@convention(thin) (@guaranteed Witness) -> () {
+func useConsumingGetterConcrete(_ c: Witness) {
+// CHECK:      [[FN:%.*]] = function_ref @$s15value_ownership7WitnessV19explicitPropertyGetSSvg : $@convention(method) (@owned Witness) -> @owned String
+// CHECK-NEXT: apply [[FN]]({{%.*}}) : $@convention(method) (@owned Witness) -> @owned String
+
+  blackHole(c.explicitPropertyGet)
+}


### PR DESCRIPTION
We checked isMutating() on the accessor, and if it was false, called
isNonMutatingSelfIndirect(), which would assert that the accessor
satisfies isNonMutating().

However, isNonMutating() is not the opposite of isMutating(); rather,
one of isMutating(), isNonMutating() or isConsuming() is true.
Change the assertion to reflect this case.

Fixes rdar://problem/74095841.