### PR TITLE
IRGen: Use opaque storage types for non-fixed indirect result types

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1631,10 +1631,13 @@ static ArrayRef<SILArgument *> emitEntryPointIndirectReturn(
     auto &paramTI = IGF.IGM.getTypeInfo(inContextResultType);
 
     // The parameter's type might be different due to looking through opaque
-    // archetypes.
+    // archetypes or for non-fixed types (llvm likes to do type based analysis
+    // for sret arguments and so we use opaque storage types for them).
     llvm::Value *ptr = emission.getIndirectResult(idx);
-    if (paramTI.getStorageType() != retTI.getStorageType()) {
-      assert(inContextResultType.getASTType()->hasOpaqueArchetype());
+    bool isFixedSize = isa<FixedTypeInfo>(paramTI);
+    if (paramTI.getStorageType() != retTI.getStorageType() || !isFixedSize) {
+      assert(!isFixedSize ||
+             inContextResultType.getASTType()->hasOpaqueArchetype());
       ptr = IGF.Builder.CreateBitCast(ptr,
                                       retTI.getStorageType()->getPointerTo());
     }

--- a/test/IRGen/TestABIInaccessible.swift
+++ b/test/IRGen/TestABIInaccessible.swift
@@ -8,7 +8,7 @@ public struct AnotherType<T> {
 }
 
 // Don't pass the metadata of Private<T> to AnotherType<T>'s outlined destroy.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s4main4copyyAA11AnotherTypeVyxGAElF"(%T4main11AnotherTypeV* noalias nocapture sret({{.*}}) %0, %T4main11AnotherTypeV* noalias nocapture %1, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s4main4copyyAA11AnotherTypeVyxGAElF"(%swift.opaque* noalias nocapture sret({{.*}}) %0, %T4main11AnotherTypeV* noalias nocapture %1, %swift.type* %T)
 // CHECK:  [[MD:%.*]] = call swiftcc %swift.metadata_response @"$s4main11AnotherTypeVMa"(i{{.*}} 0, %swift.type* %T)
 // CHECK:  [[MD1:%.*]] = extractvalue %swift.metadata_response [[MD]], 0
 // CHECK:  [[MD2:%.*]] = call swiftcc %swift.metadata_response @"$s4main6PublicVMa"(i{{.*}} 0, %swift.type* %T)

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -203,7 +203,7 @@ public func testGetFunc() {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases7TestBigC4testyyF"(%T22big_types_corner_cases7TestBigC* swiftself %0)
 // CHECK: [[CALL1:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSayy22big_types_corner_cases9BigStructVcSgGMD"
 // CHECK: [[CALL2:%.*]] = call i8** @"$sSayy22big_types_corner_cases9BigStructVcSgGSayxGSlsWl
-// CHECK:  call swiftcc void @"$sSlsE10firstIndex5where0B0QzSgSb7ElementQzKXE_tKF"(%TSq.{{.*}}* noalias nocapture sret({{.*}}) %{{[0-9]+}}, i8* bitcast ({{.*}}* @"$s22big_types_corner_cases9BigStruct{{.*}}_TRTA{{(\.ptrauth)?}}" to i8*), %swift.opaque* %{{[0-9]+}}, %swift.type* %{{[0-9]+}}, i8** [[CALL2]]
+// CHECK:  call swiftcc void @"$sSlsE10firstIndex5where0B0QzSgSb7ElementQzKXE_tKF"(%swift.opaque* noalias nocapture sret({{.*}}) %{{[0-9]+}}, i8* bitcast ({{.*}}* @"$s22big_types_corner_cases9BigStruct{{.*}}_TRTA{{(\.ptrauth)?}}" to i8*), %swift.opaque* %{{[0-9]+}}, %swift.type* %{{[0-9]+}}, i8** [[CALL2]]
 class TestBig {
     typealias Handler = (BigStruct) -> Void
 

--- a/test/IRGen/dynamic_self_cast.swift
+++ b/test/IRGen/dynamic_self_cast.swift
@@ -71,7 +71,7 @@ public class SelfCasts {
     return s as? Self
   }
 
-  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD11ConditionalxSgylFZ"(%TSq* noalias nocapture sret({{.*}}) %0, %swift.type* %T, %swift.type* swiftself %1)
+  // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD11ConditionalxSgylFZ"(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.type* %T, %swift.type* swiftself %1)
   // CHECK: call i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %1, %swift.type* %T, {{.*}})
   // CHECK: ret
   public static func genericFromSelfConditional<T>() -> T? {

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1265,8 +1265,9 @@ end:
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%T4enum20DynamicSinglePayloadO* noalias nocapture sret({{.*}}) %0, %swift.opaque* noalias nocapture %1, %swift.type* %T) {{.*}} {
-// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.opaque* noalias nocapture %1, %swift.type* %T) {{.*}} {
+// CHECK:   [[ARG:%.*]] = bitcast %swift.opaque* %0 to %T4enum20DynamicSinglePayloadO*
+// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* [[ARG]] to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[TMP2]]
@@ -1281,8 +1282,9 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%T4enum20DynamicSinglePayloadO* noalias nocapture sret({{.*}}) %0, %swift.type* %T) {{.*}} {
-// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.type* %T) {{.*}} {
+// CHECK:   [[ARG:%.*]] = bitcast %swift.opaque* %0 to %T4enum20DynamicSinglePayloadO*
+// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* [[ARG]] to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[TMP2]]

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -264,7 +264,7 @@ entry:
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_inject
-// CHECK:         ([[EITHER_OR:%T26enum_dynamic_multi_payload8EitherOrO.*]]* noalias nocapture sret({{.*}}) %0, %swift.type* %T)
+// CHECK:         ([[EITHER_OR:%swift.opaque]]* noalias nocapture sret({{.*}}) %0, %swift.type* %T)
 sil @dynamic_inject : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
   // CHECK: call void @swift_storeEnumTagMultiPayload(%swift.opaque* {{%.*}}, %swift.type* [[TYPE:%.*]], i32 0)
@@ -283,9 +283,10 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
 // CHECK:         ([[EITHER_OR]]* noalias nocapture sret({{.*}}) %0, %swift.type* %T)
 sil @dynamic_project : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
-  // CHECK: bitcast [[EITHER_OR]]* %0 to %swift.opaque*
+  // CHECK: [[ARG:%.*]] = bitcast %swift.opaque* %0 to %T26enum_dynamic_multi_payload8EitherOrO.0
+  // CHECK: bitcast %T26enum_dynamic_multi_payload8EitherOrO.0* [[ARG]] to %swift.opaque*
   %l = unchecked_take_enum_data_addr %e : $*EitherOr<T, Builtin.Int64>, #EitherOr.Left!enumelt
-  // CHECK: bitcast [[EITHER_OR]]* %0 to i64*
+  // CHECK: bitcast %T26enum_dynamic_multi_payload8EitherOrO.0* [[ARG]] to i64*
   %r = unchecked_take_enum_data_addr %e : $*EitherOr<T, Builtin.Int64>, #EitherOr.Right!enumelt
 
   return undef : $()
@@ -333,7 +334,7 @@ next(%x : $Builtin.Int8):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_value_semantics
-// CHECK:         ([[EITHER_OR]]* noalias nocapture sret({{.*}}) %0, [[EITHER_OR]]* noalias nocapture %1, %swift.type* %T)
+// CHECK:         ([[EITHER_OR]]* noalias nocapture sret({{.*}}) %0, %T26enum_dynamic_multi_payload8EitherOrO.0* noalias nocapture %1, %swift.type* %T)
 sil @dynamic_value_semantics : $@convention(thin) <T> (@in EitherOr<T, Builtin.Int64>) -> @out EitherOr<T, Builtin.Int64> {
 entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
@@ -367,7 +368,7 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_value_semantics2
-// CHECK:         ([[EITHER_OR:%T26enum_dynamic_multi_payload8EitherOrO.*]]* noalias nocapture sret({{.*}}) %0, [[EITHER_OR]]* noalias nocapture %1, %swift.type* %T)
+// CHECK:         (%swift.opaque* noalias nocapture sret({{.*}}) %0, %T26enum_dynamic_multi_payload8EitherOrO.1* noalias nocapture %1, %swift.type* %T)
 sil @dynamic_value_semantics2 : $@convention(thin) <T> (@in EitherOr<T, C>) -> @out EitherOr<T, C> {
 entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -1269,8 +1269,9 @@ end:
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%T11enum_future20DynamicSinglePayloadO* noalias nocapture sret({{.*}}) %0, %swift.opaque* noalias nocapture %1, %swift.type* %T) {{.*}} {
-// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T11enum_future20DynamicSinglePayloadO* %0 to %swift.opaque*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.opaque* noalias nocapture %1, %swift.type* %T) {{.*}} {
+// CHECK:   [[ARG:%.*]] = bitcast %swift.opaque* %0 to %T11enum_future20DynamicSinglePayloadO*
+// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T11enum_future20DynamicSinglePayloadO* [[ARG]] to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[TMP2]]
@@ -1285,8 +1286,9 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   return %v : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%T11enum_future20DynamicSinglePayloadO* noalias nocapture sret({{.*}}) %0, %swift.type* %T) {{.*}} {
-// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T11enum_future20DynamicSinglePayloadO* %0 to %swift.opaque*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.type* %T) {{.*}} {
+// CHECK:   [[ARG:%.*]] = bitcast %swift.opaque* %0 to %T11enum_future20DynamicSinglePayloadO*
+// CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T11enum_future20DynamicSinglePayloadO* [[ARG]] to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[TMP2]]

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -341,8 +341,9 @@ extension ResilientMultiPayloadGenericEnum {
   }
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience39constructExhaustiveWithResilientMembers010resilient_A011SimpleShapeOyF"(%T14resilient_enum11SimpleShapeO* noalias nocapture sret({{.*}}) %0)
-// CHECK: [[BUFFER:%.*]] = bitcast %T14resilient_enum11SimpleShapeO* %0 to %swift.opaque*
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s15enum_resilience39constructExhaustiveWithResilientMembers010resilient_A011SimpleShapeOyF"(%swift.opaque* noalias nocapture sret({{.*}}) %0)
+// CHECK: [[ARG:%.*]] = bitcast %swift.opaque* %0 to %T14resilient_enum11SimpleShapeO*
+// CHECK: [[BUFFER:%.*]] = bitcast %T14resilient_enum11SimpleShapeO* [[ARG]] to %swift.opaque*
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s16resilient_struct4SizeVMa"([[INT]] 0)
 // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[STORE_TAG:%.*]] = bitcast i8* {{%.+}} to void (%swift.opaque*, i32, i32, %swift.type*)* 

--- a/test/IRGen/generic_ternary.swift
+++ b/test/IRGen/generic_ternary.swift
@@ -4,7 +4,7 @@
 
 // <rdar://problem/13793646>
 struct OptionalStreamAdaptor<T : IteratorProtocol> {
-  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(%TSq{{.*}}* noalias nocapture sret({{.*}}) %0, %swift.type* %"OptionalStreamAdaptor<T>", %T15generic_ternary21OptionalStreamAdaptorV* nocapture swiftself dereferenceable({{.*}}) %1)
+  // CHECK: define hidden swiftcc void @"$s15generic_ternary21OptionalStreamAdaptorV4next{{[_0-9a-zA-Z]*}}F"(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.type* %"OptionalStreamAdaptor<T>", %T15generic_ternary21OptionalStreamAdaptorV* nocapture swiftself dereferenceable({{.*}}) %1)
   mutating
   func next() -> Optional<T.Element> {
     return x[0].next()

--- a/test/IRGen/multi_file_resilience.swift
+++ b/test/IRGen/multi_file_resilience.swift
@@ -17,6 +17,7 @@
 // rdar://39763787
 
 // CHECK-LABEL: define {{(dllexport |protected )?}}swiftcc void @"$s4main7copyFoo3fooAA0C0VAE_tF"
+// CHECK: [[ARG:%.*]] = bitcast %swift.opaque* %0 to %T4main3FooV
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s4main3FooVMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[VWT:%.*]] = load i8**,
@@ -34,7 +35,7 @@
 // CHECK: [[SRC:%.*]] = bitcast [[FOO]]* %1 to %swift.opaque*
 // CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
 //   Perform 'initializeWithCopy' via the VWT.
-// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* %0 to %swift.opaque*
+// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* [[ARG]] to %swift.opaque*
 // CHECK: [[SRC:%.*]] = bitcast [[FOO]]* [[COPY]] to %swift.opaque*
 // CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
 public func copyFoo(foo: Foo) -> Foo {

--- a/test/IRGen/multi_module_resilience.swift
+++ b/test/IRGen/multi_module_resilience.swift
@@ -16,6 +16,7 @@
 import OtherModule
 
 // CHECK-LABEL: define {{(dllexport |protected )?}}swiftcc void @"$s4main7copyFoo3foo11OtherModule0C0VAF_tF"
+// CHECK: [[SRET:%.*]] = bitcast %swift.opaque* %0 to %T11OtherModule3FooV*
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s11OtherModule3FooVMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[VWT:%.*]] = load i8**,
@@ -33,7 +34,7 @@ import OtherModule
 // CHECK: [[SRC:%.*]] = bitcast [[FOO]]* %1 to %swift.opaque*
 // CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
 //   Perform 'initializeWithCopy' via the VWT.
-// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* %0 to %swift.opaque*
+// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* [[SRET]] to %swift.opaque*
 // CHECK: [[SRC:%.*]] = bitcast [[FOO]]* [[COPY]] to %swift.opaque*
 // CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
 public func copyFoo(foo: Foo) -> Foo {
@@ -42,6 +43,7 @@ public func copyFoo(foo: Foo) -> Foo {
 }
 
 // CHECK-LABEL: define {{(dllexport |protected )?}}swiftcc void @"$s4main7copyBar3bar11OtherModule0C0VAF_tF"
+// CHECK: [[SRET:%.*]] = bitcast %swift.opaque* %0 to %T11OtherModule3BarV*
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s11OtherModule3BarVMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[VWT:%.*]] = load i8**,
@@ -59,7 +61,7 @@ public func copyFoo(foo: Foo) -> Foo {
 // CHECK: [[SRC:%.*]] = bitcast [[BAR]]* %1 to %swift.opaque*
 // CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
 //   Perform 'initializeWithCopy' via the VWT.
-// CHECK: [[DEST:%.*]] = bitcast [[BAR]]* %0 to %swift.opaque*
+// CHECK: [[DEST:%.*]] = bitcast [[BAR]]* [[SRET]] to %swift.opaque*
 // CHECK: [[SRC:%.*]] = bitcast [[BAR]]* [[COPY]] to %swift.opaque*
 // CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
 public func copyBar(bar: Bar) -> Bar {

--- a/test/IRGen/non_fixed_return.swift
+++ b/test/IRGen/non_fixed_return.swift
@@ -1,0 +1,75 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -O -primary-file %s -emit-ir | %FileCheck %s --check-prefix=OPT
+
+// REQUIRES: CPU=x86_64
+
+struct V : OptionSet {
+  var rawValue: UInt64
+
+  init() {
+      self.init(rawValue: 0)
+  }
+
+  init(rawValue: UInt64) {
+      self.rawValue = rawValue
+  }
+
+  subscript(index: Int) -> Bool {
+      get {
+          return (rawValue & UInt64(1) << UInt64(index)) != 0
+      }
+      set {
+          let bit = UInt64(1) << UInt64(index)
+          if newValue {
+              rawValue = rawValue | bit
+          } else {
+              rawValue = rawValue & ~bit
+          }
+      }
+  }
+
+  var count: Int { return 64 }
+  var indices: CountableRange<Int> { return 0 ..< 64 }
+}
+
+struct A {
+    var a = 0.0
+    var a2 = 0.0
+}
+
+struct B {
+  var b: UInt32?
+  var b2 = V()
+  var b3 = 0.0
+}
+
+struct C<Data> {
+   var c = A()
+   var c2: Data?
+   private var c3 = B()
+}
+
+func create<T>(_ t: T) -> C<T> {
+    return C<T>()
+}
+// We use opaque storage types because LLVM performs type based analysis based
+// on the sret storage type which goes wrong with non fixed types.
+
+// CHECK-LABEL: define hidden swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(%swift.opaque* noalias nocapture sret(%swift.opaque) %0
+
+// CHECK-LABEL: define hidden swiftcc void @"$s16non_fixed_return6createyAA1CVyxGxlF"(%swift.opaque* noalias nocapture sret(%swift.opaque) %0, %swift.opaque* noalias nocapture %1, %swift.type* %T)
+// CHECK:  [[CAST_PARAM:%.*]] = bitcast %swift.opaque* %0 to %T16non_fixed_return1CV*
+// CHECK:  [[CAST_ARG:%.*]] = bitcast %T16non_fixed_return1CV* [[CAST_PARAM]] to %swift.opaque*
+// CHECK:  call swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(%swift.opaque* noalias nocapture sret(%swift.opaque) [[CAST_ARG]]
+// CHECK:  ret void
+
+// Make sure we don't loose the stores for the optional UInt32? in optimize mode.
+// OPT-LABEL: define hidden swiftcc void @"$s16non_fixed_return1CVACyxGycfC"(%swift.opaque* noalias nocapture sret(%swift.opaque) %0
+// OPT:  [[ADDR:%.*]] = bitcast i8* [[BASE:%.*]] to i32*
+// OPT:  store i32 0, i32* [[ADDR]]
+// OPT:  [[ADDR2:%.*]] = getelementptr inbounds i8, i8* [[BASE:%.*]], i64 4
+// OPT:  [[ADDR3:%.*]] = bitcast i8* [[ADDR2]] to i1*
+// OPT:  store i1 true, i1* [[ADDR3]]
+// OPT:  [[ADDR4:%.*]] = getelementptr inbounds i8, i8* [[BASE]], i64 8
+// OPT: call void @llvm.memset.p0i8.i64(i8* {{.*}}[[ADDR4]], i8 0, i64 16, i1 false)
+// OPT: ret void

--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -18,7 +18,7 @@ public struct StructWithBaseStruct<T: BaseProt> {
     var elem2: BaseStruct<Element>
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s11outcopyaddr010StructWithbc4BaseB0V4elemAA0bcdB0VyxGvg"(%T11outcopyaddr014StructWithBaseB0V.5* noalias nocapture sret({{.*}}) %0, %swift.type* %"StructWithStructWithBaseStruct<T>", %T11outcopyaddr010StructWithbc4BaseB0V* noalias nocapture swiftself %1)
+// CHECK-LABEL: define hidden swiftcc void @"$s11outcopyaddr010StructWithbc4BaseB0V4elemAA0bcdB0VyxGvg"(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.type* %"StructWithStructWithBaseStruct<T>", %T11outcopyaddr010StructWithbc4BaseB0V* noalias nocapture swiftself %1)
 // CHECK: call %T11outcopyaddr014StructWithBaseB0V.5* @"$s11outcopyaddr014StructWithBaseB0VyxGAA9ChildProtRzlWOc"
 public struct StructWithStructWithBaseStruct<T: ChildProt> {
     public typealias Element = T

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -511,8 +511,9 @@ sil public_external @generic_indirect_return : $@convention(thin) <T> (Int) -> @
 // CHECK: insertvalue {{.*}}$s23generic_indirect_returnTA
 
 // CHECK-LABEL: define internal swiftcc void @"$s23generic_indirect_returnTA"(%T13partial_apply11GenericEnumOySiG* noalias nocapture sret({{.*}}) %0, %swift.refcounted* swiftself
-// CHECK:  [[CASTEDRETURN:%.*]] = bitcast %T13partial_apply11GenericEnumOySiG* %0 to %T13partial_apply11GenericEnumO*
-// CHECK:  call swiftcc void @generic_indirect_return({{.*}}[[CASTEDRETURN]]
+// CHECK:  [[CASTEDRETURN:%.*]] = bitcast %T13partial_apply11GenericEnumOySiG* %0  to %T13partial_apply11GenericEnumO*
+// CHECK:  [[ARG:%.*]] = bitcast %T13partial_apply11GenericEnumO* [[CASTEDRETURN]] to %swift.opaque*
+// CHECK:  call swiftcc void @generic_indirect_return({{.*}}[[ARG]]
 // CHECK:  ret void
 sil @partial_apply_generic_indirect_return : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum<Int> {
   bb0(%0 : $Int):
@@ -541,7 +542,8 @@ sil public_external @generic_indirect_return2 : $@convention(thin) <T> (Int) -> 
 
 // CHECK-LABEL: define internal swiftcc void @"$s24generic_indirect_return2TA"(%T13partial_apply12GenericEnum2OySiG* noalias nocapture sret({{.*}}) %0, %swift.refcounted* swiftself %1)
 // CHECK:  [[CASTED_ADDR:%.*]] = bitcast %T13partial_apply12GenericEnum2OySiG* %0 to %T13partial_apply12GenericEnum2O*
-// CHECK: call swiftcc void @generic_indirect_return2(%T13partial_apply12GenericEnum2O* noalias nocapture sret({{.*}}) [[CASTED_ADDR]]
+// CHECK:  [[ARG:%.*]] = bitcast %T13partial_apply12GenericEnum2O* [[CASTED_ADDR]] to %swift.opaque*
+// CHECK: call swiftcc void @generic_indirect_return2(%swift.opaque* noalias nocapture sret({{.*}}) [[ARG]]
 // CHECK:  ret void
 sil @partial_apply_generic_indirect_return2 : $@convention(thin) (Int) -> @callee_owned () -> @owned GenericEnum2<Int> {
   bb0(%0 : $Int):

--- a/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
+++ b/test/IRGen/prespecialized-metadata/struct-inmodule-1argument-1distinct_generic_use.swift
@@ -24,8 +24,8 @@ func consume<T>(_ t: T) {
 //       themselves generic (Outer<Inner<Int>>, here), a direct reference to
 //       the prespecialized metadata should be emitted here.
 // CHECK: call swiftcc void @"$s4main5OuterV5firstACyxGx_tcfC"(
-// CHECK-SAME:   %T4main5OuterV* noalias nocapture sret({{.*}}) %13, 
-// CHECK-SAME:   %swift.opaque* noalias nocapture %14, 
+// CHECK-SAME:   %swift.opaque* noalias nocapture sret({{.*}}) %{{[0-9]+}},
+// CHECK-SAME:   %swift.opaque* noalias nocapture %{{[0-9]+}}, 
 // CHECK-SAME:   %swift.type* getelementptr inbounds (
 // CHECK-SAME:     %swift.full_type, 
 // CHECK-SAME:     %swift.full_type* bitcast (


### PR DESCRIPTION
LLVM does type based analysis on sret storage types. This is a problem
with non-fixed types whose storage type does not contain the non-fixed
part.

rdar://73778591
