### PR TITLE
[ConstraintSystem] Compute bindings incrementally

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -398,7 +398,7 @@ public:
   }
 
   /// Check if this binding is viable for inclusion in the set.
-  bool isViable(PotentialBinding &binding) const;
+  bool isViable(PotentialBinding &binding);
 
   explicit operator bool() const {
     return hasViableBindings() || isDirectHole();

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -206,11 +206,6 @@ struct LiteralRequirement {
                                     bool canBeNil,
                                     DeclContext *useDC) const;
 
-  void resetCoverage() {
-    assert(isCovered() && "literal requirement is uncovered");
-    CoveredBy = nullptr;
-  }
-
   /// Determines whether literal protocol associated with this
   /// meta-information is viable for inclusion as a defaultable binding.
   bool viableAsBinding() const { return !isCovered() && hasDefaultType(); }
@@ -326,11 +321,11 @@ public:
 
   BindingSet(const PotentialBindings &info)
       : CS(info.CS), TypeVar(info.TypeVar), Info(info) {
-    for (auto *literal : info.Literals)
-      addLiteralRequirement(literal);
-
     for (const auto &binding : info.Bindings)
       addBinding(binding);
+
+    for (auto *literal : info.Literals)
+      addLiteralRequirement(literal);
 
     for (auto *constraint : info.Defaults)
       addDefault(constraint);
@@ -512,7 +507,6 @@ private:
 
   /// Finalize binding computation for this type variable by
   /// inferring bindings from context e.g. transitive bindings.
-
   void finalize(
       llvm::SmallDenseMap<TypeVariableType *, BindingSet> &inferredBindings);
 
@@ -574,6 +568,10 @@ private:
     auto defaultTy = constraint->getSecondType();
     Defaults.insert({defaultTy->getCanonicalType(), constraint});
   }
+
+  /// Check whether the given binding set covers any of the
+  /// literal protocols associated with this type variable.
+  void determineLiteralCoverage();
 };
 
 } // end namespace inference

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -417,8 +417,6 @@ public:
            !Defaults.empty();
   }
 
-  LiteralBindingKind getLiteralKind() const;
-
   ArrayRef<Constraint *> getConformanceRequirements() const {
     return Info.Protocols;
   }
@@ -459,33 +457,10 @@ public:
 
   LiteralBindingKind getLiteralKind() const;
 
-  void addDefault(Constraint *constraint);
-
-  void addLiteral(Constraint *constraint);
-
-  /// Add a potential binding to the list of bindings,
-  /// coalescing supertype bounds when we are able to compute the meet.
-  void addPotentialBinding(PotentialBinding binding, bool allowJoinMeet = true);
-
-  /// Check if this binding is viable for inclusion in the set.
-  bool isViable(PotentialBinding &binding) const;
-
-  bool isGenericParameter() const;
-
-  bool isSubtypeOf(TypeVariableType *typeVar) const {
-    auto result = SubtypeOf.find(typeVar);
-    if (result == SubtypeOf.end())
-      return false;
-
-    auto *constraint = result->second;
-    return constraint->getKind() == ConstraintKind::Subtype;
-  }
-
   /// Check if this binding is favored over a disjunction e.g.
   /// if it has only concrete types or would resolve a closure.
   bool favoredOverDisjunction(Constraint *disjunction) const;
 
-private:
   /// Detect `subtype` relationship between two type variables and
   /// attempt to infer supertype bindings transitively e.g.
   ///
@@ -509,10 +484,6 @@ private:
   /// inferring bindings from context e.g. transitive bindings.
   void finalize(
       llvm::SmallDenseMap<TypeVariableType *, BindingSet> &inferredBindings);
-
-  /// Check if this binding is favored over a disjunction e.g.
-  /// if it has only concrete types or would resolve a closure.
-  bool favoredOverDisjunction(Constraint *disjunction) const;
 
   static BindingScore formBindingScore(const BindingSet &b);
 

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -220,23 +220,16 @@ private:
 };
 
 struct PotentialBindings {
-  using BindingScore =
-      std::tuple<bool, bool, bool, bool, bool, unsigned char, int>;
-
   /// The constraint system this type variable and its bindings belong to.
   ConstraintSystem &CS;
 
   TypeVariableType *TypeVar;
 
   /// The set of potential bindings.
-  llvm::SmallSetVector<PotentialBinding, 4> Bindings;
+  llvm::SmallVector<PotentialBinding, 4> Bindings;
 
   /// The set of protocol requirements placed on this type variable.
   llvm::SmallVector<Constraint *, 4> Protocols;
-
-  /// The set of transitive protocol requirements inferred through
-  /// subtype/conversion/equivalence relations with other type variables.
-  llvm::Optional<llvm::SmallPtrSet<Constraint *, 4>> TransitiveProtocols;
 
   /// The set of unique literal protocol requirements placed on this
   /// type variable or inferred transitively through subtype chains.
@@ -244,10 +237,10 @@ struct PotentialBindings {
   /// Note that ordering is important when it comes to bindings, we'd
   /// like to add any "direct" default types first to attempt them
   /// before transitive ones.
-  llvm::SmallMapVector<ProtocolDecl *, LiteralRequirement, 2> Literals;
+  llvm::SmallPtrSet<Constraint *, 2> Literals;
 
   /// The set of constraints which would be used to infer default types.
-  llvm::SmallDenseMap<CanType, Constraint *, 2> Defaults;
+  llvm::SmallPtrSet<Constraint *, 2> Defaults;
 
   /// The set of constraints which delay attempting this type variable.
   llvm::TinyPtrVector<Constraint *> DelayedBy;
@@ -274,49 +267,81 @@ struct PotentialBindings {
   PotentialBindings(ConstraintSystem &cs, TypeVariableType *typeVar)
       : CS(cs), TypeVar(typeVar) {}
 
-  /// Determine whether the set of bindings is non-empty.
-  explicit operator bool() const {
-    return hasViableBindings()|| isDirectHole();
+  void addDefault(Constraint *constraint);
+
+  void addLiteral(Constraint *constraint);
+
+  /// Add a potential binding to the list of bindings,
+  /// coalescing supertype bounds when we are able to compute the meet.
+  void addPotentialBinding(PotentialBinding binding);
+
+  /// Check if this binding is viable for inclusion in the set.
+  bool isViable(PotentialBinding &binding) const;
+
+  bool isGenericParameter() const;
+
+  bool isSubtypeOf(TypeVariableType *typeVar) const {
+    auto result = SubtypeOf.find(typeVar);
+    if (result == SubtypeOf.end())
+      return false;
+
+    auto *constraint = result->second;
+    return constraint->getKind() == ConstraintKind::Subtype;
   }
 
-  /// Determine whether this set has any "viable" (or non-hole) bindings.
+private:
+  /// Attempt to infer a new binding and other useful information
+  /// (i.e. whether bindings should be delayed) from the given
+  /// relational constraint.
+  Optional<PotentialBinding> inferFromRelational(Constraint *constraint);
+
+public:
+  void infer(Constraint *constraint);
+
+  /// Retract all bindings and other information related to a given
+  /// constraint from this binding set.
   ///
-  /// A viable binding could be - a direct or transitive binding
-  /// inferred from a constraint, literal binding, or defaltable
-  /// binding.
-  ///
-  /// A hole is not considered a viable binding since it doesn't
-  /// add any new type information to constraint system.
-  bool hasViableBindings() const {
-    return !Bindings.empty() || getNumViableLiteralBindings() > 0 ||
-           !Defaults.empty();
+  /// This would happen when constraint is simplified or solver backtracks
+  /// (either from overload choice or (some) type variable binding).
+  void retract(Constraint *constraint);
+};
+
+class BindingSet {
+  using BindingScore =
+      std::tuple<bool, bool, bool, bool, bool, unsigned char, int>;
+
+  ConstraintSystem &CS;
+
+  TypeVariableType *TypeVar;
+
+  PotentialBindings Info;
+
+public:
+  llvm::SmallSetVector<PotentialBinding, 4> Bindings;
+  llvm::SmallMapVector<ProtocolDecl *, LiteralRequirement, 2> Literals;
+  llvm::SmallDenseMap<CanType, Constraint *, 2> Defaults;
+
+  /// The set of transitive protocol requirements inferred through
+  /// subtype/conversion/equivalence relations with other type variables.
+  llvm::Optional<llvm::SmallPtrSet<Constraint *, 4>> TransitiveProtocols;
+
+  BindingSet(const PotentialBindings info)
+      : CS(info.CS), TypeVar(info.TypeVar), Info(info) {
+    for (auto *literal : info.Literals)
+      addLiteralRequirement(literal);
+
+    for (const auto &binding : info.Bindings)
+      addBinding(binding);
+
+    for (auto *constraint : info.Defaults)
+      addDefault(constraint);
   }
 
-  /// Determines whether this type variable could be `nil`,
-  /// which means that all of its bindings should be optional.
+  ConstraintSystem &getConstraintSystem() const { return CS; }
+
+  TypeVariableType *getTypeVariable() const { return Info.TypeVar; }
+
   bool canBeNil() const;
-
-  /// Determine whether attempting this type variable should be
-  /// delayed until the rest of the constraint system is considered
-  /// "fully bound" meaning constraints, which affect completeness
-  /// of the binding set, for this type variable such as - member
-  /// constraint, disjunction, function application etc. - are simplified.
-  ///
-  /// Note that in some situations i.e. when there are no more
-  /// disjunctions or type variables left to attempt, it's still
-  /// okay to attempt "delayed" type variable to make forward progress.
-  bool isDelayed() const;
-
-  /// Whether the bindings of this type involve other type variables,
-  /// or the type variable itself is adjacent to other type variables
-  /// that could become valid bindings in the future.
-  bool involvesTypeVariables() const;
-
-  /// Whether the bindings represent (potentially) incomplete set,
-  /// there is no way to say with absolute certainty if that's the
-  /// case, but that could happen when certain constraints like
-  /// `bind param` are present in the system.
-  bool isPotentiallyIncomplete() const;
 
   /// If this type variable doesn't have any viable bindings, or
   /// if there is only one binding and it's a placeholder type, consider
@@ -340,6 +365,28 @@ struct PotentialBindings {
   /// bound to a placeholder type.
   bool isDirectHole() const;
 
+  /// Determine whether attempting this type variable should be
+  /// delayed until the rest of the constraint system is considered
+  /// "fully bound" meaning constraints, which affect completeness
+  /// of the binding set, for this type variable such as - member
+  /// constraint, disjunction, function application etc. - are simplified.
+  ///
+  /// Note that in some situations i.e. when there are no more
+  /// disjunctions or type variables left to attempt, it's still
+  /// okay to attempt "delayed" type variable to make forward progress.
+  bool isDelayed() const;
+
+  /// Whether the bindings of this type involve other type variables,
+  /// or the type variable itself is adjacent to other type variables
+  /// that could become valid bindings in the future.
+  bool involvesTypeVariables() const;
+
+  /// Whether the bindings represent (potentially) incomplete set,
+  /// there is no way to say with absolute certainty if that's the
+  /// case, but that could happen when certain constraints like
+  /// `bind param` are present in the system.
+  bool isPotentiallyIncomplete() const;
+
   /// Determine if the bindings only constrain the type variable from above
   /// with an existential type; such a binding is not very helpful because
   /// it's impossible to enumerate the existential type's subtypes.
@@ -351,6 +398,29 @@ struct PotentialBindings {
       return binding.BindingType->isExistentialType() &&
              binding.Kind == AllowedBindingKind::Subtypes;
     });
+  }
+
+  explicit operator bool() const {
+    return hasViableBindings() || isDirectHole();
+  }
+
+  /// Determine whether this set has any "viable" (or non-hole) bindings.
+  ///
+  /// A viable binding could be - a direct or transitive binding
+  /// inferred from a constraint, literal binding, or defaltable
+  /// binding.
+  ///
+  /// A hole is not considered a viable binding since it doesn't
+  /// add any new type information to constraint system.
+  bool hasViableBindings() const {
+    return !Bindings.empty() || getNumViableLiteralBindings() > 0 ||
+           !Defaults.empty();
+  }
+
+  LiteralBindingKind getLiteralKind() const;
+
+  ArrayRef<Constraint *> getConformanceRequirements() const {
+    return Info.Protocols;
   }
 
   unsigned getNumViableLiteralBindings() const;
@@ -383,46 +453,8 @@ struct PotentialBindings {
     return numDefaultable - unviable;
   }
 
-  static BindingScore formBindingScore(const PotentialBindings &b);
-
-  /// Compare two sets of bindings, where \c x < y indicates that
-  /// \c x is a better set of bindings that \c y.
-  friend bool operator<(const PotentialBindings &x,
-                        const PotentialBindings &y) {
-    auto xScore = formBindingScore(x);
-    auto yScore = formBindingScore(y);
-
-    if (xScore < yScore)
-      return true;
-
-    if (yScore < xScore)
-      return false;
-
-    auto xDefaults = x.getNumViableDefaultableBindings();
-    auto yDefaults = y.getNumViableDefaultableBindings();
-
-    // If there is a difference in number of default types,
-    // prioritize bindings with fewer of them.
-    if (xDefaults != yDefaults)
-      return xDefaults < yDefaults;
-
-    // If neither type variable is a "hole" let's check whether
-    // there is a subtype relationship between them and prefer
-    // type variable which represents superclass first in order
-    // for "subtype" type variable to attempt more bindings later.
-    // This is required because algorithm can't currently infer
-    // bindings for subtype transitively through superclass ones.
-    if (!(std::get<0>(xScore) && std::get<0>(yScore))) {
-      if (x.isSubtypeOf(y.TypeVar))
-        return false;
-
-      if (y.isSubtypeOf(x.TypeVar))
-        return true;
-    }
-
-    // As a last resort, let's check if the bindings are
-    // potentially incomplete, and if so, let's de-prioritize them.
-    return x.isPotentiallyIncomplete() < y.isPotentiallyIncomplete();
+  ASTNode getAssociatedCodeCompletionToken() const {
+    return Info.AssociatedCodeCompletionToken;
   }
 
   LiteralBindingKind getLiteralKind() const;
@@ -464,41 +496,78 @@ private:
   /// \param inferredBindings The set of all bindings inferred for type
   /// variables in the workset.
   void inferTransitiveBindings(
-      const llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
+      const llvm::SmallDenseMap<TypeVariableType *, BindingSet>
           &inferredBindings);
 
   /// Detect subtype, conversion or equivalence relationship
   /// between two type variables and attempt to propagate protocol
   /// requirements down the subtype or equivalence chain.
   void inferTransitiveProtocolRequirements(
-      llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
-          &inferredBindings);
-
-  /// Attempt to infer a new binding and other useful information
-  /// (i.e. whether bindings should be delayed) from the given
-  /// relational constraint.
-  Optional<PotentialBinding> inferFromRelational(Constraint *constraint);
-
-public:
-  void infer(Constraint *constraint);
-
-  /// Retract all bindings and other information related to a given
-  /// constraint from this binding set.
-  ///
-  /// This would happen when constraint is simplified or solver backtracks
-  /// (either from overload choice or (some) type variable binding).
-  void retract(Constraint *constraint);
+      llvm::SmallDenseMap<TypeVariableType *, BindingSet> &inferredBindings);
 
   /// Finalize binding computation for this type variable by
   /// inferring bindings from context e.g. transitive bindings.
-  void finalize(llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
-                    &inferredBindings);
+  void finalize(
+      llvm::SmallDenseMap<TypeVariableType *, BindingSet> &inferredBindings);
 
-  void dump(llvm::raw_ostream &out,
-            unsigned indent = 0) const LLVM_ATTRIBUTE_USED;
+  /// Check if this binding is favored over a disjunction e.g.
+  /// if it has only concrete types or would resolve a closure.
+  bool favoredOverDisjunction(Constraint *disjunction) const;
 
+  static BindingScore formBindingScore(const BindingSet &b);
+
+  /// Compare two sets of bindings, where \c x < y indicates that
+  /// \c x is a better set of bindings that \c y.
+  friend bool operator<(const BindingSet &x, const BindingSet &y) {
+    auto xScore = formBindingScore(x);
+    auto yScore = formBindingScore(y);
+
+    if (xScore < yScore)
+      return true;
+
+    if (yScore < xScore)
+      return false;
+
+    auto xDefaults = x.getNumViableDefaultableBindings();
+    auto yDefaults = y.getNumViableDefaultableBindings();
+
+    // If there is a difference in number of default types,
+    // prioritize bindings with fewer of them.
+    if (xDefaults != yDefaults)
+      return xDefaults < yDefaults;
+
+    // If neither type variable is a "hole" let's check whether
+    // there is a subtype relationship between them and prefer
+    // type variable which represents superclass first in order
+    // for "subtype" type variable to attempt more bindings later.
+    // This is required because algorithm can't currently infer
+    // bindings for subtype transitively through superclass ones.
+    if (!(std::get<0>(xScore) && std::get<0>(yScore))) {
+      if (x.Info.isSubtypeOf(y.getTypeVariable()))
+        return false;
+
+      if (y.Info.isSubtypeOf(x.getTypeVariable()))
+        return true;
+    }
+
+    // As a last resort, let's check if the bindings are
+    // potentially incomplete, and if so, let's de-prioritize them.
+    return x.isPotentiallyIncomplete() < y.isPotentiallyIncomplete();
+  }
+
+  void dump(llvm::raw_ostream &out, unsigned indent) const;
   void dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
-            unsigned indent = 0) const LLVM_ATTRIBUTE_USED;
+            unsigned indent) const;
+
+private:
+  void addBinding(PotentialBinding binding);
+
+  void addLiteralRequirement(Constraint *literal);
+
+  void addDefault(Constraint *constraint) {
+    auto defaultTy = constraint->getSecondType();
+    Defaults.insert({defaultTy->getCanonicalType(), constraint});
+  }
 };
 
 } // end namespace inference

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -119,12 +119,35 @@ private:
   /// Remove a type variable which used to reference this type variable.
   void removeReferencedBy(TypeVariableType *typeVar);
 
-  /// Experimental {
-  void introduceToInference(Constraint *constraint, bool notifyFixedBindings);
-  void retractFromInference(Constraint *constraint, bool notifyFixedBindings);
-  void reintroduceToInference(Constraint *constraint, bool notifyFixedBindings);
+  /// Binding Inference {
+
+  /// Infer bindings from the given constraint and notify referenced variables
+  /// about its arrival (if requested). This happens every time a new constraint
+  /// gets added to a constraint graph node.
+  void introduceToInference(Constraint *constraint, bool notifyReferencedVars);
+
+  /// Forget about the given constraint. This happens every time a constraint
+  /// gets removed for a constraint graph.
+  void retractFromInference(Constraint *constraint, bool notifyReferencedVars);
+
+  /// Re-evaluate the given constraint. This happens when there are changes
+  /// in associated type variables e.g. bound/unbound to/from a fixed type,
+  /// equivalence class changes.
+  void reintroduceToInference(Constraint *constraint, bool notifyReferencedVars);
+
+  /// Drop all previously collected bindings and re-infer based on the
+  /// current set constraints associated with this equivalence class.
   void resetBindingSet();
-  void updateAdjacentVars() const;
+
+  /// Notify all of the type variables that have this one (or any member of
+  /// its equivalence class) referenced in their fixed type.
+  ///
+  /// This is a traversal up the reference change which triggers constraint
+  /// re-introduction to affected type variables.
+  ///
+  /// This is useful in situations when type variable gets bound and unbound,
+  /// or equivalence class changes.
+  void notifyReferencingVars() const;
   /// }
 
   /// The constraint graph this node belongs to.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -48,14 +48,14 @@ class ConstraintSystem;
 /// A single node in the constraint graph, which represents a type variable.
 class ConstraintGraphNode {
 public:
-  explicit ConstraintGraphNode(ConstraintSystem &cs, TypeVariableType *typeVar)
-      : Bindings(cs, typeVar) {}
+  explicit ConstraintGraphNode(ConstraintGraph &CG, TypeVariableType *typeVar)
+      : CG(CG), TypeVar(typeVar) {}
 
   ConstraintGraphNode(const ConstraintGraphNode&) = delete;
   ConstraintGraphNode &operator=(const ConstraintGraphNode&) = delete;
 
   /// Retrieve the type variable this node represents.
-  TypeVariableType *getTypeVariable() const { return Bindings.TypeVar; }
+  TypeVariableType *getTypeVariable() const { return TypeVar; }
 
   /// Retrieve the set of constraints that mention this type variable.
   ///
@@ -77,7 +77,7 @@ public:
   /// as this type variable.
   ArrayRef<TypeVariableType *> getEquivalenceClass() const;
 
-  inference::PotentialBindings &getBindings() { return Bindings; }
+  inference::PotentialBindings &getBindings() { return *Bindings; }
 
 private:
   /// Determines whether the type variable associated with this node
@@ -119,8 +119,14 @@ private:
   /// Remove a type variable which used to reference this type variable.
   void removeReferencedBy(TypeVariableType *typeVar);
 
+  /// The constraint graph this node belongs to.
+  ConstraintGraph &CG;
+
+  /// The type variable this node represents.
+  TypeVariableType *TypeVar;
+
   /// The set of bindings associated with this type variable.
-  inference::PotentialBindings Bindings;
+  llvm::Optional<inference::PotentialBindings> Bindings;
 
   /// The vector of constraints that mention this type variable, in a stable
   /// order for iteration.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -102,6 +102,9 @@ private:
   /// Add the given type variables to this node's equivalence class.
   void addToEquivalenceClass(ArrayRef<TypeVariableType *> typeVars);
 
+  /// Remove N last members from equivalence class of the current type variable.
+  void truncateEquivalenceClass(unsigned prevSize);
+
   /// Add a type variable related to this type variable through fixed
   /// binding.
   void addReferencedVar(TypeVariableType *typeVar);

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -124,6 +124,7 @@ private:
   void retractFromInference(Constraint *constraint, bool notifyFixedBindings);
   void reintroduceToInference(Constraint *constraint, bool notifyFixedBindings);
   void resetBindingSet();
+  void updateAdjacentVars() const;
   /// }
 
   /// The constraint graph this node belongs to.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -21,6 +21,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Type.h"
+#include "swift/Sema/CSBindings.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/DenseMap.h"
@@ -47,13 +48,14 @@ class ConstraintSystem;
 /// A single node in the constraint graph, which represents a type variable.
 class ConstraintGraphNode {
 public:
-  explicit ConstraintGraphNode(TypeVariableType *typeVar) : TypeVar(typeVar) { }
+  explicit ConstraintGraphNode(ConstraintSystem &cs, TypeVariableType *typeVar)
+      : Bindings(cs, typeVar) {}
 
   ConstraintGraphNode(const ConstraintGraphNode&) = delete;
   ConstraintGraphNode &operator=(const ConstraintGraphNode&) = delete;
 
   /// Retrieve the type variable this node represents.
-  TypeVariableType *getTypeVariable() const { return TypeVar; }
+  TypeVariableType *getTypeVariable() const { return Bindings.TypeVar; }
 
   /// Retrieve the set of constraints that mention this type variable.
   ///
@@ -74,6 +76,8 @@ public:
   /// Retrieve all of the type variables in the same equivalence class
   /// as this type variable.
   ArrayRef<TypeVariableType *> getEquivalenceClass() const;
+
+  inference::PotentialBindings &getBindings() { return Bindings; }
 
 private:
   /// Determines whether the type variable associated with this node
@@ -112,8 +116,8 @@ private:
   /// Remove a type variable which used to reference this type variable.
   void removeReferencedBy(TypeVariableType *typeVar);
 
-  /// The type variable this node represents.
-  TypeVariableType *TypeVar;
+  /// The set of bindings associated with this type variable.
+  inference::PotentialBindings Bindings;
 
   /// The vector of constraints that mention this type variable, in a stable
   /// order for iteration.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -77,7 +77,7 @@ public:
   /// as this type variable.
   ArrayRef<TypeVariableType *> getEquivalenceClass() const;
 
-  inference::PotentialBindings &getBindings() { return *Bindings; }
+  inference::PotentialBindings &getCurrentBindings();
 
 private:
   /// Determines whether the type variable associated with this node
@@ -118,6 +118,13 @@ private:
 
   /// Remove a type variable which used to reference this type variable.
   void removeReferencedBy(TypeVariableType *typeVar);
+
+  /// Experimental {
+  void introduceToInference(Constraint *constraint, bool notifyFixedBindings);
+  void retractFromInference(Constraint *constraint, bool notifyFixedBindings);
+  void reintroduceToInference(Constraint *constraint, bool notifyFixedBindings);
+  void resetBindingSet();
+  /// }
 
   /// The constraint graph this node belongs to.
   ConstraintGraph &CG;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4635,9 +4635,9 @@ public:
 
   Optional<BindingSet> determineBestBindings();
 
-  /// Infer bindings for the given type variable based on current
+  /// Get bindings for the given type variable based on current
   /// state of the constraint system.
-  BindingSet inferBindingsFor(TypeVariableType *typeVar, bool finalize = true);
+  BindingSet getBindingsFor(TypeVariableType *typeVar);
 
 private:
   /// Add a constraint to the constraint system.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4637,7 +4637,7 @@ public:
 
   /// Get bindings for the given type variable based on current
   /// state of the constraint system.
-  BindingSet getBindingsFor(TypeVariableType *typeVar);
+  BindingSet getBindingsFor(TypeVariableType *typeVar, bool finalize = true);
 
 private:
   /// Add a constraint to the constraint system.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4633,12 +4633,11 @@ public:
       ConstraintKind bodyResultConstraintKind,
       ConstraintLocatorBuilder locator);
 
-  Optional<PotentialBindings> determineBestBindings();
+  Optional<BindingSet> determineBestBindings();
 
   /// Infer bindings for the given type variable based on current
   /// state of the constraint system.
-  PotentialBindings inferBindingsFor(TypeVariableType *typeVar,
-                                     bool finalize = true);
+  BindingSet inferBindingsFor(TypeVariableType *typeVar, bool finalize = true);
 
 private:
   /// Add a constraint to the constraint system.
@@ -5406,7 +5405,7 @@ class TypeVarBindingProducer : public BindingProducer<TypeVariableBinding> {
 public:
   using Element = TypeVariableBinding;
 
-  TypeVarBindingProducer(PotentialBindings &bindings);
+  TypeVarBindingProducer(BindingSet &bindings);
 
   /// Retrieve a set of bindings available in the current state.
   ArrayRef<Binding> getCurrentBindings() const { return Bindings; }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -579,7 +579,7 @@ void BindingSet::determineLiteralCoverage() {
       }
 
       std::tie(isCovered, adjustedTy) =
-          literalInfo.isCoveredBy(*binding, CS.DC, allowsNil);
+          literalInfo.isCoveredBy(*binding, allowsNil, CS.DC);
 
       if (isCovered) {
         literalInfo.setCoveredBy(binding->getSource());

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -453,7 +453,7 @@ void BindingSet::finalize(
       if (!hasViableBindings() && TransitiveProtocols.hasValue()) {
         for (auto *constraint : *TransitiveProtocols) {
           auto protocolTy = constraint->getSecondType();
-          addPotentialBinding(
+          addBinding(
               {protocolTy, AllowedBindingKind::Exact, constraint});
         }
       }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -909,7 +909,7 @@ bool BindingSet::isViable(PotentialBinding &binding) const {
 
     for (auto &existing : Bindings) {
       auto *existingNTD = existing.BindingType->getAnyNominal();
-      if (existingNTD && NTD == existingNTD && existing.Kind == binding.Kind)
+      if (existingNTD && NTD == existingNTD)
         return false;
     }
   }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -25,19 +25,19 @@ using namespace swift;
 using namespace constraints;
 using namespace inference;
 
-bool PotentialBindings::canBeNil() const {
+bool BindingSet::canBeNil() const {
   auto &ctx = CS.getASTContext();
   return Literals.count(
       ctx.getProtocol(KnownProtocolKind::ExpressibleByNilLiteral));
 }
 
-bool PotentialBindings::isDirectHole() const {
+bool BindingSet::isDirectHole() const {
   // Direct holes are only allowed in "diagnostic mode".
   if (!CS.shouldAttemptFixes())
     return false;
 
   return Bindings.empty() && getNumViableLiteralBindings() == 0 &&
-         Defaults.empty() && TypeVar->getImpl().canBindToHole();
+         Defaults.empty() && Info.TypeVar->getImpl().canBindToHole();
 }
 
 bool PotentialBindings::isGenericParameter() const {
@@ -56,7 +56,7 @@ bool PotentialBinding::isViableForJoin() const {
          !isDefaultableBinding();
 }
 
-bool PotentialBindings::isDelayed() const {
+bool BindingSet::isDelayed() const {
   if (auto *locator = TypeVar->getImpl().getLocator()) {
     if (locator->isLastElement<LocatorPathElt::MemberRefBase>()) {
       // If first binding is a "fallback" to a protocol type,
@@ -110,7 +110,7 @@ bool PotentialBindings::isDelayed() const {
     // because it's possible that variable is marked as a "hole"
     // (or that status is propagated to it) after constraints
     // mentioned below are recorded.
-    return llvm::any_of(DelayedBy, [&](Constraint *constraint) {
+    return llvm::any_of(Info.DelayedBy, [&](Constraint *constraint) {
       switch (constraint->getKind()) {
       case ConstraintKind::ApplicableFunction:
       case ConstraintKind::DynamicCallableApplicableFunction:
@@ -125,29 +125,29 @@ bool PotentialBindings::isDelayed() const {
     });
   }
 
-  return !DelayedBy.empty();
+  return !Info.DelayedBy.empty();
 }
 
-bool PotentialBindings::involvesTypeVariables() const {
+bool BindingSet::involvesTypeVariables() const {
   // This is effectively O(1) right now since bindings are re-computed
   // on each step of the solver, but once bindings are computed
   // incrementally it becomes more important to double-check that
   // any adjacent type variables found previously are still unresolved.
-  return llvm::any_of(AdjacentVars, [](const auto &adjacent) {
+  return llvm::any_of(Info.AdjacentVars, [](const auto &adjacent) {
     return !adjacent.first->getImpl().getFixedType(/*record=*/nullptr);
   });
 }
 
-bool PotentialBindings::isPotentiallyIncomplete() const {
+bool BindingSet::isPotentiallyIncomplete() const {
   // Generic parameters are always potentially incomplete.
-  if (isGenericParameter())
+  if (Info.isGenericParameter())
     return true;
 
   // If current type variable is associated with a code completion token
   // it's possible that it doesn't have enough contextual information
   // to be resolved to anything so let's delay considering it until everything
   // else is resolved.
-  if (AssociatedCodeCompletionToken)
+  if (Info.AssociatedCodeCompletionToken)
     return true;
 
   auto *locator = TypeVar->getImpl().getLocator();
@@ -217,7 +217,7 @@ bool PotentialBindings::isPotentiallyIncomplete() const {
   // represents result type of the closure body, because
   // left-hand side gets types from overload choices.
   if (llvm::any_of(
-          EquivalentTo,
+          Info.EquivalentTo,
           [&](const std::pair<TypeVariableType *, Constraint *> &equivalence) {
             auto *constraint = equivalence.second;
             return constraint->getKind() == ConstraintKind::BindParam &&
@@ -228,9 +228,8 @@ bool PotentialBindings::isPotentiallyIncomplete() const {
   return false;
 }
 
-void PotentialBindings::inferTransitiveProtocolRequirements(
-    llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
-        &inferredBindings) {
+void BindingSet::inferTransitiveProtocolRequirements(
+    llvm::SmallDenseMap<TypeVariableType *, BindingSet> &inferredBindings) {
   if (TransitiveProtocols)
     return;
 
@@ -249,7 +248,7 @@ void PotentialBindings::inferTransitiveProtocolRequirements(
 
   auto propagateProtocolsTo =
       [&protocols](TypeVariableType *dstVar,
-                   const SmallVectorImpl<Constraint *> &direct,
+                   const ArrayRef<Constraint *> &direct,
                    const SmallPtrSetImpl<Constraint *> &transitive) {
         auto &destination = protocols[dstVar];
 
@@ -280,19 +279,19 @@ void PotentialBindings::inferTransitiveProtocolRequirements(
       TypeVariableType *parent = nullptr;
       std::tie(parent, currentVar) = workList.pop_back_val();
       assert(parent);
-      propagateProtocolsTo(parent, bindings.Protocols,
+      propagateProtocolsTo(parent, bindings.getConformanceRequirements(),
                            *bindings.TransitiveProtocols);
       continue;
     }
 
-    for (const auto &entry : bindings.SubtypeOf)
+    for (const auto &entry : bindings.Info.SubtypeOf)
       addToWorkList(currentVar, entry.first);
 
     // If current type variable is part of an equivalence
     // class, make it a "representative" and let's it infer
     // supertypes and direct protocol requirements from
     // other members.
-    for (const auto &entry : bindings.EquivalentTo) {
+    for (const auto &entry : bindings.Info.EquivalentTo) {
       auto eqBindings = inferredBindings.find(entry.first);
       if (eqBindings != inferredBindings.end()) {
         const auto &bindings = eqBindings->getSecond();
@@ -301,12 +300,13 @@ void PotentialBindings::inferTransitiveProtocolRequirements(
         // Add any direct protocols from members of the
         // equivalence class, so they could be propagated
         // to all of the members.
-        propagateProtocolsTo(currentVar, bindings.Protocols, placeholder);
+        propagateProtocolsTo(currentVar, bindings.getConformanceRequirements(),
+                             placeholder);
 
         // Since type variables are equal, current type variable
         // becomes a subtype to any supertype found in the current
         // equivalence  class.
-        for (const auto &eqEntry : bindings.SubtypeOf)
+        for (const auto &eqEntry : bindings.Info.SubtypeOf)
           addToWorkList(currentVar, eqEntry.first);
       }
     }
@@ -322,7 +322,8 @@ void PotentialBindings::inferTransitiveProtocolRequirements(
     // are transitive to its parent, propogate them down the subtype/equivalence
     // chain.
     if (parent) {
-      propagateProtocolsTo(parent, bindings.Protocols, protocols[currentVar]);
+      propagateProtocolsTo(parent, bindings.getConformanceRequirements(),
+                           protocols[currentVar]);
     }
 
     auto inferredProtocols = std::move(protocols[currentVar]);
@@ -335,8 +336,9 @@ void PotentialBindings::inferTransitiveProtocolRequirements(
     // - all of the transitive protocols inferred through
     //   the members of the equivalence class.
     {
-      protocolsForEquivalence.insert(bindings.Protocols.begin(),
-                                     bindings.Protocols.end());
+      auto directRequirements = bindings.getConformanceRequirements();
+      protocolsForEquivalence.insert(directRequirements.begin(),
+                                     directRequirements.end());
 
       protocolsForEquivalence.insert(inferredProtocols.begin(),
                                      inferredProtocols.end());
@@ -344,7 +346,7 @@ void PotentialBindings::inferTransitiveProtocolRequirements(
 
     // Propogate inferred protocols to all of the members of the
     // equivalence class.
-    for (const auto &equivalence : bindings.EquivalentTo) {
+    for (const auto &equivalence : bindings.Info.EquivalentTo) {
       auto eqBindings = inferredBindings.find(equivalence.first);
       if (eqBindings != inferredBindings.end()) {
         auto &bindings = eqBindings->getSecond();
@@ -358,12 +360,12 @@ void PotentialBindings::inferTransitiveProtocolRequirements(
   } while (!workList.empty());
 }
 
-void PotentialBindings::inferTransitiveBindings(
-    const llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
+void BindingSet::inferTransitiveBindings(
+    const llvm::SmallDenseMap<TypeVariableType *, BindingSet>
         &inferredBindings) {
   using BindingKind = AllowedBindingKind;
 
-  for (const auto &entry : SupertypeOf) {
+  for (const auto &entry : Info.SupertypeOf) {
     auto relatedBindings = inferredBindings.find(entry.first);
     if (relatedBindings == inferredBindings.end())
       continue;
@@ -393,7 +395,7 @@ void PotentialBindings::inferTransitiveBindings(
     // `ExpressibleByStringLiteral` conformance, we'd end up picking
     // `T` with only one type `Any?` which is incorrect.
     for (const auto &literal : bindings.Literals)
-      addLiteral(literal.second.getSource());
+      addLiteralRequirement(literal.second.getSource());
 
     // Infer transitive defaults.
     for (const auto &def : bindings.Defaults) {
@@ -424,15 +426,13 @@ void PotentialBindings::inferTransitiveBindings(
       if (ConstraintSystem::typeVarOccursInType(TypeVar, type))
         continue;
 
-      (void)addPotentialBinding(
-          binding.withSameSource(type, BindingKind::Supertypes));
+      addBinding(binding.withSameSource(type, BindingKind::Supertypes));
     }
   }
 }
 
-void PotentialBindings::finalize(
-    llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>
-        &inferredBindings) {
+void BindingSet::finalize(
+    llvm::SmallDenseMap<TypeVariableType *, BindingSet> &inferredBindings) {
   inferTransitiveProtocolRequirements(inferredBindings);
   inferTransitiveBindings(inferredBindings);
 
@@ -481,8 +481,173 @@ void PotentialBindings::finalize(
   }
 }
 
-PotentialBindings::BindingScore
-PotentialBindings::formBindingScore(const PotentialBindings &b) {
+void BindingSet::addBinding(PotentialBinding binding) {
+  if (Bindings.count(binding))
+    return;
+
+  // If this is a non-defaulted supertype binding,
+  // check whether we can combine it with another
+  // supertype binding by computing the 'join' of the types.
+  if (binding.isViableForJoin()) {
+    auto isAcceptableJoin = [](Type type) {
+      return !type->isAny() && (!type->getOptionalObjectType() ||
+                                !type->getOptionalObjectType()->isAny());
+    };
+
+    SmallVector<PotentialBinding, 4> joined;
+    for (auto existingBinding = Bindings.begin();
+         existingBinding != Bindings.end();) {
+      if (existingBinding->isViableForJoin()) {
+        auto join =
+            Type::join(existingBinding->BindingType, binding.BindingType);
+
+        if (join && isAcceptableJoin(*join)) {
+          // Result of the join has to use new binding because it refers
+          // to the constraint that triggered the join that replaced the
+          // existing binding.
+          joined.push_back(binding.withType(*join));
+          // Remove existing binding from the set.
+          // It has to be re-introduced later, since its type has been changed.
+          existingBinding = Bindings.erase(existingBinding);
+          continue;
+        }
+      }
+
+      ++existingBinding;
+    }
+
+    for (const auto &binding : joined)
+      (void)Bindings.insert(binding);
+
+    // If new binding has been joined with at least one of existing
+    // bindings, there is no reason to include it into the set.
+    if (!joined.empty())
+      return;
+  }
+
+  // Check whether the given binding covers any of the literal protocols
+  // associated with this type variable.
+  {
+    bool allowsNil = canBeNil();
+
+    for (auto &literal : Literals) {
+      auto *protocol = literal.first;
+
+      // Skip conformance to `nil` protocol since it doesn't
+      // have a default type and can't affect binding set.
+      if (protocol->isSpecificProtocol(
+              KnownProtocolKind::ExpressibleByNilLiteral))
+        continue;
+
+      auto &info = literal.second;
+
+      if (!info.viableAsBinding())
+        continue;
+
+      bool isCovered = false;
+      Type adjustedTy;
+
+      std::tie(isCovered, adjustedTy) =
+          isLiteralCoveredBy(info, binding, allowsNil);
+
+      if (!isCovered)
+        continue;
+
+      binding = binding.withType(adjustedTy);
+      info.setCoveredBy(binding.getSource());
+    }
+  }
+
+  Bindings.insert(std::move(binding));
+>>>>>>> [CSBindings] Separate inference from final product
+}
+
+void BindingSet::addLiteralRequirement(Constraint *constraint) {
+  auto isDirectRequirement = [&](Constraint *constraint) -> bool {
+    if (auto *typeVar = constraint->getFirstType()->getAs<TypeVariableType>()) {
+      auto *repr = CS.getRepresentative(typeVar);
+      return repr == TypeVar;
+    }
+
+    return false;
+  };
+
+  auto *protocol = constraint->getProtocol();
+
+  // Let's try to coalesce integer and floating point literal protocols
+  // if they appear together because the only possible default type that
+  // could satisfy both requirements is `Double`.
+  {
+    if (protocol->isSpecificProtocol(
+            KnownProtocolKind::ExpressibleByIntegerLiteral)) {
+      auto *floatLiteral = CS.getASTContext().getProtocol(
+          KnownProtocolKind::ExpressibleByFloatLiteral);
+      if (Literals.count(floatLiteral))
+        return;
+    }
+
+    if (protocol->isSpecificProtocol(
+            KnownProtocolKind::ExpressibleByFloatLiteral)) {
+      auto *intLiteral = CS.getASTContext().getProtocol(
+          KnownProtocolKind::ExpressibleByIntegerLiteral);
+      Literals.erase(intLiteral);
+    }
+  }
+
+  if (Literals.count(protocol) > 0)
+    return;
+
+  bool isDirect = isDirectRequirement(constraint);
+
+  // Coverage is not applicable to `ExpressibleByNilLiteral` since it
+  // doesn't have a default type.
+  if (protocol->isSpecificProtocol(
+          KnownProtocolKind::ExpressibleByNilLiteral)) {
+    Literals.insert(
+        {protocol, LiteralRequirement(constraint,
+                                      /*DefaultType=*/Type(), isDirect)});
+    return;
+  }
+
+  // Check whether any of the existing bindings covers this literal
+  // protocol.
+  LiteralRequirement literal(
+      constraint, TypeChecker::getDefaultType(protocol, CS.DC), isDirect);
+
+  if (literal.viableAsBinding()) {
+    bool allowsNil = canBeNil();
+
+    for (auto binding = Bindings.begin(); binding != Bindings.end();
+         ++binding) {
+      bool isCovered = false;
+      Type adjustedTy;
+
+      std::tie(isCovered, adjustedTy) =
+          isLiteralCoveredBy(literal, *binding, allowsNil);
+
+      // No luck here, let's try next literal requirement.
+      if (!isCovered)
+        continue;
+
+      // If the type has been adjusted, we need to re-insert
+      // the binding but skip all of the previous checks.
+      //
+      // It's okay to do this here since iteration stops after
+      // first covering binding has been found.
+      if (adjustedTy) {
+        Bindings.erase(binding);
+        Bindings.insert(binding->withType(adjustedTy));
+      }
+
+      literal.setCoveredBy(binding->getSource());
+      break;
+    }
+  }
+
+  Literals.insert({protocol, std::move(literal)});
+}
+
+BindingSet::BindingScore BindingSet::formBindingScore(const BindingSet &b) {
   // If there are no bindings available but this type
   // variable represents a closure - let's consider it
   // as having a single non-default binding - that would
@@ -502,10 +667,10 @@ PotentialBindings::formBindingScore(const PotentialBindings &b) {
                          -numNonDefaultableBindings);
 }
 
-Optional<PotentialBindings> ConstraintSystem::determineBestBindings() {
+Optional<BindingSet> ConstraintSystem::determineBestBindings() {
   // Look for potential type variable bindings.
-  Optional<PotentialBindings> bestBindings;
-  llvm::SmallDenseMap<TypeVariableType *, PotentialBindings> cache;
+  Optional<BindingSet> bestBindings;
+  llvm::SmallDenseMap<TypeVariableType *, BindingSet> cache;
 
   // First, let's collect all of the possible bindings.
   for (auto *typeVar : getTypeVariables()) {
@@ -519,8 +684,8 @@ Optional<PotentialBindings> ConstraintSystem::determineBestBindings() {
   // types, default types from "defaultable" constraints or literal
   // conformances, such type variable is not viable to be evaluated to be
   // attempted next.
-  auto isViableForRanking = [this](const PotentialBindings &bindings) -> bool {
-    auto *typeVar = bindings.TypeVar;
+  auto isViableForRanking = [this](const BindingSet &bindings) -> bool {
+    auto *typeVar = bindings.getTypeVariable();
 
     // Type variable representing a base of unresolved member chain should
     // always be considered viable for ranking since it's allow to infer
@@ -564,9 +729,11 @@ Optional<PotentialBindings> ConstraintSystem::determineBestBindings() {
     if (!bindings || !isViable)
       continue;
 
+    /*
     if (isDebugMode()) {
       bindings.dump(typeVar, llvm::errs(), solverState->depth * 2);
     }
+    */
 
     // If these are the first bindings, or they are better than what
     // we saw before, use them instead.
@@ -611,8 +778,7 @@ findInferableTypeVars(Type type,
 }
 
 void PotentialBindings::addDefault(Constraint *constraint) {
-  auto defaultTy = constraint->getSecondType();
-  Defaults.insert({defaultTy->getCanonicalType(), constraint});
+  Defaults.insert(constraint);
 }
 
 bool LiteralRequirement::isCoveredBy(Type type, DeclContext *useDC) const {
@@ -691,52 +857,8 @@ LiteralRequirement::isCoveredBy(const PotentialBinding &binding,
   } while (true);
 }
 
-void PotentialBindings::addPotentialBinding(PotentialBinding binding,
-                                            bool allowJoinMeet) {
+void PotentialBindings::addPotentialBinding(PotentialBinding binding) {
   assert(!binding.BindingType->is<ErrorType>());
-
-  if (Bindings.count(binding))
-    return;
-
-  // If this is a non-defaulted supertype binding,
-  // check whether we can combine it with another
-  // supertype binding by computing the 'join' of the types.
-  if (binding.isViableForJoin() && allowJoinMeet) {
-    auto isAcceptableJoin = [](Type type) {
-      return !type->isAny() && (!type->getOptionalObjectType() ||
-                                !type->getOptionalObjectType()->isAny());
-    };
-
-    SmallVector<PotentialBinding, 4> joined;
-    for (auto existingBinding = Bindings.begin();
-         existingBinding != Bindings.end();) {
-      if (existingBinding->isViableForJoin()) {
-        auto join =
-            Type::join(existingBinding->BindingType, binding.BindingType);
-
-        if (join && isAcceptableJoin(*join)) {
-          // Result of the join has to use new binding because it refers
-          // to the constraint that triggered the join that replaced the
-          // existing binding.
-          joined.push_back(binding.withType(*join));
-          // Remove existing binding from the set.
-          // It has to be re-introduced later, since its type has been changed.
-          existingBinding = Bindings.erase(existingBinding);
-          continue;
-        }
-      }
-
-      ++existingBinding;
-    }
-
-    for (const auto &binding : joined)
-      (void)Bindings.insert(binding);
-
-    // If new binding has been joined with at least one of existing
-    // bindings, there is no reason to include it into the set.
-    if (!joined.empty())
-      return;
-  }
 
   // If the type variable can't bind to an lvalue, make sure the
   // type we pick isn't an lvalue.
@@ -748,125 +870,11 @@ void PotentialBindings::addPotentialBinding(PotentialBinding binding,
   if (!isViable(binding))
     return;
 
-  // Check whether the given binding covers any of the literal protocols
-  // associated with this type variable.
-  {
-    bool allowsNil = canBeNil();
-
-    for (auto &literal : Literals) {
-      auto *protocol = literal.first;
-
-      // Skip conformance to `nil` protocol since it doesn't
-      // have a default type and can't affect binding set.
-      if (protocol->isSpecificProtocol(
-              KnownProtocolKind::ExpressibleByNilLiteral))
-        continue;
-
-      auto &info = literal.second;
-
-      if (!info.viableAsBinding())
-        continue;
-
-      bool isCovered = false;
-      Type adjustedTy;
-
-      std::tie(isCovered, adjustedTy) =
-          info.isCoveredBy(binding, allowsNil, CS.DC);
-
-      if (!isCovered)
-        continue;
-
-      binding = binding.withType(adjustedTy);
-      info.setCoveredBy(binding.getSource());
-    }
-  }
-
-  Bindings.insert(std::move(binding));
+  Bindings.push_back(std::move(binding));
 }
 
 void PotentialBindings::addLiteral(Constraint *constraint) {
-  auto isDirectRequirement = [&](Constraint *constraint) -> bool {
-    if (auto *typeVar = constraint->getFirstType()->getAs<TypeVariableType>()) {
-      auto *repr = CS.getRepresentative(typeVar);
-      return repr == TypeVar;
-    }
-
-    return false;
-  };
-
-  auto *protocol = constraint->getProtocol();
-
-  // Let's try to coalesce integer and floating point literal protocols
-  // if they appear together because the only possible default type that
-  // could satisfy both requirements is `Double`.
-  {
-    if (protocol->isSpecificProtocol(
-            KnownProtocolKind::ExpressibleByIntegerLiteral)) {
-      auto *floatLiteral = CS.getASTContext().getProtocol(
-          KnownProtocolKind::ExpressibleByFloatLiteral);
-      if (Literals.count(floatLiteral))
-        return;
-    }
-
-    if (protocol->isSpecificProtocol(
-            KnownProtocolKind::ExpressibleByFloatLiteral)) {
-      auto *intLiteral = CS.getASTContext().getProtocol(
-          KnownProtocolKind::ExpressibleByIntegerLiteral);
-      Literals.erase(intLiteral);
-    }
-  }
-
-  if (Literals.count(protocol) > 0)
-    return;
-
-  bool isDirect = isDirectRequirement(constraint);
-
-  // Coverage is not applicable to `ExpressibleByNilLiteral` since it
-  // doesn't have a default type.
-  if (protocol->isSpecificProtocol(
-          KnownProtocolKind::ExpressibleByNilLiteral)) {
-    Literals.insert(
-        {protocol, LiteralRequirement(constraint,
-                                      /*DefaultType=*/Type(), isDirect)});
-    return;
-  }
-
-  // Check whether any of the existing bindings covers this literal
-  // protocol.
-  LiteralRequirement literal(
-      constraint, TypeChecker::getDefaultType(protocol, CS.DC), isDirect);
-
-  if (literal.viableAsBinding()) {
-    bool allowsNil = canBeNil();
-
-    for (auto binding = Bindings.begin(); binding != Bindings.end();
-         ++binding) {
-      bool isCovered = false;
-      Type adjustedTy;
-
-      std::tie(isCovered, adjustedTy) =
-          literal.isCoveredBy(*binding, allowsNil, CS.DC);
-
-      // No luck here, let's try next literal requirement.
-      if (!isCovered)
-        continue;
-
-      // If the type has been adjusted, we need to re-insert
-      // the binding but skip all of the previous checks.
-      //
-      // It's okay to do this here since iteration stops after
-      // first covering binding has been found.
-      if (adjustedTy) {
-        Bindings.erase(binding);
-        Bindings.insert(binding->withType(adjustedTy));
-      }
-
-      literal.setCoveredBy(binding->getSource());
-      break;
-    }
-  }
-
-  Literals.insert({protocol, std::move(literal)});
+  Literals.insert(constraint);
 }
 
 bool PotentialBindings::isViable(PotentialBinding &binding) const {
@@ -891,7 +899,7 @@ bool PotentialBindings::isViable(PotentialBinding &binding) const {
   return true;
 }
 
-bool PotentialBindings::favoredOverDisjunction(Constraint *disjunction) const {
+bool BindingSet::favoredOverDisjunction(Constraint *disjunction) const {
   if (isHole() || isDelayed())
     return false;
 
@@ -921,8 +929,8 @@ bool PotentialBindings::favoredOverDisjunction(Constraint *disjunction) const {
   return !involvesTypeVariables();
 }
 
-PotentialBindings ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar,
-                                                     bool finalize) {
+BindingSet ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar,
+                                              bool finalize) {
   assert(typeVar->getImpl().getRepresentative(nullptr) == typeVar &&
          "not a representative");
   assert(!typeVar->getImpl().getFixedType(nullptr) && "has a fixed type");
@@ -936,13 +944,14 @@ PotentialBindings ConstraintSystem::inferBindingsFor(TypeVariableType *typeVar,
   for (auto *constraint : constraints)
     bindings.infer(constraint);
 
-  if (finalize) {
-    llvm::SmallDenseMap<TypeVariableType *, PotentialBindings> inferred;
+  BindingSet result{bindings};
 
-    bindings.finalize(inferred);
+  if (finalize) {
+    llvm::SmallDenseMap<TypeVariableType *, BindingSet> inferred;
+    result.finalize(inferred);
   }
 
-  return bindings;
+  return result;
 }
 
 /// Check whether the given type can be used as a binding for the given
@@ -1343,9 +1352,12 @@ void PotentialBindings::infer(Constraint *constraint) {
 }
 
 void PotentialBindings::retract(Constraint *constraint) {
-  Bindings.remove_if([&constraint](const PotentialBinding &binding) {
-    return binding.getSource() == constraint;
-  });
+  Bindings.erase(
+      llvm::remove_if(Bindings,
+                      [&constraint](const PotentialBinding &binding) {
+                        return binding.getSource() == constraint;
+                      }),
+      Bindings.end());
 
   auto isMatchingConstraint = [&constraint](Constraint *existing) {
     return existing == constraint;
@@ -1365,13 +1377,12 @@ void PotentialBindings::retract(Constraint *constraint) {
     break;
 
   case ConstraintKind::LiteralConformsTo:
-    Literals.erase(constraint->getProtocol());
+    Literals.erase(constraint);
     break;
 
   case ConstraintKind::Defaultable:
   case ConstraintKind::DefaultClosureType: {
-    auto defaultType = constraint->getSecondType();
-    Defaults.erase(defaultType->getCanonicalType());
+    Defaults.erase(constraint);
     break;
   }
 
@@ -1390,11 +1401,6 @@ void PotentialBindings::retract(Constraint *constraint) {
       AdjacentVars.erase(std::make_pair(adjacentVar, constraint));
   }
 
-  for (auto &literal : Literals) {
-    if (literal.second.CoveredBy == constraint)
-      literal.second.resetCoverage();
-  }
-
   DelayedBy.erase(llvm::remove_if(DelayedBy, isMatchingConstraint),
                   DelayedBy.end());
 
@@ -1403,7 +1409,7 @@ void PotentialBindings::retract(Constraint *constraint) {
   EquivalentTo.remove_if(hasMatchingSource);
 }
 
-LiteralBindingKind PotentialBindings::getLiteralKind() const {
+LiteralBindingKind BindingSet::getLiteralKind() const {
   LiteralBindingKind kind = LiteralBindingKind::None;
 
   for (const auto &literal : Literals) {
@@ -1435,14 +1441,14 @@ LiteralBindingKind PotentialBindings::getLiteralKind() const {
   return kind;
 }
 
-unsigned PotentialBindings::getNumViableLiteralBindings() const {
+unsigned BindingSet::getNumViableLiteralBindings() const {
   return llvm::count_if(Literals, [&](const auto &literal) {
     return literal.second.viableAsBinding();
   });
 }
 
-void PotentialBindings::dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
-                             unsigned indent) const {
+void BindingSet::dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
+                      unsigned indent) const {
   out.indent(indent);
   out << "(";
   if (typeVar)
@@ -1451,7 +1457,7 @@ void PotentialBindings::dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
   out << ")\n";
 }
 
-void PotentialBindings::dump(llvm::raw_ostream &out, unsigned indent) const {
+void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
   out.indent(indent);
   if (isDirectHole())
     out << "hole ";

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2159,7 +2159,7 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
   if (typeVar->getImpl().getFixedType(nullptr))
     return;
 
-  auto bindings = cs.inferBindingsFor(typeVar);
+  auto bindings = cs.getBindingsFor(typeVar);
 
   auto numBindings =
       bindings.Bindings.size() + bindings.getNumViableLiteralBindings();

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -565,7 +565,7 @@ protected:
 };
 
 class TypeVariableStep final : public BindingStep<TypeVarBindingProducer> {
-  using BindingContainer = inference::PotentialBindings;
+  using BindingContainer = inference::BindingSet;
   using Binding = inference::PotentialBinding;
 
   TypeVariableType *TypeVar;
@@ -579,8 +579,8 @@ class TypeVariableStep final : public BindingStep<TypeVarBindingProducer> {
 public:
   TypeVariableStep(BindingContainer &bindings,
                    SmallVectorImpl<Solution> &solutions)
-      : BindingStep(bindings.CS, {bindings}, solutions),
-        TypeVar(bindings.TypeVar) {}
+      : BindingStep(bindings.getConstraintSystem(), {bindings}, solutions),
+        TypeVar(bindings.getTypeVariable()) {}
 
   void setup() override;
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -146,6 +146,11 @@ void ConstraintGraphNode::addToEquivalenceClass(
   EquivalenceClass.append(typeVars.begin(), typeVars.end());
 }
 
+void ConstraintGraphNode::truncateEquivalenceClass(unsigned prevSize) {
+  EquivalenceClass.erase(EquivalenceClass.begin() + prevSize,
+                         EquivalenceClass.end());
+}
+
 void ConstraintGraphNode::addReferencedVar(TypeVariableType *typeVar) {
   bool inserted = References.insert(typeVar);
   assert(inserted && "Attempt to reference a duplicate type variable");
@@ -255,9 +260,7 @@ void ConstraintGraph::Change::undo(ConstraintGraph &cg) {
 
   case ChangeKind::ExtendedEquivalenceClass: {
     auto &node = cg[EquivClass.TypeVar];
-    node.EquivalenceClass.erase(
-      node.EquivalenceClass.begin() + EquivClass.PrevSize,
-      node.EquivalenceClass.end());
+    node.truncateEquivalenceClass(EquivClass.PrevSize);
     break;
    }
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -59,7 +59,7 @@ ConstraintGraph::lookupNode(TypeVariableType *typeVar) {
   }
 
   // Allocate the new node.
-  auto nodePtr = new ConstraintGraphNode(typeVar);
+  auto nodePtr = new ConstraintGraphNode(CS, typeVar);
   unsigned index = TypeVariables.size();
   impl.setGraphNode(nodePtr);
   impl.setGraphIndex(index);
@@ -107,6 +107,7 @@ void ConstraintGraphNode::addConstraint(Constraint *constraint) {
   assert(ConstraintIndex.count(constraint) == 0 && "Constraint re-insertion");
   ConstraintIndex[constraint] = Constraints.size();
   Constraints.push_back(constraint);
+  Bindings.infer(constraint);
 }
 
 void ConstraintGraphNode::removeConstraint(Constraint *constraint) {
@@ -117,6 +118,8 @@ void ConstraintGraphNode::removeConstraint(Constraint *constraint) {
   auto index = pos->second;
   ConstraintIndex.erase(pos);
   assert(Constraints[index] == constraint && "Mismatched constraint");
+
+  Bindings.retract(constraint);
 
   // If this is the last constraint, just pop it off the list and we're done.
   unsigned lastIndex = Constraints.size()-1;

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -59,7 +59,7 @@ ConstraintGraph::lookupNode(TypeVariableType *typeVar) {
   }
 
   // Allocate the new node.
-  auto nodePtr = new ConstraintGraphNode(CS, typeVar);
+  auto nodePtr = new ConstraintGraphNode(*this, typeVar);
   unsigned index = TypeVariables.size();
   impl.setGraphNode(nodePtr);
   impl.setGraphIndex(index);
@@ -107,7 +107,6 @@ void ConstraintGraphNode::addConstraint(Constraint *constraint) {
   assert(ConstraintIndex.count(constraint) == 0 && "Constraint re-insertion");
   ConstraintIndex[constraint] = Constraints.size();
   Constraints.push_back(constraint);
-  Bindings.infer(constraint);
 }
 
 void ConstraintGraphNode::removeConstraint(Constraint *constraint) {
@@ -118,8 +117,6 @@ void ConstraintGraphNode::removeConstraint(Constraint *constraint) {
   auto index = pos->second;
   ConstraintIndex.erase(pos);
   assert(Constraints[index] == constraint && "Mismatched constraint");
-
-  Bindings.retract(constraint);
 
   // If this is the last constraint, just pop it off the list and we're done.
   unsigned lastIndex = Constraints.size()-1;

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -360,6 +360,10 @@ void ConstraintGraph::bindTypeVariable(TypeVariableType *typeVar, Type fixed) {
   assert(!fixed->is<TypeVariableType>() &&
          "Cannot bind to type variable; merge equivalence classes instead");
 
+  // Record the change, if there are active scopes.
+  if (ActiveScope)
+    Changes.push_back(Change::boundTypeVariable(typeVar, fixed));
+
   // If there are no type variables in the fixed type, there's nothing to do.
   if (!fixed->hasTypeVariable())
     return;
@@ -373,12 +377,6 @@ void ConstraintGraph::bindTypeVariable(TypeVariableType *typeVar, Type fixed) {
     (*this)[otherTypeVar].addReferencedBy(typeVar);
     node.addReferencedVar(otherTypeVar);
   }
-
-  // Record the change, if there are active scopes.
-  // Note: If we ever use this to undo the actual variable binding,
-  // we'll need to store the change along the early-exit path as well.
-  if (ActiveScope)
-    Changes.push_back(Change::boundTypeVariable(typeVar, fixed));
 }
 
 void ConstraintGraph::unbindTypeVariable(TypeVariableType *typeVar, Type fixed){

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5361,9 +5361,10 @@ bool ConstraintSystem::isReadOnlyKeyPathComponent(
   return false;
 }
 
-TypeVarBindingProducer::TypeVarBindingProducer(PotentialBindings &bindings)
-    : BindingProducer(bindings.CS, bindings.TypeVar->getImpl().getLocator()),
-      TypeVar(bindings.TypeVar), CanBeNil(bindings.canBeNil()) {
+TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)
+    : BindingProducer(bindings.getConstraintSystem(),
+                      bindings.getTypeVariable()->getImpl().getLocator()),
+      TypeVar(bindings.getTypeVariable()), CanBeNil(bindings.canBeNil()) {
   if (bindings.isDirectHole()) {
     auto *locator = getLocator();
     // If this type variable is associated with a code completion token
@@ -5371,8 +5372,9 @@ TypeVarBindingProducer::TypeVarBindingProducer(PotentialBindings &bindings)
     // to point to a code completion token to avoid attempting to "fix"
     // this problem since its rooted in the fact that constraint system
     // is under-constrained.
-    if (bindings.AssociatedCodeCompletionToken) {
-      locator = CS.getConstraintLocator(bindings.AssociatedCodeCompletionToken);
+    if (bindings.getAssociatedCodeCompletionToken()) {
+      locator =
+          CS.getConstraintLocator(bindings.getAssociatedCodeCompletionToken());
     }
 
     Bindings.push_back(Binding::forHole(TypeVar, locator));

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1157,7 +1157,7 @@ void ConstraintSystem::print(raw_ostream &out) const {
         out << " as ";
         Type(fixed).print(out, PO);
       } else {
-        const_cast<ConstraintSystem *>(this)->inferBindingsFor(tv).dump(out, 1);
+        const_cast<ConstraintSystem *>(this)->getBindingsFor(tv).dump(out, 1);
       }
     } else {
       out << " equivalent to ";

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -475,7 +475,8 @@ func g_2994(arg: Int) -> Double {
 C_2994<S_2994>(arg: { (r: S_2994) in f_2994(arg: g_2994(arg: r.dataOffset)) }) // expected-error {{cannot convert value of type 'Double' to expected argument type 'String'}}
 
 let _ = { $0[$1] }(1, 1) // expected-error {{value of type 'Int' has no subscripts}}
-let _ = { $0 = ($0 = {}) } // expected-error {{assigning a variable to itself}}
+// FIXME: Better diagnostic here would be `assigning a variable to itself` but binding ordering change exposed a but in diagnostics
+let _ = { $0 = ($0 = {}) } // expected-error {{function produces expected type '()'; did you mean to call it with '()'?}}
 let _ = { $0 = $0 = 42 } // expected-error {{assigning a variable to itself}}
 
 // https://bugs.swift.org/browse/SR-403

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -100,11 +100,11 @@ func f7() -> (c: Int, v: A) {
 }
 
 func f8<T:P2>(_ n: T, _ f: @escaping (T) -> T) {}  // expected-note {{where 'T' = 'Int'}}
-// expected-note@-1 {{required by global function 'f8' where 'T' = 'Tup' (aka '(Int, Double)')}}
+// expected-note@-1 {{required by global function 'f8' where 'T' = '(Int, Double)'}}
 f8(3, f4) // expected-error {{global function 'f8' requires that 'Int' conform to 'P2'}}
 typealias Tup = (Int, Double)
 func f9(_ x: Tup) -> Tup { return x }
-f8((1,2.0), f9) // expected-error {{type 'Tup' (aka '(Int, Double)') cannot conform to 'P2'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+f8((1,2.0), f9) // expected-error {{type '(Int, Double)' cannot conform to 'P2'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
 
 // <rdar://problem/19658691> QoI: Incorrect diagnostic for calling nonexistent members on literals
 1.doesntExist(0)  // expected-error {{value of type 'Int' has no member 'doesntExist'}}

--- a/test/Constraints/function.swift
+++ b/test/Constraints/function.swift
@@ -223,3 +223,25 @@ func test_passing_nonescaping_to_escaping_function() {
     bar(handler) // expected-error {{passing non-escaping parameter 'handler' to function expecting an @escaping closure}}
   }
 }
+
+func test_passing_noescape_function_ref_to_generic_parameter() {
+  func cast<T, U>(_ t: T) -> U {
+    return t as! U
+  }
+
+  class A {
+    required init(factory: () -> Self) {
+      fatalError()
+    }
+  }
+
+  struct S {
+    func converter() -> B { fatalError() }
+  }
+
+  class B : A {
+    class func test(value: S) {
+      _ = self.init(factory: cast(value.converter)) // Ok
+    }
+  }
+}

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -28,10 +28,10 @@ func testTernaryOneWayOverload(b: Bool) {
   // CHECK: 0: $T2 $T3 $T4
 
   // CHECK: solving component #1
-  // CHECK: Initial bindings: $T11 := Int16, $T11 := Int8
+  // CHECK: Initial bindings: $T11 := Int8, $T11 := Int16
 
   // CHECK: solving component #1
-  // CHECK: Initial bindings: $T11 := Int16, $T11 := Int8
+  // CHECK: Initial bindings: $T11 := Int8, $T11 := Int16
 
   // CHECK: solving component #1
   // CHECK: Initial bindings: $T11 := Int8, $T11 := Int16

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -41,7 +41,7 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
   auto intTy = getStdlibType("Int");
 
   {
-    auto bindings = cs.inferBindingsFor(literalTy);
+    auto bindings = cs.getBindingsFor(literalTy);
 
     ASSERT_EQ(bindings.Literals.size(), (unsigned)1);
 
@@ -61,7 +61,7 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
                    cs.getConstraintLocator(intLiteral));
 
   {
-    auto bindings = cs.inferBindingsFor(literalTy);
+    auto bindings = cs.getBindingsFor(literalTy);
 
     ASSERT_EQ(bindings.Bindings.size(), (unsigned)1);
     ASSERT_EQ(bindings.Literals.size(), (unsigned)1);
@@ -95,7 +95,7 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
                    cs.getConstraintLocator(intLiteral));
 
   {
-    auto bindings = cs.inferBindingsFor(floatLiteralTy);
+    auto bindings = cs.getBindingsFor(floatLiteralTy);
 
     ASSERT_EQ(bindings.Bindings.size(), (unsigned)1);
     ASSERT_EQ(bindings.Literals.size(), (unsigned)1);
@@ -118,7 +118,7 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
                    cs.getConstraintLocator({}));
 
   {
-    auto bindings = cs.inferBindingsFor(otherTy, /*finalize=*/false);
+    auto bindings = cs.getBindingsFor(otherTy);
 
     // Make sure that there are no direct bindings or protocol requirements.
 
@@ -126,7 +126,7 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
     ASSERT_EQ(bindings.Literals.size(), (unsigned)0);
 
     llvm::SmallDenseMap<TypeVariableType *, BindingSet> env;
-    env.insert({floatLiteralTy, cs.inferBindingsFor(floatLiteralTy)});
+    env.insert({floatLiteralTy, cs.getBindingsFor(floatLiteralTy)});
 
     bindings.finalize(env);
 

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -125,7 +125,7 @@ TEST_F(SemaTest, TestIntLiteralBindingInference) {
     ASSERT_EQ(bindings.Bindings.size(), (unsigned)0);
     ASSERT_EQ(bindings.Literals.size(), (unsigned)0);
 
-    llvm::SmallDenseMap<TypeVariableType *, PotentialBindings> env;
+    llvm::SmallDenseMap<TypeVariableType *, BindingSet> env;
     env.insert({floatLiteralTy, cs.inferBindingsFor(floatLiteralTy)});
 
     bindings.finalize(env);
@@ -192,7 +192,7 @@ TEST_F(SemaTest, TestTransitiveProtocolInference) {
         cs.getConstraintLocator({}, LocatorPathElt::ContextualType()));
 
     auto bindings = inferBindings(cs, typeVar);
-    ASSERT_TRUE(bindings.Protocols.empty());
+    ASSERT_TRUE(bindings.getConformanceRequirements().empty());
     ASSERT_TRUE(bool(bindings.TransitiveProtocols));
     verifyProtocolInferenceResults(*bindings.TransitiveProtocols,
                                    {protocolTy1});
@@ -214,7 +214,7 @@ TEST_F(SemaTest, TestTransitiveProtocolInference) {
                      cs.getConstraintLocator({}));
 
     auto bindings = inferBindings(cs, typeVar);
-    ASSERT_TRUE(bindings.Protocols.empty());
+    ASSERT_TRUE(bindings.getConformanceRequirements().empty());
     ASSERT_TRUE(bool(bindings.TransitiveProtocols));
     verifyProtocolInferenceResults(*bindings.TransitiveProtocols,
                                    {protocolTy1, protocolTy2});

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -127,7 +127,7 @@ BindingSet SemaTest::inferBindings(ConstraintSystem &cs,
 
   for (auto *typeVar : cs.getTypeVariables()) {
     if (!typeVar->getImpl().hasRepresentativeOrFixed())
-      cache.insert({typeVar, cs.inferBindingsFor(typeVar, /*finalize=*/false)});
+      cache.insert({typeVar, cs.getBindingsFor(typeVar)});
   }
 
   for (auto *typeVar : cs.getTypeVariables()) {

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -121,9 +121,9 @@ ProtocolType *SemaTest::createProtocol(llvm::StringRef protocolName,
   return ProtocolType::get(PD, parent, Context);
 }
 
-PotentialBindings SemaTest::inferBindings(ConstraintSystem &cs,
-                                          TypeVariableType *typeVar) {
-  llvm::SmallDenseMap<TypeVariableType *, PotentialBindings> cache;
+BindingSet SemaTest::inferBindings(ConstraintSystem &cs,
+                                   TypeVariableType *typeVar) {
+  llvm::SmallDenseMap<TypeVariableType *, BindingSet> cache;
 
   for (auto *typeVar : cs.getTypeVariables()) {
     if (!typeVar->getImpl().hasRepresentativeOrFixed())

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -127,7 +127,7 @@ BindingSet SemaTest::inferBindings(ConstraintSystem &cs,
 
   for (auto *typeVar : cs.getTypeVariables()) {
     if (!typeVar->getImpl().hasRepresentativeOrFixed())
-      cache.insert({typeVar, cs.getBindingsFor(typeVar)});
+      cache.insert({typeVar, cs.getBindingsFor(typeVar, /*finalize=*/false)});
   }
 
   for (auto *typeVar : cs.getTypeVariables()) {

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -76,8 +76,8 @@ protected:
   ProtocolType *createProtocol(llvm::StringRef protocolName,
                                Type parent = Type());
 
-  static PotentialBindings inferBindings(ConstraintSystem &cs,
-                                         TypeVariableType *typeVar);
+  static BindingSet inferBindings(ConstraintSystem &cs,
+                                  TypeVariableType *typeVar);
 };
 
 } // end namespace unittest


### PR DESCRIPTION
Instead of re-gathering constraints and computing a full new set bindings on every step of the solver,
let's keep track of _potential_ bindings as constraint system is modified (new constraints are added/removed,
equivalence classes changed and type variables are bound/unbound).
 
`PotentialBindings` lost most of its responsibilities and are no longer comparable, their main
purpose now is binding  and metadata tracking (introduction/retraction). New `BindingSet` type 
is something that represents a set of bindings at the current step of the solver.

`ConstraintGraph` has been adjusted to  split "fixed bindings" into:
  - Referenced by: The set of type variables that are referenced by a fixed type associated with
     current type variable;
  - References: The set of type variables that reference current type variable in their fixed types.

That makes it easier to compute a set of type variables that are affected by any given change in
constraint graph.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
