### PR TITLE
Warn about module name shadowing in interfaces

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -351,12 +351,10 @@ ERROR(error_opening_explicit_module_file,none,
 ERROR(error_extracting_flags_from_module_interface,none,
       "error extracting flags from module interface", ())
 WARNING(warning_module_shadowing_may_break_module_interface,none,
-        "public %0 %1 shadows module %2, which is permitted by Swift but may "
-        "stop other compiler versions from importing module %3 or its clients; "
-        "please work around this language bug (SR-898) by renaming either the "
-        "%0 %1 or the module %2, or by passing the '-Xfrontend "
-        "-module-interface-preserve-types-as-written' flags to the Swift "
-        "compiler",
+        "public %0 %1 shadows module %2, which may cause failures when "
+        "importing %3 or its clients in some configurations; please rename "
+        "either the %0 %1 or the module %2, or see "
+        "https://bugs.swift.org/browse/SR-14195 for workarounds",
         (DescriptiveDeclKind, FullyQualified<Type>,
         /*shadowedModule=*/ModuleDecl *, /*interfaceModule*/ModuleDecl *))
 REMARK(rebuilding_module_from_interface,none,

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -350,6 +350,15 @@ ERROR(error_opening_explicit_module_file,none,
       "failed to open explicit Swift module: %0", (StringRef))
 ERROR(error_extracting_flags_from_module_interface,none,
       "error extracting flags from module interface", ())
+WARNING(warning_module_shadowing_may_break_module_interface,none,
+        "public %0 %1 shadows module %2, which is permitted by Swift but may "
+        "stop other compiler versions from importing module %3 or its clients; "
+        "please work around this language bug (SR-898) by renaming either the "
+        "%0 %1 or the module %2, or by passing the '-Xfrontend "
+        "-module-interface-preserve-types-as-written' flags to the Swift "
+        "compiler",
+        (DescriptiveDeclKind, FullyQualified<Type>,
+        /*shadowedModule=*/ModuleDecl *, /*interfaceModule*/ModuleDecl *))
 REMARK(rebuilding_module_from_interface,none,
        "rebuilding module '%0' from interface '%1'", (StringRef, StringRef))
 NOTE(sdk_version_pbm_version,none,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2051,6 +2051,8 @@ bool SourceFile::isImportedImplementationOnly(const ModuleDecl *module) const {
 }
 
 bool ModuleDecl::isImportedImplementationOnly(const ModuleDecl *module) const {
+  if (module == this) return false;
+
   auto &imports = getASTContext().getImportCache();
 
   // Look through non-implementation-only imports to see if module is imported

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -36,24 +36,9 @@
 
 using namespace swift;
 
-version::Version swift::InterfaceFormatVersion({1, 0});
+// MARK: Module interface header comments
 
-/// Diagnose any scoped imports in \p imports, i.e. those with a non-empty
-/// access path. These are not yet supported by module interfaces, since the
-/// information about the declaration kind is not preserved through the binary
-/// serialization that happens as an intermediate step in non-whole-module
-/// builds.
-///
-/// These come from declarations like `import class FooKit.MainFooController`.
-static void diagnoseScopedImports(DiagnosticEngine &diags,
-                                  ArrayRef<ImportedModule> imports){
-  for (const ImportedModule &importPair : imports) {
-    if (importPair.accessPath.empty())
-      continue;
-    diags.diagnose(importPair.accessPath.front().Loc,
-                   diag::module_interface_scoped_import_unsupported);
-  }
-}
+version::Version swift::InterfaceFormatVersion({1, 0});
 
 /// Prints to \p out a comment containing a format version number, tool version
 /// string as well as any relevant command-line flags in \p Opts used to
@@ -91,6 +76,25 @@ llvm::Regex swift::getSwiftInterfaceModuleFlagsRegex() {
 llvm::Regex swift::getSwiftInterfaceCompilerVersionRegex() {
   return llvm::Regex("^// " SWIFT_COMPILER_VERSION_KEY
                      ": (.+)$", llvm::Regex::Newline);
+}
+
+// MARK: Import statements
+
+/// Diagnose any scoped imports in \p imports, i.e. those with a non-empty
+/// access path. These are not yet supported by module interfaces, since the
+/// information about the declaration kind is not preserved through the binary
+/// serialization that happens as an intermediate step in non-whole-module
+/// builds.
+///
+/// These come from declarations like `import class FooKit.MainFooController`.
+static void diagnoseScopedImports(DiagnosticEngine &diags,
+                                  ArrayRef<ImportedModule> imports){
+  for (const ImportedModule &importPair : imports) {
+    if (importPair.accessPath.empty())
+      continue;
+    diags.diagnose(importPair.accessPath.front().Loc,
+                   diag::module_interface_scoped_import_unsupported);
+  }
 }
 
 /// Prints the imported modules in \p M to \p out in the form of \c import
@@ -173,6 +177,8 @@ static void printImports(raw_ostream &out,
     out << "\n";
   }
 }
+
+// MARK: Dummy protocol conformances
 
 // FIXME: Copied from ASTPrinter.cpp...
 static bool isPublicOrUsableFromInline(const ValueDecl *VD) {
@@ -560,6 +566,8 @@ public:
 const StringLiteral InheritedProtocolCollector::DummyProtocolName =
     "_ConstraintThatIsNotPartOfTheAPIOfThisLibrary";
 } // end anonymous namespace
+
+// MARK: Interface emission
 
 bool swift::emitSwiftInterface(raw_ostream &out,
                                ModuleInterfaceOptions const &Opts,

--- a/test/ModuleInterface/Inputs/ShadowyHorror.swift
+++ b/test/ModuleInterface/Inputs/ShadowyHorror.swift
@@ -1,0 +1,1 @@
+public class module_shadowing {}

--- a/test/ModuleInterface/Inputs/TestModule.swift
+++ b/test/ModuleInterface/Inputs/TestModule.swift
@@ -1,3 +1,5 @@
 public struct TestStruct {
   public init() {}
 }
+
+public enum module_shadowing {}

--- a/test/ModuleInterface/module_shadowing.swift
+++ b/test/ModuleInterface/module_shadowing.swift
@@ -24,14 +24,14 @@
 
 #if !SELF_SHADOW
 import ShadowyHorror
-// OTHER-DAG: ShadowyHorror.module_shadowing:{{[0-9]+:[0-9]+}}: warning: public class 'ShadowyHorror.module_shadowing' shadows module 'module_shadowing', which is permitted by Swift but may stop other compiler versions from importing module 'module_shadowing' or its clients; please work around this language bug (SR-898) by renaming either the class 'ShadowyHorror.module_shadowing' or the module 'module_shadowing', or by passing the '-Xfrontend -module-interface-preserve-types-as-written' flags to the Swift compiler{{$}}
+// OTHER-DAG: ShadowyHorror.module_shadowing:{{[0-9]+:[0-9]+}}: warning: public class 'ShadowyHorror.module_shadowing' shadows module 'module_shadowing', which may cause failures when importing 'module_shadowing' or its clients in some configurations; please rename either the class 'ShadowyHorror.module_shadowing' or the module 'module_shadowing', or see https://bugs.swift.org/browse/SR-14195 for workarounds{{$}}
 
 @_implementationOnly import TestModule
 #endif
 
 public struct ShadowyHorror {
-  // OTHER-DAG: module_shadowing.swift:[[@LINE-1]]:15: warning: public struct 'module_shadowing.ShadowyHorror' shadows module 'ShadowyHorror', which is permitted by Swift but may stop other compiler versions from importing module 'module_shadowing' or its clients; please work around this language bug (SR-898) by renaming either the struct 'module_shadowing.ShadowyHorror' or the module 'ShadowyHorror', or by passing the '-Xfrontend -module-interface-preserve-types-as-written' flags to the Swift compiler{{$}}
-  // SELF: module_shadowing.swift:[[@LINE-2]]:15: warning: public struct 'ShadowyHorror.ShadowyHorror' shadows module 'ShadowyHorror', which is permitted by Swift but may stop other compiler versions from importing module 'ShadowyHorror' or its clients; please work around this language bug (SR-898) by renaming either the struct 'ShadowyHorror.ShadowyHorror' or the module 'ShadowyHorror', or by passing the '-Xfrontend -module-interface-preserve-types-as-written' flags to the Swift compiler{{$}}
+  // OTHER-DAG: module_shadowing.swift:[[@LINE-1]]:15: warning: public struct 'module_shadowing.ShadowyHorror' shadows module 'ShadowyHorror', which may cause failures when importing 'module_shadowing' or its clients in some configurations; please rename either the struct 'module_shadowing.ShadowyHorror' or the module 'ShadowyHorror', or see https://bugs.swift.org/browse/SR-14195 for workarounds{{$}}
+  // SELF: module_shadowing.swift:[[@LINE-2]]:15: warning: public struct 'ShadowyHorror.ShadowyHorror' shadows module 'ShadowyHorror', which may cause failures when importing 'ShadowyHorror' or its clients in some configurations; please rename either the struct 'ShadowyHorror.ShadowyHorror' or the module 'ShadowyHorror', or see https://bugs.swift.org/browse/SR-14195 for workarounds{{$}}
 
   init() {}
   public var property: ShadowyHorror { ShadowyHorror() }

--- a/test/ModuleInterface/module_shadowing.swift
+++ b/test/ModuleInterface/module_shadowing.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t/mcp)
+
+// Build modules imported by this file.
+// RUN: %empty-directory(%t/lib)
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/lib/ShadowyHorror.swiftinterface %S/Inputs/ShadowyHorror.swift -enable-library-evolution -module-name ShadowyHorror -swift-version 5
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -emit-module-interface-path %t/lib/TestModule.swiftinterface %S/Inputs/TestModule.swift -enable-library-evolution -module-name TestModule -swift-version 5
+
+// Build this file as a module and check that it emits the expected warnings.
+// RUN: %empty-directory(%t/subtest-1)
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-1/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -swift-version 5 2>&1 | %FileCheck --check-prefix OTHER --implicit-check-not TestModule %s
+
+// Make sure that preserve-types-as-written disables this warning.
+// RUN: %empty-directory(%t/subtest-2)
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-2/module_shadowing.swiftinterface %s -enable-library-evolution -module-name module_shadowing -I %t/lib -module-interface-preserve-types-as-written -swift-version 5 -verify
+
+// Build this module in a different configuration where it will shadow itself.
+// RUN: %empty-directory(%t/subtest-3)
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/subtest-3/ShadowyHorror.swiftinterface %s -enable-library-evolution -module-name ShadowyHorror -DSELF_SHADOW -swift-version 5 2>&1 | %FileCheck --check-prefix SELF --implicit-check-not TestModule %s
+
+// Verify that the module-shadowing bugs we're trying to address haven't been fixed. (SR-898)
+// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/subtest-1/module_shadowing.swiftinterface -module-cache-path %t/mcp -I %t/lib -module-name module_shadowing 2>&1 | %FileCheck --check-prefix VERIFICATION %s
+// RUN: %target-swift-frontend -typecheck-module-from-interface %t/subtest-2/module_shadowing.swiftinterface -module-cache-path %t/mcp -I %t/lib -module-name module_shadowing
+// RUN: not %target-swift-frontend -typecheck-module-from-interface %t/subtest-3/ShadowyHorror.swiftinterface -module-cache-path %t/mcp -I %t/lib -module-name ShadowyHorror 2>&1 | %FileCheck --check-prefix VERIFICATION %s
+
+#if !SELF_SHADOW
+import ShadowyHorror
+// OTHER-DAG: ShadowyHorror.module_shadowing:{{[0-9]+:[0-9]+}}: warning: public class 'ShadowyHorror.module_shadowing' shadows module 'module_shadowing', which is permitted by Swift but may stop other compiler versions from importing module 'module_shadowing' or its clients; please work around this language bug (SR-898) by renaming either the class 'ShadowyHorror.module_shadowing' or the module 'module_shadowing', or by passing the '-Xfrontend -module-interface-preserve-types-as-written' flags to the Swift compiler{{$}}
+
+@_implementationOnly import TestModule
+#endif
+
+public struct ShadowyHorror {
+  // OTHER-DAG: module_shadowing.swift:[[@LINE-1]]:15: warning: public struct 'module_shadowing.ShadowyHorror' shadows module 'ShadowyHorror', which is permitted by Swift but may stop other compiler versions from importing module 'module_shadowing' or its clients; please work around this language bug (SR-898) by renaming either the struct 'module_shadowing.ShadowyHorror' or the module 'ShadowyHorror', or by passing the '-Xfrontend -module-interface-preserve-types-as-written' flags to the Swift compiler{{$}}
+  // SELF: module_shadowing.swift:[[@LINE-2]]:15: warning: public struct 'ShadowyHorror.ShadowyHorror' shadows module 'ShadowyHorror', which is permitted by Swift but may stop other compiler versions from importing module 'ShadowyHorror' or its clients; please work around this language bug (SR-898) by renaming either the struct 'ShadowyHorror.ShadowyHorror' or the module 'ShadowyHorror', or by passing the '-Xfrontend -module-interface-preserve-types-as-written' flags to the Swift compiler{{$}}
+
+  init() {}
+  public var property: ShadowyHorror { ShadowyHorror() }
+  // VERIFICATION: error: 'ShadowyHorror' is not a member type of {{class|struct}} 'ShadowyHorror.{{ShadowyHorror|module_shadowing}}'
+  // VERIFICATION: error: failed to verify module interface of '{{ShadowyHorror|module_shadowing}}' due to the errors above;
+}
+
+public struct TestModule {}


### PR DESCRIPTION
There is a known issue with module interfaces where a type with the same name as a module will disrupt references to types in that module. Fully fixing it will require a new language feature (SR-898) which is not yet available. In the meantime, module interfaces support a workaround flag (`-Xfrontend -module-interface-preserve-types-as-written`) which prints an alternate form that usually works. However, you have to know to add this flag, and it’s not obvious because nothing breaks until a compiler tries to consume the affected module interface (or sometimes even one of its clients).

This PR emits a warning during module interface emission whenever the module interface either imports a type with the same name as the module being built, or declares a type with the same name as a visible module. This lets the user know that the type may cause problems and they might need to implement a workaround.

Fixes rdar://73903255.
