### PR TITLE
[Concurrency] Fix Android ARMv7 C libdispatch build

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -65,6 +65,10 @@ foreach(sdk ${DISPATCH_SDKS})
   foreach(arch ${ARCHS})
     set(LIBDISPATCH_VARIANT_NAME "libdispatch-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
 
+    if(NOT sdk STREQUAL ANDROID)
+      set(SWIFT_LIBDISPATCH_SYSTEM_PROCESSOR  -DCMAKE_SYSTEM_PROCESSOR=${arch})
+    endif()
+
     ExternalProject_Add("${LIBDISPATCH_VARIANT_NAME}"
                         SOURCE_DIR
                           "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}"
@@ -81,7 +85,7 @@ foreach(sdk ${DISPATCH_SDKS})
                           -DCMAKE_RANLIB=${CMAKE_RANLIB}
                           -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                           -DCMAKE_SYSTEM_NAME=${SWIFT_SDK_${sdk}_NAME}
-                          -DCMAKE_SYSTEM_PROCESSOR=${arch}
+                          ${SWIFT_LIBDISPATCH_SYSTEM_PROCESSOR}
                           "-DCMAKE_ANDROID_NDK=${SWIFT_ANDROID_NDK_PATH}"
                           -DCMAKE_ANDROID_ARCH_ABI=${SWIFT_SDK_ANDROID_ARCH_${arch}_ABI}
                           -DCMAKE_ANDROID_API=${SWIFT_ANDROID_API_LEVEL}
@@ -157,7 +161,7 @@ foreach(sdk ${DISPATCH_SDKS})
                             -DCMAKE_RANLIB=${CMAKE_RANLIB}
                             -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                             -DCMAKE_SYSTEM_NAME=${SWIFT_SDK_${sdk}_NAME}
-                            -DCMAKE_SYSTEM_PROCESSOR=${arch}
+                            ${SWIFT_LIBDISPATCH_SYSTEM_PROCESSOR}
                             "-DCMAKE_ANDROID_NDK=${SWIFT_ANDROID_NDK_PATH}"
                             -DCMAKE_ANDROID_ARCH_ABI=${SWIFT_SDK_ANDROID_ARCH_${arch}_ABI}
                             -DCMAKE_ANDROID_API=${SWIFT_ANDROID_API_LEVEL}


### PR DESCRIPTION
For cross-compiling Android one can simply provide
CMAKE_ANDROID_ARCH_ABI and the right CMAKE_SYSTEM_PROCESSOR will be
chosen by CMake. Since the SDK arch names are not the expected ones by the Android NDK,
it is better not to use them. The change should keep sending the
CMAKE_SYSTEM_PROCESSOR for SDKs that are not ANDROID, while skipping it
for the ANDROID SDKs.
