### PR TITLE
[stdlib] Add dependency from static-executable-args.lnk to stdlib

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -102,6 +102,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
                              DESTINATION "lib/swift_static/${lowercase_sdk}"
                              COMPONENT stdlib)
+  add_dependencies(stdlib ${static_binary_lnk_file_list})
   add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
 endif()
 


### PR DESCRIPTION
The file static-executable-args.lnk was added to the stdlib install
component, but stdlib didn't depend on it, so when invoking
install-stdlib or install-swift-components, the file was not being
generated.

Because of the magic target marked as `ALL`, when one built all the
targets, and later issued a `install-*` target, the file was there by
a lucky coincidence.

The change only creates that dependency, so a call to install the stdlib
will also create this file.
