### PR TITLE
GSB: Better handling of unresolved DependentMemberTypes in maybeResolveEquivalenceClass()

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1809,6 +1809,18 @@ static int compareAssociatedTypes(AssociatedTypeDecl *assocType1,
   return 0;
 }
 
+static void lookupConcreteNestedType(NominalTypeDecl *decl,
+                                     Identifier name,
+                                     SmallVectorImpl<TypeDecl *> &concreteDecls) {
+  SmallVector<ValueDecl *, 2> foundMembers;
+  decl->getParentModule()->lookupQualified(
+      decl, DeclNameRef(name),
+      NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers,
+      foundMembers);
+  for (auto member : foundMembers)
+    concreteDecls.push_back(cast<TypeDecl>(member));
+}
+
 TypeDecl *EquivalenceClass::lookupNestedType(
                              GenericSignatureBuilder &builder,
                              Identifier name,
@@ -1881,19 +1893,9 @@ TypeDecl *EquivalenceClass::lookupNestedType(
   // FIXME: Shouldn't we always look here?
   if (!bestAssocType && concreteDecls.empty()) {
     Type typeToSearch = concreteType ? concreteType : superclass;
-    auto *decl = typeToSearch ? typeToSearch->getAnyNominal() : nullptr;
-    if (decl) {
-      SmallVector<ValueDecl *, 2> foundMembers;
-      decl->getParentModule()->lookupQualified(
-          decl, DeclNameRef(name),
-          NL_QualifiedDefault | NL_OnlyTypes | NL_ProtocolMembers,
-          foundMembers);
-      for (auto member : foundMembers) {
-        if (auto type = dyn_cast<TypeDecl>(member)) {
-          concreteDecls.push_back(type);
-        }
-      }
-    }
+    if (typeToSearch)
+      if (auto *decl = typeToSearch->getAnyNominal())
+        lookupConcreteNestedType(decl, name, concreteDecls);
   }
 
   // Infer same-type constraints among same-named associated type anchors.
@@ -3531,8 +3533,6 @@ static Type substituteConcreteType(Type parentType,
   if (parentType->is<ErrorType>())
     return parentType;
 
-  assert(concreteDecl);
-
   auto *dc = concreteDecl->getDeclContext();
 
   // Form an unsubstituted type referring to the given type declaration,
@@ -3569,10 +3569,31 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
                                    resolutionKind,
                                    wantExactPotentialArchetype);
     if (!resolvedBase) return resolvedBase;
+
     // If the base is concrete, so is this member.
     if (auto parentType = resolvedBase.getAsConcreteType()) {
-      auto concreteType = substituteConcreteType(parentType,
-                                                 depMemTy->getAssocType());
+      TypeDecl *concreteDecl = depMemTy->getAssocType();
+      if (!concreteDecl) {
+        // If we have an unresolved dependent member type, perform a
+        // name lookup.
+        if (auto *decl = parentType->getAnyNominal()) {
+          SmallVector<TypeDecl *, 2> concreteDecls;
+          lookupConcreteNestedType(decl, depMemTy->getName(), concreteDecls);
+
+          if (concreteDecls.empty())
+            return ResolvedType::forUnresolved(nullptr);
+
+          auto bestConcreteTypeIter =
+            std::min_element(concreteDecls.begin(), concreteDecls.end(),
+                             [](TypeDecl *type1, TypeDecl *type2) {
+                               return TypeDecl::compare(type1, type2) < 0;
+                             });
+
+          concreteDecl = *bestConcreteTypeIter;
+        }
+      }
+
+      auto concreteType = substituteConcreteType(parentType, concreteDecl);
       return ResolvedType::forConcrete(concreteType);
     }
 

--- a/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
@@ -1,6 +1,4 @@
-// RUN: not --crash %target-swift-frontend -primary-file %s -emit-silgen
-
-// REQUIRES: asserts
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
 
 public protocol WrappedSignedInteger: SignedInteger where Stride == Int {
     typealias WrappedInteger = Int

--- a/validation-test/compiler_crashers_2_fixed/rdar71162777.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71162777.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public struct LowerModel {
+	public typealias Index = Int
+}
+
+public protocol LowerChildA {
+	typealias Model = LowerModel
+	typealias ModelIndex = Model.Index
+}
+
+public protocol LowerChildB {
+	typealias Model = LowerModel
+	typealias ModelIndex = Model.Index
+}
+
+public protocol Parent: LowerChildA & LowerChildB {}
+
+public func foo<T : Parent>(_: T, _: T.Model, _: T.ModelIndex) {}

--- a/validation-test/compiler_crashers_2_fixed/sr13982.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13982.swift
@@ -1,0 +1,11 @@
+// RUN: not %target-swift-frontend -emit-ir %s
+
+public protocol ProtoDelegate where Self.Manager.Delegate: Self {
+  associatedtype Manager: ProtoManager
+  func bind(to: Manager)
+}
+
+public protocol ProtoManager where Self.Delegate.Manager: Self {
+  associatedtype Delegate: ProtoDelegate
+  var name: String { get }
+}


### PR DESCRIPTION
A DependentMemberType can either have a bound AssociatedTypeDecl,
or it might be 'unresolved' and only store an identifier.

In maybeResolveEquivalenceClass(), we did not handle the unresolved
case when the base type of the DependentMemberType had itself been
resolved to a concrete type.

Fixes <rdar://problem/71162777>.