### PR TITLE
GSB: Better handling of unresolved DependentMemberTypes in maybeResolveEquivalenceClass() [5.4]

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
@@ -1,6 +1,4 @@
-// RUN: not --crash %target-swift-frontend -primary-file %s -emit-silgen
-
-// REQUIRES: asserts
+// RUN: %target-swift-frontend -primary-file %s -emit-ir
 
 public protocol WrappedSignedInteger: SignedInteger where Stride == Int {
     typealias WrappedInteger = Int

--- a/validation-test/compiler_crashers_2_fixed/rdar71162777.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar71162777.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public struct LowerModel {
+	public typealias Index = Int
+}
+
+public protocol LowerChildA {
+	typealias Model = LowerModel
+	typealias ModelIndex = Model.Index
+}
+
+public protocol LowerChildB {
+	typealias Model = LowerModel
+	typealias ModelIndex = Model.Index
+}
+
+public protocol Parent: LowerChildA & LowerChildB {}
+
+public func foo<T : Parent>(_: T, _: T.Model, _: T.ModelIndex) {}


### PR DESCRIPTION
Original: https://github.com/apple/swift/pull/35907

A DependentMemberType can either have a bound AssociatedTypeDecl,
or it might be 'unresolved' and only store an identifier.

In maybeResolveEquivalenceClass(), we did not handle the unresolved
case when the base type of the DependentMemberType had itself been
resolved to a concrete type.

Fixes <rdar://problem/71162777>.