### PR TITLE
Deprecate runAsyncAndBlock API

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -323,6 +323,7 @@ func _enqueueJobGlobal(_ task: Builtin.Job)
 @_silgen_name("swift_task_isCancelled")
 func isTaskCancelled(_ task: Builtin.NativeObject) -> Bool
 
+@available(*, deprecated)
 @_silgen_name("swift_task_runAndBlockThread")
 public func runAsyncAndBlock(_ asyncFun: @escaping () async -> ())
 


### PR DESCRIPTION
I'm throwing a deprecation warning on `runAsyncAndBlock` to keep people from starting to rely on it in the wild.
We don't want to use `runAsyncAndBlock` for a couple reasons.

First, because it blocks the thread it's on, which can cause deadlocks. If you try to run `@MainActor` code after blocking the main thread, you're going to have a bad day.
Second, because it spawns a new thread, it can contribute to thread-explosions, which are also bad news.

For new code, the correct entry-point is

```swift
@main struct Main {
  static func main() async {
    // have fun with async...
  }
}
```
Remember that for single-file tests, you'll need to pass `-parse-as-library` or it will complain about `@main` being used with top-level code.