### PR TITLE
[build-presets] Verify generated SwiftSyntax files during Swift smoke testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -591,6 +591,7 @@ libcxx
 llbuild
 swiftpm
 swiftsyntax
+swiftsyntax-verify-generated-files
 swift-driver
 indexstore-db
 sourcekit-lsp


### PR DESCRIPTION
Through #35613, we should have caught PR breakage caused by SwiftSyntax files not being updated. However, https://github.com/apple/swift-syntax/pull/259 slipped past us again. Turns out, I missed the argument to actually verify the generated SwiftSyntax files.