### PR TITLE
Improve ConcurrentValue checking for functions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4277,8 +4277,6 @@ ERROR(local_function_executed_concurrently,none,
 ERROR(concurrent_mutation_of_local_capture,none,
       "mutation of captured %0 %1 in concurrently-executing code",
       (DescriptiveDeclKind, DeclName))
-NOTE(concurrent_access_here,none,
-     "access in concurrently-executed code here", ())
 NOTE(actor_isolated_sync_func,none,
      "calls to %0 %1 from outside of its actor context are "
      "implicitly asynchronous",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4312,10 +4312,6 @@ WARNING(non_concurrent_property_type,none,
         "cannot use %0 %1 with a non-concurrent-value type %2 "
         "%select{across actors|from concurrently-executed code}3",
         (DescriptiveDeclKind, DeclName, Type, bool))
-WARNING(non_concurrent_function_type,none,
-        "`@concurrent` %select{function type|closure}0 has "
-        "non-concurrent-value %select{parameter|result}1 type %2",
-        (bool, bool, Type))
 ERROR(non_concurrent_type_member,none,
       "%select{stored property %1|associated value %1}0 of "
       "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -237,12 +237,6 @@ bool diagnoseNonConcurrentTypesInReference(
     ConcreteDeclRef declRef, const DeclContext *dc, SourceLoc loc,
     ConcurrentReferenceKind refKind);
 
-/// Diagnose the presence of any non-concurrent types within the given
-/// function type.
-bool diagnoseNonConcurrentTypesInFunctionType(
-    const AnyFunctionType *fnType, const DeclContext *dc, SourceLoc loc,
-    bool isClosure);
-
 /// Check the correctness of the given ConcurrentValue conformance.
 void checkConcurrentValueConformance(ProtocolConformance *conformance);
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2823,14 +2823,6 @@ NeverNullType TypeResolver::resolveASTFunctionType(
   if (fnTy->hasError())
     return fnTy;
 
-  // Concurrent function types must be composed of concurrent-safe parameter
-  // and result types.
-  if (concurrent && resolution.getStage() > TypeResolutionStage::Structural) {
-    (void)diagnoseNonConcurrentTypesInFunctionType(
-         fnTy, resolution.getDeclContext(), repr->getLoc(),
-         /*isClosure=*/false);
-  }
-
   // If the type is a block or C function pointer, it must be representable in
   // ObjC.
   switch (representation) {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -356,7 +356,7 @@ func checkLocalFunctions() async {
   }
 
   func local2() { // expected-error{{concurrently-executed local function 'local2()' must be marked as '@concurrent'}}{{3-3=@concurrent }}
-    j = 42 // expected-error{{mutation of captured var 'j' in concurrently-executing code}}
+    j = 42
   }
 
   // Okay to call locally.
@@ -371,7 +371,7 @@ func checkLocalFunctions() async {
 
   // Escaping closures can make the local function execute concurrently.
   acceptConcurrentClosure {
-    local2() // expected-note{{access in concurrently-executed code here}}
+    local2()
   }
 
   print(i)
@@ -380,7 +380,7 @@ func checkLocalFunctions() async {
   var k = 17
   func local4() {
     acceptConcurrentClosure {
-      local3() // expected-note{{access in concurrently-executed code here}}
+      local3()
     }
   }
 

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -87,8 +87,8 @@ func first_allMustSucceed() async throws {
 }
 
 func first_ignoreFailures() async throws {
-  func work() async -> Int { 42 }
-  func boom() async throws -> Int { throw Boom() }
+  @concurrent func work() async -> Int { 42 }
+  @concurrent func boom() async throws -> Int { throw Boom() }
 
   let first: Int = try await Task.withGroup(resultType: Int.self) { group in
     await group.add { await work() }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -151,13 +151,13 @@ class SomeClass: MainActorProto {
 @concurrent func concurrentFunc() -> NotConcurrent? { nil } // expected-warning{{cannot call function returning non-concurrent-value type 'NotConcurrent?' across actors}}
 
 // ----------------------------------------------------------------------
-// ConcurrentValue restriction on @concurrent types.
+// No ConcurrentValue restriction on @concurrent function types.
 // ----------------------------------------------------------------------
-typealias CF = @concurrent () -> NotConcurrent? // expected-warning{{`@concurrent` function type has non-concurrent-value result type 'NotConcurrent?'}}
-typealias BadGenericCF<T> = @concurrent () -> T? // expected-warning{{`@concurrent` function type has non-concurrent-value result type 'T?'}}
+typealias CF = @concurrent () -> NotConcurrent?
+typealias BadGenericCF<T> = @concurrent () -> T?
 typealias GoodGenericCF<T: ConcurrentValue> = @concurrent () -> T? // okay
 
-var concurrentFuncVar: (@concurrent (NotConcurrent) -> Void)? = nil // expected-warning{{`@concurrent` function type has non-concurrent-value parameter type 'NotConcurrent'}}
+var concurrentFuncVar: (@concurrent (NotConcurrent) -> Void)? = nil
 
 // ----------------------------------------------------------------------
 // ConcurrentValue restriction on @concurrent closures.
@@ -165,8 +165,9 @@ var concurrentFuncVar: (@concurrent (NotConcurrent) -> Void)? = nil // expected-
 func acceptConcurrentUnary<T>(_: @concurrent (T) -> T) { }
 
 func concurrentClosures<T>(_: T) {
-  acceptConcurrentUnary { (x: T) in // expected-warning{{`@concurrent` closure has non-concurrent-value parameter type 'T'}}
-    x
+  acceptConcurrentUnary { (x: T) in
+    _ = x // ok
+    acceptConcurrentUnary { _ in x } // expected-warning{{cannot use parameter 'x' with a non-concurrent-value type 'T' from concurrently-executed code}}
   }
 }
 


### PR DESCRIPTION
Based on the discussion in the pitch, tweak ConcurrentValue checking for functions:
* Collapse all of the logic about concurrently-executing local functions into a simple "local capture" check
* Don't require the parameter and result types of a `@concurrent` function (type) to conform to `ConcurrentValue`.