### PR TITLE
[Lexer] Improve lexing of BOM trivia

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -553,7 +553,13 @@ private:
   void lexOperatorIdentifier();
   void lexHexNumber();
   void lexNumber();
-  StringRef lexTrivia(bool IsForTrailingTrivia);
+
+  /// Skip over trivia and return characters that were skipped over in a \c
+  /// StringRef. \p AllTriviaStart determines the start of the trivia. In nearly
+  /// all cases, this should be \c CurPtr. If other trivia has already been
+  /// skipped over (like a BOM), this can be used to point to the start of the
+  /// BOM. The returned \c StringRef will always start at \p AllTriviaStart.
+  StringRef lexTrivia(bool IsForTrailingTrivia, const char *AllTriviaStart);
   static unsigned lexUnicodeEscape(const char *&CurPtr, Lexer *Diags);
 
   unsigned lexCharacter(const char *&CurPtr, char StopQuote,

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -291,7 +291,7 @@ void Lexer::formToken(tok Kind, const char *TokStart) {
   StringRef TokenText { TokStart, static_cast<size_t>(CurPtr - TokStart) };
 
   if (TriviaRetention == TriviaRetentionMode::WithTrivia && Kind != tok::eof) {
-    TrailingTrivia = lexTrivia(/*IsForTrailingTrivia=*/true);
+    TrailingTrivia = lexTrivia(/*IsForTrailingTrivia=*/true, CurPtr);
   } else {
     TrailingTrivia = StringRef();
   }
@@ -2344,11 +2344,8 @@ void Lexer::lexImpl() {
     NextToken.setAtStartOfLine(false);
   }
 
-  // Advance CurPtr to the end of the first trivia in the source file and form
-  // the leading trivia including the BOM
-  lexTrivia(/*IsForTrailingTrivia=*/false);
-  LeadingTrivia = StringRef(LeadingTriviaStart, CurPtr - LeadingTriviaStart);
-  
+  LeadingTrivia = lexTrivia(/*IsForTrailingTrivia=*/false, LeadingTriviaStart);
+
   // Remember the start of the token so we can form the text range.
   const char *TokStart = CurPtr;
   
@@ -2525,8 +2522,8 @@ Token Lexer::getTokenAtLocation(const SourceManager &SM, SourceLoc Loc,
   return L.peekNextToken();
 }
 
-StringRef Lexer::lexTrivia(bool IsForTrailingTrivia) {
-  const char *AllTriviaStart = CurPtr;
+StringRef Lexer::lexTrivia(bool IsForTrailingTrivia,
+                           const char *AllTriviaStart) {
   CommentStart = nullptr;
 
 Restart:


### PR DESCRIPTION
As discussed [here](https://github.com/apple/swift/pull/35649#discussion_r572243021).

Simplify lexing of BOM trivia, eliminating the need to manually construct the trivia `StringRef`.