### PR TITLE
don't load raw comments for invalid serialized ranges

### DIFF
--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -156,6 +156,11 @@ RawComment Decl::getRawComment(bool SerializedOK) const {
           for (const auto &Range : CachedLocs->DocRanges) {
             if (Range.isValid()) {
               SRCs.push_back({ Range, Context.SourceMgr });
+            } else {
+              // if we've run into an invalid range, don't bother trying to load any of
+              // the other comments
+              SRCs.clear();
+              break;
             }
           }
           auto RC = RawComment(Context.AllocateCopy(llvm::makeArrayRef(SRCs)));

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -154,7 +154,9 @@ RawComment Decl::getRawComment(bool SerializedOK) const {
         if (!CachedLocs->DocRanges.empty()) {
           SmallVector<SingleRawComment, 4> SRCs;
           for (const auto &Range : CachedLocs->DocRanges) {
-            SRCs.push_back({ Range, Context.SourceMgr });
+            if (Range.isValid()) {
+              SRCs.push_back({ Range, Context.SourceMgr });
+            }
           }
           auto RC = RawComment(Context.AllocateCopy(llvm::makeArrayRef(SRCs)));
 

--- a/test/SymbolGraph/Module/NoSourceInfo.swift
+++ b/test/SymbolGraph/Module/NoSourceInfo.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Source)
+// RUN: %empty-directory(%t/NoSourceInfo.framework/Modules/NoSourceInfo.swiftmodule)
+// RUN: %empty-directory(%t/NoSourceInfo.framework/Modules/NoSourceInfo.swiftmodule/Project)
+
+// RUN: cp %s %t/Source/Input.swift
+
+// RUN: %target-swift-frontend -module-name NoSourceInfo -emit-module -emit-module-path %t/NoSourceInfo.framework/Modules/NoSourceInfo.swiftmodule/%target-swiftmodule-name -emit-module-doc-path %t/NoSourceInfo.framework/Modules/NoSourceInfo.swiftmodule/%target-swiftdoc-name -emit-module-interface-path %t/NoSourceInfo.framework/Modules/NoSourceInfo.swiftmodule/%target-swiftinterface-name -emit-module-source-info-path %t/NoSourceInfo.framework/Modules/NoSourceInfo.swiftmodule/Project/%target-swiftsourceinfo-name %t/Source/Input.swift
+
+// RUN: mv %t/Source %t/MovedSource
+
+// RUN: %target-swift-symbolgraph-extract -module-name NoSourceInfo -F %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/NoSourceInfo.symbols.json
+
+// CHECK: s:12NoSourceInfo1SV
+// CHECK: docComment
+// CHECK: This is a test
+
+/// This is a test
+public struct S {
+    /// This is also a test
+    public var x: Int
+}
+
+/// writing some docs here
+open class C<Data> {
+    /// writing more docs over there
+    public init() {}
+}
+
+open class CO: C<String> {
+    override public init() { super.init() }
+}


### PR DESCRIPTION
When the symbol graph tool is run over a framework with source info that points to nonexistent files, it will eventually try to load RawComments from the file module, even though all its ranges don't have source files to load from. This causes a situation where it hits an assertion in the RawComment initializer and crashes the tool. This PR aims to sidestep the error by only calling the RawComment initializer for valid ranges.

~~I couldn't figure out how to write a test for this, so i could only verify it by running the compiled tool over the framework that previously caused the crash. While that worked out, it doesn't mean that this can continue to be verified in the future. Like i mentioned earlier, i'm not entirely sure what's going on; the frameworks i was given had `.swiftsourceinfo` files in them, but something about them meant that they couldn't get loaded. The person who opened the issue (linked below) was handed the frameworks by the team that manages the library, and didn't know how they were created. The source library is open-source (CareKit), so if we need to, we can ask them directly. If you know more about how to mess with these source-info files so we can put something into a SymbolGraph test (or can pass it off to someone who does), let me know!~~ I've been able to reproduce this in a test, which is now part of this PR. The issue isn't about scrubbed source info, it's about source info that refers to files that don't exist on the current system.

Fixes rdar://73833411
