### PR TITLE
build: build target libdispatch as necessary

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -34,19 +34,23 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif()
 
 set(DISPATCH_SDKS)
+
+# Build the host libdispatch if needed.
 if(SWIFT_BUILD_HOST_DISPATCH)
   if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     if(NOT "${SWIFT_HOST_VARIANT_SDK}" IN_LIST SWIFT_SDKS)
       list(APPEND DISPATCH_SDKS "${SWIFT_HOST_VARIANT_SDK}")
     endif()
   endif()
-
-  foreach(sdk ${SWIFT_SDKS})
-    if(NOT "${sdk}" IN_LIST SWIFT_APPLE_PLATFORMS)
-      list(APPEND DISPATCH_SDKS "${sdk}")
-    endif()
-  endforeach()
 endif()
+
+# Build any target libdispatch if needed.
+foreach(sdk ${SWIFT_SDKS})
+  # Apple targets have libdispatch available, do not build it.
+  if(NOT "${sdk}" IN_LIST SWIFT_APPLE_PLATFORMS)
+    list(APPEND DISPATCH_SDKS "${sdk}")
+  endif()
+endforeach()
 
 foreach(sdk ${DISPATCH_SDKS})
   set(ARCHS ${SWIFT_SDK_${sdk}_ARCHITECTURES})


### PR DESCRIPTION
This should not be predicated on the host libdispatch being built, only
if concurrency is being built in multithreaded mode.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
