### PR TITLE
Sema: Clarify the «can only be used as a generic constraint» error message

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -138,7 +138,7 @@ ERROR(could_not_use_instance_member_on_type,none,
       "%select{| instance of nested}3 type %0",
       (Type, DeclNameRef, Type, bool))
 ERROR(could_not_use_member_on_existential,none,
-      "member %1 cannot be used on value of protocol type %0; use a generic"
+      "member %1 cannot be used on value of protocol type %0; use a conformance"
       " constraint instead",
       (Type, DeclNameRef))
 FIXIT(replace_with_type,"%0",(Type))
@@ -879,7 +879,7 @@ NOTE(object_literal_resolve_import,none,
 ERROR(use_local_before_declaration,none,
       "use of local variable %0 before its declaration", (DeclNameRef))
 ERROR(unsupported_existential_type,none,
-      "protocol %0 can only be used as a generic constraint because it has "
+      "protocol %0 can only be used as a conformance constraint because it has "
       "Self or associated type requirements", (Identifier))
 
 ERROR(decl_does_not_exist_in_module,none,

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -370,8 +370,8 @@ func testClonableExistential(_ v: Clonable, _ vv: Clonable.Type) {
   let _: (Bool) -> Clonable? = id(vv.returnSelfIUOStatic as (Bool) -> Clonable?)
   let _: Clonable! = id(vv.returnSelfIUOStatic(true))
 
-  let _ = v.badClonerFn() // expected-error {{member 'badClonerFn' cannot be used on value of protocol type 'Clonable'; use a generic constraint instead}}
-  let _ = v.veryBadClonerFn() // expected-error {{member 'veryBadClonerFn' cannot be used on value of protocol type 'Clonable'; use a generic constraint instead}}
+  let _ = v.badClonerFn() // expected-error {{member 'badClonerFn' cannot be used on value of protocol type 'Clonable'; use a conformance constraint instead}}
+  let _ = v.veryBadClonerFn() // expected-error {{member 'veryBadClonerFn' cannot be used on value of protocol type 'Clonable'; use a conformance constraint instead}}
 
 }
 

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -37,7 +37,7 @@ func existential<T : EqualComparable, U : EqualComparable>(_ t1: T, t2: T, u: U)
   var eqComp : EqualComparable = t1 // expected-error{{protocol 'EqualComparable' can only be used as a generic constraint}}
   eqComp = u
   if t1.isEqual(eqComp) {} // expected-error{{cannot convert value of type 'EqualComparable' to expected argument type 'T'}}
-  if eqComp.isEqual(t2) {} // expected-error{{member 'isEqual' cannot be used on value of protocol type 'EqualComparable'; use a generic constraint instead}}
+  if eqComp.isEqual(t2) {} // expected-error{{member 'isEqual' cannot be used on value of protocol type 'EqualComparable'; use a conformance constraint instead}}
 }
 
 protocol OtherEqualComparable {

--- a/test/Sema/existential_nested_type.swift
+++ b/test/Sema/existential_nested_type.swift
@@ -15,7 +15,7 @@ enum MyError : Error {
 
 func checkIt(_ js: Any) throws {
   switch js {
-    case let dbl as HasAssoc: // expected-error {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+    case let dbl as HasAssoc: // expected-error {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
       throw MyError.bad(dbl)
 
     default:

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -32,7 +32,7 @@ struct ConformsToOuterProtocol : OuterProtocol {
   typealias Hen = Int
 
   func f() { let _ = InnerProtocol.self }
-  // expected-error@-1 {{protocol 'InnerProtocol' can only be used as a generic constraint because it has Self or associated type requirements}}
+  // expected-error@-1 {{protocol 'InnerProtocol' can only be used as a conformance constraint because it has Self or associated type requirements}}
 }
 
 protocol Racoon {

--- a/test/decl/nested/type_in_function.swift
+++ b/test/decl/nested/type_in_function.swift
@@ -145,7 +145,7 @@ func freeFunction() {
     typealias T = Int
 
     func method() -> ProtoWithAssocType {}
-    // expected-error@-1 {{can only be used as a generic constraint because it has Self or associated type requirements}}
+    // expected-error@-1 {{can only be used as a conformance constraint because it has Self or associated type requirements}}
   }
 }
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -268,7 +268,7 @@ struct WrongIsEqual : IsEqualComparable { // expected-error{{type 'WrongIsEqual'
 //===----------------------------------------------------------------------===//
 
 func existentialSequence(_ e: Sequence) { // expected-error{{has Self or associated type requirements}}
-  var x = e.makeIterator() // expected-error{{member 'makeIterator' cannot be used on value of protocol type 'Sequence'; use a generic constraint instead}}
+  var x = e.makeIterator() // expected-error{{member 'makeIterator' cannot be used on value of protocol type 'Sequence'; use a conformance constraint instead}}
   x.next()
   x.nonexistent()
 }
@@ -280,7 +280,7 @@ protocol HasSequenceAndStream {
 
 func existentialSequenceAndStreamType(_ h: HasSequenceAndStream) { // expected-error{{has Self or associated type requirements}}
   // FIXME: Crummy diagnostics.
-  var x = h.getR() // expected-error{{member 'getR' cannot be used on value of protocol type 'HasSequenceAndStream'; use a generic constraint instead}}
+  var x = h.getR() // expected-error{{member 'getR' cannot be used on value of protocol type 'HasSequenceAndStream'; use a conformance constraint instead}}
   x.makeIterator()
   x.next()
 
@@ -309,7 +309,7 @@ struct DictionaryIntInt {
 
 func testSubscripting(_ iis: IntIntSubscriptable, i_s: IntSubscriptable) { // expected-error{{has Self or associated type requirements}}
   var i: Int = iis[17] 
-  var i2 = i_s[17] // expected-error{{member 'subscript' cannot be used on value of protocol type 'IntSubscriptable'; use a generic constraint instead}}
+  var i2 = i_s[17] // expected-error{{member 'subscript' cannot be used on value of protocol type 'IntSubscriptable'; use a conformance constraint instead}}
 }
 
 //===----------------------------------------------------------------------===//
@@ -488,18 +488,18 @@ func g<T : C2>(_ x : T) {
 
 class C3 : P1 {} // expected-error{{type 'C3' does not conform to protocol 'P1'}}
 func h<T : C3>(_ x : T) {
-  _ = x as P1 // expected-error{{protocol 'P1' can only be used as a generic constraint because it has Self or associated type requirements}}
+  _ = x as P1 // expected-error{{protocol 'P1' can only be used as a conformance constraint because it has Self or associated type requirements}}
 }
 func i<T : C3>(_ x : T?) -> Bool {
-  return x is P1 // expected-error{{protocol 'P1' can only be used as a generic constraint because it has Self or associated type requirements}}
+  return x is P1 // expected-error{{protocol 'P1' can only be used as a conformance constraint because it has Self or associated type requirements}}
   // FIXME: Bogus diagnostic.  See SR-11920.
   // expected-warning@-2 {{checking a value with optional type 'T?' against dynamic type 'P1' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
 }
 func j(_ x : C1) -> Bool {
-  return x is P1 // expected-error{{protocol 'P1' can only be used as a generic constraint because it has Self or associated type requirements}}
+  return x is P1 // expected-error{{protocol 'P1' can only be used as a conformance constraint because it has Self or associated type requirements}}
 }
 func k(_ x : C1?) -> Bool {
-  return x is P1 // expected-error{{protocol 'P1' can only be used as a generic constraint because it has Self or associated type requirements}}
+  return x is P1 // expected-error{{protocol 'P1' can only be used as a conformance constraint because it has Self or associated type requirements}}
 }
 
 

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -95,7 +95,7 @@ protocol AsExistentialB {
 }
 
 protocol AsExistentialAssocTypeA {
-  var delegate : AsExistentialAssocTypeB? { get } // expected-error {{protocol 'AsExistentialAssocTypeB' can only be used as a generic constraint because it has Self or associated type requirements}}
+  var delegate : AsExistentialAssocTypeB? { get } // expected-error {{protocol 'AsExistentialAssocTypeB' can only be used as a conformance constraint because it has Self or associated type requirements}}
 }
 protocol AsExistentialAssocTypeB {
   func aMethod(_ object : AsExistentialAssocTypeA)
@@ -107,7 +107,7 @@ protocol AsExistentialAssocTypeAgainA {
   associatedtype Bar
 }
 protocol AsExistentialAssocTypeAgainB {
-  func aMethod(_ object : AsExistentialAssocTypeAgainA) // expected-error {{protocol 'AsExistentialAssocTypeAgainA' can only be used as a generic constraint because it has Self or associated type requirements}}
+  func aMethod(_ object : AsExistentialAssocTypeAgainA) // expected-error {{protocol 'AsExistentialAssocTypeAgainA' can only be used as a conformance constraint because it has Self or associated type requirements}}
 }
 
 // SR-547

--- a/test/decl/protocol/req/dynamic_self.swift
+++ b/test/decl/protocol/req/dynamic_self.swift
@@ -100,8 +100,8 @@ protocol P4 {
   subscript<T: Sequence>() -> T where T.Element == Self { get set }
 }
 func takesP2P3P4(p2: P2, p3: P3, p4: P4) { }
-// expected-error@-1{{protocol 'P2' can only be used as a generic constraint because it has Self or associated type requirements}}
-// expected-error@-2{{protocol 'P3' can only be used as a generic constraint because it has Self or associated type requirements}}
+// expected-error@-1{{protocol 'P2' can only be used as a conformance constraint because it has Self or associated type requirements}}
+// expected-error@-2{{protocol 'P3' can only be used as a conformance constraint because it has Self or associated type requirements}}
 
 protocol P5 {
 }
@@ -118,7 +118,7 @@ extension P5 {
 }
 func takesP5(p5: P5) {
   _ = p5[]
-  // expected-error@-1{{member 'subscript' cannot be used on value of protocol type 'P5'; use a generic constraint instead}}
+  // expected-error@-1{{member 'subscript' cannot be used on value of protocol type 'P5'; use a conformance constraint instead}}
   _ = p5.prop
-  // expected-error@-1{{member 'prop' cannot be used on value of protocol type 'P5'; use a generic constraint instead}}
+  // expected-error@-1{{member 'prop' cannot be used on value of protocol type 'P5'; use a conformance constraint instead}}
 }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -176,7 +176,7 @@ func testOptionalSequence() {
 }
 
 // Crash with (invalid) for each over an existential
-func testExistentialSequence(s: Sequence) { // expected-error {{protocol 'Sequence' can only be used as a generic constraint because it has Self or associated type requirements}}
+func testExistentialSequence(s: Sequence) { // expected-error {{protocol 'Sequence' can only be used as a conformance constraint because it has Self or associated type requirements}}
   for x in s { // expected-error {{protocol 'Sequence' as a type cannot conform to the protocol itself}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
     _ = x
   }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -499,9 +499,9 @@ extension OpaqueProtocol {
 
 func takesOpaqueProtocol(existential: OpaqueProtocol) {
   // this is not allowed:
-  _ = existential.asSome // expected-error{{member 'asSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
-  _ = existential.getAsSome() // expected-error{{member 'getAsSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
-  _ = existential[0] // expected-error{{member 'subscript' cannot be used on value of protocol type 'OpaqueProtocol'; use a generic constraint instead}}
+  _ = existential.asSome // expected-error{{member 'asSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a conformance constraint instead}}
+  _ = existential.getAsSome() // expected-error{{member 'getAsSome' cannot be used on value of protocol type 'OpaqueProtocol'; use a conformance constraint instead}}
+  _ = existential[0] // expected-error{{member 'subscript' cannot be used on value of protocol type 'OpaqueProtocol'; use a conformance constraint instead}}
 }
 
 func takesOpaqueProtocol<T : OpaqueProtocol>(generic: T) {

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -3,7 +3,7 @@
 protocol HasSelfRequirements {
   func foo(_ x: Self)
 
-  func returnsOwnProtocol() -> HasSelfRequirements // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint because it has Self or associated type requirements}} {{educational-notes=associated-type-requirements}}
+  func returnsOwnProtocol() -> HasSelfRequirements // expected-error{{protocol 'HasSelfRequirements' can only be used as a conformance constraint because it has Self or associated type requirements}} {{educational-notes=associated-type-requirements}}
 }
 protocol Bar {
   // init() methods should not prevent use as an existential.
@@ -36,10 +36,10 @@ func useCompoAsWhereRequirement<T>(_ x: T) where T: HasSelfRequirements & Bar {}
 func useCompoAliasAsWhereRequirement<T>(_ x: T) where T: Compo {}
 func useNestedCompoAliasAsWhereRequirement<T>(_ x: T) where T: CompoAssocType.Compo {}
 
-func useAsType(_ x: HasSelfRequirements) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
-func useCompoAsType(_ x: HasSelfRequirements & Bar) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
-func useCompoAliasAsType(_ x: Compo) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
-func useNestedCompoAliasAsType(_ x: CompoAssocType.Compo) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a generic constraint}}
+func useAsType(_ x: HasSelfRequirements) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a conformance constraint}}
+func useCompoAsType(_ x: HasSelfRequirements & Bar) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a conformance constraint}}
+func useCompoAliasAsType(_ x: Compo) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a conformance constraint}}
+func useNestedCompoAliasAsType(_ x: CompoAssocType.Compo) { } // expected-error{{protocol 'HasSelfRequirements' can only be used as a conformance constraint}}
 
 struct TypeRequirement<T: HasSelfRequirements> {}
 struct CompoTypeRequirement<T: HasSelfRequirements & Bar> {}
@@ -68,7 +68,7 @@ protocol HasAssoc {
 }
 
 func testHasAssoc(_ x: Any) {
-  if let p = x as? HasAssoc { // expected-error {{protocol 'HasAssoc' can only be used as a generic constraint}} {{educational-notes=associated-type-requirements}}
+  if let p = x as? HasAssoc { // expected-error {{protocol 'HasAssoc' can only be used as a conformance constraint}} {{educational-notes=associated-type-requirements}}
     p.foo() // don't crash here.
   }
 }
@@ -78,18 +78,18 @@ protocol InheritsAssoc : HasAssoc {
   func silverSpoon()
 }
 
-func testInheritsAssoc(_ x: InheritsAssoc) { // expected-error {{protocol 'InheritsAssoc' can only be used as a generic constraint}}
+func testInheritsAssoc(_ x: InheritsAssoc) { // expected-error {{protocol 'InheritsAssoc' can only be used as a conformance constraint}}
   x.silverSpoon()
 }
 
 // SR-38
-var b: HasAssoc // expected-error {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+var b: HasAssoc // expected-error {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
 
 // Further generic constraint error testing - typealias used inside statements
 protocol P {}
 typealias MoreHasAssoc = HasAssoc & P
 func testHasMoreAssoc(_ x: Any) {
-  if let p = x as? MoreHasAssoc { // expected-error {{protocol 'HasAssoc' can only be used as a generic constraint}}
+  if let p = x as? MoreHasAssoc { // expected-error {{protocol 'HasAssoc' can only be used as a conformance constraint}}
     p.foo() // don't crash here.
   }
 }
@@ -105,35 +105,35 @@ _ = Struct1<Pub & Bar>.self
 
 typealias BadAlias<T> = T
 where T : HasAssoc, T.Assoc == HasAssoc
-// expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+// expected-error@-1 {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
 
 struct BadStruct<T>
 where T : HasAssoc,
       T.Assoc == HasAssoc {}
-// expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+// expected-error@-1 {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
 
 protocol BadProtocol where T == HasAssoc {
-  // expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+  // expected-error@-1 {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
   associatedtype T
 
   associatedtype U : HasAssoc
     where U.Assoc == HasAssoc
-  // expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+  // expected-error@-1 {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
 }
 
 extension HasAssoc where Assoc == HasAssoc {}
-// expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+// expected-error@-1 {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
 
 func badFunction<T>(_: T)
 where T : HasAssoc,
       T.Assoc == HasAssoc {}
-// expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+// expected-error@-1 {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
 
 struct BadSubscript {
   subscript<T>(_: T) -> Int
   where T : HasAssoc,
         T.Assoc == HasAssoc {
-    // expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+    // expected-error@-1 {{protocol 'HasAssoc' can only be used as a conformance constraint because it has Self or associated type requirements}}
     get {}
     set {}
   }

--- a/userdocs/diagnostics/associated-type-requirements.md
+++ b/userdocs/diagnostics/associated-type-requirements.md
@@ -16,7 +16,7 @@ While all Swift protocols can be used as generic constraints and as part of opaq
 
 ```swift
 func foo(bar: Identifiable) { /* ... */ }
-// error: protocol 'Identifiable' can only be used as a generic constraint because it has Self or associated type requirements
+// error: protocol 'Identifiable' can only be used as a conformance constraint because it has Self or associated type requirements
 ```
 
 Protocols like `Identifiable` which have `Self` or associated type requirements cannot be used as types because such types would rarely be useful in practice. They would be unable to allow use of `Self` or associated type requirements like `var id: ID { get }` because the associated type is not specified.


### PR DESCRIPTION
When a protocol is under the existential type restriction, it can only be used as a conformance constraint in:
* a generic `where` clause 
* a generic parameter declaration
* an opaque type declaration
