### PR TITLE
don't crash the symbol graph tool when a module fails to load

### DIFF
--- a/test/SymbolGraph/Module/FailedLoad.swift
+++ b/test/SymbolGraph/Module/FailedLoad.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/FailedLoad/A.swift -module-name A -emit-module -emit-module-path %t/
+// RUN: %target-build-swift %s -module-name FailedLoad -emit-module -I %t -emit-module-path %t/
+
+// RUN: rm %t/A.swiftmodule
+
+// RUN: not %target-swift-symbolgraph-extract -module-name FailedLoad -I %t -pretty-print -output-dir %t 2>&1 | %FileCheck %s
+
+// CHECK-NOT: Emitting symbol graph for module file
+
+import A
+
+public struct Outer {
+    public var Something: A.Inner
+}

--- a/test/SymbolGraph/Module/Inputs/FailedLoad/A.swift
+++ b/test/SymbolGraph/Module/Inputs/FailedLoad/A.swift
@@ -1,0 +1,3 @@
+public struct Inner {
+    public var Field: String
+}

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -238,6 +238,14 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
     }
     return EXIT_FAILURE;
   }
+  
+  if (M->failedToLoad()) {
+    llvm::errs() << "Error: Failed to load the module '" << options::ModuleName
+      << "'. Are you missing build dependencies or include/framework directories?\n"
+      << "See the previous error messages for details. Aborting.\n";
+    
+    return EXIT_FAILURE;
+  }
 
   const auto &MainFile = M->getMainFile(FileUnitKind::SerializedAST);
   llvm::errs() << "Emitting symbol graph for module file: " << MainFile.getModuleDefiningPath() << '\n';


### PR DESCRIPTION
When the symbol graph tool fails to load a module, it currently crashes upon trying to load the main-file name. This PR adds a check before loading symbols to ensure that the module loaded properly; if it failed to load, the tool now prints an error message and cleanly exits instead of hitting an assertion and crashing.

Fixes rdar://74239464