### PR TITLE
[concurrency] add fix-it to note for "add 'async' to function"

### DIFF
--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -125,7 +125,7 @@ func anotherAsyncFunc() async {
 
 }
 
-// expected-note@+2 {{add 'async' to function 'regularFunc()' to make it asynchronous}} {{none}}
+// expected-note@+2 {{add 'async' to function 'regularFunc()' to make it asynchronous}} {{19-19= async}}
 // expected-note@+1 {{add '@asyncHandler' to function 'regularFunc()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
 func regularFunc() {
   let a = BankAccount(initialDeposit: 34)

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -45,7 +45,7 @@ extension MyActor {
     set { }
   }
 
-  // expected-note@+1 {{add 'async' to function 'actorIndependentFunc(otherActor:)' to make it asynchronous}} {{none}}
+  // expected-note@+1 {{add 'async' to function 'actorIndependentFunc(otherActor:)' to make it asynchronous}} {{67-67= async}}
   @actorIndependent func actorIndependentFunc(otherActor: MyActor) -> Int {
     _ = immutable
     _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from an '@actorIndependent' context}}
@@ -279,7 +279,7 @@ struct GenericStruct<T> {
   }
 
   // expected-note@+2 {{add '@asyncHandler' to function 'h()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'h()' to make it asynchronous}} {{none}}
+  // expected-note@+1 {{add 'async' to function 'h()' to make it asynchronous}} {{39-39= async}}
   @GenericGlobalActor<String> func h() {
     f() // expected-error{{'async' in a function that does not support concurrency}}
     _ = f // expected-error{{instance method 'f()' isolated to global actor 'GenericGlobalActor<T>' can not be referenced from different global actor 'GenericGlobalActor<String>'}}

--- a/test/Concurrency/async_throwing.swift
+++ b/test/Concurrency/async_throwing.swift
@@ -45,7 +45,7 @@ func throwingTask() async throws -> String {
 }
 
 // expected-note@+2 7 {{add '@asyncHandler' to function 'syncTest()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+1 7 {{add 'async' to function 'syncTest()' to make it asynchronous}} {{none}}
+// expected-note@+1 7 {{add 'async' to function 'syncTest()' to make it asynchronous}} {{16-16= async}}
 func syncTest() {
   let _ = invoke(fn: normalTask) // expected-error{{'async' in a function that does not support concurrency}}
   let _ = invokeAuto(42) // expected-error{{'async' in a function that does not support concurrency}}

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -49,7 +49,7 @@ func referenceGlobalActor2() {
 
 
 // expected-note@+2 {{add '@asyncHandler' to function 'referenceAsyncGlobalActor()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+1 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}} {{none}}
+// expected-note@+1 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}} {{33-33= async}}
 func referenceAsyncGlobalActor() {
   let y = asyncGlobalActFn
   y() // expected-error{{'async' in a function that does not support concurrency}}
@@ -57,7 +57,7 @@ func referenceAsyncGlobalActor() {
 
 
 // expected-note@+3 {{add '@asyncHandler' to function 'callGlobalActor()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+2 {{add 'async' to function 'callGlobalActor()' to make it asynchronous}} {{none}}
+// expected-note@+2 {{add 'async' to function 'callGlobalActor()' to make it asynchronous}} {{23-23= async}}
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'callGlobalActor()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func callGlobalActor() {
   syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
@@ -76,7 +76,7 @@ func fromClosure() {
 }
 
 class Taylor {
-  init() { // expected-note {{add 'async' to function 'init()' to make it asynchronous}} {{none}}
+  init() { // expected-note {{add 'async' to function 'init()' to make it asynchronous}} {{9-9= async}}
     syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
@@ -92,7 +92,7 @@ class Taylor {
 
   // expected-note@+3 2 {{add '@SomeGlobalActor' to make instance method 'method1()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
   // expected-note@+2 {{add '@asyncHandler' to function 'method1()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'method1()' to make it asynchronous}} {{none}}
+  // expected-note@+1 {{add 'async' to function 'method1()' to make it asynchronous}} {{17-17= async}}
   func method1() {
     syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -46,7 +46,7 @@ class C1: P1 {
   func method() { } // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
   // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{none}}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{38-38= async}}
   @OtherGlobalActor func testMethod() {
     method() // expected-error {{'async' in a function that does not support concurrency}}
     _ = method  // expected-error {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
@@ -58,7 +58,7 @@ class C2: P2 {
   func method2() { }
 
   // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{none}}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{38-38= async}}
   @OtherGlobalActor func testMethod() {
     method1() // expected-error{{'async' in a function that does not support concurrency}}
     _ = method1 // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
@@ -94,7 +94,7 @@ class C5 {
 }
 
 // expected-note@+2 5 {{add '@asyncHandler' to function 'testGlobalActorInference(c3:c4:c5:)' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+1 5 {{add 'async' to function 'testGlobalActorInference(c3:c4:c5:)' to make it asynchronous}} {{none}}
+// expected-note@+1 5 {{add 'async' to function 'testGlobalActorInference(c3:c4:c5:)' to make it asynchronous}} {{72-72= async}}
 @OtherGlobalActor func testGlobalActorInference(c3: C3, c4: C4, c5: C5) {
   // Propagation via class annotation
   c3.method1() // expected-error{{'async' in a function that does not support concurrency}}
@@ -156,7 +156,7 @@ actor GenericSub<T> : GenericSuper<[T]> {
   @actorIndependent override func method3() { } // expected-error{{actor-independent instance method 'method3()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
 
   // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{none}}
+  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{38-38= async}}
   @OtherGlobalActor func testMethod() {
     method() // expected-error{{'async' in a function that does not support concurrency}}
     _ = method  // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[T]>' can not be referenced from different global actor 'OtherGlobalActor'}}
@@ -233,7 +233,7 @@ func bar() async {
 
 // expected-note@+3 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 // expected-note@+2 {{add '@asyncHandler' to function 'barSync()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+1 {{add 'async' to function 'barSync()' to make it asynchronous}} {{none}}
+// expected-note@+1 {{add 'async' to function 'barSync()' to make it asynchronous}} {{15-15= async}}
 func barSync() {
   foo() // expected-error {{'async' in a function that does not support concurrency}}
 }

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -60,7 +60,7 @@ class Y: P {
   // @asyncHandler is not inferred for classes
 
   func callback() {
-    // expected-note@-1{{add 'async' to function 'callback()' to make it asynchronous}} {{none}}
+    // expected-note@-1{{add 'async' to function 'callback()' to make it asynchronous}} {{18-18= async}}
     // expected-note@-2{{add '@asyncHandler' to function 'callback()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
 
     // okay, it's an async context

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -37,7 +37,7 @@ actor MyActor {
 
   // Actor-isolated entities cannot be exposed to Objective-C.
   @objc func synchronousBad() { } // expected-error{{actor-isolated instance method 'synchronousBad()' cannot be @objc}}
-  // expected-note@-1{{add 'async' to function 'synchronousBad()' to make it asynchronous}} {{none}}
+  // expected-note@-1{{add 'async' to function 'synchronousBad()' to make it asynchronous}} {{30-30= async}}
   // expected-note@-2{{add '@asyncHandler' to function 'synchronousBad()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
 
   @objc var badProp: AnyObject { self } // expected-error{{actor-isolated property 'badProp' cannot be @objc}}

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -22,9 +22,17 @@ func test2(
   print("foo")
 }
 
-func test3() { // expected-note{{add 'async' to function 'test3()' to make it asynchronous}} {{none}}
+func test3() { // expected-note{{add 'async' to function 'test3()' to make it asynchronous}} {{13-13= async}}
   // expected-note@-1{{add '@asyncHandler' to function 'test3()' to create an implicit asynchronous context}}{{1-1=@asyncHandler }}
   _ = await getInt() // expected-error{{'async' in a function that does not support concurrency}}
+}
+
+func test4()throws { // expected-note{{add 'async' to function 'test4()' to make it asynchronous}} {{13-19=async throws}}
+  _ = await getInt() // expected-error{{'async' in a function that does not support concurrency}}
+}
+
+func test5<T>(_ f : () async throws -> T)  rethrows->T { // expected-note{{add 'async' to function 'test5' to make it asynchronous}} {{44-52=async rethrows}}
+  return try await f() // expected-error{{'async' in a function that does not support concurrency}}
 }
 
 enum SomeEnum: Int {
@@ -43,7 +51,7 @@ func acceptAutoclosureAsyncThrowsRethrows(_: @autoclosure () async throws -> Int
 
 func acceptAutoclosureNonAsyncBad(_: @autoclosure () async -> Int) -> Int { 0 }
 // expected-error@-1{{'async' autoclosure parameter in a non-'async' function}}
-// expected-note@-2{{add 'async' to function 'acceptAutoclosureNonAsyncBad' to make it asynchronous}} {{none}}
+// expected-note@-2{{add 'async' to function 'acceptAutoclosureNonAsyncBad' to make it asynchronous}} {{67-67= async}}
 
 struct HasAsyncBad {
   init(_: @autoclosure () async -> Int) { }
@@ -182,7 +190,7 @@ func testAsyncLet() async throws {
   _ = await x5
 }
 
-// expected-note@+2 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}} {{none}}
+// expected-note@+2 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}} {{30-30= async}}
 // expected-note@+1 4{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
 func testAsyncLetOutOfAsync() {
   async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}


### PR DESCRIPTION
We were emitting a note on functions saying that they might want to add 'async' to it, because there is an async call in its body, but no fix-it was being emitted. I thought it was more tricky to get the right source location, but it turns out to not be too hard (thanks @bnbarham for the tip!)

This patch handles functions that either have no effects specifiers, `throws`, or `rethrows`.

resolves rdar://72313654

