### PR TITLE
[Diagnostics] Add diagnostic when using nonexistent '**' operator

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -844,6 +844,9 @@ NOTE(unspaced_binary_operators_candidate,none,
 ERROR(unspaced_unary_operator,none,
       "unary operators must not be juxtaposed; parenthesize inner expression",
       ())
+ERROR(nonexistent_power_operator,none,
+      "no operator '**' is defined; did you mean 'pow(_:_:)'?",
+      ())
 
 ERROR(cannot_find_in_scope,none,
       "cannot %select{find|find operator}1 %0 in scope", (DeclNameRef, bool))

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -422,3 +422,11 @@ func testPostfixOperatorOnTuple<A, B>(a: A, b: B) {
   (§)((a, (b, b), a))
   _ = (a, ((), (b, (a, a), b)§), a)§
 }
+
+func testNonexistentPowerOperatorWithPowFunctionOutOfScope() {
+  func a(_ value: Double) { }
+  let x: Double = 3.0
+  let y: Double = 3.0
+  let z: Double = x**y // expected-error {{cannot find operator '**' in scope}}
+  let w: Double = a(x**2.0) // expected-error {{cannot find operator '**' in scope}}
+}

--- a/test/decl/operator/declared_power_operator.swift
+++ b/test/decl/operator/declared_power_operator.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+infix operator **
+
+func **(a: Double, b: Double) -> Double { return 0 }
+
+func testDeclaredPowerOperator() { 
+  let x: Double = 3.0
+  let y: Double = 3.0
+  _ = 2.0**2.0 // no error
+  _ = x**y // no error
+}
+
+func testDeclaredPowerOperatorWithIncompatibleType() { 
+  let x: Int8 = 3
+  let y: Int8 = 3
+  _ = x**y // expected-error{{cannot convert value of type 'Int8' to expected argument type 'Double'}} expected-error{{cannot convert value of type 'Int8' to expected argument type 'Double'}}
+}

--- a/test/decl/operator/power_operator_imported.swift
+++ b/test/decl/operator/power_operator_imported.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -I %t %s -verify
+
+import cfuncs
+
+func testNonexistentPowerOperatorWithPowFunctionInScope() {
+  func a(_ value: Double) { }
+  let x: Double = 3.0
+  let y: Double = 3.0
+  let z: Double = x**y // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
+  let w: Double = a(x**2.0) // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR adds a special error explaining that `**` operator does not exist in Swift and `Foundation.pow(_:_:)` should be used instead. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Addresses [SR-14095](https://bugs.swift.org/browse/SR-14095)
Resolved [SR-14196](https://bugs.swift.org/browse/SR-14196)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
