### PR TITLE
[CMake] Formalize whether libdispatch is used/allowed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 # First include general CMake utilities.
 include(SwiftUtils)
 include(CheckSymbolExists)
+include(CMakeDependentOption)
 
 #
 # User-configurable options that control the inclusion and default build
@@ -406,6 +407,24 @@ option(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY
   "Enable experimental Swift concurrency model"
   FALSE)
 
+option(SWIFT_ENABLE_DISPATCH
+  "Enable use of libdispatch"
+  TRUE)
+
+cmake_dependent_option(SWIFT_BUILD_SYNTAXPARSERLIB
+  "Build the Swift Syntax Parser library" TRUE
+  "SWIFT_ENABLE_DISPATCH" FALSE)
+cmake_dependent_option(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB
+  "Only build the Swift Syntax Parser library" FALSE
+  "SWIFT_BUILD_SYNTAXPARSERLIB" FALSE)
+
+cmake_dependent_option(SWIFT_BUILD_SOURCEKIT
+  "Build SourceKit" TRUE
+  "SWIFT_ENABLE_DISPATCH" FALSE)
+cmake_dependent_option(SWIFT_ENABLE_SOURCEKIT_TESTS
+  "Enable running SourceKit tests" TRUE
+  "SWIFT_BUILD_SOURCEKIT" FALSE)
+
 #
 # End of user-configurable options.
 #
@@ -429,11 +448,6 @@ if(CMAKE_C_COMPILER_ID MATCHES Clang)
   add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-Werror=gnu>)
 endif()
 
-option(SWIFT_BUILD_SYNTAXPARSERLIB "Build the Swift Syntax Parser library" TRUE)
-option(SWIFT_BUILD_ONLY_SYNTAXPARSERLIB "Only build the Swift Syntax Parser library" FALSE)
-option(SWIFT_BUILD_SOURCEKIT "Build SourceKit" TRUE)
-option(SWIFT_ENABLE_SOURCEKIT_TESTS "Enable running SourceKit tests" ${SWIFT_BUILD_SOURCEKIT})
-
 # Use dispatch as the system scheduler by default.
 # For convenience, we set this to false when concurrency is disabled.
 set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)
@@ -442,14 +456,12 @@ if(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY AND NOT SWIFT_STDLIB_SINGLE_THREADED_RU
 endif()
 
 set(SWIFT_BUILD_HOST_DISPATCH FALSE)
-if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+if(SWIFT_ENABLE_DISPATCH AND NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  if(SWIFT_BUILD_SYNTAXPARSERLIB OR SWIFT_BUILD_SOURCEKIT)
     set(SWIFT_BUILD_HOST_DISPATCH TRUE)
   endif()
-endif()
 
-if(SWIFT_BUILD_HOST_DISPATCH OR SWIFT_CONCURRENCY_USES_DISPATCH)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  if(SWIFT_BUILD_HOST_DISPATCH OR SWIFT_CONCURRENCY_USES_DISPATCH)
     if(NOT EXISTS "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}")
       message(SEND_ERROR "SyntaxParserLib, SourceKit, and concurrency require libdispatch on non-Darwin hosts.  Please specify SWIFT_PATH_TO_LIBDISPATCH_SOURCE")
     endif()
@@ -961,7 +973,9 @@ if (LLVM_ENABLE_DOXYGEN)
   message(STATUS "Doxygen: enabled")
 endif()
 
-include(Libdispatch)
+if(SWIFT_ENABLE_DISPATCH)
+  include(Libdispatch)
+endif()
 
 # Add all of the subdirectories, where we actually do work.
 


### PR DESCRIPTION
Accidentally requiring libdispatch is a repeated cmake regression. Let's avoid this entirely by formalizing whether libdispatch is enabled or not rather than infer it.