### PR TITLE
[5.4] SILCombine: don't create a strong_retain/strong_release with an Optional<reference> as an operand

### DIFF
--- a/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
+++ b/lib/SILOptimizer/Analysis/SimplifyInstruction.cpp
@@ -348,8 +348,13 @@ static SILValue simplifyDeadCast(SingleValueInstruction *Cast) {
   for (Operand *op : Cast->getUses()) {
     switch (op->getUser()->getKind()) {
       case SILInstructionKind::DestroyValueInst:
+        break;
       case SILInstructionKind::StrongReleaseInst:
       case SILInstructionKind::StrongRetainInst:
+        // ref-casts can cast from an Optional<Classtype>. But strong_retain/
+        // strong_release don't accept an optional.
+        if (!Cast->getOperand(0)->getType().isReferenceCounted(Cast->getModule()))
+          return SILValue();
         break;
       default:
         return SILValue();

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -836,6 +836,20 @@ bb0(%0 : $C1):
   return %0 : $C1
 }
 
+// strong_retain/strong_release don't accept an Optional<reference>.
+//
+// CHECK-LABEL: sil @dontOptimizeRefCastOfOptional
+// CHECK:   %1 = unchecked_ref_cast %0
+// CHECK:   strong_retain %1
+// CHECK: } // end sil function 'dontOptimizeRefCastOfOptional'
+sil @dontOptimizeRefCastOfOptional : $@convention(thin) (@guaranteed Optional<C1>) -> () {
+bb0(%0 : $Optional<C1>):
+  %1 = unchecked_ref_cast %0 : $Optional<C1> to $C1
+  strong_retain %1 : $C1
+  %3 = tuple ()
+  return %3 : $()
+}
+
 // CHECK-LABEL: sil @dead_end_cow_mutation
 // CHECK: bb0
 // CHECK-NEXT: strong_retain %0


### PR DESCRIPTION
strong_retain/strong_release with an optional reference as operand are rejected by the verifier and are not supported by IRGen.
SILCombine created such retains/releases when optimizing ref_cast instructions.

This fixes a compiler crash.
rdar://74146617

This is a cherry-pick of https://github.com/apple/swift/pull/35934