### PR TITLE
test: repair the test on Windows

### DIFF
--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -8,6 +8,7 @@ import Darwin
 import Glibc
 #elseif os(Windows)
 import CRT
+import WinSDK
 #else
 #error("Unsupported platform")
 #endif
@@ -34,7 +35,11 @@ func test_multiple_lo_indirectly_escalated() async {
   @concurrent
   func loopUntil(priority: Task.Priority) async {
     while (await Task.__unsafeCurrentAsync().task.priority != priority) {
+#if os(Windows)
+      Sleep(1)
+#else
       sleep(1)
+#endif
     }
   }
 


### PR DESCRIPTION
`sleep` is not portable as it is not part of the C standard.  Use the
platform specific sleep function.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
