### PR TITLE
[5.4][Stdlib] Fix _swift_modifyAtWritableKeyPath_impl to check for ReferenceWritableKeyPaths.

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1932,6 +1932,11 @@ func _modifyAtWritableKeyPath_impl<Root, Value>(
   root: inout Root,
   keyPath: WritableKeyPath<Root, Value>
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
+  if type(of: keyPath).kind == .reference {
+    return _modifyAtReferenceWritableKeyPath_impl(root: root,
+      keyPath: _unsafeUncheckedDowncast(keyPath,
+        to: ReferenceWritableKeyPath<Root, Value>.self))
+  }
   return keyPath._projectMutableAddress(from: &root)
 }
 

--- a/test/stdlib/KeyPath.swift
+++ b/test/stdlib/KeyPath.swift
@@ -1041,6 +1041,16 @@ keyPath.test("ReferenceWritableKeyPath statically typed as WritableKeyPath") {
   expectEqual(outer[keyPath: upcastKeyPath], 43)
   outer[keyPath: upcastKeyPath] = 44
   expectEqual(outer[keyPath: upcastKeyPath], 44)
+
+  func setWithInout<T>(_ lhs: inout T, _ rhs: T) { lhs = rhs }
+
+  expectEqual(outer[keyPath: keyPath], 44)
+  setWithInout(&outer[keyPath: keyPath], 45);
+  expectEqual(outer[keyPath: keyPath], 45)
+
+  expectEqual(outer[keyPath: upcastKeyPath], 45)
+  setWithInout(&outer[keyPath: upcastKeyPath], 46)
+  expectEqual(outer[keyPath: upcastKeyPath], 46)
 }
 
 runAllTests()


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/35922 to 5.4.

Call through to _swift_modifyAtReferenceWritableKeyPath_impl in that case. This fixes an assertion failure (or worse) when upcasting a ReferenceWritableKeyPath and then using subscript(keyPath:) to modify a value with it.

rdar://74191390