### PR TITLE
GSB: An unresolved DependentMemberType might resolve to a concrete TypeAliasDecl with a dependent underlying type

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1821,6 +1821,13 @@ static void lookupConcreteNestedType(NominalTypeDecl *decl,
     concreteDecls.push_back(cast<TypeDecl>(member));
 }
 
+static auto findBestConcreteNestedType(SmallVectorImpl<TypeDecl *> &concreteDecls) {
+  return std::min_element(concreteDecls.begin(), concreteDecls.end(),
+                          [](TypeDecl *type1, TypeDecl *type2) {
+                            return TypeDecl::compare(type1, type2) < 0;
+                          });
+}
+
 TypeDecl *EquivalenceClass::lookupNestedType(
                              GenericSignatureBuilder &builder,
                              Identifier name,
@@ -1928,11 +1935,7 @@ TypeDecl *EquivalenceClass::lookupNestedType(
            "Lookup should never keep a non-anchor associated type");
   } else if (!concreteDecls.empty()) {
     // Find the best concrete type.
-    auto bestConcreteTypeIter =
-      std::min_element(concreteDecls.begin(), concreteDecls.end(),
-                       [](TypeDecl *type1, TypeDecl *type2) {
-                         return TypeDecl::compare(type1, type2) < 0;
-                       });
+    auto bestConcreteTypeIter = findBestConcreteNestedType(concreteDecls);
 
     // Put the best concrete type first; the rest will follow.
     entry.types.push_back(*bestConcreteTypeIter);
@@ -3530,7 +3533,8 @@ static Type getStructuralType(TypeDecl *typeDecl, bool keepSugar) {
 
 static Type substituteConcreteType(Type parentType,
                                    TypeDecl *concreteDecl) {
-  if (parentType->is<ErrorType>())
+  if (parentType->is<ErrorType>() ||
+      parentType->is<UnresolvedType>())
     return parentType;
 
   auto *dc = concreteDecl->getDeclContext();
@@ -3583,18 +3587,14 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
           if (concreteDecls.empty())
             return ResolvedType::forUnresolved(nullptr);
 
-          auto bestConcreteTypeIter =
-            std::min_element(concreteDecls.begin(), concreteDecls.end(),
-                             [](TypeDecl *type1, TypeDecl *type2) {
-                               return TypeDecl::compare(type1, type2) < 0;
-                             });
-
+          auto bestConcreteTypeIter = findBestConcreteNestedType(concreteDecls);
           concreteDecl = *bestConcreteTypeIter;
         }
       }
 
       auto concreteType = substituteConcreteType(parentType, concreteDecl);
-      return ResolvedType::forConcrete(concreteType);
+      return maybeResolveEquivalenceClass(concreteType, resolutionKind,
+                                          wantExactPotentialArchetype);
     }
 
     // Find the nested type declaration for this.

--- a/validation-test/compiler_crashers_2_fixed/sr11639.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11639.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+public protocol FooProtocol {
+  associatedtype Bar
+}
+
+public struct Foo<Bar>: FooProtocol {
+  public var bar: Bar
+}
+
+public protocol BazProtocol: FooProtocol {
+  associatedtype Foo1: FooProtocol where Foo1.Bar == Foo2.Bar
+  associatedtype Foo2Bar
+  typealias Foo2 = Foo<Foo2Bar>
+}


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-11639 / rdar://problem/56466696