### PR TITLE
[string] Add null termination check to _deconstructUTF8

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -173,6 +173,16 @@ extension _StringGuts {
   }
 }
 
+// Convenience optional getters.
+extension _StringGuts {
+  internal var cocoaObject: _CocoaString? {
+     guard _object.isLarge && _object.largeIsCocoa && !_object.isImmortal else {
+       return nil
+     }
+     return _object.cocoaObject
+  }
+}
+
 // Internal invariants
 extension _StringGuts {
   #if !INTERNAL_CHECKS_ENABLED

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -802,7 +802,9 @@ extension _StringObject {
     _internalInvariant(largeFastIsShared)
 #if _runtime(_ObjC)
     if largeIsCocoa {
-      return stableCocoaASCIIPointer(cocoaObject)._unsafelyUnwrappedUnchecked
+      return stableCocoaASCIIPointer(
+        cocoaObject, requiresZeroTerminated: false
+      )._unsafelyUnwrappedUnchecked
     }
 #endif
 
@@ -887,7 +889,7 @@ extension _StringObject {
   @inline(__always)
   internal var isNFC: Bool {
     if isSmall {
-      // TODO(String performance): Worth implementing more sophisiticated
+      // TODO(String performance): Worth implementing more sophisticated
       // check, or else performing normalization on- construction. For now,
       // approximate it with isASCII
       return smallIsASCII
@@ -930,10 +932,11 @@ extension _StringObject {
     // Small strings nul-terminate when spilling for contiguous access
     if isSmall { return true }
 
-    // TODO(String performance): Use performance flag, which could be more
-    // inclusive. For now, we only know native strings and small strings (when
-    // accessed) are. We could also know about some shared strings.
-
+    // TODO(String performance): Add performance flag for zero terminated. We
+    // can check bridged shared strings when bridging and normal shared
+    // strings can have it be a condition on construction. For now, we do the
+    // more conservative approach of only allowing strings we allocated (and
+    // know are null-terminated).
     return largeFastIsTailAllocated
   }
 }


### PR DESCRIPTION
Cocoa C strings might not be null terminated, so add a check by requesting a
null-terminated C string inside _deconstructUTF8.

WIP: This does not build because _deconstructUTF8 is AEIC. We don't want to
expose bridging logic. We need to figure out the lesser evil for this.

