### PR TITLE
[SE-0298: Async/Await: Sequences] Enable by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@ Swift Next
   }
   ```
 
+* [SE-0298][]:
+
+  The "for" loop can be used to traverse asynchronous sequences in asynchronous code:
+
+	```swift
+  for try await line in myFile.lines() {
+    // Do something with each line
+  }
+	```
+
+  Asynchronous for loops use asynchronous sequences, defined by the protocol
+  `AsyncSequence` and its corresponding `AsyncIterator`.
+
 **Add new entries to the top of this section, not here!**
 
 Swift 5.4
@@ -8309,6 +8322,7 @@ Swift 1.0
 [SE-0286]: <https://github.com/apple/swift-evolution/blob/main/proposals/0286-forward-scan-trailing-closures.md>
 [SE-0287]: <https://github.com/apple/swift-evolution/blob/main/proposals/0287-implicit-member-chains.md>
 [SE-0296]: <https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md>
+[SE-0298: <https://github.com/apple/swift-evolution/blob/main/proposals/0298-asyncsequence.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8322,7 +8322,7 @@ Swift 1.0
 [SE-0286]: <https://github.com/apple/swift-evolution/blob/main/proposals/0286-forward-scan-trailing-closures.md>
 [SE-0287]: <https://github.com/apple/swift-evolution/blob/main/proposals/0287-implicit-member-chains.md>
 [SE-0296]: <https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md>
-[SE-0298: <https://github.com/apple/swift-evolution/blob/main/proposals/0298-asyncsequence.md>
+[SE-0298]: <https://github.com/apple/swift-evolution/blob/main/proposals/0298-asyncsequence.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2127,11 +2127,9 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
   SourceLoc AwaitLoc;
   SourceLoc TryLoc;
 
-  if (shouldParseExperimentalConcurrency() && 
-      Tok.isContextualKeyword("await")) {
+  if (Tok.isContextualKeyword("await")) {
     AwaitLoc = consumeToken();
-  } else if (shouldParseExperimentalConcurrency() &&
-      Tok.is(tok::kw_try)) {
+  } else if (Tok.is(tok::kw_try)) {
     TryLoc = consumeToken();
     if (Tok.isContextualKeyword("await")) {
       AwaitLoc = consumeToken();

--- a/test/Parse/foreach_async.swift
+++ b/test/Parse/foreach_async.swift
@@ -1,5 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// RUN: %target-typecheck-verify-swift
 // REQUIRES: concurrency
+import _Concurrency
 
 struct AsyncRange<Bound: Comparable & Strideable>: AsyncSequence, AsyncIteratorProtocol where Bound.Stride : SignedInteger {
   var range: Range<Bound>.Iterator


### PR DESCRIPTION
One still needs to import the _Concurrency library to use it.
