### PR TITLE
GSB: An unresolved DependentMemberType might resolve to a concrete TypeAliasDecl with a dependent underlying type [5.4]

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/sr11639.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11639.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s
+
+public protocol FooProtocol {
+  associatedtype Bar
+}
+
+public struct Foo<Bar>: FooProtocol {
+  public var bar: Bar
+}
+
+public protocol BazProtocol: FooProtocol {
+  associatedtype Foo1: FooProtocol where Foo1.Bar == Foo2.Bar
+  associatedtype Foo2Bar
+  typealias Foo2 = Foo<Foo2Bar>
+}


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-11639 / rdar://problem/56466696

Original: https://github.com/apple/swift/pull/35950