### PR TITLE
Release node factory storage after each demangling operation

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -287,6 +287,8 @@ public:
 
   Demangle::NodeFactory &getNodeFactory() { return Dem; }
 
+  void clearNodeFactory() { Dem.clear(); }
+
   BuiltType decodeMangledType(Node *node);
   
   ///

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -393,7 +393,7 @@ public:
                    /*BitwiseTakable*/ true,
                    EnumKind::NoPayloadEnum, Cases) {
     assert(Cases.size() >= 2);
-//    assert(getNumPayloadCases() == 0);
+    assert(getNumPayloadCases() == 0);
   }
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
@@ -437,7 +437,7 @@ public:
     : EnumTypeInfo(Size, Alignment, Stride, NumExtraInhabitants,
                    BitwiseTakable, EnumKind::SinglePayloadEnum, Cases) {
     assert(Cases[0].TR != 0);
-//    assert(getNumPayloadCases() == 1);
+    assert(getNumPayloadCases() == 1);
   }
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
@@ -555,6 +555,7 @@ public:
     assert(Cases[1].TR != 0);
     assert(getNumPayloadCases() > 1);
     assert(getSize() > getPayloadSize());
+    assert(getCases().size() > 1);
   }
 
   bool readExtraInhabitantIndex(remote::MemoryReader &reader,
@@ -1766,14 +1767,14 @@ class EnumTypeInfoBuilder {
     if (TI == nullptr) {
       DEBUG_LOG(fprintf(stderr, "No TypeInfo for case type: "); TR->dump());
       Invalid = true;
-      return;
+      static TypeInfo emptyTI;
+      Cases.push_back({Name, /*offset=*/0, /*value=*/-1, TR, emptyTI});
+    } else {
+      Size = std::max(Size, TI->getSize());
+      Alignment = std::max(Alignment, TI->getAlignment());
+      BitwiseTakable &= TI->isBitwiseTakable();
+      Cases.push_back({Name, /*offset=*/0, /*value=*/-1, TR, *TI});
     }
-
-    Size = std::max(Size, TI->getSize());
-    Alignment = std::max(Alignment, TI->getAlignment());
-    BitwiseTakable &= TI->isBitwiseTakable();
-
-    Cases.push_back({Name, /*offset=*/0, /*value=*/-1, TR, *TI});
   }
 
 public:
@@ -1800,6 +1801,7 @@ public:
       } else {
         PayloadCases.push_back(Case);
         auto *CaseTR = getCaseTypeRef(Case);
+        assert(CaseTR != nullptr);
         auto *CaseTI = TC.getTypeInfo(CaseTR, ExternalTypeInfo);
         addCase(Case.Name, CaseTR, CaseTI);
       }

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_SingleCaseCFPayload
+// RUN: %target-codesign %t/reflect_Enum_SingleCaseCFPayload
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_SingleCaseCFPayload | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+
+// REQUIRES: objc_interop
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+import Foundation
+
+enum SingleCaseCFPayloadEnum {
+case only(CFString)
+}
+
+let cfs1 = "1" as CFString
+let cfs2 = "2" as CFString
+
+class ClassWithSingleCaseCFPayloadEnum {
+  var e1: SingleCaseCFPayloadEnum?
+  var e2: SingleCaseCFPayloadEnum = .only(cfs1)
+  var e3: SingleCaseCFPayloadEnum? = .some(.only(cfs2))
+  var e4: SingleCaseCFPayloadEnum??
+}
+
+reflect(object: ClassWithSingleCaseCFPayloadEnum())
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (class reflect_Enum_SingleCaseCFPayload.ClassWithSingleCaseCFPayloadEnum)
+// CHECK-64: Type info:
+// CHECK-64: <null type info>
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_SingleCaseCFPayload.ClassWithSingleCaseCFPayloadEnum)
+// CHECK-32: Type info:
+// CHECK-32: <null type info>
+
+reflect(enum: SingleCaseCFPayloadEnum.only(cfs1))
+
+// CHECK-64: Reflecting an enum.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (enum reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
+// CHECK-64: Type info:
+// CHECK-64: <null type info>
+// CHECK-64: Enum value:
+// CHECK-64: <null type info>
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (class reflect_Enum_SingleCaseCFPayload.ClassWithSingleCaseCFPayloadEnum)
+// CHECK-32: Type info:
+// CHECK-32: <null type info>
+// CHECK-32: Enum value:
+// CHECK-32: <null type info>
+
+doneReflecting()
+
+// CHECK-64: Done.
+
+// CHECK-32: Done.

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -53,10 +53,10 @@ reflect(enum: SingleCaseCFPayloadEnum.only(cfs1))
 // CHECK-64: Enum value:
 // CHECK-64: <null type info>
 
-// CHECK-32: Reflecting an object.
+// CHECK-32: Reflecting an enum.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32: Type reference:
-// CHECK-32: (class reflect_Enum_SingleCaseCFPayload.ClassWithSingleCaseCFPayloadEnum)
+// CHECK-32: (class reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
 // CHECK-32: Type info:
 // CHECK-32: <null type info>
 // CHECK-32: Enum value:

--- a/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
+++ b/validation-test/Reflection/reflect_Enum_SingleCaseCFPayload.swift
@@ -56,7 +56,7 @@ reflect(enum: SingleCaseCFPayloadEnum.only(cfs1))
 // CHECK-32: Reflecting an enum.
 // CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
 // CHECK-32: Type reference:
-// CHECK-32: (class reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
+// CHECK-32: (enum reflect_Enum_SingleCaseCFPayload.SingleCaseCFPayloadEnum)
 // CHECK-32: Type info:
 // CHECK-32: <null type info>
 // CHECK-32: Enum value:


### PR DESCRIPTION
This adds missing clear() operations to a number of places in
RemoteMirror in order to reclaim memory after (de)mangling results
are no longer needed.

Before this, the RemoteMirror library had an unfortunate tendency to use
excessive amounts of memory as the demangler kept appending data to its
internal slab allocator.

Resolves rdar://72958641