### PR TITLE
[cxx-interop] Don't crash when importing invalid decl.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3747,6 +3747,16 @@ namespace {
       if (isSpecializationDepthGreaterThan(def, 8))
         return nullptr;
 
+      // If we have an inline data member, it won't get eagerly instantiated
+      // when we instantiate the class. So, make sure we do that now to catch
+      // any instantiation errors.
+      for (auto member : decl->decls()) {
+        if (auto varDecl = dyn_cast<clang::VarDecl>(member)) {
+          Impl.getClangSema()
+            .InstantiateVariableDefinition(varDecl->getLocation(), varDecl);
+        }
+      }
+
       return VisitCXXRecordDecl(def);
     }
 
@@ -8318,6 +8328,10 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
                                               bool &TypedefIsSuperfluous,
                                               bool &HadForwardDeclaration) {
   assert(ClangDecl);
+
+  // If this decl isn't valid, don't import it. Bail now.
+  if (ClangDecl->isInvalidDecl())
+    return nullptr;
 
   // Private and protected C++ class members should never be used, so we skip
   // them entirely (instead of importing them with a corresponding Swift access

--- a/test/Interop/Cxx/static/Inputs/constexpr-static-member-var-errors.h
+++ b/test/Interop/Cxx/static/Inputs/constexpr-static-member-var-errors.h
@@ -1,0 +1,13 @@
+template <class T>
+struct GetTypeValue {
+  static constexpr const bool value = T::value;
+};
+
+using Invalid1 = GetTypeValue<int>;
+
+template <class T>
+struct GetTypeValueInline {
+  inline static constexpr const bool value = T::value;
+};
+
+using Invalid2 = GetTypeValueInline<int>;

--- a/test/Interop/Cxx/static/Inputs/module.modulemap
+++ b/test/Interop/Cxx/static/Inputs/module.modulemap
@@ -22,3 +22,8 @@ module StaticMemberFunc {
   header "static-member-func.h"
   requires cplusplus
 }
+
+module ConstexprStaticMemberVarErrors {
+  header "constexpr-static-member-var-errors.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ConstexprStaticMemberVarErrors -I %S/Inputs -source-filename=x -enable-cxx-interop 2>&1 | %FileCheck %s
+
+// Check that we properly report the error and don't crash when importing an
+// invalid decl.
+
+// CHECK: error: type 'int' cannot be used prior to '::' because it has no members
+// CHECK: {{note: in instantiation of template class 'GetTypeValue<int>' requested here|note: in instantiation of static data member 'GetTypeValue<int>::value' requested here}}
+
+// CHECK: error: type 'int' cannot be used prior to '::' because it has no members
+// CHECK: note: in instantiation of static data member 'GetTypeValueInline<int>::value' requested here


### PR DESCRIPTION
If we see an invalid decl, rather than potentially crashing, simply bail.