### PR TITLE
[cxx-interop] Bail on deep template specializations.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3697,6 +3697,22 @@ namespace {
       return VisitRecordDecl(decl);
     }
 
+    bool isSpecializationDepthGreaterThan(
+        const clang::ClassTemplateSpecializationDecl *decl, unsigned maxDepth) {
+      for (auto arg : decl->getTemplateArgs().asArray()) {
+        if (arg.getKind() == clang::TemplateArgument::Type) {
+          if (auto classSpec =
+                  dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+                      arg.getAsType()->getAsCXXRecordDecl())) {
+            if (maxDepth == 0 ||
+                isSpecializationDepthGreaterThan(classSpec, maxDepth - 1))
+              return true;
+          }
+        }
+      }
+      return false;
+    }
+
     Decl *VisitClassTemplateSpecializationDecl(
                  const clang::ClassTemplateSpecializationDecl *decl) {
       // `Sema::isCompleteType` will try to instantiate the class template as a
@@ -3713,6 +3729,13 @@ namespace {
       auto def = dyn_cast<clang::ClassTemplateSpecializationDecl>(
           decl->getDefinition());
       assert(def && "Class template instantiation didn't have definition");
+
+      // Currently this is a relatively low number, in the future we might
+      // consider increasing it, but this should keep compile time down,
+      // especially for types that become exponentially large when
+      // instantiating.
+      if (isSpecializationDepthGreaterThan(def, 8))
+        return nullptr;
 
       // FIXME: This will instantiate all members of the specialization (and detect
       // instantiation failures in them), which can be more than is necessary

--- a/test/Interop/Cxx/templates/Inputs/large-class-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/large-class-templates.h
@@ -1,0 +1,6 @@
+template <class T>
+struct HasTypeWithSelfAsParam {
+  using TT = HasTypeWithSelfAsParam<HasTypeWithSelfAsParam<T>>;
+};
+
+using WillBeInfinite = HasTypeWithSelfAsParam<int>;

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -112,3 +112,8 @@ module MemberTemplates {
   header "member-templates.h"
   requires cplusplus
 }
+
+module LargeClassTemplates {
+  header "large-class-templates.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=LargeClassTemplates -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct HasTypeWithSelfAsParam<T> {
+// CHECK: }
+
+// CHECK: struct __CxxTemplateInst22HasTypeWithSelfAsParamIiE {
+// CHECK:   typealias TT = __CxxTemplateInst22HasTypeWithSelfAsParamIS_IiEE
+// CHECK:   init()
+// CHECK: }
+
+// CHECK: typealias WillBeInfinite = __CxxTemplateInst22HasTypeWithSelfAsParamIiE


### PR DESCRIPTION
If a template specialization is more than 8 types deep, bail.

In future we could make this number (much) greater than 8 but first
we'll need to somehow make instantiating these types much faster.
Currently, I think there is some exponential type behavior happening so
this is super slow.