### PR TITLE
[cxx-interop] Skip already-imported sub decls.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3371,6 +3371,11 @@ namespace {
           }
         }
 
+        // If we've already imported this decl, skip it so we don't add the same
+        // member twice.
+        if (Impl.ImportedDecls.count({nd->getCanonicalDecl(), getVersion()}))
+          continue;
+
         auto member = Impl.importDecl(nd, getActiveSwiftVersion());
         if (!member) {
           if (!isa<clang::TypeDecl>(nd) && !isa<clang::FunctionDecl>(nd)) {
@@ -3383,11 +3388,6 @@ namespace {
         }
 
         if (auto nestedType = dyn_cast<TypeDecl>(member)) {
-          // Only import definitions. Otherwise, we might add the same member
-          // twice.
-          if (auto tagDecl = dyn_cast<clang::TagDecl>(nd))
-            if (tagDecl->getDefinition() != tagDecl)
-              continue;
           nestedTypes.push_back(nestedType);
           continue;
         }

--- a/test/Interop/Cxx/class/Inputs/nested-records.h
+++ b/test/Interop/Cxx/class/Inputs/nested-records.h
@@ -51,6 +51,18 @@ struct HasForwardDeclaredNestedType {
   struct ForwardDeclaredType { };
 };
 
+struct HasForwardDeclaredTemplateChild {
+  template <class T> struct ForwardDeclaredClassTemplate;
+  
+  struct DeclaresForwardDeclaredClassTemplateFriend {
+    template <class T>
+    friend struct HasForwardDeclaredTemplateChild::ForwardDeclaredClassTemplate;
+  };
+  
+  template <class T> struct ForwardDeclaredClassTemplate { };
+};
+
+
 // TODO: Nested class templates (SR-13853).
 
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_NESTED_RECORDS_H

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -57,10 +57,19 @@
 // CHECK: }
 
 // CHECK: struct HasForwardDeclaredNestedType {
+// CHECK:   struct ForwardDeclaredType {
+// CHECK:     init()
+// CHECK:   }
 // CHECK:   struct NormalSubType {
 // CHECK:     init()
 // CHECK:   }
-// CHECK:   struct ForwardDeclaredType {
+// CHECK:   init()
+// CHECK: }
+
+// CHECK: struct HasForwardDeclaredTemplateChild {
+// CHECK:   struct ForwardDeclaredClassTemplate<T> {
+// CHECK:   }
+// CHECK:   struct DeclaresForwardDeclaredClassTemplateFriend {
 // CHECK:     init()
 // CHECK:   }
 // CHECK:   init()


### PR DESCRIPTION
Rather than skipping non-definitions, we should just check whether we've already seen this decl. This not only fixes the specific problem with class templates but also is a more general fix for other sub decls that might have this issue in the future (i.e., methods).