### PR TITLE
[concurrency] allow 'get' access to properties from outside the actor

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4190,8 +4190,12 @@ ERROR(async_call_without_await_in_autoclosure,none,
 ERROR(async_call_without_await_in_async_let,none,
       "call is 'async' in an 'async let' initializer that is not marked "
       "with 'await'", ())
+ERROR(async_prop_access_without_await,none,
+      "property access is 'async' but is not marked with 'await'", ())
+ERROR(async_subscript_access_without_await,none,
+      "subscript access is 'async' but is not marked with 'await'", ())
 WARNING(no_async_in_await,none,
-        "no calls to 'async' functions occur within 'await' expression", ())
+        "no 'async' operations occur within 'await' expression", ())
 ERROR(async_call_in_illegal_context,none,
       "'async' call cannot occur in "
       "%select{<<ERROR>>|a default argument|a property wrapper initializer|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}0",
@@ -4201,7 +4205,7 @@ ERROR(await_in_illegal_context,none,
       "%select{<<ERROR>>|a default argument|a property wrapper initializer|a property initializer|a global variable initializer|an enum case raw value|a catch pattern|a catch guard expression|a defer body}0",
       (unsigned))
 ERROR(async_in_nonasync_function,none,
-      "%select{'async'|'await'|'async let'}0 in "
+      "%select{'async'|'async' call|'await'|'async let'|'async' property access|'async' subscript access}0 in "
       "%select{a function|an autoclosure}1 that does not support concurrency",
       (unsigned, bool))
 NOTE(note_add_async_to_function,none,
@@ -4279,13 +4283,13 @@ ERROR(actor_with_nonactor_superclass,none,
       "actor class cannot inherit from non-actor class %0", (DeclName))
 
 ERROR(actor_isolated_non_self_reference,none,
-        "actor-isolated %0 %1 can only be referenced "
-        "%select{inside the actor|on 'self'}2",
-        (DescriptiveDeclKind, DeclName, bool))
+        "actor-isolated %0 %1 can only be %select{referenced|mutated|used 'inout'}3 "
+        "%select{from inside the actor|on 'self'}2",
+        (DescriptiveDeclKind, DeclName, bool, unsigned))
 ERROR(actor_isolated_self_independent_context,none,
-        "actor-isolated %0 %1 can not be referenced from an "
+        "actor-isolated %0 %1 can not be %select{referenced|mutated|used 'inout'}2 from an "
         "'@actorIndependent' context",
-        (DescriptiveDeclKind, DeclName))
+        (DescriptiveDeclKind, DeclName, unsigned))
 ERROR(actor_isolated_inout_state,none,
       "actor-isolated %0 %1 cannot be passed 'inout' to"
       "%select{| implicitly}2 'async' function call",
@@ -4298,16 +4302,16 @@ ERROR(actor_isolated_global_actor_context,none,
       "actor %2",
       (DescriptiveDeclKind, DeclName, Type))
 ERROR(global_actor_from_instance_actor_context,none,
-      "%0 %1 isolated to global actor %2 can not be referenced from actor %3",
-      (DescriptiveDeclKind, DeclName, Type, DeclName))
+      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4 from actor %3",
+      (DescriptiveDeclKind, DeclName, Type, DeclName, unsigned))
 ERROR(global_actor_from_other_global_actor_context,none,
-      "%0 %1 isolated to global actor %2 can not be referenced from "
-      "different global actor %3",
-      (DescriptiveDeclKind, DeclName, Type, Type))
+      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
+      " from different global actor %3",
+      (DescriptiveDeclKind, DeclName, Type, Type, unsigned))
 ERROR(global_actor_from_nonactor_context,none,
-      "%0 %1 isolated to global actor %2 can not be referenced from "
-      "%select{this|an '@actorIndependent'}3 context",
-      (DescriptiveDeclKind, DeclName, Type, bool))
+      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
+      " from %select{this|an '@actorIndependent'}3 context",
+      (DescriptiveDeclKind, DeclName, Type, bool, unsigned))
 ERROR(actor_isolated_partial_apply,none,
         "actor-isolated %0 %1 can not be partially applied",
         (DescriptiveDeclKind, DeclName))
@@ -4315,17 +4319,17 @@ ERROR(concurrent_access_local,none,
         "use of local %0 %1 in concurrently-executing code",
         (DescriptiveDeclKind, DeclName))
 ERROR(actor_isolated_from_concurrent_closure,none,
-        "actor-isolated %0 %1 cannot be referenced from a concurrent closure",
-        (DescriptiveDeclKind, DeclName))
+        "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from a concurrent closure",
+        (DescriptiveDeclKind, DeclName, unsigned))
 ERROR(actor_isolated_from_concurrent_function,none,
-        "actor-isolated %0 %1 cannot be referenced from a concurrent function",
-        (DescriptiveDeclKind, DeclName))
+        "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from a concurrent function",
+        (DescriptiveDeclKind, DeclName, unsigned))
 ERROR(actor_isolated_from_async_let,none,
-        "actor-isolated %0 %1 cannot be referenced from 'async let' initializer",
-        (DescriptiveDeclKind, DeclName))
+        "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from 'async let' initializer",
+        (DescriptiveDeclKind, DeclName, unsigned))
 ERROR(actor_isolated_from_escaping_closure,none,
-        "actor-isolated %0 %1 cannot be referenced from an '@escaping' closure",
-        (DescriptiveDeclKind, DeclName))
+        "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from an '@escaping' closure",
+        (DescriptiveDeclKind, DeclName, unsigned))
 ERROR(local_function_executed_concurrently,none,
       "concurrently-executed %0 %1 must be marked as '@concurrent'",
       (DescriptiveDeclKind, DeclName))
@@ -4338,7 +4342,8 @@ NOTE(actor_isolated_sync_func,none,
      "implicitly asynchronous",
      (DescriptiveDeclKind, DeclName))
 NOTE(actor_mutable_state,none,
-     "mutable state is only available within the actor instance", ())
+     "mutation of this %0 is only permitted within the actor",
+     (DescriptiveDeclKind))
 WARNING(shared_mutable_state_access,none,
         "reference to %0 %1 is not concurrency-safe because it involves "
         "shared mutable state", (DescriptiveDeclKind, DeclName))

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -209,10 +209,16 @@ class PhysicalPathComponent : public PathComponent {
   virtual void _anchor() override;
 
 protected:
-  PhysicalPathComponent(LValueTypeData typeData, KindTy Kind)
-    : PathComponent(typeData, Kind) {
+  Optional<ActorIsolation> ActorIso;
+  PhysicalPathComponent(LValueTypeData typeData, KindTy Kind,
+                        Optional<ActorIsolation> actorIso = None)
+    : PathComponent(typeData, Kind), ActorIso(actorIso) {
     assert(isPhysical() && "PhysicalPathComponent Kind isn't physical");
   }
+
+public:
+  // Obtains the actor-isolation required for any loads of this component.
+  Optional<ActorIsolation> getActorIsolation() const { return ActorIso; }
 };
 
 inline PhysicalPathComponent &PathComponent::asPhysical() {
@@ -421,12 +427,19 @@ public:
     Path.emplace_back(new T(std::forward<As>(args)...));
   }
 
+  // NOTE: Optional<ActorIsolation> inside of LValues
+  // Some path components carry an ActorIsolation value, which is an indicator
+  // that the access to that component must be performed by switching to the
+  // given actor's isolation domain. If the indicator is not present, that
+  // only means that a switch does not need to be emitted during the access.
+
   void addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                                 VarDecl *var, SubstitutionMap subs,
                                 LValueOptions options,
                                 SGFAccessKind accessKind,
                                 AccessStrategy strategy,
-                                CanType formalRValueType);
+                                CanType formalRValueType,
+                                Optional<ActorIsolation> actorIso = None);
 
   /// Add a member component to the access path of this lvalue.
   void addMemberComponent(SILGenFunction &SGF, SILLocation loc,
@@ -448,7 +461,8 @@ public:
                              SGFAccessKind accessKind,
                              AccessStrategy accessStrategy,
                              CanType formalRValueType,
-                             bool isOnSelf = false);
+                             bool isOnSelf = false,
+                             Optional<ActorIsolation> actorIso = None);
 
   void addMemberSubscriptComponent(SILGenFunction &SGF, SILLocation loc,
                                    SubscriptDecl *subscript,
@@ -460,7 +474,8 @@ public:
                                    CanType formalRValueType,
                                    PreparedArguments &&indices,
                                    Expr *indexExprForDiagnostics,
-                                   bool isOnSelfParameter = false);
+                                   bool isOnSelfParameter = false,
+                                   Optional<ActorIsolation> actorIso = None);
 
   /// Add a subst-to-orig reabstraction component.  That is, given
   /// that this l-value trafficks in values following the substituted

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -15,7 +15,6 @@
 #include "Callee.h"
 #include "Condition.h"
 #include "Conversion.h"
-#include "ExitableFullExpr.h"
 #include "Initialization.h"
 #include "LValue.h"
 #include "RValue.h"

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -927,7 +927,6 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
 }
 
 RValue RValueEmitter::visitDeclRefExpr(DeclRefExpr *E, SGFContext C) {
-  assert(!E->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
   return SGF.emitRValueForDecl(E, E->getDeclRef(), E->getType(),
                                E->getAccessSemantics(), C);
 }
@@ -2183,7 +2182,6 @@ RValue RValueEmitter::visitMemberRefExpr(MemberRefExpr *e,
   assert(!e->getType()->is<LValueType>() &&
          "RValueEmitter shouldn't be called on lvalues");
   assert(isa<VarDecl>(e->getMember().getDecl()));
-  assert(!e->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
 
   // Everything else should use the l-value logic.
 
@@ -2211,7 +2209,6 @@ visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *E, SGFContext C) {
 }
 
 RValue RValueEmitter::visitSubscriptExpr(SubscriptExpr *E, SGFContext C) {
-  assert(!E->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
   // Any writebacks for this access are tightly scoped.
   FormalEvaluationScope scope(SGF);
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -927,6 +927,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
 }
 
 RValue RValueEmitter::visitDeclRefExpr(DeclRefExpr *E, SGFContext C) {
+  assert(!E->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
   return SGF.emitRValueForDecl(E, E->getDeclRef(), E->getType(),
                                E->getAccessSemantics(), C);
 }
@@ -2182,6 +2183,7 @@ RValue RValueEmitter::visitMemberRefExpr(MemberRefExpr *e,
   assert(!e->getType()->is<LValueType>() &&
          "RValueEmitter shouldn't be called on lvalues");
   assert(isa<VarDecl>(e->getMember().getDecl()));
+  assert(!e->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
 
   // Everything else should use the l-value logic.
 
@@ -2198,6 +2200,7 @@ RValue RValueEmitter::visitMemberRefExpr(MemberRefExpr *e,
 
 RValue RValueEmitter::visitDynamicMemberRefExpr(DynamicMemberRefExpr *E,
                                                 SGFContext C) {
+  assert(!E->isImplicitlyAsync() && "actors do not have @objc members");
   return SGF.emitDynamicMemberRefExpr(E, C);
 }
 
@@ -2208,6 +2211,7 @@ visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *E, SGFContext C) {
 }
 
 RValue RValueEmitter::visitSubscriptExpr(SubscriptExpr *E, SGFContext C) {
+  assert(!E->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
   // Any writebacks for this access are tightly scoped.
   FormalEvaluationScope scope(SGF);
 
@@ -2219,6 +2223,7 @@ RValue RValueEmitter::visitSubscriptExpr(SubscriptExpr *E, SGFContext C) {
 
 RValue RValueEmitter::visitDynamicSubscriptExpr(
                                       DynamicSubscriptExpr *E, SGFContext C) {
+  assert(!E->isImplicitlyAsync() && "actors do not have @objc members");
   return SGF.emitDynamicSubscriptExpr(E, C);
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -857,12 +857,13 @@ public:
   // Concurrency
   //===--------------------------------------------------------------------===//
 
-  /// Generates code to obtain the callee function's executor, if the function
-  /// is actor-isolated.
+  /// Generates code to obtain the executor for the given actor isolation,
+  /// as-needed, and emits a \c hop_to_executor to that executor.
   ///
-  /// \returns a SILValue representing the executor, if an executor exists.
-  Optional<SILValue> emitLoadActorExecutorForCallee(ValueDecl *calleeVD,
-                                                    ArrayRef<ManagedValue> args);
+  /// \returns a non-null pointer if a \c hop_to_executor was emitted.
+  HopToExecutorInst* emitHopToTargetActor(SILLocation loc,
+                            Optional<ActorIsolation> actorIso,
+                            Optional<ManagedValue> actorSelf);
 
   /// Generates code to obtain the executor given the actor's decl.
   /// \returns a SILValue representing the executor.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2944,6 +2944,7 @@ LValue SILGenLValue::visitDiscardAssignmentExpr(DiscardAssignmentExpr *e,
 
 LValue SILGenLValue::visitDeclRefExpr(DeclRefExpr *e, SGFAccessKind accessKind,
                                       LValueOptions options) {
+  assert(!e->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
   return emitLValueForNonMemberVarDecl(SGF, e, e->getDeclRef(),
                                        getSubstFormalRValueType(e),
                                        accessKind, options,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -996,8 +996,9 @@ namespace {
     ValueComponent(ManagedValue value,
                    Optional<SILAccessEnforcement> enforcement,
                    LValueTypeData typeData,
-                   bool isRValue = false) :
-      PhysicalPathComponent(typeData, ValueKind),
+                   bool isRValue = false,
+                   Optional<ActorIsolation> actorIso = None) :
+      PhysicalPathComponent(typeData, ValueKind, actorIso),
       Value(value),
       Enforcement(enforcement),
       IsRValue(isRValue) {
@@ -1031,6 +1032,10 @@ namespace {
         OS << getSILAccessEnforcementName(*Enforcement);
       } else {
         OS << "unenforced";
+      }
+      if (ActorIso) {
+        OS << "requires actor-hop because ";
+        simple_display(OS, *ActorIso);
       }
       OS << "):\n";
       Value.dump(OS, indent + 2);
@@ -1243,6 +1248,7 @@ namespace {
     bool IsDirectAccessorUse;
     bool IsOnSelfParameter;
     SubstitutionMap Substitutions;
+    Optional<ActorIsolation> ActorIso;
 
   public:
     AccessorBasedComponent(PathComponent::KindTy kind,
@@ -1252,12 +1258,14 @@ namespace {
                            CanType baseFormalType, LValueTypeData typeData,
                            Expr *indexExprForDiagnostics,
                            PreparedArguments &&indices,
-                           bool isOnSelfParameter = false)
+                           bool isOnSelfParameter = false,
+                           Optional<ActorIsolation> actorIso = None)
         : super(kind, decl, baseFormalType, typeData, indexExprForDiagnostics,
                 std::move(indices)),
           Accessor(accessor), IsSuper(isSuper),
           IsDirectAccessorUse(isDirectAccessorUse),
-          IsOnSelfParameter(isOnSelfParameter), Substitutions(substitutions) {}
+          IsOnSelfParameter(isOnSelfParameter), Substitutions(substitutions),
+          ActorIso(actorIso) {}
 
     AccessorBasedComponent(const AccessorBasedComponent &copied,
                            SILGenFunction &SGF,
@@ -1267,7 +1275,8 @@ namespace {
         IsSuper(copied.IsSuper),
         IsDirectAccessorUse(copied.IsDirectAccessorUse),
         IsOnSelfParameter(copied.IsOnSelfParameter),
-        Substitutions(copied.Substitutions) {}
+        Substitutions(copied.Substitutions),
+        ActorIso(copied.ActorIso) {}
 
     AccessorDecl *getAccessorDecl() const {
       return cast<AccessorDecl>(Accessor.getFuncDecl());
@@ -1286,11 +1295,12 @@ namespace {
                            LValueTypeData typeData,
                            Expr *subscriptIndexExpr,
                            PreparedArguments &&indices,
-                           bool isOnSelfParameter)
+                           bool isOnSelfParameter,
+                           Optional<ActorIsolation> actorIso)
       : AccessorBasedComponent(GetterSetterKind, decl, accessor, isSuper,
                                isDirectAccessorUse, substitutions,
                                baseFormalType, typeData, subscriptIndexExpr,
-                               std::move(indices), isOnSelfParameter)
+                               std::move(indices), isOnSelfParameter, actorIso)
     {
       assert(getAccessorDecl()->isGetterOrSetter());
     }
@@ -1398,6 +1408,7 @@ namespace {
     void set(SILGenFunction &SGF, SILLocation loc,
              ArgumentSource &&value, ManagedValue base) && override {
       assert(getAccessorDecl()->isSetter());
+      assert(!ActorIso && "no support for cross-actor set operations");
       SILDeclRef setter = Accessor;
 
       if (canRewriteSetAsPropertyWrapperInit(SGF) &&
@@ -1575,16 +1586,30 @@ namespace {
     RValue get(SILGenFunction &SGF, SILLocation loc,
                ManagedValue base, SGFContext c) && override {
       assert(getAccessorDecl()->isGetter());
+
       SILDeclRef getter = Accessor;
+      bool didHop = false;
+      RValue rvalue;
+      {
+        FormalEvaluationScope scope(SGF);
 
-      FormalEvaluationScope scope(SGF);
+        // If the 'get' is in the context of the target's actor, do a hop first.
+        didHop = SGF.emitHopToTargetActor(loc, ActorIso, base);
 
-      auto args =
-        std::move(*this).prepareAccessorArgs(SGF, loc, base, getter);
+        auto args =
+            std::move(*this).prepareAccessorArgs(SGF, loc, base, getter);
 
-      return SGF.emitGetAccessor(
-          loc, getter, Substitutions, std::move(args.base), IsSuper,
-          IsDirectAccessorUse, std::move(args.Indices), c, IsOnSelfParameter);
+        rvalue = SGF.emitGetAccessor(
+            loc, getter, Substitutions, std::move(args.base), IsSuper,
+            IsDirectAccessorUse, std::move(args.Indices), c, IsOnSelfParameter);
+
+      } // End the evaluation scope before any hop back to the current executor.
+
+      // If we hopped to the target's executor, then we need to hop back.
+      if (didHop)
+        SGF.emitHopToCurrentExecutor(loc);
+
+      return rvalue;
     }
     
     std::unique_ptr<LogicalPathComponent>
@@ -1704,7 +1729,8 @@ namespace {
         } else {
           lv.addNonMemberVarComponent(SGF, loc, var, Substitutions, Options,
                                       accessKind, strategy,
-                                      getSubstFormalType());
+                                      getSubstFormalType(),
+                                      /*actorIsolation=*/None);
         }
       }
 
@@ -2632,7 +2658,8 @@ static LValue emitLValueForNonMemberVarDecl(SILGenFunction &SGF,
                                             CanType formalRValueType,
                                             SGFAccessKind accessKind,
                                             LValueOptions options,
-                                            AccessSemantics semantics) {
+                                            AccessSemantics semantics,
+                                            Optional<ActorIsolation> actorIso) {
   LValue lv;
 
   auto *var = cast<VarDecl>(declRef.getDecl());
@@ -2646,7 +2673,8 @@ static LValue emitLValueForNonMemberVarDecl(SILGenFunction &SGF,
                                          SGF.F.getResilienceExpansion());
 
   lv.addNonMemberVarComponent(SGF, loc, var, subs,
-                              options, accessKind, strategy, formalRValueType);
+                              options, accessKind, strategy, formalRValueType,
+                              actorIso);
 
   return lv;
 }
@@ -2675,24 +2703,29 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                                       LValueOptions options,
                                       SGFAccessKind accessKind,
                                       AccessStrategy strategy,
-                                      CanType formalRValueType) {
+                                      CanType formalRValueType,
+                                      Optional<ActorIsolation> actorIso) {
   struct NonMemberVarAccessEmitter :
       AccessEmitter<NonMemberVarAccessEmitter, VarDecl> {
     LValue &LV;
     SILLocation Loc;
     SubstitutionMap Subs;
     LValueOptions Options;
+    Optional<ActorIsolation> ActorIso;
 
     NonMemberVarAccessEmitter(SILGenFunction &SGF, SILLocation loc,
                               VarDecl *var, SubstitutionMap subs,
                               SGFAccessKind accessKind,
                               CanType formalRValueType,
-                              LValueOptions options, LValue &lv)
+                              LValueOptions options,
+                              Optional<ActorIsolation> actorIso,
+                              LValue &lv)
       : AccessEmitter(SGF, var, accessKind, formalRValueType),
-        LV(lv), Loc(loc), Subs(subs), Options(options) {}
+        LV(lv), Loc(loc), Subs(subs), Options(options), ActorIso(actorIso) {}
 
     void emitUsingAddressor(SILDeclRef addressor, bool isDirect,
                             LValueTypeData typeData) {
+      assert(!ActorIso);
       SILType storageType =
         SGF.getLoweredType(Storage->getType()).getAddressType();
       LV.add<AddressorComponent>(Storage, addressor,
@@ -2704,6 +2737,7 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
 
     void emitUsingCoroutineAccessor(SILDeclRef accessor, bool isDirect,
                                     LValueTypeData typeData) {
+      assert(!ActorIso);
       LV.add<CoroutineAccessorComponent>(
           Storage, accessor,
           /*isSuper*/ false, isDirect, Subs, CanType(), typeData, nullptr,
@@ -2715,12 +2749,14 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       LV.add<GetterSetterComponent>(
           Storage, accessor,
           /*isSuper=*/false, isDirect, Subs, CanType(), typeData, nullptr,
-          PreparedArguments(), /* isOnSelfParameter */ false);
+          PreparedArguments(), /* isOnSelfParameter */ false,
+          ActorIso);
     }
 
     void emitUsingMaterialization(AccessStrategy readStrategy,
                                   AccessStrategy writeStrategy,
                                   LValueTypeData typeData) {
+      assert(!ActorIso);
       LV.add<MaterializeToTemporaryComponent>(
           Storage, /*super*/ false, Subs, Options, readStrategy,
           writeStrategy,
@@ -2739,6 +2775,8 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       // The only other case that should get here is a global variable.
       if (!address) {
         address = SGF.emitGlobalVariableRef(Loc, Storage);
+      } else {
+        assert(!ActorIso && "local var should not be actor isolated!");
       }
       assert(address.isLValue() &&
              "physical lvalue decl ref must evaluate to an address");
@@ -2758,12 +2796,14 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
         }
       }
 
-      LV.add<ValueComponent>(address, enforcement, typeData);
+      LV.add<ValueComponent>(address, enforcement, typeData,
+                             /*isRValue=*/false, ActorIso);
 
       if (address.getType().is<ReferenceStorageType>())
         LV.add<OwnershipComponent>(typeData);
     }
-  } emitter(SGF, loc, var, subs, accessKind, formalRValueType, options, *this);
+  } emitter(SGF, loc, var, subs, accessKind, formalRValueType, options,
+            actorIso, *this);
 
   emitter.emitUsingStrategy(strategy);
 }
@@ -2921,7 +2961,8 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
   LValue lv = emitLValueForNonMemberVarDecl(*this, loc, declRef,
                                             formalRValueType,
                                             SGFAccessKind::OwnedObjectRead,
-                                            LValueOptions(), semantics);
+                                            LValueOptions(), semantics,
+                                            /*actorIsolation=*/None);
   return emitLoadOfLValue(loc, std::move(lv), C);
 }
 
@@ -2944,11 +2985,15 @@ LValue SILGenLValue::visitDiscardAssignmentExpr(DiscardAssignmentExpr *e,
 
 LValue SILGenLValue::visitDeclRefExpr(DeclRefExpr *e, SGFAccessKind accessKind,
                                       LValueOptions options) {
-  assert(!e->isImplicitlyAsync() && "TODO: Implement SILGen lowering");
+  Optional<ActorIsolation> actorIso;
+  if (e->isImplicitlyAsync())
+    actorIso = getActorIsolation(e->getDecl());
+
   return emitLValueForNonMemberVarDecl(SGF, e, e->getDeclRef(),
                                        getSubstFormalRValueType(e),
                                        accessKind, options,
-                                       e->getAccessSemantics());
+                                       e->getAccessSemantics(),
+                                       actorIso);
 }
 
 LValue SILGenLValue::visitOpaqueValueExpr(OpaqueValueExpr *e,
@@ -3127,10 +3172,14 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
                        getBaseOptions(options, strategy));
   assert(lv.isValid());
 
+  Optional<ActorIsolation> actorIso;
+  if (e->isImplicitlyAsync())
+    actorIso = getActorIsolation(var);
+
   CanType substFormalRValueType = getSubstFormalRValueType(e);
   lv.addMemberVarComponent(SGF, e, var, e->getMember().getSubstitutions(),
                            options, e->isSuper(), accessKind, strategy,
-                           substFormalRValueType, isOnSelfParameter);
+                           substFormalRValueType, isOnSelfParameter, actorIso);
   return lv;
 }
 
@@ -3152,21 +3201,25 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
   SubstitutionMap Subs;
   Expr *IndexExprForDiagnostics;
   PreparedArguments Indices;
+  // If any, holds the actor we must switch to when performing the access.
+  Optional<ActorIsolation> ActorIso;
 
   MemberStorageAccessEmitter(SILGenFunction &SGF, SILLocation loc,
                              StorageType *storage, SubstitutionMap subs,
                              bool isSuper, SGFAccessKind accessKind,
                              CanType formalRValueType, LValueOptions options,
                              LValue &lv, Expr *indexExprForDiagnostics,
-                             PreparedArguments &&indices, bool isSelf = false)
+                             PreparedArguments &&indices, bool isSelf = false,
+                             Optional<ActorIsolation> actorIso = None)
       : super(SGF, storage, accessKind, formalRValueType), LV(lv),
         Options(options), Loc(loc), IsSuper(isSuper), IsOnSelfParameter(isSelf),
         BaseFormalType(lv.getSubstFormalType()), Subs(subs),
         IndexExprForDiagnostics(indexExprForDiagnostics),
-        Indices(std::move(indices)) {}
+        Indices(std::move(indices)), ActorIso(actorIso) {}
 
   void emitUsingAddressor(SILDeclRef addressor, bool isDirect,
                           LValueTypeData typeData) {
+    assert(!ActorIso);
     SILType varStorageType = SGF.SGM.Types.getSubstitutedStorageType(
         SGF.getTypeExpansionContext(), Storage, FormalRValueType);
 
@@ -3178,6 +3231,7 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
 
   void emitUsingCoroutineAccessor(SILDeclRef accessor, bool isDirect,
                                   LValueTypeData typeData) {
+    assert(!ActorIso);
     LV.add<CoroutineAccessorComponent>(
         Storage, accessor, IsSuper, isDirect, Subs, BaseFormalType, typeData,
         IndexExprForDiagnostics, std::move(Indices), IsOnSelfParameter);
@@ -3187,12 +3241,14 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
                              LValueTypeData typeData) {
     LV.add<GetterSetterComponent>(
         Storage, accessor, IsSuper, isDirect, Subs, BaseFormalType, typeData,
-        IndexExprForDiagnostics, std::move(Indices), IsOnSelfParameter);
+        IndexExprForDiagnostics, std::move(Indices), IsOnSelfParameter,
+        ActorIso);
   }
 
   void emitUsingMaterialization(AccessStrategy readStrategy,
                                 AccessStrategy writeStrategy,
                                 LValueTypeData typeData) {
+    assert(!ActorIso);
     LV.add<MaterializeToTemporaryComponent>(
         Storage, IsSuper, Subs, Options, readStrategy, writeStrategy,
         BaseFormalType, typeData, IndexExprForDiagnostics, std::move(Indices),
@@ -3209,12 +3265,15 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                                    SGFAccessKind accessKind,
                                    AccessStrategy strategy,
                                    CanType formalRValueType,
-                                   bool isOnSelfParameter) {
+                                   bool isOnSelfParameter,
+                                   Optional<ActorIsolation> actorIso) {
   struct MemberVarAccessEmitter
       : MemberStorageAccessEmitter<MemberVarAccessEmitter, VarDecl> {
     using MemberStorageAccessEmitter::MemberStorageAccessEmitter;
 
     void emitUsingStorage(LValueTypeData typeData) {
+      assert(!ActorIso);
+
       // For static variables, emit a reference to the global variable backing
       // them.
       // FIXME: This has to be dynamically looked up for classes, and
@@ -3227,7 +3286,8 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
         LV.addNonMemberVarComponent(SGF, Loc, Storage, Subs, Options,
                                     typeData.getAccessKind(),
                                     AccessStrategy::getStorage(),
-                                    FormalRValueType);
+                                    FormalRValueType,
+                                    /*actorIsolation=*/None);
         return;
       }
 
@@ -3250,7 +3310,7 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
   } emitter(SGF, loc, var, subs, isSuper, accessKind,
             formalRValueType, options, *this,
             /*indices for diags*/ nullptr, /*indices*/ PreparedArguments(),
-            isOnSelfParameter);
+            isOnSelfParameter, actorIso);
 
   emitter.emitUsingStrategy(strategy);
 }
@@ -3298,6 +3358,12 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
                        getBaseOptions(options, strategy));
   assert(lv.isValid());
 
+  // Now that the base components have been resolved, check the isolation for
+  // this subscript decl.
+  Optional<ActorIsolation> actorIso;
+  if (e->isImplicitlyAsync())
+    actorIso = getActorIsolation(decl);
+
   Expr *indexExpr = e->getIndex();
   auto indices = SGF.prepareSubscriptIndices(decl, subs, strategy, indexExpr);
 
@@ -3305,7 +3371,7 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
   lv.addMemberSubscriptComponent(SGF, e, decl, subs,
                                  options, e->isSuper(), accessKind, strategy,
                                  formalRValueType, std::move(indices),
-                                 indexExpr, isOnSelfParameter);
+                                 indexExpr, isOnSelfParameter, actorIso);
   return lv;
 }
 
@@ -3406,7 +3472,8 @@ void LValue::addMemberSubscriptComponent(SILGenFunction &SGF, SILLocation loc,
                                          CanType formalRValueType,
                                          PreparedArguments &&indices,
                                          Expr *indexExprForDiagnostics,
-                                         bool isOnSelfParameter) {
+                                         bool isOnSelfParameter,
+                                         Optional<ActorIsolation> actorIso) {
   struct MemberSubscriptAccessEmitter
       : MemberStorageAccessEmitter<MemberSubscriptAccessEmitter,
                                    SubscriptDecl> {
@@ -3417,7 +3484,7 @@ void LValue::addMemberSubscriptComponent(SILGenFunction &SGF, SILLocation loc,
     }
   } emitter(SGF, loc, decl, subs, isSuper, accessKind, formalRValueType,
             options, *this, indexExprForDiagnostics, std::move(indices),
-            isOnSelfParameter);
+            isOnSelfParameter, actorIso);
 
   emitter.emitUsingStrategy(strategy);
 }
@@ -4087,38 +4154,51 @@ static ArgumentSource emitBaseValueForAccessor(SILGenFunction &SGF,
 RValue SILGenFunction::emitLoadOfLValue(SILLocation loc, LValue &&src,
                                         SGFContext C, bool isBaseGuaranteed) {
   assert(isReadAccess(src.getAccessKind()));
+  bool didHop = false;
+  RValue result;
+  {
+    // Any writebacks should be scoped to after the load.
+    FormalEvaluationScope scope(*this);
 
-  // Any writebacks should be scoped to after the load.
-  FormalEvaluationScope scope(*this);
+    // We shouldn't need to re-abstract here, but we might have to bridge.
+    // This should only happen if we have a global variable of NSString type.
+    auto origFormalType = src.getOrigFormalType();
+    auto substFormalType = src.getSubstFormalType();
+    auto &rvalueTL = getTypeLowering(src.getTypeOfRValue());
 
-  // We shouldn't need to re-abstract here, but we might have to bridge.
-  // This should only happen if we have a global variable of NSString type.
-  auto origFormalType = src.getOrigFormalType();
-  auto substFormalType = src.getSubstFormalType();
-  auto &rvalueTL = getTypeLowering(src.getTypeOfRValue());
+    ManagedValue addr;
+    PathComponent &&component =
+        drillToLastComponent(*this, loc, std::move(src), addr);
 
-  ManagedValue addr;
-  PathComponent &&component =
-    drillToLastComponent(*this, loc, std::move(src), addr);
+    // If the last component is physical, drill down and load from it.
+    if (component.isPhysical()) {
+      auto actorIso = component.asPhysical().getActorIsolation();
 
-  // If the last component is physical, drill down and load from it.
-  if (component.isPhysical()) {
-    auto projection = std::move(component).project(*this, loc, addr);
-    if (projection.getType().isAddress()) {
-      projection = emitLoad(loc, projection.getValue(),
-                            origFormalType, substFormalType,
-                            rvalueTL, C, IsNotTake,
-                            isBaseGuaranteed);
-    } else if (isReadAccessResultOwned(src.getAccessKind()) &&
-               !projection.isPlusOne(*this)) {
-      projection = projection.copy(*this, loc);
+      // If the load must happen in the context of an actor, do a hop first.
+        didHop = emitHopToTargetActor(loc, actorIso, /*actorSelf=*/None);
+
+      auto projection = std::move(component).project(*this, loc, addr);
+      if (projection.getType().isAddress()) {
+        projection =
+            emitLoad(loc, projection.getValue(), origFormalType,
+                     substFormalType, rvalueTL, C, IsNotTake, isBaseGuaranteed);
+      } else if (isReadAccessResultOwned(src.getAccessKind()) &&
+                 !projection.isPlusOne(*this)) {
+        projection = projection.copy(*this, loc);
+      }
+
+      result = RValue(*this, loc, substFormalType, projection);
+    } else {
+      // If the last component is logical, emit a get.
+      result = std::move(component.asLogical()).get(*this, loc, addr, C);
     }
+  } // End the evaluation scope before any hop back to the current executor.
 
-    return RValue(*this, loc, substFormalType, projection);
-  }
+  // If we hopped to the target's executor, then we need to hop back.
+  if (didHop)
+    emitHopToCurrentExecutor(loc);
 
-  // If the last component is logical, emit a get.
-  return std::move(component.asLogical()).get(*this, loc, addr, C);
+  return result;
 }
 
 static AbstractionPattern

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -542,7 +542,50 @@ SILValue SILGenFunction::emitLoadGlobalActorExecutor(Type globalActor) {
     actorType, /*isSuper*/ false, sharedInstanceDecl, PreparedArguments(),
     subs, AccessSemantics::Ordinary, instanceType, SGFContext());
   ManagedValue actorInstance = std::move(actorInstanceRV).getScalarValue();
-  return actorInstance.borrow(*this, loc).getValue();
+
+  if (isInFormalEvaluationScope())
+    return actorInstance.formalAccessBorrow(*this, loc).getValue();
+  else
+    return actorInstance.borrow(*this, loc).getValue();
+}
+
+
+HopToExecutorInst* SILGenFunction::emitHopToTargetActor(SILLocation loc,
+                                          Optional<ActorIsolation> maybeIso,
+                                          Optional<ManagedValue> maybeSelf) {
+  if (!maybeIso)
+    return nullptr;
+
+  auto actorIso = maybeIso.getValue();
+  Optional<SILValue> executor = None;
+
+  switch (actorIso.getKind()) {
+  case ActorIsolation::Unspecified:
+  case ActorIsolation::Independent:
+  case ActorIsolation::IndependentUnsafe:
+    break;
+
+  case ActorIsolation::ActorInstance: {
+    // "self" here means the actor instance's "self" value.
+    assert(maybeSelf.hasValue() && "actor-instance but no self provided?");
+    auto self = maybeSelf.getValue();
+    if (isInFormalEvaluationScope())
+      executor = self.formalAccessBorrow(*this, loc).getValue();
+    else
+      executor = self.borrow(*this, loc).getValue();
+    break;
+  }
+
+  case ActorIsolation::GlobalActor:
+  case ActorIsolation::GlobalActorUnsafe:
+    executor = emitLoadGlobalActorExecutor(actorIso.getGlobalActor());
+    break;
+  }
+
+  if (executor)
+    return B.createHopToExecutor(loc, executor.getValue());
+
+  return nullptr;
 }
 
 static void emitIndirectResultParameters(SILGenFunction &SGF, Type resultType,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -542,6 +542,11 @@ ActorIsolationRestriction ActorIsolationRestriction::forDeclaration(
 
     // A function that provides an asynchronous context has no restrictions
     // on its access.
+    //
+    // FIXME: technically, synchronous functions are allowed to be cross-actor.
+    // The call-sites are just conditionally async based on where they appear
+    // (outside or inside the actor). This suggests that the implicitly-async
+    // concept could be merged into the CrossActorSelf concept.
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
       if (func->isAsyncContext())
         isAccessibleAcrossActors = true;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -909,13 +909,74 @@ namespace {
     llvm::SmallDenseMap<VarDecl *, TinyPtrVector<const DeclContext *>>
       captureContexts;
 
-    using MutableVarSource = llvm::PointerUnion<DeclRefExpr *, InOutExpr *>;
-    using MutableVarParent = llvm::PointerUnion<InOutExpr *, LoadExpr *>;
+    using MutableVarSource
+        = llvm::PointerUnion<DeclRefExpr *, InOutExpr *, LookupExpr *>;
 
-    /// Mapping from mutable local variables or inout expressions to the
-    /// parent expression, when that parent is either a load or a inout expression.
+    using MutableVarParent
+        = llvm::PointerUnion<InOutExpr *, LoadExpr *, AssignExpr *>;
+
+    /// Mapping from mutable variable reference exprs, or inout expressions,
+    /// to the parent expression, when that parent is either a load or
+    /// an inout expr.
     llvm::SmallDenseMap<MutableVarSource, MutableVarParent, 4>
       mutableLocalVarParent;
+
+    /// The values for each case in this enum correspond to %select numbers
+    /// in a diagnostic, so be sure to update it if you add new cases.
+    enum class VarRefUseEnv {
+      Read = 0,
+      Mutating = 1,
+      Inout = 2 // means Mutating; having a separate kind helps diagnostics
+    };
+
+    static bool isPropOrSubscript(ValueDecl const* decl) {
+      return isa<VarDecl>(decl) || isa<SubscriptDecl>(decl);
+    }
+
+    /// In the given expression \c use that refers to the decl, this
+    /// function finds the kind of environment tracked by
+    /// \c mutableLocalVarParent that corresponds to that \c use.
+    ///
+    /// Note that an InoutExpr is not considered a use of the decl!
+    ///
+    /// @returns None if the context expression is either an InOutExpr,
+    ///               not tracked, or if the decl is not a property or subscript
+    Optional<VarRefUseEnv> kindOfUsage(ValueDecl *decl, Expr *use) const {
+      // we need a use for lookup.
+      if (!use)
+        return None;
+
+      // must be a property or subscript
+      if (!isPropOrSubscript(decl))
+        return None;
+
+      if (auto lookup = dyn_cast<DeclRefExpr>(use))
+        return usageEnv(lookup);
+      else if (auto lookup = dyn_cast<LookupExpr>(use))
+        return usageEnv(lookup);
+
+      return None;
+    }
+
+    /// @returns the kind of environment in which this expression appears, as
+    ///          tracked by \c mutableLocalVarParent
+    VarRefUseEnv usageEnv(MutableVarSource src) const {
+      auto result = mutableLocalVarParent.find(src);
+      if (result != mutableLocalVarParent.end()) {
+        MutableVarParent parent = result->second;
+        assert(!parent.isNull());
+        if (parent.is<LoadExpr*>())
+          return VarRefUseEnv::Read;
+        else if (parent.is<AssignExpr*>())
+          return VarRefUseEnv::Mutating;
+        else if (auto inout = parent.dyn_cast<InOutExpr*>())
+          return inout->isImplicit() ? VarRefUseEnv::Mutating
+                                     : VarRefUseEnv::Inout;
+        else
+          llvm_unreachable("non-exhaustive case match");
+      }
+      return VarRefUseEnv::Read; // assume if it's not tracked, it's only read.
+    }
 
     const DeclContext *getDeclContext() const {
       return contextStack.back();
@@ -944,9 +1005,9 @@ namespace {
           return false;
 
         // Only mutable variables outside of the current context. This is an
-        // optimization, because the parent map won't be queried in this case, and
-        // it is the most common case for variables to be referenced in their
-        // own context.
+        // optimization, because the parent map won't be queried in this case,
+        // and it is the most common case for variables to be referenced in
+        // their own context.
         if (var->getDeclContext() == getDeclContext())
           return false;
 
@@ -955,14 +1016,17 @@ namespace {
         return true;
       }
 
-      // For a member reference, try to record a parent for the base
-      // expression.
+      // For a member reference, try to record a parent for the base expression.
       if (auto memberRef = dyn_cast<MemberRefExpr>(subExpr)) {
+        // Record the parent of this LookupExpr too.
+        mutableLocalVarParent[memberRef] = parent;
         return recordMutableVarParent(parent, memberRef->getBase());
       }
 
       // For a subscript, try to record a parent for the base expression.
       if (auto subscript = dyn_cast<SubscriptExpr>(subExpr)) {
+        // Record the parent of this LookupExpr too.
+        mutableLocalVarParent[subscript] = parent;
         return recordMutableVarParent(parent, subscript->getBase());
       }
 
@@ -1064,13 +1128,22 @@ namespace {
           recordMutableVarParent(inout, inout->getSubExpr());
       }
 
-      if (auto load = dyn_cast<LoadExpr>(expr)) {
-        recordMutableVarParent(load, load->getSubExpr());
+      if (auto assign = dyn_cast<AssignExpr>(expr)) {
+        // mark vars in the destination expr as being part of the Assign.
+        if (auto destExpr = assign->getDest())
+          recordMutableVarParent(assign, destExpr);
+
+        return {true, expr };
       }
+
+      if (auto load = dyn_cast<LoadExpr>(expr))
+        recordMutableVarParent(load, load->getSubExpr());
 
       if (auto lookup = dyn_cast<LookupExpr>(expr)) {
         checkMemberReference(lookup->getBase(), lookup->getMember(),
-                             lookup->getLoc());
+                             lookup->getLoc(),
+                             /*isEscapingPartialApply*/false,
+                             lookup);
         return { true, expr };
       }
 
@@ -1092,7 +1165,7 @@ namespace {
             // implicitly async, regardless of whether they are escaping.
             checkMemberReference(
                 partialApply->base, memberRef->first, memberRef->second,
-                partialApply->isEscaping, /*maybeImplicitAsync=*/false);
+                partialApply->isEscaping);
 
             partialApply->base->walk(*this);
 
@@ -1111,7 +1184,7 @@ namespace {
         if (auto memberRef = findMemberReference(fn)) {
           checkMemberReference(
               call->getArg(), memberRef->first, memberRef->second,
-              /*isEscapingPartialApply=*/false, /*maybeImplicitAsync=*/true);
+              /*isEscapingPartialApply=*/false, call);
 
           call->getArg()->walk(*this);
 
@@ -1179,12 +1252,12 @@ namespace {
       }
 
       // Clear out the mutable local variable parent map on the way out.
-      if (auto *declRefExpr = dyn_cast<DeclRefExpr>(expr)) {
+      if (auto *declRefExpr = dyn_cast<DeclRefExpr>(expr))
         mutableLocalVarParent.erase(declRefExpr);
-      }
-      if (auto *inoutExpr = dyn_cast<InOutExpr>(expr)) {
+      else if (auto *lookupExpr = dyn_cast<LookupExpr>(expr))
+        mutableLocalVarParent.erase(lookupExpr);
+      else if (auto *inoutExpr = dyn_cast<InOutExpr>(expr))
         mutableLocalVarParent.erase(inoutExpr);
-      }
 
       // Remove the tracked capture contexts.
       if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
@@ -1231,15 +1304,23 @@ namespace {
     }
 
     /// Note that the given actor member is isolated.
-    static void noteIsolatedActorMember(ValueDecl *decl) {
+    /// @param context is allowed to be null if no context is appropriate.
+    void noteIsolatedActorMember(ValueDecl *decl, Expr *context) {
       // FIXME: Make this diagnostic more sensitive to the isolation context
       // of the declaration.
       if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
         func->diagnose(diag::actor_isolated_sync_func, 
           decl->getDescriptiveKind(),
           decl->getName());
-      } else if (isa<VarDecl>(decl)) {
-        decl->diagnose(diag::actor_mutable_state);
+
+        // was it an attempt to mutate an actor instance's isolated state?
+      } else if (auto environment = kindOfUsage(decl, context)) {
+
+        if (environment.getValue() == VarRefUseEnv::Read)
+          decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
+        else
+          decl->diagnose(diag::actor_mutable_state, decl->getDescriptiveKind());
+
       } else {
         decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
       }
@@ -1440,39 +1521,62 @@ namespace {
     /// Check a reference to an entity within a global actor.
     bool checkGlobalActorReference(
         ConcreteDeclRef valueRef, SourceLoc loc, Type globalActor,
-        bool isCrossActor) {
+        bool isCrossActor,
+        Expr *context) {
       ValueDecl *value = valueRef.getDecl();
 
-      /// Returns true if this global actor reference is the callee of an Apply.
-      /// NOTE: This check mutates the identified ApplyExpr if it returns true!
+      /// Returns true if this global-actor reference is acceptable because
+      /// it is part of an implicitly async operation, such as a call or
+      /// property access.
+      /// NOTE: This check will mutate the AST if it returns true!
       auto inspectForImplicitlyAsync = [&] () -> bool {
         // If our current context isn't an asynchronous one, don't
         if (!isInAsynchronousContext())
           return false;
 
-        // Is this global actor reference outside of an ApplyExpr?
-        if (applyStack.size() == 0)
-          return false;
+        bool asyncAccess = false;
 
-        // Check our applyStack metadata from the traversal.
-        // Our goal is to identify whether this global actor reference appears
-        // as the called value of the enclosing ApplyExpr. We cannot simply
-        // inspect Parent here because of expressions like (callee)()
-        ApplyExpr *apply = applyStack.back();
-        Expr *fn = apply->getFn()->getValueProvidingExpr();
-        if (auto memberRef = findMemberReference(fn)) {
-          auto concDecl = memberRef->first;
-          if (value == concDecl.getDecl() && !apply->implicitlyAsync()) {
-            // then this ValueDecl appears as the called value of the ApplyExpr.
-            markNearestCallAsImplicitlyAsync();
-
-            // Check for non-concurrent types.
-            (void)diagnoseNonConcurrentTypesInReference(
-                valueRef, getDeclContext(), loc,
-                ConcurrentReferenceKind::SynchronousAsAsyncCall);
-
-            return true;
+        // Is this global-actor reference part of a LookupExpr or DeclRefExpr?
+        if (isPropOrSubscript(valueRef.getDecl())) {
+          if (auto declRef = dyn_cast_or_null<DeclRefExpr>(context)) {
+            if (usageEnv(declRef) == VarRefUseEnv::Read) {
+              declRef->setImplicitlyAsync(true);
+              asyncAccess = true;
+            }
+          } else if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
+            if (usageEnv(lookupExpr) == VarRefUseEnv::Read) {
+              lookupExpr->setImplicitlyAsync(true);
+              asyncAccess = true;
+            }
           }
+        }
+
+        // Is this global-actor reference within an apply?
+        if (!applyStack.empty()) {
+          // Check our applyStack metadata from the traversal.
+          // Our goal is to identify whether this global actor reference appears
+          // as the called value of the enclosing ApplyExpr. We cannot simply
+          // inspect Parent here because of expressions like (callee)()
+          // and the fact that the reference may be just an argument to an apply
+          ApplyExpr *apply = applyStack.back();
+          Expr *fn = apply->getFn()->getValueProvidingExpr();
+          if (auto memberRef = findMemberReference(fn)) {
+            auto concDecl = memberRef->first;
+            if (value == concDecl.getDecl() && !apply->implicitlyAsync()) {
+              // then this ValueDecl appears as the called value of the ApplyExpr.
+              markNearestCallAsImplicitlyAsync();
+              asyncAccess = true;
+            }
+          }
+        }
+
+        if (asyncAccess) {
+          // Check for non-concurrent types.
+          (void)diagnoseNonConcurrentTypesInReference(
+              valueRef, getDeclContext(), loc,
+              ConcurrentReferenceKind::SynchronousAsAsyncCall);
+
+          return true;
         }
 
         return false;
@@ -1496,16 +1600,20 @@ namespace {
       }
 
       switch (contextIsolation) {
-      case ActorIsolation::ActorInstance:
+      case ActorIsolation::ActorInstance: {
         if (inspectForImplicitlyAsync())
           return false;
 
-        ctx.Diags.diagnose(
-            loc, diag::global_actor_from_instance_actor_context,
-            value->getDescriptiveKind(), value->getName(), globalActor,
-            contextIsolation.getActor()->getName());
-        noteIsolatedActorMember(value);
+        auto useKind = static_cast<unsigned>(
+            kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
+
+        ctx.Diags.diagnose(loc, diag::global_actor_from_instance_actor_context,
+                           value->getDescriptiveKind(), value->getName(),
+                           globalActor, contextIsolation.getActor()->getName(),
+                           useKind);
+        noteIsolatedActorMember(value, context);
         return true;
+      }
 
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe: {
@@ -1514,12 +1622,15 @@ namespace {
         if (inspectForImplicitlyAsync())
           return false;
 
+        auto useKind = static_cast<unsigned>(
+            kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
+
         // Otherwise, this is a problematic global actor decl reference.
         ctx.Diags.diagnose(
             loc, diag::global_actor_from_other_global_actor_context,
             value->getDescriptiveKind(), value->getName(), globalActor,
-            contextIsolation.getGlobalActor());
-        noteIsolatedActorMember(value);
+            contextIsolation.getGlobalActor(), useKind);
+        noteIsolatedActorMember(value, context);
         return true;
       }
 
@@ -1527,38 +1638,44 @@ namespace {
         // Allow unrestricted use of something in a global actor.
         return false;
 
-      case ActorIsolation::Independent:
+      case ActorIsolation::Independent: {
         if (inspectForImplicitlyAsync())
           return false;
 
-        ctx.Diags.diagnose(
-            loc, diag::global_actor_from_nonactor_context,
-            value->getDescriptiveKind(), value->getName(), globalActor,
-            /*actorIndependent=*/true);
-        noteIsolatedActorMember(value);
+        auto useKind = static_cast<unsigned>(
+            kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
+
+        ctx.Diags.diagnose(loc, diag::global_actor_from_nonactor_context,
+                           value->getDescriptiveKind(), value->getName(),
+                           globalActor,
+                           /*actorIndependent=*/true, useKind);
+        noteIsolatedActorMember(value, context);
         return true;
+      }
 
       case ActorIsolation::Unspecified: {
         // NOTE: we must always inspect for implicitlyAsync
-        bool implicitlyAsyncCall = inspectForImplicitlyAsync();
+        bool implicitlyAsyncExpr = inspectForImplicitlyAsync();
         bool didEmitDiagnostic = false;
 
         auto emitError = [&](bool justNote = false) {
           didEmitDiagnostic = true;
           if (!justNote) {
+            auto useKind = static_cast<unsigned>(
+                kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
             ctx.Diags.diagnose(
               loc, diag::global_actor_from_nonactor_context,
               value->getDescriptiveKind(), value->getName(), globalActor,
-              /*actorIndependent=*/false);
+              /*actorIndependent=*/false, useKind);
           }
-          noteIsolatedActorMember(value);
+          noteIsolatedActorMember(value, context);
         };
 
         if (AbstractFunctionDecl const* fn =
             dyn_cast_or_null<AbstractFunctionDecl>(declContext->getAsDecl())) {
           bool isAsyncContext = fn->isAsyncContext();
 
-          if (implicitlyAsyncCall && isAsyncContext)
+          if (implicitlyAsyncExpr && isAsyncContext)
             return didEmitDiagnostic; // definitely an OK reference.
 
           // otherwise, there's something wrong.
@@ -1567,7 +1684,7 @@ namespace {
           // then we know later type-checking will raise an error,
           // so we just emit a note pointing out that callee of the call is
           // implicitly async.
-          emitError(/*justNote=*/implicitlyAsyncCall);
+          emitError(/*justNote=*/implicitlyAsyncExpr);
 
           // otherwise, if it's any kind of global-actor reference within
           // this synchronous function, we'll additionally suggest becoming
@@ -1702,7 +1819,8 @@ namespace {
 
       case ActorIsolationRestriction::GlobalActor:
         return checkGlobalActorReference(
-            valueRef, loc, isolation.getGlobalActor(), isolation.isCrossActor);
+            valueRef, loc, isolation.getGlobalActor(), isolation.isCrossActor,
+            declRefExpr);
 
       case ActorIsolationRestriction::Unsafe:
         return diagnoseReferenceToUnsafeGlobal(value, loc);
@@ -1712,7 +1830,7 @@ namespace {
 
     /// Determine the reason for the given declaration context to be
     /// actor-independent.
-    static Diag<DescriptiveDeclKind, DeclName>
+    static Diag<DescriptiveDeclKind, DeclName, unsigned>
     findActorIndependentReason(DeclContext *dc) {
       if (auto autoclosure = dyn_cast<AutoClosureExpr>(dc)) {
         switch (autoclosure->getThunkKind()) {
@@ -1754,7 +1872,7 @@ namespace {
     bool checkMemberReference(
         Expr *base, ConcreteDeclRef memberRef, SourceLoc memberLoc,
         bool isEscapingPartialApply = false, 
-        bool maybeImplicitAsync = false) {
+        Expr *context = nullptr) {
       if (!base || !memberRef)
         return false;
 
@@ -1780,16 +1898,32 @@ namespace {
       }
 
       case ActorIsolationRestriction::ActorSelf: {
-        // Local function to check for implicit async promotion.
+        /// Local function to check for implicit async promotion.
+        /// returns None if it is not applicable; true if there is an error.
         auto checkImplicitlyAsync = [&]() -> Optional<bool> {
           if (!isInAsynchronousContext())
             return None;
 
+          bool validAccess = false;
+
           // actor-isolated non-isolated-self calls are implicitly async
           // and thus OK.
-          if (maybeImplicitAsync && isa<AbstractFunctionDecl>(member)) {
+          if (llvm::isa_and_nonnull<SelfApplyExpr>(context) &&
+              isa<AbstractFunctionDecl>(member)) {
             markNearestCallAsImplicitlyAsync();
+            validAccess = true;
 
+          } else if (llvm::isa_and_nonnull<LookupExpr>(context) &&
+                    isPropOrSubscript(member) &&
+                    usageEnv(cast<LookupExpr>(context)) == VarRefUseEnv::Read) {
+            cast<LookupExpr>(context)->setImplicitlyAsync(true);
+            validAccess = true;
+          } else {
+            // It's not wrong to have declref context here; simply unimplemented
+            assert(context == nullptr || !isa<DeclRefExpr>(context));
+          }
+
+          if (validAccess) {
             // Check for non-concurrent types.
             return diagnoseNonConcurrentTypesInReference(
                 memberRef, getDeclContext(), memberLoc,
@@ -1806,13 +1940,18 @@ namespace {
           if (auto result = checkImplicitlyAsync())
             return *result;
 
+          auto useKind = static_cast<unsigned>(
+              kindOfUsage(member, context).getValueOr(VarRefUseEnv::Read));
+
           ctx.Diags.diagnose(
               memberLoc, diag::actor_isolated_non_self_reference,
               member->getDescriptiveKind(),
               member->getName(),
               isolation.getActorClass() ==
-                getNearestEnclosingActorContext(getDeclContext()));
-          noteIsolatedActorMember(member);
+                getNearestEnclosingActorContext(getDeclContext()),
+              useKind
+              );
+          noteIsolatedActorMember(member, context);
           return true;
         }
 
@@ -1827,7 +1966,7 @@ namespace {
                   memberLoc, diag::actor_isolated_partial_apply,
                   member->getDescriptiveKind(),
                   member->getName());
-              noteIsolatedActorMember(member);
+              noteIsolatedActorMember(member, context);
               return true;
             }
 
@@ -1844,10 +1983,12 @@ namespace {
 
             // The 'self' is for an actor-independent member, which means
             // we cannot refer to actor-isolated state.
+            auto useKind = static_cast<unsigned>(
+                kindOfUsage(member, context).getValueOr(VarRefUseEnv::Read));
             auto diag = findActorIndependentReason(curDC);
             ctx.Diags.diagnose(memberLoc, diag, member->getDescriptiveKind(),
-                               member->getName());
-            noteIsolatedActorMember(member);
+                               member->getName(), useKind);
+            noteIsolatedActorMember(member, context);
             return true;
           }
 
@@ -1864,7 +2005,7 @@ namespace {
                 member->getDescriptiveKind(),
                 member->getName(),
                 contextIsolation.getGlobalActor());
-            noteIsolatedActorMember(member);
+            noteIsolatedActorMember(member, context);
             return true;
         }
         llvm_unreachable("Unhandled actor isolation");
@@ -1880,7 +2021,7 @@ namespace {
       case ActorIsolationRestriction::GlobalActor:
         return checkGlobalActorReference(
             memberRef, memberLoc, isolation.getGlobalActor(),
-            isolation.isCrossActor);
+            isolation.isCrossActor, context);
 
       case ActorIsolationRestriction::Unsafe:
         // This case is hit when passing actor state inout to functions in some

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -431,6 +431,8 @@ public:
       recurse = asImpl().checkOptionalTry(optionalTryExpr);
     } else if (auto apply = dyn_cast<ApplyExpr>(E)) {
       recurse = asImpl().checkApply(apply);
+    } else if (auto lookup = dyn_cast<LookupExpr>(E)) {
+      recurse = asImpl().checkLookup(lookup);
     } else if (auto declRef = dyn_cast<DeclRefExpr>(E)) {
       recurse = asImpl().checkDeclRef(declRef);
     } else if (auto interpolated = dyn_cast<InterpolatedStringLiteralExpr>(E)) {
@@ -980,6 +982,9 @@ private:
       ThrowKind = std::max(ThrowKind, classification.getConditionalKind(EffectKind::Throws));
       return ShouldRecurse;
     }
+    ShouldRecurse_t checkLookup(LookupExpr *E) {
+      return ShouldRecurse; // NOTE: currently, lookups can't throw
+    }
     ShouldRecurse_t checkDeclRef(DeclRefExpr *E) {
       return ShouldNotRecurse;
     }
@@ -1081,7 +1086,12 @@ private:
       AsyncKind = std::max(AsyncKind, classification.getConditionalKind(EffectKind::Async));
       return ShouldRecurse;
     }
+    ShouldRecurse_t checkLookup(LookupExpr *E) {
+      // FIXME should the logic from CheckEffectsCoverage::checkLookup be here?
+      return ShouldRecurse;
+    }
     ShouldRecurse_t checkDeclRef(DeclRefExpr *E) {
+      // FIXME should the logic from CheckEffectsCoverage::checkDeclRef be here?
       return ShouldNotRecurse;
     }
     ShouldRecurse_t checkAsyncLet(PatternBindingDecl *patternBinding) {
@@ -1771,47 +1781,73 @@ public:
     llvm_unreachable("bad context kind");
   }
 
-  void diagnoseUncoveredAsyncSite(ASTContext &ctx, ASTNode node) {
-    SourceRange highlight;
+  /// NOTE: the values backing these enums match up with a %select
+  /// in the diagnostics!
+  enum AsyncSiteKind {
+    Unspecified = 0,
+    Call = 1,
+    Await = 2,
+    AsyncLet = 3,
+    Property = 4,
+    Subscript = 5
+  };
 
-    // Generate more specific messages in some cases.
-
-    // Reference to an 'async let' missing an 'await'.
-    if (auto declRef = dyn_cast_or_null<DeclRefExpr>(node.dyn_cast<Expr *>())) {
-      if (auto var = dyn_cast<VarDecl>(declRef->getDecl())) {
-        if (var->isAsyncLet()) {
-          ctx.Diags.diagnose(
-              declRef->getLoc(), diag::async_let_without_await, var->getName());
-          return;
-        }
-      }
-    }
-
-    if (auto apply = dyn_cast_or_null<ApplyExpr>(node.dyn_cast<Expr*>()))
-      highlight = apply->getSourceRange();
-
+  void diagnoseUncoveredAsyncSite(ASTContext &ctx, ASTNode node,
+                                  AsyncSiteKind kind) {
+    SourceRange highlight = node.getSourceRange();
     auto diag = diag::async_call_without_await;
 
-    // To produce a better error message, check if it is an autoclosure.
-    // We do not use 'Context::isAutoClosure' b/c it gives conservative answers.
-    if (Function) {
-      if (auto autoclosure = dyn_cast_or_null<AutoClosureExpr>(
-              Function->getAbstractClosureExpr())) {
-        switch (autoclosure->getThunkKind()) {
-        case AutoClosureExpr::Kind::None:
-          diag = diag::async_call_without_await_in_autoclosure;
-          break;
-
-        case AutoClosureExpr::Kind::AsyncLet:
-          diag = diag::async_call_without_await_in_async_let;
-          break;
-
-        case AutoClosureExpr::Kind::SingleCurryThunk:
-        case AutoClosureExpr::Kind::DoubleCurryThunk:
-          break;
+    switch (kind) {
+    case AsyncSiteKind::AsyncLet:
+      // Reference to an 'async let' missing an 'await'.
+      if (auto declR = dyn_cast_or_null<DeclRefExpr>(node.dyn_cast<Expr*>())) {
+        if (auto var = dyn_cast<VarDecl>(declR->getDecl())) {
+          if (var->isAsyncLet()) {
+            ctx.Diags.diagnose(declR->getLoc(), diag::async_let_without_await,
+                               var->getName());
+            return;
+          }
         }
       }
+      LLVM_FALLTHROUGH; // fallthrough to a message about property access
+
+    case AsyncSiteKind::Property:
+      diag = diag::async_prop_access_without_await;
+      break;
+
+    case AsyncSiteKind::Subscript:
+      diag = diag::async_subscript_access_without_await;
+      break;
+
+    case AsyncSiteKind::Unspecified:
+    case AsyncSiteKind::Call: {
+      if (Function) {
+        // To produce a better error message, check if it is an autoclosure.
+        // We do not use 'Context::isAutoClosure' b/c it gives conservative
+        // answers.
+        if (auto autoclosure = dyn_cast_or_null<AutoClosureExpr>(
+                Function->getAbstractClosureExpr())) {
+          switch (autoclosure->getThunkKind()) {
+          case AutoClosureExpr::Kind::None:
+            diag = diag::async_call_without_await_in_autoclosure;
+            break;
+
+          case AutoClosureExpr::Kind::AsyncLet:
+            diag = diag::async_call_without_await_in_async_let;
+            break;
+
+          case AutoClosureExpr::Kind::SingleCurryThunk:
+          case AutoClosureExpr::Kind::DoubleCurryThunk:
+            break;
+          }
+        }
+      }
+      break;
     }
+
+    case AsyncSiteKind::Await:
+      llvm_unreachable("diagnosing an uncovered await?");
+    };
 
     ctx.Diags.diagnose(node.getStartLoc(), diag)
         .fixItInsert(node.getStartLoc(), "await ")
@@ -1859,20 +1895,15 @@ public:
       addAsyncNotes(func);
   }
 
-  void diagnoseUnhandledAsyncSite(DiagnosticEngine &Diags, ASTNode node) {
+  /// providing a \c kind helps tailor the emitted message.
+  void diagnoseUnhandledAsyncSite(DiagnosticEngine &Diags, ASTNode node,
+                                  AsyncSiteKind kind) {
     switch (getKind()) {
-    case Kind::PotentiallyHandled: {
-      unsigned kind = 0;
-      if (node.isExpr(ExprKind::Await))
-        kind = 1;
-      else if (node.isExpr(ExprKind::DeclRef) ||
-               node.isDecl(DeclKind::PatternBinding))
-        kind = 2;
+    case Kind::PotentiallyHandled:
       Diags.diagnose(node.getStartLoc(), diag::async_in_nonasync_function,
-                     kind, isAutoClosure());
+                     static_cast<unsigned>(kind), isAutoClosure());
       maybeAddAsyncNote(Diags);
       return;
-    }
 
     case Kind::EnumElementInitializer:
     case Kind::GlobalVarInitializer:
@@ -2264,7 +2295,8 @@ private:
     classifier.ReasyncDC = ReasyncDC;
     auto classification = classifier.classifyApply(E);
 
-    checkThrowAsyncSite(E, /*requiresTry*/ true, classification);
+    checkThrowAsyncSite(E, /*requiresTry*/ true, classification,
+                        Context::Call);
 
     // HACK: functions can get queued multiple times in
     // definedFunctions, so be sure to be idempotent.
@@ -2284,8 +2316,31 @@ private:
     return !type || type->hasError() ? ShouldNotRecurse : ShouldRecurse;
   }
 
+  ShouldRecurse_t checkLookup(LookupExpr *E) {
+    if (E->isImplicitlyAsync()) {
+      Context::AsyncSiteKind lookupKind = Context::Property;
+      // check the kind of thing we're looking up to give better diagnostics
+      if (auto valueDecl = E->getMember().getDecl())
+        if (isa<SubscriptDecl>(valueDecl))
+          lookupKind = Context::Subscript;
+
+      checkThrowAsyncSite(E, /*requiresTry=*/false,
+            Classification::forUnconditional(EffectKind::Async,
+                                             PotentialEffectReason::forApply()),
+                          lookupKind);
+    }
+
+    return ShouldRecurse;
+  }
+
   ShouldRecurse_t checkDeclRef(DeclRefExpr *E) {
-    if (auto decl = E->getDecl()) {
+    if (E->isImplicitlyAsync()) {
+      checkThrowAsyncSite(E, /*requiresTry=*/false,
+            Classification::forUnconditional(EffectKind::Async,
+                                             PotentialEffectReason::forApply()),
+                          Context::Property);
+
+    } else if (auto decl = E->getDecl()) {
       if (auto var = dyn_cast<VarDecl>(decl)) {
         // "Async let" declarations are treated as an asynchronous call
         // (to the underlying task's "get"). If the initializer was throwing,
@@ -2309,7 +2364,8 @@ private:
                            EffectKind::Throws,
                            PotentialEffectReason::forThrowingAsyncLet()));
           }
-          checkThrowAsyncSite(E, /*requiresTry=*/throws, result);
+          checkThrowAsyncSite(E, /*requiresTry=*/throws, result,
+                              Context::AsyncLet);
         }
       }
     }
@@ -2320,7 +2376,8 @@ private:
   ShouldRecurse_t checkAsyncLet(PatternBindingDecl *patternBinding) {
     // Diagnose async let in a context that doesn't handle async.
     if (!CurContext.handlesAsync(ConditionalEffectKind::Always)) {
-      CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, patternBinding);
+      CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, patternBinding,
+                                            Context::AsyncLet);
     }
 
     return ShouldRecurse;
@@ -2377,8 +2434,11 @@ private:
     return ShouldRecurse;
   }
 
+  /// providing a \c kind helps tailor any possible diagnostic messages
+  /// related to async-ness
   void checkThrowAsyncSite(ASTNode E, bool requiresTry,
-                           const Classification &classification) {
+                           const Classification &classification,
+                           Context::AsyncSiteKind kind) {
     // Suppress all diagnostics when there's an un-analyzable throw site.
     if (classification.isInvalid()) {
       Flags.set(ContextFlags::HasAnyThrowSite);
@@ -2401,11 +2461,11 @@ private:
 
       // Diagnose async calls in a context that doesn't handle async.
       if (!CurContext.handlesAsync(asyncKind)) {
-        CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, E);
+        CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, E, kind);
       }
       // Diagnose async calls that are outside of an await context.
       else if (!Flags.has(ContextFlags::IsAsyncCovered)) {
-        CurContext.diagnoseUncoveredAsyncSite(Ctx, E);
+        CurContext.diagnoseUncoveredAsyncSite(Ctx, E, kind);
       }
     }
 
@@ -2459,7 +2519,7 @@ private:
       if (CurContext.handlesAsync(ConditionalEffectKind::Conditional))
         Ctx.Diags.diagnose(E->getAwaitLoc(), diag::no_async_in_await);
       else
-        CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, E);
+        CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, E, Context::Await);
     }
     
     // Inform the parent of the walk that an 'await' exists here.
@@ -2541,7 +2601,7 @@ private:
         S->getSequenceConformance(), EffectKind::Async);
     auto asyncKind = classification.getConditionalKind(EffectKind::Async);
     if (!CurContext.handlesAsync(asyncKind))
-      CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, S);
+      CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, S, Context::Unspecified);
 
     return ShouldRecurse;
   }

--- a/test/Concurrency/Runtime/async_properties_actor.swift
+++ b/test/Concurrency/Runtime/async_properties_actor.swift
@@ -1,0 +1,173 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -enable-experimental-concurrency %import-libdispatch) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+@propertyWrapper
+struct SuccessTracker {
+    private var _stored: Bool
+    private var numReads : Int = 0 // an unchecked statistic to exercise mutating get
+    init(initially: Bool) {
+        self._stored = initially
+    }
+
+    var wrappedValue: Bool {
+        mutating get {
+            numReads += 1
+            return _stored
+        }
+        set { _stored = newValue }
+    }
+}
+
+func writeToBool(_ b : inout Bool, _ val : Bool) {
+    b = val
+}
+
+actor List<T : ConcurrentValue> {
+    var head : T
+    var tail : List<T>?
+
+    lazy var hasTail : Bool = (tail != nil)
+
+    var computedTail : List<T>? {
+        get { tail }
+    }
+
+    subscript(_ offset : Int) -> T? {
+        // since we don't have async subscripts, we just return nil for non-zero inputs! :)
+        if offset != 0 {
+            return nil
+        }
+
+        return head
+    }
+
+    /// this silly property is here just for testing wrapped-property access
+    @SuccessTracker(initially: true) var success : Bool
+    func setSuccess(_ b : Bool) { writeToBool(&success, b) }
+
+    init(_ value : T) {
+        self.head = value
+        self.tail = nil
+    }
+
+    init(_ value : T, _ tail : List<T>) {
+        self.head = value
+        self.tail = tail
+    }
+
+    func last() async -> T {
+        switch tail {
+        case .none:
+            return head
+        case .some(let tl):
+            if await tl.hasTail {
+                return await tl.last()
+            }
+            return await tl.head
+        }
+    }
+
+    static func tabulate(_ n : Int, _ f : (Int) -> T) -> List<T> {
+        if n == 0 {
+            return List<T>(f(n))
+        }
+        return List<T>(f(n), tabulate(n-1, f))
+    }
+
+    static func foldr<R>(_ f : (T, R) -> R, _ start : R, _ lst : List<T>) async -> R {
+        switch await lst.tail {
+            case .none:
+                return f(await lst.head, start)
+            case .some(let tl):
+                return f(await lst.head, await foldr(f, start, tl))
+        }
+    }
+}
+
+
+actor Tester {
+    /// returns true iff success
+    func doListTest() async -> Bool {
+        let n = 4 // if you change this, you'll have to update other stuff too
+
+        let ints = List<Int>.tabulate(n, { $0 })
+
+        let last1 = await ints.tail!.computedTail!.tail!.tail![0]
+        let last2 = await ints.last()
+
+        guard last1 == last2 else {
+            print("fail 1")
+            return false
+        }
+
+
+        let expected = (n * (n + 1)) / 2
+        let sum = await List<Int>.foldr({ $0 + $1 }, 0, ints)
+
+        guard sum == expected else {
+            print("fail 2")
+            return false
+        }
+
+        // CHECK: done list test
+        // CHECK-NOT: fail
+        print("done list test")
+        return true
+    }
+
+    func doPropertyWrapperTest() async -> Bool {
+        let actor = List<String>("blah")
+
+        await actor.setSuccess(false)
+        guard await actor.success == false else {
+            print("fail 3")
+            return false
+        }
+
+        await actor.setSuccess(true)
+        guard await actor.success == true else {
+            print("fail 4")
+            return false
+        }
+
+        // CHECK: done property wrapper test
+        // CHECK-NOT: fail
+        print("done property wrapper test")
+        return true
+    }
+}
+
+@globalActor
+struct SillyActor {
+    actor _Impl {}
+    static let shared = _Impl()
+}
+
+@SillyActor
+var test : Tester = Tester()
+
+@SillyActor
+var expectedResult : Bool {
+    get { true }
+    set {}
+}
+
+@main struct RunIt {
+    static func main() async {
+        let success = await expectedResult
+
+        guard await test.doListTest() == success else {
+            fatalError("fail list test")
+        }
+
+        guard await test.doPropertyWrapperTest() == success else {
+            fatalError("fail property wrapper test")
+        }
+
+        // CHECK: done all testing
+        print("done all testing")
+    }
+}

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -7,7 +7,7 @@ actor BankAccount {
 
   private var accountHolder : String = "unknown"
 
-  // expected-note@+1 2 {{mutable state is only available within the actor instance}}
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   var owner : String {
     get { accountHolder }
     set { accountHolder = newValue }
@@ -35,7 +35,7 @@ actor BankAccount {
   }
 
   func testSelfBalance() async {
-    _ = await balance() // expected-warning {{no calls to 'async' functions occur within 'await' expression}}
+    _ = await balance() // expected-warning {{no 'async' operations occur within 'await' expression}}
   }
 
   // returns the amount actually withdrawn
@@ -118,19 +118,21 @@ func anotherAsyncFunc() async {
   _ = a.deposit(1)  // expected-error{{call is 'async' but is not marked with 'await'}}
   _ = b.balance()   // expected-error{{call is 'async' but is not marked with 'await'}}
   
-  _ = b.balance // expected-error {{actor-isolated instance method 'balance()' can only be referenced inside the actor}}
+  _ = b.balance // expected-error {{actor-isolated instance method 'balance()' can only be referenced from inside the actor}}
 
-  a.owner = "cat" // expected-error{{actor-isolated property 'owner' can only be referenced inside the actor}}
-  _ = b.owner // expected-error{{actor-isolated property 'owner' can only be referenced inside the actor}}
+  a.owner = "cat" // expected-error{{actor-isolated property 'owner' can only be mutated from inside the actor}}
+  _ = b.owner // expected-error{{property access is 'async' but is not marked with 'await'}}
+  _ = await b.owner == "cat"
+
 
 }
 
 func regularFunc() {
   let a = BankAccount(initialDeposit: 34)
 
-  _ = a.deposit //expected-error{{actor-isolated instance method 'deposit' can only be referenced inside the actor}}
+  _ = a.deposit //expected-error{{actor-isolated instance method 'deposit' can only be referenced from inside the actor}}
 
-  _ = a.deposit(1)  // expected-error{{actor-isolated instance method 'deposit' can only be referenced inside the actor}}
+  _ = a.deposit(1)  // expected-error{{actor-isolated instance method 'deposit' can only be referenced from inside the actor}}
 }
 
 
@@ -150,11 +152,30 @@ func blender(_ peeler : () -> Void) {
   peeler()
 }
 
-@BananaActor func wisk(_ something : Any) { } // expected-note 4 {{calls to global function 'wisk' from outside of its actor context are implicitly asynchronous}}
+// expected-note@+2 {{var declared here}}
+// expected-note@+1 2 {{mutation of this var is only permitted within the actor}}
+@BananaActor var dollarsInBananaStand : Int = 250000
+
+@BananaActor func wisk(_ something : Any) { } // expected-note 5 {{calls to global function 'wisk' from outside of its actor context are implicitly asynchronous}}
 
 @BananaActor func peelBanana() { } // expected-note 2 {{calls to global function 'peelBanana()' from outside of its actor context are implicitly asynchronous}}
 
+@BananaActor func takeInout(_ x : inout Int) {}
+
 @OrangeActor func makeSmoothie() async {
+  var money = await dollarsInBananaStand
+  money -= 1200
+
+  dollarsInBananaStand = money // expected-error{{var 'dollarsInBananaStand' isolated to global actor 'BananaActor' can not be mutated from different global actor 'OrangeActor'}}
+
+  // FIXME: these two errors seem a bit redundant.
+  // expected-error@+2 {{actor-isolated var 'dollarsInBananaStand' cannot be passed 'inout' to implicitly 'async' function call}}
+  // expected-error@+1 {{var 'dollarsInBananaStand' isolated to global actor 'BananaActor' can not be used 'inout' from different global actor 'OrangeActor'}}
+  await takeInout(&dollarsInBananaStand)
+
+  _ = wisk // expected-error {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
+
+
   await wisk({})
   // expected-warning@-1{{cannot pass argument of non-concurrent-value type 'Any' across actors}}
   await wisk(1)
@@ -173,11 +194,11 @@ func blender(_ peeler : () -> Void) {
   await (((wisk)))(((wisk))) // expected-error {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
   // expected-warning@-1{{cannot pass argument of non-concurrent-value type 'Any' across actors}}
 
-  // expected-warning@+2 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
   // expected-error@+1 {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
   await {wisk}()(1)
 
-  // expected-warning@+2 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
   // expected-error@+1 {{global function 'wisk' isolated to global actor 'BananaActor' can not be referenced from different global actor 'OrangeActor'}}
   await (true ? wisk : {n in return})(1)
 }
@@ -210,14 +231,14 @@ actor Calculator {
 @OrangeActor func doSomething() async {
   let _ = (await bananaAdd(1))(2)
   // expected-warning@-1{{cannot call function returning non-concurrent-value type}}
-  let _ = await (await bananaAdd(1))(2) // expected-warning{{no calls to 'async' functions occur within 'await' expression}}
+  let _ = await (await bananaAdd(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
   // expected-warning@-1{{cannot call function returning non-concurrent-value type}}
 
   let calc = Calculator()
   
   let _ = (await calc.addCurried(1))(2)
   // expected-warning@-1{{cannot call function returning non-concurrent-value type}}
-  let _ = await (await calc.addCurried(1))(2) // expected-warning{{no calls to 'async' functions occur within 'await' expression}}
+  let _ = await (await calc.addCurried(1))(2) // expected-warning{{no 'async' operations occur within 'await' expression}}
   // expected-warning@-1{{cannot call function returning non-concurrent-value type}}
 
   let plusOne = await calc.addCurried(await calc.add(0, 1))

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -29,6 +29,11 @@ actor TestActor {
   var value1: Int = 0
   var value2: Int = 1
   var points: [Point] = []
+
+  subscript(x : inout Int) -> Int { // expected-error {{'inout' must not be used on subscript parameters}}
+    x += 1
+    return x
+  }
 }
 
 func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -23,7 +23,7 @@ struct Point {
 }
 
 actor TestActor {
-  // expected-note@+1{{mutable state is only available within the actor instance}}
+  // expected-note@+1{{mutation of this property is only permitted within the actor}}
   var position = Point(x: 0, y: 0)
   var nextPosition = Point(x: 0, y: 1)
   var value1: Int = 0
@@ -169,10 +169,10 @@ actor MyActor {
 
     // This warning is emitted because this fails to typecheck before the
     // async-ness is attached.
-    // expected-warning@+2{{no calls to 'async' functions occur within 'await' expression}}
+    // expected-warning@+2{{no 'async' operations occur within 'await' expression}}
     // expected-error@+1{{cannot pass immutable value of type 'Int' as inout argument}}
     await modifyAsynchronously(&(maybePoint?.z)!)
-    // expected-error@+2{{actor-isolated property 'position' can only be referenced inside the actor}}
+    // expected-error@+2{{actor-isolated property 'position' can only be used 'inout' from inside the actor}}
     // expected-error@+1{{actor-isolated property 'myActor' cannot be passed 'inout' to 'async' function call}}
     await modifyAsynchronously(&myActor.position.x)
   }
@@ -188,10 +188,10 @@ struct MyGlobalActor {
 @MyGlobalActor var number: Int = 0
 // expected-note@-1{{var declared here}}
 // expected-note@-2{{var declared here}}
-// expected-note@-3{{mutable state is only available within the actor instance}}
+// expected-note@-3{{mutation of this var is only permitted within the actor}}
 
 // expected-error@+2{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-// expected-error@+1{{var 'number' isolated to global actor 'MyGlobalActor' can not be referenced from this context}}
+// expected-error@+1{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from this context}}
 let _ = Task.runDetached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
 
 // attempt to pass global state owned by the global actor to another async function

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -50,6 +50,14 @@ actor MyActor: MySuperActor {
 
   let point : Point = Point()
 
+  @MainActor
+  var name : String = "koala"
+
+  // FIXME: if you take the 'async' off of this, you get a very confusing error message.
+  func accessProp() async -> String {
+    return await self.name
+  }
+
   class func synchronousClass() { }
   static func synchronousStatic() { }
 
@@ -57,6 +65,12 @@ actor MyActor: MySuperActor {
   func asynchronous() async -> String {
     super.superState += 4
     return synchronous()
+  }
+}
+
+actor Camera {
+  func accessProp(act : MyActor) async -> String {
+    return await act.name
   }
 }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -12,31 +12,72 @@ func acceptEscapingClosure<T>(_: @escaping (String) -> ()) async -> T? { nil }
 
 func acceptAsyncClosure<T>(_: () async -> T) { }
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
+func acceptInout<T>(_: inout T) {}
 
 
 // ----------------------------------------------------------------------
 // Actor state isolation restrictions
 // ----------------------------------------------------------------------
 actor MySuperActor {
-  var superState: Int = 25 // expected-note {{mutable state is only available within the actor instance}}
+  var superState: Int = 25 // expected-note {{mutation of this property is only permitted within the actor}}
 
-  func superMethod() { } // expected-note 2 {{calls to instance method 'superMethod()' from outside of its actor context are implicitly asynchronous}}
+
+  func superMethod() { // expected-note 2 {{calls to instance method 'superMethod()' from outside of its actor context are implicitly asynchronous}}
+    self.superState += 5
+  }
+
   func superAsyncMethod() async { }
 
-  subscript (index: Int) -> String { // expected-note 3{{subscript declared here}}
+  subscript (index: Int) -> String {
     "\(index)"
   }
 }
 
+class Point {
+  var x : Int = 0
+  var y : Int = 0
+}
+
 actor MyActor: MySuperActor {
   let immutable: Int = 17
-  var text: [String] = [] // expected-note 10{{mutable state is only available within the actor instance}}
+  // expected-note@+2 3{{property declared here}}
+  // expected-note@+1 8{{mutation of this property is only permitted within the actor}}
+  var mutable: Int = 71
+
+  // expected-note@+2 3 {{mutation of this property is only permitted within the actor}}
+  // expected-note@+1 5{{property declared here}}
+  var text: [String] = []
+
+  let point : Point = Point()
 
   class func synchronousClass() { }
   static func synchronousStatic() { }
 
   func synchronous() -> String { text.first ?? "nothing" } // expected-note 20{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
-  func asynchronous() async -> String { synchronous() }
+  func asynchronous() async -> String {
+    super.superState += 4
+    return synchronous()
+  }
+}
+
+func checkAsyncPropertyAccess() async {
+  let act = MyActor()
+  let _ : Int = await act.mutable + act.mutable
+  act.mutable += 1  // expected-error {{actor-isolated property 'mutable' can only be mutated from inside the actor}}
+
+  act.superState += 1 // expected-error {{actor-isolated property 'superState' can only be mutated from inside the actor}}
+
+  act.text[0].append("hello") // expected-error{{actor-isolated property 'text' can only be mutated from inside the actor}}
+
+  // this is not the same as the above, because Array is a value type
+  var arr = await act.text
+  arr[0].append("hello")
+
+  act.text.append("no") // expected-error{{actor-isolated property 'text' can only be mutated from inside the actor}}
+
+  act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can only be mutated from inside the actor}}
+
+  _ = act.point // expected-warning{{cannot use property 'point' with a non-concurrent-value type 'Point' across actors}}
 }
 
 extension MyActor {
@@ -47,6 +88,7 @@ extension MyActor {
 
   @actorIndependent func actorIndependentFunc(otherActor: MyActor) -> Int {
     _ = immutable
+    _ = mutable // expected-error{{actor-isolated property 'mutable' can not be referenced from an '@actorIndependent'}}
     _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from an '@actorIndependent' context}}
     _ = synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from an '@actorIndependent' context}}
 
@@ -90,28 +132,45 @@ extension MyActor {
 
   func testAsynchronous(otherActor: MyActor) async {
     _ = immutable
+    _ = mutable
+    mutable = 0
     _ = synchronous()
     _ = text[0]
+    acceptInout(&mutable)
 
     // Accesses on 'self' are okay.
     _ = self.immutable
+    _ = self.mutable
+    self.mutable = 0
     _ = self.synchronous()
     _ = await self.asynchronous()
     _ = self.text[0]
+    acceptInout(&self.mutable)
     _ = self[0]
 
     // Accesses on 'super' are okay.
     _ = super.superState
+    super.superState = 0
+    acceptInout(&super.superState)
     super.superMethod()
     await super.superAsyncMethod()
     _ = super[0]
 
-    // Accesses on other actors can only reference immutable data or
-    // call methods
+    // Accesses on other actors can only reference immutable data synchronously,
+    // otherwise the access is treated as async
     _ = otherActor.immutable // okay
+    _ = otherActor.mutable // expected-error{{property access is 'async' but is not marked with 'await'}}
+    _ = await otherActor.mutable
+    otherActor.mutable = 0  // expected-error{{actor-isolated property 'mutable' can only be mutated on 'self'}}
+    acceptInout(&otherActor.mutable)  // expected-error{{actor-isolated property 'mutable' can only be used 'inout' on 'self'}}
+    // expected-error@+2{{actor-isolated property 'mutable' can only be mutated on 'self'}}
+    // expected-warning@+1{{no 'async' operations occur within 'await' expression}}
+    await otherActor.mutable = 0
+
     _ = otherActor.synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
     _ = await otherActor.asynchronous()
-    _ = otherActor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced on 'self'}}
+    _ = otherActor.text[0] // expected-error{{property access is 'async' but is not marked with 'await'}}
+    _ = await otherActor.text[0] // okay
 
     // Global data is okay if it is immutable.
     _ = immutableGlobal
@@ -148,6 +207,10 @@ extension MyActor {
       }
 
       _ = self.text[0] // expected-error{{actor-isolated property 'text' cannot be referenced from a concurrent closure}}
+      _ = self.mutable // expected-error{{actor-isolated property 'mutable' cannot be referenced from a concurrent closure}}
+      self.mutable = 0 // expected-error{{actor-isolated property 'mutable' cannot be mutated from a concurrent closure}}
+      acceptInout(&self.mutable) // expected-error{{actor-isolated property 'mutable' cannot be used 'inout' from a concurrent closure}}
+      _ = self.immutable
       _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be referenced from a concurrent closure}}
       _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
       localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
@@ -168,6 +231,10 @@ extension MyActor {
     // Escaping closures might run concurrently.
     acceptEscapingClosure {
       _ = self.text[0] // expected-error{{actor-isolated property 'text' cannot be referenced from an '@escaping' closure}}
+      _ = self.mutable // expected-error{{actor-isolated property 'mutable' cannot be referenced from an '@escaping' closure}}
+      self.mutable = 0 // expected-error{{actor-isolated property 'mutable' cannot be mutated from an '@escaping' closure}}
+      acceptInout(&self.mutable) // expected-error{{actor-isolated property 'mutable' cannot be used 'inout' from an '@escaping' closure}}
+      _ = self.immutable
       _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be referenced from an '@escaping' closure}}
       _ = localVar // okay, don't complain about escaping
       _ = localConstant
@@ -234,6 +301,35 @@ struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
+actor Crystal {
+  // expected-note@+2 {{property declared here}}
+  // expected-note@+1 2 {{mutation of this property is only permitted within the actor}}
+  @SomeGlobalActor var globActorVar : Int = 0
+
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
+  @SomeGlobalActor var globActorProp : Int {
+    get { return 0 }
+    set {}
+  }
+
+  // expected-note@+1 {{calls to instance method 'foo' from outside of its actor context are implicitly asynchronous}}
+  @SomeGlobalActor func foo(_ x : inout Int) {}
+
+  func referToGlobProps() async {
+    _ = await globActorVar + globActorProp
+
+    globActorProp = 20 // expected-error {{property 'globActorProp' isolated to global actor 'SomeGlobalActor' can not be mutated from actor 'Crystal'}}
+
+    globActorVar = 30 // expected-error {{property 'globActorVar' isolated to global actor 'SomeGlobalActor' can not be mutated from actor 'Crystal'}}
+
+    // expected-error@+2 {{property 'globActorVar' isolated to global actor 'SomeGlobalActor' can not be used 'inout' from actor 'Crystal'}}
+    // expected-error@+1 {{actor-isolated property 'globActorVar' cannot be passed 'inout' to implicitly 'async' function call}}
+    await self.foo(&globActorVar)
+
+    _ = self.foo // expected-error {{instance method 'foo' isolated to global actor 'SomeGlobalActor' can not be referenced from actor 'Crystal'}}
+  }
+}
+
 @SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note 2{{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
 @SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
@@ -262,9 +358,12 @@ extension MyActor {
     await asyncOtherGlobalActorFunc()
 
     _ = immutable
+    _ = mutable // expected-error{{property access is 'async' but is not marked with 'await'}}
+    _ = await mutable
     _ = synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
     _ = await synchronous()
-    _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from context of global actor 'SomeGlobalActor'}}
+    _ = text[0] // expected-error{{property access is 'async' but is not marked with 'await'}}
+    _ = await text[0]
 
     // Accesses on 'self' are only okay for immutable and asynchronous, because
     // we are outside of the actor instance.
@@ -273,15 +372,19 @@ extension MyActor {
     _ = await self.synchronous()
 
     _ = await self.asynchronous()
-    _ = self.text[0] // expected-error{{actor-isolated property 'text' can not be referenced from context of global actor 'SomeGlobalActor'}}
-    _ = self[0] // expected-error{{actor-isolated subscript 'subscript(_:)' can not be referenced from context of global actor 'SomeGlobalActor'}}
+    _ = self.text[0] // expected-error{{property access is 'async' but is not marked with 'await'}}
+    _ = self[0] // expected-error{{subscript access is 'async' but is not marked with 'await'}}
+    _ = await self.text[0]
+    _ = await self[0]
 
-    // Accesses on 'super' are not okay; we're outside of the actor.
-    _ = super.superState // expected-error{{actor-isolated property 'superState' can not be referenced from context of global actor 'SomeGlobalActor'}}
+    // Accesses on 'super' are not okay without 'await'; we're outside of the actor.
+    _ = super.superState // expected-error{{property access is 'async' but is not marked with 'await'}}
+    _ = await super.superState
     super.superMethod() // expected-error{{call is 'async' but is not marked with 'await'}}
     await super.superMethod()
     await super.superAsyncMethod()
-    _ = super[0] // expected-error{{actor-isolated subscript 'subscript(_:)' can not be referenced from context of global actor 'SomeGlobalActor'}}
+    _ = super[0] // expected-error{{subscript access is 'async' but is not marked with 'await'}}
+    _ = await super[0]
 
     // Accesses on other actors can only reference immutable data or
     // call asychronous methods
@@ -289,7 +392,8 @@ extension MyActor {
     _ = otherActor.synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
     _ = otherActor.synchronous  // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced on 'self'}}
     _ = await otherActor.asynchronous()
-    _ = otherActor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced on 'self'}}
+    _ = otherActor.text[0] // expected-error{{property access is 'async' but is not marked with 'await'}}
+    _ = await otherActor.text[0]
   }
 }
 
@@ -316,12 +420,16 @@ extension GenericStruct where T == String {
 }
 
 @SomeGlobalActor
-var number: Int = 42 // expected-note 2 {{mutable state is only available within the actor instance}}
+var number: Int = 42 // expected-note {{var declared here}}
 
-//expected-note@+1{{add '@SomeGlobalActor' to make global function 'badNumberUser()' part of global actor 'SomeGlobalActor'}}
+// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'badNumberUser()' part of global actor 'SomeGlobalActor'}}
 func badNumberUser() {
   //expected-error@+1{{var 'number' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
   print("The protected number is: \(number)")
+}
+
+func asyncBadNumberUser() async {
+  print("The protected number is: \(await number)")
 }
 
 // ----------------------------------------------------------------------
@@ -330,15 +438,25 @@ func badNumberUser() {
 func testGlobalRestrictions(actor: MyActor) async {
   let _ = MyActor()
 
-  // Asynchronous functions and immutable state are permitted.
-  _ = await actor.asynchronous()
-  _ = actor.immutable
+  // references to sync methods must be fully applied.
+  _ = actor.synchronous // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced from inside the actor}}
+  _ = actor.asynchronous
 
-  // Synchronous operations are ok, mutable state references are not.
-  _ = actor.synchronous // expected-error{{actor-isolated instance method 'synchronous()' can only be referenced inside the actor}}
+  // any kind of method can be called from outside the actor, so long as it's marked with 'await'
   _ = actor.synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
-  _ = actor.text[0] // expected-error{{actor-isolated property 'text' can only be referenced inside the actor}}
-  _ = actor[0] // expected-error{{actor-isolated subscript 'subscript(_:)' can only be referenced inside the actor}}
+  _ = actor.asynchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
+  _ = await actor.synchronous()
+  _ = await actor.asynchronous()
+
+  // stored and computed properties can be accessed. Only immutable stored properties can be accessed without 'await'
+  _ = actor.immutable
+  _ = await actor.immutable // expected-warning {{no 'async' operations occur within 'await' expression}}
+  _ = actor.mutable  // expected-error{{property access is 'async' but is not marked with 'await'}}
+  _ = await actor.mutable
+  _ = actor.text[0] // expected-error{{property access is 'async' but is not marked with 'await'}}
+  _ = await actor.text[0]
+  _ = actor[0] // expected-error{{subscript access is 'async' but is not marked with 'await'}}
+  _ = await actor[0]
 
   // @actorIndependent declarations are permitted.
   _ = actor.actorIndependentFunc(otherActor: actor)
@@ -365,8 +483,7 @@ func testGlobalRestrictions(actor: MyActor) async {
     _ = i
   }
 
-  //expected-error@+1{{var 'number' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
-  print("\(number)")
+  print("\(number)") //expected-error {{property access is 'async' but is not marked with 'await'}}
 }
 
 func f() {
@@ -432,7 +549,7 @@ func checkLocalFunctions() async {
 
 actor LazyActor {
     var v: Int = 0
-    // expected-note@-1 6 {{mutable state is only available within the actor instance}}
+    // expected-note@-1 6 {{property declared here}}
 
     let l: Int = 0
 

--- a/test/Concurrency/async_throwing.swift
+++ b/test/Concurrency/async_throwing.swift
@@ -47,15 +47,15 @@ func throwingTask() async throws -> String {
 // expected-note@+2 7 {{add '@asyncHandler' to function 'syncTest()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
 // expected-note@+1 7 {{add 'async' to function 'syncTest()' to make it asynchronous}} {{16-16= async}}
 func syncTest() {
-  let _ = invoke(fn: normalTask) // expected-error{{'async' in a function that does not support concurrency}}
-  let _ = invokeAuto(42) // expected-error{{'async' in a function that does not support concurrency}}
-  let _ = invokeAuto("intuitive") // expected-error{{'async' in a function that does not support concurrency}}
+  let _ = invoke(fn: normalTask) // expected-error{{'async' call in a function that does not support concurrency}}
+  let _ = invokeAuto(42) // expected-error{{'async' call in a function that does not support concurrency}}
+  let _ = invokeAuto("intuitive") // expected-error{{'async' call in a function that does not support concurrency}}
   
-  let _ = try! asyncRethrows(fn: throwingTask) // expected-error{{'async' in a function that does not support concurrency}}
-  let _ = try? invoke(fn: throwingTask) // expected-error{{'async' in a function that does not support concurrency}}
+  let _ = try! asyncRethrows(fn: throwingTask) // expected-error{{'async' call in a function that does not support concurrency}}
+  let _ = try? invoke(fn: throwingTask) // expected-error{{'async' call in a function that does not support concurrency}}
   do {
-   let _ = try invoke(fn: throwingTask) // expected-error{{'async' in a function that does not support concurrency}}
-   let _ = try asyncThrows() // expected-error{{'async' in a function that does not support concurrency}}
+   let _ = try invoke(fn: throwingTask) // expected-error{{'async' call in a function that does not support concurrency}}
+   let _ = try asyncThrows() // expected-error{{'async' call in a function that does not support concurrency}}
   } catch {
     // ignore it
   }

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -16,9 +16,11 @@ struct SomeGlobalActor {
 
 actor Alex {
   @SomeGlobalActor let const_memb = 20
-  @SomeGlobalActor var mut_memb = 30 // expected-note 2 {{mutable state is only available within the actor instance}}
+  @SomeGlobalActor var mut_memb = 30
   @SomeGlobalActor func method() {} // expected-note 2 {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
-  @SomeGlobalActor subscript(index : Int) -> Int { // expected-note 4 {{subscript declared here}}
+
+  // expected-note@+1 2 {{mutation of this subscript is only permitted within the actor}}
+  @SomeGlobalActor subscript(index : Int) -> Int {
     get {
       return index * 2
     }
@@ -26,17 +28,14 @@ actor Alex {
   }
 }
 
-
-// expected-note@+1 4 {{add '@SomeGlobalActor' to make global function 'referenceGlobalActor()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
-func referenceGlobalActor() {
+func referenceGlobalActor() async {
   let a = Alex()
-  // expected-error@+1 {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
-  _ = a.method
+  _ = a.method // expected-error {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
   _ = a.const_memb
-  _ = a.mut_memb  // expected-error{{property 'mut_memb' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  _ = a.mut_memb  // expected-error{{property access is 'async' but is not marked with 'await'}}
 
-  _ = a[1]  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
-  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  _ = a[1]  // expected-error{{subscript access is 'async' but is not marked with 'await'}}
+  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be mutated from this context}}
 }
 
 
@@ -52,7 +51,7 @@ func referenceGlobalActor2() {
 // expected-note@+1 {{add 'async' to function 'referenceAsyncGlobalActor()' to make it asynchronous}} {{33-33= async}}
 func referenceAsyncGlobalActor() {
   let y = asyncGlobalActFn
-  y() // expected-error{{'async' in a function that does not support concurrency}}
+  y() // expected-error{{'async' call in a function that does not support concurrency}}
 }
 
 
@@ -118,15 +117,16 @@ func fromAsync() async {
   // expected-error@+1 {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
   _ = a.method
   _ = a.const_memb
-  _ = a.mut_memb  // expected-error{{property 'mut_memb' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  _ = a.mut_memb  // expected-error{{property access is 'async' but is not marked with 'await'}}
 
-  _ = a[1]  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
-  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  _ = a[1]  // expected-error{{subscript access is 'async' but is not marked with 'await'}}
+  _ = await a[1]
+  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be mutated from this context}}
 }
 
-// expected-note@+1{{mutable state is only available within the actor instance}}
+// expected-note@+1{{mutation of this var is only permitted within the actor}}
 @SomeGlobalActor var value: Int = 42
 
 func topLevelSyncFunction(_ number: inout Int) { }
-// expected-error@+1{{var 'value' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+// expected-error@+1{{var 'value' isolated to global actor 'SomeGlobalActor' can not be used 'inout' from this context}}
 topLevelSyncFunction(&value)

--- a/test/Concurrency/reasync.swift
+++ b/test/Concurrency/reasync.swift
@@ -39,7 +39,7 @@ func asyncFunction() async {}
 
 func callReasyncFunction() async {
   reasyncFunction { }
-  await reasyncFunction { } // expected-warning {{no calls to 'async' functions occur within 'await' expression}}
+  await reasyncFunction { } // expected-warning {{no 'async' operations occur within 'await' expression}}
 
   reasyncFunction { await asyncFunction() } // expected-error {{call is 'async' but is not marked with 'await'}}
   await reasyncFunction { await asyncFunction() }
@@ -52,11 +52,11 @@ enum HorseError : Error {
 func callReasyncRethrowsFunction() async throws {
   reasyncRethrowsFunction { }
   await reasyncRethrowsFunction { }
-  // expected-warning@-1 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
   try reasyncRethrowsFunction { }
   // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
   try await reasyncRethrowsFunction { }
-  // expected-warning@-1 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
   // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
 
   reasyncRethrowsFunction { await asyncFunction() }
@@ -74,10 +74,10 @@ func callReasyncRethrowsFunction() async throws {
   await reasyncRethrowsFunction { throw HorseError.colic }
   // expected-error@-1 {{call can throw but is not marked with 'try'}}
   // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
-  // expected-warning@-3 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-warning@-3 {{no 'async' operations occur within 'await' expression}}
   try reasyncRethrowsFunction { throw HorseError.colic }
   try await reasyncRethrowsFunction { throw HorseError.colic }
-  // expected-warning@-1 {{no calls to 'async' functions occur within 'await' expression}}
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
 
   reasyncRethrowsFunction { await asyncFunction(); throw HorseError.colic }
   // expected-error@-1 {{call can throw but is not marked with 'try'}}
@@ -101,11 +101,11 @@ func callReasyncWithAutoclosure1() {
 // expected-note@-2 2{{add '@asyncHandler' to function 'callReasyncWithAutoclosure1()' to create an implicit asynchronous context}}
   reasyncWithAutoclosure(computeValue())
   await reasyncWithAutoclosure(await computeValueAsync())
-  // expected-error@-1 {{'async' in a function that does not support concurrency}}
+  // expected-error@-1 {{'async' call in a function that does not support concurrency}}
 
   await reasyncWithAutoclosure(computeValueAsync())
   // expected-error@-1 {{call is 'async' in an autoclosure argument that is not marked with 'await'}}
-  // expected-error@-2 {{'async' in a function that does not support concurrency}}
+  // expected-error@-2 {{'async' call in a function that does not support concurrency}}
 }
 
 func callReasyncWithAutoclosure2() async {
@@ -123,7 +123,7 @@ func callReasyncWithAutoclosure2() async {
 func invalidReasyncBody(_: () async -> ()) reasync {
 // expected-note@-1 {{add 'async' to function 'invalidReasyncBody' to make it asynchronous}}
   _ = await computeValueAsync()
-  // expected-error@-1 {{'async' in a function that does not support concurrency}}
+  // expected-error@-1 {{'async' call in a function that does not support concurrency}}
 }
 
 func validReasyncBody(_ fn: () async -> ()) reasync {

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -1,0 +1,439 @@
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -enable-experimental-concurrency | %FileCheck --enable-var-scope %s
+// REQUIRES: concurrency
+
+@propertyWrapper
+struct GiftWrapped<T> {
+    private var _stored: T
+    private var numReads : Int
+    init(initially: T) {
+        self._stored = initially
+    }
+
+    var wrappedValue: T {
+        mutating get {
+            numReads += 1
+            return _stored
+        }
+        set { _stored = newValue }
+    }
+}
+
+actor Birb {
+    private var _storage : Int = 24
+
+    var feathers : Int {
+        _read {
+            yield _storage
+        }
+        _modify {
+            yield &_storage
+        }
+    }
+}
+
+actor Cat {
+    @GlobalCat var leader : String {
+        get { "Tiger" }
+    }
+
+    var storedBool : Bool = false
+
+    private(set) var computedSweater : Sweater {
+        get { return Sweater(self) }
+        set {}
+    }
+
+    subscript(_ x : Int) -> Cat {
+        get { self }
+        set {}
+    }
+
+    var friend : Cat = Cat()
+
+    var maybeFriend : Cat?
+
+    @GiftWrapped<Birb>(initially: Birb())
+    var bestFriend : Birb
+}
+
+struct Sweater : ConcurrentValue {
+    let owner : Cat
+    init (_ owner : Cat) {
+        self.owner = owner
+    }
+}
+
+class CatBox {
+    var cat : Cat = Cat()
+}
+
+@globalActor
+struct GlobalCat {
+    static let shared : Cat = Cat()
+}
+
+@GlobalCat var globalBool : Bool = false
+
+@GlobalCat var someBirb : Birb {
+    get { Birb() }
+    set {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test015accessSweaterOfC03catAA0C0VAA3CatC_tYF : $@convention(thin) @async (@guaranteed Cat) -> @owned Sweater {
+// CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat):
+// CHECK:    hop_to_executor [[CAT]] : $Cat
+// CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+
+//               Notice that we don't hop back to the previous executor after invoking the getter,
+//               following the current code emission style when calling an actor from a non-actor async function.
+
+// CHECK-NOT: hop_to_executor
+// CHECK:    [[SWEATER1:%[0-9]+]] = begin_borrow [[SWEATER1_REF]] : $Sweater
+// CHECK:    [[SWEATER1_OWNER:%[0-9]+]] = struct_extract [[SWEATER1]] : $Sweater, #Sweater.owner
+// CHECK:    [[CAT2_REF:%[0-9]+]] = copy_value [[SWEATER1_OWNER]] : $Cat
+// CHECK:    end_borrow [[SWEATER1]] : $Sweater
+// CHECK:    destroy_value [[SWEATER1_REF]] : $Sweater
+// CHECK:    [[CAT2:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
+
+// CHECK:    hop_to_executor [[CAT2]] : $Cat
+// CHECK:    [[CAT2_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
+// CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
+// CHECK:    end_borrow [[CAT2]] : $Cat
+
+// CHECK-NOT: hop_to_executor
+// CHECK:    destroy_value [[CAT2_REF]] : $Cat
+// CHECK:    return [[SWEATER2_OWNER]] : $Sweater
+// CHECK: } // end sil function '$s4test015accessSweaterOfC03catAA0C0VAA3CatC_tYF'
+func accessSweaterOfSweater(cat : Cat) async -> Sweater {
+    // note that Sweater is not an actor!
+    return await cat.computedSweater.owner.computedSweater
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test26accessGlobalIsolatedMember3catSSAA3CatC_tYF : $@convention(thin) @async (@guaranteed Cat) -> @owned String {
+// CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat):
+// CHECK:    [[GLOBAL_CAT_SHARED:%[0-9]+]] = function_ref @$s4test9GlobalCatV6sharedAA0C0Cvau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:    [[GLOBAL_CAT_RAWPTR:%[0-9]+]] = apply [[GLOBAL_CAT_SHARED]]() : $@convention(thin) () -> Builtin.RawPointer
+// CHECK:    [[GLOBAL_CAT_ADDR:%[0-9]+]] = pointer_to_address [[GLOBAL_CAT_RAWPTR]] : $Builtin.RawPointer to [strict] $*Cat
+// CHECK:    [[GLOBAL_CAT_REF:%[0-9]+]] = load [copy] [[GLOBAL_CAT_ADDR]] : $*Cat
+// CHECK:    [[GLOBAL_CAT:%[0-9]+]] = begin_borrow [[GLOBAL_CAT_REF]] : $Cat
+
+// CHECK:    hop_to_executor [[GLOBAL_CAT]] : $Cat
+// CHECK:    [[GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.leader!getter : (Cat) -> () -> String, $@convention(method) (@guaranteed Cat) -> @owned String
+// CHECK:    [[THE_STRING:%[0-9]+]] = apply [[GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned String
+// CHECK:    end_borrow [[GLOBAL_CAT]] : $Cat
+// CHECK:    destroy_value [[GLOBAL_CAT_REF]] : $Cat
+// CHECK:    return [[THE_STRING]] : $String
+// CHECK: } // end sil function '$s4test26accessGlobalIsolatedMember3catSSAA3CatC_tYF'
+func accessGlobalIsolatedMember(cat : Cat) async -> String {
+    return await cat.leader
+}
+
+
+actor Dog {
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC15accessGlobalVarSbyYF : $@convention(method) @async (@guaranteed Dog) -> Bool {
+    // CHECK:   [[GLOBAL_BOOL_ADDR:%[0-9]+]] = global_addr @$s4test10globalBoolSbvp : $*Bool
+    // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
+    // CHECK:   [[SHARED_REF_FN:%[0-9]+]] = function_ref @$s4test9GlobalCatV6sharedAA0C0Cvau : $@convention(thin) () -> Builtin.RawPointer
+    // CHECK:   [[SHARED_REF:%[0-9]+]] = apply [[SHARED_REF_FN]]() : $@convention(thin) () -> Builtin.RawPointer
+    // CHECK:   [[SHARED_CAT_ADDR:%[0-9]+]] = pointer_to_address [[SHARED_REF]] : $Builtin.RawPointer to [strict] $*Cat
+    // CHECK:   [[CAT:%[0-9]+]] = load [copy] [[SHARED_CAT_ADDR]] : $*Cat
+    // CHECK:   [[BORROWED_CAT:%[0-9]+]] = begin_borrow [[CAT]] : $Cat
+
+    // CHECK:   hop_to_executor [[BORROWED_CAT]] : $Cat
+    // CHECK:   [[GLOBAL_BOOL_ACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[GLOBAL_BOOL_ADDR]] : $*Bool
+    // CHECK:   [[THE_BOOL:%[0-9]+]] = load [trivial] [[GLOBAL_BOOL_ACCESS]] : $*Bool
+    // CHECK:   end_access [[GLOBAL_BOOL_ACCESS]] : $*Bool
+    // CHECK:   end_borrow [[BORROWED_CAT]] : $Cat
+
+    // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   destroy_value [[CAT]] : $Cat
+    // CHECK:   return [[THE_BOOL]] : $Bool
+    // CHECK: } // end sil function '$s4test3DogC15accessGlobalVarSbyYF'
+    func accessGlobalVar() async -> Bool {
+        return await globalBool
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC24accessGlobalComputedPropSiyYF : $@convention(method) @async (@guaranteed Dog) -> Int {
+    // CHECK:  bb0([[SELF:%[0-9]+]] : @guaranteed $Dog):
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    [[SHARED_REF_FN:%[0-9]+]] = function_ref @$s4test9GlobalCatV6sharedAA0C0Cvau : $@convention(thin) () -> Builtin.RawPointer
+    // CHECK:    [[SHARED_REF:%[0-9]+]] = apply [[SHARED_REF_FN]]() : $@convention(thin) () -> Builtin.RawPointer
+    // CHECK:    [[SHARED_CAT_ADDR:%[0-9]+]] = pointer_to_address [[SHARED_REF]] : $Builtin.RawPointer to [strict] $*Cat
+    // CHECK:    [[CAT:%[0-9]+]] = load [copy] [[SHARED_CAT_ADDR]] : $*Cat
+    // CHECK:    [[BORROWED_CAT:%[0-9]+]] = begin_borrow [[CAT]] : $Cat
+
+    // CHECK:    hop_to_executor [[BORROWED_CAT]] : $Cat
+    // CHECK:    [[SOMEBIRB_GETTER:%[0-9]+]] = function_ref @$s4test8someBirbAA0C0Cvg : $@convention(thin) () -> @owned Birb
+    // CHECK:    [[BIRB:%[0-9]+]] = apply [[SOMEBIRB_GETTER]]() : $@convention(thin) () -> @owned Birb
+    // CHECK:    end_borrow [[BORROWED_CAT:%[0-9]+]] : $Cat
+
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    [[BORROWED_BIRB:%[0-9]+]] = begin_borrow [[BIRB]] : $Birb
+    // CHECK:    hop_to_executor [[BORROWED_BIRB]] : $Birb
+    // CHECK:    [[BORROWED_BIRB_FOR_LOAD:%[0-9]+]] = begin_borrow [[BIRB]] : $Birb
+    // CHECK:    [[FEATHER_GETTER:%[0-9]+]] = class_method [[BORROWED_BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (Birb) -> () -> Int, $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    [[THE_INT:%[0-9]+]] = apply [[FEATHER_GETTER]]([[BORROWED_BIRB_FOR_LOAD]]) : $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    end_borrow [[BORROWED_BIRB_FOR_LOAD]] : $Birb
+    // CHECK:    end_borrow [[BORROWED_BIRB]] : $Birb
+
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    destroy_value [[BIRB]] : $Birb
+    // CHECK:    destroy_value [[CAT]] : $Cat
+    // CHECK:    return [[THE_INT]] : $Int
+    // CHECK: } // end sil function '$s4test3DogC24accessGlobalComputedPropSiyYF'
+    func accessGlobalComputedProp() async -> Int {
+        return await someBirb.feathers
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC21accessWrappedProperty3catSiAA3CatC_tYF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> Int {
+    // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
+    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.bestFriend!getter : (Cat) -> () -> Birb, $@convention(method) (@guaranteed Cat) -> @owned Birb
+    // CHECK:    [[BIRB_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Birb
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    [[BIRB:%[0-9]+]] = begin_borrow [[BIRB_REF]] : $Birb
+    // CHECK:    hop_to_executor [[BIRB]] : $Birb
+    // CHECK:    [[BIRB_FOR_LOAD:%[0-9]+]] = begin_borrow [[BIRB_REF]] : $Birb
+    // CHECK:    [[BIRB_GETTER:%[0-9]+]] = class_method [[BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (Birb) -> () -> Int, $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    [[THE_INT:%[0-9]+]] = apply [[BIRB_GETTER]]([[BIRB_FOR_LOAD]]) : $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    end_borrow [[BIRB_FOR_LOAD]] : $Birb
+    // CHECK:    end_borrow [[BIRB]] : $Birb
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    destroy_value [[BIRB_REF]] : $Birb
+    // CHECK:    return [[THE_INT]] : $Int
+    // CHECK: } // end sil function '$s4test3DogC21accessWrappedProperty3catSiAA3CatC_tYF'
+    func accessWrappedProperty(cat : Cat) async -> Int {
+        return await cat.bestFriend.feathers
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC16accessFromRValueSbyYF : $@convention(method) @async (@guaranteed Dog) -> Bool {
+    // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
+    // CHECK:   [[INIT:%[0-9]+]] = function_ref @$s4test3CatCACycfC : $@convention(method) (@thick Cat.Type) -> @owned Cat
+    // CHECK:   [[CAT_REF:%[0-9]+]] = apply [[INIT]]({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
+    // CHECK:   [[CAT_BORROW_FOR_HOP:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
+
+    // CHECK:   hop_to_executor [[CAT_BORROW_FOR_HOP]] : $Cat
+    // CHECK:   [[CAT_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
+    // CHECK:   [[GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   end_borrow [[CAT_BORROW_FOR_LOAD]] : $Cat
+    // CHECK:   end_borrow [[CAT_BORROW_FOR_HOP]] : $Cat
+
+    // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   destroy_value [[CAT_REF]] : $Cat
+    // CHECK:   return [[THE_BOOL]] : $Bool
+    // CHECK: } // end sil function '$s4test3DogC16accessFromRValueSbyYF'
+    func accessFromRValue() async -> Bool {
+        return await Cat().storedBool
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC23accessFromRValueChainedSbyYF : $@convention(method) @async (@guaranteed Dog) -> Bool {
+    // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
+    // CHECK:   [[INIT:%[0-9]+]] = function_ref @$s4test3CatCACycfC : $@convention(method) (@thick Cat.Type) -> @owned Cat
+    // CHECK:   [[CAT_REF:%[0-9]+]] = apply [[INIT]]({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
+    // CHECK:   [[CAT_BORROW_FOR_HOP:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
+
+    // CHECK:   hop_to_executor [[CAT_BORROW_FOR_HOP]] : $Cat
+    // CHECK:   [[CAT_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
+    // CHECK:   [[FRIEND_GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.friend!getter : (Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:   [[FRIEND_REF:%[0-9]+]] = apply [[FRIEND_GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:   end_borrow [[CAT_BORROW_FOR_LOAD]] : $Cat
+    // CHECK:   end_borrow [[CAT_BORROW_FOR_HOP]] : $Cat
+
+    // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   destroy_value [[CAT_REF]] : $Cat
+    // CHECK:   [[FRIEND_BORROW_FOR_HOP:%[0-9]+]] = begin_borrow [[FRIEND_REF]] : $Cat
+
+    // CHECK:   hop_to_executor [[FRIEND_BORROW_FOR_HOP]] : $Cat
+    // CHECK:   [[FRIEND_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND_REF]] : $Cat
+    // CHECK:   [[BOOL_GETTER:%[0-9]+]] = class_method [[FRIEND_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[BOOL_GETTER]]([[FRIEND_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   end_borrow [[FRIEND_BORROW_FOR_LOAD]] : $Cat
+    // CHECK:   end_borrow [[FRIEND_BORROW_FOR_HOP]] : $Cat
+
+    // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   destroy_value [[FRIEND_REF]] : $Cat
+    // CHECK:   return [[THE_BOOL]] : $Bool
+    // CHECK: } // end sil function '$s4test3DogC23accessFromRValueChainedSbyYF'
+    func accessFromRValueChained() async -> Bool {
+        return await Cat().friend.storedBool
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC15accessSubscript3catAA3CatCAG_tYF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Cat {
+    // CHECK: bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[DOG:%[0-9]+]] : @guaranteed $Dog):
+    // CHECK:   hop_to_executor [[DOG]] : $Dog
+    // CHECK:   [[INTEGER1:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+
+    // CHECK:   hop_to_executor [[CAT]] : $Cat
+    // CHECK:   [[SUBSCRIPT_FN:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.subscript!getter : (Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[OTHER_CAT:%[0-9]+]] = apply [[SUBSCRIPT_FN]]([[INTEGER1]], [[CAT]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+
+    // CHECK:   hop_to_executor [[DOG]] : $Dog
+    // CHECK:   return [[OTHER_CAT]] : $Cat
+    // CHECK: } // end sil function '$s4test3DogC15accessSubscript3catAA3CatCAG_tYF'
+    func accessSubscript(cat : Cat) async -> Cat {
+        return await cat[1]
+    }
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC27accessRValueNestedSubscriptAA3CatCyYF : $@convention(method) @async (@guaranteed Dog) -> @owned Cat {
+    // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
+    // CHECK:   [[RVALUE_CAT_REF:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
+    // CHECK:   [[LIT_ONE:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
+    // CHECK:   [[INT_ONE:%[0-9]+]] = apply {{%[0-9]+}}([[LIT_ONE]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+    // CHECK:   [[RVALUE_CAT:%[0-9]+]] = begin_borrow [[RVALUE_CAT_REF]] : $Cat
+
+    // CHECK:   hop_to_executor [[RVALUE_CAT]] : $Cat
+    // CHECK:   [[RVALUE_CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[RVALUE_CAT_REF]] : $Cat
+    // CHECK:   [[RVALUE_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[RVALUE_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[FIRST_CAT_REF:%[0-9]+]] = apply [[RVALUE_CAT_SUBSCRIPT]]([[INT_ONE]], [[RVALUE_CAT_FOR_LOAD]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   end_borrow [[RVALUE_CAT_FOR_LOAD]] : $Cat
+    // CHECK:   end_borrow [[RVALUE_CAT]] : $Cat
+
+    // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   destroy_value [[RVALUE_CAT_REF]] : $Cat
+    // CHECK:   [[LIT_TWO:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 2
+    // CHECK:   [[INT_TWO:%[0-9]+]] = apply {{%[0-9]+}}([[LIT_TWO]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
+    // CHECK:   [[FIRST_CAT:%[0-9]+]] = begin_borrow [[FIRST_CAT_REF]] : $Cat
+
+    // CHECK:   hop_to_executor [[FIRST_CAT]] : $Cat
+    // CHECK:   [[FIRST_CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[FIRST_CAT_REF]] : $Cat
+    // CHECK:   [[FIRST_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[FIRST_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[SECOND_CAT_REF:%[0-9]+]] = apply [[FIRST_CAT_SUBSCRIPT]]([[INT_TWO]], [[FIRST_CAT_FOR_LOAD]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   end_borrow [[FIRST_CAT_FOR_LOAD]] : $Cat
+    // CHECK:   end_borrow [[FIRST_CAT]] : $Cat
+
+    // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   destroy_value [[FIRST_CAT_REF]] : $Cat
+    // CHECK:   return [[SECOND_CAT_REF]] : $Cat
+    // CHECK: } // end sil function '$s4test3DogC27accessRValueNestedSubscriptAA3CatCyYF'
+    func accessRValueNestedSubscript() async -> Cat {
+        return await Cat()[1][2]
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC33accessStoredPropFromRefProjection3boxSbAA6CatBoxC_tYF : $@convention(method) @async (@guaranteed CatBox, @guaranteed Dog) -> Bool {
+    // CHECK:   bb0([[BOX:%[0-9]+]] : @guaranteed $CatBox, [[SELF:%[0-9]+]] : @guaranteed $Dog):
+    // CHECK:     hop_to_executor [[SELF]] : $Dog
+    // CHECK:     [[BOX_GETTER:%[0-9]+]] = class_method [[BOX]] : $CatBox, #CatBox.cat!getter : (CatBox) -> () -> Cat, $@convention(method) (@guaranteed CatBox) -> @owned Cat
+    // CHECK:     [[CAT_REF:%[0-9]+]] = apply [[BOX_GETTER]]([[BOX]]) : $@convention(method) (@guaranteed CatBox) -> @owned Cat
+    // CHECK:     [[CAT:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
+
+    // CHECK:     hop_to_executor [[CAT]] : $Cat
+    // CHECK:     [[CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF:%[0-9]+]] : $Cat
+    // CHECK:     [[GETTER:%[0-9]+]] = class_method [[CAT_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:     [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:     end_borrow [[CAT_FOR_LOAD]] : $Cat
+    // CHECK:     end_borrow [[CAT]] : $Cat
+
+    // CHECK:     hop_to_executor [[SELF]] : $Dog
+    // CHECK:     destroy_value [[CAT_REF]] : $Cat
+    // CHECK:    return [[THE_BOOL]] : $Bool
+    // CHECK: } // end sil function '$s4test3DogC33accessStoredPropFromRefProjection3boxSbAA6CatBoxC_tYF'
+    func accessStoredPropFromRefProjection(box : CatBox) async -> Bool {
+        return await box.cat.storedBool
+    }
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC015accessSweaterOfD03catAA0D0VAA3CatC_tYF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Sweater {
+    // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
+    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    [[SWEATER1:%[0-9]+]] = begin_borrow [[SWEATER1_REF]] : $Sweater
+    // CHECK:    [[SWEATER1_OWNER:%[0-9]+]] = struct_extract [[SWEATER1]] : $Sweater, #Sweater.owner
+    // CHECK:    [[CAT2_REF:%[0-9]+]] = copy_value [[SWEATER1_OWNER]] : $Cat
+    // CHECK:    end_borrow [[SWEATER1]] : $Sweater
+    // CHECK:    destroy_value [[SWEATER1_REF]] : $Sweater
+    // CHECK:    [[CAT2:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
+
+    // CHECK:    hop_to_executor [[CAT2]] : $Cat
+    // CHECK:    [[CAT2_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
+    // CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
+    // CHECK:    end_borrow [[CAT2]] : $Cat
+
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    destroy_value [[CAT2_REF]] : $Cat
+    // CHECK:    return [[SWEATER2_OWNER]] : $Sweater
+    // CHECK: } // end sil function '$s4test3DogC015accessSweaterOfD03catAA0D0VAA3CatC_tYF'
+    func accessSweaterOfSweater(cat : Cat) async -> Sweater {
+        // note that Sweater is not an actor!
+        return await cat.computedSweater.owner.computedSweater
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC13accessCatList3catAA0D0CAG_tYF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Cat {
+    // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
+    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.friend!getter : (Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    [[FRIEND1:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
+    // CHECK:    hop_to_executor [[FRIEND1]] : $Cat
+    // CHECK:    [[FRIEND1_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
+    // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
+    // CHECK:    end_borrow [[FRIEND1]] : $Cat
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    destroy_value [[FRIEND1_REF]] : $Cat
+    // CHECK:    return [[FRIEND2_REF]] : $Cat
+    // CHECK: } // end sil function '$s4test3DogC13accessCatList3catAA0D0CAG_tYF'
+    func accessCatList(cat : Cat) async -> Cat {
+        return await cat.friend.friend
+    }
+
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC21accessOptionalCatList3catAA0E0CSgAG_tYF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Optional<Cat> {
+    // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    [[FRIEND1_STACK:%[0-9]+]] = alloc_stack $Optional<Cat>
+
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
+    // CHECK:    [[MAYBE_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.maybeFriend!getter : (Cat) -> () -> Cat?, $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+    // CHECK:    [[MAYBE_FRIEND:%[0-9]+]] = apply [[MAYBE_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+    // CHECK:    store [[MAYBE_FRIEND]] to [init] [[FRIEND1_STACK]] : $*Optional<Cat>
+
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    [[IS_SOME:%[0-9]+]] = select_enum_addr [[FRIEND1_STACK]] : $*Optional<Cat>
+    // CHECK:    cond_br [[IS_SOME]], bb1, bb3
+
+    // CHECK:  bb1:
+    // CHECK:    [[FRIEND1_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[FRIEND1_STACK]] : $*Optional<Cat>, #Optional.some!enumelt
+    // CHECK:    [[FRIEND1_REF:%[0-9]+]] = load [copy] [[FRIEND1_ADDR]] : $*Cat
+    // CHECK:    destroy_addr [[FRIEND1_STACK]] : $*Optional<Cat>
+    // CHECK:    [[FRIEND1:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
+    // CHECK:    hop_to_executor [[FRIEND1]] : $Cat
+    // CHECK:    [[FRIEND1_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
+    // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
+    // CHECK:    end_borrow [[FRIEND1]] : $Cat
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    destroy_value [[FRIEND1_REF]] : $Cat
+    // CHECK:    [[FRIEND2_OPTIONAL:%[0-9]+]] = enum $Optional<Cat>, #Optional.some!enumelt, [[FRIEND2_REF]] : $Cat
+    // CHECK:    dealloc_stack [[FRIEND1_STACK]] : $*Optional<Cat>
+    // CHECK:    br bb2([[FRIEND2_OPTIONAL]] : $Optional<Cat>)
+
+    // CHECK-NOT:  hop_to_executor
+    // CHECK: } // end sil function '$s4test3DogC21accessOptionalCatList3catAA0E0CSgAG_tYF'
+    func accessOptionalCatList(cat : Cat) async -> Cat? {
+        return await cat.maybeFriend?.friend
+    }
+} // END OF DOG ACTOR
+

--- a/test/attr/actorindependent.swift
+++ b/test/attr/actorindependent.swift
@@ -81,9 +81,8 @@ actor A {
 }
 
 actor FromProperty {
-  // expected-note@+3{{mutable state is only available within the actor instance}}
-  // expected-note@+2{{mutable state is only available within the actor instance}}
-  // expected-note@+1{{mutable state is only available within the actor instance}}
+  // expected-note@+2 1{{mutation of this property is only permitted within the actor}}
+  // expected-note@+1 2{{property declared here}}
   var counter : Int = 0
 
   // expected-error@+2{{actor-isolated property 'counter' can not be referenced from an '@actorIndependent' context}}
@@ -94,7 +93,7 @@ actor FromProperty {
   var ticks : Int {
     // expected-error@+1{{actor-isolated property 'counter' can not be referenced from an '@actorIndependent' context}}
     get { counter }
-    // expected-error@+1{{actor-isolated property 'counter' can not be referenced from an '@actorIndependent' context}}
+    // expected-error@+1{{actor-isolated property 'counter' can not be mutated from an '@actorIndependent' context}}
     set { counter = newValue }
   }
 }

--- a/test/attr/asynchandler.swift
+++ b/test/attr/asynchandler.swift
@@ -64,7 +64,7 @@ class Y: P {
     // expected-note@-2{{add '@asyncHandler' to function 'callback()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
 
     // okay, it's an async context
-    let _ = await globalAsyncFunction() // expected-error{{'async' in a function that does not support concurrency}}
+    let _ = await globalAsyncFunction() // expected-error{{'async' call in a function that does not support concurrency}}
  }
 }
 

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -6,7 +6,7 @@ func test1(asyncfp : () async -> Int, fp : () -> Int) async {
   _ = await asyncfp()
   _ = await asyncfp() + asyncfp()
   _ = await asyncfp() + fp()
-  _ = await fp() + 42  // expected-warning {{no calls to 'async' functions occur within 'await' expression}}
+  _ = await fp() + 42  // expected-warning {{no 'async' operations occur within 'await' expression}}
   _ = asyncfp() // expected-error {{call is 'async' but is not marked with 'await'}}{{7-7=await }}
 }
 
@@ -24,15 +24,15 @@ func test2(
 
 func test3() { // expected-note{{add 'async' to function 'test3()' to make it asynchronous}} {{13-13= async}}
   // expected-note@-1{{add '@asyncHandler' to function 'test3()' to create an implicit asynchronous context}}{{1-1=@asyncHandler }}
-  _ = await getInt() // expected-error{{'async' in a function that does not support concurrency}}
+  _ = await getInt() // expected-error{{'async' call in a function that does not support concurrency}}
 }
 
 func test4()throws { // expected-note{{add 'async' to function 'test4()' to make it asynchronous}} {{13-19=async throws}}
-  _ = await getInt() // expected-error{{'async' in a function that does not support concurrency}}
+  _ = await getInt() // expected-error{{'async' call in a function that does not support concurrency}}
 }
 
 func test5<T>(_ f : () async throws -> T)  rethrows->T { // expected-note{{add 'async' to function 'test5' to make it asynchronous}} {{44-52=async rethrows}}
-  return try await f() // expected-error{{'async' in a function that does not support concurrency}}
+  return try await f() // expected-error{{'async' call in a function that does not support concurrency}}
 }
 
 enum SomeEnum: Int {
@@ -60,13 +60,13 @@ struct HasAsyncBad {
 
 func testAutoclosure() async {
   await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}{{32-32=await }}
-  await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
+  await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' call in an autoclosure that does not support concurrency}}
 
   await acceptAutoclosureAsync(await getInt())
-  await acceptAutoclosureNonAsync(await getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
+  await acceptAutoclosureNonAsync(await getInt()) // expected-error{{'async' call in an autoclosure that does not support concurrency}}
 
   await acceptAutoclosureAsync(getInt()) // expected-error{{call is 'async' in an autoclosure argument that is not marked with 'await'}}{{32-32=await }}
-  await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' in an autoclosure that does not support concurrency}}
+  await acceptAutoclosureNonAsync(getInt()) // expected-error{{'async' call in an autoclosure that does not support concurrency}}
 }
 
 // Test inference of 'async' from the body of a closure.
@@ -194,7 +194,7 @@ func testAsyncLet() async throws {
 // expected-note@+1 4{{add '@asyncHandler' to function 'testAsyncLetOutOfAsync()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
 func testAsyncLetOutOfAsync() {
   async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}
-  // FIXME: expected-error@-1{{'async' in a function that does not support concurrency}}
+  // FIXME: expected-error@-1{{'async' call in a function that does not support concurrency}}
 
   _ = await x  // expected-error{{'async let' in a function that does not support concurrency}}
   _ = x // expected-error{{'async let' in a function that does not support concurrency}}

--- a/test/stmt/async.swift
+++ b/test/stmt/async.swift
@@ -4,7 +4,7 @@
 
 func f() async -> Int { 0 }
 
-_ = await f() // expected-error{{'async' in a function that does not support concurrency}}
+_ = await f() // expected-error{{'async' call in a function that does not support concurrency}}
 
 async let y = await f() // expected-error{{'async let' in a function that does not support concurrency}}
-// expected-error@-1{{'async' in a function that does not support concurrency}}
+// expected-error@-1{{'async' call in a function that does not support concurrency}}


### PR DESCRIPTION
Resolves rdar://74199653

TODOs:
- [x] Typechecker modifications to allow async 'get' access to
  - An actor's
    - [x] properties
    - [x] subscripts
  - A global actor's
    - [x] properties
    - [x] subscripts
- [x] Bonus: improve error messages that say `'async' in a function that does not support concurrency` (rdar://72403401)
- [x] Expand support so that such accesses are valid in global actor and nonisolated contexts.
- [x] adjust / fix diagnostic message for mutations via subscript
- [x] Extra testing of typechecker and its various diagnostics
- [x] Support for lowering such accesses in SILGen
- [x] More testing of SILGen for global actor properties
- [x] ~Make sure we disallow read accesses to subscripts that take an `inout` argument.~ Turns out we don't allow `inout` on subscript parameters in general.
- [x] Test what happens with property wrappers
- [x] Test what happens for `_modify` and `_read` accessors.
- [x] Create an execution test.

Something to fix in a later PR:
- [x] If you accidentally try to access one of these properties (or any implicity-async thing) in a function that is synchronous, you get a very confusing error message that claims that it's not even possible to access it *due to isolation* but that's not true, it's due to it being a sync context. We need to improve those messages.
- [x] Test what happens with keypaths
