### PR TITLE
OSSA: Disable cond_br arguments

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -955,14 +955,17 @@ public:
     // Verify that the `isPhiArgument` property is sound:
     // - Phi arguments come from branches.
     // - Non-phi arguments have a single predecessor.
-    if (arg->isPhiArgument()) {
-      for (SILBasicBlock *predBB : arg->getParent()->getPredecessorBlocks()) {
-        auto *TI = predBB->getTerminator();
-        // FIXME: when critical edges are removed, only allow BranchInst.
-        require(isa <BranchInst>(TI) || isa<CondBranchInst>(TI),
+    assert(arg->isPhiArgument() && "precondition");
+    for (SILBasicBlock *predBB : arg->getParent()->getPredecessorBlocks()) {
+      auto *TI = predBB->getTerminator();
+      if (F.hasOwnership()) {
+        require(isa<BranchInst>(TI), "All phi inputs must be branch operands.");
+      } else {
+        // FIXME: when critical edges are removed and cond_br arguments are
+        // disallowed, only allow BranchInst.
+        require(isa<BranchInst>(TI) || isa<CondBranchInst>(TI),
                 "All phi argument inputs must be from branches.");
       }
-    } else {
     }
     if (arg->isPhiArgument() && prohibitAddressPhis()) {
       // As a property of well-formed SIL, we disallow address-type

--- a/test/SILOptimizer/accessed_storage.sil
+++ b/test/SILOptimizer/accessed_storage.sil
@@ -389,13 +389,13 @@ bb1(%5 : $Builtin.RawPointer):
   %9 = integer_literal $Builtin.Word, 1
   %10 = index_addr %6 : $*AnyObject, %9 : $Builtin.Word
   %11 = address_to_pointer %10 : $*AnyObject to $Builtin.RawPointer
-  cond_br undef, bb2, bb3(%11 : $Builtin.RawPointer)
+  cond_br undef, bb2, bb3
 
 bb2:
   br bb1(%11 : $Builtin.RawPointer)
 
-bb3(%14 : $Builtin.RawPointer):
-  %15 = struct $UnsafeMutablePointer<AnyObject> (%14 : $Builtin.RawPointer)
+bb3:
+  %15 = struct $UnsafeMutablePointer<AnyObject> (%11 : $Builtin.RawPointer)
   return %15 : $UnsafeMutablePointer<AnyObject>
 }
 

--- a/test/SILOptimizer/accessed_storage_ossa.sil
+++ b/test/SILOptimizer/accessed_storage_ossa.sil
@@ -401,14 +401,14 @@ bb1(%5 : $Builtin.RawPointer):
   %9 = integer_literal $Builtin.Word, 1
   %10 = index_addr %6 : $*AnyObject, %9 : $Builtin.Word
   %11 = address_to_pointer %10 : $*AnyObject to $Builtin.RawPointer
-  cond_br undef, bb2, bb3(%11 : $Builtin.RawPointer)
+  cond_br undef, bb2, bb3
 
 bb2:
   br bb1(%11 : $Builtin.RawPointer)
 
-bb3(%14 : $Builtin.RawPointer):
+bb3:
   destroy_value %3 : $AnyObject
-  %15 = struct $UnsafeMutablePointer<AnyObject> (%14 : $Builtin.RawPointer)
+  %15 = struct $UnsafeMutablePointer<AnyObject> (%11 : $Builtin.RawPointer)
   return %15 : $UnsafeMutablePointer<AnyObject>
 }
 

--- a/test/SILOptimizer/accesspath_uses.sil
+++ b/test/SILOptimizer/accesspath_uses.sil
@@ -34,7 +34,7 @@ struct MyStruct {
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %7 to %10 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  %16 = load %15 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 // CHECK: ###For MemOp:   %7 = load %6 : $*AnyObject
@@ -51,7 +51,7 @@ struct MyStruct {
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %7 to %10 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  %16 = load %15 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 // CHECK: ###For MemOp:   store %7 to %6 : $*AnyObject
@@ -68,7 +68,7 @@ struct MyStruct {
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %7 to %10 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  %16 = load %15 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 // CHECK: ###For MemOp:   store %7 to %10 : $*AnyObject
@@ -85,10 +85,10 @@ struct MyStruct {
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %7 to %10 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  %16 = load %15 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
-// CHECK: ###For MemOp:   %17 = load %16 : $*AnyObject
+// CHECK: ###For MemOp:   %16 = load %15 : $*AnyObject
 // CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
 // CHECK: Path: (@Unknown)
 // CHECK: Exact Uses {
@@ -102,7 +102,7 @@ struct MyStruct {
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %7 to %10 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+// CHECK-NEXT:  %16 = load %15 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 sil shared @testIndexLoop : $@convention(thin) (UnsafeMutablePointer<AnyObject>) -> AnyObject {
@@ -120,13 +120,13 @@ bb1(%5 : $Builtin.RawPointer):
   %10 = index_addr %6 : $*AnyObject, %9 : $Builtin.Word
   store %7 to %10 : $*AnyObject
   %12 = address_to_pointer %10 : $*AnyObject to $Builtin.RawPointer
-  cond_br undef, bb2, bb3(%12 : $Builtin.RawPointer)
+  cond_br undef, bb2, bb3
 
 bb2:
   br bb1(%12 : $Builtin.RawPointer)
 
-bb3(%15 : $Builtin.RawPointer):
-  %16 = pointer_to_address %15 : $Builtin.RawPointer to [strict] $*AnyObject
+bb3:
+  %16 = pointer_to_address %12 : $Builtin.RawPointer to [strict] $*AnyObject
   %17 = load %16 : $*AnyObject
   return %17 : $AnyObject
 }

--- a/test/SILOptimizer/accesspath_uses_ossa.sil
+++ b/test/SILOptimizer/accesspath_uses_ossa.sil
@@ -305,7 +305,7 @@ bb0(%0 : $Builtin.RawPointer):
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %8 to [assign] %11 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%13 : $Builtin.RawPointer)
+// CHECK-NEXT:  %17 = load [copy] %16 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 // CHECK: ###For MemOp:   %7 = load [copy] %6 : $*AnyObject
@@ -322,7 +322,7 @@ bb0(%0 : $Builtin.RawPointer):
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %8 to [assign] %11 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%13 : $Builtin.RawPointer)
+// CHECK-NEXT:  %17 = load [copy] %16 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 // CHECK: ###For MemOp:   store %7 to [assign] %6 : $*AnyObject
@@ -339,7 +339,7 @@ bb0(%0 : $Builtin.RawPointer):
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %8 to [assign] %11 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%13 : $Builtin.RawPointer)
+// CHECK-NEXT:  %17 = load [copy] %16 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 // CHECK: ###For MemOp:   store %8 to [assign] %11 : $*AnyObject
@@ -356,10 +356,10 @@ bb0(%0 : $Builtin.RawPointer):
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %8 to [assign] %11 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%13 : $Builtin.RawPointer)
+// CHECK-NEXT:  %17 = load [copy] %16 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
-// CHECK: ###For MemOp:   %18 = load [copy] %17 : $*AnyObject
+// CHECK: ###For MemOp:   %17 = load [copy] %16 : $*AnyObject
 // CHECK: Storage: Unidentified   %1 = struct_extract %0 : $UnsafeMutablePointer<AnyObject>, #UnsafeMutablePointer._rawValue
 // CHECK: Path: (@Unknown)
 // CHECK: Exact Uses {
@@ -373,7 +373,7 @@ bb0(%0 : $Builtin.RawPointer):
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT:  store %8 to [assign] %11 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
-// CHECK-NEXT:  cond_br undef, bb2, bb3(%13 : $Builtin.RawPointer)
+// CHECK-NEXT:  %17 = load [copy] %16 : $*AnyObject
 // CHECK-NEXT:  Path: (@Unknown)
 // CHECK-NEXT: }
 sil shared [ossa] @testIndexLoop : $@convention(thin) (UnsafeMutablePointer<AnyObject>) -> @owned AnyObject {
@@ -392,13 +392,13 @@ bb1(%5 : $Builtin.RawPointer):
   %11 = index_addr %6 : $*AnyObject, %10 : $Builtin.Word
   store %8 to [assign] %11 : $*AnyObject
   %13 = address_to_pointer %11 : $*AnyObject to $Builtin.RawPointer
-  cond_br undef, bb2, bb3(%13 : $Builtin.RawPointer)
+  cond_br undef, bb2, bb3
 
 bb2:
   br bb1(%13 : $Builtin.RawPointer)
 
-bb3(%16 : $Builtin.RawPointer):
-  %17 = pointer_to_address %16 : $Builtin.RawPointer to [strict] $*AnyObject
+bb3:
+  %17 = pointer_to_address %13 : $Builtin.RawPointer to [strict] $*AnyObject
   %18 = load [copy] %17 : $*AnyObject
   destroy_value %3 : $AnyObject
   return %18 : $AnyObject

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -110,15 +110,15 @@ bb4:
   %44 = struct_extract %43 : $Bool, #Bool._value
 // CHECK-NOT: cond_br
 // CHECK: br bb5
-  cond_br %44, bb5, bb6(%28 : $Int32)
+  cond_br %44, bb5, bb6
 
 bb5:
   %46 = integer_literal $Builtin.Int32, 0
   %47 = struct $Int32 (%46 : $Builtin.Int32)
   br bb7(%47 : $Int32)
 
-bb6(%28a : $Int32):
- br bb7(%28a : $Int32)
+bb6:
+ br bb7(%28 : $Int32)
 
 bb7(%49 : $Int32):
   %50 = integer_literal $Builtin.Int32, 10
@@ -126,15 +126,15 @@ bb7(%49 : $Int32):
   %53 = builtin "cmp_eq_Int32"(%50 : $Builtin.Int32, %52 : $Builtin.Int32) : $Builtin.Int1
   %54 = struct $Bool (%53 : $Builtin.Int1)
   %55 = struct_extract %54 : $Bool, #Bool._value
-  cond_br %55, bb8, bb9(%29 : $Int32)
+  cond_br %55, bb8, bb9
 
 bb8:
   %57 = integer_literal $Builtin.Int32, 0
   %58 = struct $Int32 (%57 : $Builtin.Int32)
   br bb10(%58 : $Int32)
 
-bb9(%29a : $Int32):
-  br bb10(%29a : $Int32)
+bb9:
+  br bb10(%29 : $Int32)
 
 // CHECK: bb5([[BBARG:%.*]]):
 bb10(%60 : $Int32):

--- a/test/SILOptimizer/loop_unroll_ossa.sil
+++ b/test/SILOptimizer/loop_unroll_ossa.sil
@@ -299,12 +299,15 @@ bb4(%58 : $Builtin.Int64, %59 : $Builtin.Int64):
   %64 = builtin "smul_with_overflow_Int64"(%59 : $Builtin.Int64, %28 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %65 = tuple_extract %64 : $(Builtin.Int64, Builtin.Int1), 0
   %70 = builtin "cmp_slt_Int64"(%61 : $Builtin.Int64, %28 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %70, bb5, bb6(%61 : $Builtin.Int64)
+  cond_br %70, bb5, bb6
 
 bb5:
   br bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64)
 
-bb6(%72 : $Builtin.Int64):
+bb6:
+  br bb7(%61 : $Builtin.Int64)
+
+bb7(%72 : $Builtin.Int64):
   %401 = tuple ()
   return %401 : $()
 }
@@ -337,12 +340,15 @@ bb4(%58 : $Builtin.Int64, %59 : $Builtin.Int64):
   %64 = builtin "smul_with_overflow_Int64"(%59 : $Builtin.Int64, %28 : $Builtin.Int64, %56 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
   %65 = tuple_extract %64 : $(Builtin.Int64, Builtin.Int1), 0
   %70 = builtin "cmp_slt_Int64"(%61 : $Builtin.Int64, %28 : $Builtin.Int64) : $Builtin.Int1
-  cond_br %70, bb5, bb6(%61 : $Builtin.Int64)
+  cond_br %70, bb5, bb6
 
 bb5:
   br bb4(%61 : $Builtin.Int64, %65 : $Builtin.Int64)
 
-bb6(%72 : $Builtin.Int64):
+bb6:
+  br bb7(%61 : $Builtin.Int64)
+
+bb7(%72 : $Builtin.Int64):
   %401 = tuple ()
   return %401 : $()
 }

--- a/test/SILOptimizer/looprotate_ossa.sil
+++ b/test/SILOptimizer/looprotate_ossa.sil
@@ -178,7 +178,7 @@ bb0(%0 : $Int32):
 bb1(%4 : $Builtin.Int32, %5 : $Builtin.Int32):
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %8 = builtin "cmp_eq_Word"(%5 : $Builtin.Int32, %1 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %8, bb3(%4 : $Builtin.Int32), bb2
+  cond_br %8, bb3, bb2
 
 bb2:
   %10 = integer_literal $Builtin.Int32, 1
@@ -193,8 +193,8 @@ bb2:
   %21 = tuple_extract %20 : $(Builtin.Int32, Builtin.Int1), 0
   br bb1(%21 : $Builtin.Int32, %14 : $Builtin.Int32)
 
-bb3 (%23 : $Builtin.Int32) :
-  %24 = struct $Int32 (%23 : $Builtin.Int32)
+bb3:
+  %24 = struct $Int32 (%4 : $Builtin.Int32)
   return %24 : $Int32
 }
 

--- a/test/SILOptimizer/redundant_load_elim_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_ossa.sil
@@ -1129,13 +1129,13 @@ bb2(%20 : $Builtin.Int32):
   %39 = load [trivial] %12 : $*Builtin.Int32
   %40 = load [trivial] %13 : $*Builtin.Int32
   %41 = builtin "cmp_eq_Int32"(%39 : $Builtin.Int32, %40 : $Builtin.Int32) : $Builtin.Int1
-  cond_br %41, bb2a, bb2b(%39 : $Builtin.Int32)
+  cond_br %41, bb2a, bb2b
 
 bb2a:
   br bb3
 
-bb2b(%39a : $Builtin.Int32):
-  br bb2(%39a : $Builtin.Int32)
+bb2b:
+  br bb2(%39 : $Builtin.Int32)
 
 // bb1 is after bb2 to make sure the first predecessor of bb2 is not bb2 to
 // expose the bug.


### PR DESCRIPTION
In OSSA, there is no reason for the cond_br instruction to take arguments.

In OSSA utilities, we have two types of block arguments: terminator
results and phis. cond_br arguments don't fit into either one of these
categories. Supporting them would be prohibitively complex. In fact, I
have no idea model it.

I have already made the assumption in several places that we don't
support cond_br args. It would be impossible to test all the code that
makes this assumption, so even if we wanted to support cond_br args,
they would always be broken in practice.

Simply mark them illegal in the SILVerifier and make sure no OSSA
passes generate them.