### PR TITLE
Add CHANGELOG entry for #34140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ CHANGELOG
 Swift Next
 ----------
 
+* Whenever a reference to `Self` does not impede the usage of a protocol as a value type, or a protocol member on a value of protocol type, the same is now true for references to `[Self]` and `[Key : Self]`:
+
+  ```swift
+  protocol Copyable {
+    func copy() -> Self
+    func copy(count: Int) -> [Self]
+  }
+
+  func test(c: Copyable) {
+    let copy: Copyable = c.copy() // OK
+    let copies: [Copyable] = c.copy(count: 5) // also OK
+  }
+  ```
+
 * [SE-0296][]:
 
   Asynchronous programming is now natively supported using async/await. Asynchronous functions can be defined using `async`:


### PR DESCRIPTION
Couldn't come up with a decent example for Dictionary, but I guess that's fine. I also chose not to mention the subtle impact on conformances in non-final classes. I think we can document that once we have proper support for covariant `Self` inside classes. Right now the change affects only the contravariant case, which I found problematic to explain in isolation from an end user perspective.