### PR TITLE
Driver: add support for baremetal targets

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -327,6 +327,12 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::WASI:
     addPlatformConditionValue(PlatformConditionKind::OS, "WASI");
     break;
+  case llvm::Triple::UnknownOS:
+    if (Target.getOSName() == "none") {
+      addPlatformConditionValue(PlatformConditionKind::OS, "none");
+      break;
+    }
+    LLVM_FALLTHROUGH;
   default:
     UnsupportedOS = true;
     break;

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -175,8 +175,6 @@ static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {
 
 StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   switch (triple.getOS()) {
-  case llvm::Triple::UnknownOS:
-    llvm_unreachable("unknown OS");
   case llvm::Triple::ZOS:
   case llvm::Triple::Ananas:
   case llvm::Triple::CloudABI:
@@ -234,6 +232,8 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
     return "haiku";
   case llvm::Triple::WASI:
     return "wasi";
+  case llvm::Triple::UnknownOS:
+    return "none";
   }
   llvm_unreachable("unsupported OS");
 }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -368,6 +368,8 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
     return std::make_unique<toolchains::GenericUnix>(*this, target);
   case llvm::Triple::WASI:
     return std::make_unique<toolchains::GenericUnix>(*this, target);
+  case llvm::Triple::UnknownOS:
+    return std::make_unique<toolchains::GenericUnix>(*this, target);
   default:
     Diags.diagnose(SourceLoc(), diag::error_unknown_target,
                    ArgList.getLastArg(options::OPT_target)->getValue());

--- a/test/Driver/baremetal-target.swift
+++ b/test/Driver/baremetal-target.swift
@@ -1,0 +1,4 @@
+// RUN: %swiftc_driver_plain -target aarch64-unknwon-none-none -driver-print-jobs %s 2>&1 | %FileCheck %s
+
+// CHECK: {{.*}}swift{{c|-frontend}}{{(.exe)?"?}} -frontend -c
+// CHECK: {{.*}}clang{{(.exe)?"?}} -fuse-ld=gold

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -80,8 +80,8 @@
 // RUN: %swift_driver -g -### %s 2>&1 | %FileCheck -check-prefix=OPTIONS_BEFORE_FILE %s
 // OPTIONS_BEFORE_FILE: -g
 
-// RUN: not %swift_driver -target abc -### %s 2>&1 | %FileCheck -check-prefix=BAD_TARGET %s
-// BAD_TARGET: error: unknown target 'abc'
+// RUN: not %swiftc_driver_plain -target x86_64-unknown-hurd -### %s 2>&1 | %FileCheck -check-prefix=BAD_TARGET %s
+// BAD_TARGET: error: unknown target 'x86_64-unknown-hurd'
 
 // RUN: %swiftc_driver -incremental %s -### 2>&1 | %FileCheck -check-prefix=INCREMENTAL_WITHOUT_OFM %s
 // INCREMENTAL_WITHOUT_OFM: warning: ignoring -incremental (currently requires an output file map)


### PR DESCRIPTION
This allows building the Swift standard library for targets which may
not have an actual OS running.  This is identified by the OS field in
the target triple being set to `none`.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
