### PR TITLE
[Diagnostics] Add a note to exclusivity diagnostics referencing the TSPL explanations

### DIFF
--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -92,4 +92,9 @@ EDUCATIONAL_NOTES(result_builder_missing_build_either,
 EDUCATIONAL_NOTES(result_builder_missing_build_array,
                   "result-builder-methods.md")
 
+EDUCATIONAL_NOTES(exclusivity_access_required,
+                  "exclusivity.md")
+EDUCATIONAL_NOTES(exclusivity_access_required_unknown_decl,
+                  "exclusivity.md")
+
 #undef EDUCATIONAL_NOTES

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -12,7 +12,7 @@ func simpleInoutDiagnostic() {
   // turned on by default.
   // expected-error@+4{{inout arguments are not allowed to alias each other}}
   // expected-note@+3{{previous aliasing argument}}
-  // expected-error@+2{{overlapping accesses to 'i', but modification requires exclusive access; consider copying to a local variable}}
+  // expected-error@+2{{overlapping accesses to 'i', but modification requires exclusive access; consider copying to a local variable}} {{educational-notes=exclusivity}}
   // expected-note@+1{{conflicting access is here}}
   takesTwoInouts(&i, &i)
 }

--- a/userdocs/diagnostics/exclusivity.md
+++ b/userdocs/diagnostics/exclusivity.md
@@ -1,0 +1,9 @@
+# Exclusive Access to Memory
+
+Swift's **Law of Exclusivity** states that two accesses to the same mutable memory aren't allowed to overlap in time _unless_ both accesses are reads (as opposed to writes) or both accesses are atomic.
+
+In many cases, overlapping accesses aren't a problem because many are instantaneous and, by definition, cannot overlap with each other. In other words, from the perspective of the current thread the access begins and ends without any other code being able to interfere. One example of an instantaneous access is assigning to a stored property. However, some operations, like calling a `mutating` method on a stored property, are non-instantaneous. In this case, the write access to the stored property will last until the method returns. If the body of the method contains another access to the property, an exclusivity violation will occur.
+
+Some exclusivity violations can be flagged at compile time and will be reported as errors. However, others can only be detected at runtime. The Swift runtime will dynamically enforce exclusivity and trap if it encounters a violation.
+
+To see more examples and learn more about ensuring exclusive access to memory, see the [Memory Safety](https://docs.swift.org/swift-book/LanguageGuide/MemorySafety.html) chapter of _The Swift Programming Language_.


### PR DESCRIPTION
This PR adds a short educational note to the static exclusivity diagnostics, since those seem to be confusing to a lot of users on stack overflow, etc. The _TSPL_ chapter on this is a lot better than anything I could write, but as far as I can tell its CC BY 4.0 license is incompatible with the Apache license used by the rest of the project. As a result, I kept the explanation here pretty short to encourage users to follow the link to the web version. I did introduce the difference between instantaneous/non-instantaneous access briefly here because I think it's a pretty important concept to understand for anyone running into this error for the first time.