### PR TITLE
[ownership] Small code improvements around interior pointers

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -707,13 +707,12 @@ bool InteriorPointerOperand::findTransitiveUsesForAddress(
     // and do not need to check transitive uses of.
     if (isa<LoadInst>(user) || isa<CopyAddrInst>(user) ||
         isIncidentalUse(user) || isa<StoreInst>(user) ||
-        isa<StoreBorrowInst>(user) || isa<PartialApplyInst>(user) ||
-        isa<DestroyAddrInst>(user) || isa<AssignInst>(user) ||
-        isa<AddressToPointerInst>(user) || isa<YieldInst>(user) ||
-        isa<LoadUnownedInst>(user) || isa<StoreUnownedInst>(user) ||
-        isa<EndApplyInst>(user) || isa<LoadWeakInst>(user) ||
-        isa<StoreWeakInst>(user) || isa<AssignByWrapperInst>(user) ||
-        isa<BeginUnpairedAccessInst>(user) ||
+        isa<PartialApplyInst>(user) || isa<DestroyAddrInst>(user) ||
+        isa<AssignInst>(user) || isa<AddressToPointerInst>(user) ||
+        isa<YieldInst>(user) || isa<LoadUnownedInst>(user) ||
+        isa<StoreUnownedInst>(user) || isa<EndApplyInst>(user) ||
+        isa<LoadWeakInst>(user) || isa<StoreWeakInst>(user) ||
+        isa<AssignByWrapperInst>(user) || isa<BeginUnpairedAccessInst>(user) ||
         isa<EndUnpairedAccessInst>(user) || isa<WitnessMethodInst>(user) ||
         isa<SwitchEnumAddrInst>(user) || isa<CheckedCastAddrBranchInst>(user) ||
         isa<SelectEnumAddrInst>(user) || isa<InjectEnumAddrInst>(user)) {
@@ -726,7 +725,7 @@ bool InteriorPointerOperand::findTransitiveUsesForAddress(
         isa<OpenExistentialAddrInst>(user) ||
         isa<InitExistentialAddrInst>(user) || isa<InitEnumDataAddrInst>(user) ||
         isa<BeginAccessInst>(user) || isa<TailAddrInst>(user) ||
-        isa<IndexAddrInst>(user) ||
+        isa<IndexAddrInst>(user) || isa<StoreBorrowInst>(user) ||
         isa<UnconditionalCheckedCastAddrInst>(user) ||
         isa<UncheckedAddrCastInst>(user)) {
       for (SILValue r : user->getResults()) {

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -648,16 +648,15 @@ bool BorrowedValue::visitInteriorPointerOperandHelper(
     if (isa<DebugValueInst>(user) || isa<SuperMethodInst>(user) ||
         isa<ClassMethodInst>(user) || isa<CopyValueInst>(user) ||
         isa<EndBorrowInst>(user) || isa<ApplyInst>(user) ||
-        isa<StoreBorrowInst>(user) || isa<StoreInst>(user) ||
-        isa<PartialApplyInst>(user) || isa<UnmanagedRetainValueInst>(user) ||
+        isa<StoreInst>(user) || isa<PartialApplyInst>(user) ||
+        isa<UnmanagedRetainValueInst>(user) ||
         isa<UnmanagedReleaseValueInst>(user) ||
         isa<UnmanagedAutoreleaseValueInst>(user)) {
       continue;
     }
 
     // These are interior pointers that have not had support yet added for them.
-    if (isa<OpenExistentialBoxInst>(user) ||
-        isa<ProjectExistentialBoxInst>(user)) {
+    if (isa<ProjectExistentialBoxInst>(user)) {
       continue;
     }
 

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -255,7 +255,10 @@ bool OwnershipModelEliminatorVisitor::visitStoreBorrowInst(
                               StoreOwnershipQualifier::Unqualified);
   });
 
-  // Then remove the qualified store.
+  // Then remove the qualified store after RAUWing si with its dest. This
+  // ensures that any uses of the interior pointer result of the store_borrow
+  // are rewritten to be on the dest point.
+  si->replaceAllUsesWith(si->getDest());
   eraseInstruction(si);
   return true;
 }

--- a/test/SIL/ownership-verifier/interior_pointer.sil
+++ b/test/SIL/ownership-verifier/interior_pointer.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -ownership-verifier-textual-error-dumper -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -module-name Swift -sil-ownership-verifier-enable-testing -ownership-verifier-textual-error-dumper -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
 // REQUIRES: asserts
 
 sil_stage canonical
@@ -9,6 +9,10 @@ class Klass {}
 
 class KlassUser {
   var field: Klass
+}
+
+protocol Error {
+  var _code: Int { get }
 }
 
 sil @use_builtinnativeobject_inguaranteed : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
@@ -135,4 +139,22 @@ bb0(%0 : @owned $KlassUser, %0a : @guaranteed $Klass):
   destroy_value %0 : $KlassUser
   %3 = load [copy] %result : $*Klass
   return %3 : $Klass
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'open_existential_box_interior_pointer_error'
+// CHECK-NEXT: Found outside of lifetime use?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Error                   // users: %3, %2
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $Error                          // id: %3
+// CHECK-NEXT: Non Consuming User:   %6 = apply %5<@opened("01234567-89AB-CDEF-0123-000000000000") Error>(%2) : $@convention(witness_method: Error) <τ_0_0 where τ_0_0 : Error> (@in_guaranteed τ_0_0) -> Int // type-defs: %2; user: %7
+// CHECK-NEXT: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'open_existential_box_interior_pointer_error'
+sil [ossa] @open_existential_box_interior_pointer_error : $@convention(thin) (@owned Error) -> Int {
+bb0(%0 : @owned $Error):
+  %1 = begin_borrow %0 : $Error
+  %2 = open_existential_box %1 : $Error to $*@opened("01234567-89AB-CDEF-0123-000000000000") Error
+  end_borrow %1 : $Error
+  destroy_value %0 : $Error
+  %m = witness_method $@opened("01234567-89AB-CDEF-0123-000000000000") Error, #Error._code!getter, %2 : $*@opened("01234567-89AB-CDEF-0123-000000000000") Error : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
+  %result = apply %m<@opened("01234567-89AB-CDEF-0123-000000000000") Error>(%2) : $@convention(witness_method: Error) <Self: Error> (@in_guaranteed Self) -> Int
+  return %result : $Int
 }

--- a/test/SIL/ownership-verifier/interior_pointer.sil
+++ b/test/SIL/ownership-verifier/interior_pointer.sil
@@ -1,15 +1,17 @@
 // RUN: %target-sil-opt -sil-ownership-verifier-enable-testing -ownership-verifier-textual-error-dumper -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
 // REQUIRES: asserts
 
-import Swift
-
 sil_stage canonical
+
+import Builtin
 
 class Klass {}
 
 class KlassUser {
   var field: Klass
 }
+
+sil @use_builtinnativeobject_inguaranteed : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
 
 // CHECK-LABEL: Function: 'simple_error_ref_element_addr'
 // CHECK-NEXT: Found outside of lifetime use?!
@@ -43,8 +45,13 @@ bb0(%0 : @owned $KlassUser):
   return %3 : $Klass
 }
 
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
 class OptionalBox<T> {
-  var t: T?
+  var t: FakeOptional<T>
 }
 
 // CHECK-NOT: Function: 'inject_enum_addr_test'
@@ -52,7 +59,7 @@ sil [ossa] @inject_enum_addr_test : $@convention(thin) <T> (@owned OptionalBox<T
 bb0(%0 : @owned $OptionalBox<T>):
   %1 = begin_borrow %0 : $OptionalBox<T>
   %2 = ref_element_addr %1 : $OptionalBox<T>, #OptionalBox.t
-  inject_enum_addr %2 : $*Optional<T>, #Optional.none!enumelt
+  inject_enum_addr %2 : $*FakeOptional<T>, #FakeOptional.none!enumelt
   end_borrow %1 : $OptionalBox<T>
   destroy_value %0 : $OptionalBox<T>
   %3 = tuple ()
@@ -64,7 +71,7 @@ sil [ossa] @init_enum_data_addr_test : $@convention(thin) <T> (@owned OptionalBo
 bb0(%0 : @owned $OptionalBox<T>, %1 : $*T):
   %2 = begin_borrow %0 : $OptionalBox<T>
   %3 = ref_element_addr %2 : $OptionalBox<T>, #OptionalBox.t
-  %4 = init_enum_data_addr %3 : $*Optional<T>, #Optional.some!enumelt
+  %4 = init_enum_data_addr %3 : $*FakeOptional<T>, #FakeOptional.some!enumelt
   copy_addr %1 to [initialization] %4 : $*T
   end_borrow %2 : $OptionalBox<T>
   destroy_value %0 : $OptionalBox<T>
@@ -74,6 +81,10 @@ bb0(%0 : @owned $OptionalBox<T>, %1 : $*T):
 
 class Box<T> {
   var t: T
+}
+
+struct Int {
+  var _value: Builtin.Int64
 }
 
 // CHECK-NOT: Function: 'unconditional_cast_test'
@@ -86,4 +97,24 @@ bb0(%0 : @owned $Box<T>, %1 : $*Int):
   destroy_value %0 : $Box<T>
   %4 = tuple ()
   return %4 : $()
+}
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'store_borrow_result_used_outside_of_borrow_lifetime'
+// CHECK-NEXT: Found outside of lifetime use?!
+// CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Builtin.NativeObject    // users: %4, %3
+// CHECK-NEXT: Consuming User:   end_borrow %1 : $Builtin.NativeObject           // id: %4
+// CHECK-NEXT: Non Consuming User:   %7 = apply %6(%3) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+// CHECK-NEXT: Block: bb0
+sil [ossa] @store_borrow_result_used_outside_of_borrow_lifetime : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  %0a = begin_borrow %0 : $Builtin.NativeObject
+  %1 = alloc_stack $Builtin.NativeObject
+  %result = store_borrow %0a to %1 : $*Builtin.NativeObject
+  end_borrow %0a : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %func = function_ref @use_builtinnativeobject_inguaranteed : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %func(%result) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
 }

--- a/test/SIL/ownership-verifier/interior_pointer.sil
+++ b/test/SIL/ownership-verifier/interior_pointer.sil
@@ -118,3 +118,21 @@ bb0(%0 : @owned $Builtin.NativeObject):
   %9999 = tuple()
   return %9999 : $()
 }
+
+// CHECK-LABEL: Error#: 0. Begin Error in Function: 'recursive_interior_pointer_error'
+// CHECK-NEXT: Found outside of lifetime use?!
+// CHECK-NEXT: Value:   %2 = begin_borrow %0 : $KlassUser               // users: %5, %3
+// CHECK-NEXT: Consuming User:   end_borrow %2 : $KlassUser                      // id: %5
+// CHECK-NEXT: Non Consuming User:   %7 = load [copy] %4 : $*Klass                   // user: %8
+// CHECK-NEXT: Block: bb0
+// CHECK: Error#: 0. End Error in Function: 'recursive_interior_pointer_error'
+sil [ossa] @recursive_interior_pointer_error : $@convention(thin) (@owned KlassUser, @guaranteed Klass) -> @owned Klass {
+bb0(%0 : @owned $KlassUser, %0a : @guaranteed $Klass):
+  %1 = begin_borrow %0 : $KlassUser
+  %2 = ref_tail_addr %1 : $KlassUser, $Klass
+  %result = store_borrow %0a to %2 : $*Klass
+  end_borrow %1 : $KlassUser
+  destroy_value %0 : $KlassUser
+  %3 = load [copy] %result : $*Klass
+  return %3 : $Klass
+}

--- a/test/SILOptimizer/ownership_model_eliminator.sil
+++ b/test/SILOptimizer/ownership_model_eliminator.sil
@@ -5,6 +5,7 @@ sil_stage raw
 import Builtin
 
 sil @use_native_object : $@convention(thin) (@owned Builtin.NativeObject) -> ()
+sil @use_native_object_inguaranteed : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
 sil @use_int32 : $@convention(thin) (Builtin.Int32) -> ()
 
 enum Either<T, R> {
@@ -357,4 +358,24 @@ sil [ossa] @lower_unchecked_value_cast_to_unchecked_bitwise_cast : $@convention(
 bb0(%0a : $PairOfInt):
   %0b = unchecked_value_cast %0a : $PairOfInt to $Builtin.Int64
   return %0b : $Builtin.Int64
+}
+
+// Make sure we RAUW the store_borrow's result with its dest while lowering.
+//
+// CHECK-LABEL: sil @lower_store_borrow_result_correctly : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[STACK:%.*]] = alloc_stack
+// CHECK:   store [[ARG]] to [[STACK]]
+// CHECK:   apply {{%.*}}([[STACK]])
+// CHECK: } // end sil function 'lower_store_borrow_result_correctly'
+sil [ossa] @lower_store_borrow_result_correctly : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  // This is materializing %0 into memory to be passed as an in_guaranteed arg.
+  %1 = alloc_stack $Builtin.NativeObject
+  %result = store_borrow %0 to %1 : $*Builtin.NativeObject
+  %f = function_ref @use_native_object_inguaranteed : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  apply %f(%result) : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> ()
+  dealloc_stack %1 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
 }


### PR DESCRIPTION
I am just doing some incremental work towards formalizing store_borrow into an interior pointer and cleaning up a few other things in the process. More specifically:

1. I eliminated some dead code in BorrowedValue's interior pointer finding code. We were always handling open_existential_box, store_borrow earlier since they are interior pointer operands.
2. I changed OME to while lowering RAUW store_borrow's result with its dst and added a test.
3. I added interior pointer error tests for store_borrow, open_existential_box, and an interior pointer that is stored into by a store_borrow (we want to in that case treat the store_borrow result's uses as uses of the interior pointer).