### PR TITLE
Mark Task.runDetached as @discardableResult.

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -377,6 +377,7 @@ extension Task {
   /// - Returns: handle to the task, allowing to `await handle.get()` on the
   ///     tasks result or `cancel` it. If the operation fails the handle will
   ///     throw the error the operation has thrown when awaited on.
+  @discardableResult
   public static func runDetached<T>(
     priority: Priority = .default,
     startingOn executor: ExecutorRef? = nil,
@@ -431,6 +432,7 @@ extension Task {
   /// - Returns: handle to the task, allowing to `await handle.get()` on the
   ///     tasks result or `cancel` it. If the operation fails the handle will
   ///     throw the error the operation has thrown when awaited on.
+  @discardableResult
   public static func runDetached<T, Failure>(
     priority: Priority = .default,
     startingOn executor: ExecutorRef? = nil,
@@ -458,7 +460,7 @@ extension Task {
 
 public func _runAsyncHandler(operation: @escaping () async -> ()) {
   typealias ConcurrentFunctionType = @concurrent () async -> ()
-  _ = Task.runDetached(
+  Task.runDetached(
     operation: unsafeBitCast(operation, to: ConcurrentFunctionType.self)
   )
 }
@@ -578,7 +580,7 @@ public func runAsyncAndBlock(_ asyncFun: @escaping () async -> ())
 public func _asyncMainDrainQueue() -> Never
 
 public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
-  let _ = Task.runDetached {
+  Task.runDetached {
     do {
       try await asyncFun()
       exit(0)
@@ -680,7 +682,7 @@ internal func _runTaskForBridgedAsyncMethod(_ body: @escaping () async -> Void) 
   // if we're already running on behalf of a task,
   // if the receiver of the method invocation is itself an Actor, or in other
   // situations.
-  _ = Task.runDetached { await body() }
+  Task.runDetached { await body() }
 }
 
 #endif


### PR DESCRIPTION
Often, this API is used for its side effects and nobody cares about the
handle.
