### PR TITLE
Temporarily disable three SILOptimizer tests on 32-bit

### DIFF
--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -2,6 +2,7 @@
 //
 // REQUIRES: VENDOR=apple
 // REQUIRES: swift_stdlib_no_asserts
+// REQUIRES: PTRSIZE=64
 
 // This tests the optimality of the IR generated for the new os log APIs. This
 // is not testing the output of a specific optimization pass (which has separate

--- a/test/SILOptimizer/dead_array_elim.swift
+++ b/test/SILOptimizer/dead_array_elim.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -O -emit-sil -primary-file %s | %FileCheck %s
 
 // REQUIRES: swift_stdlib_no_asserts
+// REQUIRES: PTRSIZE=64
 
 // These tests check whether DeadObjectElimination pass runs as a part of the
 // optimization pipeline and eliminates dead array literals in Swift code.

--- a/test/SILOptimizer/string_optimization.swift
+++ b/test/SILOptimizer/string_optimization.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts
+// REQUIRES: PTRSIZE=64
 
 #if _runtime(_ObjC)
 import Foundation


### PR DESCRIPTION
The proper fix is tracked by rdar://problem/74359824.