### PR TITLE
[Concurrency][Task Locals] Fix missing flag setting on next pointer

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -300,7 +300,7 @@ public:
                 // therefore skip also skip pointing to that parent and point
                 // to whichever parent it was pointing to as well, it may be its
                 // immediate parent, or some super-parent.
-                item->next = reinterpret_cast<uintptr_t>(parentHead->getNext());
+                item->next = reinterpret_cast<uintptr_t>(parentHead->getNext()) |
                                   static_cast<uintptr_t>(NextLinkType::IsParent);
                 break;
               case NextLinkType::IsNext:
@@ -308,7 +308,7 @@ public:
                                 "this should not happen, as it implies the parent must have stored some value.");
                 break;
               case NextLinkType::IsTerminal:
-                item->next = reinterpret_cast<uintptr_t>(parentHead->getNext());
+                item->next = reinterpret_cast<uintptr_t>(parentHead->getNext()) | 
                                   static_cast<uintptr_t>(NextLinkType::IsTerminal);
                 break;
             }


### PR DESCRIPTION
Functionally these actually didn't change much as "is terminal" just means we are at the end of the chain, in which case we stop searching anyway (next is `null`), and `isNext` is the "normal case that is "not isParent" so the logic didn't do anything special for it.

The flags should be set correctly though at all times.

Thanks for spotting this @yln  https://github.com/apple/swift/commit/b811b12246cd6d78790fc85887698f3dc727f17c#r47156808