### PR TITLE
Respect unavailable annotations when computing availability for linkage

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -869,6 +869,10 @@ bool Decl::isAlwaysWeakImported() const {
   if (getAttrs().hasAttribute<WeakLinkedAttr>())
     return true;
 
+  if (getAttrs().isUnavailable(getASTContext()))
+    return true;
+
+
   if (auto *accessor = dyn_cast<AccessorDecl>(this))
     return accessor->getStorage()->isAlwaysWeakImported();
 

--- a/test/IRGen/enum_availability.swift
+++ b/test/IRGen/enum_availability.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-emit-ir %s | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+
+// CHECK: @"$ss7Float16VMn" = extern_weak global %swift.type_descriptor
+
+internal enum Payload {
+  case float(Float)
+
+  @available(iOS 14.0, *)
+  @available(macOS, unavailable)
+  case half(Float16)
+
+  init?() {
+    return nil
+  }
+}

--- a/test/SILGen/objc_init_unavailable.swift
+++ b/test/SILGen/objc_init_unavailable.swift
@@ -6,7 +6,7 @@ public func callUnavailableInit(name: String) -> ClassWithUnavailableInit {
   return ClassWithUnavailableInit(bundleID: name)
 }
 
-// CHECK-LABEL: sil [ossa] @$s21objc_init_unavailable19callUnavailableInit4nameSo09ClassWitheF0CSS_tF : $@convention(thin) (@guaranteed String) -> @owned ClassWithUnavailableInit {
+// CHECK-LABEL: sil {{(\[weak_imported\])?}} [ossa] @$s21objc_init_unavailable19callUnavailableInit4nameSo09ClassWitheF0CSS_tF : $@convention(thin) (@guaranteed String) -> @owned ClassWithUnavailableInit {
 // CHECK: function_ref @$sSo24ClassWithUnavailableInitC8bundleIDABSgSSSg_tcfC : $@convention(method) (@owned Optional<String>, @thick ClassWithUnavailableInit.Type) -> @owned Optional<ClassWithUnavailableInit>
 // CHECK: return
 


### PR DESCRIPTION
Unavailable cases should be weakly linked against.

rdar://72151067
