### PR TITLE
Sema: Misc fixes for 'Self' in final classes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2556,8 +2556,8 @@ ERROR(override_ownership_mismatch,none,
       "cannot override %0 property with %1 property",
       (ReferenceOwnership, ReferenceOwnership))
 ERROR(override_dynamic_self_mismatch,none,
-      "cannot override a Self return type with a non-Self return type",
-      ())
+      "cannot override a Self return type with a non-Self return type in "
+      "non-final class", ())
 ERROR(override_class_declaration_in_extension,none,
       "cannot override a non-dynamic class declaration from an extension",
       ())

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -248,6 +248,9 @@ enum class ConversionRestrictionKind {
   /// Implicit conversion from an Objective-C class type to its
   /// toll-free-bridged CF type.
   ObjCTollFreeBridgeToCF,
+  /// Implicit downcast from a final class type to its \c DynamicSelfType
+  /// (C -> DynamicSelfType<C>).
+  FinalClassToDynamicSelf,
 };
 
 /// Specifies whether a given conversion requires the creation of a temporary

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6515,6 +6515,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       return cs.cacheType(new (ctx)
                               ForeignObjectConversionExpr(result, toType));
     }
+
+    case ConversionRestrictionKind::FinalClassToDynamicSelf:
+      return cs.cacheType(new (ctx)
+                              CovariantReturnConversionExpr(expr, toType));
     }
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6379,6 +6379,7 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
   case ConversionRestrictionKind::HashableToAnyHashable:
   case ConversionRestrictionKind::CFTollFreeBridgeToObjC:
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
+  case ConversionRestrictionKind::FinalClassToDynamicSelf:
     llvm_unreachable("Expected an ephemeral conversion!");
   }
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5286,7 +5286,19 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       }
     }
   }
-  
+
+  // C -> DynamicSelfType<C> for a final class type.
+  if (kind == ConstraintKind::Conversion) {
+    auto *const fromClassDecl = desugar1->getClassOrBoundGenericClass();
+    if (fromClassDecl && fromClassDecl->isFinal()) {
+      // The class type must match the static Self type.
+      auto *const toDynamicSelf = desugar2->getAs<DynamicSelfType>();
+      if (toDynamicSelf && toDynamicSelf->getSelfType()->isEqual(desugar1))
+        conversionsOrFixes.push_back(
+            ConversionRestrictionKind::FinalClassToDynamicSelf);
+    }
+  }
+
   if (kind == ConstraintKind::BindToPointerType) {
     if (desugar2->isEqual(getASTContext().TheEmptyTupleType))
       return getTypeMatchSuccess();
@@ -10056,6 +10068,9 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
                       bridgedObjCClass->getDeclaredInterfaceType(),
                       ConstraintKind::Subtype, subflags, locator);
   }
+  case ConversionRestrictionKind::FinalClassToDynamicSelf:
+    increaseScore(SK_UserConversion); // FIXME: Use separate score kind?
+    return getTypeMatchSuccess();
   }
   
   llvm_unreachable("bad conversion restriction");

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -542,6 +542,8 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[cf-toll-free-bridge-to-objc]";
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
     return "[objc-toll-free-bridge-to-cf]";
+  case ConversionRestrictionKind::FinalClassToDynamicSelf:
+    return "[final-class-to-dynamic-self]";
   }
   llvm_unreachable("bad conversion restriction kind");
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4703,6 +4703,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
   case ConversionRestrictionKind::HashableToAnyHashable:
   case ConversionRestrictionKind::CFTollFreeBridgeToObjC:
   case ConversionRestrictionKind::ObjCTollFreeBridgeToCF:
+  case ConversionRestrictionKind::FinalClassToDynamicSelf:
     // @_nonEphemeral has no effect on these conversions, so treat them as all
     // being non-ephemeral in order to allow their passing to an @_nonEphemeral
     // parameter.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1304,7 +1304,8 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
 
   // In enums and structs, 'Self' is just a shorthand for the nominal type,
   // and can be used anywhere.
-  if (!typeDC->getSelfClassDecl())
+  auto *const classDecl = typeDC->getSelfClassDecl();
+  if (!classDecl)
     return SelfTypeKind::StaticSelf;
 
   // In class methods, 'Self' is the DynamicSelfType and can only appear in
@@ -1312,11 +1313,16 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
   switch (options.getBaseContext()) {
   case TypeResolverContext::FunctionResult:
   case TypeResolverContext::PatternBindingDecl:
+    // Because we have been using DynamicSelf here since before ABI stability
+    // kicked in, we cannot afford to have final classes use StaticSelf today.
     return SelfTypeKind::DynamicSelf;
   case TypeResolverContext::AbstractFunctionDecl:
   case TypeResolverContext::SubscriptDecl:
   case TypeResolverContext::TypeAliasDecl:
   case TypeResolverContext::GenericTypeAliasDecl:
+    if (classDecl->isFinal())
+      return SelfTypeKind::StaticSelf;
+
     // When checking a function or subscript parameter list, we have to go up
     // one level to determine if we're in a local context or not.
     if (dc->getParent()->isLocalContext())
@@ -1324,10 +1330,10 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
 
     return SelfTypeKind::InvalidSelf;
   default:
-    // In local functions inside classes, 'Self' is the DynamicSelfType and can
-    // be used anywhere.
+    // In local contexts inside classes, 'Self' can be used anywhere.
     if (dc->isLocalContext())
-      return SelfTypeKind::DynamicSelf;
+      return classDecl->isFinal() ? SelfTypeKind::StaticSelf
+                                  : SelfTypeKind::DynamicSelf;
 
     return SelfTypeKind::InvalidSelf;
   }

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -347,7 +347,6 @@ class Runce : Runcible {
 // Forming a type with 'Self' in invariant position
 
 struct Generic<T> { init(_: T) {} } // expected-note {{arguments to generic parameter 'T' ('Self' and 'InvariantSelf') are expected to be equal}}
-// expected-note@-1 {{arguments to generic parameter 'T' ('Self' and 'FinalInvariantSelf') are expected to be equal}}
 
 class InvariantSelf {
   func me() -> Self {
@@ -359,13 +358,10 @@ class InvariantSelf {
   }
 }
 
-// FIXME: This should be allowed
-
 final class FinalInvariantSelf {
   func me() -> Self {
     let a = Generic(self)
-    let _: Generic<FinalInvariantSelf> = a
-    // expected-error@-1 {{cannot assign value of type 'Generic<Self>' to type 'Generic<FinalInvariantSelf>'}}
+    let _: Generic<FinalInvariantSelf> = a // okay
 
     return self
   }

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -43,6 +43,18 @@ final class FinalMario : Mario {
     }
 }
 
+do {
+  final class GenericClass<T> {
+    func me() -> Self { self }
+
+    func invalidMe() -> Self {
+      GenericClass<Never>() // expected-error{{cannot convert return expression of type 'GenericClass<Never>' to return type 'Self'}}
+    }
+
+    func inAndOut(arg: GenericClass) -> Self { arg }
+  }
+}
+
 // These references to Self are now possible (SE-0068)
 
 class A<T> {

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -52,6 +52,8 @@ do {
     }
 
     func inAndOut(arg: GenericClass) -> Self { arg }
+
+    func nonCovariantSelf(_: GenericClass<Self>, _: Self) {}
   }
 }
 

--- a/test/type/self.swift
+++ b/test/type/self.swift
@@ -32,7 +32,7 @@ class Mario {
   func getEnemy() -> Mario { return self }
 }
 class SuperMario : Mario {
-  override func getFriend() -> SuperMario { // expected-error{{cannot override a Self return type with a non-Self return type}}
+  override func getFriend() -> SuperMario { // expected-error{{cannot override a Self return type with a non-Self return type in non-final class}}
     return SuperMario()
   }
   override func getEnemy() -> Self { return self }


### PR DESCRIPTION
Resolves SR-12023, SR-11414 and SR-13915.

I also noticed that the following does not work:
```swift
class Class {
  func foo() -> Self { self }
}

final class Sub: Class {
  override func foo() -> Self { super.foo() }
}
```
I think `super.foo()` should return a `Sub`  regardless of whether the subclass is final or not.