### PR TITLE
[CusorInfo] Fix ASAN heap-use-after-free failure when reporting parent contexts.

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_parents.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_parents.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar74150023
-
 /// Something about variable global
 let global = 1
 


### PR DESCRIPTION
Resolves rdar://problem/74289832