### PR TITLE
Sema: Inherited designated initializers should inherit the 'rethrows' attribute

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -557,6 +557,12 @@ configureInheritedDesignatedInitAttributes(ClassDecl *classDecl,
     ctor->getAttrs().add(clonedAttr);
   }
 
+  // Inherit the rethrows attribute.
+  if (superclassCtor->getAttrs().hasAttribute<RethrowsAttr>()) {
+    auto *clonedAttr = new (ctx) RethrowsAttr(/*implicit=*/true);
+    ctor->getAttrs().add(clonedAttr);
+  }
+
   // If the superclass has its own availability, make sure the synthesized
   // constructor is only as available as its superclass's constructor.
   if (superclassCtor->getAttrs().hasAttribute<AvailableAttr>()) {

--- a/test/Sema/rethrows_init.swift
+++ b/test/Sema/rethrows_init.swift
@@ -1,0 +1,61 @@
+// RUN: %target-typecheck-verify-swift
+
+enum MyError : Error {
+  case bad
+}
+
+class Base {
+  init(_ fn: () throws -> ()) rethrows {} // expected-note {{overridden declaration is here}}
+
+  convenience init(rethrows: (), fn: () throws -> ()) rethrows {
+    try self.init(fn)
+  }
+
+  convenience init(throws1: (), fn: () throws -> ()) rethrows {
+    throw MyError.bad // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+
+  convenience init(throws2: (), fn: () throws -> ()) rethrows {
+    try self.init { throw MyError.bad } // FIXME
+  }
+
+  convenience init() {
+    self.init {}
+  }
+}
+
+class DerivedInheritInit : Base {}
+
+_ = DerivedInheritInit {}
+_ = try DerivedInheritInit { throw MyError.bad }
+
+_ = DerivedInheritInit(rethrows: ()) {}
+_ = try DerivedInheritInit(rethrows: ()) { throw MyError.bad }
+
+class DerivedOverrideInitBad : Base {
+  override init(_ fn: () throws -> ()) throws {} // expected-error {{override of 'rethrows' initializer should also be 'rethrows'}}
+}
+
+class DerivedOverrideInitGood : Base {
+  override init(_ fn: () throws -> ()) rethrows {}
+}
+
+_ = DerivedOverrideInitGood {}
+_ = try DerivedOverrideInitGood { throw MyError.bad }
+
+_ = DerivedOverrideInitGood(rethrows: ()) {}
+_ = try DerivedOverrideInitGood(rethrows: ()) { throw MyError.bad }
+
+class DerivedWithSuperInitCall : Base {
+  override init(_ fn: () throws -> ()) rethrows {
+    try super.init(fn)
+  }
+
+  init(throws1: (), _ fn: () throws -> ()) rethrows {
+    throw MyError.bad // expected-error {{a function declared 'rethrows' may only throw if its parameter does}}
+  }
+
+  init(throws2: (), _ fn: () throws -> ()) rethrows {
+    try super.init { throw MyError.bad } // FIXME
+  }
+}


### PR DESCRIPTION
I found this by inspection. We did not mark the override as 'rethrows'
when the base designated initializer was 'rethrows'.

The FIXMEs in the test case are a separate issue, tracked by
https://bugs.swift.org/browse/SR-680.
