### PR TITLE
[AutoDiff] Change derivative vtable thunk linkage to private.

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -701,7 +701,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     AutoDiffConfig silConfig(
         silParameterIndices, resultIndices,
         derivativeFunctionIdentifier->getDerivativeGenericSignature());
-  return mangler.mangleAutoDiffDerivativeFunction(
+    return mangler.mangleAutoDiffDerivativeFunction(
         asAutoDiffOriginalFunction().getAbstractFunctionDecl(),
         derivativeFunctionIdentifier->getKind(),
         silConfig);

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -242,8 +242,7 @@ public:
 
   /// Get or create a derivative function vtable entry thunk for the given
   /// SILDeclRef and derivative function type.
-  SILFunction *
-  getOrCreateDerivativeVTableThunk(
+  SILFunction *getOrCreateDerivativeVTableThunk(
       SILDeclRef derivativeFnRef, CanSILFunctionType derivativeFnTy);
 
   /// Determine whether we need to emit an ivar destroyer for the given class.

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -418,9 +418,9 @@ SILFunction *SILGenModule::getOrCreateDerivativeVTableThunk(
                      derivativeId->getDerivativeGenericSignature()),
       /*isVTableThunk*/ true);
   auto *thunk = builder.getOrCreateFunction(
-      derivativeFnDecl, name, originalFnDeclRef.getLinkage(ForDefinition),
-      constantTy, IsBare, IsTransparent, derivativeFnDeclRef.isSerialized(),
-      IsNotDynamic, ProfileCounter(), IsThunk);
+      derivativeFnDecl, name, SILLinkage::Private, constantTy, IsBare,
+      IsTransparent, derivativeFnDeclRef.isSerialized(), IsNotDynamic,
+      ProfileCounter(), IsThunk);
   if (!thunk->empty())
     return thunk;
 

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -97,7 +97,7 @@ class SubSub: Sub {}
 
 // Check vtable entry thunks.
 
-// CHECK-LABEL: sil hidden [transparent] [thunk] [ossa] @$s6vtable5SuperC6methodyS2f_SftFTJVfSUUpSr : $@convention(method) (Float, Float, @guaranteed Super) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s6vtable5SuperC6methodyS2f_SftFTJVfSUUpSr : $@convention(method) (Float, Float, @guaranteed Super) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK: bb0(%0 : $Float, %1 : $Float, %2 : @guaranteed $Super):
 // CHECK:   %3 = function_ref @$s6vtable5SuperC6methodyS2f_SftF : $@convention(method) (Float, Float, @guaranteed Super) -> Float
 // CHECK:   %4 = differentiable_function [parameters 0] [results 0] %3 : $@convention(method) (Float, Float, @guaranteed Super) -> Float

--- a/test/AutoDiff/TBD/derivative_symbols.swift
+++ b/test/AutoDiff/TBD/derivative_symbols.swift
@@ -97,22 +97,22 @@ public protocol P: Differentiable {
   subscript(_ x: Float) -> Float { get set }
 }
 
-/* FIXME(rdar://73791807): Enable the following tests once we've fixed TBDGen
-   for derivative vtable entry thunks.
 public final class Class: Differentiable {
   var stored: Float
 
   // Test initializer.
-  @differentiable(reverse)
+  // FIXME(rdar://74380324)
+  // @differentiable(reverse)
   public init(_ x: Float) {
     stored = x
   }
 
   // Test delegating initializer.
-  @differentiable(reverse)
-  public convenience init(blah x: Float) {
-    self.init(x)
-  }
+  // FIXME(rdar://74380324)
+  // @differentiable(reverse)
+  // public convenience init(blah x: Float) {
+  //   self.init(x)
+  // }
 
   // Test method.
   public func method(_ x: Float, _ y: Float) -> Float { x }
@@ -149,4 +149,3 @@ public final class Class: Differentiable {
   //   fatalError()
   // }
 }
-*/


### PR DESCRIPTION
Derivative vtable thunks should never be public. They are only called through vtable lookup.

Resolves rdar://73791807.