### PR TITLE
IRGen: fix two bugs which cause crashes with statically initialized function pointers

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -249,6 +249,8 @@ llvm::Constant *irgen::emitConstantValue(IRGenModule &IGM, SILValue operand) {
       fnPtr = IGM.getConstantSignedPointer(fnPtr, authInfo.getKey(), nullptr,
         constantDiscriminator);
     }
+    llvm::Type *ty = IGM.getTypeInfo(FRI->getType()).getStorageType();
+    fnPtr = llvm::ConstantExpr::getBitCast(fnPtr, ty);
     return fnPtr;
   } else {
     llvm_unreachable("Unsupported SILInstruction in static initializer!");

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1326,8 +1326,8 @@ void IRGenerator::addLazyFunction(SILFunction *f) {
     // f is a specialization. Try to emit all specializations of the same
     // original function into the same IGM. This increases the chances that
     // specializations are merged by LLVM's function merging.
-    auto iter =
-      IGMForSpecializations.insert(std::make_pair(orig, CurrentIGM)).first;
+    IRGenModule *IGM = CurrentIGM ? CurrentIGM : getPrimaryIGM();
+    auto iter = IGMForSpecializations.insert(std::make_pair(orig, IGM)).first;
     DefaultIGMForFunction.insert(std::make_pair(f, iter->second));
     return;
   }

--- a/test/SILOptimizer/Inputs/global-functionptr-main.swift
+++ b/test/SILOptimizer/Inputs/global-functionptr-main.swift
@@ -1,0 +1,4 @@
+import Test
+
+testit(0)
+

--- a/test/SILOptimizer/global-c-functionptr.swift
+++ b/test/SILOptimizer/global-c-functionptr.swift
@@ -1,0 +1,32 @@
+// Testcase for an IRGen crash with function pointers in static globals and multi-threaded compilation.
+
+// First test: check if the compilation succeeds and the code is correct.
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -module-name=Test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// Second test (bonus): check if the optimization is done: statically initialize a global with a C-function pointer
+
+// RUN: %target-build-swift -O -module-name=Test %s -emit-sil | %FileCheck %s -check-prefix=CHECK-SIL
+
+// REQUIRES: executable_test
+
+
+internal func cFn(_ i: Int) -> Int {
+  return i + 1
+}
+
+public struct S {
+  // CHECK-SIL-LABEL: sil_global @$s4Test1SV6cFnPtryS2iXCvpZ : $@convention(c) (Int) -> Int = {
+  // CHECK-SIL:         %initval = function_ref @$s4Test3cFnyS2iFTo : $@convention(c) (Int) -> Int
+  static public var cFnPtr: @convention(c) (Int) -> Int = cFn
+}
+
+func testit() {
+  // CHECK-OUTPUT: 28
+  print(S.cFnPtr(27))
+}
+
+testit()

--- a/test/SILOptimizer/global-functionptr.swift
+++ b/test/SILOptimizer/global-functionptr.swift
@@ -1,0 +1,49 @@
+// Testcase for an IRGen crash with function pointers in static globals and multi-threaded compilation.
+
+// First test: check if the compilation succeeds and the code is correct.
+
+// RUN: %empty-directory(%t) 
+// RUN: touch %t/empty.swift
+// RUN: %target-build-swift -O -wmo -parse-as-library -num-threads 2 -emit-module -emit-module-path=%t/Test.swiftmodule -module-name=Test %s %t/empty.swift -c -o %t/test.o
+// RUN: %target-build-swift -O -wmo -module-name=Main -I%t %S/Inputs/global-functionptr-main.swift -c -o %t/main.o
+// RUN: %target-swiftc_driver %t/main.o %t/test.o -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// Second test (bonus): check if the optimization is done: statically initialize the array of function pointers.
+
+// RUN: %target-build-swift -O -wmo -parse-as-library -module-name=Test %s -emit-sil | %FileCheck %s -check-prefix=CHECK-SIL
+
+// REQUIRES: executable_test
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+internal protocol P {
+  init()
+}
+
+private struct FuncPtr {
+  let cl: () -> Void
+
+  init<C: P>(_: C.Type) {
+    self.cl = { _ = C.init() }
+  }
+}
+
+public struct S: P {
+  init() {
+    print("init S")
+  }
+}
+
+// CHECK-SIL-LABEL: sil_global private @$s4Test8funcPtrs{{.*}}_WZTv_ : $_ContiguousArrayStorage<FuncPtr> = {
+// CHECK-SIL: %0 = function_ref @$s4Test7FuncPtr{{.*}}Tg5 : $@convention(thin) () -> ()
+// CHECK-SIL: %initval = object $_ContiguousArrayStorage<FuncPtr> ({{%[0-9]+}} : $_ArrayBody, [tail_elems] {{%[0-9]+}} : $FuncPtr, {{%[0-9]+}} : $FuncPtr)
+private let funcPtrs = [
+  FuncPtr(S.self),
+  FuncPtr(S.self)]
+
+public func testit(_ i: Int) {
+  // CHECK-OUTPUT: init S
+  funcPtrs[i].cl()
+}
+


### PR DESCRIPTION
Those bugs were introduced with https://github.com/apple/swift/pull/35780.

For details see the commit messages.

rdar://74358251
rdar://74358259