### PR TITLE
[Concurrency] Guard use of async calling convention.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,13 @@ if(SWIFT_PROFDATA_FILE AND EXISTS ${SWIFT_PROFDATA_FILE})
   add_definitions("-fprofile-instr-use=${SWIFT_PROFDATA_FILE}")
 endif()
 
+option(USE_SWIFT_ASYNC_LOWERING
+       "Indicates if Swiftc should use async-specific lowering for async
+        functions if it is supported for the target. The runtime also checks
+        this setting before using async-specific attributes. This only applies
+        to the async calling convention and not to the async context attribute."
+	FALSE)
+
 #
 # User-configurable Swift Standard Library specific options.
 #

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -23,6 +23,7 @@
 #include "swift/Basic/Sanitizers.h"
 #include "swift/Basic/OptionSet.h"
 #include "swift/Basic/OptimizationMode.h"
+#include "swift/Config.h"
 #include "clang/Basic/PointerAuthOptions.h"
 // FIXME: This include is just for llvm::SanitizerCoverageOptions. We should
 // split the header upstream so we don't include so much.
@@ -336,6 +337,10 @@ public:
 
   /// Pointer authentication.
   PointerAuthOptions PointerAuth;
+
+  /// Use async-specific lowering for async functions if it is supported for
+  /// the target.
+  bool UseAsyncLowering = USE_SWIFT_ASYNC_LOWERING;
 
   /// The different modes for dumping IRGen type info.
   enum class TypeInfoDumpFilter {

--- a/include/swift/Config.h.in
+++ b/include/swift/Config.h.in
@@ -8,4 +8,6 @@
 
 #cmakedefine HAVE_PROC_PID_RUSAGE 1
 
+#cmakedefine01 USE_SWIFT_ASYNC_LOWERING
+
 #endif // SWIFT_CONFIG_H

--- a/include/swift/Runtime/CMakeConfig.h.in
+++ b/include/swift/Runtime/CMakeConfig.h.in
@@ -7,4 +7,6 @@
 #cmakedefine01 SWIFT_BNI_OS_BUILD
 #cmakedefine01 SWIFT_BNI_XCODE_BUILD
 
+#cmakedefine01 USE_SWIFT_ASYNC_LOWERING
+
 #endif

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -184,7 +184,8 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 
 // SWIFT_CC(swiftasync) is the Swift async calling convention.
 // We assume that it supports mandatory tail call elimination.
-#if __has_attribute(swiftasynccall)
+#if __has_feature(swiftasynccc) && USE_SWIFT_ASYNC_LOWERING && \
+    __has_attribute(swiftasynccall)
 #define SWIFT_CC_swiftasync __attribute__((swiftasynccall))
 #else
 #define SWIFT_CC_swiftasync SWIFT_CC_swift


### PR DESCRIPTION
Certain targets don't support the async calling convention, so we first
add the feature check to avoid breaking the codegen/runtime while doing
gradual rollout for different targets.

LLVM patch introducing feature: https://reviews.llvm.org/D96802