### PR TITLE
[Concurrency] Check actor isolation in TapExprs

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1072,7 +1072,7 @@ namespace {
 
     bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
-    bool shouldWalkIntoTapExpression() override { return false; }
+    bool shouldWalkIntoTapExpression() override { return true; }
 
     bool walkToDeclPre(Decl *decl) override {
       if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -295,6 +295,14 @@ extension GenericStruct where T == String {
   }
 }
 
+@SomeGlobalActor
+var number: Int = 42 // expected-note 2 {{mutable state is only available within the actor instance}}
+
+//expected-note@+1{{add '@SomeGlobalActor' to make global function 'badNumberUser()' part of global actor 'SomeGlobalActor'}}
+func badNumberUser() {
+  //expected-error@+1{{var 'number' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  print("The protected number is: \(number)")
+}
 
 // ----------------------------------------------------------------------
 // Non-actor code isolation restrictions
@@ -336,6 +344,9 @@ func testGlobalRestrictions(actor: MyActor) async {
   acceptConcurrentClosure { [i] in
     _ = i
   }
+
+  //expected-error@+1{{var 'number' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  print("\(number)")
 }
 
 func f() {


### PR DESCRIPTION
The actor isolation checker wasn't checking that tap expressions weren't
incorrectly using actor-isolated state. As a result, we could read actor
isolated state anywhere we wanted to. This was most prominent in string
interpolations.

I think it's okay if the ActorIsolationChecker checks the contents of a `TapExpr`. 
I've only seen them in string interpolations, so if I'm missing test cases, definitely call them out please.

rdar://74397425