### PR TITLE
[stdlib] Make MutableCollection.partition(by:) implementation inlinable

### DIFF
--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -330,8 +330,8 @@ extension MutableCollection where Self: BidirectionalCollection {
       return try _partitionImpl(by: belongsInSecondPartition)
     }
   }
-  
-  @usableFromInline
+
+  @inlinable
   internal mutating func _partitionImpl(
     by belongsInSecondPartition: (Element) throws -> Bool
   ) rethrows -> Index {


### PR DESCRIPTION
The default `partition(by:)` implementation cannot currently be specialized, which makes it ~64-100x slower than it could be for common cases. (E.g., `Array<Int>.partition(by: { $0 >= foo})` is slower than `.sort()` by a factor of 2-32.)

Make the implementation inlinable.
