### PR TITLE
[stdlib] Deprecate MutableCollection._withUnsafeMutableBufferPointerIfSupported

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -656,7 +656,7 @@ self.test("\(testNamePrefix).sorted/DispatchesThroughDirectStorageAccessors/Pred
   // This sort operation is not in-place.
   // The collection is copied into an array before sorting.
   expectEqual(0, actualWUMBPIF + actualWCMSIA)
-  expectEqual(0, actualWUMBPIFNonNil + actualWUMBPIFNonNil)
+  expectEqual(0, actualWUMBPIFNonNil + actualWCMSIAIFNonNil)
 
   expectEqualSequence([ 1, 2, 3, 4, 5 ], extractedResult.map { $0.value })
 }
@@ -980,7 +980,7 @@ self.test("\(testNamePrefix).partition/DispatchesThroughDirectStorageAccessors")
   expectEqual(1, actualWUMBPIF + actualWCMSIA)
   expectEqual(
     withUnsafeMutableBufferPointerIsSupported ? 1 : 0,
-    actualWUMBPIFNonNil + actualWUMBPIFNonNil)
+    actualWUMBPIFNonNil + actualWCMSIAIFNonNil)
 
   if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
     // `partition(by:)` is expected to dispatch to the public API in releases

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -512,7 +512,7 @@ func checkSortedPredicateThrow(
   }
 }
 
-self.test("\(testNamePrefix).sorted/DispatchesThrough_withUnsafeMutableBufferPointerIfSupported/WhereElementIsComparable") {
+self.test("\(testNamePrefix).sorted/DispatchesThroughDirectStorageAccessors/WhereElementIsComparable") {
   let sequence = [ 5, 4, 3, 2, 1 ]
   let elements: [MinimalComparableValue] =
     zip(sequence, 0..<sequence.count).map {
@@ -525,13 +525,16 @@ self.test("\(testNamePrefix).sorted/DispatchesThrough_withUnsafeMutableBufferPoi
   let result = lc.sorted()
   let extractedResult = result.map(extractValueFromComparable)
 
+  let actualWUMBPIF = lc.log._withUnsafeMutableBufferPointerIfSupported[type(of: lc)]
+  let actualWCMSIA =  lc.log.withContiguousMutableStorageIfAvailable[type(of: lc)]
+
+  let actualWUMBPIFNonNil = lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)]
+  let actualWCMSIANonNil =  lc.log.withContiguousMutableStorageIfAvailableNonNilReturns[type(of: lc)]
+
   // This sort operation is not in-place.
   // The collection is copied into an array before sorting.
-  expectEqual(
-    0, lc.log._withUnsafeMutableBufferPointerIfSupported[type(of: lc)])
-  expectEqual(
-    0,
-    lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)])
+  expectEqual(0, actualWUMBPIF + actualWCMSIA)
+  expectEqual(0, actualWUMBPIFNonNil + actualWCMSIANonNil)
 
   expectEqualSequence([ 1, 2, 3, 4, 5 ], extractedResult.map { $0.value })
 }
@@ -631,7 +634,7 @@ self.test("\(testNamePrefix).sorted/ThrowingPredicateWithLargeNumberElements") {
 }
 
 
-self.test("\(testNamePrefix).sorted/DispatchesThrough_withUnsafeMutableBufferPointerIfSupported/Predicate") {
+self.test("\(testNamePrefix).sorted/DispatchesThroughDirectStorageAccessors/Predicate") {
   let sequence = [ 5, 4, 3, 2, 1 ]
   let elements: [OpaqueValue<Int>] =
     zip(sequence, 0..<sequence.count).map {
@@ -644,13 +647,16 @@ self.test("\(testNamePrefix).sorted/DispatchesThrough_withUnsafeMutableBufferPoi
   let result = lc.sorted { extractValue($0).value < extractValue($1).value }
   let extractedResult = result.map(extractValue)
 
+  let actualWUMBPIF = lc.log._withUnsafeMutableBufferPointerIfSupported[type(of: lc)]
+  let actualWCMSIA =  lc.log.withContiguousMutableStorageIfAvailable[type(of: lc)]
+
+  let actualWUMBPIFNonNil = lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)]
+  let actualWUMBPIFNonNil =  lc.log.withContiguousMutableStorageIfAvailableNonNilReturns[type(of: lc)]
+
   // This sort operation is not in-place.
   // The collection is copied into an array before sorting.
-  expectEqual(
-    0, lc.log._withUnsafeMutableBufferPointerIfSupported[type(of: lc)])
-  expectEqual(
-    0,
-    lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)])
+  expectEqual(0, actualWUMBPIF + actualWCMSIA)
+  expectEqual(0, actualWUMBPIFNonNil + actualWUMBPIFNonNil)
 
   expectEqualSequence([ 1, 2, 3, 4, 5 ], extractedResult.map { $0.value })
 }
@@ -949,7 +955,7 @@ self.test("\(testNamePrefix).reverse()") {
 // partition(by:)
 //===----------------------------------------------------------------------===//
 
-self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBufferPointerIfSupported") {
+self.test("\(testNamePrefix).partition/DispatchesThroughDirectStorageAccessors") {
   let sequence = [ 5, 4, 3, 2, 1 ]
   let elements: [OpaqueValue<Int>] =
     zip(sequence, 0..<sequence.count).map {
@@ -965,11 +971,23 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
     return !(extractValue(val).value < extractValue(first!).value)
   })
 
-  expectEqual(
-    1, lc.log._withUnsafeMutableBufferPointerIfSupported[type(of: lc)])
+  let actualWUMBPIF = lc.log._withUnsafeMutableBufferPointerIfSupported[type(of: lc)]
+  let actualWCMSIA =  lc.log.withContiguousMutableStorageIfAvailable[type(of: lc)]
+
+  let actualWUMBPIFNonNil = lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)]
+  let actualWUMBPIFNonNil =  lc.log.withContiguousMutableStorageIfAvailableNonNilReturns[type(of: lc)]
+
+  expectEqual(1, actualWUMBPIF + actualWCMSIA)
   expectEqual(
     withUnsafeMutableBufferPointerIsSupported ? 1 : 0,
-    lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)])
+    actualWUMBPIFNonNil + actualWUMBPIFNonNil)
+
+  if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+    // `partition(by:)` is expected to dispatch to the public API in releases
+    // that contain https://github.com/apple/swift/pull/36003.
+    expectEqual(0, actualWUMBPIF)
+    expectEqual(0, actualWUMBPIFNonNil)
+  }
 
   expectEqual(4, lc.distance(from: lc.startIndex, to: pivot))
   expectEqualsUnordered([1, 2, 3, 4], lc.prefix(upTo: pivot).map { extractValue($0).value })

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -975,7 +975,7 @@ self.test("\(testNamePrefix).partition/DispatchesThroughDirectStorageAccessors")
   let actualWCMSIA =  lc.log.withContiguousMutableStorageIfAvailable[type(of: lc)]
 
   let actualWUMBPIFNonNil = lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)]
-  let actualWUMBPIFNonNil =  lc.log.withContiguousMutableStorageIfAvailableNonNilReturns[type(of: lc)]
+  let actualWCMSIAIFNonNil =  lc.log.withContiguousMutableStorageIfAvailableNonNilReturns[type(of: lc)]
 
   expectEqual(1, actualWUMBPIF + actualWCMSIA)
   expectEqual(
@@ -1297,4 +1297,3 @@ self.test("\(testNamePrefix).sort/ThrowingPredicateWithLargeNumberElements") {
 
   } // addMutableRandomAccessCollectionTests
 }
-

--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift
@@ -651,7 +651,7 @@ self.test("\(testNamePrefix).sorted/DispatchesThroughDirectStorageAccessors/Pred
   let actualWCMSIA =  lc.log.withContiguousMutableStorageIfAvailable[type(of: lc)]
 
   let actualWUMBPIFNonNil = lc.log._withUnsafeMutableBufferPointerIfSupportedNonNilReturns[type(of: lc)]
-  let actualWUMBPIFNonNil =  lc.log.withContiguousMutableStorageIfAvailableNonNilReturns[type(of: lc)]
+  let actualWCMSIAIFNonNil =  lc.log.withContiguousMutableStorageIfAvailableNonNilReturns[type(of: lc)]
 
   // This sort operation is not in-place.
   // The collection is copied into an array before sorting.

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
@@ -404,7 +404,7 @@ extension LoggingMutableCollection: MutableCollection {
     MutableCollectionLog.withContiguousMutableStorageIfAvailable[selfType] += 1
     let result = try base.withContiguousMutableStorageIfAvailable(body)
     if result != nil {
-      Log.withContiguousMutableStorageIfAvailable[selfType] += 1
+      Log.withContiguousMutableStorageIfAvailableNonNilReturns[selfType] += 1
     }
     return result
   }
@@ -618,7 +618,7 @@ extension BufferAccessLoggingMutableCollection: MutableCollection {
     Log.withContiguousMutableStorageIfAvailable[selfType] += 1
     let result = try base.withContiguousMutableStorageIfAvailable(body)
     if result != nil {
-      Log.withContiguousMutableStorageIfAvailable[selfType] += 1
+      Log.withContiguousMutableStorageIfAvailableNonNilReturns[selfType] += 1
     }
     return result
   }

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1356,6 +1356,7 @@ extension Array: RangeReplaceableCollection {
   //===--- algorithms -----------------------------------------------------===//
 
   @inlinable
+  @available(*, deprecated, renamed: "withContiguousMutableStorageIfAvailable")
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1079,6 +1079,7 @@ extension ArraySlice: RangeReplaceableCollection {
   //===--- algorithms -----------------------------------------------------===//
 
   @inlinable
+  @available(*, deprecated, renamed: "withContiguousMutableStorageIfAvailable")
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -318,7 +318,7 @@ extension MutableCollection where Self: BidirectionalCollection {
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
   ) rethrows -> Index {
-    let maybeOffset = try _withUnsafeMutableBufferPointerIfSupported {
+    let maybeOffset = try withContiguousMutableStorageIfAvailable {
       (bufferPointer) -> Int in
       let unsafeBufferPivot = try bufferPointer._partitionImpl(
         by: belongsInSecondPartition)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -980,6 +980,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   //===--- algorithms -----------------------------------------------------===//
 
   @inlinable
+  @available(*, deprecated, renamed: "withContiguousMutableStorageIfAvailable")
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -177,6 +177,7 @@ where SubSequence: MutableCollection
   /// within an algorithm, but when that fails, invoking the
   /// same algorithm on `body`\ 's argument lets you trade safety for
   /// speed.
+  @available(*, deprecated, renamed: "withContiguousMutableStorageIfAvailable")
   mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R?
@@ -199,6 +200,7 @@ where SubSequence: MutableCollection
 // TODO: swift-3-indexing-model - review the following
 extension MutableCollection {
   @inlinable
+  @available(*, deprecated, renamed: "withContiguousMutableStorageIfAvailable")
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -246,7 +246,7 @@ extension MutableCollection where Self: RandomAccessCollection {
   public mutating func sort(
     by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows {
-    let didSortUnsafeBuffer =
+    let didSortUnsafeBuffer: Void? =
       try withContiguousMutableStorageIfAvailable { buffer in
         try buffer._stableSortImpl(by: areInIncreasingOrder)
       }

--- a/stdlib/public/core/Sort.swift
+++ b/stdlib/public/core/Sort.swift
@@ -246,10 +246,10 @@ extension MutableCollection where Self: RandomAccessCollection {
   public mutating func sort(
     by areInIncreasingOrder: (Element, Element) throws -> Bool
   ) rethrows {
-    let didSortUnsafeBuffer: Void? = try _withUnsafeMutableBufferPointerIfSupported {
-      buffer -> Void in
+    let didSortUnsafeBuffer =
+      try withContiguousMutableStorageIfAvailable { buffer in
         try buffer._stableSortImpl(by: areInIncreasingOrder)
-    }
+      }
     if didSortUnsafeBuffer == nil {
       // Fallback since we can't use an unsafe buffer: sort into an outside
       // array, then copy elements back in.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -446,6 +446,7 @@ extension Unsafe${Mutable}BufferPointer {
   }
 
   @inlinable
+  @available(*, deprecated, renamed: "withContiguousMutableStorageIfAvailable")
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {


### PR DESCRIPTION
In Swift 5.0, [SE-0237] introduced the public `MutableCollection.withContiguousMutableStorageIfAvailable` method. It’s time we migrated off the old, underscored variant and deprecated it.

The default `MutableCollection.sort` and `.partition(by:)` implementations are currently calling this hidden method rather than the documented interface, preventing custom Collection implementations from achieving good performance, even if they have contiguous storage.

[SE-0237]: https://github.com/apple/swift-evolution/blob/master/proposals/0237-contiguous-collection.md
