### PR TITLE
SILGen: Handle pseudogeneric completion-handler-based async APIs.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -222,6 +222,9 @@ types where the metadata itself has unknown layout.)
   global ::= from-type to-type generic-signature? 'TR'  // reabstraction thunk
   global ::= impl-function-type type 'Tz'     // objc-to-swift-async completion handler block implementation
   global ::= impl-function-type type 'TZ'     // objc-to-swift-async completion handler block implementation (predefined by runtime)
+  global ::= from-type to-type generic-signature? 'TR'  // reabstraction thunk
+  global ::= impl-function-type type generic-signature? 'Tz'     // objc-to-swift-async completion handler block implementation
+  global ::= impl-function-type type generic-signature? 'TZ'     // objc-to-swift-async completion handler block implementation (predefined by runtime)
   global ::= from-type to-type self-type generic-signature? 'Ty'  // reabstraction thunk with dynamic 'Self' capture
   global ::= from-type to-type generic-signature? 'Tr'  // obsolete mangling for reabstraction thunk
   global ::= entity generic-signature? type type* 'TK' // key path getter

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -171,6 +171,7 @@ public:
   /// predefined in the Swift runtime for the given type signature.
   std::string mangleObjCAsyncCompletionHandlerImpl(CanSILFunctionType BlockType,
                                                    CanType ResultType,
+                                                   CanGenericSignature Sig,
                                                    bool predefined);
   
   /// Mangle the derivative function (JVP/VJP), or optionally its vtable entry

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -398,10 +398,13 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
 std::string ASTMangler::mangleObjCAsyncCompletionHandlerImpl(
                                                    CanSILFunctionType BlockType,
                                                    CanType ResultType,
+                                                   CanGenericSignature Sig,
                                                    bool predefined) {
   beginMangling();
   appendType(BlockType);
   appendType(ResultType);
+  if (Sig)
+    appendGenericSignature(Sig);
   appendOperator(predefined ? "TZ" : "Tz");
   return finalize();
 }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -2301,12 +2301,16 @@ NodePointer Demangler::demangleThunkOrSpecialization() {
     }
     case 'z':
     case 'Z': {
+      NodePointer sig = popNode(Node::Kind::DependentGenericSignature);
       NodePointer resultType = popNode(Node::Kind::Type);
       NodePointer implType = popNode(Node::Kind::Type);
-      return createWithChildren(c == 'z'
+      auto node = createWithChildren(c == 'z'
                                   ? Node::Kind::ObjCAsyncCompletionHandlerImpl
                                   : Node::Kind::PredefinedObjCAsyncCompletionHandlerImpl,
                                 implType, resultType);
+      if (sig)
+        addChild(node, sig);
+      return node;
     }
     case 'V': {
       NodePointer Base = popNode(isEntity);

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -608,7 +608,15 @@ AbstractionPattern::getObjCMethodAsyncCompletionHandlerType(
     auto callbackParamTy = getObjCMethod()->parameters()[paramIndex]
                                           ->getType().getTypePtr();
     
-    return AbstractionPattern(swiftCompletionHandlerType, callbackParamTy);
+    CanGenericSignature patternSig;
+    if (auto origSig = getGenericSignature()) {
+      patternSig = origSig;
+    } else if (auto genFnTy = dyn_cast<GenericFunctionType>(getType())) {
+      patternSig = genFnTy->getGenericSignature()->getCanonicalSignature();
+    }
+    
+    return AbstractionPattern(patternSig,
+                              swiftCompletionHandlerType, callbackParamTy);
   }
   case Kind::Opaque:
   case Kind::OpaqueFunction:

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -181,6 +181,7 @@ public:
   SILFunction *getOrCreateForeignAsyncCompletionHandlerImplFunction(
                                            CanSILFunctionType blockType,
                                            CanType continuationTy,
+                                           CanGenericSignature sig,
                                            ForeignAsyncConvention convention);
 
   /// Determine whether the given class has any instance variables that

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -117,6 +117,11 @@ typedef void ( ^ObjCErrorHandler )( NSError * _Nullable inError );
   - (void) myMethod:(NSInteger)value1 foo:(NSInteger)value2;
 @end
 
+@interface GenericObject<T> : NSObject
+- (void)doSomethingWithCompletionHandler:(void (^)(T _Nullable_result, NSError * _Nullable))completionHandler;
+- (void)doAnotherThingWithCompletionHandler:(void (^)(GenericObject<T> *_Nullable))completionHandler;
+@end
+
 #define MAGIC_NUMBER 42
 
 #pragma clang assume_nonnull end

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -64,6 +64,16 @@ func testSlowServer(slowServer: SlowServer) async throws {
   let _: NSObject = try await slowServer.someObject()
 }
 
+func testGeneric<T: AnyObject>(x: GenericObject<T>) async throws {
+  let _: T? = try await x.doSomething()
+  let _: GenericObject<T>? = await x.doAnotherThing()
+}
+
+func testGeneric2<T: AnyObject, U>(x: GenericObject<T>, y: U) async throws {
+  let _: T? = try await x.doSomething()
+  let _: GenericObject<T>? = await x.doAnotherThing()
+}
+
 // CHECK: sil{{.*}}@[[INT_COMPLETION_BLOCK]]
 // CHECK:   [[CONT_ADDR:%.*]] = project_block_storage %0
 // CHECK:   [[CONT:%.*]] = load [trivial] [[CONT_ADDR]]


### PR DESCRIPTION
Plumb generic signatures through the codegen for invoking foreign APIs as async, so that we
correctly handle APIs declared on ObjC lightweight generic classes. rdar://74361267