### PR TITLE
Fix long-standing soundness hole in rethrows checking

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -624,6 +624,11 @@ SIMPLE_DECL_ATTR(reasync, AtReasync,
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   110)
 
+SIMPLE_DECL_ATTR(_rethrowsUnchecked, RethrowsUnchecked,
+  OnFunc | OnConstructor |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  111)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -766,6 +766,17 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     }
     break;
   }
+  case DAK_RethrowsUnchecked: {
+    if (!Options.IsForSwiftInterface)
+      break;
+
+    // Don't print @_rethrowsUnchecked on non-inlinable functions in Swift
+    // interfaces, since it is logically part of the body and does not
+    // affect now the function declaration is used.
+    auto *AFD = cast<AbstractFunctionDecl>(D);
+    if (AFD->getResilienceExpansion() == ResilienceExpansion::Maximal)
+      return false;
+  }
   default:
     break;
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1825,7 +1825,6 @@ synthesizeMainBody(AbstractFunctionDecl *fn, void *arg) {
 
   auto *callExpr = CallExpr::createImplicit(context, memberRefExpr, {}, {});
   callExpr->setImplicit(true);
-  callExpr->setThrows(mainFunction->hasThrows());
   callExpr->setType(context.TheEmptyTupleType);
 
   Expr *returnedExpr;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -130,6 +130,9 @@ public:
   IGNORED_ATTR(NoDerivative)
   IGNORED_ATTR(SpecializeExtension)
   IGNORED_ATTR(Concurrent)
+  IGNORED_ATTR(AtRethrows)
+  IGNORED_ATTR(AtReasync)
+  IGNORED_ATTR(RethrowsUnchecked)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {
@@ -224,7 +227,6 @@ public:
   void visitNSCopyingAttr(NSCopyingAttr *attr);
   void visitRequiredAttr(RequiredAttr *attr);
   void visitRethrowsAttr(RethrowsAttr *attr);
-  void visitAtRethrowsAttr(AtRethrowsAttr *attr);
 
   void checkApplicationMainAttribute(DeclAttribute *attr,
                                      Identifier Id_ApplicationDelegate,
@@ -279,7 +281,6 @@ public:
   void visitMarkerAttr(MarkerAttr *attr);
 
   void visitReasyncAttr(ReasyncAttr *attr);
-  void visitAtReasyncAttr(AtReasyncAttr *attr);
 };
 } // end anonymous namespace
 
@@ -2063,8 +2064,6 @@ void AttributeChecker::visitRethrowsAttr(RethrowsAttr *attr) {
   diagnose(attr->getLocation(), diag::rethrows_without_throwing_parameter);
   attr->setInvalid();
 }
-
-void AttributeChecker::visitAtRethrowsAttr(AtRethrowsAttr *attr) {}
 
 /// Collect all used generic parameter types from a given type.
 static void collectUsedGenericParameters(
@@ -5473,5 +5472,3 @@ void AttributeChecker::visitMarkerAttr(MarkerAttr *attr) {
 void AttributeChecker::visitReasyncAttr(ReasyncAttr *attr) {
   // FIXME
 }
-
-void AttributeChecker::visitAtReasyncAttr(AtReasyncAttr *attr) {}

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1540,6 +1540,8 @@ namespace  {
 
     UNINTERESTING_ATTR(AtReasync)
 
+    UNINTERESTING_ATTR(RethrowsUnchecked)
+
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1023,9 +1023,8 @@ private:
     }
 
     // The body result cannot be 'none' unless it's an autoclosure.
-    if (!allowNone) {
+    if (!allowNone && result == ThrowingKind::None)
       result = ThrowingKind::RethrowingOnly;
-    }
 
     // Remember the result.
     Cache[key] = result;

--- a/stdlib/public/Darwin/Foundation/IndexSet.swift
+++ b/stdlib/public/Darwin/Foundation/IndexSet.swift
@@ -587,6 +587,7 @@ public struct IndexSet : ReferenceConvertible, Equatable, BidirectionalCollectio
     ///
     /// - parameter range: A range of integers. For each integer in the range that intersects the integers in the IndexSet, then the `includeInteger` predicate will be invoked.
     /// - parameter includeInteger: The predicate which decides if an integer will be included in the result or not.
+    @_rethrowsUnchecked
     public func filteredIndexSet(in range : Range<Element>, includeInteger: (Element) throws -> Bool) rethrows -> IndexSet {
         let r : NSRange = _toNSRange(range)
         return try _handle.map {

--- a/test/ModuleInterface/rethrows.swift
+++ b/test/ModuleInterface/rethrows.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -module-name MyModule | %FileCheck %s
+
+// CHECK-LABEL: {{^}}public func rethrowsFunction(_: () throws -> ()) rethrows
+public func rethrowsFunction(_: () throws -> ()) rethrows {}
+
+// CHECK-LABEL: {{^}}public func uncheckedRethrowsFunction(_: () throws -> ()) rethrows
+@_rethrowsUnchecked
+public func uncheckedRethrowsFunction(_: () throws -> ()) rethrows {}
+
+// CHECK-LABEL: {{^}}@inlinable @_rethrowsUnchecked public func inlinableUncheckedRethrowsFunction(_: () throws -> ()) rethrows
+@inlinable @_rethrowsUnchecked
+public func inlinableUncheckedRethrowsFunction(_: () throws -> ()) rethrows {}

--- a/test/SILOptimizer/di_property_wrappers_errors.swift
+++ b/test/SILOptimizer/di_property_wrappers_errors.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
-// RUN: %target-swift-frontend -emit-sil -verify %s
 
 @propertyWrapper
 final class ClassWrapper<T> {

--- a/test/Sema/rethrows_init.swift
+++ b/test/Sema/rethrows_init.swift
@@ -16,7 +16,9 @@ class Base {
   }
 
   convenience init(throws2: (), fn: () throws -> ()) rethrows {
-    try self.init { throw MyError.bad } // FIXME
+    try self.init { throw MyError.bad }
+    // expected-error@-1 {{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
+    // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
   }
 
   convenience init() {
@@ -56,6 +58,8 @@ class DerivedWithSuperInitCall : Base {
   }
 
   init(throws2: (), _ fn: () throws -> ()) rethrows {
-    try super.init { throw MyError.bad } // FIXME
+    try super.init { throw MyError.bad }
+    // expected-error@-1 {{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
+    // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
   }
 }

--- a/test/attr/attr_rethrows_unchecked.swift
+++ b/test/attr/attr_rethrows_unchecked.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+func alwaysThrows() throws {}
+
+func unsafeRethrowsBad(_ fn: () throws -> ()) rethrows {
+  try alwaysThrows()
+  // expected-error@-1 {{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
+}
+
+@_rethrowsUnchecked
+func unsafeRethrowsGood(_ fn: () throws -> ()) rethrows {
+  try alwaysThrows()
+}

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -612,3 +612,17 @@ func rdar_47550715() {
   func foo(_: A<F>? = nil) {} // Ok
   func bar(_: A<F>? = .none) {} // Ok
 }
+
+// https://bugs.swift.org/browse/SR-680 - rethrows function called with
+// unconditionally throws function argument
+func alwaysThrows() throws {}
+
+func rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
+  try fn()
+}
+
+func rethrowsUnsound(_ fn: () throws -> ()) rethrows {
+  try rethrowsViaClosure { try alwaysThrows() }
+  // expected-error@-1 {{call can throw, but the error is not handled; a function declared 'rethrows' may only throw if its parameter does}}
+  // expected-note@-2 {{call is to 'rethrows' function, but argument function can throw}}
+}


### PR DESCRIPTION
A rethrows function would still be considered rethrows if one of
its argument functions unconditionally throws. This meant that we
would accept the following, even though it was invalid:

```
enum MyError : Error {
  case bad
}
func rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
  try fn()
}
func invalidRethrows(_ fn: () throws -> ()) rethrows {
  try rethrowsViaClosure { throw MyError.bad }
}

invalidRethrows()
```

The problem was simple. When visiting a function argument in
rethrows analysis, we would always just drop the result of
the classification walk on the floor, which meant that we
returned `ThrowingKind::RethrowingOnly` instead of possibly
returning `ThrowingKind::Throws`.

Since the Dispatch overlay was relying on this hole in the
implementation of `DispatchQueue.sync`, I also added a
`@_rethrowsUnchecked` attribute to bypass rethrows checking
entirely for rare cases like this.

Fixes https://bugs.swift.org/browse/SR-680 / rdar://problem/27868617.