### PR TITLE
[CSBindings] A couple of minor refactorings

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -231,7 +231,8 @@ struct PotentialBindings {
   /// bindings (contained in the binding type e.g. `Foo<$T0>`), or
   /// reachable through subtype/conversion  relationship e.g.
   /// `$T0 subtype of $T1` or `$T0 arg conversion $T1`.
-  llvm::SmallPtrSet<TypeVariableType *, 2> AdjacentVars;
+  llvm::SmallDenseSet<std::pair<TypeVariableType *, Constraint *>, 2>
+      AdjacentVars;
 
   ASTNode AssociatedCodeCompletionToken = ASTNode();
 

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -185,11 +185,33 @@ struct LiteralRequirement {
     CoveredBy = coveredBy;
   }
 
-  bool isCoveredBy(Type type, DeclContext *useDC) const;
+  /// Determines whether this literal requirement is "covered"
+  /// by the given binding - type of the binding could either be
+  /// equal (in canonical sense) to the protocol's default type,
+  /// or conform to a protocol.
+  ///
+  /// \param binding The binding to check for coverage.
+  ///
+  /// \param canBeNil The flag that determines whether given type
+  /// variable requires all of its bindings to be optional.
+  ///
+  /// \param useDC The declaration context in which this literal
+  /// requirement is used.
+  ///
+  /// \returns a pair of bool and a type:
+  ///    - bool, true if binding covers given literal protocol;
+  ///    - type, non-null if binding type has to be adjusted
+  ///      to cover given literal protocol;
+  std::pair<bool, Type> isCoveredBy(const PotentialBinding &binding,
+                                    bool canBeNil,
+                                    DeclContext *useDC) const;
 
   /// Determines whether literal protocol associated with this
   /// meta-information is viable for inclusion as a defaultable binding.
   bool viableAsBinding() const { return !isCovered() && hasDefaultType(); }
+
+private:
+  bool isCoveredBy(Type type, DeclContext *useDC) const;
 };
 
 struct PotentialBindings {
@@ -391,26 +413,6 @@ struct PotentialBindings {
   void addDefault(Constraint *constraint);
 
   void addLiteral(Constraint *constraint);
-
-  /// Determines whether the given literal protocol is "covered"
-  /// by the given binding - type of the binding could either be
-  /// equal (in canonical sense) to the protocol's default type,
-  /// or conform to a protocol.
-  ///
-  /// \param literal The literal protocol requirement to check.
-  ///
-  /// \param binding The binding to check for coverage.
-  ///
-  /// \param canBeNil The flag that determines whether given type
-  /// variable requires all of its bindings to be optional.
-  ///
-  /// \returns a pair of bool and a type:
-  ///    - bool, true if binding covers given literal protocol;
-  ///    - type, non-null if binding type has to be adjusted
-  ///      to cover given literal protocol;
-  std::pair<bool, Type> isLiteralCoveredBy(const LiteralRequirement &literal,
-                                           const PotentialBinding &binding,
-                                           bool canBeNil) const;
 
   /// Add a potential binding to the list of bindings,
   /// coalescing supertype bounds when we are able to compute the meet.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -119,8 +119,8 @@ bool PotentialBindings::involvesTypeVariables() const {
   // on each step of the solver, but once bindings are computed
   // incrementally it becomes more important to double-check that
   // any adjacent type variables found previously are still unresolved.
-  return llvm::any_of(AdjacentVars, [](TypeVariableType *typeVar) {
-    return !typeVar->getImpl().getFixedType(/*record=*/nullptr);
+  return llvm::any_of(AdjacentVars, [](const auto &adjacent) {
+    return !adjacent.first->getImpl().getFixedType(/*record=*/nullptr);
   });
 }
 
@@ -983,7 +983,8 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
     findInferableTypeVars(second, typeVars);
 
     if (typeVars.erase(TypeVar)) {
-      AdjacentVars.insert(typeVars.begin(), typeVars.end());
+      for (auto *typeVar : typeVars)
+        AdjacentVars.insert({typeVar, constraint});
     }
 
     return None;
@@ -1016,9 +1017,21 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
   if (type->getWithoutSpecifierType()
           ->lookThroughAllOptionalTypes()
           ->is<DependentMemberType>()) {
-    type->getTypeVariables(AdjacentVars);
+    llvm::SmallPtrSet<TypeVariableType *, 4> referencedVars;
+    type->getTypeVariables(referencedVars);
 
-    bool containsSelf = AdjacentVars.erase(TypeVar);
+    bool containsSelf = false;
+    for (auto *var : referencedVars) {
+      // Add all type variables encountered in the type except
+      // to the current type variable.
+      if (var != TypeVar) {
+        AdjacentVars.insert({var, constraint});
+        continue;
+      }
+
+      containsSelf = true;
+    }
+
     // If inferred type doesn't contain the current type variable,
     // let's mark bindings as delayed until dependent member type
     // is resolved.
@@ -1043,15 +1056,20 @@ PotentialBindings::inferFromRelational(Constraint *constraint) {
   // Check whether we can perform this binding.
   if (auto boundType = checkTypeOfBinding(TypeVar, type)) {
     type = *boundType;
-    if (type->hasTypeVariable())
-      type->getTypeVariables(AdjacentVars);
+    if (type->hasTypeVariable()) {
+      llvm::SmallPtrSet<TypeVariableType *, 4> referencedVars;
+      type->getTypeVariables(referencedVars);
+      for (auto *var : referencedVars) {
+        AdjacentVars.insert({var, constraint});
+      }
+    }
   } else {
     auto *bindingTypeVar = type->getRValueType()->getAs<TypeVariableType>();
 
     if (!bindingTypeVar)
       return None;
 
-    AdjacentVars.insert(bindingTypeVar);
+    AdjacentVars.insert({bindingTypeVar, constraint});
 
     // If current type variable is associated with a code completion token
     // it's possible that it doesn't have enough contextual information

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -594,9 +594,9 @@ bool LiteralRequirement::isCoveredBy(Type type, DeclContext *useDC) const {
 }
 
 std::pair<bool, Type>
-PotentialBindings::isLiteralCoveredBy(const LiteralRequirement &literal,
-                                      const PotentialBinding &binding,
-                                      bool canBeNil) const {
+LiteralRequirement::isCoveredBy(const PotentialBinding &binding,
+                                bool canBeNil,
+                                DeclContext *useDC) const {
   auto type = binding.BindingType;
   switch (binding.Kind) {
   case AllowedBindingKind::Exact:
@@ -616,7 +616,7 @@ PotentialBindings::isLiteralCoveredBy(const LiteralRequirement &literal,
     if (type->isTypeVariableOrMember() || type->isHole())
       return std::make_pair(false, Type());
 
-    if (literal.isCoveredBy(type, CS.DC)) {
+    if (isCoveredBy(type, useDC)) {
       return std::make_pair(true, requiresUnwrap ? type : binding.BindingType);
     }
 
@@ -628,7 +628,7 @@ PotentialBindings::isLiteralCoveredBy(const LiteralRequirement &literal,
     // If this literal protocol is not a direct requirement it
     // would not be possible to change optionality while inferring
     // bindings for a supertype, so this hack doesn't apply.
-    if (!literal.isDirectRequirement())
+    if (!isDirectRequirement())
       return std::make_pair(false, Type());
 
     // If we're allowed to bind to subtypes, look through optionals.
@@ -726,7 +726,7 @@ void PotentialBindings::addPotentialBinding(PotentialBinding binding,
       Type adjustedTy;
 
       std::tie(isCovered, adjustedTy) =
-          isLiteralCoveredBy(info, binding, allowsNil);
+          info.isCoveredBy(binding, allowsNil, CS.DC);
 
       if (!isCovered)
         continue;
@@ -800,7 +800,7 @@ void PotentialBindings::addLiteral(Constraint *constraint) {
       Type adjustedTy;
 
       std::tie(isCovered, adjustedTy) =
-        isLiteralCoveredBy(literal, *binding, allowsNil);
+          literal.isCoveredBy(*binding, allowsNil, CS.DC);
 
       // No luck here, let's try next literal requirement.
       if (!isCovered)


### PR DESCRIPTION
- Adjacent variables should track what constraint they have originated from so it easy to retract them later.
- `isLiteralCoveredBy` belongs on `LiteralRequirement` instead of `PotentialBindings`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
