### PR TITLE
[android][tests] Add config.target_swift_api_extract for Android.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1413,6 +1413,10 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         config.swift_symbolgraph_extract,
         '-target', config.variant_triple,
         mcp_opt])
+    config.target_swift_api_extract = ' '.join([
+        config.swift_api_extract,
+        '-target', config.variant_triple,
+        '-sdk', shell_quote(config.variant_sdk)])
     config.target_swift_ide_test = ' '.join([
         config.swift_ide_test,
         '-target', config.variant_triple,


### PR DESCRIPTION
The configuration for Android of target_swift_api_extract was missing
and the CI machines could not start testing anything. These changes add
the missing line to the testing configuration.

Started happening in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/7704/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/9279/ with the introduction of #35690.