### PR TITLE
Add support for @Concurrent attribute on closures.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -283,6 +283,10 @@ ERROR(incorrect_explicit_closure_result,none,
       "declared closure result %0 is incompatible with contextual type %1",
       (Type, Type))
 
+ERROR(unsupported_closure_attr,none,
+      "%select{attribute |}0 '%1' is not supported on a closure",
+      (bool, StringRef))
+
 NOTE(suggest_expected_match,none,
      "%select{expected an argument list|produces result}0 of type '%1'",
      (bool, StringRef))

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_EXPR_H
 #define SWIFT_AST_EXPR_H
 
+#include "swift/AST/Attr.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DeclContext.h"
@@ -3786,6 +3787,9 @@ public:
   };
 
 private:
+  /// The attributes attached to the closure.
+  DeclAttributes Attributes;
+
   /// The range of the brackets of the capture list, if present.
   SourceRange BracketRange;
     
@@ -3818,13 +3822,14 @@ private:
   /// was originally just a single expression.
   llvm::PointerIntPair<BraceStmt *, 1, bool> Body;
 public:
-  ClosureExpr(SourceRange bracketRange, VarDecl *capturedSelfDecl,
+  ClosureExpr(const DeclAttributes &attributes,
+              SourceRange bracketRange, VarDecl *capturedSelfDecl,
               ParameterList *params, SourceLoc asyncLoc, SourceLoc throwsLoc,
               SourceLoc arrowLoc, SourceLoc inLoc, TypeExpr *explicitResultType,
               unsigned discriminator, DeclContext *parent)
     : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
                           discriminator, parent),
-      BracketRange(bracketRange),
+      Attributes(attributes), BracketRange(bracketRange),
       CapturedSelfDecl(capturedSelfDecl),
       AsyncLoc(asyncLoc), ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc),
       InLoc(inLoc),
@@ -3844,6 +3849,9 @@ public:
     Body.setPointer(S);
     Body.setInt(isSingleExpression);
   }
+
+  DeclAttributes &getAttrs() { return Attributes; }
+  const DeclAttributes &getAttrs() const { return Attributes; }
 
   /// Determine whether the parameters of this closure are actually
   /// anonymous closure variables.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -688,6 +688,9 @@ public:
   /// Skip over SIL decls until we encounter the start of a Swift decl or eof.
   void skipSILUntilSwiftDecl();
 
+  /// Skip over any attribute.
+  void skipAnyAttribute();
+
   /// If the parser is generating only a syntax tree, try loading the current
   /// node from a previously generated syntax tree.
   /// Returns \c true if the node has been loaded and inserted into the current
@@ -1575,6 +1578,7 @@ public:
   /// \returns ParserStatus error if an error occurred. Success if no signature
   /// is present or succssfully parsed.
   ParserStatus parseClosureSignatureIfPresent(
+          DeclAttributes &attributes,
           SourceRange &bracketRange,
           SmallVectorImpl<CaptureListEntry> &captureList,
           VarDecl *&capturedSelfParamDecl,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5728,6 +5728,15 @@ void Parser::skipSILUntilSwiftDecl() {
   }
 }
 
+void Parser::skipAnyAttribute() {
+  consumeToken(tok::at_sign);
+  if (!consumeIf(tok::identifier))
+    return;
+
+  if (consumeIf(tok::l_paren))
+    skipUntil(tok::r_paren);
+}
+
 /// Returns a descriptive name for the given accessor/addressor kind.
 static StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind,
                                               bool article) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7710,8 +7710,12 @@ namespace {
           });
 
       switch (result) {
-      case SolutionApplicationToFunctionResult::Success:
+      case SolutionApplicationToFunctionResult::Success: {
+        if (auto closure = dyn_cast_or_null<ClosureExpr>(
+                fn.getAbstractClosureExpr()))
+          TypeChecker::checkClosureAttributes(closure);
         return false;
+      }
 
       case SolutionApplicationToFunctionResult::Failure:
         return true;

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -226,7 +226,8 @@ private:
     // Create the closure.
     auto *Params = ParameterList::createEmpty(Ctx);
     auto *Closure = new (Ctx)
-        ClosureExpr(SourceRange(), nullptr, Params, SourceLoc(), SourceLoc(),
+        ClosureExpr(DeclAttributes(), SourceRange(), nullptr, Params,
+                    SourceLoc(), SourceLoc(),
                     SourceLoc(), SourceLoc(), nullptr,
                     DF.getNextDiscriminator(), getCurrentDeclContext());
     Closure->setImplicit(true);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5482,10 +5482,9 @@ namespace {
 class ClosureAttributeChecker
     : public AttributeVisitor<ClosureAttributeChecker> {
   ASTContext &ctx;
-  ClosureExpr *closure;
 public:
   ClosureAttributeChecker(ClosureExpr *closure)
-    : ctx(closure->getASTContext()), closure(closure) { }
+    : ctx(closure->getASTContext()) { }
 
   void visitDeclAttribute(DeclAttribute *attr) {
     ctx.Diags.diagnose(
@@ -5493,6 +5492,10 @@ public:
         attr->isDeclModifier(), attr->getAttrName())
       .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
+  }
+
+  void visitConcurrentAttr(ConcurrentAttr *attr) {
+    // Nothing else to check.
   }
 };
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5476,3 +5476,31 @@ void AttributeChecker::visitReasyncAttr(ReasyncAttr *attr) {
 }
 
 void AttributeChecker::visitAtReasyncAttr(AtReasyncAttr *attr) {}
+
+namespace {
+
+class ClosureAttributeChecker
+    : public AttributeVisitor<ClosureAttributeChecker> {
+  ASTContext &ctx;
+  ClosureExpr *closure;
+public:
+  ClosureAttributeChecker(ClosureExpr *closure)
+    : ctx(closure->getASTContext()), closure(closure) { }
+
+  void visitDeclAttribute(DeclAttribute *attr) {
+    ctx.Diags.diagnose(
+        attr->getLocation(), diag::unsupported_closure_attr,
+        attr->isDeclModifier(), attr->getAttrName())
+      .fixItRemove(attr->getRangeWithAt());
+    attr->setInvalid();
+  }
+};
+
+}
+
+void TypeChecker::checkClosureAttributes(ClosureExpr *closure) {
+  ClosureAttributeChecker checker(closure);
+  for (auto attr : closure->getAttrs()) {
+    checker.visit(attr);
+  }
+}

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2077,6 +2077,7 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
 }
 
 bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
+  TypeChecker::checkClosureAttributes(closure);
   TypeChecker::checkParameterList(closure->getParameters(), closure);
 
   BraceStmt *body = closure->getBody();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -451,6 +451,7 @@ void typeCheckDecl(Decl *D);
 
 void addImplicitDynamicAttribute(Decl *D);
 void checkDeclAttributes(Decl *D);
+void checkClosureAttributes(ClosureExpr *closure);
 void checkParameterList(ParameterList *params, DeclContext *owner);
 
 void diagnoseDuplicateBoundVars(Pattern *pattern);

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -118,3 +118,10 @@ func testCaseNonTrivialValue() {
 
   j = 17
 }
+
+func testExplicitConcurrentClosure() {
+  let fn = { @concurrent in
+    17
+  }
+  let _: String = fn // expected-error{{cannot convert value of type '@concurrent () -> Int' to specified type 'String'}}
+}

--- a/test/attr/closures.swift
+++ b/test/attr/closures.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+func testNonacceptedClosures() {
+  let fn = { @usableFromInline in // expected-error{{'usableFromInline' is not supported on a closure}}
+    "hello"
+  }
+
+  let fn2: (Int) -> Int = { @usableFromInline x in  // expected-error{{'usableFromInline' is not supported on a closure}}
+    print("hello")
+    return x
+  }
+
+  _ = fn
+  _ = fn2
+}


### PR DESCRIPTION
This allows one to specify `@concurrent` on closures, e.g.,

```swift
let fn = { @concurrent in ... }
```