### PR TITLE
[Sema][CodeCompletion] Allow empty case statement bodies in the result builder transform...

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -754,8 +754,13 @@ protected:
     // statements by excluding invalid cases.
     if (auto *BS = dyn_cast<BraceStmt>(body)) {
       if (BS->getNumElements() == 0) {
-        hadError = true;
-        return nullptr;
+        // HACK: still allow empty bodies if typechecking for code
+        // completion. Code completion ignores diagnostics
+        // and won't get any types if we fail.
+        if (!ctx.SourceMgr.hasCodeCompletionBuffer()) {
+          hadError = true;
+          return nullptr;
+        }
       }
     }
 

--- a/test/IDE/complete_invalid_result_builder.swift
+++ b/test/IDE/complete_invalid_result_builder.swift
@@ -1,0 +1,60 @@
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+enum Either<T,U> { case first(T), second(U) }
+indirect enum ResultBuilderTerm<Expression> {
+    case expression(Expression)
+    case block([ResultBuilderTerm])
+    case either(Either<ResultBuilderTerm, ResultBuilderTerm>)
+}
+
+protocol ResultBuilder {
+    associatedtype Expression
+    typealias Component = ResultBuilderTerm<Expression>
+    associatedtype FinalResult
+
+    static func buildFinalResult(_ component: Component) -> FinalResult
+}
+
+extension ResultBuilder {
+    static func buildExpression(_ expression: Expression) -> Component { .expression(expression) }
+    static func buildBlock(_ components: Component...) -> Component { .block(components) }
+    static func buildEither(first: Component) -> Component { .either(.first(first)) }
+    static func buildEither(second: Component) -> Component { .either(.second(second)) }
+
+}
+
+@resultBuilder
+enum ArrayBuilder<E>: ResultBuilder {
+    typealias Expression = E
+    typealias FinalResult = [E]
+
+    static func buildFinalResult(_ component: Component) -> FinalResult {
+        switch component {
+        case .expression(let e): return [e]
+        case .block(let children): return children.flatMap(buildFinalResult)
+        case .either(.first(let child)): return buildFinalResult(child)
+        case .either(.second(let child)): return buildFinalResult(child)
+        }
+    }
+}
+
+func test(@ArrayBuilder<Int> a: () -> [Int]) {}
+enum MyEnum { case a, b } 
+
+test {
+  switch MyEnum.a {
+  case .#^EMPTYCASE?check=MYENUM_MEMBERS^#
+  }
+}
+
+test {
+  switch MyEnum.a {
+  case .a:
+  case .#^SECONDEMPTYCASE?check=MYENUM_MEMBERS^#
+  }
+}
+
+// MYENUM_MEMBERS: Begin completions
+// MYENUM_MEMBERS-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: a[#MyEnum#]; name=a
+// MYENUM_MEMBERS-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: b[#MyEnum#]; name=b
+// MYENUM_MEMBERS: End completions 


### PR DESCRIPTION
...when typechecking for code completion.

They were disallowed to give better diagnostics, but code completion suppresses diagnostics and doesn't provide any completions at all if the transform fails.

Resolves rdar://problem/74028722