### PR TITLE
[Concurrency] Allow async closures to be annotated with global actors.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4387,6 +4387,9 @@ ERROR(global_actor_on_struct_property,none,
 ERROR(actor_isolation_multiple_attr,none,
       "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",
       (DescriptiveDeclKind, DeclName, StringRef, StringRef))
+ERROR(global_actor_isolated_synchronous_closure,none,
+      "closure isolated to global actor %0 must be 'async'",
+      (Type))
 
 ERROR(actor_isolation_override_mismatch,none,
       "%0 %1 %2 has different actor isolation from %3 overridden declaration",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -283,6 +283,10 @@ ERROR(incorrect_explicit_closure_result,none,
       "declared closure result %0 is incompatible with contextual type %1",
       (Type, Type))
 
+ERROR(unsupported_closure_attr,none,
+      "%select{attribute |}0 '%1' is not supported on a closure",
+      (bool, StringRef))
+
 NOTE(suggest_expected_match,none,
      "%select{expected an argument list|produces result}0 of type '%1'",
      (bool, StringRef))

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_AST_EXPR_H
 #define SWIFT_AST_EXPR_H
 
+#include "swift/AST/Attr.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DeclContext.h"
@@ -3786,6 +3787,9 @@ public:
   };
 
 private:
+  /// The attributes attached to the closure.
+  DeclAttributes Attributes;
+
   /// The range of the brackets of the capture list, if present.
   SourceRange BracketRange;
     
@@ -3818,13 +3822,14 @@ private:
   /// was originally just a single expression.
   llvm::PointerIntPair<BraceStmt *, 1, bool> Body;
 public:
-  ClosureExpr(SourceRange bracketRange, VarDecl *capturedSelfDecl,
+  ClosureExpr(const DeclAttributes &attributes,
+              SourceRange bracketRange, VarDecl *capturedSelfDecl,
               ParameterList *params, SourceLoc asyncLoc, SourceLoc throwsLoc,
               SourceLoc arrowLoc, SourceLoc inLoc, TypeExpr *explicitResultType,
               unsigned discriminator, DeclContext *parent)
     : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
                           discriminator, parent),
-      BracketRange(bracketRange),
+      Attributes(attributes), BracketRange(bracketRange),
       CapturedSelfDecl(capturedSelfDecl),
       AsyncLoc(asyncLoc), ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc),
       InLoc(inLoc),
@@ -3844,6 +3849,9 @@ public:
     Body.setPointer(S);
     Body.setInt(isSingleExpression);
   }
+
+  DeclAttributes &getAttrs() { return Attributes; }
+  const DeclAttributes &getAttrs() const { return Attributes; }
 
   /// Determine whether the parameters of this closure are actually
   /// anonymous closure variables.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -962,7 +962,8 @@ using CustomAttrNominalPair = std::pair<CustomAttr *, NominalTypeDecl *>;
 class GlobalActorAttributeRequest :
     public SimpleRequest<
         GlobalActorAttributeRequest,
-        Optional<CustomAttrNominalPair>(Decl *),
+        Optional<CustomAttrNominalPair>(
+            llvm::PointerUnion<Decl *, ClosureExpr *>),
         RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -972,7 +973,8 @@ private:
 
   // Evaluation.
   Optional<std::pair<CustomAttr *, NominalTypeDecl *>>
-  evaluate(Evaluator &evaluator, Decl *decl) const;
+  evaluate(
+      Evaluator &evaluator, llvm::PointerUnion<Decl *, ClosureExpr *>) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -102,7 +102,8 @@ SWIFT_REQUEST(TypeChecker, GlobalActorInstanceRequest,
               VarDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GlobalActorAttributeRequest,
-              Optional<CustomAttrNominalPair>(Decl *),
+              Optional<CustomAttrNominalPair>(
+                  llvm::PointerUnion<Decl *, ClosureExpr *>),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ActorIsolationRequest,
               ActorIsolationState(ValueDecl *),

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -688,6 +688,9 @@ public:
   /// Skip over SIL decls until we encounter the start of a Swift decl or eof.
   void skipSILUntilSwiftDecl();
 
+  /// Skip over any attribute.
+  void skipAnyAttribute();
+
   /// If the parser is generating only a syntax tree, try loading the current
   /// node from a previously generated syntax tree.
   /// Returns \c true if the node has been loaded and inserted into the current
@@ -1575,6 +1578,7 @@ public:
   /// \returns ParserStatus error if an error occurred. Success if no signature
   /// is present or succssfully parsed.
   ParserStatus parseClosureSignatureIfPresent(
+          DeclAttributes &attributes,
           SourceRange &bracketRange,
           SmallVectorImpl<CaptureListEntry> &captureList,
           VarDecl *&capturedSelfParamDecl,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5728,6 +5728,15 @@ void Parser::skipSILUntilSwiftDecl() {
   }
 }
 
+void Parser::skipAnyAttribute() {
+  consumeToken(tok::at_sign);
+  if (!consumeIf(tok::identifier))
+    return;
+
+  if (consumeIf(tok::l_paren))
+    skipUntil(tok::r_paren);
+}
+
 /// Returns a descriptive name for the given accessor/addressor kind.
 static StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind,
                                               bool article) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7710,8 +7710,12 @@ namespace {
           });
 
       switch (result) {
-      case SolutionApplicationToFunctionResult::Success:
+      case SolutionApplicationToFunctionResult::Success: {
+        if (auto closure = dyn_cast_or_null<ClosureExpr>(
+                fn.getAbstractClosureExpr()))
+          TypeChecker::checkClosureAttributes(closure);
         return false;
+      }
 
       case SolutionApplicationToFunctionResult::Failure:
         return true;

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -226,7 +226,8 @@ private:
     // Create the closure.
     auto *Params = ParameterList::createEmpty(Ctx);
     auto *Closure = new (Ctx)
-        ClosureExpr(SourceRange(), nullptr, Params, SourceLoc(), SourceLoc(),
+        ClosureExpr(DeclAttributes(), SourceRange(), nullptr, Params,
+                    SourceLoc(), SourceLoc(),
                     SourceLoc(), SourceLoc(), nullptr,
                     DF.getNextDiscriminator(), getCurrentDeclContext());
     Closure->setImplicit(true);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5482,10 +5482,9 @@ namespace {
 class ClosureAttributeChecker
     : public AttributeVisitor<ClosureAttributeChecker> {
   ASTContext &ctx;
-  ClosureExpr *closure;
 public:
   ClosureAttributeChecker(ClosureExpr *closure)
-    : ctx(closure->getASTContext()), closure(closure) { }
+    : ctx(closure->getASTContext()) { }
 
   void visitDeclAttribute(DeclAttribute *attr) {
     ctx.Diags.diagnose(
@@ -5493,6 +5492,10 @@ public:
         attr->isDeclModifier(), attr->getAttrName())
       .fixItRemove(attr->getRangeWithAt());
     attr->setInvalid();
+  }
+
+  void visitConcurrentAttr(ConcurrentAttr *attr) {
+    // Nothing else to check.
   }
 };
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5482,9 +5482,10 @@ namespace {
 class ClosureAttributeChecker
     : public AttributeVisitor<ClosureAttributeChecker> {
   ASTContext &ctx;
+  ClosureExpr *closure;
 public:
   ClosureAttributeChecker(ClosureExpr *closure)
-    : ctx(closure->getASTContext()) { }
+    : ctx(closure->getASTContext()), closure(closure) { }
 
   void visitDeclAttribute(DeclAttribute *attr) {
     ctx.Diags.diagnose(
@@ -5496,6 +5497,29 @@ public:
 
   void visitConcurrentAttr(ConcurrentAttr *attr) {
     // Nothing else to check.
+  }
+
+  void visitCustomAttr(CustomAttr *attr) {
+    // Check whether this custom attribute is the global actor attribute.
+    auto globalActorAttr = evaluateOrDefault(
+        ctx.evaluator, GlobalActorAttributeRequest{closure}, None);
+    if (globalActorAttr && globalActorAttr->first == attr)
+      return;
+
+    // Otherwise, it's an error.
+    std::string typeName;
+    if (auto typeRepr = attr->getTypeRepr()) {
+      llvm::raw_string_ostream out(typeName);
+      typeRepr->print(out);
+    } else {
+      typeName = attr->getType().getString();
+    }
+
+    ctx.Diags.diagnose(
+        attr->getLocation(), diag::unsupported_closure_attr,
+        attr->isDeclModifier(), typeName)
+      .fixItRemove(attr->getRangeWithAt());
+    attr->setInvalid();
   }
 };
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5476,3 +5476,31 @@ void AttributeChecker::visitReasyncAttr(ReasyncAttr *attr) {
 }
 
 void AttributeChecker::visitAtReasyncAttr(AtReasyncAttr *attr) {}
+
+namespace {
+
+class ClosureAttributeChecker
+    : public AttributeVisitor<ClosureAttributeChecker> {
+  ASTContext &ctx;
+  ClosureExpr *closure;
+public:
+  ClosureAttributeChecker(ClosureExpr *closure)
+    : ctx(closure->getASTContext()), closure(closure) { }
+
+  void visitDeclAttribute(DeclAttribute *attr) {
+    ctx.Diags.diagnose(
+        attr->getLocation(), diag::unsupported_closure_attr,
+        attr->isDeclModifier(), attr->getAttrName())
+      .fixItRemove(attr->getRangeWithAt());
+    attr->setInvalid();
+  }
+};
+
+}
+
+void TypeChecker::checkClosureAttributes(ClosureExpr *closure) {
+  ClosureAttributeChecker checker(closure);
+  for (auto attr : closure->getAttrs()) {
+    checker.visit(attr);
+  }
+}

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -403,13 +403,26 @@ VarDecl *GlobalActorInstanceRequest::evaluate(
 
 Optional<std::pair<CustomAttr *, NominalTypeDecl *>>
 GlobalActorAttributeRequest::evaluate(
-    Evaluator &evaluator, Decl *decl) const {
-  ASTContext &ctx = decl->getASTContext();
-  auto dc = decl->getDeclContext();
+    Evaluator &evaluator,
+    llvm::PointerUnion<Decl *, ClosureExpr *> subject) const {
+  DeclContext *dc;
+  DeclAttributes *declAttrs;
+  SourceLoc loc;
+  if (auto decl = subject.dyn_cast<Decl *>()) {
+    dc = decl->getDeclContext();
+    declAttrs = &decl->getAttrs();
+    loc = decl->getLoc();
+  } else {
+    auto closure = subject.get<ClosureExpr *>();
+    dc = closure;
+    declAttrs = &closure->getAttrs();
+    loc = closure->getLoc();
+  }
+  ASTContext &ctx = dc->getASTContext();
   CustomAttr *globalActorAttr = nullptr;
   NominalTypeDecl *globalActorNominal = nullptr;
 
-  for (auto attr : decl->getAttrs().getAttributes<CustomAttr>()) {
+  for (auto attr : declAttrs->getAttributes<CustomAttr>()) {
     auto mutableAttr = const_cast<CustomAttr *>(attr);
     // Figure out which nominal declaration this custom attribute refers to.
     auto nominal = evaluateOrDefault(ctx.evaluator,
@@ -424,10 +437,10 @@ GlobalActorAttributeRequest::evaluate(
     if (!nominal->isGlobalActor())
       continue;
 
-    // Only a single global actor can be applied to a given declaration.
+    // Only a single global actor can be applied to a given entity.
     if (globalActorAttr) {
-      decl->diagnose(
-          diag::multiple_global_actors, globalActorNominal->getName(),
+      ctx.Diags.diagnose(
+          loc, diag::multiple_global_actors, globalActorNominal->getName(),
           nominal->getName());
       continue;
     }
@@ -439,8 +452,14 @@ GlobalActorAttributeRequest::evaluate(
   if (!globalActorAttr)
     return None;
 
+  // Closures can always have a global actor attached.
+  if (auto closure = subject.dyn_cast<ClosureExpr *>()) {
+    return std::make_pair(globalActorAttr, globalActorNominal);
+  }
+
   // Check that a global actor attribute makes sense on this kind of
   // declaration.
+  auto decl = subject.get<Decl *>();
   if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
     // Nominal types are okay...
     if (auto classDecl = dyn_cast<ClassDecl>(nominal)){
@@ -1384,8 +1403,13 @@ namespace {
 
       auto dc = const_cast<DeclContext *>(constDC);
       while (!dc->isModuleScopeContext()) {
-        // Look through non-escaping closures.
         if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
+          // If this closure has specific isolation, use it.
+          auto closureIsolation = getActorIsolationOfContext(dc);
+          if (closureIsolation != ActorIsolation::Independent)
+            return closureIsolation;
+
+          // Look through non-escaping closures.
           if (auto type = closure->getType()) {
             if (auto fnType = type->getAs<AnyFunctionType>()) {
               if (fnType->isNoEscape()) {
@@ -1816,12 +1840,50 @@ namespace {
       llvm_unreachable("unhandled actor isolation kind!");
     }
 
+    // Attempt to resolve the global actor type of a closure.
+    Type resolveGlobalActorType(ClosureExpr *closure) {
+      auto globalActorAttr = evaluateOrDefault(
+          ctx.evaluator, GlobalActorAttributeRequest{closure}, None);
+      if (!globalActorAttr)
+        return Type();
+
+      Type globalActor = evaluateOrDefault(
+          ctx.evaluator,
+          CustomAttrTypeRequest{
+            globalActorAttr->first, closure, CustomAttrTypeKind::GlobalActor},
+            Type());
+      if (!globalActor || globalActor->hasError())
+        return Type();
+
+      // Actor-isolated closures must be async.
+      bool isAsync = false;
+      if (Type closureType = closure->getType()) {
+        if (auto closureFnType = closureType->getAs<FunctionType>())
+          isAsync = closureFnType->isAsync();
+      }
+
+      if (!isAsync) {
+        ctx.Diags.diagnose(
+            closure->getLoc(), diag::global_actor_isolated_synchronous_closure,
+            globalActor);
+        return Type();
+      }
+
+      return globalActor;
+    }
+
     /// Determine the isolation of a particular closure.
     ///
     /// This function assumes that enclosing closures have already had their
     /// isolation checked.
     ClosureActorIsolation determineClosureIsolation(
         AbstractClosureExpr *closure) {
+      // If the closure specifies a global actor, use it.
+      if (auto explicitClosure = dyn_cast<ClosureExpr>(closure)) {
+        if (Type globalActorType = resolveGlobalActorType(explicitClosure))
+          return ClosureActorIsolation::forGlobalActor(globalActorType);
+      }
+
       // Escaping and concurrent closures are always actor-independent.
       if (isEscapingClosure(closure) || isConcurrentClosure(closure))
         return ClosureActorIsolation::forIndependent();

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2077,6 +2077,7 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
 }
 
 bool TypeChecker::typeCheckClosureBody(ClosureExpr *closure) {
+  TypeChecker::checkClosureAttributes(closure);
   TypeChecker::checkParameterList(closure->getParameters(), closure);
 
   BraceStmt *body = closure->getBody();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -451,6 +451,7 @@ void typeCheckDecl(Decl *D);
 
 void addImplicitDynamicAttribute(Decl *D);
 void checkDeclAttributes(Decl *D);
+void checkClosureAttributes(ClosureExpr *closure);
 void checkParameterList(ParameterList *params, DeclContext *owner);
 
 void diagnoseDuplicateBoundVars(Pattern *pattern);

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -10,7 +10,7 @@ func acceptConcurrentClosure<T>(_: @concurrent () -> T) { }
 func acceptEscapingClosure<T>(_: @escaping () -> T) { }
 func acceptEscapingClosure<T>(_: @escaping (String) -> ()) async -> T? { nil }
 
-func acceptAsyncClosure<T>(_: () async -> T) { }
+@discardableResult func acceptAsyncClosure<T>(_: () async -> T) -> T { }
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
 
 
@@ -232,6 +232,17 @@ struct GenericGlobalActor<T> {
   goo2()
 }
 @asyncHandler @SomeOtherGlobalActor func goo2() { await goo1() }
+
+func testGlobalActorClosures() {
+  let _: Int = acceptAsyncClosure { @SomeGlobalActor in
+    syncGlobalActorFunc()
+    syncOtherGlobalActorFunc() // expected-error{{call is 'async' but is not marked with 'await'}}
+    await syncOtherGlobalActorFunc()
+    return 17
+  }
+
+  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-error{{closure isolated to global actor 'SomeGlobalActor' must be 'async'}}
+}
 
 extension MyActor {
   @SomeGlobalActor func onGlobalActor(otherActor: MyActor) async {

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -118,3 +118,10 @@ func testCaseNonTrivialValue() {
 
   j = 17
 }
+
+func testExplicitConcurrentClosure() {
+  let fn = { @concurrent in
+    17
+  }
+  let _: String = fn // expected-error{{cannot convert value of type '@concurrent () -> Int' to specified type 'String'}}
+}

--- a/test/attr/closures.swift
+++ b/test/attr/closures.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+func testNonacceptedClosures() {
+  let fn = { @usableFromInline in // expected-error{{'usableFromInline' is not supported on a closure}}
+    "hello"
+  }
+
+  let fn2: (Int) -> Int = { @usableFromInline x in  // expected-error{{'usableFromInline' is not supported on a closure}}
+    print("hello")
+    return x
+  }
+
+  _ = fn
+  _ = fn2
+}


### PR DESCRIPTION
Allow an asynchronous closure to be annotated with a global actor,
which isolates it to that actor. For example:

```swift
Task.runDetached { @mainactor in
  // runs on main actor
}
```