### PR TITLE
[android][test] Add REQUIRES: executable_test to simple_partial_apply_or_not

### DIFF
--- a/test/IRGen/simple_partial_apply_or_not.swift
+++ b/test/IRGen/simple_partial_apply_or_not.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-emit-ir -module-name test %s | %FileCheck %s
 // RUN: %target-run-simple-swift %s | %FileCheck %s --check-prefix=CHECK-EXEC
 
+// REQUIRES: executable_test
+
 @propertyWrapper
 struct State<T> {
   private class Reference {


### PR DESCRIPTION
The test tries to execute the result of the compilation, so it needs to
be marked as executable to be able to be filtered out in platforms that
cannot execute the tests in CI (like Android).

Started happening in https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/9290/ and https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/7716/ with the introduction of #36011.