### PR TITLE
[Runtime] Fix calling convention of async function.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -179,7 +179,7 @@ const void *const swift::_swift_concurrency_debug_asyncTaskMetadata =
 
 /// The function that we put in the context of a simple task
 /// to handle the final return.
-SWIFT_CC(swift)
+SWIFT_CC(swiftasync)
 static void completeTask(AsyncTask *task, ExecutorRef executor,
                          SWIFT_ASYNC_CONTEXT AsyncContext *context) {
   // Tear down the task-local allocator immediately;


### PR DESCRIPTION
Otherwise, we run into a type error on turning on swiftasync.
