### PR TITLE
stdlib: Float16 needs an @available annotation for macOS [5.4]

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1353,7 +1353,7 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
 ${SelfDocComment}
 @frozen
 %  if bits == 16:
-@available(iOS 14, tvOS 14, watchOS 7, *)
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
 @available(macOS, unavailable)
 @available(macCatalyst, unavailable)
 %  else:

--- a/test/IRGen/float16_macos.swift
+++ b/test/IRGen/float16_macos.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s -target x86_64-apple-macos10.15 | %FileCheck %s --check-prefix=CHECK10
+// RUN: %target-swift-frontend -emit-ir %s -target x86_64-apple-macos11 | %FileCheck %s --check-prefix=CHECK11
+
+// REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
+// UNSUPPORTED: use_os_stdlib
+
+@available(macOS 11, *)
+public struct Float16Wrapper {
+  @available(macOS, unavailable)
+  var x: Float16
+}
+
+// CHECK10-LABEL: @"$ss7Float16VMn" = extern_weak global %swift.type_descriptor
+// CHECK11-LABEL: @"$ss7Float16VMn" = external global %swift.type_descriptor


### PR DESCRIPTION
Even though Float16 is unavailable on macOS, the type metadata can
still be referenced, for example from another unavailable declaration.

Make sure it has the correct OS version annotation so that it can be
weak linked.

Part of <rdar://problem/72151067>.