### PR TITLE
[CSBindings] Add an ability to retract previously inferred bindings

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -465,6 +465,13 @@ private:
 public:
   void infer(Constraint *constraint);
 
+  /// Retract all bindings and other information related to a given
+  /// constraint from this binding set.
+  ///
+  /// This would happen when constraint is simplified or solver backtracks
+  /// (either from overload choice or (some) type variable binding).
+  void retract(Constraint *constraint);
+
   /// Finalize binding computation for this type variable by
   /// inferring bindings from context e.g. transitive bindings.
   void finalize(llvm::SmallDenseMap<TypeVariableType *, PotentialBindings>

--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -206,6 +206,11 @@ struct LiteralRequirement {
                                     bool canBeNil,
                                     DeclContext *useDC) const;
 
+  void resetCoverage() {
+    assert(isCovered() && "literal requirement is uncovered");
+    CoveredBy = nullptr;
+  }
+
   /// Determines whether literal protocol associated with this
   /// meta-information is viable for inclusion as a defaultable binding.
   bool viableAsBinding() const { return !isCovered() && hasDefaultType(); }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1250,6 +1250,62 @@ void PotentialBindings::infer(Constraint *constraint) {
   }
 }
 
+void PotentialBindings::retract(Constraint *constraint) {
+  Bindings.remove_if([&constraint](const PotentialBinding &binding) {
+    return binding.getSource() == constraint;
+  });
+
+  auto isMatchingConstraint = [&constraint](Constraint *existing) {
+    return existing == constraint;
+  };
+
+  auto hasMatchingSource =
+      [&constraint](
+          const std::pair<TypeVariableType *, Constraint *> &adjacency) {
+        return adjacency.second == constraint;
+      };
+
+  switch (constraint->getKind()) {
+  case ConstraintKind::ConformsTo:
+  case ConstraintKind::SelfObjectOfProtocol:
+    Protocols.erase(llvm::remove_if(Protocols, isMatchingConstraint),
+                    Protocols.end());
+    break;
+
+  case ConstraintKind::LiteralConformsTo:
+    Literals.erase(constraint->getProtocol());
+    break;
+
+  case ConstraintKind::Defaultable:
+  case ConstraintKind::DefaultClosureType: {
+    auto defaultType = constraint->getSecondType();
+    Defaults.erase(defaultType->getCanonicalType());
+    break;
+  }
+
+  default:
+    break;
+  }
+
+  {
+    llvm::SmallPtrSet<TypeVariableType *, 2> unviable;
+    for (const auto &adjacent : AdjacentVars) {
+      if (adjacent.second == constraint)
+        unviable.insert(adjacent.first);
+    }
+
+    for (auto *adjacentVar : unviable)
+      AdjacentVars.erase(std::make_pair(adjacentVar, constraint));
+  }
+
+  DelayedBy.erase(llvm::remove_if(DelayedBy, isMatchingConstraint),
+                  DelayedBy.end());
+
+  SubtypeOf.remove_if(hasMatchingSource);
+  SupertypeOf.remove_if(hasMatchingSource);
+  EquivalentTo.remove_if(hasMatchingSource);
+}
+
 LiteralBindingKind PotentialBindings::getLiteralKind() const {
   LiteralBindingKind kind = LiteralBindingKind::None;
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1298,6 +1298,11 @@ void PotentialBindings::retract(Constraint *constraint) {
       AdjacentVars.erase(std::make_pair(adjacentVar, constraint));
   }
 
+  for (auto &literal : Literals) {
+    if (literal.second.CoveredBy == constraint)
+      literal.second.resetCoverage();
+  }
+
   DelayedBy.erase(llvm::remove_if(DelayedBy, isMatchingConstraint),
                   DelayedBy.end());
 


### PR DESCRIPTION
Infer is used to introduce new bindings/literals/defaults to the set of potential bindings
and new `retract` could be used to remove them once constraint is retired.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
