### PR TITLE
SIL: Fix vtable layout with @usableFromInline methods

### DIFF
--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -92,8 +92,11 @@ template <class T> class SILVTableVisitor {
       //   replace the vtable entry for B.f(); a call to A.f()
       //   will correctly dispatch to the implementation of B.f()
       //   in the subclass.
+      auto *UseDC = declRef.getDecl()->getDeclContext();
       if (!baseRef.getDecl()->isAccessibleFrom(
-            declRef.getDecl()->getDeclContext()))
+            UseDC,
+            /*forConformance=*/false,
+            /*allowUsableFromInline=*/true))
         break;
 
       asDerived().addMethodOverride(baseRef, declRef);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3418,13 +3418,16 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
 }
 
 bool ValueDecl::isMoreVisibleThan(ValueDecl *other) const {
-  auto scope = getFormalAccessScope();
+  auto scope = getFormalAccessScope(/*UseDC=*/nullptr,
+                                    /*treatUsableFromInlineAsPublic=*/true);
 
   // 'other' may have come from a @testable import, so we need to upgrade it's
   // visibility to public here. That is not the same as whether 'other' is
   // being built with -enable-testing though -- we don't want to treat it
   // differently in that case.
-  auto otherScope = other->getFormalAccessScope(getDeclContext());
+  auto otherScope =
+      other->getFormalAccessScope(getDeclContext(),
+                                  /*treatUsableFromInlineAsPublic=*/true);
 
   if (scope.isPublic())
     return !otherScope.isPublic();

--- a/test/SILGen/Inputs/accessibility_vtables_usableFromInline_helper.swift
+++ b/test/SILGen/Inputs/accessibility_vtables_usableFromInline_helper.swift
@@ -1,0 +1,9 @@
+open class Base {
+  internal func internalMethod() {}
+  @usableFromInline internal func usableFromInlineMethod() {}
+}
+
+open class Middle : Base {
+  open override func internalMethod() {}
+  open override func usableFromInlineMethod() {}
+}

--- a/test/SILGen/accessibility_vtables_testable.swift
+++ b/test/SILGen/accessibility_vtables_testable.swift
@@ -20,7 +20,7 @@
 import accessibility_vtables_testable_helper
 
 public class Derived : Middle {
-	open override func method() {}
+  open override func method() {}
 }
 
 // LIBRARY-LABEL: sil_vtable {{(\[serialized\] )?}}Base {

--- a/test/SILGen/accessibility_vtables_usableFromInline.swift
+++ b/test/SILGen/accessibility_vtables_usableFromInline.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-silgen %S/Inputs/accessibility_vtables_usableFromInline_helper.swift | %FileCheck %s --check-prefix=LIBRARY
+// RUN: %target-swift-frontend -enable-library-evolution -emit-silgen %S/Inputs/accessibility_vtables_usableFromInline_helper.swift | %FileCheck %s --check-prefix=LIBRARY
+
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/accessibility_vtables_usableFromInline_helper.swift
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t | %FileCheck %s --check-prefix=FRAGILE-CLIENT
+
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module -o %t %S/Inputs/accessibility_vtables_usableFromInline_helper.swift
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t | %FileCheck %s --check-prefix=RESILIENT-CLIENT
+
+import accessibility_vtables_usableFromInline_helper
+
+public class Derived : Middle {
+  open override func internalMethod() {}
+  open override func usableFromInlineMethod() {}
+}
+
+// LIBRARY-LABEL: sil_vtable {{(\[serialized\] )?}}Base {
+// LIBRARY-NEXT:    #Base.internalMethod: (Base) -> () -> () : @$s45accessibility_vtables_usableFromInline_helper4BaseC14internalMethodyyF
+// LIBRARY-NEXT:    #Base.usableFromInlineMethod: (Base) -> () -> () : @$s45accessibility_vtables_usableFromInline_helper4BaseC0cdE6MethodyyF
+// LIBRARY-NEXT:    #Base.init!allocator: (Base.Type) -> () -> Base : @$s45accessibility_vtables_usableFromInline_helper4BaseCACycfC
+// LIBRARY-NEXT:    #Base.deinit!deallocator: @$s45accessibility_vtables_usableFromInline_helper4BaseCfD
+// LIBRARY-NEXT:  }
+
+// LIBRARY-LABEL: sil_vtable {{(\[serialized\] )?}}Middle {
+// LIBRARY-NEXT:    #Base.internalMethod: (Base) -> () -> () : @$s45accessibility_vtables_usableFromInline_helper6MiddleC14internalMethodyyFAA4BaseCADyyFTV [override]
+// LIBRARY-NEXT:      #Base.usableFromInlineMethod: (Base) -> () -> () : @$s45accessibility_vtables_usableFromInline_helper6MiddleC0cdE6MethodyyF [override]
+// LIBRARY-NEXT:      #Base.init!allocator: (Base.Type) -> () -> Base : @$s45accessibility_vtables_usableFromInline_helper6MiddleCACycfC [override]
+// LIBRARY-NEXT:      #Middle.internalMethod: (Middle) -> () -> () : @$s45accessibility_vtables_usableFromInline_helper6MiddleC14internalMethodyyF
+// LIBRARY-NEXT:      #Middle.deinit!deallocator: @$s45accessibility_vtables_usableFromInline_helper6MiddleCfD
+// LIBRARY-NEXT:  }
+
+// FRAGILE-CLIENT-LABEL: sil_vtable [serialized] Derived {
+// FRAGILE-CLIENT-NEXT:    #Base.internalMethod: (Base) -> () -> () : @$s45accessibility_vtables_usableFromInline_helper6MiddleC14internalMethodyyFAA4BaseCADyyFTV [inherited]
+// FRAGILE-CLIENT-NEXT:    #Base.usableFromInlineMethod: (Base) -> () -> () : @$s38accessibility_vtables_usableFromInline7DerivedC0cdE6MethodyyF [override]
+// FRAGILE-CLIENT-NEXT:    #Base.init!allocator: (Base.Type) -> () -> Base : @$s45accessibility_vtables_usableFromInline_helper6MiddleCACycfC [inherited]
+// FRAGILE-CLIENT-NEXT:    #Middle.internalMethod: (Middle) -> () -> () : @$s38accessibility_vtables_usableFromInline7DerivedC14internalMethodyyF [override]
+// FRAGILE-CLIENT-NEXT:    #Derived.deinit!deallocator: @$s38accessibility_vtables_usableFromInline7DerivedCfD
+
+// FRAGILE-CLIENT-NEXT:  }
+
+// RESILIENT-CLIENT-LABEL: sil_vtable [serialized] Derived {
+// RESILIENT-CLIENT-NEXT:    #Base.usableFromInlineMethod: (Base) -> () -> () : @$s38accessibility_vtables_usableFromInline7DerivedC0cdE6MethodyyF [override]
+// RESILIENT-CLIENT-NEXT:    #Middle.internalMethod: (Middle) -> () -> () : @$s38accessibility_vtables_usableFromInline7DerivedC14internalMethodyyF [override]
+// RESILIENT-CLIENT-NEXT:    #Derived.deinit!deallocator: @$s38accessibility_vtables_usableFromInline7DerivedCfD
+// RESILIENT-CLIENT-NEXT:  }


### PR DESCRIPTION
A @usableFromInline method is public at the ABI level, so we do not
need to introduce a new vtable entry.

Fixes <rdar://problem/74489981>.