### PR TITLE
Fix EscapeAnalysis::mayReleaseContent

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -989,8 +989,13 @@ private:
   /// The allocator for the connection graphs in Function2ConGraph.
   llvm::SpecificBumpPtrAllocator<FunctionInfo> Allocator;
 
+  // TODO: Use per-function caches, at least for Resilient types, to use Maximal
+  // expansion.
+
   /// Cache for isPointer().
   PointerKindCache pointerKindCache;
+  /// Cache for checking the aggregate pointerness of class properties.
+  PointerKindCache classPropertiesKindCache;
 
   SILModule *M;
 
@@ -1013,6 +1018,12 @@ private:
   PointerKind findRecursivePointerKind(SILType Ty, const SILFunction &F) const;
 
   PointerKind findCachedPointerKind(SILType Ty, const SILFunction &F) const;
+
+  PointerKind findClassPropertiesPointerKind(SILType Ty,
+                                             const SILFunction &F) const;
+
+  PointerKind findCachedClassPropertiesKind(SILType Ty,
+                                            const SILFunction &F) const;
 
   // Returns true if the type \p Ty must be a reference or must transitively
   // contain a reference and no other pointer or address type.

--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -1114,6 +1114,10 @@ private:
   bool canEscapeToUsePoint(SILValue value, SILInstruction *usePoint,
                            ConnectionGraph *conGraph);
 
+  /// Common implementation for mayReleaseReferenceContent and
+  /// mayReleaseAddressContent.
+  bool mayReleaseContent(SILValue releasedPtr, SILValue liveAddress);
+
   friend struct ::CGForDotView;
 
 public:
@@ -1163,8 +1167,38 @@ public:
   bool canEscapeTo(SILValue V, DestroyValueInst *DVI);
 
   /// Return true if \p releasedReference deinitialization may release memory
-  /// pointed to by \p accessedAddress.
-  bool mayReleaseContent(SILValue releasedReference, SILValue accessedAddress);
+  /// pointed to by \p liveAddress.
+  ///
+  /// This determines whether a direct release of \p releasedReference, such as
+  /// destroy_value or strong_release may release memory pointed to by \p
+  /// liveAddress. It can also be used to determine whether passing a
+  /// reference-type call argument may release \p liveAddress.
+  ///
+  /// This does not distinguish between a call that releases \p
+  /// releasedReference directly, vs. a call that releases one of indirect
+  /// references.The side effects of releasing any object reachable from \p
+  /// releasedReference are a strict subset of the side effects of directly
+  /// releasing the parent reference.
+  bool mayReleaseReferenceContent(SILValue releasedReference,
+                                  SILValue liveAddress) {
+    assert(!releasedReference->getType().isAddress() &&
+           "expected a potentially nontrivial value, not an address");
+    return mayReleaseContent(releasedReference, liveAddress);
+  }
+
+  /// Return true if accessing memory at \p accessedAddress may release memory
+  /// pointed to by \p liveAddress.
+  ///
+  /// This makes sense for determining whether accessing indirect call argument
+  /// \p accessedAddress may release memory pointed to by \p liveAddress.
+  ///
+  /// "Access" to the memory can be any release of a reference pointed to by \p
+  /// accessedAddress, so '@in' and '@inout' are handled the same.
+  bool mayReleaseAddressContent(SILValue accessedAddress,
+                                SILValue liveAddress) {
+    assert(accessedAddress->getType().isAddress() && "expected an address");
+    return mayReleaseContent(accessedAddress, liveAddress);
+  }
 
   /// Returns true if the pointers \p V1 and \p V2 can possibly point to the
   /// same memory.

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -723,8 +723,18 @@ bool AliasAnalysis::canApplyDecrementRefCount(FullApplySite FAS, SILValue Ptr) {
     if (ArgEffect.mayRelease()) {
       // The function may release this argument, so check if the pointer can
       // escape to it.
-      if (EA->mayReleaseContent(FAS.getArgument(Idx), Ptr))
-        return true;
+      auto arg = FAS.getArgument(Idx);
+      if (arg->getType().isAddress()) {
+        // Handle indirect argument as if they are a release to any references
+        // pointed to by the argument's address.
+        if (EA->mayReleaseAddressContent(arg, Ptr))
+          return true;
+      } else {
+        // Handle direct arguments as if they are a direct release of the
+        // reference (just like a destroy_value).
+        if (EA->mayReleaseReferenceContent(arg, Ptr))
+          return true;
+      }
     }
   }
   return false;
@@ -744,7 +754,7 @@ bool AliasAnalysis::canBuiltinDecrementRefCount(BuiltinInst *BI, SILValue Ptr) {
     // to be an owned reference and disallows addresses. Conservatively handle
     // address type arguments as and conservatively treat all other values
     // potential owned references.
-    if (Arg->getType().isAddress() || EA->mayReleaseContent(Arg, Ptr))
+    if (Arg->getType().isAddress() || EA->mayReleaseReferenceContent(Arg, Ptr))
       return true;
   }
   return false;
@@ -788,7 +798,7 @@ bool AliasAnalysis::mayValueReleaseInterfereWithInstruction(
   // accessedPointer. Access to any objects beyond the first released refcounted
   // object are irrelevant--they must already have sufficient refcount that they
   // won't be released when releasing Ptr.
-  return EA->mayReleaseContent(releasedReference, accessedPointer);
+  return EA->mayReleaseReferenceContent(releasedReference, accessedPointer);
 }
 
 void AliasAnalysis::initialize(SILPassManager *PM) {

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -2727,95 +2727,115 @@ bool EscapeAnalysis::canPointToSameMemory(SILValue V1, SILValue V2) {
   return true;
 }
 
-// Return true if deinitialization of \p releasedReference may release memory
-// directly pointed to by \p accessAddress.
+// Returns true if deinitialization of \p releasedPtr may release memory
+// directly pointed to by \p livePtr.
 //
-// Note that \p accessedAddress could be a reference itself, an address of a
+// The implementation is common between mayReleaseReferenceContent and
+// mayReleaseAddressContent, but the semantics are different. For references,
+// this models the release of the reference itself. For addresses, this models
+// the release of any reference pointed to by the address. The caller should
+// explicitly ask for the right one so they aren't surprised. Here we simply
+// switch behavior based on whether \p releasedPtr is an address type.
+//
+// Note that \p livePtr could be a reference itself, an address of a
 // local/argument that contains a reference, or even a pointer to the middle of
-// an object (even if it is an exclusive argument).
+// an object. (Even an exclusive argument may point to the middle of an object).
 //
-// This is almost the same as asking "is the content node for accessedAddress
-// reachable via releasedReference", with three subtle differences:
+// This is similar to asking "is the content of livePtr reachable via
+// releasedPtr". There are two interesting cases in which a connection graph
+// query can determine that the accessed memory cannot be released:
 //
-// (1) A locally referenced object can only be freed when deinitializing
-// releasedReference if it is the same object. Indirect references will be kept
-// alive by their distinct local references--ARC can't remove those without
-// inserting a mark_dependence/end_dependence scope.
-//
-// (2) the content of exclusive arguments may be indirectly reachable via
-// releasedReference, but the exclusive argument must have it's own reference
-// count, so cannot be freed via the locally released reference.
-//
-// (3) Objects may contain raw pointers into themselves or into other
-// objects. Any access to the raw pointer is not considered a use of the object
-// because that access must be "guarded" by a fix_lifetime or
-// mark_dependence/end_dependence that acts as a placeholder.
-//
-// There are two interesting cases in which a connection graph query can
-// determine that the accessed memory cannot be released:
-//
-// Case #1: accessedAddress points to a uniquely identified object that does not
+// Case #1: \p livePtr points to a uniquely identified object that does not
 // escape within this function.
 //
-// Note: A "uniquely identified object" is either a locally allocated object,
-// which is obviously not reachable outside this function, or an exclusive
-// address argument, which *is* reachable outside this function, but must
-// have its own reference count so cannot be released locally.
+// In this case, it is sufficient to ensure that no connection graph path exists
+// from the content of \p livePtr to the content of \p releasedPtr.
+//
+// Note: A "uniquely identified object" is either locally allocated, which is
+// obviously not reachable outside this function, or an exclusive address, which
+// *is* reachable outside this function, but must have its own reference count
+// so cannot be released in this function or its callees.
 //
 // Case #2: The released reference points to a local object and no connection
 // graph path exists from the referenced object to a global-escaping or
-// argument-escaping node without traversing a non-interior edge.
+// argument-escaping node.
 //
-// In both cases, the connection graph is sufficient to determine if the
-// accessed content may be released. To prove that the accessed memory is
-// distinct from any released memory it is now sufficient to check that no
-// connection graph path exists from the released object's node to the accessed
-// content node without traversing a non-interior edge.
-bool EscapeAnalysis::mayReleaseContent(SILValue releasedReference,
-                                       SILValue accessedAddress) {
-  assert(!releasedReference->getType().isAddress()
-         && "an address is never a reference");
-
-  SILFunction *f = getCommonFunction(releasedReference, accessedAddress);
+// TODO: This API is inneffective for release hoisting, because the release
+// itself is often the only place that an object's contents may escape. We can't
+// currently determine that since the contents cannot escape prior to \p
+// releasePtr, then livePtr cannot possible point to the same memory!
+//
+// TODO: In the future, we may have an AliasAnalysis query that distinguishes
+// between retain-sinking vs. release-hoisting. With SemanticARC, we may not
+// need to do this, but it is possible to be much more aggressive with
+// release-hoisting. This is becase, for a retain/release pair, it's always ok
+// to release earlier as long as there are no subsequent aliasing uses. If the
+// caller is only concerned with release hoisting and knows there are no
+// subsequent aliasing uses protected by a local release, then the connection
+// graph reachability check here only needs to search within the current object
+// (it can stop at a non-interior edge). This would assume that any indirectly
+// released reference needs to be kept alive by some distinct local
+// references--ARC can't remove those without inserting a
+// mark_dependence/end_dependence scope. It would also ignore the fact that
+// objects may contain raw pointers into themselves or into other objects. Any
+// access to the raw pointer is not considered a use of the object because that
+// access must be "guarded" by a fix_lifetime or mark_dependence/end_dependence
+// that acts as a placeholder.
+bool EscapeAnalysis::mayReleaseContent(SILValue releasedPtr, SILValue livePtr) {
+  SILFunction *f = getCommonFunction(releasedPtr, livePtr);
   if (!f)
     return true;
 
   auto *conGraph = getConnectionGraph(f);
 
-  CGNode *addrContentNode = conGraph->getValueContent(accessedAddress);
-  if (!addrContentNode)
+  CGNode *liveContentNode = conGraph->getValueContent(livePtr);
+  if (!liveContentNode)
     return true;
 
-  // Case #1: Unique accessedAddress whose content does not escape.
-  bool isAccessUniq =
-      isUniquelyIdentified(accessedAddress)
-      && !addrContentNode->valueEscapesInsideFunction(accessedAddress);
+  // Case #1: Unique livePtr whose content does not escape.
+  //
+  // If \p livePtr is an exclusive function argument, it may be indirectly
+  // reachable via releasedPtr, but the exclusive argument must have it's own
+  // reference count retained by the called. We consider \p livePtr unique since
+  // it so cannot be freed via a release of \p releasedPtr within this function
+  // or its callees.
+  bool isLiveAddressUnique =
+      isUniquelyIdentified(livePtr)
+      && !liveContentNode->valueEscapesInsideFunction(livePtr);
 
-  // Case #2: releasedReference points to a local object.
-  if (!isAccessUniq && !pointsToLocalObject(releasedReference))
+  // Case #2: releasedPtr points to a local object.
+  if (!isLiveAddressUnique && !pointsToLocalObject(releasedPtr))
     return true;
 
-  CGNode *releasedObjNode = conGraph->getValueContent(releasedReference);
+  // If \p releasedPtr is an address, then its released content is at least two
+  // levels away: the address points to a reference, which points to an object.
+  // CGNode *releasedObjNode = nullptr;
+  CGNode *releasedObjNode = nullptr;
+  if (releasedPtr->getType().isAddress()) {
+    CGNode *addrContentObjNode = conGraph->getValueContent(releasedPtr);
+    if (!addrContentObjNode)
+      return true;
+    releasedObjNode = conGraph->getOrCreateUnknownContent(addrContentObjNode);
+  } else {
+    releasedObjNode = conGraph->getValueContent(releasedPtr);
+  }
   // Make sure we have at least one value CGNode for releasedReference.
   if (!releasedObjNode)
     return true;
 
-  // Check for reachability from releasedObjNode to addrContentNode.
+  // Check for reachability from releasedObjNode to liveContentNode.
   // A pointsTo cycle is equivalent to a null pointsTo.
   CGNodeWorklist worklist(conGraph);
   for (CGNode *releasedNode = releasedObjNode;
        releasedNode && worklist.tryPush(releasedNode);
        releasedNode = releasedNode->getContentNodeOrNull()) {
     // A path exists from released content to accessed content.
-    if (releasedNode == addrContentNode)
+    if (releasedNode == liveContentNode)
       return true;
 
     // A path exists to an escaping node.
-    if (!isAccessUniq && releasedNode->escapesInsideFunction())
+    if (!isLiveAddressUnique && releasedNode->escapesInsideFunction())
       return true;
-
-    if (!releasedNode->isInterior())
-      break;
   }
   return false; // no path to escaping memory that may be freed.
 }

--- a/test/SILOptimizer/arc_crash.swift
+++ b/test/SILOptimizer/arc_crash.swift
@@ -1,0 +1,50 @@
+// RUN: %target-swift-frontend -O %s -parse-as-library -emit-sil -enforce-exclusivity=none -Xllvm -sil-disable-pass=function-signature-opts | %FileCheck %s
+
+// Test ARC optimizations on source level tests that have been
+// miscompiled and crash (e.g. because of use-after-free).
+
+// -----------------------------------------------------------------------------
+// rdar://74469299 (ARC miscompile: EscapeAnalysis::mayReleaseContent;
+// potential use-after-free)
+// -----------------------------------------------------------------------------
+
+public class Base {
+  var i = 3
+  init() {}
+}
+public class Node : Base {
+  var node: Base
+
+  init(node: Base) { self.node = node }
+}
+struct Queue {
+  var node: Node
+}
+
+@inline(never)
+func useQueue(q: __owned Queue) {}
+
+@inline(never)
+func useNode(n: Base) -> Int {
+  return n.i
+}
+
+// CHECK-LABEL: sil [noinline] @$s9arc_crash14testMayReleaseAA4BaseCyF : $@convention(thin) () -> @owned Base {
+// CHECK:   [[BASE:%.*]] = alloc_ref $Base
+// CHECK:   strong_retain [[BASE]] : $Base
+// CHECK:   apply %{{.*}} : $@convention(thin) (@owned Queue) -> ()
+// CHECK-LABEL: } // end sil function '$s9arc_crash14testMayReleaseAA4BaseCyF'
+@inline(never)
+public func testMayRelease() -> Base {
+  let n2 = Base()
+  let n1 = Node(node: n2)
+  let q = Queue(node: n1)
+  // n2 must not be release before useQueue.
+  useQueue(q: q)
+  return n2
+}
+
+// This crashes when testMayRelease releases the object too early.
+// print("Object:")
+// print(testMayRelease())
+// -----------------------------------------------------------------------------

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -630,9 +630,18 @@ bb0(%0 : $Cls):
 // 'Container' object, so the child will be destroyed with the parent.
 // The original SIL already has an over-release of the parent.
 //
+// TODO: This optimization is currently defeated because
+// - release_container marks anything '%2 = alloc_ref $Container' points to as escaping
+// - in this function, '%2 = alloc_ref $Container' points to '%1 = alloc_ref $Cls'
+// - therefore, the 'apply' may potentially release '%1 = alloc_ref $Cls'
+//
+// To hoist this 'release %1 : $Cls', AliasAnalysis alsos need to prove that
+// it isn't being hoisted above the last use. This information is not
+// properly communicated between AliasAnalysis and EscapeAnalysis.
+//
 // CHECK-LABEL: sil @remove_as_local_object_indirectly_escapes_to_callee
-// CHECK-NOT: retain_value
-// CHECK-NOT: release_value
+// CHECK: retain_value
+// CHECK: release_value
 sil @remove_as_local_object_indirectly_escapes_to_callee : $@convention(thin) (Cls) -> () {
 bb0(%0 : $Cls):
   %1 = alloc_ref $Cls

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -8,7 +8,7 @@ import Builtin
 import Swift
 import SwiftShims
 
-protocol ClassP : class {
+protocol ClassP : AnyObject {
   func foo()
 }
 
@@ -1774,7 +1774,7 @@ class IntWrapper {
 
 // CHECK-LABEL: CG of testInteriorCycle
 // CHECK-NEXT:   Arg [ref] %0 Esc: A, Succ: (%2)
-// CHECK-NEXT:   Con [int] %2 Esc: G, Succ: (%2)
+// CHECK-NEXT:   Con [int] %2 Esc: A, Succ: (%2)
 // CHECK-NEXT:   Val %6 Esc: , Succ: %0, %2
 // CHECK-NEXT:   Ret return Esc: , Succ: %6
 // CHECK-LABEL: End

--- a/test/SILOptimizer/late_release_hoisting.sil
+++ b/test/SILOptimizer/late_release_hoisting.sil
@@ -17,6 +17,14 @@ class HasInt64 {
   var i : Int64
 }
 
+class HasInt64Sub : HasObj {
+  var i : Int64
+}
+
+class HasHasInt64 : HasObj {
+  var hi : HasInt64
+}
+
 class HasHasObj {
   var ho : HasObj
 }
@@ -26,10 +34,10 @@ class HasHasObj {
 //
 // CHECK-LABEL: sil @testLocalNotReachesEscaped : $@convention(thin) (Int64, @owned HasObj) -> AnyObject {
 // CHECK: bb0(%0 : $Int64, %1 : $HasObj):
-// CHECK:   [[LO:%.*]] = alloc_ref $HasInt
+// CHECK:   [[LO:%.*]] = alloc_ref $HasInt64
 // CHECK:   [[IADR:%.*]] = ref_element_addr [[LO]] : $HasInt64, #HasInt64.i
 // CHECK:   store %0 to [[IADR]] : $*Int64
-// CHECK:   strong_release [[LO]] : $HasInt
+// CHECK:   strong_release [[LO]] : $HasInt64
 // CHECK:   [[OADR:%.*]] = ref_element_addr %1 : $HasObj, #HasObj.o
 // CHECK:   [[O:%.*]] = load [[OADR]] : $*AnyObject
 // CHECK:   return [[O]] : $AnyObject
@@ -39,10 +47,36 @@ bb0(%0 : $Int64, %1 : $HasObj):
   %lo = alloc_ref $HasInt64
   %iadr = ref_element_addr %lo : $HasInt64, #HasInt64.i
   store %0 to %iadr : $*Int64
-
   %oadr = ref_element_addr %1 : $HasObj, #HasObj.o
   %o = load %oadr : $*AnyObject
   strong_release %lo : $HasInt64
+  return %o : $AnyObject
+}
+
+// The release of %lo cannot be hoisted over the load because it the
+// release of %lo causes all objects pointed to by its fields to
+// escape. Since it has at least one reference-type field, it may
+// point to escaping memory.
+//
+// CHECK-LABEL: sil @testLocalMayReachEscaped : $@convention(thin) (Int64, @owned HasObj) -> AnyObject {
+// CHECK: bb0(%0 : $Int64, %1 : $HasObj):
+// CHECK:   [[LO:%.*]] = alloc_ref $HasInt64Sub
+// CHECK:   [[IADR:%.*]] = ref_element_addr [[LO]] : $HasInt64Sub, #HasInt64Sub.i
+// CHECK:   store %0 to [[IADR]] : $*Int64
+// CHECK:   [[OADR:%.*]] = ref_element_addr %1 : $HasObj, #HasObj.o
+// CHECK:   [[O:%.*]] = load [[OADR]] : $*AnyObject
+// CHECK:   strong_release [[LO]] : $HasInt64Sub
+// CHECK:   return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testLocalMayReachEscaped'
+sil @testLocalMayReachEscaped : $@convention(thin) (Int64, @owned HasObj) -> AnyObject {
+bb0(%0 : $Int64, %1 : $HasObj):
+  %lo = alloc_ref $HasInt64Sub
+  %iadr = ref_element_addr %lo : $HasInt64Sub, #HasInt64Sub.i
+  store %0 to %iadr : $*Int64
+
+  %oadr = ref_element_addr %1 : $HasObj, #HasObj.o
+  %o = load %oadr : $*AnyObject
+  strong_release %lo : $HasInt64Sub
   return %o : $AnyObject
 }
 
@@ -70,10 +104,12 @@ bb0(%0 : $AnyObject):
   return %o : $AnyObject
 }
 
-// The release of %lo can be hoisted above the load from %oadr.  There
-// is a points-to relation between %lo and %oadr. However, the
-// points-to path from %lo to %oadr reaches another reference counted
-// object before reaching $oadr.
+// The release of %lo cannot be hoisted above the load from %oadr
+// because there is a points-to relation between %lo and %oadr.
+//
+// TODO: To hoist this release, AliasAnalysis also need to prove that
+// it isn't being hoisted above the last use. This information is not
+// properly communicated between AliasAnalysis and EscapeAnalysis.
 //
 // CHECK-LABEL: sil @testLocalReachesRCEscaped : $@convention(thin) (@owned HasObj) -> AnyObject {
 // CHECK: bb0(%0 : $HasObj):
@@ -82,9 +118,9 @@ bb0(%0 : $AnyObject):
 // CHECK:   strong_retain %0 : $HasObj
 // CHECK:   store %0 to [[HOADR]] : $*HasObj
 // CHECK:   [[HO:%.*]] = load [[HOADR]] : $*HasObj
-// CHECK:   strong_release [[LO]] : $HasHasObj
 // CHECK:   [[OADR:%.*]] = ref_element_addr [[HO]] : $HasObj, #HasObj.o
 // CHECK:   [[O:%.*]] = load [[OADR]] : $*AnyObject
+// CHECK:   strong_release [[LO]] : $HasHasObj
 // CHECK:   return [[O]] : $AnyObject
 // CHECK-LABEL: } // end sil function 'testLocalReachesRCEscaped'
 sil @testLocalReachesRCEscaped : $@convention(thin) (@owned HasObj) -> AnyObject {
@@ -144,9 +180,13 @@ bb0(%0 : $AnyObject):
   return %o : $AnyObject
 }
 
-// Two local references, one reachable from the other. We assume that
+// Two local references, one reachable from the other. We cannot assume that
 // the reachable one has its own reference count and hoist
-// strong_release %hho above load %oadr.
+// strong_release %hho above load %oadr without more information.
+//
+// TODO: To hoist this release, AliasAnalysis also need to prove that
+// it isn't being hoisted above the last use. This information is not
+// properly communicated between AliasAnalysis and EscapeAnalysis.
 //
 // CHECK-LABEL: sil @testLocalReachesRCLocal : $@convention(thin) (AnyObject) -> AnyObject {
 // CHECK: bb0(%0 : $AnyObject):
@@ -158,9 +198,9 @@ bb0(%0 : $AnyObject):
 // CHECK: [[HOADR:%.*]] = ref_element_addr [[HHO]] : $HasHasObj, #HasHasObj.ho
 // CHECK: store [[LO]] to [[HOADR]] : $*HasObj
 // CHECK: [[HO:%.*]] = load [[HOADR]] : $*HasObj
-// CHECK: strong_release [[HHO]] : $HasHasObj
 // CHECK: [[OADR2:%.*]] = ref_element_addr [[HO]] : $HasObj, #HasObj.o
 // CHECK: [[O:%.*]] = load [[OADR2]] : $*AnyObject
+// CHECK: strong_release [[HHO]] : $HasHasObj
 // CHECK: strong_retain [[O]] : $AnyObject
 // CHECK: return [[O]] : $AnyObject
 // CHECK-LABEL: } // end sil function 'testLocalReachesRCLocal'
@@ -230,5 +270,35 @@ bb0(%0 : $AnyObject, %1 : $HasHasObj):
   store %lo to %hoadr : $*HasObj
   %o = load %oadr : $*AnyObject
   strong_release %1 : $HasHasObj
+  return %o : $AnyObject
+}
+
+// 'strong_release %lo : $HasHasInt64' cannot be hoisted because it
+// contains a reference that appears to escape. With the current
+// information, we can't be sure if that escaping reference points to
+// the load of '%oadr'.
+//
+// TODO: To hoist this release, AliasAnalysis also need to prove that
+// it isn't being hoisted above the last use. This information is not
+// properly communicated between AliasAnalysis and EscapeAnalysis.
+//
+// CHECK-LABEL: sil @testLocalWithReferenceProperty : $@convention(thin) (Int64, @owned HasObj) -> AnyObject {
+// CHECK: bb0(%0 : $Int64, %1 : $HasObj):
+// CHECK:   [[O:%.*]] = load {{.*}} : $*AnyObject
+// CHECK:   strong_release %{{.*}} : $HasHasInt64
+// CHECK:   return [[O]] : $AnyObject
+// CHECK-LABEL: } // end sil function 'testLocalWithReferenceProperty'
+sil @testLocalWithReferenceProperty : $@convention(thin) (Int64, @owned HasObj) -> AnyObject {
+bb0(%0 : $Int64, %1 : $HasObj):
+  %hi = alloc_ref $HasInt64
+  %iadr = ref_element_addr %hi : $HasInt64, #HasInt64.i
+  store %0 to %iadr : $*Int64
+  %lo = alloc_ref $HasHasInt64
+  %hiadr = ref_element_addr %lo : $HasHasInt64, #HasHasInt64.hi
+  store %hi to %hiadr : $*HasInt64
+
+  %oadr = ref_element_addr %1 : $HasObj, #HasObj.o
+  %o = load %oadr : $*AnyObject
+  strong_release %lo : $HasHasInt64
   return %o : $AnyObject
 }

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -31,7 +31,7 @@ struct A {
 
 class fuzz { }
 
-protocol P : class { }
+protocol P : AnyObject { }
 
 enum Boo {
   case one
@@ -884,4 +884,164 @@ bb2:
 
 bb3(%24 : $Optional<P>):
   return %24 : $Optional<P>
+}
+
+// -----------------------------------------------------------------------------
+// Test EscapeAnalysis::mayReleaseContent
+// -----------------------------------------------------------------------------
+
+class Node {
+  var node: Node
+}
+struct Queue {
+  var node: Node
+}
+
+sil @getNode : $@convention(thin) () -> @owned Node
+
+// testInoutRelease helper.
+//
+// To test a corner case in canApplyDecrementRefCount, this function
+// cannot have "mayReadRC" or "global mayRelease" side effects.
+sil [ossa] @setNode : $@convention(thin) (@owned Node, @inout Queue) -> () {
+bb0(%0 : @owned $Node, %1 : $*Queue):
+  %new = struct $Queue(%0 : $Node)
+  store %new to [assign] %1 : $*Queue
+  %6 = tuple ()
+  return %6 : $()
+}
+
+// When analyzing this function for retain code motion,
+// AliasAnalysis::canApplyDecrementRefCount will query
+// EscapeAnalysis::mayReleaseContent, passing it an inout pointer for
+// the "released reference".
+//
+// rdar://74360041 (Assertion failed:
+// (!releasedReference->getType().isAddress() && "an address is never
+// a reference"), function mayReleaseContent
+//
+// CHECK-LABEL: sil @testInoutRelease : $@convention(thin) (@inout Queue) -> () {
+// CHECK: strong_retain
+// CHECK: apply {{.*}} : $@convention(thin) (@owned Node, @inout Queue) -> ()
+// CHECK-LABEL: } // end sil function 'testInoutRelease'
+sil @testInoutRelease : $@convention(thin) (@inout Queue) -> () {
+bb0(%0 : $*Queue):
+  %get = function_ref @getNode : $@convention(thin) () -> @owned Node
+  %node = apply %get() : $@convention(thin) () -> @owned Node
+  %set = function_ref @setNode : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  strong_retain %node : $Node
+  %call = apply %set(%node, %0) : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// Still cannot sink the retain because %extraNode is not unique.
+//
+// CHECK-LABEL: sil @testMayReleaseNoSink : $@convention(thin) (@inout Queue) -> () {
+// CHECK: strong_retain
+// CHECK: apply {{.*}} : $@convention(thin) (@owned Node, @inout Queue) -> ()
+// CHECK-LABEL: } // end sil function 'testMayReleaseNoSink'
+sil @testMayReleaseNoSink : $@convention(thin) (@inout Queue) -> () {
+bb0(%0 : $*Queue):
+  %get = function_ref @getNode : $@convention(thin) () -> @owned Node
+  %node = apply %get() : $@convention(thin) () -> @owned Node
+  %extraNode = apply %get() : $@convention(thin) () -> @owned Node
+  %set = function_ref @setNode : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  strong_retain %extraNode : $Node
+  %call = apply %set(%node, %0) : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// The retain of extraNode can sink here because is unique within this
+// function and not released by setNode.
+//
+// CHECK-LABEL: sil @testMayReleaseSink : $@convention(thin) (@inout Queue) -> () {
+// CHECK: apply {{.*}} : $@convention(thin) (@owned Node, @inout Queue) -> ()
+// CHECK: strong_retain
+// CHECK-LABEL: } // end sil function 'testMayReleaseSink'
+sil @testMayReleaseSink : $@convention(thin) (@inout Queue) -> () {
+bb0(%0 : $*Queue):
+  %get = function_ref @getNode : $@convention(thin) () -> @owned Node
+  %node = apply %get() : $@convention(thin) () -> @owned Node
+  %extraNode = alloc_ref $Node
+  %set = function_ref @setNode : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  strong_retain %extraNode : $Node
+  %call = apply %set(%node, %0) : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// Both the queue and node are unique and non-escaping, but we still
+// can't sink because the queue may point to the node.
+//
+// CHECK-LABEL: sil @testMayReleaseUniqNoSink : $@convention(thin) () -> () {
+// CHECK: strong_retain
+// CHECK: apply {{.*}} : $@convention(thin) (@owned Node, @inout Queue) -> ()
+// CHECK-LABEL: } // end sil function 'testMayReleaseUniqNoSink'
+sil @testMayReleaseUniqNoSink : $@convention(thin) () -> () {
+bb0:
+  %queue = alloc_stack $Queue
+  %extraNode = alloc_ref $Node
+  %set = function_ref @setNode : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  strong_retain %extraNode : $Node
+  %call = apply %set(%extraNode, %queue) : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  dealloc_stack %queue : $*Queue
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// %queue is unique, but %extraNode is not. We can still sink because
+// there's no connection.
+//
+// CHECK-LABEL: sil @testMayReleaseUniqSink : $@convention(thin) () -> () {
+// CHECK: apply {{.*}} : $@convention(thin) (@owned Node, @inout Queue) -> ()
+// CHECK: strong_retain
+// CHECK-LABEL: } // end sil function 'testMayReleaseUniqSink'
+sil @testMayReleaseUniqSink : $@convention(thin) () -> () {
+bb0:
+  %queue = alloc_stack $Queue
+  %get = function_ref @getNode : $@convention(thin) () -> @owned Node
+  %extraNode = apply %get() : $@convention(thin) () -> @owned Node
+  %node = alloc_ref $Node
+  %set = function_ref @setNode : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  strong_retain %extraNode : $Node
+  %call = apply %set(%node, %queue) : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  dealloc_stack %queue : $*Queue
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// CG: %queue -> %node1 -> %node2
+//
+// If the retain of %node2 sink below the call to @setNode, then when
+// @inout %queue is overwritten by setNode, both node1 and node2 are
+// freed. The subsequent retain of %node2 will crash.
+//
+// This used to be allowed because we reasoned that a local reference
+// to %node2 should have "its own retain". This is true, but it's
+// still important not to sink that retain for that local reference
+// below a call where that object may be indirectly released via
+// another destroyed object.
+//
+// CHECK-LABEL: sil @testMayReleaseIndirectSink : $@convention(thin) () -> () {
+// CHECK: strong_retain
+// CHECK: apply {{.*}} : $@convention(thin) (@owned Node, @inout Queue) -> ()
+// CHECK-LABEL: } // end sil function 'testMayReleaseIndirectSink'
+sil @testMayReleaseIndirectSink : $@convention(thin) () -> () {
+bb0:
+  %set = function_ref @setNode : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  %queue = alloc_stack $Queue
+  %node1 = alloc_ref $Node
+  %node2 = alloc_ref $Node
+  %addr = ref_element_addr %node1 : $Node, #Node.node
+  store %node2 to %addr : $*Node
+  %call1 = apply %set(%node1, %queue) : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  %extraNode = alloc_ref $Node
+  strong_retain %node2 : $Node
+  // This call destroys %node1 which releases %node2.
+  %call2 = apply %set(%extraNode, %queue) : $@convention(thin) (@owned Node, @inout Queue) -> ()
+  dealloc_stack %queue : $*Queue
+  %12 = tuple ()
+  return %12 : $()
 }


### PR DESCRIPTION
The previous implementation made extremely subtle and specific
assumptions about how the API is used which doesn't apply
everywhere. It was trying very hard to avoid regressing performance
relative to an even older implementation that didn't even try to consider deinitializer side effects.

The aggressive logic was based on the idea that a release must have a
corresponding retain somewhere in the same function and we don't care
if the last release happens early if there are no more aliasing
uses. All the unit tests I wrote previously were based on release
hoisting, which happens to work given the way the API is used.

But this logic is incorrect for retain sinking. In that case sinking
past an "unrelated" release could cause the object to be freed
early. See test/SILOptimizer/arc_crash.swift.

With SemanticARC and other SIL improvements being made, I'm afraid
bugs like this will begin to surface.

To fix it, just remove the subtle logic to leave behind a simple and
sound EscapeAnalysis API. To do better, we will need to rewrite the
AliasAnalysis logic for release side effects, which is currently
a tangled web. In the meantime, SemanticARC can handle many cases without EscapeAnalysis.

Fixes rdar://74469299 (ARC miscompile:
EscapeAnalysis::mayReleaseContent; potential use-after-free)

While fixing this, add support for address-type queries too:

Fixes rdar://74360041 (Assertion failed:
(!releasedReference->getType().isAddress() && "an address is never a
reference"), function mayReleaseContent

---

Deinitializer side effects severely handicap the connection-graph
based EscapeAnalysis. Because it's not flow-sensitive, this approach
falls apart whenever an object is released in the current function,
which makes it seem to have escaped everywhere (it generally doesn't
matter if it doesn't escape until the release point, but the analysis
can't discern that).

This can be slightly mitigated by realizing that releasing an object
can only cause things it points to to escape if the object itself has
references or pointers.

Fix: Don't create a escaping content node when releasing an object
that can't contain any references or pointers.  The previous commit,
"Fix EscapeAnalysis::mayReleaseContent" would defeat release-hoisting
in important cases without doing anything else. Adding this extra
precision to the connection graph avoids some regressions.
