### PR TITLE
GSB: Fix getMinimalConformanceSource() for top-level requirements in a requirement signature

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2157,37 +2157,40 @@ void EquivalenceClass::dump(llvm::raw_ostream &out,
   }, [&]() {
     out << ", ";
   });
-  out << "\nConformances:";
-  interleave(conformsTo,
-             [&](const std::pair<
-                        ProtocolDecl *,
-                        std::vector<Constraint<ProtocolDecl *>>> &entry) {
-               out << entry.first->getNameStr();
-             },
-             [&] { out << ", "; });
-  out << "\nSame-type constraints:";
-  llvm::interleave(
-      sameTypeConstraints,
-      [&](const Constraint<Type> &constraint) {
-        out << "\n  " << constraint.getSubjectDependentType({})
-            << " == " << constraint.value;
+  out << "\n";
+  out << "Conformance constraints:\n";
+  for (auto entry : conformsTo) {
+    out << "  " << entry.first->getNameStr() << "\n";
+    for (auto constraint : entry.second) {
+      constraint.source->dump(out, &builder->getASTContext().SourceMgr, 4);
+      if (constraint.source->isDerivedRequirement())
+        out << " [derived]";
+      out << "\n";
+    }
+  }
 
-        if (constraint.source->isDerivedRequirement())
-          out << " [derived]";
-      },
-      [&] { out << ", "; });
+  out << "Same-type constraints:\n";
+  for (auto constraint : sameTypeConstraints) {
+    out << "  " << constraint.getSubjectDependentType({})
+        << " == " << constraint.value << "\n";
+    constraint.source->dump(out, &builder->getASTContext().SourceMgr, 4);
+    if (constraint.source->isDerivedRequirement())
+      out << " [derived]";
+    out << "\n";
+  }
+
   if (concreteType)
-    out << "\nConcrete type: " << concreteType.getString();
+    out << "Concrete type: " << concreteType.getString() << "\n";
   if (superclass)
-    out << "\nSuperclass: " << superclass.getString();
+    out << "Superclass: " << superclass.getString() << "\n";
   if (layout)
-    out << "\nLayout: " << layout.getString();
+    out << "Layout: " << layout.getString() << "\n";
 
   if (!delayedRequirements.empty()) {
-    out << "\nDelayed requirements:";
+    out << "Delayed requirements:\n";
     for (const auto &req : delayedRequirements) {
-      out << "\n  ";
       req.dump(out);
+      out << "\n";
     }
   }
 

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -820,6 +820,19 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
     switch (source->kind) {
     case ProtocolRequirement:
     case InferredProtocolRequirement: {
+      // Special handling for top-level requirement signature requirements;
+      // pretend the root type is the subject type as written in the
+      // protocol, and not 'Self', so that we can consider this requirement
+      // self-derived if it depends on one of the conformances that make
+      // the root type valid.
+      if (requirementSignatureSelfProto) {
+        if (source->getProtocolDecl() == requirementSignatureSelfProto &&
+            source->parent->kind == RequirementSource::RequirementSignatureSelf) {
+          rootType = source->getAffectedType();
+          return false;
+        }
+      }
+
       // Note that we've seen a protocol requirement.
       sawProtocolRequirement = true;
 

--- a/test/Generics/sr13850.swift
+++ b/test/Generics/sr13850.swift
@@ -1,0 +1,27 @@
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// https://bugs.swift.org/browse/SR-13850
+
+// CHECK: Requirement signature: <Self where Self.A : P2>
+protocol P1 {
+  associatedtype A: P2
+}
+
+// CHECK: Requirement signature: <Self>
+protocol P2 {
+  associatedtype A
+}
+
+// Neither one of 'P3', 'P4' or 'f()' should have diagnosed
+// redundant conformance requirements.
+
+// CHECK: Requirement signature: <Self where Self : P2, Self == Self.A.A, Self.A : P1>
+protocol P3 : P2 where Self.A: P1, Self.A.A == Self { }
+
+// CHECK: Requirement signature: <Self where Self.X : P2, Self.X == Self.X.A.A, Self.X.A : P1>
+protocol P4 {
+  associatedtype X where X : P2, X.A: P1, X.A.A == X
+}
+
+// CHECK: Generic signature: <T where T : P2, T == T.A.A, T.A : P1>
+func f<T : P2>(_: T) where T.A : P1, T.A.A == T { }


### PR DESCRIPTION
Consider the following program:

```
protocol P1 {
  associatedtype A : P2
}

protocol P2 {
  associatedtype A
}

func f<T>(_: T) where T : P2, T.A : P1, T.A.A == T {}
```

There are two proofs of T : P2:

- The explicit requirement in f()'s generic signature.

- Since T.A.A == T, we can also prove T : P2 via T.A.A : P2:
  - First, we prove that T.A : P1 via the explicit requirement
    in f()'s generic signature.
  - Second, we prove that T.A.A : P1 via Self.A : P2 in P1's
    requirement signature.

However, the second proof does not render the explicit requirement
T : P2 redundant, because it relies on the existence of the
nested type T.A, which only exists if T : P2.

This is captured in getMinimalConformanceSource(), which returns
nullptr for the requirement source corresponding to the second proof
above. It does this by looking at the root type of the requirement
source, T.A.

Now consider the analogous situation but with protocols -- let's
replace f() with a protocol P3:

```
protocol P3 : P2 where Self.A : P1, Self.A.A == Self {}
```

Here, we also have two proofs of Self : P2:

- The explicit requirement in P3's requirement signature.
  - First, we prove that Self.A : P1 via the explicit requirement
    in P3's requirement siganture.
  - Second, we prove that Self.A.A : P1 via Self.A : P2 in P1's
    requirement signature.

Once again, the second proof implicitly depends on the explicit
requirement, so we cannot use it to mark the explicit requirement
as redundant. However, since the requirement source root type here
is just 'Self', we were unable to recognize this, and we would
diagnose the requirement as redundant and drop it, resulting in
computing an invalid requirement signature for protocol P3.

To fix this, handle requirements at the top level of a protocol
requirement signature just like they are explicit requirements.

Fixes https://bugs.swift.org/browse/SR-13850 / rdar://problem/71377571.
