### PR TITLE
Simplify printing of marker protocols in Swift interfaces

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -968,8 +968,21 @@ public:
 
     ASTVisitor::visit(D);
 
-    if (haveFeatureChecks)
+    if (haveFeatureChecks) {
+      // If we guarded a marker protocol, print an alternative typealias
+      // for Any.
+      if (auto proto = dyn_cast<ProtocolDecl>(D)) {
+        if (proto->isMarkerProtocol()) {
+          Printer.printNewline();
+          Printer << "#else";
+          Printer.printNewline();
+          printAccess(proto);
+          Printer << "typealias " << proto->getName() << " = Any";
+        }
+      }
+
       printCompatibilityFeatureChecksPost(Printer);
+    }
 
     if (Synthesize) {
       Printer.setSynthesizedTarget({});
@@ -2426,53 +2439,16 @@ static bool usesFeatureAsyncAwait(Decl *decl) {
 }
 
 static bool usesFeatureMarkerProtocol(Decl *decl) {
-  // Check an inheritance clause for a marker protocol.
-  auto checkInherited = [&](ArrayRef<TypeLoc> inherited) -> bool {
-    for (const auto &inheritedEntry : inherited) {
-      if (auto inheritedType = inheritedEntry.getType()) {
-        if (inheritedType->isExistentialType()) {
-          auto layout = inheritedType->getExistentialLayout();
-          for (ProtocolType *protoTy : layout.getProtocols()) {
-            if (protoTy->getDecl()->isMarkerProtocol())
-              return true;
-          }
-        }
-      }
-    }
-
-    return false;
-  };
-
-  // Check generic requirements for a marker protocol.
-  auto checkRequirements = [&](ArrayRef<Requirement> requirements) -> bool {
-    for (const auto &req: requirements) {
-      if (req.getKind() == RequirementKind::Conformance &&
-          req.getSecondType()->castTo<ProtocolType>()->getDecl()
-              ->isMarkerProtocol())
-        return true;
-    }
-
-    return false;
-  };
-
   if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
     if (proto->isMarkerProtocol())
-      return true;
-
-    if (checkInherited(proto->getInherited()))
-      return true;
-
-    if (checkRequirements(proto->getRequirementSignature()))
       return true;
   }
 
   if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    if (checkRequirements(ext->getGenericRequirements()))
-      return true;
-
-    if (checkInherited(ext->getInherited()))
-      return true;
-  }
+    if (auto proto = ext->getSelfProtocolDecl())
+      if (proto->isMarkerProtocol())
+        return true;
+  }       
 
   return false;
 }

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -32,20 +32,32 @@ public extension MyActor {
 public func globalAsync() async { }
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: public protocol MP
+// CHECK-NEXT: public protocol MP {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public typealias MP = Any
+// CHECK-NEXT: #endif
 @_marker public protocol MP { }
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
 // CHECK-NEXT: @_marker public protocol MP2 : FeatureTest.MP {
 // CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public typealias MP2 = Any
 // CHECK-NEXT: #endif
 @_marker public protocol MP2: MP { }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: public protocol MP3
+// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK: public protocol MP3 : FeatureTest.MP {
 // CHECK-NEXT: }
 public protocol MP3: MP { }
-// CHECK-NEXT: #endif
+
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: extension MP2 {
+// CHECK-NEXT: func inMP2
+extension MP2 {
+  public func inMP2() { }
+}
 
 // CHECK: class OldSchool {
 public class OldSchool: MP {
@@ -55,17 +67,15 @@ public class OldSchool: MP {
   public func takeClass() async { }
 }
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension Array : FeatureTest.MP where Element : FeatureTest.MP {
+// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK: extension Array : FeatureTest.MP where Element : FeatureTest.MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
 // CHECK-NEXT: }
-// CHECK-NEXT: #endif
 
-// CHECK: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK-NEXT: extension OldSchool : Swift.UnsafeConcurrentValue {
+// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK: extension OldSchool : Swift.UnsafeConcurrentValue {
 extension OldSchool: UnsafeConcurrentValue { }
 // CHECK-NEXT: }
-// CHECK-NEXT: #endif
 
 // CHECK: #if compiler(>=5.3) && $AsyncAwait
 // CHECK-NEXT: func runSomethingSomewhere


### PR DESCRIPTION
Thanks to a great idea from Slava, simplify the printing of marker
protocols in Swift interfaces while maintaining backward compatibility.
For compilers that cannot handle marker protocols, print a typealias
to `Any` instead, which is a good stand-in for just about everything.
