### PR TITLE
Enable CopyPropagation consistently at -Onone for all object lifetimes.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -837,6 +837,9 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   P.startPipeline("non-Diagnostic Enabling Mandatory Optimizations");
   P.addForEachLoopUnroll();
   P.addMandatoryCombine();
+  P.addMandatoryCopyPropagation();
+  // TODO: GuaranteedARCOpts should be subsumed by CopyPropagation. There should
+  // be no need to run another analysis of copies at -Onone.
   P.addGuaranteedARCOpts();
 
   // First serialize the SIL if we are asked to.

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -83,9 +83,14 @@ void CopyPropagation::run() {
   llvm::SmallSetVector<SILValue, 16> copiedDefs;
   for (auto &bb : *f) {
     for (auto &i : bb) {
-      if (auto *copy = dyn_cast<CopyValueInst>(&i))
+      if (auto *copy = dyn_cast<CopyValueInst>(&i)) {
         copiedDefs.insert(
             CanonicalizeOSSALifetime::getCanonicalCopiedDef(copy));
+      } else if (auto *destroy = dyn_cast<DestroyValueInst>(&i)) {
+        copiedDefs.insert(
+          CanonicalizeOSSALifetime::getCanonicalCopiedDef(
+            destroy->getOperand()));
+      }
     }
   }
   // Perform copy propgation for each copied value.


### PR DESCRIPTION
Consistently shorten lifetimes of owned values, regardless of whether
copies are present.

This is important for establishing predictable objects
lifetimes. Without this, changes to unrelated code could result in
lifetime shortening and weak reference invalidation that would be very
hard to track down.

Fixes rdar://74296982 (Enable object lifetime shortening for all objects)

Also enable MandatoryCopyPropagation at -Onone

This won't be quite as powerful as the -O form of the pass because it
needs to respect debug information (this version of the pass won't
remove debug_value instructions).

There are two reasons to do this, both related to predictable behavior
across Debug and Release builds.

1. Shortening object lifetimes can cause observable changes in program
   behavior in the presense of weak/unowned reference and
   deinitializer side effects.

2. Programmers need to know reliably whether a given code pattern will
   copy the storage for copy-on-write types (Array, Set). Eliminating
   the "unexpected" copies the same way at -Onone and -O both makes
   debugging tractable and provides assurance that the code isn't
   relying on the luck of the optimizer in a particular compiler
   release.

Fixes rdar://73903961 (Enable CopyPropagation at -Onone)
