### PR TITLE
Semantic fixes for marker protocols

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5625,8 +5625,8 @@ ERROR(marker_protocol_requirement, none,
 ERROR(marker_protocol_inherit_nonmarker, none,
       "marker protocol %0 cannot inherit non-marker protocol %1",
       (DeclName, DeclName))
-ERROR(marker_protocol_value,none,
-      "marker protocol %0 can only be used in generic constraints", (DeclName))
+ERROR(marker_protocol_cast,none,
+      "marker protocol %0 cannot be used in a conditional cast", (DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: differentiable programming diagnostics

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -918,8 +918,8 @@ ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
 
   // Due to an IRGen limitation, witness tables cannot be passed from an
   // existential to an archetype parameter, so for now we restrict this to
-  // @objc protocols.
-  if (!layout.isObjC()) {
+  // @objc protocols and marker protocols.
+  if (!layout.isObjC() && !protocol->isMarkerProtocol()) {
     // There's a specific exception for protocols with self-conforming
     // witness tables, but the existential has to be *exactly* that type.
     // TODO: synthesize witness tables on-demand for protocol compositions

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -643,8 +643,12 @@ ProtocolRequiresClassRequest::evaluate(Evaluator &evaluator,
 bool
 ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
                                            ProtocolDecl *decl) const {
-  // If it's not @objc, it conforms to itself only if it has a self-conformance
-  // witness table.
+  // Marker protocols always self-conform.
+  if (decl->isMarkerProtocol())
+    return true;
+
+  // Otherwise, if it's not @objc, it conforms to itself only if it has a
+  // self-conformance witness table.
   if (!decl->isObjC())
     return decl->requiresSelfConformanceWitnessTable();
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3906,12 +3906,6 @@ public:
                            proto->getName());
         T->setInvalid();
       }
-      if (proto->isMarkerProtocol()) {
-        Ctx.Diags.diagnose(comp->getNameLoc(),
-                           diag::marker_protocol_value,
-                           proto->getName());
-        T->setInvalid();
-      }
     } else if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(comp->getBoundDecl())) {
       auto type = Type(alias->getDeclaredInterfaceType()->getDesugaredType());
       type.findIf([&](Type type) -> bool {
@@ -3921,15 +3915,6 @@ public:
           auto layout = type->getExistentialLayout();
           for (auto *proto : layout.getProtocols()) {
             auto *protoDecl = proto->getDecl();
-
-            if (protoDecl->isMarkerProtocol()) {
-              Ctx.Diags.diagnose(comp->getNameLoc(),
-                                 diag::marker_protocol_value,
-                                 protoDecl->getName());
-              T->setInvalid();
-              continue;
-            }
-
             if (protoDecl->existentialTypeSupported())
               continue;
             

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -38,14 +38,14 @@ func testGenericOk(i: Int, arr: [Int], nope: [Double]) {
 
 // Incorrect uses of marker protocols in types.
 func testNotOkay(a: Any) {
-  var mp1: P3 = 17 // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+  var mp1: P3 = 17
   _ = mp1
   mp1 = 17
 
-  if let mp2 = a as? P3 { _ = mp2 } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
-  if let mp3 = a as? AnyObject & P3 { _ = mp3 } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
-  if a is AnyObject & P3 { } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+  if let mp2 = a as? P3 { _ = mp2 } // expected-error{{marker protocol 'P3' cannot be used in a conditional cast}}
+  if let mp3 = a as? AnyObject & P3 { _ = mp3 } // expected-error{{marker protocol 'P3' cannot be used in a conditional cast}}
+  if a is AnyObject & P3 { } // expected-error{{marker protocol 'P3' cannot be used in a conditional cast}}
 
-  func inner(p3: P3) { } // expected-error{{marker protocol 'P3' can only be used in generic constraints}}
+  func inner(p3: P3) { }
 }
 

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -30,10 +30,12 @@ protocol P6: P3 { } // okay
 
 func genericOk<T: P3>(_: T) { }
 
-func testGenericOk(i: Int, arr: [Int], nope: [Double]) {
+func testGenericOk(i: Int, arr: [Int], nope: [Double], p3: P3, p3array: [P3]) {
   genericOk(i)
   genericOk(arr)
   genericOk(nope) // expected-error{{global function 'genericOk' requires that 'Double' conform to 'P3'}}
+  genericOk(p3)
+  genericOk(p3array)
 }
 
 // Incorrect uses of marker protocols in types.


### PR DESCRIPTION
Two semantic fixes for marker protocols:
* They can be used in values of existential type, so long as they aren't on the right-hand side of `as?` or `is` conditional casts, and
* They are self-conforming, by definition.