### PR TITLE
[Serialization] Only diagnose invalid declarations when allowing errors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -779,9 +779,6 @@ NOTE(serialization_compatibility_version_mismatch,none,
 ERROR(serialization_allowing_invalid_decl,none,
       "allowing deserialization of invalid declaration %0 from module '%1'",
       (DeclName, StringRef))
-ERROR(serialization_invalid_decl,Fatal,
-      "invalid declaration %0 read from module '%1'; "
-      SWIFT_BUG_REPORT_MESSAGE, ())
 
 ERROR(reserved_member_name,none,
       "type member must not be named %0, since it would conflict with the"

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4085,11 +4085,8 @@ ModuleFile::getDeclChecked(
       return deserialized;
 
     auto *decl = declOrOffset.get();
-    if (decl->isInvalid()) {
-      if (!isAllowModuleWithCompilerErrorsEnabled()) {
-        getContext().Diags.diagnose(SourceLoc(),
-                                    diag::serialization_invalid_decl);
-      } else if (!isa<ParamDecl>(decl) && !decl->isImplicit()) {
+    if (isAllowModuleWithCompilerErrorsEnabled() && decl->isInvalid()) {
+      if (!isa<ParamDecl>(decl) && !decl->isImplicit()) {
         // The parent function will be invalid if the parameter is invalid,
         // implicits should have an invalid explicit as well
         if (auto *VD = dyn_cast<ValueDecl>(decl)) {


### PR DESCRIPTION
Remove the invalid declaration check when deserializing decls as it is
currently causing failures. Will investigate separately.

rdar://74514357