### PR TITLE
MemoryLifetimeVerifier: support verifying enum memory locations.

### DIFF
--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -634,8 +634,11 @@ public:
     auto &errorTL = SGF.getTypeLowering(errorType);
 
     // Allocate a temporary.
+    // It's flagged with "hasDynamicLifetime" because it's not possible to
+    // statically verify the lifetime of the value.
     SILValue errorTemp =
-        SGF.emitTemporaryAllocation(loc, errorTL.getLoweredType());
+        SGF.emitTemporaryAllocation(loc, errorTL.getLoweredType(),
+                                    /*hasDynamicLifetime*/ true);
 
     // Nil-initialize it.
     SGF.emitInjectOptionalNothingInto(loc, errorTemp, errorTL);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1021,13 +1021,13 @@ RValue RValueEmitter::visitLoadExpr(LoadExpr *E, SGFContext C) {
   return SGF.emitLoadOfLValue(E, std::move(lv), C.withFollowingSideEffects());
 }
 
-SILValue SILGenFunction::emitTemporaryAllocation(SILLocation loc,
-                                                 SILType ty) {
+SILValue SILGenFunction::emitTemporaryAllocation(SILLocation loc, SILType ty,
+                                                 bool hasDynamicLifetime) {
   ty = ty.getObjectType();
   Optional<SILDebugVariable> DbgVar;
   if (auto *VD = loc.getAsASTNode<VarDecl>())
     DbgVar = SILDebugVariable(VD->isLet(), 0);
-  auto alloc = B.createAllocStack(loc, ty, DbgVar);
+  auto alloc = B.createAllocStack(loc, ty, DbgVar, hasDynamicLifetime);
   enterDeallocStackCleanup(alloc);
   return alloc;
 }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -955,7 +955,8 @@ public:
   
   /// Emits a temporary allocation that will be deallocated automatically at the
   /// end of the current scope. Returns the address of the allocation.
-  SILValue emitTemporaryAllocation(SILLocation loc, SILType ty);
+  SILValue emitTemporaryAllocation(SILLocation loc, SILType ty,
+                                   bool hasDynamicLifetime = false);
   
   /// Prepares a buffer to receive the result of an expression, either using the
   /// 'emit into' initialization buffer if available, or allocating a temporary

--- a/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
@@ -123,7 +123,10 @@ class DestroyHoisting {
 
 public:
   DestroyHoisting(SILFunction *function, DominanceAnalysis *DA) :
-    function(function), DA(DA) { }
+    function(function),
+    // We currently don't handle enum data projections, because they cannot
+    // re-created easily. We could support this in future.
+    locations(/*handleEnumDataProjections*/ false), DA(DA) {}
 
   bool hoistDestroys();
 };
@@ -348,6 +351,7 @@ void DestroyHoisting::getUsedLocationsOfInst(Bits &bits, SILInstruction *I) {
     case SILInstructionKind::LoadInst:
     case SILInstructionKind::StoreInst:
     case SILInstructionKind::CopyAddrInst:
+    case SILInstructionKind::InjectEnumAddrInst:
     case SILInstructionKind::ApplyInst:
     case SILInstructionKind::TryApplyInst:
     case SILInstructionKind::YieldInst:

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -394,3 +394,73 @@ bb3:
   %9999 = tuple()
   return %9999 : $()
 }
+
+sil [ossa] @test_switch_enum_addr : $@convention(thin) (@in Optional<T>) -> () {
+bb0(%0 : $*Optional<T>):
+  switch_enum_addr %0 : $*Optional<T>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1:
+  %2 = unchecked_take_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  destroy_addr %2 : $*T
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @test_switch_enum : $@convention(thin) (@in Optional<T>) -> () {
+bb0(%0 : $*Optional<T>):
+  %1 = load_borrow %0 : $*Optional<T>
+  switch_enum %1 : $Optional<T>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%3 : $T):
+  end_borrow %1 : $Optional<T>
+  %2 = unchecked_take_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  destroy_addr %2 : $*T
+  br bb3
+
+bb2:
+  end_borrow %1 : $Optional<T>
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @test_init_enum : $@convention(thin) (@in_guaranteed T) -> @out Optional<T> {
+bb0(%0 : $*Optional<T>, %1 : $*T):
+  cond_br undef, bb1, bb2
+
+bb1:
+  inject_enum_addr %0 : $*Optional<T>, #Optional.none!enumelt
+  br bb3
+
+bb2:
+  %5 = init_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  copy_addr %1 to [initialization] %5 : $*T
+  inject_enum_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+sil [ossa] @test_store_to_enum : $@convention(thin) (@owned T) -> () {
+bb0(%0 : @owned $T):
+  %1 = alloc_stack $Optional<T>
+  %2 = enum $Optional<T>, #Optional.some!enumelt, %0 : $T
+  store %2 to [init] %1 : $*Optional<T>
+  destroy_addr %1 : $*Optional<T>
+  %3 = enum $Optional<T>, #Optional.none!enumelt
+  store %3 to [trivial] %1 : $*Optional<T>
+  dealloc_stack %1 : $*Optional<T>
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -168,3 +168,73 @@ bb0(%0 : $Int):
   return %3 : $Int
 }
 
+// CHECK: SIL memory lifetime failure in @test_switch_enum_addr: memory is initialized at function return but shouldn't
+sil [ossa] @test_switch_enum_addr : $@convention(thin) (@in Optional<T>) -> () {
+bb0(%0 : $*Optional<T>):
+  switch_enum_addr %0 : $*Optional<T>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1:
+  %2 = unchecked_take_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK: SIL memory lifetime failure in @test_switch_enum: memory is initialized at function return but shouldn't
+sil [ossa] @test_switch_enum : $@convention(thin) (@in Optional<T>) -> () {
+bb0(%0 : $*Optional<T>):
+  %1 = load_borrow %0 : $*Optional<T>
+  switch_enum %1 : $Optional<T>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%3 : $T):
+  end_borrow %1 : $Optional<T>
+  %2 = unchecked_take_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  br bb3
+
+bb2:
+  end_borrow %1 : $Optional<T>
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK: SIL memory lifetime failure in @test_init_enum: indirect argument is not alive at function return
+sil [ossa] @test_init_enum : $@convention(thin) (@in_guaranteed T) -> @out Optional<T> {
+bb0(%0 : $*Optional<T>, %1 : $*T):
+  cond_br undef, bb1, bb2
+
+bb1:
+  inject_enum_addr %0 : $*Optional<T>, #Optional.none!enumelt
+  br bb3
+
+bb2:
+  %5 = init_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  inject_enum_addr %0 : $*Optional<T>, #Optional.some!enumelt
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK: SIL memory lifetime failure in @test_store_to_enum: memory is initialized, but shouldn't
+sil [ossa] @test_store_to_enum : $@convention(thin) (@owned T) -> () {
+bb0(%0 : @owned $T):
+  %1 = alloc_stack $Optional<T>
+  %2 = enum $Optional<T>, #Optional.none!enumelt
+  store %2 to [trivial] %1 : $*Optional<T>
+  destroy_addr %1 : $*Optional<T>
+  %3 = enum $Optional<T>, #Optional.some!enumelt, %0 : $T
+  store %3 to [init] %1 : $*Optional<T>
+  dealloc_stack %1 : $*Optional<T>
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -11,7 +11,7 @@ import errors
 // CHECK-LABEL: sil hidden [ossa] @$s14foreign_errors5test0yyKF : $@convention(thin) () -> @error Error
 func test0() throws {
   //   Create a strong temporary holding nil before we perform any further parts of function emission.
-  // CHECK: [[ERR_TEMP0:%.*]] = alloc_stack $Optional<NSError>
+  // CHECK: [[ERR_TEMP0:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
   // CHECK: inject_enum_addr [[ERR_TEMP0]] : $*Optional<NSError>, #Optional.none!enumelt
 
   // CHECK: [[SELF:%.*]] = metatype $@objc_metatype ErrorProne.Type
@@ -154,7 +154,7 @@ let fn = ErrorProne.fail
 // CHECK-NEXT: return [[T1]]
 
 // CHECK-LABEL: sil private [ossa] @$s14foreign_errors2fnyyKcvpfiyyKcSo10ErrorProneCmcfu_yyKcfu0_ : $@convention(thin) (@thick ErrorProne.Type) -> @error Error {
-// CHECK:      [[TEMP:%.*]] = alloc_stack $Optional<NSError>
+// CHECK:      [[TEMP:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
 // CHECK:      [[SELF:%.*]] = thick_to_objc_metatype %0 : $@thick ErrorProne.Type to $@objc_metatype ErrorProne.Type
 // CHECK:      [[METHOD:%.*]] = objc_method [[SELF]] : $@objc_metatype ErrorProne.Type, #ErrorProne.fail!foreign : (ErrorProne.Type) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> ObjCBool
 // CHECK:      [[RESULT:%.*]] = apply [[METHOD]]({{%.*}}, [[SELF]])
@@ -236,7 +236,7 @@ func testNonNilError() throws -> Float {
   return try ErrorProne.bounce()
 }
 // CHECK-LABEL: sil hidden [ossa] @$s14foreign_errors15testNonNilErrorSfyKF :
-// CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
+// CHECK:   [[OPTERR:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
 // CHECK:   [[T0:%.*]] = metatype $@objc_metatype ErrorProne.Type
 // CHECK:   [[T1:%.*]] = objc_method [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.bounce!foreign : (ErrorProne.Type) -> () throws -> Float, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Float
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
@@ -252,7 +252,7 @@ func testPreservedResult() throws -> CInt {
   return try ErrorProne.ounce()
 }
 // CHECK-LABEL: sil hidden [ossa] @$s14foreign_errors19testPreservedResults5Int32VyKF
-// CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
+// CHECK:   [[OPTERR:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
 // CHECK:   [[T0:%.*]] = metatype $@objc_metatype ErrorProne.Type
 // CHECK:   [[T1:%.*]] = objc_method [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.ounce!foreign : (ErrorProne.Type) -> () throws -> Int32, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int32
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
@@ -270,7 +270,7 @@ func testPreservedResultBridged() throws -> Int {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s14foreign_errors26testPreservedResultBridgedSiyKF
-// CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
+// CHECK:   [[OPTERR:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
 // CHECK:   [[T0:%.*]] = metatype $@objc_metatype ErrorProne.Type
 // CHECK:   [[T1:%.*]] = objc_method [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.ounceWord!foreign : (ErrorProne.Type) -> () throws -> Int, $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](
@@ -288,7 +288,7 @@ func testPreservedResultInverted() throws {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s14foreign_errors27testPreservedResultInvertedyyKF
-// CHECK:   [[OPTERR:%.*]] = alloc_stack $Optional<NSError>
+// CHECK:   [[OPTERR:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
 // CHECK:   [[T0:%.*]] = metatype $@objc_metatype ErrorProne.Type
 // CHECK:   [[T1:%.*]] = objc_method [[T0]] : $@objc_metatype ErrorProne.Type, #ErrorProne.once!foreign : (ErrorProne.Type) -> () throws -> (), $@convention(objc_method) (Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype ErrorProne.Type) -> Int32
 // CHECK:   [[RESULT:%.*]] = apply [[T1]](

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -48,7 +48,7 @@ extension Hive {
   // CHECK:   [[SELF_BOX:%.*]] = alloc_box ${ var Hive }, let, name "self"
   // CHECK:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[MU]] : ${ var Hive }, 0
-  // CHECK:   [[FOREIGN_ERROR_STACK:%.*]] = alloc_stack $Optional<NSError>
+  // CHECK:   [[FOREIGN_ERROR_STACK:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
   // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [[QUEEN]]
   // CHECK:   [[COPIED_BORROWED_QUEEN:%.*]] = copy_value [[BORROWED_QUEEN]]

--- a/test/SILOptimizer/accesspath_uses_ossa.sil
+++ b/test/SILOptimizer/accesspath_uses_ossa.sil
@@ -897,6 +897,8 @@ bb5:
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  %{{.*}} = load [copy] %1 : $*Optional<AnyObject>
 // CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  destroy_addr %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  dealloc_stack %1 : $*Optional<AnyObject>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT: }
@@ -909,6 +911,8 @@ bb5:
 // CHECK-NEXT:  inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  %{{.*}} = load [copy] %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  destroy_addr %1 : $*Optional<AnyObject>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  dealloc_stack %1 : $*Optional<AnyObject>
 // CHECK-NEXT:  Path: ()
@@ -923,6 +927,8 @@ bb5:
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  %{{.*}} = load [copy] %1 : $*Optional<AnyObject>
 // CHECK-NEXT:  Path: ()
+// CHECK-NEXT:  destroy_addr %1 : $*Optional<AnyObject>
+// CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  dealloc_stack %1 : $*Optional<AnyObject>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT: }
@@ -933,6 +939,7 @@ bb0(%0 : @owned $AnyObject):
   store %0 to [init] %2 : $*AnyObject
   inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
   %5 = load [copy] %1 : $*Optional<AnyObject>
+  destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   return %5 : $Optional<AnyObject>
 }

--- a/test/SILOptimizer/load_borrow_verify.sil
+++ b/test/SILOptimizer/load_borrow_verify.sil
@@ -73,6 +73,7 @@ bb0(%0 : @owned $AnyObject):
   inject_enum_addr %1 : $*Optional<AnyObject>, #Optional.some!enumelt
   %5 = load_borrow %1 : $*Optional<AnyObject>
   end_borrow %5 : $Optional<AnyObject>
+  destroy_addr %1 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   %99 = tuple ()
   return %99 : $()


### PR DESCRIPTION
This is kind of complicated, because an enum can be trivial for one case and not trivial for another case. We need to check at which parts of the function we can prove that the enum does (or could) have a trivial case. In such a branch, it's not required in SIL to destroy the enum location.

Also, I added some documentation of the rules and requirements for enum memory locations in SIL.rst.

rdar://73770085
