### PR TITLE
Patch a Huge Soundness Hole in Codable Synthesis

### DIFF
--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -53,13 +53,118 @@ static Identifier getVarNameForCoding(VarDecl *var) {
   return var->getName();
 }
 
+// Create CodingKeys in the parent type always, because both
+// Encodable and Decodable might want to use it, and they may have
+// different conditional bounds. CodingKeys is simple and can't
+// depend on those bounds.
+//
+// FIXME: Eventually we should find a way to expose this function to the lookup
+// machinery so it no longer costs two protocol conformance lookups to retrieve
+// CodingKeys. It will also help in our quest to separate semantic and parsed
+// members.
+static EnumDecl *addImplicitCodingKeys(NominalTypeDecl *target) {
+  auto &C = target->getASTContext();
+  assert(target->lookupDirect(DeclName(C.Id_CodingKeys)).empty());
+
+  // We want to look through all the var declarations of this type to create
+  // enum cases based on those var names.
+  auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
+  auto codingKeyType = codingKeyProto->getDeclaredInterfaceType();
+  TypeLoc protoTypeLoc[1] = {TypeLoc::withoutLoc(codingKeyType)};
+  ArrayRef<TypeLoc> inherited = C.AllocateCopy(protoTypeLoc);
+
+  auto *enumDecl = new (C) EnumDecl(SourceLoc(), C.Id_CodingKeys, SourceLoc(),
+                                    inherited, nullptr, target);
+  enumDecl->setImplicit();
+  enumDecl->setSynthesized();
+  enumDecl->setAccess(AccessLevel::Private);
+
+  // For classes which inherit from something Encodable or Decodable, we
+  // provide case `super` as the first key (to be used in encoding super).
+  auto *classDecl = dyn_cast<ClassDecl>(target);
+  if (superclassConformsTo(classDecl, KnownProtocolKind::Encodable) ||
+      superclassConformsTo(classDecl, KnownProtocolKind::Decodable)) {
+    // TODO: Ensure the class doesn't already have or inherit a variable named
+    // "`super`"; otherwise we will generate an invalid enum. In that case,
+    // diagnose and bail.
+    auto *super = new (C) EnumElementDecl(SourceLoc(), C.Id_super, nullptr,
+                                          SourceLoc(), nullptr, enumDecl);
+    super->setImplicit();
+    enumDecl->addMember(super);
+  }
+
+  for (auto *varDecl : target->getStoredProperties()) {
+    if (!varDecl->isUserAccessible()) {
+      continue;
+    }
+
+    auto *elt =
+        new (C) EnumElementDecl(SourceLoc(), getVarNameForCoding(varDecl),
+                                nullptr, SourceLoc(), nullptr, enumDecl);
+    elt->setImplicit();
+    enumDecl->addMember(elt);
+  }
+
+  // Forcibly derive conformance to CodingKey.
+  TypeChecker::checkConformancesInContext(enumDecl);
+
+  // Add to the type.
+  target->addMember(enumDecl);
+
+  return enumDecl;
+}
+
 /// Validates the given CodingKeys enum decl by ensuring its cases are a 1-to-1
 /// match with the stored vars of the given type.
-///
-/// \param codingKeysDecl The \c CodingKeys enum decl to validate.
-static bool validateCodingKeysEnum(const DerivedConformance &derived,
-                                   EnumDecl *codingKeysDecl) {
-  auto conformanceDC = derived.getConformanceContext();
+static bool validateCodingKeysEnum(DerivedConformance &derived) {
+  auto &C = derived.Context;
+  auto codingKeysDecls =
+      derived.Nominal->lookupDirect(DeclName(C.Id_CodingKeys));
+
+  if (codingKeysDecls.size() > 1) {
+    return false;
+  }
+
+  ValueDecl *result = codingKeysDecls.empty()
+                          ? addImplicitCodingKeys(derived.Nominal)
+                          : codingKeysDecls.front();
+  auto *codingKeysTypeDecl = dyn_cast<TypeDecl>(result);
+  if (!codingKeysTypeDecl) {
+    result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,
+                     derived.getProtocolType());
+    return false;
+  }
+
+  // CodingKeys may be a typealias. If so, follow the alias to its canonical
+  // type.
+  auto codingKeysType = codingKeysTypeDecl->getDeclaredInterfaceType();
+  if (isa<TypeAliasDecl>(codingKeysTypeDecl))
+    codingKeysTypeDecl = codingKeysType->getAnyNominal();
+
+  // Ensure that the type we found conforms to the CodingKey protocol.
+  auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
+  if (!TypeChecker::conformsToProtocol(codingKeysType, codingKeyProto,
+                                       derived.getConformanceContext())) {
+    // If CodingKeys is a typealias which doesn't point to a valid nominal type,
+    // codingKeysTypeDecl will be nullptr here. In that case, we need to warn on
+    // the location of the usage, since there isn't an underlying type to
+    // diagnose on.
+    SourceLoc loc = codingKeysTypeDecl ? codingKeysTypeDecl->getLoc()
+                                       : cast<TypeDecl>(result)->getLoc();
+
+    C.Diags.diagnose(loc, diag::codable_codingkeys_type_does_not_conform_here,
+                     derived.getProtocolType());
+    return false;
+  }
+
+  auto *codingKeysDecl =
+      dyn_cast_or_null<EnumDecl>(codingKeysType->getAnyNominal());
+  if (!codingKeysDecl) {
+    codingKeysTypeDecl->diagnose(
+        diag::codable_codingkeys_type_is_not_an_enum_here,
+        derived.getProtocolType());
+    return false;
+  }
 
   // Look through all var decls in the given type.
   // * Filter out lazy/computed vars.
@@ -93,9 +198,10 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
     }
 
     // We have a property to map to. Ensure it's {En,De}codable.
-    auto target =
-        conformanceDC->mapTypeIntoContext(it->second->getValueInterfaceType());
-    if (TypeChecker::conformsToProtocol(target, derived.Protocol, conformanceDC)
+    auto target = derived.getConformanceContext()->mapTypeIntoContext(
+        it->second->getValueInterfaceType());
+    if (TypeChecker::conformsToProtocol(target, derived.Protocol,
+                                        derived.getConformanceContext())
             .isInvalid()) {
       TypeLoc typeLoc = {
           it->second->getTypeReprOrParentPatternTypeRepr(),
@@ -136,164 +242,6 @@ static bool validateCodingKeysEnum(const DerivedConformance &derived,
   }
 
   return propertiesAreValid;
-}
-
-/// A type which has information about the validity of an encountered
-/// \c CodingKeys type.
-enum class CodingKeysClassification {
-  /// A \c CodingKeys declaration was found, but it is invalid.
-  Invalid,
-  /// No \c CodingKeys declaration was found, so it must be synthesized.
-  NeedsSynthesizedCodingKeys,
-  /// A valid \c CodingKeys declaration was found.
-  Valid,
-};
-
-/// Returns whether the given type has a valid nested \c CodingKeys enum.
-///
-/// If the type has an invalid \c CodingKeys entity, produces diagnostics to
-/// complain about the error. In this case, the error result will be true -- in
-/// the case where we don't have a valid CodingKeys enum and have produced
-/// diagnostics here, we don't want to then attempt to synthesize a CodingKeys
-/// enum.
-///
-/// \returns A \c CodingKeysValidity value representing the result of the check.
-static CodingKeysClassification
-classifyCodingKeys(const DerivedConformance &derived) {
-  auto &C = derived.Context;
-  auto codingKeysDecls =
-      derived.Nominal->lookupDirect(DeclName(C.Id_CodingKeys));
-  if (codingKeysDecls.empty()) {
-    return CodingKeysClassification::NeedsSynthesizedCodingKeys;
-  }
-
-  // Only ill-formed code would produce multiple results for this lookup.
-  // This would get diagnosed later anyway, so we're free to only look at the
-  // first result here.
-  auto result = codingKeysDecls.front();
-
-  auto *codingKeysTypeDecl = dyn_cast<TypeDecl>(result);
-  if (!codingKeysTypeDecl) {
-    result->diagnose(diag::codable_codingkeys_type_is_not_an_enum_here,
-                     derived.getProtocolType());
-    return CodingKeysClassification::Invalid;
-  }
-
-  // CodingKeys may be a typealias. If so, follow the alias to its canonical
-  // type.
-  auto codingKeysType = codingKeysTypeDecl->getDeclaredInterfaceType();
-  if (isa<TypeAliasDecl>(codingKeysTypeDecl))
-    codingKeysTypeDecl = codingKeysType->getAnyNominal();
-
-  // Ensure that the type we found conforms to the CodingKey protocol.
-  auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
-  if (!TypeChecker::conformsToProtocol(codingKeysType, codingKeyProto,
-                                       derived.getConformanceContext())) {
-    // If CodingKeys is a typealias which doesn't point to a valid nominal type,
-    // codingKeysTypeDecl will be nullptr here. In that case, we need to warn on
-    // the location of the usage, since there isn't an underlying type to
-    // diagnose on.
-    SourceLoc loc = codingKeysTypeDecl ?
-                    codingKeysTypeDecl->getLoc() :
-                    cast<TypeDecl>(result)->getLoc();
-
-    C.Diags.diagnose(loc, diag::codable_codingkeys_type_does_not_conform_here,
-                     derived.getProtocolType());
-
-    return CodingKeysClassification::Invalid;
-  }
-
-  // CodingKeys must be an enum for synthesized conformance.
-  auto *codingKeysEnum = dyn_cast<EnumDecl>(codingKeysTypeDecl);
-  if (!codingKeysEnum) {
-    codingKeysTypeDecl->diagnose(
-        diag::codable_codingkeys_type_is_not_an_enum_here,
-        derived.getProtocolType());
-    return CodingKeysClassification::Invalid;
-  }
-
-  return validateCodingKeysEnum(derived, codingKeysEnum)
-             ? CodingKeysClassification::Valid
-             : CodingKeysClassification::Invalid;
-}
-
-/// Synthesizes a new \c CodingKeys enum based on the {En,De}codable members of
-/// the given type (\c nullptr if unable to synthesize).
-///
-/// If able to synthesize the enum, adds it directly to \c derived.Nominal.
-static EnumDecl *synthesizeCodingKeysEnum(DerivedConformance &derived) {
-  auto &C = derived.Context;
-  // Create CodingKeys in the parent type always, because both
-  // Encodable and Decodable might want to use it, and they may have
-  // different conditional bounds. CodingKeys is simple and can't
-  // depend on those bounds.
-  auto target = derived.Nominal;
-
-  // We want to look through all the var declarations of this type to create
-  // enum cases based on those var names.
-  auto *codingKeyProto = C.getProtocol(KnownProtocolKind::CodingKey);
-  auto codingKeyType = codingKeyProto->getDeclaredInterfaceType();
-  TypeLoc protoTypeLoc[1] = {TypeLoc::withoutLoc(codingKeyType)};
-  ArrayRef<TypeLoc> inherited = C.AllocateCopy(protoTypeLoc);
-
-  auto *enumDecl = new (C) EnumDecl(SourceLoc(), C.Id_CodingKeys, SourceLoc(),
-                                    inherited, nullptr, target);
-  enumDecl->setImplicit();
-  enumDecl->setSynthesized();
-  enumDecl->setAccess(AccessLevel::Private);
-
-  // For classes which inherit from something Encodable or Decodable, we
-  // provide case `super` as the first key (to be used in encoding super).
-  auto *classDecl = dyn_cast<ClassDecl>(target);
-  if (superclassConformsTo(classDecl, KnownProtocolKind::Encodable) ||
-      superclassConformsTo(classDecl, KnownProtocolKind::Decodable)) {
-    // TODO: Ensure the class doesn't already have or inherit a variable named
-    // "`super`"; otherwise we will generate an invalid enum. In that case,
-    // diagnose and bail.
-    auto *super = new (C) EnumElementDecl(SourceLoc(), C.Id_super, nullptr,
-                                          SourceLoc(), nullptr, enumDecl);
-    super->setImplicit();
-    enumDecl->addMember(super);
-  }
-
-  // Each of these vars needs a case in the enum. For each var decl, if the type
-  // conforms to {En,De}codable, add it to the enum.
-  bool allConform = true;
-  auto *conformanceDC = derived.getConformanceContext();
-  for (auto *varDecl : target->getStoredProperties()) {
-    if (!varDecl->isUserAccessible()) {
-      continue;
-    }
-
-    auto target =
-        conformanceDC->mapTypeIntoContext(varDecl->getValueInterfaceType());
-    if (TypeChecker::conformsToProtocol(target, derived.Protocol, conformanceDC)
-            .isInvalid()) {
-      TypeLoc typeLoc = {
-          varDecl->getTypeReprOrParentPatternTypeRepr(),
-          varDecl->getType(),
-      };
-      varDecl->diagnose(diag::codable_non_conforming_property_here,
-                        derived.getProtocolType(), typeLoc);
-      allConform = false;
-    } else {
-      auto *elt =
-          new (C) EnumElementDecl(SourceLoc(), getVarNameForCoding(varDecl),
-                                  nullptr, SourceLoc(), nullptr, enumDecl);
-      elt->setImplicit();
-      enumDecl->addMember(elt);
-    }
-  }
-
-  if (!allConform)
-    return nullptr;
-
-  // Forcibly derive conformance to CodingKey.
-  TypeChecker::checkConformancesInContext(enumDecl);
-
-  // Add to the type.
-  target->addMember(enumDecl);
-  return enumDecl;
 }
 
 /// Fetches the \c CodingKeys enum nested in \c target, potentially reaching
@@ -1060,17 +1008,13 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
     }
   }
 
-  switch (classifyCodingKeys(derived)) {
-  case CodingKeysClassification::Invalid:
+  if (!validateCodingKeysEnum(derived)) {
     return false;
-  case CodingKeysClassification::NeedsSynthesizedCodingKeys: {
-    auto *synthesizedEnum = synthesizeCodingKeysEnum(derived);
-    if (!synthesizedEnum)
-      return false;
   }
-    LLVM_FALLTHROUGH;
-  case CodingKeysClassification::Valid:
-    return true;
+
+  return true;
+}
+
 static bool canDeriveCodable(NominalTypeDecl *NTD,
                              KnownProtocolKind Kind) {
   assert(Kind == KnownProtocolKind::Encodable ||

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -278,6 +278,11 @@ public:
   /// \returns the derived member, which will also be added to the type.
   ValueDecl *deriveBridgedNSError(ValueDecl *requirement);
 
+  /// Determine if \c Encodable can be derived for the given type.
+  static bool canDeriveEncodable(NominalTypeDecl *NTD);
+  /// Determine if \c Decodable can be derived for the given type.
+  static bool canDeriveDecodable(NominalTypeDecl *NTD);
+
   /// Derive a CodingKey requirement for an enum type.
   ///
   /// \returns the derived member, which will also be added to the type.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -732,8 +732,12 @@ static Type validateTypedPattern(TypedPattern *TP, TypeResolution resolution) {
 Type TypeChecker::typeCheckPattern(ContextualPattern pattern) {
   DeclContext *dc = pattern.getDeclContext();
   ASTContext &ctx = dc->getASTContext();
-  return evaluateOrDefault(
-      ctx.evaluator, PatternTypeRequest{pattern}, ErrorType::get(ctx));
+  if (auto type = evaluateOrDefault(ctx.evaluator, PatternTypeRequest{pattern},
+                                    Type())) {
+    return type;
+  }
+
+  return ErrorType::get(ctx);
 }
 
 /// Apply the contextual pattern's context to the type resolution options.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1207,9 +1207,8 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       return I->second;
     }
 
-    diags.diagnose(L, diag::cannot_find_type_in_scope,
-                comp->getNameRef())
-      .highlight(R);
+    diags.diagnose(L, diag::cannot_find_type_in_scope, comp->getNameRef())
+        .highlight(R);
 
     return ErrorType::get(ctx);
   }

--- a/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/class_codable_nonconforming_property.swift
@@ -165,11 +165,10 @@ class NonConformingClass : Codable { // expected-error {{type 'NonConformingClas
   // These lines have to be within the NonConformingClass type because
   // CodingKeys should be private.
   func foo() {
-    // They should not get a CodingKeys type.
-    let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
-    let _ = NonConformingClass.CodingKeys.x // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
-    let _ = NonConformingClass.CodingKeys.y // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
-    let _ = NonConformingClass.CodingKeys.z // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+    let _ = NonConformingClass.CodingKeys.self
+    let _ = NonConformingClass.CodingKeys.x
+    let _ = NonConformingClass.CodingKeys.y
+    let _ = NonConformingClass.CodingKeys.z // expected-error {{type 'NonConformingClass.CodingKeys' has no member 'z'}}
   }
 }
 
@@ -178,4 +177,4 @@ let _ = NonConformingClass.init(from:) // expected-error {{type 'NonConformingCl
 let _ = NonConformingClass.encode(to:) // expected-error {{type 'NonConformingClass' has no member 'encode(to:)'}}
 
 // They should not get a CodingKeys type.
-let _ = NonConformingClass.CodingKeys.self // expected-error {{type 'NonConformingClass' has no member 'CodingKeys'}}
+let _ = NonConformingClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/struct_codable_nonconforming_property.swift
@@ -165,11 +165,10 @@ struct NonConformingStruct : Codable { // expected-error {{type 'NonConformingSt
   // These lines have to be within the NonConformingStruct type because
   // CodingKeys should be private.
   func foo() {
-    // They should not get a CodingKeys type.
-    let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
-    let _ = NonConformingStruct.CodingKeys.x // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
-    let _ = NonConformingStruct.CodingKeys.y // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
-    let _ = NonConformingStruct.CodingKeys.z // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+    let _ = NonConformingStruct.CodingKeys.self
+    let _ = NonConformingStruct.CodingKeys.x
+    let _ = NonConformingStruct.CodingKeys.y
+    let _ = NonConformingStruct.CodingKeys.z // expected-error {{type 'NonConformingStruct.CodingKeys' has no member 'z'}}
   }
 }
 
@@ -178,4 +177,4 @@ let _ = NonConformingStruct.init(from:) // expected-error {{type 'NonConformingS
 let _ = NonConformingStruct.encode(to:) // expected-error {{type 'NonConformingStruct' has no member 'encode(to:)'}}
 
 // They should not get a CodingKeys type.
-let _ = NonConformingStruct.CodingKeys.self // expected-error {{type 'NonConformingStruct' has no member 'CodingKeys'}}
+let _ = NonConformingStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_simple.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple.swift
@@ -31,19 +31,19 @@ let _ = SimpleStruct.encode(to:)
 let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
 
 // rdar://problem/59655704 
-struct SR_12248_1: Codable { // expected-error {{type 'SR_12248_1' does not conform to protocol 'Encodable'}}
+struct SR_12248_1: Codable { // expected-error {{type 'SR_12248_1' does not conform to protocol 'Encodable'}} expected-error {{type 'SR_12248_1' does not conform to protocol 'Decodable'}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
   // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'Int' does not conform to 'Encodable'}}
   // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'Int' does not conform to 'Encodable'}}
 }
 
-struct SR_12248_2: Decodable { 
+struct SR_12248_2: Decodable { // expected-error {{type 'SR_12248_2' does not conform to protocol 'Decodable'}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }
 
-struct SR_12248_3: Encodable { 
+struct SR_12248_3: Encodable { // expected-error {{type 'SR_12248_3' does not conform to protocol 'Encodable'}}
   var x: Int // expected-note {{'x' previously declared here}}
   var x: Int // expected-error {{invalid redeclaration of 'x'}}
 }

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -136,8 +136,6 @@ foo(b:
 // CHECK: [[#LINE]]   | struct B: Decodable {
 // CHECK:             |        ^ error: type 'B' does not conform to protocol 'Decodable'
 // CHECK: [[#LINE+1]] |   let a: Foo
-// CHECK:             |       ^ note: cannot automatically synthesize 'Decodable' because 'Foo' does not conform to 'Decodable'
-// CHECK: [[#LINE+2]] | }
 // CHECK: Swift.Decodable:2:5
 // CHECK: 1 | public protocol Decodable {
 // CHECK: 2 |     init(from decoder: Decoder) throws


### PR DESCRIPTION
The order of diagnostic emission absolutely does not matter. What this transaction was actually doing was suppressing valid diagnostics. This is a deeply unsound thing to do since if errors are emitted but Codable synthesis succeeds then invalid code can make its way past Sema.

rdar://74392492