### PR TITLE
Fix a case where guard let bindings were not emitted in their own scope. 

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5432,6 +5432,8 @@ public:
     for (SILInstruction &SI : *BB) {
       if (SI.isMetaInstruction())
         continue;
+      if (SI.getLoc().getKind() == SILLocation::CleanupKind)
+        continue;
 
       // If we haven't seen this debug scope yet, update the
       // map and go on.

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -297,7 +297,7 @@ void SILGenFunction::emitRethrowEpilog(SILLocation topLevel) {
 
   Cleanups.emitCleanupsForReturn(ThrowDest.getCleanupLocation(), IsForUnwind);
 
-  B.createThrow(throwLoc, exn);
+  B.createThrow(CleanupLocation(throwLoc), exn);
 
   ThrowDest = JumpDest::invalid();
 }

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -729,11 +729,10 @@ void StmtEmitter::visitGuardStmt(GuardStmt *S) {
   // Emit the condition bindings, branching to the bodyBB if they fail.
   auto NumFalseTaken = SGF.loadProfilerCount(S->getBody());
   auto NumNonTaken = SGF.loadProfilerCount(S);
-  SGF.emitStmtCondition(S->getCond(), bodyBB, S, NumNonTaken, NumFalseTaken);
-
   // Begin a new 'guard' scope, which is popped when the next innermost debug
   // scope ends.
   SGF.enterDebugScope(S, /*isGuardScope=*/true);
+  SGF.emitStmtCondition(S->getCond(), bodyBB, S, NumNonTaken, NumFalseTaken);
 }
 
 void StmtEmitter::visitWhileStmt(WhileStmt *S) {

--- a/test/DebugInfo/guard-let-scope.swift
+++ b/test/DebugInfo/guard-let-scope.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-sil -Xllvm -sil-print-debuginfo %s \
+// RUN:  | %FileCheck %s
+func f(c: AnyObject?) {
+  let x = c
+  // CHECK: sil_scope [[S1:[0-9]+]] { loc "{{.*}}":[[@LINE-2]]:23 parent 
+  // CHECK: sil_scope [[S2:[0-9]+]] { loc "{{.*}}":[[@LINE+3]]:3 parent [[S1]] }
+  // CHECK: debug_value %0 : $Optional<AnyObject>, let, name "x"{{.*}} scope [[S1]]
+  // CHECK: debug_value %6 : $AnyObject, let, name "x", {{.*}} scope [[S2]]
+  guard let x = x else {
+    fatalError(".")
+  }
+  print(x)
+}

--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -141,7 +141,6 @@ public func constvar_${name}() {
   // DWARF: DW_AT_name ("self")
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_artificial
-  // DWARF-NOT: DW_TAG
   // DWARF: DW_TAG_variable
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
@@ -266,6 +265,7 @@ public func guard_let_${name}() {
     fatalError()
   }
   // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_lexical_block
   // DWARF: DW_TAG_variable
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_location

--- a/test/SILOptimizer/definite-init-wrongscope.swift
+++ b/test/SILOptimizer/definite-init-wrongscope.swift
@@ -30,14 +30,14 @@ public class M {
 
 // CHECK-LABEL: sil [ossa] @$s3del1MC4fromAcA12WithDelegate_p_tKcfc : $@convention(method) (@in WithDelegate, @owned M) -> (@owned M, @error Error)
 
-// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 4
-// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 4
-// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 4
-// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 4
-// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:23:20, scope 4
+// CHECK:   [[I:%.*]] = integer_literal $Builtin.Int2, 1, loc {{.*}}:20:12, scope 3
+// CHECK:   [[V:%.*]] = load [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 3
+// CHECK:   [[OR:%.*]] = builtin "or_Int2"([[V]] : $Builtin.Int2, [[I]] : $Builtin.Int2) : $Builtin.Int2, loc {{.*}}:20:12, scope 3
+// CHECK:   store [[OR]] to [trivial] %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 3
+// CHECK:   store %{{.*}} to [init] %{{.*}} : $*C, loc {{.*}}:23:20, scope 3
 
 // Make sure the dealloc_stack gets the same scope of the instructions surrounding it.
 
-// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 4
-// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 4
-// CHECK:   throw %{{.*}} : $Error, loc {{.*}}:20:12, scope 4
+// CHECK:   destroy_addr %0 : $*WithDelegate, loc {{.*}}:26:5, scope 3
+// CHECK:   dealloc_stack %2 : $*Builtin.Int2, loc {{.*}}:20:12, scope 3
+// CHECK:   throw %{{.*}} : $Error, loc {{.*}}:20:12, scope 1


### PR DESCRIPTION
This is a follow-up to e9d557ae287c3f5ea77d4ca79511834db76b66b3.  The
debug_value for the guard let binding is introduced by SGF.emitStmtCondition(),
so we also need to enter the debug scope before running that function.

rdar://74538257
