### PR TITLE
While cloning OwnershipForwardingConversionInst make sure to copy forwardingOwnershipKind from the original instruction

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1028,9 +1028,17 @@ public:
   ConvertFunctionInst *createConvertFunction(SILLocation Loc, SILValue Op,
                                              SILType Ty,
                                              bool WithoutActuallyEscaping) {
-    return insert(ConvertFunctionInst::create(getSILDebugLocation(Loc), Op, Ty,
-                                              getModule(), F, C.OpenedArchetypes,
-                                              WithoutActuallyEscaping));
+    return createConvertFunction(Loc, Op, Ty, WithoutActuallyEscaping,
+                                 Op.getOwnershipKind());
+  }
+
+  ConvertFunctionInst *
+  createConvertFunction(SILLocation Loc, SILValue Op, SILType Ty,
+                        bool WithoutActuallyEscaping,
+                        ValueOwnershipKind forwardingOwnershipKind) {
+    return insert(ConvertFunctionInst::create(
+        getSILDebugLocation(Loc), Op, Ty, getModule(), F, C.OpenedArchetypes,
+        WithoutActuallyEscaping, forwardingOwnershipKind));
   }
 
   ConvertEscapeToNoEscapeInst *
@@ -1054,8 +1062,14 @@ public:
   }
 
   UpcastInst *createUpcast(SILLocation Loc, SILValue Op, SILType Ty) {
+    return createUpcast(Loc, Op, Ty, Op.getOwnershipKind());
+  }
+
+  UpcastInst *createUpcast(SILLocation Loc, SILValue Op, SILType Ty,
+                           ValueOwnershipKind forwardingOwnershipKind) {
     return insert(UpcastInst::create(getSILDebugLocation(Loc), Op, Ty,
-                                     getFunction(), C.OpenedArchetypes));
+                                     getFunction(), C.OpenedArchetypes,
+                                     forwardingOwnershipKind));
   }
 
   AddressToPointerInst *createAddressToPointer(SILLocation Loc, SILValue Op,
@@ -1075,7 +1089,16 @@ public:
   UncheckedRefCastInst *createUncheckedRefCast(SILLocation Loc, SILValue Op,
                                                SILType Ty) {
     return insert(UncheckedRefCastInst::create(
-        getSILDebugLocation(Loc), Op, Ty, getFunction(), C.OpenedArchetypes));
+        getSILDebugLocation(Loc), Op, Ty, getFunction(), C.OpenedArchetypes,
+        Op.getOwnershipKind()));
+  }
+
+  UncheckedRefCastInst *
+  createUncheckedRefCast(SILLocation Loc, SILValue Op, SILType Ty,
+                         ValueOwnershipKind forwardingOwnershipKind) {
+    return insert(UncheckedRefCastInst::create(
+        getSILDebugLocation(Loc), Op, Ty, getFunction(), C.OpenedArchetypes,
+        forwardingOwnershipKind));
   }
 
   UncheckedRefCastAddrInst *
@@ -1107,22 +1130,41 @@ public:
 
   UncheckedValueCastInst *createUncheckedValueCast(SILLocation Loc, SILValue Op,
                                                    SILType Ty) {
+    return createUncheckedValueCast(Loc, Op, Ty, Op.getOwnershipKind());
+  }
+
+  UncheckedValueCastInst *
+  createUncheckedValueCast(SILLocation Loc, SILValue Op, SILType Ty,
+                           ValueOwnershipKind forwardingOwnershipKind) {
     assert(hasOwnership());
     return insert(UncheckedValueCastInst::create(
-        getSILDebugLocation(Loc), Op, Ty, getFunction(), C.OpenedArchetypes));
+        getSILDebugLocation(Loc), Op, Ty, getFunction(), C.OpenedArchetypes,
+        forwardingOwnershipKind));
   }
 
   RefToBridgeObjectInst *createRefToBridgeObject(SILLocation Loc, SILValue Ref,
                                                  SILValue Bits) {
+    return createRefToBridgeObject(Loc, Ref, Bits, Ref.getOwnershipKind());
+  }
+
+  RefToBridgeObjectInst *
+  createRefToBridgeObject(SILLocation Loc, SILValue Ref, SILValue Bits,
+                          ValueOwnershipKind forwardingOwnershipKind) {
     auto Ty = SILType::getBridgeObjectType(getASTContext());
     return insert(new (getModule()) RefToBridgeObjectInst(
-        getSILDebugLocation(Loc), Ref, Bits, Ty));
+        getSILDebugLocation(Loc), Ref, Bits, Ty, forwardingOwnershipKind));
   }
 
   BridgeObjectToRefInst *createBridgeObjectToRef(SILLocation Loc, SILValue Op,
                                                  SILType Ty) {
+    return createBridgeObjectToRef(Loc, Op, Ty, Op.getOwnershipKind());
+  }
+
+  BridgeObjectToRefInst *
+  createBridgeObjectToRef(SILLocation Loc, SILValue Op, SILType Ty,
+                          ValueOwnershipKind forwardingOwnershipKind) {
     return insert(new (getModule()) BridgeObjectToRefInst(
-        getSILDebugLocation(Loc), Op, Ty));
+        getSILDebugLocation(Loc), Op, Ty, forwardingOwnershipKind));
   }
 
   ValueToBridgeObjectInst *createValueToBridgeObject(SILLocation Loc,
@@ -1158,8 +1200,15 @@ public:
 
   ThinToThickFunctionInst *createThinToThickFunction(SILLocation Loc,
                                                      SILValue Op, SILType Ty) {
+    return createThinToThickFunction(Loc, Op, Ty, Op.getOwnershipKind());
+  }
+
+  ThinToThickFunctionInst *
+  createThinToThickFunction(SILLocation Loc, SILValue Op, SILType Ty,
+                            ValueOwnershipKind forwardingOwnershipKind) {
     return insert(ThinToThickFunctionInst::create(
-        getSILDebugLocation(Loc), Op, Ty, getModule(), F, C.OpenedArchetypes));
+        getSILDebugLocation(Loc), Op, Ty, getModule(), F, C.OpenedArchetypes,
+        forwardingOwnershipKind));
   }
 
   ThickToObjCMetatypeInst *createThickToObjCMetatype(SILLocation Loc,
@@ -1201,9 +1250,17 @@ public:
   createUnconditionalCheckedCast(SILLocation Loc, SILValue op,
                                  SILType destLoweredTy,
                                  CanType destFormalTy) {
+    return createUnconditionalCheckedCast(Loc, op, destLoweredTy, destFormalTy,
+                                          op.getOwnershipKind());
+  }
+
+  UnconditionalCheckedCastInst *
+  createUnconditionalCheckedCast(SILLocation Loc, SILValue op,
+                                 SILType destLoweredTy, CanType destFormalTy,
+                                 ValueOwnershipKind forwardingOwnershipKind) {
     return insert(UnconditionalCheckedCastInst::create(
         getSILDebugLocation(Loc), op, destLoweredTy, destFormalTy,
-        getFunction(), C.OpenedArchetypes));
+        getFunction(), C.OpenedArchetypes, forwardingOwnershipKind));
   }
 
   UnconditionalCheckedCastAddrInst *

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1405,7 +1405,8 @@ SILCloner<ImplClass>::visitConvertFunctionInst(ConvertFunctionInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createConvertFunction(
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
-                getOpType(Inst->getType()), Inst->withoutActuallyEscaping()));
+                getOpType(Inst->getType()), Inst->withoutActuallyEscaping(),
+                Inst->getForwardingOwnershipKind()));
 }
 
 template <typename ImplClass>
@@ -1445,7 +1446,8 @@ SILCloner<ImplClass>::visitUpcastInst(UpcastInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createUpcast(getOpLocation(Inst->getLoc()),
                                       getOpValue(Inst->getOperand()),
-                                      getOpType(Inst->getType())));
+                                      getOpType(Inst->getType()),
+                                      Inst->getForwardingOwnershipKind()));
 }
 
 template<typename ImplClass>
@@ -1474,10 +1476,11 @@ void
 SILCloner<ImplClass>::
 visitUncheckedRefCastInst(UncheckedRefCastInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  recordClonedInstruction(
-      Inst, getBuilder().createUncheckedRefCast(getOpLocation(Inst->getLoc()),
-                                                getOpValue(Inst->getOperand()),
-                                                getOpType(Inst->getType())));
+  recordClonedInstruction(Inst, getBuilder().createUncheckedRefCast(
+                                    getOpLocation(Inst->getLoc()),
+                                    getOpValue(Inst->getOperand()),
+                                    getOpType(Inst->getType()),
+                                    Inst->getForwardingOwnershipKind()));
 }
 
 template<typename ImplClass>
@@ -1542,7 +1545,8 @@ void SILCloner<ImplClass>::visitUncheckedValueCastInst(
   recordClonedInstruction(Inst, getBuilder().createUncheckedValueCast(
                                     getOpLocation(Inst->getLoc()),
                                     getOpValue(Inst->getOperand()),
-                                    getOpType(Inst->getType())));
+                                    getOpType(Inst->getType()),
+                                    Inst->getForwardingOwnershipKind()));
 }
 
 template<typename ImplClass>
@@ -1553,7 +1557,8 @@ visitRefToBridgeObjectInst(RefToBridgeObjectInst *Inst) {
   recordClonedInstruction(Inst, getBuilder().createRefToBridgeObject(
                                     getOpLocation(Inst->getLoc()),
                                     getOpValue(Inst->getConverted()),
-                                    getOpValue(Inst->getBitsOperand())));
+                                    getOpValue(Inst->getBitsOperand()),
+                                    Inst->getForwardingOwnershipKind()));
 }
 
 template<typename ImplClass>
@@ -1564,7 +1569,8 @@ visitBridgeObjectToRefInst(BridgeObjectToRefInst *Inst) {
   recordClonedInstruction(Inst, getBuilder().createBridgeObjectToRef(
                                     getOpLocation(Inst->getLoc()),
                                     getOpValue(Inst->getConverted()),
-                                    getOpType(Inst->getType())));
+                                    getOpType(Inst->getType()),
+                                    Inst->getForwardingOwnershipKind()));
 }
 
 template<typename ImplClass>
@@ -1615,7 +1621,8 @@ visitThinToThickFunctionInst(ThinToThickFunctionInst *Inst) {
   recordClonedInstruction(Inst, getBuilder().createThinToThickFunction(
                                     getOpLocation(Inst->getLoc()),
                                     getOpValue(Inst->getOperand()),
-                                    getOpType(Inst->getType())));
+                                    getOpType(Inst->getType()),
+                                    Inst->getForwardingOwnershipKind()));
 }
 
 template<typename ImplClass>
@@ -1650,8 +1657,8 @@ SILCloner<ImplClass>::visitUnconditionalCheckedCastInst(
   CanType OpFormalType = getOpASTType(Inst->getTargetFormalType());
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createUnconditionalCheckedCast(
-                                    OpLoc, OpValue,
-                                    OpLoweredType, OpFormalType));
+                                    OpLoc, OpValue, OpLoweredType, OpFormalType,
+                                    Inst->getForwardingOwnershipKind()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4800,10 +4800,11 @@ class ConvertFunctionInst final
 
   ConvertFunctionInst(SILDebugLocation DebugLoc, SILValue Operand,
                       ArrayRef<SILValue> TypeDependentOperands, SILType Ty,
-                      bool WithoutActuallyEscaping)
-      : UnaryInstructionWithTypeDependentOperandsBase(
-            DebugLoc, Operand, TypeDependentOperands, Ty,
-            Operand.getOwnershipKind()) {
+                      bool WithoutActuallyEscaping,
+                      ValueOwnershipKind forwardingOwnershipKind)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                                      TypeDependentOperands, Ty,
+                                                      forwardingOwnershipKind) {
     SILNode::Bits.ConvertFunctionInst.WithoutActuallyEscaping =
         WithoutActuallyEscaping;
     assert((Operand->getType().castTo<SILFunctionType>()->isNoEscape() ==
@@ -4813,11 +4814,10 @@ class ConvertFunctionInst final
            "Change of escapeness is not ABI compatible");
   }
 
-  static ConvertFunctionInst *create(SILDebugLocation DebugLoc,
-                                     SILValue Operand, SILType Ty,
-                                     SILModule &Mod, SILFunction *F,
-                                     SILOpenedArchetypesState &OpenedArchetypes,
-                                     bool WithoutActuallyEscaping);
+  static ConvertFunctionInst *create(
+      SILDebugLocation DebugLoc, SILValue Operand, SILType Ty, SILModule &Mod,
+      SILFunction *F, SILOpenedArchetypesState &OpenedArchetypes,
+      bool WithoutActuallyEscaping, ValueOwnershipKind forwardingOwnershipKind);
 
 public:
   /// Returns `true` if this converts a non-escaping closure into an escaping
@@ -4917,14 +4917,17 @@ class UpcastInst final : public UnaryInstructionWithTypeDependentOperandsBase<
   friend SILBuilder;
 
   UpcastInst(SILDebugLocation DebugLoc, SILValue Operand,
-             ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
-      : UnaryInstructionWithTypeDependentOperandsBase(
-            DebugLoc, Operand, TypeDependentOperands, Ty,
-            Operand.getOwnershipKind()) {}
+             ArrayRef<SILValue> TypeDependentOperands, SILType Ty,
+             ValueOwnershipKind forwardingOwnershipKind)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                                      TypeDependentOperands, Ty,
+                                                      forwardingOwnershipKind) {
+  }
 
-  static UpcastInst *
-  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
-         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+  static UpcastInst *create(SILDebugLocation DebugLoc, SILValue Operand,
+                            SILType Ty, SILFunction &F,
+                            SILOpenedArchetypesState &OpenedArchetypes,
+                            ValueOwnershipKind forwardingOwnershipKind);
 };
 
 /// AddressToPointerInst - Convert a SIL address to a Builtin.RawPointer value.
@@ -4976,13 +4979,17 @@ class UncheckedRefCastInst final
   friend SILBuilder;
 
   UncheckedRefCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                       ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
-      : UnaryInstructionWithTypeDependentOperandsBase(
-            DebugLoc, Operand, TypeDependentOperands, Ty,
-            Operand.getOwnershipKind()) {}
+                       ArrayRef<SILValue> TypeDependentOperands, SILType Ty,
+                       ValueOwnershipKind forwardingOwnershipKind)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                                      TypeDependentOperands, Ty,
+                                                      forwardingOwnershipKind) {
+  }
+
   static UncheckedRefCastInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
-         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes,
+         ValueOwnershipKind forwardingOwnershipKind);
 };
 
 /// Convert a value's binary representation to a trivial type of the same size.
@@ -5032,13 +5039,17 @@ class UncheckedValueCastInst final
   friend SILBuilder;
 
   UncheckedValueCastInst(SILDebugLocation DebugLoc, SILValue Operand,
-                         ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
-      : UnaryInstructionWithTypeDependentOperandsBase(
-            DebugLoc, Operand, TypeDependentOperands, Ty,
-            Operand.getOwnershipKind()) {}
+                         ArrayRef<SILValue> TypeDependentOperands, SILType Ty,
+                         ValueOwnershipKind forwardingOwnershipKind)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                                      TypeDependentOperands, Ty,
+                                                      forwardingOwnershipKind) {
+  }
+
   static UncheckedValueCastInst *
   create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
-         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes,
+         ValueOwnershipKind forwardingOwnershipKind);
 };
 
 /// Build a Builtin.BridgeObject from a heap object reference by bitwise-or-ing
@@ -5050,9 +5061,9 @@ class RefToBridgeObjectInst
 
   FixedOperandList<2> Operands;
   RefToBridgeObjectInst(SILDebugLocation DebugLoc, SILValue ConvertedValue,
-                        SILValue MaskValue, SILType BridgeObjectTy)
-      : InstructionBase(DebugLoc, BridgeObjectTy,
-                        ConvertedValue.getOwnershipKind()),
+                        SILValue MaskValue, SILType BridgeObjectTy,
+                        ValueOwnershipKind forwardingOwnershipKind)
+      : InstructionBase(DebugLoc, BridgeObjectTy, forwardingOwnershipKind),
         Operands(this, ConvertedValue, MaskValue) {}
 
 public:
@@ -5080,9 +5091,9 @@ class BridgeObjectToRefInst
                                   OwnershipForwardingConversionInst> {
   friend SILBuilder;
 
-  BridgeObjectToRefInst(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty)
-      : UnaryInstructionBase(DebugLoc, Operand, Ty,
-                             Operand.getOwnershipKind()) {}
+  BridgeObjectToRefInst(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+                        ValueOwnershipKind forwardingOwnershipKind)
+      : UnaryInstructionBase(DebugLoc, Operand, Ty, forwardingOwnershipKind) {}
 };
 
 /// Sets the BridgeObject to a tagged pointer representation holding its
@@ -5159,14 +5170,18 @@ class ThinToThickFunctionInst final
   friend SILBuilder;
 
   ThinToThickFunctionInst(SILDebugLocation DebugLoc, SILValue Operand,
-                          ArrayRef<SILValue> TypeDependentOperands, SILType Ty)
-      : UnaryInstructionWithTypeDependentOperandsBase(
-            DebugLoc, Operand, TypeDependentOperands, Ty,
-            Operand.getOwnershipKind()) {}
+                          ArrayRef<SILValue> TypeDependentOperands, SILType Ty,
+                          ValueOwnershipKind forwardingOwnershipKind)
+      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
+                                                      TypeDependentOperands, Ty,
+                                                      forwardingOwnershipKind) {
+  }
 
   static ThinToThickFunctionInst *
-  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty, SILModule &Mod,
-         SILFunction *F, SILOpenedArchetypesState &OpenedArchetypes);
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType Ty,
+         SILModule &Mod, SILFunction *F,
+         SILOpenedArchetypesState &OpenedArchetypes,
+         ValueOwnershipKind forwardingOwnershipKind);
 
 public:
   /// Return the callee of the thin_to_thick_function.
@@ -5257,16 +5272,18 @@ class UnconditionalCheckedCastInst final
 
   UnconditionalCheckedCastInst(SILDebugLocation DebugLoc, SILValue Operand,
                                ArrayRef<SILValue> TypeDependentOperands,
-                               SILType DestLoweredTy, CanType DestFormalTy)
+                               SILType DestLoweredTy, CanType DestFormalTy,
+                               ValueOwnershipKind forwardingOwnershipKind)
       : UnaryInstructionWithTypeDependentOperandsBase(
             DebugLoc, Operand, TypeDependentOperands, DestLoweredTy,
-          Operand.getOwnershipKind()),
+            forwardingOwnershipKind),
         DestFormalTy(DestFormalTy) {}
 
   static UnconditionalCheckedCastInst *
-  create(SILDebugLocation DebugLoc, SILValue Operand,
-         SILType DestLoweredTy, CanType DestFormalTy,
-         SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes);
+  create(SILDebugLocation DebugLoc, SILValue Operand, SILType DestLoweredTy,
+         CanType DestFormalTy, SILFunction &F,
+         SILOpenedArchetypesState &OpenedArchetypes,
+         ValueOwnershipKind forwardingOwnershipKind);
 
 public:
   SILType getSourceLoweredType() const { return getOperand()->getType(); }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2142,7 +2142,8 @@ BeginCOWMutationInst::create(SILDebugLocation loc, SILValue operand,
 UncheckedRefCastInst *
 UncheckedRefCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
                              SILType Ty, SILFunction &F,
-                             SILOpenedArchetypesState &OpenedArchetypes) {
+                             SILOpenedArchetypesState &OpenedArchetypes,
+                             ValueOwnershipKind forwardingOwnershipKind) {
   SILModule &Mod = F.getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
@@ -2150,14 +2151,15 @@ UncheckedRefCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
   unsigned size =
       totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(UncheckedRefCastInst));
-  return ::new (Buffer) UncheckedRefCastInst(DebugLoc, Operand,
-                                             TypeDependentOperands, Ty);
+  return ::new (Buffer) UncheckedRefCastInst(
+      DebugLoc, Operand, TypeDependentOperands, Ty, forwardingOwnershipKind);
 }
 
 UncheckedValueCastInst *
 UncheckedValueCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
                                SILType Ty, SILFunction &F,
-                               SILOpenedArchetypesState &OpenedArchetypes) {
+                               SILOpenedArchetypesState &OpenedArchetypes,
+                               ValueOwnershipKind forwardingOwnershipKind) {
   SILModule &Mod = F.getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
@@ -2165,8 +2167,8 @@ UncheckedValueCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
   unsigned size =
       totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(UncheckedValueCastInst));
-  return ::new (Buffer)
-      UncheckedValueCastInst(DebugLoc, Operand, TypeDependentOperands, Ty);
+  return ::new (Buffer) UncheckedValueCastInst(
+      DebugLoc, Operand, TypeDependentOperands, Ty, forwardingOwnershipKind);
 }
 
 UncheckedAddrCastInst *
@@ -2216,9 +2218,10 @@ UncheckedBitwiseCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
 }
 
 UnconditionalCheckedCastInst *UnconditionalCheckedCastInst::create(
-    SILDebugLocation DebugLoc, SILValue Operand,
-    SILType DestLoweredTy, CanType DestFormalTy,
-    SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes) {
+    SILDebugLocation DebugLoc, SILValue Operand, SILType DestLoweredTy,
+    CanType DestFormalTy, SILFunction &F,
+    SILOpenedArchetypesState &OpenedArchetypes,
+    ValueOwnershipKind forwardingOwnershipKind) {
   SILModule &Mod = F.getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
@@ -2226,10 +2229,9 @@ UnconditionalCheckedCastInst *UnconditionalCheckedCastInst::create(
   unsigned size =
       totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(UnconditionalCheckedCastInst));
-  return ::new (Buffer) UnconditionalCheckedCastInst(DebugLoc, Operand,
-                                                     TypeDependentOperands,
-                                                     DestLoweredTy,
-                                                     DestFormalTy);
+  return ::new (Buffer) UnconditionalCheckedCastInst(
+      DebugLoc, Operand, TypeDependentOperands, DestLoweredTy, DestFormalTy,
+      forwardingOwnershipKind);
 }
 
 UnconditionalCheckedCastValueInst *UnconditionalCheckedCastValueInst::create(
@@ -2303,7 +2305,8 @@ MetatypeInst *MetatypeInst::create(SILDebugLocation Loc, SILType Ty,
 
 UpcastInst *UpcastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
                                SILType Ty, SILFunction &F,
-                               SILOpenedArchetypesState &OpenedArchetypes) {
+                               SILOpenedArchetypesState &OpenedArchetypes,
+                               ValueOwnershipKind forwardingOwnershipKind) {
   SILModule &Mod = F.getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
@@ -2311,14 +2314,15 @@ UpcastInst *UpcastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
   unsigned size =
     totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(UpcastInst));
-  return ::new (Buffer) UpcastInst(DebugLoc, Operand,
-                                   TypeDependentOperands, Ty);
+  return ::new (Buffer) UpcastInst(DebugLoc, Operand, TypeDependentOperands, Ty,
+                                   forwardingOwnershipKind);
 }
 
 ThinToThickFunctionInst *
 ThinToThickFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
                                 SILType Ty, SILModule &Mod, SILFunction *F,
-                                SILOpenedArchetypesState &OpenedArchetypes) {
+                                SILOpenedArchetypesState &OpenedArchetypes,
+                                ValueOwnershipKind forwardingOwnershipKind) {
   SmallVector<SILValue, 8> TypeDependentOperands;
   if (F) {
     assert(&F->getModule() == &Mod);
@@ -2328,8 +2332,8 @@ ThinToThickFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
   unsigned size =
     totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(ThinToThickFunctionInst));
-  return ::new (Buffer) ThinToThickFunctionInst(DebugLoc, Operand,
-                                                TypeDependentOperands, Ty);
+  return ::new (Buffer) ThinToThickFunctionInst(
+      DebugLoc, Operand, TypeDependentOperands, Ty, forwardingOwnershipKind);
 }
 
 PointerToThinFunctionInst *
@@ -2349,8 +2353,8 @@ PointerToThinFunctionInst::create(SILDebugLocation DebugLoc, SILValue Operand,
 
 ConvertFunctionInst *ConvertFunctionInst::create(
     SILDebugLocation DebugLoc, SILValue Operand, SILType Ty, SILModule &Mod,
-    SILFunction *F,
-    SILOpenedArchetypesState &OpenedArchetypes, bool WithoutActuallyEscaping) {
+    SILFunction *F, SILOpenedArchetypesState &OpenedArchetypes,
+    bool WithoutActuallyEscaping, ValueOwnershipKind forwardingOwnershipKind) {
   SmallVector<SILValue, 8> TypeDependentOperands;
   if (F) {
     assert(&F->getModule() == &Mod);
@@ -2360,8 +2364,9 @@ ConvertFunctionInst *ConvertFunctionInst::create(
   unsigned size =
     totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(ConvertFunctionInst));
-  auto *CFI = ::new (Buffer) ConvertFunctionInst(
-      DebugLoc, Operand, TypeDependentOperands, Ty, WithoutActuallyEscaping);
+  auto *CFI = ::new (Buffer)
+      ConvertFunctionInst(DebugLoc, Operand, TypeDependentOperands, Ty,
+                          WithoutActuallyEscaping, forwardingOwnershipKind);
   // If we do not have lowered SIL, make sure that are not performing
   // ABI-incompatible conversions.
   //

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+// RUN: %target-sil-opt -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -generic-specializer | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
 
 // Declare this SIL to be canonical because some tests break raw SIL
 // conventions. e.g. address-type block args. -enforce-exclusivity=none is also
@@ -4926,3 +4927,29 @@ bb1(%result : @owned $Builtin.NativeObject):
 bb2(%error : @owned $Error):
   unreachable
 }
+
+sil [ossa] @takeKlass : $@convention(thin) (@owned Optional<Klass>) -> ()
+
+// CHECK_FORWARDING_OWNERSHIP_KIND-LABEL: sil shared [ossa] @$s8refcast24main5KlassC_Tg5 : 
+// CHECK_FORWARDING_OWNERSHIP_KIND: unchecked_ref_cast 
+// CHECK_FORWARDING_OWNERSHIP_KIND-LABEL: } // end sil function '$s8refcast24main5KlassC_Tg5'
+sil [ossa] @refcast2 : $@convention(thin) <T> (@in T, @owned Klass) -> () {
+bb0(%0 : $*T, %1 : @owned $Klass):
+  destroy_addr %0 : $*T
+  %2 = unchecked_bitwise_cast %1 : $Klass to $Optional<Klass>
+  %3 = copy_value %2 : $Optional<Klass>
+  destroy_value %1 : $Klass
+  %func = function_ref @takeKlass : $@convention(thin) (@owned Optional<Klass>) -> ()
+  apply %func(%3) : $@convention(thin) (@owned Optional<Klass>) -> ()
+  %res = tuple ()
+  return %res : $()
+}
+
+sil [ossa] @caller : $@convention(thin) (@in Klass, @owned Klass) -> () {
+bb0(%0 :  $*Klass, %1 : @owned $Klass):
+  %f = function_ref @refcast2 : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned Klass) -> ()
+  %res = apply %f<Klass>(%0, %1) : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned Klass) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
The forwardingOwnershipKind need not be the same as operandOwnershipKind
after optimizations like SILCombine. While cloning, make sure to
propagate this correctly, if not this results in unnecessary ownership
verifier errors.

