### PR TITLE
[CodeCompletion] Don't try to re-typecheck ClosureExpr

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -315,10 +315,6 @@ void swift::ide::collectPossibleReturnTypesFromContext(
   }
 
   if (auto ACE = dyn_cast<AbstractClosureExpr>(DC)) {
-    // Try type checking the closure signature if it hasn't.
-    if (!ACE->getType())
-      swift::typeCheckASTNodeAtLoc(ACE->getParent(), ACE->getLoc());
-
     // Use the type checked type if it has.
     if (ACE->getType() && !ACE->getType()->hasError() &&
         !ACE->getResultType()->hasUnresolvedType()) {


### PR DESCRIPTION
At the every usage of `collectPossibleReturnTypesFromContext()`, the closure must have been typechecked earlier. If the closure has no valid type at the point, there's no chance to be type-checked by re-typechecking.

rdar://problem/74430478
