### PR TITLE
[IRGen] Fix miscount for protocol requirements involving marker protocols

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5219,10 +5219,10 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
   assert(sig);
   GenericRequirementsMetadata metadata;
   for (auto &requirement : requirements) {
-    ++metadata.NumRequirements;
-
     switch (auto kind = requirement.getKind()) {
     case RequirementKind::Layout:
+      ++metadata.NumRequirements;
+
       switch (auto layoutKind =
                 requirement.getLayoutConstraint()->getKind()) {
       case LayoutConstraintKind::Class: {
@@ -5247,9 +5247,11 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
         ->getDecl();
 
       // Marker protocols do not record generic requirements at all.
-      if (protocol->isMarkerProtocol())
+      if (protocol->isMarkerProtocol()) {
         break;
+      }
 
+      ++metadata.NumRequirements;
       bool needsWitnessTable =
         Lowering::TypeConverter::protocolRequiresWitnessTable(protocol);
       auto flags = GenericRequirementFlags(GenericRequirementKind::Protocol,
@@ -5273,6 +5275,7 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
 
     case RequirementKind::SameType:
     case RequirementKind::Superclass: {
+      ++metadata.NumRequirements;
       auto abiKind = kind == RequirementKind::SameType
         ? GenericRequirementKind::SameType
         : GenericRequirementKind::BaseClass;

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -11,6 +11,17 @@
 extension Int: P { }
 extension Array: P where Element: P { }
 
+// CHECK: @"$s15marker_protocol1QMp" = constant
+// CHECK-SAME: i32 trunc{{.*}}s15marker_protocolMXM{{.*}}s15marker_protocol1QMp
+// CHECK-SAME: i32 0, i32 5, i32 0
+public protocol Q: P {
+  func f()
+  func g()
+  func h()
+  func i()
+  func j()
+}
+
 // Note: no witness tables
 // CHECK: swiftcc void @"$s15marker_protocol7genericyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T)
 public func generic<T: P>(_: T) { }
@@ -19,5 +30,3 @@ public func testGeneric(i: Int, array: [Int]) {
   generic(i)
   generic(array)
 }
-
-public protocol Q: P { }

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -11,7 +11,7 @@
 extension Int: P { }
 extension Array: P where Element: P { }
 
-// CHECK: @"$s15marker_protocol1QMp" = constant
+// CHECK: @"$s15marker_protocol1QMp" = {{(protected )?}}constant
 // CHECK-SAME: i32 trunc{{.*}}s15marker_protocolMXM{{.*}}s15marker_protocol1QMp
 // CHECK-SAME: i32 0, i32 5, i32 0
 public protocol Q: P {


### PR DESCRIPTION
We had an imbalance where we counted conformance requirements to
marker protocols in the number of requirements in a protocol's
requirement signature, but then did not emit the requirement. Don't
count them, either.
