### PR TITLE
Marker protocols and conditional conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5624,6 +5624,10 @@ ERROR(marker_protocol_inherit_nonmarker, none,
       (DeclName, DeclName))
 ERROR(marker_protocol_cast,none,
       "marker protocol %0 cannot be used in a conditional cast", (DeclName))
+ERROR(marker_protocol_conditional_conformance,none,
+      "conditional conformance to non-marker protocol %0 cannot depend on "
+      "conformance of %1 to non-marker protocol %2",
+      (Identifier, Type, Identifier))
 
 //------------------------------------------------------------------------------
 // MARK: differentiable programming diagnostics

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1935,6 +1935,23 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
 
       nestedType = nestedType.getNominalParent();
     }
+
+    // If the protocol to which we are conditionally conforming is not a marker
+    // protocol, the conditional requirements must not involve conformance to a
+    // marker protocol. We cannot evaluate such a conformance at runtime.
+    if (!Proto->isMarkerProtocol()) {
+      for (const auto &req : *conditionalReqs) {
+        if (req.getKind() == RequirementKind::Conformance &&
+            req.getSecondType()->castTo<ProtocolType>()->getDecl()
+              ->isMarkerProtocol()) {
+          C.Diags.diagnose(
+            ComplainLoc, diag::marker_protocol_conditional_conformance,
+            Proto->getName(), req.getFirstType(),
+            req.getSecondType()->castTo<ProtocolType>()->getDecl()->getName());
+          conformance->setInvalid();
+        }
+      }
+    }
   }
 
   // If the protocol contains missing requirements, it can't be conformed to

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1962,7 +1962,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
   }
 
   bool impliedDisablesMissingWitnessFixits = false;
-  if (conformance->getSourceKind() == ConformanceEntryKind::Implied) {
+  if (conformance->getSourceKind() == ConformanceEntryKind::Implied &&
+      !Proto->isMarkerProtocol()) {
     // We've got something like:
     //
     //   protocol Foo : Proto {}

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -51,3 +51,10 @@ func testNotOkay(a: Any) {
   func inner(p3: P3) { }
 }
 
+
+@_marker protocol P8 { }
+protocol P9: P8 { }
+
+// Implied conditional conformance to P8 is okay because P8 is a marker
+// protocol.
+extension Array: P9 where Element: P9 { }

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -58,3 +58,8 @@ protocol P9: P8 { }
 // Implied conditional conformance to P8 is okay because P8 is a marker
 // protocol.
 extension Array: P9 where Element: P9 { }
+
+protocol P10 { }
+
+extension Array: P10 where Element: P10, Element: P8 { }
+// expected-error@-1{{conditional conformance to non-marker protocol 'P10' cannot depend on conformance of 'Element' to non-marker protocol 'P8'}}


### PR DESCRIPTION
Introduce two semantic tweaks for marker protocols:
* Allow implied conditional conformances to marker protocols.
* Ban use of marker protocols in conditional conformances to non-marker protocols