### PR TITLE
Make Error and CodingKey conform to ConcurrentValue.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4320,20 +4320,38 @@ ERROR(non_concurrent_type_member,none,
       "%select{stored property %1|associated value %1}0 of "
       "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",
       (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
+WARNING(non_concurrent_type_member_warn,none,
+      "%select{stored property %1|associated value %1}0 of "
+      "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",
+      (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
 ERROR(concurrent_value_class_mutable_property,none,
       "stored property %0 of 'ConcurrentValue'-conforming %1 %2 is mutable",
       (DeclName, DescriptiveDeclKind, DeclName))
+WARNING(concurrent_value_class_mutable_property_warn,none,
+      "stored property %0 of 'ConcurrentValue'-conforming %1 %2 is mutable",
+      (DeclName, DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_outside_source_file,none,
-      "conformance 'ConcurrentValue' must occur in the same source file as "
+      "conformance to 'ConcurrentValue' must occur in the same source file as "
+      "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
+      (DescriptiveDeclKind, DeclName))
+WARNING(concurrent_value_outside_source_file_warn,none,
+      "conformance to 'ConcurrentValue' must occur in the same source file as "
       "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
       (DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_open_class,none,
+      "open class %0 cannot conform to `ConcurrentValue`; "
+      "use `UnsafeConcurrentValue`", (DeclName))
+WARNING(concurrent_value_open_class_warn,none,
       "open class %0 cannot conform to `ConcurrentValue`; "
       "use `UnsafeConcurrentValue`", (DeclName))
 ERROR(concurrent_value_inherit,none,
       "`ConcurrentValue` class %1 cannot inherit from another class"
       "%select{| other than 'NSObject'}0",
       (bool, DeclName))
+WARNING(concurrent_value_inherit_warn,none,
+        "`ConcurrentValue` class %1 cannot inherit from another class"
+        "%select{| other than 'NSObject'}0",
+        (bool, DeclName))
 
 ERROR(actorindependent_let,none,
       "'@actorIndependent' is meaningless on 'let' declarations because "
@@ -5624,6 +5642,10 @@ ERROR(marker_protocol_inherit_nonmarker, none,
       (DeclName, DeclName))
 ERROR(marker_protocol_cast,none,
       "marker protocol %0 cannot be used in a conditional cast", (DeclName))
+ERROR(marker_protocol_conditional_conformance,none,
+      "conditional conformance to non-marker protocol %0 cannot depend on "
+      "conformance of %1 to non-marker protocol %2",
+      (Identifier, Type, Identifier))
 
 //------------------------------------------------------------------------------
 // MARK: differentiable programming diagnostics

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -238,7 +238,8 @@ bool diagnoseNonConcurrentTypesInReference(
     ConcurrentReferenceKind refKind);
 
 /// Check the correctness of the given ConcurrentValue conformance.
-void checkConcurrentValueConformance(ProtocolConformance *conformance);
+void checkConcurrentValueConformance(
+    ProtocolConformance *conformance, bool asWarning);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5660,6 +5660,8 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
 
   ProtocolConformance *concurrentValueConformance = nullptr;
   ProtocolConformance *unsafeConcurrentValueConformance = nullptr;
+  ProtocolConformance *errorConformance = nullptr;
+  ProtocolConformance *codingKeyConformance = nullptr;
   bool anyInvalid = false;
   for (auto conformance : conformances) {
     // Check and record normal conformances.
@@ -5691,12 +5693,18 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     } else if (proto->isSpecificProtocol(
                    KnownProtocolKind::UnsafeConcurrentValue)) {
       unsafeConcurrentValueConformance = conformance;
+    } else if (proto->isSpecificProtocol(KnownProtocolKind::Error)) {
+      errorConformance = conformance;
+    } else if (proto->isSpecificProtocol(KnownProtocolKind::CodingKey)) {
+      codingKeyConformance = conformance;
     }
   }
 
   // Check constraints of ConcurrentValue.
-  if (concurrentValueConformance && !unsafeConcurrentValueConformance)
-    checkConcurrentValueConformance(concurrentValueConformance);
+  if (concurrentValueConformance && !unsafeConcurrentValueConformance) {
+    bool asWarning = errorConformance || codingKeyConformance;
+    checkConcurrentValueConformance(concurrentValueConformance, asWarning);
+  }
 
   // Check all conformances.
   groupChecker.checkAllConformances();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1935,6 +1935,23 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
 
       nestedType = nestedType.getNominalParent();
     }
+
+    // If the protocol to which we are conditionally conforming is not a marker
+    // protocol, the conditional requirements must not involve conformance to a
+    // marker protocol. We cannot evaluate such a conformance at runtime.
+    if (!Proto->isMarkerProtocol()) {
+      for (const auto &req : *conditionalReqs) {
+        if (req.getKind() == RequirementKind::Conformance &&
+            req.getSecondType()->castTo<ProtocolType>()->getDecl()
+              ->isMarkerProtocol()) {
+          C.Diags.diagnose(
+            ComplainLoc, diag::marker_protocol_conditional_conformance,
+            Proto->getName(), req.getFirstType(),
+            req.getSecondType()->castTo<ProtocolType>()->getDecl()->getName());
+          conformance->setInvalid();
+        }
+      }
+    }
   }
 
   // If the protocol contains missing requirements, it can't be conformed to

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1962,7 +1962,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
   }
 
   bool impliedDisablesMissingWitnessFixits = false;
-  if (conformance->getSourceKind() == ConformanceEntryKind::Implied) {
+  if (conformance->getSourceKind() == ConformanceEntryKind::Implied &&
+      !Proto->isMarkerProtocol()) {
     // We've got something like:
     //
     //   protocol Foo : Proto {}

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -51,7 +51,8 @@ public typealias Codable = Encodable & Decodable
 //===----------------------------------------------------------------------===//
 
 /// A type that can be used as a key for encoding and decoding.
-public protocol CodingKey: CustomStringConvertible,
+public protocol CodingKey: ConcurrentValue,
+                           CustomStringConvertible,
                            CustomDebugStringConvertible {
   /// The string to use in a named collection (e.g. a string-keyed dictionary).
   var stringValue: String { get }
@@ -3179,7 +3180,7 @@ public struct CodingUserInfoKey: RawRepresentable, Equatable, Hashable, Concurre
 /// An error that occurs during the encoding of a value.
 public enum EncodingError: Error {
   /// The context in which the error occurred.
-  public struct Context {
+  public struct Context: ConcurrentValue {
     /// The path of coding keys taken to get to the point of the failing encode
     /// call.
     public let codingPath: [CodingKey]
@@ -3262,7 +3263,7 @@ public enum EncodingError: Error {
 /// An error that occurs during the decoding of a value.
 public enum DecodingError: Error {
   /// The context in which the error occurred.
-  public struct Context {
+  public struct Context: ConcurrentValue {
     /// The path of coding keys taken to get to the point of the failing decode
     /// call.
     public let codingPath: [CodingKey]

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -110,7 +110,7 @@ import SwiftShims
 ///         print("Other error: \(error)")
 ///     }
 ///     // Prints "Parsing error: mismatchedTag [19:5]"
-public protocol Error {
+public protocol Error: ConcurrentValue {
   var _domain: String { get }
   var _code: Int { get }
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -221,7 +221,7 @@ public struct URL : _ObjectiveCBridgeable {
  }
 }
 
-extension NSError : Error {
+extension NSError : Error, UnsafeConcurrentValue {
   public var _domain: String { return domain }
   public var _code: Int { return code }
 }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -7,8 +7,8 @@ class Cat {}
 enum HomeworkError : Error {
   case TooHard
   case TooMuch
-  case CatAteIt(Cat)
-  case CatHidIt(Cat)
+  case CatAteIt(Cat) // expected-warning{{associated value 'CatAteIt' of 'ConcurrentValue'-conforming enum 'HomeworkError' has non-concurrent-value type 'Cat'}}
+  case CatHidIt(Cat) // expected-warning{{associated value 'CatHidIt' of 'ConcurrentValue'-conforming enum 'HomeworkError' has non-concurrent-value type 'Cat'}}
 }
 
 func someValidPointer<T>() -> UnsafePointer<T> { fatalError() }

--- a/test/Sema/existential_nested_type.swift
+++ b/test/Sema/existential_nested_type.swift
@@ -10,7 +10,7 @@ protocol HasAssoc {
 }
 
 enum MyError : Error {
-  case bad(Any)
+  case bad(Any) // expected-warning{{associated value 'bad' of 'ConcurrentValue'-conforming enum 'MyError' has non-concurrent-value type 'Any'}}
 }
 
 func checkIt(_ js: Any) throws {

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -1,0 +1,4 @@
+Protocol CodingKey has added inherited protocol ConcurrentValue
+Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.ConcurrentValue, Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible>
+Protocol Error has added inherited protocol ConcurrentValue
+Protocol Error has generic signature change from to <Self : Swift.ConcurrentValue>

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -43,4 +43,8 @@ Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @avai
 Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
 Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
 Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
+Protocol CodingKey has added inherited protocol ConcurrentValue
+Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.ConcurrentValue, Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible>
+Protocol Error has added inherited protocol ConcurrentValue
+Protocol Error has generic signature change from to <Self : Swift.ConcurrentValue>
 Struct _RuntimeFunctionCounters is a new API without @available attribute

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -51,3 +51,10 @@ func testNotOkay(a: Any) {
   func inner(p3: P3) { }
 }
 
+
+@_marker protocol P8 { }
+protocol P9: P8 { }
+
+// Implied conditional conformance to P8 is okay because P8 is a marker
+// protocol.
+extension Array: P9 where Element: P9 { }

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -58,3 +58,8 @@ protocol P9: P8 { }
 // Implied conditional conformance to P8 is okay because P8 is a marker
 // protocol.
 extension Array: P9 where Element: P9 { }
+
+protocol P10 { }
+
+extension Array: P10 where Element: P10, Element: P8 { }
+// expected-error@-1{{conditional conformance to non-marker protocol 'P10' cannot depend on conformance of 'Element' to non-marker protocol 'P8'}}

--- a/test/decl/protocol/special/coding/Inputs/enum_coding_key_extension_multi2.swift
+++ b/test/decl/protocol/special/coding/Inputs/enum_coding_key_extension_multi2.swift
@@ -1,3 +1,3 @@
-extension NoRawTypeKey : CodingKey {}
-extension StringKey : CodingKey {}
-extension IntKey : CodingKey {}
+extension NoRawTypeKey : CodingKey, UnsafeConcurrentValue {}
+extension StringKey : CodingKey, UnsafeConcurrentValue {}
+extension IntKey : CodingKey, UnsafeConcurrentValue {}


### PR DESCRIPTION
Make both Error and CodingKey conform to ConcurrentValue, so that
thrown errors always conform to ConcurrentValue. Downgrade (to
warnings) and ConcurrentValue-related diagnostics that are triggered
by this change in existing Error and CodingKey-conforming types to
reduce the impact on source compatibility.