### PR TITLE
[stdlib] Reinstate some tests

### DIFF
--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1,15 +1,17 @@
-// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2017 - 2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: rdar49026133
 
 import Foundation
 import CoreGraphics
@@ -544,6 +546,10 @@ class TestCodable : TestCodableSuper {
     @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     func test_Measurement_JSON() {
         for (testLine, unit) in unitValues {
+            // FIXME: <rdar://problem/49026133>
+            // Terminating due to uncaught exception NSInvalidArgumentException:
+            // *** You must override baseUnit in your class NSDimension to define its base unit.
+            expectCrashLater()
             expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: unit), lineNumber: testLine)
         }
     }
@@ -551,7 +557,11 @@ class TestCodable : TestCodableSuper {
     @available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     func test_Measurement_Plist() {
         for (testLine, unit) in unitValues {
-            expectRoundTripEqualityThroughJSON(for: Measurement(value: 42, unit: unit), lineNumber: testLine)
+            // FIXME: <rdar://problem/49026133>
+            // Terminating due to uncaught exception NSInvalidArgumentException:
+            // *** You must override baseUnit in your class NSDimension to define its base unit.
+            expectCrashLater()
+            expectRoundTripEqualityThroughPlist(for: Measurement(value: 42, unit: unit), lineNumber: testLine)
         }
     }
 
@@ -915,10 +925,10 @@ if #available(macOS 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0, *) {
 }
 
 if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
-    // tests["test_DateInterval_JSON"] = TestCodable.test_DateInterval_JSON
+    tests["test_DateInterval_JSON"] = TestCodable.test_DateInterval_JSON
     tests["test_DateInterval_Plist"] = TestCodable.test_DateInterval_Plist
-    // tests["test_Measurement_JSON"] = TestCodable.test_Measurement_JSON
-    // tests["test_Measurement_Plist"] = TestCodable.test_Measurement_Plist
+    tests["test_Measurement_JSON"] = TestCodable.test_Measurement_JSON
+    tests["test_Measurement_Plist"] = TestCodable.test_Measurement_Plist
 }
 
 if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -1,10 +1,5 @@
-// RUN: %empty-directory(%t)
-// RUN: %gyb %s -o %t/FloatingPoint.swift
-// RUN: %line-directive %t/FloatingPoint.swift -- %target-build-swift -parse-stdlib %t/FloatingPoint.swift -o %t/a.out
-// RUN: %target-codesign %t/a.out
-// RUN: %line-directive %t/FloatingPoint.swift -- %target-run %t/a.out
+// RUN: %target-run-simple-swiftgyb(-parse-stdlib)
 // REQUIRES: executable_test
-// REQUIRES: rdar49026133
 
 import Swift
 import StdlibUnittest
@@ -118,17 +113,17 @@ FloatingPoint.test("BinaryFloatingPoint/genericIntegerConversion") {
 FloatingPoint.test("BinaryFloatingPoint/genericFloatingPointConversion") {
   func convert<
     T: BinaryFloatingPoint, U: BinaryFloatingPoint
-  >(exactly value: T, to: U.Type) -> U { U(exactly: value) }
+  >(exactly value: T, to: U.Type) -> U? { U(exactly: value) }
   
   expectEqual(convert(exactly: 0 as Float, to: Double.self), 0.0)
   expectEqual(convert(exactly: -0.0 as Float, to: Double.self), -0.0)
   expectEqual(
-    convert(exactly: -0.0 as Float, to: Double.self).sign,
+    convert(exactly: -0.0 as Float, to: Double.self)?.sign,
     FloatingPointSign.minus)
   expectEqual(convert(exactly: 0 as Double, to: Float.self), 0.0 as Float)
   expectEqual(convert(exactly: -0.0 as Double, to: Float.self), -0.0 as Float)
   expectEqual(
-    convert(exactly: -0.0 as Double, to: Float.self).sign,
+    convert(exactly: -0.0 as Double, to: Float.self)?.sign,
     FloatingPointSign.minus)
   expectEqual(convert(exactly: 1 as Float, to: Double.self), 1.0)
   expectEqual(convert(exactly: -1 as Float, to: Double.self), -1.0)
@@ -827,10 +822,11 @@ FloatingPoint.test("${FloatSelf}/{Comparable,Hashable,Equatable}") {
       //  If either lhs or rhs is signaling, or if both are quiet NaNs, the
       //  result is a quiet NaN.
       if lhs.isSignalingNaN || rhs.isSignalingNaN || (lhs.isNaN && rhs.isNaN) {
-        expectTrue(min.isQuietNaN)
-        expectTrue(max.isQuietNaN)
-        expectTrue(minMag.isQuietNaN)
-        expectTrue(maxMag.isQuietNaN)
+        // FIXME: <rdar://problem/48917925>
+        // expectTrue(min.isQuietNaN)
+        // expectTrue(max.isQuietNaN)
+        // expectTrue(minMag.isQuietNaN)
+        // expectTrue(maxMag.isQuietNaN)
       }
       //  If only one of lhs and rhs is NaN, the result of the min/max
       //  operations is always the other value.  While contrary to all other

--- a/test/stdlib/SetTrapsObjC.swift
+++ b/test/stdlib/SetTrapsObjC.swift
@@ -1,14 +1,7 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -o %t/a.out_Debug -Onone
-// RUN: %target-build-swift %s -o %t/a.out_Release -O
-//
-// RUN: %target-codesign %t/a.out_Debug
-// RUN: %target-codesign %t/a.out_Release
-// RUN: %target-run %t/a.out_Debug
-// RUN: %target-run %t/a.out_Release
+// RUN: %target-run-simple-swift(-Onone)
+// RUN: %target-run-simple-swift(-O)
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: rdar49026133
 
 import StdlibUnittest
 import Foundation

--- a/validation-test/stdlib/DictionaryTrapsObjC.swift
+++ b/validation-test/stdlib/DictionaryTrapsObjC.swift
@@ -1,14 +1,7 @@
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -o %t/a.out_Debug -Onone
-// RUN: %target-build-swift %s -o %t/a.out_Release -O
-// RUN: %target-codesign %t/a.out_Debug
-// RUN: %target-codesign %t/a.out_Release
-//
-// RUN: %target-run %t/a.out_Debug
-// RUN: %target-run %t/a.out_Release
+// RUN: %target-run-simple-swift(-Onone -DDEBUG)
+// RUN: %target-run-simple-swift(-O)
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-// REQUIRES: rdar49026133
 
 import StdlibUnittest
 import Foundation
@@ -205,6 +198,10 @@ DictionaryTraps.test("ForcedNonverbatimBridge.Value")
   _ = d1 as! Dictionary<NSObject, String>
 }
 
+// FIXME: <https://bugs.swift.org/browse/SR-14282>
+// Segmentation fault: 11 (when compiling with optimizations).
+// While running pass #0 SILModuleTransform "SILGenCleanup".
+#if DEBUG
 
 DictionaryTraps.test("ForcedVerbatimBridge.StringKey")
   .skip(.custom(
@@ -283,6 +280,8 @@ DictionaryTraps.test("ForcedVerbatimBridge.Value")
     _ = (key, value)
   }
 }
+
+#endif // DEBUG
 
 DictionaryTraps.test("Downcast.Verbatim")
   .skip(.custom(


### PR DESCRIPTION
Follow-up to: apple/swift#23423

I've tested (on macOS 11.2.1 and Xcode 12.4) with:

```shell
utils/run-test \
  --build-dir ../build/Ninja-RelWithDebInfoAssert \
  --verbose \
  test/stdlib/CodableTests.swift \
  test/stdlib/FloatingPoint.swift.gyb \
  test/stdlib/SetTrapsObjC.swift \
  validation-test/stdlib/DictionaryTrapsObjC.swift
```

I've replaced multi-line [substitutions][] with one of:

```swift
// RUN: %target-run-simple-swift(...)
// RUN: %target-run-simple-swiftgyb(...)
```

I've marked the remaining test failures with one of:

```swift
// FIXME: <rdar://problem/49026133>
// FIXME: <rdar://problem/48917925>
// FIXME: <https://bugs.swift.org/browse/SR-14282>
```

[substitutions]: <https://github.com/apple/swift/blob/main/docs/Testing.md#substitutions-in-lit-tests>