### PR TITLE
C++ Interop: import call operators

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -509,6 +509,12 @@ class AbstractionPattern {
     case Kind::CFunctionAsMethodType:
     case Kind::CurriedCFunctionAsMethodType:
     case Kind::PartialCurriedCFunctionAsMethodType:
+    case Kind::CXXMethodType:
+    case Kind::CurriedCXXMethodType:
+    case Kind::PartialCurriedCXXMethodType:
+    case Kind::CXXOperatorMethodType:
+    case Kind::CurriedCXXOperatorMethodType:
+    case Kind::PartialCurriedCXXOperatorMethodType:
       return true;
 
     default:
@@ -552,9 +558,11 @@ class AbstractionPattern {
   }
 
   void initCXXMethod(CanGenericSignature signature, CanType origType,
-                     const clang::CXXMethodDecl *method, Kind kind) {
+                     const clang::CXXMethodDecl *method, Kind kind,
+                     ImportAsMemberStatus memberStatus) {
     initSwiftType(signature, origType, kind);
     CXXMethod = method;
+    OtherData = memberStatus.getRawValue();
   }
 
   AbstractionPattern() {}
@@ -715,19 +723,22 @@ public:
   /// then the uncurried type is:
   ///   ((RefrigeratorCompartment, Temperature), Refrigerator) -> ()
   static AbstractionPattern getCXXMethod(CanType origType,
-                                         const clang::CXXMethodDecl *method) {
+                                         const clang::CXXMethodDecl *method,
+                                         ImportAsMemberStatus memberStatus) {
     assert(isa<AnyFunctionType>(origType));
     AbstractionPattern pattern;
-    pattern.initCXXMethod(nullptr, origType, method, Kind::CXXMethodType);
+    pattern.initCXXMethod(nullptr, origType, method,
+                          Kind::CXXMethodType, memberStatus);
     return pattern;
   }
 
   static AbstractionPattern
-  getCXXOperatorMethod(CanType origType, const clang::CXXMethodDecl *method) {
+  getCXXOperatorMethod(CanType origType, const clang::CXXMethodDecl *method,
+                       ImportAsMemberStatus memberStatus) {
     assert(isa<AnyFunctionType>(origType));
     AbstractionPattern pattern;
     pattern.initCXXMethod(nullptr, origType, method,
-                          Kind::CXXOperatorMethodType);
+                          Kind::CXXOperatorMethodType, memberStatus);
     return pattern;
   }
 
@@ -739,21 +750,23 @@ public:
   /// then the curried type:
   ///   (Refrigerator) -> (Compartment, Temperature) -> ()
   static AbstractionPattern
-  getCurriedCXXMethod(CanType origType, const clang::CXXMethodDecl *method) {
+  getCurriedCXXMethod(CanType origType, const clang::CXXMethodDecl *method,
+                      ImportAsMemberStatus memberStatus) {
     assert(isa<AnyFunctionType>(origType));
     AbstractionPattern pattern;
     pattern.initCXXMethod(nullptr, origType, method,
-                          Kind::CurriedCXXMethodType);
+                          Kind::CurriedCXXMethodType, memberStatus);
     return pattern;
   }
 
   static AbstractionPattern
   getCurriedCXXOperatorMethod(CanType origType,
-                              const clang::CXXMethodDecl *method) {
+                              const clang::CXXMethodDecl *method,
+                              ImportAsMemberStatus memberStatus) {
     assert(isa<AnyFunctionType>(origType));
     AbstractionPattern pattern;
     pattern.initCXXMethod(nullptr, origType, method,
-                          Kind::CurriedCXXOperatorMethodType);
+                          Kind::CurriedCXXOperatorMethodType, memberStatus);
     return pattern;
   }
 
@@ -855,22 +868,24 @@ private:
   ///   (Compartment, Temperature) -> ()
   static AbstractionPattern
   getPartialCurriedCXXMethod(CanGenericSignature signature, CanType origType,
-                             const clang::CXXMethodDecl *method) {
+                             const clang::CXXMethodDecl *method,
+                             ImportAsMemberStatus memberStatus) {
     assert(isa<AnyFunctionType>(origType));
     AbstractionPattern pattern;
     pattern.initCXXMethod(signature, origType, method,
-                          Kind::PartialCurriedCXXMethodType);
+                          Kind::PartialCurriedCXXMethodType, memberStatus);
     return pattern;
   }
 
   static AbstractionPattern
   getPartialCurriedCXXOperatorMethod(CanGenericSignature signature,
                                      CanType origType,
-                                     const clang::CXXMethodDecl *method) {
+                                     const clang::CXXMethodDecl *method,
+                                     ImportAsMemberStatus memberStatus) {
     assert(isa<AnyFunctionType>(origType));
     AbstractionPattern pattern;
     pattern.initCXXMethod(signature, origType, method,
-                          Kind::PartialCurriedCXXOperatorMethodType);
+                          Kind::PartialCurriedCXXOperatorMethodType, memberStatus);
     return pattern;
   }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1815,7 +1815,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
   // imported into Swift as static methods that have an additional
   // parameter for the left-hand side operand instead of the receiver object.
   if (auto CMD = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
-    if (clangDecl->isOverloadedOperator()) {
+    if (clangDecl->isOverloadedOperator() && isImportedAsStatic(clangDecl->getOverloadedOperator())) {
       auto param = new (SwiftContext)
           ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
                     SwiftContext.getIdentifier("lhs"), dc);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1473,6 +1473,10 @@ bool shouldSuppressDeclImport(const clang::Decl *decl);
 /// but are now renamed using the swift_name attribute.
 bool isSpecialUIKitStructZeroProperty(const clang::NamedDecl *decl);
 
+/// \returns true if this operator should be made a static function
+/// even if imported as a non-static member function.
+bool isImportedAsStatic(clang::OverloadedOperatorKind op);
+
 /// Add command-line arguments for a normal import of Clang code.
 void getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
                                   ASTContext &ctx);

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -176,13 +176,13 @@ AbstractionPattern
 AbstractionPattern::getCurriedCXXMethod(CanType origType,
                                         const AbstractFunctionDecl *function) {
   auto clangMethod = cast<clang::CXXMethodDecl>(function->getClangDecl());
-  return getCurriedCXXMethod(origType, clangMethod);
+  return getCurriedCXXMethod(origType, clangMethod, function->getImportAsMemberStatus());
 }
 
 AbstractionPattern AbstractionPattern::getCurriedCXXOperatorMethod(
     CanType origType, const AbstractFunctionDecl *function) {
   auto clangMethod = cast<clang::CXXMethodDecl>(function->getClangDecl());
-  return getCurriedCXXOperatorMethod(origType, clangMethod);
+  return getCurriedCXXOperatorMethod(origType, clangMethod, function->getImportAsMemberStatus());
 }
 
 AbstractionPattern
@@ -529,11 +529,12 @@ AbstractionPattern AbstractionPattern::getFunctionResultType() const {
                                       getImportAsMemberStatus());
   case Kind::CurriedCXXMethodType:
     return getPartialCurriedCXXMethod(getGenericSignatureForFunctionComponent(),
-                                      getResultType(getType()), getCXXMethod());
+                                      getResultType(getType()), getCXXMethod(),
+                                      getImportAsMemberStatus());
   case Kind::CurriedCXXOperatorMethodType:
     return getPartialCurriedCXXOperatorMethod(
         getGenericSignatureForFunctionComponent(), getResultType(getType()),
-        getCXXMethod());
+        getCXXMethod(), getImportAsMemberStatus());
   case Kind::PartialCurriedObjCMethodType:
   case Kind::ObjCMethodType: {
     // If this is a foreign async function, the result type comes from the
@@ -753,10 +754,19 @@ AbstractionPattern::getFunctionParamType(unsigned index) const {
     auto params = cast<AnyFunctionType>(getType()).getParams();
     auto paramType = params[index].getParameterType();
 
-    // The first parameter holds the left-hand-side operand, which gets passed
-    // to the C++ function as the this pointer.
-    if (index == 0)
-      return getCXXMethodSelfPattern(paramType);
+    // See importer::isImportedAsStatic
+    bool isStatic = getImportAsMemberStatus().isStatic();
+    if (isStatic) {
+      // The first parameter holds the left-hand-side operand, which gets passed
+      // to the C++ function as the this pointer.
+      if (index == 0)
+        return getCXXMethodSelfPattern(paramType);
+    } else {
+      // The last parameter is 'self'.
+      if (getKind() == Kind::CXXOperatorMethodType &&
+          index == params.size() - 1)
+        return getCXXMethodSelfPattern(params.back().getParameterType());
+    }
 
     // A parameter of type () does not correspond to a Clang parameter.
     if (paramType->isVoid())
@@ -766,7 +776,7 @@ AbstractionPattern::getFunctionParamType(unsigned index) const {
     auto methodType = getCXXMethod()->getType().getTypePtr();
     return AbstractionPattern(
         getGenericSignatureForFunctionComponent(), paramType,
-        getClangFunctionParameterType(methodType, index - 1));
+        getClangFunctionParameterType(methodType, index - (isStatic ? 1 : 0)));
   }
   case Kind::CurriedObjCMethodType: {
     auto params = cast<AnyFunctionType>(getType()).getParams();

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2903,8 +2903,8 @@ static CanSILFunctionType getSILFunctionTypeForClangDecl(
 
   if (auto method = dyn_cast<clang::CXXMethodDecl>(clangDecl)) {
     AbstractionPattern origPattern = method->isOverloadedOperator() ?
-        AbstractionPattern::getCXXOperatorMethod(origType, method):
-        AbstractionPattern::getCXXMethod(origType, method);
+        AbstractionPattern::getCXXOperatorMethod(origType, method, foreignInfo.Self):
+        AbstractionPattern::getCXXMethod(origType, method, foreignInfo.Self);
     auto conventions = CXXMethodConventions(method);
     return getSILFunctionType(TC, TypeExpansionContext::minimal(), origPattern,
                               substInterfaceType, extInfoBuilder, conventions,

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -6,6 +6,33 @@ struct LoadableIntWrapper {
   LoadableIntWrapper operator-(LoadableIntWrapper rhs) {
     return LoadableIntWrapper{.value = value - rhs.value};
   }
+
+  int operator()() {
+    return value;
+  }
+  int operator()(int x) {
+    return value + x;
+  }
+  int operator()(int x, int y) {
+    return value + x * y;
+  }
+};
+
+struct AddressOnlyIntWrapper {
+  int value;
+
+  AddressOnlyIntWrapper(int value) : value(value) {}
+  AddressOnlyIntWrapper(const AddressOnlyIntWrapper &other) : value(other.value) {}
+
+  int operator()() {
+    return value;
+  }
+  int operator()(int x) {
+    return value + x;
+  }
+  int operator()(int x, int y) {
+    return value + x * y;
+  }
 };
 
 struct HasDeletedOperator {

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
@@ -3,3 +3,27 @@
 LoadableIntWrapper LoadableIntWrapper::operator+(LoadableIntWrapper rhs) const {
   return LoadableIntWrapper{.value = value + rhs.value};
 }
+
+int LoadableIntWrapper::operator()() const {
+  return value;
+}
+
+int LoadableIntWrapper::operator()(int x) const {
+  return value + x;
+}
+
+int LoadableIntWrapper::operator()(int x, int y) const {
+  return value + x * y;
+}
+
+int AddressOnlyIntWrapper::operator()() const {
+  return value;
+}
+
+int AddressOnlyIntWrapper::operator()(int x) const {
+  return value + x;
+}
+
+int AddressOnlyIntWrapper::operator()(int x, int y) const {
+  return value + x * y;
+}

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -4,6 +4,20 @@
 struct LoadableIntWrapper {
   int value;
   LoadableIntWrapper operator+(LoadableIntWrapper rhs) const;
+  int operator()() const;
+  int operator()(int x) const;
+  int operator()(int x, int y) const;
+};
+
+struct AddressOnlyIntWrapper {
+  int value;
+
+  AddressOnlyIntWrapper(int value) : value(value) {}
+  AddressOnlyIntWrapper(const AddressOnlyIntWrapper &other) : value(other.value) {}
+
+  int operator()() const;
+  int operator()(int x) const;
+  int operator()(int x, int y) const;
 };
 
 #endif

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -9,3 +9,13 @@ public func sub(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> L
 
 // CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN18LoadableIntWrappermiES_|"\?\?GLoadableIntWrapper@@QEAA\?AU0@U0@@Z")]](%struct.LoadableIntWrapper* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\) align 4}} {{%[0-9]+}})
 // CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4) {{.*}}, {{i32 %rhs.coerce|\[1 x i32\] %rhs.coerce|i64 %rhs.coerce|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %rhs}})
+
+public func call(_ wrapper: inout LoadableIntWrapper, _ arg: Int32) -> Int32 { wrapper(arg) }
+
+// CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN18LoadableIntWrapperclEi|"\?\?GLoadableIntWrapper@@QEAAHH@Z")]](%struct.LoadableIntWrapper* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\) align 4}} {{%[0-9]+}})
+// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4) {{.*}}, {{i32 %x|\[1 x i32\] %x|i64 %x|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %rhs}})
+
+public func call(_ wrapper: inout AddressOnlyIntWrapper) -> Int32 { wrapper() }
+
+// CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN21AddressOnlyIntWrapperclEv|"\?\?GAddressOnlyIntWrapper@@QEAAHXZ")]](%struct.AddressOnlyIntWrapper* {{%[0-9]+}})
+// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.AddressOnlyIntWrapper* nonnull dereferenceable(4) {{.*}})

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -2,6 +2,15 @@
 
 // CHECK: struct LoadableIntWrapper {
 // CHECK:   static func - (lhs: inout LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK:   mutating func callAsFunction() -> Int32
+// CHECK:   mutating func callAsFunction(_ x: Int32) -> Int32
+// CHECK:   mutating func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
+// CHECK: }
+
+// CHECK: struct AddressOnlyIntWrapper {
+// CHECK:   mutating func callAsFunction() -> Int32
+// CHECK:   mutating func callAsFunction(_ x: Int32) -> Int32
+// CHECK:   mutating func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK: }
 
 // CHECK: struct HasDeletedOperator {

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -12,3 +12,23 @@ public func sub(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> L
 // CHECK: end_access [[SELFACCESS]] : $*LoadableIntWrapper
 
 // CHECK: sil [clang LoadableIntWrapper."-"] [[NAME]] : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
+
+public func call(_ wrapper: inout LoadableIntWrapper, _ arg: Int32) -> Int32 { wrapper(arg) }
+
+// CHECK: bb0([[SELF:%.*]] : $*LoadableIntWrapper, [[RHS:%.*]] : $Int32):
+// CHECK: [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*LoadableIntWrapper
+// CHECK: [[OP:%.*]] = function_ref [[NAME:@(_ZN18LoadableIntWrapperclEi|\?\?RLoadableIntWrapper@@QEAAHH@Z)]] : $@convention(c) (@inout LoadableIntWrapper, Int32) -> Int32
+// CHECK: apply [[OP]]([[SELFACCESS]], [[RHS]]) : $@convention(c) (@inout LoadableIntWrapper, Int32) -> Int32
+// CHECK: end_access [[SELFACCESS]] : $*LoadableIntWrapper
+
+// CHECK: sil [clang LoadableIntWrapper.callAsFunction] [[NAME]] : $@convention(c) (@inout LoadableIntWrapper, Int32) -> Int32
+
+public func call(_ wrapper: inout AddressOnlyIntWrapper) -> Int32 { wrapper() }
+
+// CHECK: bb0([[SELF:%.*]] : $*AddressOnlyIntWrapper):
+// CHECK: [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*AddressOnlyIntWrapper
+// CHECK: [[OP:%.*]] = function_ref [[NAME:@(_ZN21AddressOnlyIntWrapperclEv|\?\?RAddressOnlyIntWrapper@@QEAAHXZ)]] : $@convention(c) (@inout AddressOnlyIntWrapper) -> Int32
+// CHECK: apply [[OP]]([[SELFACCESS]]) : $@convention(c) (@inout AddressOnlyIntWrapper) -> Int32
+// CHECK: end_access [[SELFACCESS]] : $*AddressOnlyIntWrapper
+
+// CHECK: sil [clang AddressOnlyIntWrapper.callAsFunction] [[NAME]] : $@convention(c) (@inout AddressOnlyIntWrapper) -> Int32

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -6,3 +6,12 @@ var lhs = LoadableIntWrapper(value: 42)
 let rhs = LoadableIntWrapper(value: 23)
 
 let resultPlus = lhs - rhs
+let resultCall0 = lhs()
+let resultCall1 = lhs(1)
+let resultCall2 = lhs(1, 2)
+
+var addressOnly = AddressOnlyIntWrapper(42)
+
+let addressOnlyResultCall0 = addressOnly()
+let addressOnlyResultCall1 = addressOnly(1)
+let addressOnlyResultCall2 = addressOnly(1, 2)

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -10,13 +10,37 @@ import StdlibUnittest
 
 var OperatorsTestSuite = TestSuite("Operators")
 
-OperatorsTestSuite.test("LoadableIntWrapper.plus") {
+OperatorsTestSuite.test("LoadableIntWrapper.plus (inline)") {
   var lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs - rhs
 
   expectEqual(19, result.value)
+}
+
+OperatorsTestSuite.test("LoadableIntWrapper.call (inline)") {
+  var wrapper = LoadableIntWrapper(value: 42)
+
+  let resultNoArgs = wrapper()
+  let resultOneArg = wrapper(23)
+  let resultTwoArgs = wrapper(3, 5)
+
+  expectEqual(42, resultNoArgs)
+  expectEqual(65, resultOneArg)
+  expectEqual(57, resultTwoArgs)
+}
+
+OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
+  var wrapper = AddressOnlyIntWrapper(42)
+
+  let resultNoArgs = wrapper()
+  let resultOneArg = wrapper(23)
+  let resultTwoArgs = wrapper(3, 5)
+
+  expectEqual(42, resultNoArgs)
+  expectEqual(65, resultOneArg)
+  expectEqual(57, resultTwoArgs)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -14,13 +14,37 @@ import StdlibUnittest
 
 var OperatorsTestSuite = TestSuite("Operators")
 
-OperatorsTestSuite.test("plus") {
+OperatorsTestSuite.test("LoadableIntWrapper.plus (out-of-line)") {
   var lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs + rhs
 
   expectEqual(65, result.value)
+}
+
+OperatorsTestSuite.test("LoadableIntWrapper.call (out-of-line)") {
+  var wrapper = LoadableIntWrapper(value: 42)
+
+  let resultNoArgs = wrapper()
+  let resultOneArg = wrapper(23)
+  let resultTwoArgs = wrapper(3, 5)
+
+  expectEqual(42, resultNoArgs)
+  expectEqual(65, resultOneArg)
+  expectEqual(57, resultTwoArgs)
+}
+
+OperatorsTestSuite.test("AddressOnlyIntWrapper.call (out-of-line)") {
+  var wrapper = AddressOnlyIntWrapper(42)
+
+  let resultNoArgs = wrapper()
+  let resultOneArg = wrapper(23)
+  let resultTwoArgs = wrapper(3, 5)
+
+  expectEqual(42, resultNoArgs)
+  expectEqual(65, resultOneArg)
+  expectEqual(57, resultTwoArgs)
 }
 
 runAllTests()


### PR DESCRIPTION
This change adds support for calling `operator()` from Swift code.

As the C++ interop manifesto describes, `operator()` is imported into Swift as `callAsFunction`.
