### PR TITLE
[SR-2705][Sema] Always favor non-autoclosure parameter function overload on ranking

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -802,8 +802,10 @@ enum ScoreKind {
   SK_KeyPathSubscript,
   /// A conversion from a string, array, or inout to a pointer.
   SK_ValueToPointerConversion,
+  /// A closure/function conversion to an autoclosure parameter.
+  SK_FunctionToAutoClosureConversion,
 
-  SK_LastScoreKind = SK_ValueToPointerConversion,
+  SK_LastScoreKind = SK_FunctionToAutoClosureConversion,
 };
 
 /// The number of score kinds.

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -81,6 +81,9 @@ static StringRef getScoreKindName(ScoreKind kind) {
 
   case SK_ValueToPointerConversion:
     return "value-to-pointer conversion";
+
+  case SK_FunctionToAutoClosureConversion:
+    return "function to autoclosure parameter";
   }
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2230,9 +2230,15 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     //
     //   let _ = autoclosure as (() -> (Int)) -> () // non-autoclosure preferred
     //
-    if (func1Param.isAutoClosure() &&
-        (!func2Param.isAutoClosure() &&
-         func2Param.getPlainType()->is<FunctionType>())) {
+    auto isAutoClosureFunctionMatch = [](AnyFunctionType::Param &param1,
+                                         AnyFunctionType::Param &param2) {
+      return param1.isAutoClosure() &&
+             (!param2.isAutoClosure() &&
+              param2.getPlainType()->is<FunctionType>());
+    };
+
+    if (isAutoClosureFunctionMatch(func1Param, func2Param) ||
+        isAutoClosureFunctionMatch(func2Param, func1Param)) {
       increaseScore(SK_FunctionToAutoClosureConversion);
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1355,7 +1355,7 @@ ConstraintSystem::TypeMatchResult constraints::matchCallArguments(
         //
         //    f { } // OK
         if (isExpr<ClosureExpr>(argExpr)) {
-          cs.increaseScore(SK_FunctionConversion);
+          cs.increaseScore(SK_FunctionToAutoClosureConversion);
         }
 
         // If the argument is not marked as @autoclosure or
@@ -2233,7 +2233,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     if (func1Param.isAutoClosure() &&
         (!func2Param.isAutoClosure() &&
          func2Param.getPlainType()->is<FunctionType>())) {
-      increaseScore(SK_FunctionConversion);
+      increaseScore(SK_FunctionToAutoClosureConversion);
     }
 
     // Variadic bit must match.

--- a/test/Constraints/sr2705.swift
+++ b/test/Constraints/sr2705.swift
@@ -1,30 +1,37 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-emit-silgen %s -verify | %FileCheck %s
 
 func f<T>(_: () -> T) {}
 func f<T>(_: @autoclosure () -> T) {}
 
+// CHECK: function_ref @$s6sr27051fyyxyXElF
 f { } // OK
 
 func f1<T>(_: () -> T, _: () -> T) {}
 func f1<T>(_: @autoclosure () -> T, _: @autoclosure () -> T) {}
 
+// CHECK: function_ref @$s6sr27052f1yyxyXE_xyXEtlF 
 f1({}, {}) // OK
 
 func f2<T>(_: () -> T, _: () -> T) { }
 func f2<T>(_: () -> T, _: @autoclosure () -> T) { }
 
+// CHECK: function_ref @$s6sr27052f2yyxyXE_xyXEtlF 
 f2({}, {}) // OK
 
 func f3(_: () -> Int) {}
 func f3(_: @autoclosure () -> Int) {}
 
+// CHECK: function_ref @$s6sr27052f3yySiyXEF 
 f3 { 0 } // OK
  
 func autoclosure(f: () -> Int) { }
 func autoclosure(f: @autoclosure () -> Int) { }
 func autoclosure(f: Int) { }
 
+// CHECK: function_ref @$s6sr270511autoclosure1fySiyXE_tF
 autoclosure(f: { 0 }) // OK
+
+// CHECK: function_ref @$s6sr27052fnyySiyXEF 
 let _ = autoclosure as (() -> (Int)) -> () // OK
 
 func test(_: (@autoclosure () -> Int) -> Void) {}
@@ -32,4 +39,5 @@ func test(_: (() -> Int) -> Void) {}
 
 func fn(_: () -> Int) {}
 
+// CHECK: function_ref @$s6sr27054testyyySiyXEXEF
 test(fn) // OK

--- a/test/Constraints/sr2705.swift
+++ b/test/Constraints/sr2705.swift
@@ -26,3 +26,10 @@ func autoclosure(f: Int) { }
 
 autoclosure(f: { 0 }) // OK
 let _ = autoclosure as (() -> (Int)) -> () // OK
+
+func test(_: (@autoclosure () -> Int) -> Void) {}
+func test(_: (() -> Int) -> Void) {}
+
+func fn(_: () -> Int) {}
+
+test(fn) // OK

--- a/test/Constraints/sr2705.swift
+++ b/test/Constraints/sr2705.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+
+func f<T>(_: () -> T) {}
+func f<T>(_: @autoclosure () -> T) {}
+
+f { } // OK
+
+func f1<T>(_: () -> T, _: () -> T) {}
+func f1<T>(_: @autoclosure () -> T, _: @autoclosure () -> T) {}
+
+f1({}, {}) // OK
+
+func f2<T>(_: () -> T, _: () -> T) { }
+func f2<T>(_: () -> T, _: @autoclosure () -> T) { }
+
+f2({}, {}) // OK
+
+func f3(_: () -> Int) {}
+func f3(_: @autoclosure () -> Int) {}
+
+f3 { 0 } // OK
+ 
+func autoclosure(f: () -> Int) { }
+func autoclosure(f: @autoclosure () -> Int) { }
+func autoclosure(f: Int) { }
+
+autoclosure(f: { 0 }) // OK
+let _ = autoclosure as (() -> (Int)) -> () // OK


### PR DESCRIPTION
<!-- What's in this pull request? -->
Implement a rule on ranking where overload choices that has `@autoclosure` parameters are disfavored over the ones that aren't to avoid ambiguity in situations like

```swift
func f<T>(_: () -> T) {}
func f<T>(_: @autoclosure () -> T) {}

f { } // ok

``` 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-2705.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
