### PR TITLE
[SymbolGraph] Use the frontend option tables instead of llvm::cl for argument parsing

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -394,6 +394,11 @@ REMARK(interface_file_lock_failure,none,
 REMARK(interface_file_lock_timed_out,none,
       "timed out waiting to acquire lock file for module interface '%0'", (StringRef))
 
+ERROR(error_option_required,none, "option '%0' is required", (StringRef))
+ERROR(error_nonexistent_output_dir,none,
+      "'-output-dir' argument '%0' does not exist or is not a directory", (StringRef))
+
+
 // Dependency Verifier Diagnostics
 ERROR(missing_member_dependency,none,
       "expected "

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -38,13 +38,14 @@ namespace options {
     ModuleInterfaceOption = (1 << 13),
     SupplementaryOutput = (1 << 14),
     SwiftAPIExtractOption = (1 << 15),
+    SwiftSymbolGraphExtractOption = (1 << 16),
   };
 
   enum ID {
     OPT_INVALID = 0, // This is not an option ID.
 #define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
                HELPTEXT, METAVAR, VALUES)                                      \
-  OPT_##ID,
+    OPT_##ID,
 #include "swift/Option/Options.inc"
     LastOption
 #undef OPTION

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -58,6 +58,9 @@ def SupplementaryOutput : OptionFlag;
 // The option should be accepted by swift-api-extract.
 def SwiftAPIExtractOption : OptionFlag;
 
+// The option should be accepted by swift-symbolgraph-extract.
+def SwiftSymbolGraphExtractOption : OptionFlag;
+
 /////////
 // Options
 
@@ -173,7 +176,8 @@ def driver_mode : Joined<["--"], "driver-mode=">, Flags<[HelpHidden]>,
 
 def help : Flag<["-", "--"], "help">,
   Flags<[FrontendOption, AutolinkExtractOption, ModuleWrapOption,
-         SwiftIndentOption, SwiftAPIExtractOption]>,
+         SwiftIndentOption, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption]>,
   HelpText<"Display available options">;
 def h : Flag<["-"], "h">, Alias<help>;
 def help_hidden : Flag<["-", "--"], "help-hidden">,
@@ -202,10 +206,12 @@ def o : JoinedOrSeparate<["-"], "o">,
 def j : JoinedOrSeparate<["-"], "j">, Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Number of commands to execute in parallel">, MetaVarName<"<n>">;
 
-def sdk : Separate<["-"], "sdk">, Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
+def sdk : Separate<["-"], "sdk">,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Compile against <sdk>">, MetaVarName<"<sdk>">;
 
-def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption]>,
+def swift_version : Separate<["-"], "swift-version">,
+  Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Interpret input according to a specific Swift language version number">,
   MetaVarName<"<vers>">;
 
@@ -222,16 +228,18 @@ def tools_directory : Separate<["-"], "tools-directory">,
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
 
-def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
+def F : JoinedOrSeparate<["-"], "F">,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Add directory to framework search path">;
 def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<F>;
 
 def Fsystem : Separate<["-"], "Fsystem">,
-  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Add directory to system framework search path">;
 
-def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption]>,
+def I : JoinedOrSeparate<["-"], "I">,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Add directory to the import search path">;
 def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
   Alias<I>;
@@ -377,7 +385,8 @@ def localization_path : Separate<["-"], "localization-path">,
   MetaVarName<"<path>">;
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption]>,
   HelpText<"Specifies the Clang module cache path">;
 
 def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
@@ -398,7 +407,8 @@ def define_availability : Separate<["-"], "define-availability">,
   MetaVarName<"<macro>">;
 
 def module_name : Separate<["-"], "module-name">,
-  Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption]>,
+  Flags<[FrontendOption, ModuleInterfaceOption, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption]>,
   HelpText<"Name of the module to build">;
 def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
   Alias<module_name>;
@@ -667,7 +677,8 @@ def framework : Separate<["-"], "framework">, Group<linker_option_Group>,
   HelpText<"Specifies a framework which should be linked against">;
 
 def L : JoinedOrSeparate<["-"], "L">, Group<linker_option_Group>,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption]>,
   HelpText<"Add directory to library link search path">;
 def L_EQ : Joined<["-"], "L=">, Group<linker_option_Group>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
@@ -1014,7 +1025,7 @@ def num_threads : Separate<["-"], "num-threads">,
 def Xfrontend : Separate<["-"], "Xfrontend">, Flags<[HelpHidden]>,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to the Swift frontend">;
 
-def Xcc : Separate<["-"], "Xcc">, Flags<[FrontendOption]>,
+def Xcc : Separate<["-"], "Xcc">, Flags<[FrontendOption, SwiftSymbolGraphExtractOption]>,
   MetaVarName<"<arg>">,
   HelpText<"Pass <arg> to the C/C++/Objective-C compiler">;
 
@@ -1026,12 +1037,12 @@ def Xllvm : Separate<["-"], "Xllvm">,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to LLVM.">;
 
 def resource_dir : Separate<["-"], "resource-dir">,
-  Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
+  Flags<[FrontendOption, SwiftSymbolGraphExtractOption, HelpHidden, ArgumentIsPath]>,
   MetaVarName<"</usr/lib/swift>">,
   HelpText<"The directory that holds the compiler resource files">;
 
 def target : Separate<["-"], "target">,
-  Flags<[FrontendOption, ModuleWrapOption, ModuleInterfaceOption, SwiftAPIExtractOption]>,
+  Flags<[FrontendOption, ModuleWrapOption, ModuleInterfaceOption, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Generate code for the given target <triple>, such as x86_64-apple-macos10.9">, MetaVarName<"<triple>">;
 def target_legacy_spelling : Joined<["--"], "target=">,
   Flags<[FrontendOption]>, Alias<target>;
@@ -1187,8 +1198,23 @@ def emit_symbol_graph_dir : Separate<["-"], "emit-symbol-graph-dir">,
   HelpText<"Emit a symbol graph to directory <dir>">,
   MetaVarName<"<dir>">;
 
-// Swift API Extraction only options
-def pretty_print: Flag<["-"], "pretty-print">, Flags<[SwiftAPIExtractOption]>,
+def pretty_print: Flag<["-"], "pretty-print">,
+  Flags<[SwiftAPIExtractOption, SwiftSymbolGraphExtractOption]>,
   HelpText<"Pretty-print the output JSON">;
+
+// swift-symbolgraph-extract-only options
+def output_dir : Separate<["-"], "output-dir">,
+  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption, ArgumentIsPath]>,
+  HelpText<"Symbol Graph JSON Output Directory (Required)">,
+  MetaVarName<"<dir>">;
+
+def skip_synthesized_members: Flag<[ "-" ], "skip-synthesized-members">,
+  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption]>,
+  HelpText<"Skip members inherited through classes or default implementations">;
+
+def minimum_access_level : Separate<["-"], "minimum-access-level">,
+  Flags<[NoDriverOption, SwiftSymbolGraphExtractOption]>,
+  HelpText<"Include symbols with this access level or more">,
+  MetaVarName<"<level>">;
 
 include "FrontendOptions.td"

--- a/test/SILOptimizer/lazy_property_getters.swift
+++ b/test/SILOptimizer/lazy_property_getters.swift
@@ -2,7 +2,7 @@
 
 // Also do an end-to-end test to check if the generated code is correct.
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -O -Xllvm -module-name=test %s -o %t/a.out
+// RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
 // REQUIRES: executable_test

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -20,206 +20,174 @@
 #include "swift/Basic/Version.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
+#include "swift/Option/Options.h"
 #include "swift/SymbolGraphGen/SymbolGraphGen.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/CommandLine.h"
 
 using namespace swift;
-using namespace llvm::opt;
+using namespace options;
 
-namespace options {
-static llvm::cl::OptionCategory Category("swift-symbolgraph-extract Options");
-
-static llvm::cl::opt<std::string>
-ModuleName("module-name", llvm::cl::desc("Name of the module to extract (Required)"), llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-FrameworkSearchPaths("F", llvm::cl::desc("Add a directory to the framework search paths"), llvm::cl::ZeroOrMore,
-                     llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-SystemFrameworkSearchPaths("Fsystem", llvm::cl::desc("Add directory to system framework search path"), llvm::cl::ZeroOrMore,
-                     llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-LibrarySearchPaths("L", llvm::cl::desc("Add a directory to the library search paths"), llvm::cl::ZeroOrMore,
-                   llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-ImportSearchPaths("I", llvm::cl::desc("Add directory to the import search paths"), llvm::cl::ZeroOrMore,
-                  llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-ModuleCachePath("module-cache-path", llvm::cl::desc("Specifies a path to cache modules"), llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-SDK("sdk", llvm::cl::desc("Path to the SDK"),
-    llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-Target("target", llvm::cl::desc("Target triple (Required)"),
-       llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-SwiftVersion("swift-version", llvm::cl::desc("Interpret input according to a specific Swift language version number"), llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-PrettyPrint("pretty-print", llvm::cl::desc("Pretty-print the resulting Symbol Graph JSON"), llvm::cl::cat(Category));
-
-static llvm::cl::opt<bool>
-SkipSynthesizedMembers("skip-synthesized-members",
-                       llvm::cl::desc("Skip members inherited through classes or default implementations"),
-                       llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-MinimumAccessLevel("minimum-access-level", llvm::cl::desc("Include symbols with this access level or more"), llvm::cl::cat(Category));
-
-static llvm::cl::list<std::string>
-Xcc("Xcc", llvm::cl::desc("Pass the following command-line flag to Clang"),
-         llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-ResourceDir("resource-dir",
-            llvm::cl::desc("Override the directory that holds the compiler resource files"),
-            llvm::cl::cat(Category));
-
-static llvm::cl::opt<std::string>
-OutputDir("output-dir", llvm::cl::desc("Symbol Graph JSON Output Directory (Required)"), llvm::cl::cat(Category));
-} // end namespace options
-
-static bool argumentsAreValid() {
-  bool Valid = true;
-  if (options::Target.empty()) {
-    llvm::errs() << "Required -target option is missing\n";
-    Valid = false;
-  }
-
-  if (options::ModuleName.empty()) {
-    llvm::errs() << "Required -module-name argument is missing\n";
-    Valid = false;
-  }
-
-  if (options::OutputDir.empty()) {
-    llvm::errs() << "Required -output-dir argument is missing\n";
-    Valid = false;
-  }
-
-  return Valid;
-}
-
-int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv0, void *MainAddr) {
+int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
+                                   const char *Argv0, void *MainAddr) {
   INITIALIZE_LLVM();
 
-  llvm::cl::HideUnrelatedOptions(options::Category);
-
-  // LLVM Command Line expects to trim off argv[0].
-  SmallVector<const char *, 8> ArgsWithArgv0 { Argv0 };
-  ArgsWithArgv0.append(Args.begin(), Args.end());
-
-  if (Args.empty()) {
-    ArgsWithArgv0.push_back("-help");
-  }
-
-  llvm::cl::ParseCommandLineOptions(ArgsWithArgv0.size(),
-      llvm::makeArrayRef(ArgsWithArgv0).data(),
-      "Swift Symbol Graph Extractor\n");
-
-  if (!argumentsAreValid()) {
-    llvm::cl::PrintHelpMessage();
-    return EXIT_FAILURE;
-  }
-
-  if (!llvm::sys::fs::is_directory(options::OutputDir)) {
-    llvm::errs() << "-output-dir argument '" << options::OutputDir
-      << " does not exist or is not a directory\n";
-    return EXIT_FAILURE;
-  }
-
   CompilerInvocation Invocation;
+  CompilerInstance CI;
+  PrintingDiagnosticConsumer DiagPrinter;
+  auto &Diags = CI.getDiags();
+  Diags.addConsumer(DiagPrinter);
 
-  Invocation.setMainExecutablePath(
-      llvm::sys::fs::getMainExecutable(Argv0, MainAddr));
-  Invocation.setModuleName("swift_symbolgraph_extract");
-  if (!options::ResourceDir.empty()) {
-    Invocation.setRuntimeResourcePath(options::ResourceDir);
+  std::unique_ptr<llvm::opt::OptTable> Table = createSwiftOptTable();
+  unsigned MissingIndex;
+  unsigned MissingCount;
+  llvm::opt::InputArgList ParsedArgs = Table->ParseArgs(
+      Args, MissingIndex, MissingCount, SwiftSymbolGraphExtractOption);
+  if (MissingCount) {
+    Diags.diagnose(SourceLoc(), diag::error_missing_arg_value,
+                   ParsedArgs.getArgString(MissingIndex), MissingCount);
+    return EXIT_FAILURE;
   }
-  Invocation.setSDKPath(options::SDK);
-  Invocation.setTargetTriple(options::Target);
 
-  for (auto &Arg : options::Xcc) {
-    Invocation.getClangImporterOptions().ExtraArgs.push_back(Arg);
+  if (ParsedArgs.hasArg(OPT_UNKNOWN)) {
+    for (const auto *A : ParsedArgs.filtered(OPT_UNKNOWN)) {
+      Diags.diagnose(SourceLoc(), diag::error_unknown_arg,
+                     A->getAsString(ParsedArgs));
+    }
+    return EXIT_FAILURE;
+  }
+
+  auto MainExecutablePath = llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
+
+  if (ParsedArgs.getLastArg(OPT_help) || Args.empty()) {
+    std::string ExecutableName =
+        llvm::sys::path::stem(MainExecutablePath).str();
+    Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
+                     "Swift Symbol Graph Extractor",
+                     SwiftSymbolGraphExtractOption, 0,
+                     /*ShowAllAliases*/ false);
+    return EXIT_FAILURE;
+  }
+
+  std::string ModuleName;
+  if (auto *A = ParsedArgs.getLastArg(OPT_module_name)) {
+    ModuleName = A->getValue();
+  } else {
+    Diags.diagnose(SourceLoc(), diag::error_option_required, "-module-name");
+    return EXIT_FAILURE;
+  }
+
+  llvm::Triple Target;
+  if (auto *A = ParsedArgs.getLastArg(OPT_target)) {
+    Target = llvm::Triple(A->getValue());
+  } else {
+    Diags.diagnose(SourceLoc(), diag::error_option_required, "-target");
+    return EXIT_FAILURE;
+  }
+
+  std::string OutputDir;
+  if (auto *A = ParsedArgs.getLastArg(OPT_output_dir)) {
+    OutputDir = A->getValue();
+  } else {
+    Diags.diagnose(SourceLoc(), diag::error_option_required, "-output-dir");
+    return EXIT_FAILURE;
+  }
+
+  if (!llvm::sys::fs::is_directory(OutputDir)) {
+    Diags.diagnose(SourceLoc(), diag::error_nonexistent_output_dir, OutputDir);
+    return EXIT_FAILURE;
+  }
+
+  Invocation.setMainExecutablePath(MainExecutablePath);
+  Invocation.setModuleName("swift_symbolgraph_extract");
+
+  if (auto *A = ParsedArgs.getLastArg(OPT_resource_dir)) {
+    Invocation.setRuntimeResourcePath(A->getValue());
+  }
+
+  std::string SDK = "";
+  if (auto *A = ParsedArgs.getLastArg(OPT_sdk)) {
+    SDK = A->getValue();
+  }
+  Invocation.setSDKPath(SDK);
+
+  Invocation.setTargetTriple(Target);
+
+  for (const auto *A : ParsedArgs.filtered(OPT_Xcc)) {
+    Invocation.getClangImporterOptions().ExtraArgs.push_back(A->getValue());
   }
 
   std::vector<SearchPathOptions::FrameworkSearchPath> FrameworkSearchPaths;
-  for (const auto &Path : options::FrameworkSearchPaths) {
-    FrameworkSearchPaths.push_back({ Path, /*isSystem*/ false});
+  for (const auto *A : ParsedArgs.filtered(OPT_F)) {
+    FrameworkSearchPaths.push_back({A->getValue(), /*isSystem*/ false});
   }
-  for (const auto &Path : options::SystemFrameworkSearchPaths) {
-    FrameworkSearchPaths.push_back({ Path, /*isSystem*/ true });
+  for (const auto *A : ParsedArgs.filtered(OPT_Fsystem)) {
+    FrameworkSearchPaths.push_back({A->getValue(), /*isSystem*/ true});
   }
   Invocation.setFrameworkSearchPaths(FrameworkSearchPaths);
-  Invocation.getSearchPathOptions().LibrarySearchPaths = options::LibrarySearchPaths;
-  Invocation.setImportSearchPaths(options::ImportSearchPaths);
+  Invocation.getSearchPathOptions().LibrarySearchPaths =
+      ParsedArgs.getAllArgValues(OPT_L);
+  Invocation.setImportSearchPaths(ParsedArgs.getAllArgValues(OPT_I));
 
-  Invocation.getLangOptions().EnableObjCInterop = llvm::Triple(options::Target).isOSDarwin();
+  Invocation.getLangOptions().EnableObjCInterop = Target.isOSDarwin();
   Invocation.getLangOptions().DebuggerSupport = true;
 
   Invocation.getFrontendOptions().EnableLibraryEvolution = true;
 
-  Invocation.setClangModuleCachePath(options::ModuleCachePath);
-  Invocation.getClangImporterOptions().ModuleCachePath = options::ModuleCachePath;
+  std::string ModuleCachePath = "";
+  if (auto *A = ParsedArgs.getLastArg(OPT_module_cache_path)) {
+    ModuleCachePath = A->getValue();
+  }
+  Invocation.setClangModuleCachePath(ModuleCachePath);
+  Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
   Invocation.setDefaultPrebuiltCacheIfNecessary();
 
-  if (!options::SwiftVersion.empty()) {
+  if (auto *A = ParsedArgs.getLastArg(OPT_swift_version)) {
     using version::Version;
+    auto SwiftVersion = A->getValue();
     bool isValid = false;
-    if (auto Version = Version::parseVersionString(options::SwiftVersion,
-                                                   SourceLoc(), nullptr)) {
+    if (auto Version =
+            Version::parseVersionString(SwiftVersion, SourceLoc(), nullptr)) {
       if (auto Effective = Version.getValue().getEffectiveLanguageVersion()) {
         Invocation.getLangOptions().EffectiveLanguageVersion = *Effective;
         isValid = true;
       }
     }
     if (!isValid) {
-      llvm::errs() << "Unsupported Swift Version.\n";
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     "-swift-version", SwiftVersion);
       return EXIT_FAILURE;
     }
   }
 
-  symbolgraphgen::SymbolGraphOptions Options {
-    options::OutputDir,
-    llvm::Triple(options::Target),
-    options::PrettyPrint,
-    AccessLevel::Public,
-    !options::SkipSynthesizedMembers,
+  symbolgraphgen::SymbolGraphOptions Options{
+      OutputDir,
+      Target,
+      ParsedArgs.hasArg(OPT_pretty_print),
+      AccessLevel::Public,
+      !ParsedArgs.hasArg(OPT_skip_synthesized_members),
   };
 
-  if (!options::MinimumAccessLevel.empty()) {
+  if (auto *A = ParsedArgs.getLastArg(OPT_minimum_access_level)) {
     Options.MinimumAccessLevel =
-        llvm::StringSwitch<AccessLevel>(options::MinimumAccessLevel)
-      .Case("open", AccessLevel::Open)     
-      .Case("public", AccessLevel::Public)     
-      .Case("internal", AccessLevel::Internal)     
-      .Case("fileprivate", AccessLevel::FilePrivate)     
-      .Case("private", AccessLevel::Private)     
-      .Default(AccessLevel::Public);
+        llvm::StringSwitch<AccessLevel>(A->getValue())
+            .Case("open", AccessLevel::Open)
+            .Case("public", AccessLevel::Public)
+            .Case("internal", AccessLevel::Internal)
+            .Case("fileprivate", AccessLevel::FilePrivate)
+            .Case("private", AccessLevel::Private)
+            .Default(AccessLevel::Public);
   }
-
-  PrintingDiagnosticConsumer DiagPrinter;
-
-  CompilerInstance CI;
-  CI.getDiags().addConsumer(DiagPrinter);
 
   if (CI.setup(Invocation)) {
     llvm::outs() << "Failed to setup compiler instance\n";
     return EXIT_FAILURE;
   }
 
-  auto M = CI.getASTContext().getModuleByName(options::ModuleName);
+  auto M = CI.getASTContext().getModuleByName(ModuleName);
   if (!M) {
     llvm::errs()
-      << "Couldn't load module '" << options::ModuleName << '\''
+      << "Couldn't load module '" << ModuleName << '\''
       << " in the current SDK and search paths.\n";
     
     SmallVector<Identifier, 32> VisibleModuleNames;
@@ -241,10 +209,11 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
   }
   
   if (M->failedToLoad()) {
-    llvm::errs() << "Error: Failed to load the module '" << options::ModuleName
-      << "'. Are you missing build dependencies or include/framework directories?\n"
-      << "See the previous error messages for details. Aborting.\n";
-    
+    llvm::errs() << "Error: Failed to load the module '" << ModuleName
+                 << "'. Are you missing build dependencies or "
+                    "include/framework directories?\n"
+                 << "See the previous error messages for details. Aborting.\n";
+
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
I found one spot where an optimizer test was accidentally using one of the symbol graph options via `-Xllvm`, but the main motivation here is to migrate `swift-api-digester` from a standalone tool to a frontend-integrated one. I was running into some issues because that also uses `llvm::cl` and a number of the option definitions were clashing with those of `swift-symbolgraph-extract`. I think gradually migrating all of the frontend tools to the shared option table should scale a little better in the long run. 

The existing tests seemed to cover the existing options well, but I'm happy to add more if there's any I missed!