### PR TITLE
Revert "Make Error and CodingKey conform to ConcurrentValue."

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4323,38 +4323,20 @@ ERROR(non_concurrent_type_member,none,
       "%select{stored property %1|associated value %1}0 of "
       "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",
       (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
-WARNING(non_concurrent_type_member_warn,none,
-      "%select{stored property %1|associated value %1}0 of "
-      "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",
-      (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
 ERROR(concurrent_value_class_mutable_property,none,
       "stored property %0 of 'ConcurrentValue'-conforming %1 %2 is mutable",
       (DeclName, DescriptiveDeclKind, DeclName))
-WARNING(concurrent_value_class_mutable_property_warn,none,
-      "stored property %0 of 'ConcurrentValue'-conforming %1 %2 is mutable",
-      (DeclName, DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_outside_source_file,none,
-      "conformance to 'ConcurrentValue' must occur in the same source file as "
-      "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
-      (DescriptiveDeclKind, DeclName))
-WARNING(concurrent_value_outside_source_file_warn,none,
-      "conformance to 'ConcurrentValue' must occur in the same source file as "
+      "conformance 'ConcurrentValue' must occur in the same source file as "
       "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
       (DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_open_class,none,
-      "open class %0 cannot conform to `ConcurrentValue`; "
-      "use `UnsafeConcurrentValue`", (DeclName))
-WARNING(concurrent_value_open_class_warn,none,
       "open class %0 cannot conform to `ConcurrentValue`; "
       "use `UnsafeConcurrentValue`", (DeclName))
 ERROR(concurrent_value_inherit,none,
       "`ConcurrentValue` class %1 cannot inherit from another class"
       "%select{| other than 'NSObject'}0",
       (bool, DeclName))
-WARNING(concurrent_value_inherit_warn,none,
-        "`ConcurrentValue` class %1 cannot inherit from another class"
-        "%select{| other than 'NSObject'}0",
-        (bool, DeclName))
 
 ERROR(actorindependent_let,none,
       "'@actorIndependent' is meaningless on 'let' declarations because "

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -208,8 +208,7 @@ bool diagnoseNonConcurrentTypesInReference(
     ConcurrentReferenceKind refKind);
 
 /// Check the correctness of the given ConcurrentValue conformance.
-void checkConcurrentValueConformance(
-    ProtocolConformance *conformance, bool asWarning);
+void checkConcurrentValueConformance(ProtocolConformance *conformance);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5660,8 +5660,6 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
 
   ProtocolConformance *concurrentValueConformance = nullptr;
   ProtocolConformance *unsafeConcurrentValueConformance = nullptr;
-  ProtocolConformance *errorConformance = nullptr;
-  ProtocolConformance *codingKeyConformance = nullptr;
   bool anyInvalid = false;
   for (auto conformance : conformances) {
     // Check and record normal conformances.
@@ -5693,18 +5691,12 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     } else if (proto->isSpecificProtocol(
                    KnownProtocolKind::UnsafeConcurrentValue)) {
       unsafeConcurrentValueConformance = conformance;
-    } else if (proto->isSpecificProtocol(KnownProtocolKind::Error)) {
-      errorConformance = conformance;
-    } else if (proto->isSpecificProtocol(KnownProtocolKind::CodingKey)) {
-      codingKeyConformance = conformance;
     }
   }
 
   // Check constraints of ConcurrentValue.
-  if (concurrentValueConformance && !unsafeConcurrentValueConformance) {
-    bool asWarning = errorConformance || codingKeyConformance;
-    checkConcurrentValueConformance(concurrentValueConformance, asWarning);
-  }
+  if (concurrentValueConformance && !unsafeConcurrentValueConformance)
+    checkConcurrentValueConformance(concurrentValueConformance);
 
   // Check all conformances.
   groupChecker.checkAllConformances();

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -51,8 +51,7 @@ public typealias Codable = Encodable & Decodable
 //===----------------------------------------------------------------------===//
 
 /// A type that can be used as a key for encoding and decoding.
-public protocol CodingKey: ConcurrentValue,
-                           CustomStringConvertible,
+public protocol CodingKey: CustomStringConvertible,
                            CustomDebugStringConvertible {
   /// The string to use in a named collection (e.g. a string-keyed dictionary).
   var stringValue: String { get }
@@ -3180,7 +3179,7 @@ public struct CodingUserInfoKey: RawRepresentable, Equatable, Hashable, Concurre
 /// An error that occurs during the encoding of a value.
 public enum EncodingError: Error {
   /// The context in which the error occurred.
-  public struct Context: ConcurrentValue {
+  public struct Context {
     /// The path of coding keys taken to get to the point of the failing encode
     /// call.
     public let codingPath: [CodingKey]
@@ -3263,7 +3262,7 @@ public enum EncodingError: Error {
 /// An error that occurs during the decoding of a value.
 public enum DecodingError: Error {
   /// The context in which the error occurred.
-  public struct Context: ConcurrentValue {
+  public struct Context {
     /// The path of coding keys taken to get to the point of the failing decode
     /// call.
     public let codingPath: [CodingKey]

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -110,7 +110,7 @@ import SwiftShims
 ///         print("Other error: \(error)")
 ///     }
 ///     // Prints "Parsing error: mismatchedTag [19:5]"
-public protocol Error: ConcurrentValue {
+public protocol Error {
   var _domain: String { get }
   var _code: Int { get }
 

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -221,7 +221,7 @@ public struct URL : _ObjectiveCBridgeable {
  }
 }
 
-extension NSError : Error, UnsafeConcurrentValue {
+extension NSError : Error {
   public var _domain: String { return domain }
   public var _code: Int { return code }
 }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -7,8 +7,8 @@ class Cat {}
 enum HomeworkError : Error {
   case TooHard
   case TooMuch
-  case CatAteIt(Cat) // expected-warning{{associated value 'CatAteIt' of 'ConcurrentValue'-conforming enum 'HomeworkError' has non-concurrent-value type 'Cat'}}
-  case CatHidIt(Cat) // expected-warning{{associated value 'CatHidIt' of 'ConcurrentValue'-conforming enum 'HomeworkError' has non-concurrent-value type 'Cat'}}
+  case CatAteIt(Cat)
+  case CatHidIt(Cat)
 }
 
 func someValidPointer<T>() -> UnsafePointer<T> { fatalError() }

--- a/test/Sema/existential_nested_type.swift
+++ b/test/Sema/existential_nested_type.swift
@@ -10,7 +10,7 @@ protocol HasAssoc {
 }
 
 enum MyError : Error {
-  case bad(Any) // expected-warning{{associated value 'bad' of 'ConcurrentValue'-conforming enum 'MyError' has non-concurrent-value type 'Any'}}
+  case bad(Any)
 }
 
 func checkIt(_ js: Any) throws {

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -1,4 +1,0 @@
-Protocol CodingKey has added inherited protocol ConcurrentValue
-Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.ConcurrentValue, Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible>
-Protocol Error has added inherited protocol ConcurrentValue
-Protocol Error has generic signature change from to <Self : Swift.ConcurrentValue>

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -43,8 +43,4 @@ Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @avai
 Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
 Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
 Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
-Protocol CodingKey has added inherited protocol ConcurrentValue
-Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.ConcurrentValue, Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible>
-Protocol Error has added inherited protocol ConcurrentValue
-Protocol Error has generic signature change from to <Self : Swift.ConcurrentValue>
 Struct _RuntimeFunctionCounters is a new API without @available attribute

--- a/test/decl/protocol/special/coding/Inputs/enum_coding_key_extension_multi2.swift
+++ b/test/decl/protocol/special/coding/Inputs/enum_coding_key_extension_multi2.swift
@@ -1,3 +1,3 @@
-extension NoRawTypeKey : CodingKey, UnsafeConcurrentValue {}
-extension StringKey : CodingKey, UnsafeConcurrentValue {}
-extension IntKey : CodingKey, UnsafeConcurrentValue {}
+extension NoRawTypeKey : CodingKey {}
+extension StringKey : CodingKey {}
+extension IntKey : CodingKey {}


### PR DESCRIPTION
Reverts apple/swift#36070

It breaks the api-digester/stability-stdlib-abi-without-asserts.test.

rdar://74594091