### PR TITLE
[5.4] Correct an Incremental Miscompile For Edits to Overloaded Extension Members

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -881,6 +881,8 @@ public:
   /// available.
   Optional<Fingerprint> getBodyFingerprint() const;
 
+  bool areTokensHashedForThisBodyInsteadOfInterfaceHash() const;
+
 private:
   /// Add a member to the list for iteration purposes, but do not notify the
   /// subclass that we have done so.

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1034,6 +1034,11 @@ Optional<Fingerprint> IterableDeclContext::getBodyFingerprint() const {
 
 bool IterableDeclContext::areTokensHashedForThisBodyInsteadOfInterfaceHash()
     const {
+  // Do not keep separate hashes for extension bodies because the dependencies
+  // can miss the addition of a member in an extension because there is nothing
+  // corresponding to the fingerprinted nominal dependency node.
+  if (isa<ExtensionDecl>(this))
+    return false;
   return true;
 }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1032,6 +1032,11 @@ Optional<Fingerprint> IterableDeclContext::getBodyFingerprint() const {
       .fingerprint;
 }
 
+bool IterableDeclContext::areTokensHashedForThisBodyInsteadOfInterfaceHash()
+    const {
+  return true;
+}
+
 /// Return the DeclContext to compare when checking private access in
 /// Swift 4 mode. The context returned is the type declaration if the context
 /// and the type declaration are in the same file, otherwise it is the types

--- a/test/Incremental/Fingerprints/Inputs/extension-adds-member/definesAB-after.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-adds-member/definesAB-after.swift
@@ -3,7 +3,7 @@ struct A {
 struct B {
 }
 extension A {
-  init(_ x: String = "") {}
+  var x: Int {17}
 }
 extension B {
 }

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-after.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-after.swift
@@ -1,0 +1,8 @@
+public struct S {
+  private // commenting out this line works
+  static func foo(_ i: Int) {print("1: other:2 commented out")}
+}
+extension S {
+  // private // commenting out this line fails
+  static func foo2(_ i: Int) {print("2: other:6 commented out")}
+}

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-before.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-before.swift
@@ -1,0 +1,8 @@
+public struct S {
+  private // commenting out this line works
+  static func foo(_ i: Int) {print("1: other:2 commented out")}
+}
+extension S {
+  private // commenting out this line fails
+  static func foo2(_ i: Int) {print("2: other:6 commented out")}
+}

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/main.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/main.swift
@@ -1,0 +1,11 @@
+extension S {
+  static func foo<I: SignedInteger>(_ si: I) {
+    print("1: other:2 not commented out")
+  }
+  static func foo2<I: SignedInteger>(_ si: I) {
+    print("2: other:6 not commented out")
+  }
+}
+
+S.foo(3)
+S.foo2(3)

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/ofm.json
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/ofm.json
@@ -1,0 +1,14 @@
+{
+  "main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "definesS.swift": {
+    "object": "./definesS.o",
+    "swift-dependencies": "./definesS.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}
+

--- a/test/Incremental/Fingerprints/extension-changes-member.swift
+++ b/test/Incremental/Fingerprints/extension-changes-member.swift
@@ -1,0 +1,32 @@
+// Test per-type-body fingerprints using simple extensions
+//
+// If the parser is allowed to use a body fingerprint for an extension
+// this test will fail because usesA.swift won't be recompiled for the
+// last step.
+
+// Establish status quo
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/extension-changes-member/* %t
+// RUN: cp %t/definesS{-before,}.swift
+
+// Seeing weird failure on CI, so set the mod times
+// RUN: touch -t 200101010101 %t/*.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output3
+
+// Change one type, only uses of that type get recompiled
+
+// RUN: cp %t/definesS{-after,}.swift
+
+// Seeing weird failure on CI, so ensure that definesS.swift is newer
+// RUN: touch -t 200201010101 %t/*
+// RUN: touch -t 200101010101 %t/*.swift
+// RUN: touch -t 200301010101 %t/definesS.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output4
+
+// RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
+
+// CHECK-RECOMPILED-W: {compile: definesS.o <= definesS.swift}
+// CHECK-RECOMPILED-W: {compile: main.o <= main.swift}


### PR DESCRIPTION
The type body fingerprint for a nominal type currently controls when the Driver runs off and recompiles member references like this. Unfortunately, when we run lookups for the member, we only record a dependency on the interface hash of the nominal type, not any of the extensions we happened to find the member in. This means that if only the extension's overload changes, we will assume that nothing has happened since the nominal type's fingerprint hasn't changed and we have no direct dependency arc to the extension decl. We should be able to correct that with some work on mainline to get richer dependencies on extensions. For now, avoid the miscompile by restoring the old behavior of just treating extensions edits like changes to the top-level interface hash.

rdar://74583179