### PR TITLE
[silgen-cleanup] Ensure that we move nextII past /all/ instructions we are going to delete no matter order of visitation.

### DIFF
--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -216,3 +216,26 @@ bb0(%0 : $*X3, %1 : @guaranteed $Builtin.NativeObject):
   %12 = tuple ()
   return %12 : $()
 }
+
+// We used to hit a memory error on this test.
+//
+// CHECK-LABEL: sil [ossa] @testDestructureTupleNoCrash : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+// CHECK: bb0(
+// CHECK-NEXT: destroy_value
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'testDestructureTupleNoCrash'
+sil [ossa] @testDestructureTupleNoCrash : $@convention(thin) (@owned (Builtin.NativeObject, Builtin.NativeObject)) -> () {
+bb0(%0 : @owned $(Builtin.NativeObject, Builtin.NativeObject)):
+  (%1, %2) = destructure_tuple %0 : $(Builtin.NativeObject, Builtin.NativeObject)
+  debug_value %1 : $Builtin.NativeObject, let, name "key"
+  debug_value %2 : $Builtin.NativeObject, let, name "value"
+  %3 = begin_borrow %1 : $Builtin.NativeObject
+  end_borrow %3 : $Builtin.NativeObject
+  %4 = begin_borrow %2 : $Builtin.NativeObject
+  end_borrow %4 : $Builtin.NativeObject
+  destroy_value %2 : $Builtin.NativeObject
+  destroy_value %1 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -7,10 +7,6 @@
 // RUN: %target-codesign %t/Dictionary && %line-directive %t/main.swift -- %target-run %t/Dictionary
 // REQUIRES: executable_test
 
-// rdar71933996
-// UNSUPPORTED: swift_test_mode_optimize
-// UNSUPPORTED: swift_test_mode_optimize_size
-
 import StdlibUnittest
 import StdlibCollectionUnittest
 


### PR DESCRIPTION
Specifically, given code like the following:

```
(%1, %2) = multi_result_inst %0   (a)
inst_to_delete %1                 (b)
inst_to_delete %2                 (c)
```

We would sometimes visit (c) before (b). So if nextII was (b) at that point, we
would think that we were safe. Then we process (b), move nextII from (b) ->
(c). Then we delete both (b) and (c). =><=.

The solution to this is each iteration of the delete loop, we track /all/
instructions that eliminateDeadInstruction is going to eliminate and ensure that
after each callback is called we have moved past all visited instructions (even
ones we visited previously). This is done using a small set that I clear each
iteration.

I also re-enabled the dictionary test that exposed this issue when testing
-O/-Osize.

rdar://71933996
