### PR TITLE
Revert "disable DebugInfo/async-args.swift"

### DIFF
--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -3,8 +3,6 @@
 // RUN:    -parse-as-library | %FileCheck %s
 // REQUIRES: concurrency
 
-// REQUIRES: rdar74551043
-
 func use<T>(_ t: T) {}
 func forceSplit() async {
 }


### PR DESCRIPTION
Reverts apple/swift#36067

This isn't supposed to fail so let's see how it's failing.