### PR TITLE
Bump CMake version to 3.19.6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.4)
+cmake_minimum_required(VERSION 3.19.6)
 
 # TODO: Fix RPATH usage to be CMP0068 compliant
 # Disable Policy CMP0068 for CMake 3.9
@@ -183,7 +183,7 @@ endif()
 set(SWIFT_USE_LINKER ${SWIFT_USE_LINKER_default} CACHE STRING
     "Build Swift with a non-default linker")
 
-option(SWIFT_DISABLE_DEAD_STRIPPING 
+option(SWIFT_DISABLE_DEAD_STRIPPING
       "Turn off Darwin-specific dead stripping for Swift host tools." FALSE)
 
 set(SWIFT_TOOLS_ENABLE_LTO OFF CACHE STRING "Build Swift tools with LTO. One

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,6 +1,6 @@
 # -*- mode: cmake -*-
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.19.6)
 
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -43,7 +43,7 @@ library should be distributed alongside them.
 ### CMake Standalone (no build-script)
 
 To build the Swift benchmarks using only an Xcode installation: install an
-Xcode version with Swift support, install cmake 2.8.12, and ensure Xcode is
+Xcode version with Swift support, install cmake 3.19.6 or higher, and ensure Xcode is
 selected with xcode-select.
 
 The following build options are available:

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -158,7 +158,7 @@ Double-check that running `pwd` prints a path ending with `swift`.
    * [CentOS 7](https://github.com/apple/swift-docker/blob/main/swift-ci/master/centos/7/Dockerfile)
    * [CentOS 8](https://github.com/apple/swift-docker/blob/main/swift-ci/master/centos/8/Dockerfile)
    * [Amazon Linux 2](https://github.com/apple/swift-docker/blob/main/swift-ci/master/amazon-linux/2/Dockerfile)
-   
+
 2. To install sccache (optional):
    ```
    sudo snap install sccache --candidate --classic
@@ -170,7 +170,7 @@ Double-check that running `pwd` prints a path ending with `swift`.
 
 ### Spot check dependencies
 
-* Run `cmake --version`: This should be 3.18.1 or higher for macOS.
+* Run `cmake --version`: This should be 3.19.6 or higher.
 * Run `python3 --version`: Check that this succeeds.
 * Run `ninja --version`: Check that this succeeds.
 * Run `sccache --version`: Check that this succeeds.


### PR DESCRIPTION
Updates the required CMake version for Swift and the Swift Benchmarks to ~~3.18~~ 3.19.6. Updates the docs to reflect this change. Doesn't modify the required version for building the stdlib.

Required for #36082.