### PR TITLE
[SymbolGraph] don't emit navigator name if it's the same as subHeading

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -594,17 +594,9 @@ void
 SymbolGraph::serializeNavigatorDeclarationFragments(StringRef Key,
                                                     const Symbol &S,
                                                     llvm::json::OStream &OS) {
-  DeclarationFragmentPrinter Printer(this, OS, Key);
-
   if (const auto *TD = dyn_cast<GenericTypeDecl>(S.getSymbolDecl())) {
+    DeclarationFragmentPrinter Printer(this, OS, Key);
     Printer.printAbridgedType(TD, /*PrintKeyword=*/false);
-  } else {
-    auto Options = getSubHeadingDeclarationFragmentsPrintOptions();
-    if (S.getBaseType()) {
-      Options.setBaseType(S.getBaseType());
-      Options.PrintAsMember = true;
-    }
-    S.getSymbolDecl()->print(Printer, Options);
   }
 }
 

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -169,33 +169,6 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-REPLACEMENT4:         "identifier": "swift.method"
 // CHECK-REPLACEMENT4:       },
 // CHECK-REPLACEMENT4:       "names": {
-// CHECK-REPLACEMENT4:         "navigator": [
-// CHECK-REPLACEMENT4:           {
-// CHECK-REPLACEMENT4:             "kind": "keyword",
-// CHECK-REPLACEMENT4:             "spelling": "func"
-// CHECK-REPLACEMENT4:           },
-// CHECK-REPLACEMENT4:           {
-// CHECK-REPLACEMENT4:             "kind": "text",
-// CHECK-REPLACEMENT4:             "spelling": " "
-// CHECK-REPLACEMENT4:           },
-// CHECK-REPLACEMENT4:           {
-// CHECK-REPLACEMENT4:             "kind": "identifier",
-// CHECK-REPLACEMENT4:             "spelling": "append"
-// CHECK-REPLACEMENT4:           },
-// CHECK-REPLACEMENT4:           {
-// CHECK-REPLACEMENT4:             "kind": "text",
-// CHECK-REPLACEMENT4:             "spelling": "("
-// CHECK-REPLACEMENT4:           },
-// CHECK-REPLACEMENT4:           {
-// CHECK-REPLACEMENT4:             "kind": "typeIdentifier",
-// CHECK-REPLACEMENT4:             "preciseIdentifier": "s:13cursor_stdlib2S1V",
-// CHECK-REPLACEMENT4:             "spelling": "S1"
-// CHECK-REPLACEMENT4:           },
-// CHECK-REPLACEMENT4:           {
-// CHECK-REPLACEMENT4:             "kind": "text",
-// CHECK-REPLACEMENT4:             "spelling": ")"
-// CHECK-REPLACEMENT4:           }
-// CHECK-REPLACEMENT4:         ],
 // CHECK-REPLACEMENT4:         "subHeading": [
 // CHECK-REPLACEMENT4:           {
 // CHECK-REPLACEMENT4:             "kind": "keyword",

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
@@ -126,29 +126,6 @@ enum MyEnum {
 // CHECKX:         "uri": "{{.*}}cursor_symbol_graph.swift"
 // CHECKX:       },
 // CHECKX:       "names": {
-// CHECKX:         "navigator": [
-// CHECKX:           {
-// CHECKX:             "kind": "keyword",
-// CHECKX:             "spelling": "let"
-// CHECKX:           },
-// CHECKX:           {
-// CHECKX:             "kind": "text",
-// CHECKX:             "spelling": " "
-// CHECKX:           },
-// CHECKX:           {
-// CHECKX:             "kind": "identifier",
-// CHECKX:             "spelling": "x"
-// CHECKX:           },
-// CHECKX:           {
-// CHECKX:             "kind": "text",
-// CHECKX:             "spelling": ": "
-// CHECKX:           },
-// CHECKX:           {
-// CHECKX:             "kind": "typeIdentifier",
-// CHECKX:             "preciseIdentifier": "s:Si",
-// CHECKX:             "spelling": "Int"
-// CHECKX:           }
-// CHECKX:         ],
 // CHECKX:         "subHeading": [
 // CHECKX:           {
 // CHECKX:             "kind": "keyword",
@@ -294,29 +271,6 @@ enum MyEnum {
 // CHECKY:         "uri": "{{.*}}cursor_symbol_graph.swift"
 // CHECKY:       },
 // CHECKY:       "names": {
-// CHECKY:         "navigator": [
-// CHECKY:           {
-// CHECKY:             "kind": "keyword",
-// CHECKY:             "spelling": "var"
-// CHECKY:           },
-// CHECKY:           {
-// CHECKY:             "kind": "text",
-// CHECKY:             "spelling": " "
-// CHECKY:           },
-// CHECKY:           {
-// CHECKY:             "kind": "identifier",
-// CHECKY:             "spelling": "y"
-// CHECKY:           },
-// CHECKY:           {
-// CHECKY:             "kind": "text",
-// CHECKY:             "spelling": ": "
-// CHECKY:           },
-// CHECKY:           {
-// CHECKY:             "kind": "typeIdentifier",
-// CHECKY:             "preciseIdentifier": "s:SS",
-// CHECKY:             "spelling": "String"
-// CHECKY:           }
-// CHECKY:         ],
 // CHECKY:         "subHeading": [
 // CHECKY:           {
 // CHECKY:             "kind": "keyword",
@@ -639,44 +593,6 @@ enum MyEnum {
 // CHECKBAR_ALL:         "uri": "{{.*}}cursor_symbol_graph.swift"
 // CHECKBAR_ALL:       },
 // CHECKBAR_ALL:       "names": {
-// CHECKBAR_ALL:         "navigator": [
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "keyword",
-// CHECKBAR_ALL:             "spelling": "func"
-// CHECKBAR_ALL:           },
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "text",
-// CHECKBAR_ALL:             "spelling": " "
-// CHECKBAR_ALL:           },
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "identifier",
-// CHECKBAR_ALL:             "spelling": "bar"
-// CHECKBAR_ALL:           },
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "text",
-// CHECKBAR_ALL:             "spelling": "("
-// CHECKBAR_ALL:           },
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "externalParam",
-// CHECKBAR_ALL:             "spelling": "x"
-// CHECKBAR_ALL:           },
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "text",
-// CHECKBAR_ALL:             "spelling": ": "
-// CHECKBAR_ALL:           },
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "typeIdentifier",
-// CHECKBAR_GEN:             "spelling": "T"
-// CHECKBAR_INT:             "preciseIdentifier": "s:Si",
-// CHECKBAR_INT:             "spelling": "Int"
-// CHECKBAR_STR:             "preciseIdentifier": "s:SS",
-// CHECKBAR_STR:             "spelling": "String"
-// CHECKBAR_ALL:           },
-// CHECKBAR_ALL:           {
-// CHECKBAR_ALL:             "kind": "text",
-// CHECKBAR_ALL:             "spelling": ")"
-// CHECKBAR_ALL:           }
-// CHECKBAR_ALL:         ],
 // CHECKBAR_ALL:         "subHeading": [
 // CHECKBAR_ALL:           {
 // CHECKBAR_ALL:             "kind": "keyword",
@@ -815,20 +731,6 @@ enum MyEnum {
 // CHECKCASE:         "uri": "{{.*}}cursor_symbol_graph.swift"
 // CHECKCASE:       },
 // CHECKCASE:       "names": {
-// CHECKCASE:         "navigator": [
-// CHECKCASE:           {
-// CHECKCASE:             "kind": "keyword",
-// CHECKCASE:             "spelling": "case"
-// CHECKCASE:           },
-// CHECKCASE:           {
-// CHECKCASE:             "kind": "text",
-// CHECKCASE:             "spelling": " "
-// CHECKCASE:           },
-// CHECKCASE:           {
-// CHECKCASE:             "kind": "identifier",
-// CHECKCASE:             "spelling": "someCase"
-// CHECKCASE:           }
-// CHECKCASE:         ],
 // CHECKCASE:         "subHeading": [
 // CHECKCASE:           {
 // CHECKCASE:             "kind": "keyword",

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
@@ -62,24 +62,6 @@ func callObjC() {
 // CHECK:         "identifier": "swift.func"
 // CHECK:       },
 // CHECK:       "names": {
-// CHECK:         "navigator": [
-// CHECK:           {
-// CHECK:             "kind": "keyword",
-// CHECK:             "spelling": "func"
-// CHECK:           },
-// CHECK:           {
-// CHECK:             "kind": "text",
-// CHECK:             "spelling": " "
-// CHECK:           },
-// CHECK:           {
-// CHECK:             "kind": "identifier",
-// CHECK:             "spelling": "fooFuncWithComment5"
-// CHECK:           },
-// CHECK:           {
-// CHECK:             "kind": "text",
-// CHECK:             "spelling": "()"
-// CHECK:           }
-// CHECK:         ],
 // CHECK:         "subHeading": [
 // CHECK:           {
 // CHECK:             "kind": "keyword",

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator/Navigator.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Navigator/Navigator.swift
@@ -22,10 +22,12 @@ public struct MyStruct<S> { public var x: S
 // MYSTRUCT-NEXT:          }
 // MYSTRUCT-NEXT:      ]
 
+// when `navigator` and `subHeading` would be identical, the former is elided
+
 // FOO-LABEL: "precise": "s:9Navigator8MyStructV3fooyySTRzlF"
 // FOO:        names
 // FOO-NEXT:      "title": "foo()",
-// FOO-NEXT:      "navigator": [
+// FOO-NEXT:      "subHeading": [
 // FOO-NEXT:          {
 // FOO-NEXT:              "kind": "keyword"
 // FOO-NEXT:              "spelling": "func"
@@ -47,7 +49,7 @@ public struct MyStruct<S> { public var x: S
 // BAR-LABEL: "precise": "s:9Navigator8MyStructV3bar1xyqd___tSTRd__lF"
 // BAR:        names
 // BAR-NEXT:      "title": "bar(x:)",
-// BAR-NEXT:      "navigator": [
+// BAR-NEXT:      "subHeading": [
 // BAR-NEXT:          {
 // BAR-NEXT:            "kind": "keyword",
 // BAR-NEXT:            "spelling": "func"


### PR DESCRIPTION
Fixes rdar://70202693

<!-- What's in this pull request? -->
When rendering a symbol graph, often there are situations where the `names` object has duplicate information in the `navigator` and `subHeading` field. Since the fields of `names` can cascade from `subHeading` to `navigator` when the latter is absent, choosing to omit this field in this situation can decrease the size of the symbol graph with no loss of data.
