### PR TITLE
[NFC] Convert the Templates Computing DependencyKeys to the Builder Pattern

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_FINE_GRAINED_DEPENDENCIES_H
 #define SWIFT_AST_FINE_GRAINED_DEPENDENCIES_H
 
+#include "swift/AST/EvaluatorDependencies.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/Fingerprint.h"
 #include "swift/Basic/LLVM.h"
@@ -57,11 +58,14 @@
 //==============================================================================
 
 namespace swift {
+class Decl;
 class DependencyTracker;
 class DiagnosticEngine;
 class FrontendOptions;
 class ModuleDecl;
 class SourceFile;
+class NominalTypeDecl;
+class ValueDecl;
 
 /// Use a new namespace to help keep the experimental code from clashing.
 namespace fine_grained_dependencies {
@@ -417,6 +421,57 @@ class DependencyKey {
   // For import/export
   friend ::llvm::yaml::MappingTraits<DependencyKey>;
 
+public:
+  class Builder {
+  private:
+    const NodeKind kind;
+    const DeclAspect aspect;
+    const NominalTypeDecl *context;
+    StringRef name;
+
+  private:
+    // A private copy constructor so our clients are forced to use the
+    // move-only builder interface.
+    explicit Builder(NodeKind kind, DeclAspect aspect,
+                     const NominalTypeDecl *context, StringRef name)
+        : kind(kind), aspect(aspect), context(context), name(name) {}
+
+  public:
+    /// Creates a DependencyKey::Builder from the given \p kind and \p aspect
+    /// with a \c null context and empty name.
+    explicit Builder(NodeKind kind, DeclAspect aspect)
+        : kind(kind), aspect(aspect), context(nullptr), name("") {}
+
+  public:
+    /// Consumes this builder and returns a dependency key created from its
+    /// data.
+    DependencyKey build() &&;
+
+  public:
+    /// Extracts the data from the given \p ref into a this builder.
+    Builder fromReference(const evaluator::DependencyCollector::Reference &ref);
+
+  public:
+    /// Extracts the context data from the given declaration, if any.
+    Builder withContext(const Decl *D) &&;
+    /// Extracts the context data from the given decl-member pair, if any.
+    Builder withContext(std::pair<const NominalTypeDecl *, const ValueDecl *>
+                            holderAndMember) &&;
+
+  public:
+    /// Copies the name data for the given swiftdeps file into this builder.
+    Builder withName(StringRef swiftDeps) &&;
+    /// Copies the name of the given declaration into this builder, if any.
+    Builder withName(const Decl *decl) &&;
+    /// Extracts the name from the given decl-member pair, if any.
+    Builder withName(std::pair<const NominalTypeDecl *, const ValueDecl *>
+                         holderAndMember) &&;
+
+  private:
+    static StringRef getTopLevelName(const Decl *decl);
+  };
+
+private:
   NodeKind kind;
   DeclAspect aspect;
   /// The mangled context type name of the holder for \ref potentialMember, \ref
@@ -485,10 +540,6 @@ public:
   template <NodeKind kind, typename Entity>
   static DependencyKey createForProvidedEntityInterface(Entity);
 
-  /// Given some type of provided entity compute the context field of the key.
-  template <NodeKind kind, typename Entity>
-  static std::string computeContextForProvidedEntity(Entity);
-
   DependencyKey correspondingImplementation() const {
     return withAspect(DeclAspect::implementation);
   }
@@ -496,10 +547,6 @@ public:
   DependencyKey withAspect(DeclAspect aspect) const {
     return DependencyKey(kind, aspect, context, name);
   }
-
-  /// Given some type of provided entity compute the name field of the key.
-  template <NodeKind kind, typename Entity>
-  static std::string computeNameForProvidedEntity(Entity);
 
   static DependencyKey createKeyForWholeSourceFile(DeclAspect,
                                                    StringRef swiftDeps);

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -186,12 +186,9 @@ std::string DependencyKey::demangleTypeAsContext(StringRef s) {
 DependencyKey DependencyKey::createKeyForWholeSourceFile(DeclAspect aspect,
                                                          StringRef swiftDeps) {
   assert(!swiftDeps.empty());
-  const std::string context = DependencyKey::computeContextForProvidedEntity<
-      NodeKind::sourceFileProvide>(swiftDeps);
-  const std::string name =
-      DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
-          swiftDeps);
-  return DependencyKey(NodeKind::sourceFileProvide, aspect, context, name);
+  return DependencyKey::Builder(NodeKind::sourceFileProvide, aspect)
+      .withName(swiftDeps)
+      .build();
 }
 
 //==============================================================================

--- a/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
+++ b/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
@@ -82,12 +82,9 @@ UnitTestSourceFileDepGraphFactory::computeUseKey(StringRef s,
   if (!s.empty())
     return parseADefinedDecl(s, kindOfUse, aspectOfUse).getValue();
   StringRef swiftDepsRef(swiftDeps);
-  return DependencyKey(
-      NodeKind::sourceFileProvide, aspectOfUse,
-      DependencyKey::computeContextForProvidedEntity<
-          NodeKind::sourceFileProvide>(swiftDepsRef),
-      DependencyKey::computeNameForProvidedEntity<NodeKind::sourceFileProvide>(
-          swiftDepsRef));
+  return DependencyKey::Builder(NodeKind::sourceFileProvide, aspectOfUse)
+          .withName(swiftDepsRef)
+          .build();
 }
 
 //==============================================================================


### PR DESCRIPTION
It can be quite difficult to tell at a glance just how any particular decl is going to be converted into a key. The space of available template specializations is also 2-dimensional which adds an additional level of difficulty when the time comes to extend or refactor any of them. Unroll all of the templates into a builder that coalesces the commonalities of the ways DependencyKeys are built to combat this.