### PR TITLE
Register Dependency Arcs for Extension Members

### DIFF
--- a/include/swift/AST/AbstractSourceFileDepGraphFactory.h
+++ b/include/swift/AST/AbstractSourceFileDepGraphFactory.h
@@ -73,9 +73,11 @@ protected:
     for (const auto &declOrPair : contentsVec) {
       auto fp =
           AbstractSourceFileDepGraphFactory::getFingerprintIfAny(declOrPair);
-      addADefinedDecl(
-          DependencyKey::createForProvidedEntityInterface<kind>(declOrPair),
-          fp);
+      auto key = DependencyKey::Builder{kind, DeclAspect::interface}
+                    .withContext(declOrPair)
+                    .withName(declOrPair)
+                    .build();
+      addADefinedDecl(key, fp);
     }
   }
 

--- a/include/swift/AST/DependencyCollector.h
+++ b/include/swift/AST/DependencyCollector.h
@@ -23,7 +23,7 @@
 
 namespace swift {
 
-class NominalTypeDecl;
+class DeclContext;
 
 namespace evaluator {
 
@@ -50,31 +50,31 @@ struct DependencyCollector {
       Dynamic,
     } kind;
 
-    NominalTypeDecl *subject;
+    DeclContext *subject;
     DeclBaseName name;
 
   private:
-    Reference(Kind kind, NominalTypeDecl *subject, DeclBaseName name)
+    Reference(Kind kind, DeclContext *subject, DeclBaseName name)
         : kind(kind), subject(subject), name(name) {}
 
   public:
     static Reference empty() {
-      return {Kind::Empty, llvm::DenseMapInfo<NominalTypeDecl *>::getEmptyKey(),
+      return {Kind::Empty, llvm::DenseMapInfo<DeclContext *>::getEmptyKey(),
               llvm::DenseMapInfo<DeclBaseName>::getEmptyKey()};
     }
 
     static Reference tombstone() {
       return {Kind::Tombstone,
-              llvm::DenseMapInfo<NominalTypeDecl *>::getTombstoneKey(),
+              llvm::DenseMapInfo<DeclContext *>::getTombstoneKey(),
               llvm::DenseMapInfo<DeclBaseName>::getTombstoneKey()};
     }
 
   public:
-    static Reference usedMember(NominalTypeDecl *subject, DeclBaseName name) {
+    static Reference usedMember(DeclContext *subject, DeclBaseName name) {
       return {Kind::UsedMember, subject, name};
     }
 
-    static Reference potentialMember(NominalTypeDecl *subject) {
+    static Reference potentialMember(DeclContext *subject) {
       return {Kind::PotentialMember, subject, DeclBaseName()};
     }
 
@@ -119,7 +119,7 @@ public:
   /// up front. A used member dependency causes the file to be rebuilt if the
   /// definition of that member changes in any way - via
   /// deletion, addition, or mutation of a member with that same name.
-  void addUsedMember(NominalTypeDecl *subject, DeclBaseName name);
+  void addUsedMember(DeclContext *subject, DeclBaseName name);
   /// Registers a reference from the current dependency scope to a
   /// "potential member" of the given \p subject type.
   ///
@@ -133,7 +133,7 @@ public:
   ///
   /// These dependencies are most appropriate for protocol conformances,
   /// superclass constraints, and other requirements involving entire types.
-  void addPotentialMember(NominalTypeDecl *subject);
+  void addPotentialMember(DeclContext *subject);
   /// Registers a reference from the current dependency scope to a given
   /// top-level \p name.
   ///

--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -535,11 +535,6 @@ public:
   }
   bool isInterface() const { return getAspect() == DeclAspect::interface; }
 
-  /// Create just the interface half of the keys for a provided Decl or Decl
-  /// pair
-  template <NodeKind kind, typename Entity>
-  static DependencyKey createForProvidedEntityInterface(Entity);
-
   DependencyKey correspondingImplementation() const {
     return withAspect(DeclAspect::implementation);
   }

--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -426,14 +426,14 @@ public:
   private:
     const NodeKind kind;
     const DeclAspect aspect;
-    const NominalTypeDecl *context;
+    const DeclContext *context;
     StringRef name;
 
   private:
     // A private copy constructor so our clients are forced to use the
     // move-only builder interface.
     explicit Builder(NodeKind kind, DeclAspect aspect,
-                     const NominalTypeDecl *context, StringRef name)
+                     const DeclContext *context, StringRef name)
         : kind(kind), aspect(aspect), context(context), name(name) {}
 
   public:

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "swift/AST/Evaluator.h"
+#include "swift/AST/DeclContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Range.h"
@@ -112,13 +113,14 @@ evaluator::DependencyCollector::~DependencyCollector() {
 #endif
 }
 
-void evaluator::DependencyCollector::addUsedMember(NominalTypeDecl *subject,
+void evaluator::DependencyCollector::addUsedMember(DeclContext *subject,
                                                    DeclBaseName name) {
+  assert(subject->isTypeContext());
   return parent.recordDependency(Reference::usedMember(subject, name));
 }
 
-void evaluator::DependencyCollector::addPotentialMember(
-    NominalTypeDecl *subject) {
+void evaluator::DependencyCollector::addPotentialMember(DeclContext *subject) {
+  assert(subject->isTypeContext());
   return parent.recordDependency(Reference::potentialMember(subject));
 }
 

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -65,14 +65,6 @@ static std::string mangleTypeAsContext(const NominalTypeDecl *NTD) {
 // MARK: DependencyKey::Builder
 //==============================================================================
 
-template <NodeKind kindArg, typename Entity>
-DependencyKey DependencyKey::createForProvidedEntityInterface(Entity entity) {
-  return DependencyKey::Builder{kindArg, DeclAspect::interface}
-      .withContext(entity)
-      .withName(entity)
-      .build();
-}
-
 DependencyKey DependencyKey::Builder::build() && {
   return DependencyKey{
     kind,

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -84,13 +84,13 @@ DependencyKey::Builder DependencyKey::Builder::fromReference(
   case Kind::Tombstone:
     llvm_unreachable("Cannot enumerate dead reference!");
   case Kind::PotentialMember:
-    return Builder{kind, aspect}.withContext(ref.subject);
+    return Builder{kind, aspect}.withContext(ref.subject->getAsDecl());
   case Kind::TopLevel:
   case Kind::Dynamic:
     return Builder{kind, aspect, nullptr, ref.name.userFacingName()};
   case Kind::UsedMember:
     return Builder{kind, aspect, nullptr, ref.name.userFacingName()}
-        .withContext(ref.subject);
+        .withContext(ref.subject->getAsDecl());
   }
 }
 
@@ -455,14 +455,14 @@ private:
   void enumerateNominalUses(UseEnumerator enumerator) {
     auto &Ctx = SF->getASTContext();
     Ctx.evaluator.enumerateReferencesInFile(SF, [&](const auto &ref) {
-      const NominalTypeDecl *subject = ref.subject;
+      const DeclContext *subject = ref.subject;
       if (!subject) {
         return;
       }
 
       auto key =
           DependencyKey::Builder(NodeKind::nominal, DeclAspect::interface)
-              .withContext(subject)
+              .withContext(subject->getAsDecl())
               .build();
       enumerateUse(key, enumerator);
     });

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -305,6 +305,13 @@ void DirectLookupRequest::writeDependencySink(
     evaluator::DependencyCollector &tracker,
     const TinyPtrVector<ValueDecl *> &result) const {
   auto &desc = std::get<0>(getStorage());
+  // Add used members from the perspective of
+  // 1) The decl context they are found in
+  // 2) The decl context of the request
+  // This gets us a dependency not just on `Foo.bar` but on `extension Foo.bar`.
+  for (const auto *member : result) {
+    tracker.addUsedMember(member->getDeclContext(), desc.Name.getBaseName());
+  }
   tracker.addUsedMember(desc.DC, desc.Name.getBaseName());
 }
 

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -395,12 +395,12 @@ bool DependencyVerifier::constructObligations(const SourceFile *SF,
       llvm_unreachable("Cannot enumerate dead dependency!");
 
     case NodeKind::PotentialMember: {
-      auto key = copyQualifiedTypeName(Ctx, reference.subject);
+      auto key = copyQualifiedTypeName(Ctx, reference.subject->getSelfNominalTypeDecl());
       Obligations.insert({Obligation::Key::forPotentialMember(key),
                           {"", Expectation::Kind::PotentialMember}});
     } break;
     case NodeKind::UsedMember: {
-      auto demContext = copyQualifiedTypeName(Ctx, reference.subject);
+      auto demContext = copyQualifiedTypeName(Ctx, reference.subject->getSelfNominalTypeDecl());
       auto name = reference.name.userFacingName();
       auto key = Ctx.AllocateCopy((demContext + "." + name).str());
       Obligations.insert(

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -188,7 +188,7 @@ struct Obligation {
       }
       static bool isEqual(const Obligation::Key &LHS,
                           const Obligation::Key &RHS) {
-        return LHS.Name == RHS.Name && LHS.Kind == RHS.Kind;
+        return LHS.Name.equals(RHS.Name) && LHS.Kind == RHS.Kind;
       }
     };
   };

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-after.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-after.swift
@@ -1,0 +1,8 @@
+public struct S {
+  private
+  static func foo(_ i: Int) {print("1: other:2 commented out")}
+}
+extension S {
+  // private // commented out to ensure we see a change to the fingerprint
+  static func foo2(_ i: Int) {print("2: other:6 commented out")}
+}

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-before.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/definesS-before.swift
@@ -1,0 +1,8 @@
+public struct S {
+  private // commenting out this line works
+  static func foo(_ i: Int) {print("1: other:2 commented out")}
+}
+extension S {
+  private // commenting out this line fails
+  static func foo2(_ i: Int) {print("2: other:6 commented out")}
+}

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/main.swift
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/main.swift
@@ -1,0 +1,11 @@
+extension S {
+  static func foo<I: SignedInteger>(_ si: I) {
+    print("1: other:2 not commented out")
+  }
+  static func foo2<I: SignedInteger>(_ si: I) {
+    print("2: other:6 not commented out")
+  }
+}
+
+S.foo(3)
+S.foo2(3)

--- a/test/Incremental/Fingerprints/Inputs/extension-changes-member/ofm.json
+++ b/test/Incremental/Fingerprints/Inputs/extension-changes-member/ofm.json
@@ -1,0 +1,14 @@
+{
+  "main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "definesS.swift": {
+    "object": "./definesS.o",
+    "swift-dependencies": "./definesS.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}
+

--- a/test/Incremental/Fingerprints/Inputs/member-moves-extensions/definesS-after.swift
+++ b/test/Incremental/Fingerprints/Inputs/member-moves-extensions/definesS-after.swift
@@ -1,0 +1,17 @@
+public protocol P {
+  func foo()
+}
+
+public protocol Q: P {
+  func bar()
+}
+
+public struct S {}
+
+extension S: P {
+  public func foo() {}
+}
+
+extension S: Q {
+  public func bar() {}
+}

--- a/test/Incremental/Fingerprints/Inputs/member-moves-extensions/definesS-before.swift
+++ b/test/Incremental/Fingerprints/Inputs/member-moves-extensions/definesS-before.swift
@@ -1,0 +1,18 @@
+public protocol P {
+  func foo()
+}
+
+public protocol Q: P {
+  func bar()
+}
+
+public struct S {}
+
+extension S: P {
+  public func foo() {}
+  public func bar() {}
+}
+
+extension S: Q {
+
+}

--- a/test/Incremental/Fingerprints/Inputs/member-moves-extensions/main.swift
+++ b/test/Incremental/Fingerprints/Inputs/member-moves-extensions/main.swift
@@ -1,0 +1,7 @@
+extension S {
+  public func foo(_ parameter: Int = 42) {}
+  public func bar(_ parameter: Int = 42) {}
+}
+
+S().foo()
+S().bar()

--- a/test/Incremental/Fingerprints/Inputs/member-moves-extensions/ofm.json
+++ b/test/Incremental/Fingerprints/Inputs/member-moves-extensions/ofm.json
@@ -1,0 +1,14 @@
+{
+  "main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "definesS.swift": {
+    "object": "./definesS.o",
+    "swift-dependencies": "./definesS.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}
+

--- a/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/definesS-after.swift
+++ b/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/definesS-after.swift
@@ -1,0 +1,8 @@
+public struct S {
+  private
+  static func foo(_ i: Int) {print("1: other:2 commented out")}
+}
+extension S {
+  private
+  static func foo2(_ i: Int) {print("2: other:6 commented out")}
+}

--- a/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/definesS-before.swift
+++ b/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/definesS-before.swift
@@ -1,0 +1,5 @@
+public struct S {
+  private // commenting out this line works
+  static func foo(_ i: Int) {print("1: other:2 commented out")}
+}
+

--- a/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/main.swift
+++ b/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/main.swift
@@ -1,0 +1,11 @@
+extension S {
+  static func foo<I: SignedInteger>(_ si: I) {
+    print("1: other:2 not commented out")
+  }
+  static func foo2<I: SignedInteger>(_ si: I) {
+    print("2: other:6 not commented out")
+  }
+}
+
+S.foo(3)
+S.foo2(3)

--- a/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/ofm.json
+++ b/test/Incremental/Fingerprints/Inputs/nominal-adds-extension/ofm.json
@@ -1,0 +1,14 @@
+{
+  "main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps"
+  },
+  "definesS.swift": {
+    "object": "./definesS.o",
+    "swift-dependencies": "./definesS.swiftdeps"
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}
+

--- a/test/Incremental/Fingerprints/extension-adds-member.swift
+++ b/test/Incremental/Fingerprints/extension-adds-member.swift
@@ -1,8 +1,5 @@
-// Test per-type-body fingerprints using simple extensions
-//
-// If the parser is allowed to use a body fingerprint for an extension
-// this test will fail because usesA.swift won't be recompiled for the
-// last step.
+// Test that adding an overloaded member to an extension causes the users
+// depending on that extension to rebuild.
 
 // Establish status quo
 

--- a/test/Incremental/Fingerprints/extension-changes-member.swift
+++ b/test/Incremental/Fingerprints/extension-changes-member.swift
@@ -1,0 +1,30 @@
+// Test that moving an overloaded member from one extension to another forces a
+// rebuild of existing users. We do not strictly need this behavior to occur in
+// all cases, but it's good to be safe.
+
+// Establish status quo
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/extension-changes-member/* %t
+// RUN: cp %t/definesS{-before,}.swift
+
+// Seeing weird failure on CI, so set the mod times
+// RUN: touch -t 200101010101 %t/*.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output3
+
+// Change one type, only uses of that type get recompiled
+
+// RUN: cp %t/definesS{-after,}.swift
+
+// Seeing weird failure on CI, so ensure that definesS.swift is newer
+// RUN: touch -t 200201010101 %t/*
+// RUN: touch -t 200101010101 %t/*.swift
+// RUN: touch -t 200301010101 %t/definesS.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output4
+
+// RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
+
+// CHECK-RECOMPILED-W: {compile: definesS.o <= definesS.swift}
+// CHECK-RECOMPILED-W: {compile: main.o <= main.swift}

--- a/test/Incremental/Fingerprints/member-moves-extensions.swift
+++ b/test/Incremental/Fingerprints/member-moves-extensions.swift
@@ -1,0 +1,32 @@
+// Test per-type-body fingerprints using simple extensions
+//
+// If the parser is allowed to use a body fingerprint for an extension
+// this test will fail because usesA.swift won't be recompiled for the
+// last step.
+
+// Establish status quo
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/member-moves-extensions/* %t
+// RUN: cp %t/definesS{-before,}.swift
+
+// Seeing weird failure on CI, so set the mod times
+// RUN: touch -t 200101010101 %t/*.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output3
+
+// Change one type, only uses of that type get recompiled
+
+// RUN: cp %t/definesS{-after,}.swift
+
+// Seeing weird failure on CI, so ensure that definesS.swift is newer
+// RUN: touch -t 200201010101 %t/*
+// RUN: touch -t 200101010101 %t/*.swift
+// RUN: touch -t 200301010101 %t/definesS.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output4
+
+// RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
+
+// CHECK-RECOMPILED-W: {compile: definesS.o <= definesS.swift}
+// CHECK-RECOMPILED-W: {compile: main.o <= main.swift}

--- a/test/Incremental/Fingerprints/nominal-adds-extension.swift
+++ b/test/Incremental/Fingerprints/nominal-adds-extension.swift
@@ -1,0 +1,30 @@
+// Test that moving an overloaded member from one extension to another forces a
+// rebuild of existing users. We do not strictly need this behavior to occur in
+// all cases, but it's good to be safe.
+
+// Establish status quo
+
+// RUN: %empty-directory(%t)
+// RUN: cp %S/Inputs/nominal-adds-extension/* %t
+// RUN: cp %t/definesS{-before,}.swift
+
+// Seeing weird failure on CI, so set the mod times
+// RUN: touch -t 200101010101 %t/*.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output3
+
+// Change one type, only uses of that type get recompiled
+
+// RUN: cp %t/definesS{-after,}.swift
+
+// Seeing weird failure on CI, so ensure that definesS.swift is newer
+// RUN: touch -t 200201010101 %t/*
+// RUN: touch -t 200101010101 %t/*.swift
+// RUN: touch -t 200301010101 %t/definesS.swift
+
+// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesS.swift -module-name main -output-file-map ofm.json  >& %t/output4
+
+// RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
+
+// CHECK-RECOMPILED-W: {compile: definesS.o <= definesS.swift}
+// CHECK-RECOMPILED-W: {compile: main.o <= main.swift}


### PR DESCRIPTION
Built on top of #36096

-----

This was a hole in the existing dependency tracking infrastructure. David managed to discover a way to exploit this bug to get a miscompile in rdar://74583179. There, members of extensions were not counted towards the interface hash of a type and so mutating them could lead to e.g. the wrong declaration being selected in an overload set.

To start tracking extensions, we need to add two new kinds of arcs:
1) A nominal arc to the extension
2) A member arc to the extension

Unfortunately, extensions are also non-nominal in Swift: they do not have a name to allow us to unique them. Luckily, we do have a way of identifying extensions: their fingerprint. These arcs are therefore emitted with the extended nominal type and the fingerprint of the extension as their context. This effectively invents a new nominal type for every extension.