### PR TITLE
[ownership] Enable it everywhere else in the stdlib/overlays beyond stdlibCore.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1645,6 +1645,9 @@ function(add_swift_target_library name)
                       "-Xfrontend;-disable-implicit-concurrency-module-import")
   endif()
 
+  # Turn on ossa modules for all swift that we compile.
+  list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-ossa-modules")
+
   # If we are building this library for targets, loop through the various
   # SDKs building the variants of this library.
   list_intersect(

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -286,7 +286,6 @@ endif()
 
 # STAGING: Temporarily avoids having to write #fileID in Swift.swiftinterface.
 list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-experimental-concise-pound-file")
-list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-ossa-modules")
 
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_target_library(swift_stdlib_essential ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE


### PR DESCRIPTION
This is now just a draft to get some testing.