### PR TITLE
Re-implement GenericSignature::getConformanceAccessPath()

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -234,13 +234,6 @@ class alignas(1 << TypeAlignInBits) GenericSignatureImpl final
   mutable llvm::PointerUnion<const GenericSignatureImpl *, ASTContext *>
     CanonicalSignatureOrASTContext;
 
-  void buildConformanceAccessPath(
-      SmallVectorImpl<ConformanceAccessPath::Entry> &path,
-      ArrayRef<Requirement> reqs,
-      const void /*GenericSignatureBuilder::RequirementSource*/ *source,
-      ProtocolDecl *conformingProto, Type rootType,
-      ProtocolDecl *requirementSignatureProto) const;
-
   friend class ArchetypeType;
 
 public:

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -626,7 +626,6 @@ public:
   /// After this point, one cannot introduce new requirements, and the
   /// generic signature builder no longer has valid state.
   GenericSignature computeGenericSignature(
-                      SourceLoc loc,
                       bool allowConcreteGenericParams = false,
                       bool allowBuilderToMove = true) &&;
 
@@ -639,8 +638,7 @@ private:
   ///
   /// \param allowConcreteGenericParams If true, allow generic parameters to
   /// be made concrete.
-  void finalize(SourceLoc loc,
-                TypeArrayView<GenericTypeParamType> genericParams,
+  void finalize(TypeArrayView<GenericTypeParamType> genericParams,
                 bool allowConcreteGenericParams=false);
 
 public:

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -921,10 +921,6 @@ private:
   /// Whether there is a trailing written requirement location.
   const bool hasTrailingWrittenRequirementLoc;
 
-public:
-  /// Whether a protocol requirement came from the requirement signature.
-  const bool usesRequirementSignature;
-
 private:
   /// The actual storage, described by \c storageKind.
   union {
@@ -1020,7 +1016,7 @@ public:
                     WrittenRequirementLoc writtenReqLoc)
     : kind(kind), storageKind(StorageKind::StoredType),
       hasTrailingWrittenRequirementLoc(!writtenReqLoc.isNull()),
-      usesRequirementSignature(false), parent(nullptr) {
+      parent(nullptr) {
     assert(isAcceptableStorageKind(kind, storageKind) &&
            "RequirementSource kind/storageKind mismatch");
 
@@ -1036,7 +1032,6 @@ public:
                     WrittenRequirementLoc writtenReqLoc)
     : kind(kind), storageKind(StorageKind::StoredType),
       hasTrailingWrittenRequirementLoc(!writtenReqLoc.isNull()),
-      usesRequirementSignature(!protocol->isComputingRequirementSignature()),
       parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
@@ -1053,8 +1048,7 @@ public:
   RequirementSource(Kind kind, const RequirementSource *parent,
                     ProtocolConformanceRef conformance)
     : kind(kind), storageKind(StorageKind::ProtocolConformance),
-      hasTrailingWrittenRequirementLoc(false),
-      usesRequirementSignature(false), parent(parent) {
+      hasTrailingWrittenRequirementLoc(false), parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
     assert(isAcceptableStorageKind(kind, storageKind) &&
@@ -1066,8 +1060,7 @@ public:
   RequirementSource(Kind kind, const RequirementSource *parent,
                     AssociatedTypeDecl *assocType)
     : kind(kind), storageKind(StorageKind::AssociatedTypeDecl),
-      hasTrailingWrittenRequirementLoc(false),
-      usesRequirementSignature(false), parent(parent) {
+      hasTrailingWrittenRequirementLoc(false), parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
     assert(isAcceptableStorageKind(kind, storageKind) &&
@@ -1078,8 +1071,7 @@ public:
 
   RequirementSource(Kind kind, const RequirementSource *parent)
     : kind(kind), storageKind(StorageKind::None),
-      hasTrailingWrittenRequirementLoc(false),
-      usesRequirementSignature(false), parent(parent) {
+      hasTrailingWrittenRequirementLoc(false), parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
     assert(isAcceptableStorageKind(kind, storageKind) &&
@@ -1089,8 +1081,7 @@ public:
   RequirementSource(Kind kind, const RequirementSource *parent,
                     Type newType)
     : kind(kind), storageKind(StorageKind::StoredType),
-      hasTrailingWrittenRequirementLoc(false),
-      usesRequirementSignature(false), parent(parent) {
+      hasTrailingWrittenRequirementLoc(false), parent(parent) {
     assert((static_cast<bool>(parent) != isRootKind(kind)) &&
            "Root RequirementSource should not have parent (or vice versa)");
     assert(isAcceptableStorageKind(kind, storageKind) &&

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1742,8 +1742,7 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
 
 #if SWIFT_GSB_EXPENSIVE_ASSERTIONS
   auto builderSig =
-    builder->computeGenericSignature(SourceLoc(),
-                                     /*allowConcreteGenericParams=*/true);
+    builder->computeGenericSignature(/*allowConcreteGenericParams=*/true);
   if (builderSig.getCanonicalSignature() != sig) {
     llvm::errs() << "ERROR: generic signature builder is not idempotent.\n";
     llvm::errs() << "Original generic signature   : ";

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -729,16 +729,6 @@ CanGenericSignature::getGenericParams() const{
   return {base, params.size()};
 }
 
-/// Remove all of the associated type declarations from the given type
-/// parameter, producing \c DependentMemberTypes with names alone.
-static Type eraseAssociatedTypes(Type type) {
-  if (auto depMemTy = type->getAs<DependentMemberType>())
-    return DependentMemberType::get(eraseAssociatedTypes(depMemTy->getBase()),
-                                    depMemTy->getName());
-
-  return type;
-}
-
 namespace {
   typedef GenericSignatureBuilder::RequirementSource RequirementSource;
 
@@ -765,225 +755,20 @@ static bool hasConformanceInSignature(ArrayRef<Requirement> requirements,
   return false;
 }
 
-/// Check whether the given requirement source has any non-canonical protocol
-/// requirements in it.
-static bool hasNonCanonicalSelfProtocolRequirement(
-                                          const RequirementSource *source,
-                                          ProtocolDecl *conformingProto) {
-  for (; source; source = source->parent) {
-    // Only look at protocol requirements.
-    if (!source->isProtocolRequirement())
-      continue;
-
-    // If we don't already have a requirement signature for this protocol,
-    // build one now.
-    auto inProto = source->getProtocolDecl();
-
-    // Check whether the given requirement is in the requirement signature.
-    if (!source->usesRequirementSignature &&
-        !hasConformanceInSignature(inProto->getRequirementSignature(),
-                                   source->getStoredType(), conformingProto))
-      return true;
-
-    // Update the conforming protocol for the rest of the search.
-    conformingProto = inProto;
-  }
-
-  return false;
-}
-
-/// Retrieve the best requirement source from the list
-static const RequirementSource *
-getBestRequirementSource(GenericSignatureBuilder &builder,
-                         ArrayRef<GSBConstraint<ProtocolDecl *>> constraints) {
-  const RequirementSource *bestSource = nullptr;
-  bool bestIsNonCanonical = false;
-
-  auto isBetter = [&](const RequirementSource *source, bool isNonCanonical) {
-    if (!bestSource) return true;
-
-    if (bestIsNonCanonical != isNonCanonical)
-      return bestIsNonCanonical;
-
-    return bestSource->compare(source) > 0;
-  };
-
-  for (const auto &constraint : constraints) {
-    auto source = constraint.source;
-
-    // Skip self-recursive sources.
-    bool derivedViaConcrete = false;
-    if (source->getMinimalConformanceSource(
-                                        builder,
-                                        constraint.getSubjectDependentType({ }),
-                                        constraint.value,
-                                        derivedViaConcrete)
-          != source)
-      continue;
-
-    // If there is a non-canonical protocol requirement next to the root,
-    // skip this requirement source.
-    bool isNonCanonical =
-      hasNonCanonicalSelfProtocolRequirement(source, constraint.value);
-
-    if (isBetter(source, isNonCanonical)) {
-      bestSource = source;
-      bestIsNonCanonical = isNonCanonical;
-      continue;
-    }
-  }
-
-  assert(bestSource && "All sources were self-recursive?");
-  return bestSource;
-}
-
-void GenericSignatureImpl::buildConformanceAccessPath(
-    SmallVectorImpl<ConformanceAccessPath::Entry> &path,
-    ArrayRef<Requirement> reqs, const void *opaqueSource,
-    ProtocolDecl *conformingProto, Type rootType,
-    ProtocolDecl *requirementSignatureProto) const {
-  auto *source = reinterpret_cast<const RequirementSource *>(opaqueSource);
-  // Each protocol requirement is a step along the path.
-  if (source->isProtocolRequirement()) {
-    // If we're expanding for a protocol that had no requirement signature
-    // and have hit the penultimate step, this is the last step
-    // that would occur in the requirement signature.
-    Optional<GenericSignatureBuilder> replacementBuilder;
-    if (!source->parent->parent && requirementSignatureProto) {
-      // If we have a requirement signature now, we're done.
-      if (source->usesRequirementSignature) {
-        Type subjectType = source->getStoredType()->getCanonicalType();
-        path.push_back({subjectType, conformingProto});
-        return;
-      }
-
-      // The generic signature builder we're using for this protocol
-      // wasn't built from its own requirement signature, so we can't
-      // trust it, build a new generic signature builder.
-      // FIXME: It would be better if we could replace the canonical generic
-      // signature builder with the rebuilt one.
-
-      replacementBuilder.emplace(getASTContext());
-      replacementBuilder->addGenericSignature(
-                          requirementSignatureProto->getGenericSignature());
-      replacementBuilder->processDelayedRequirements();
-    }
-
-    // Follow the rest of the path to derive the conformance into which
-    // this particular protocol requirement step would look.
-    auto inProtocol = source->getProtocolDecl();
-    buildConformanceAccessPath(path, reqs, source->parent, inProtocol, rootType,
-                               requirementSignatureProto);
-    assert(path.back().second == inProtocol &&
-           "path produces incorrect conformance");
-
-    // If this step was computed via the requirement signature, add it
-    // directly.
-    if (source->usesRequirementSignature) {
-      // Add this step along the path, which involves looking for the
-      // conformance we want (\c conformingProto) within the protocol
-      // described by this source.
-
-      // Canonicalize the subject type within the protocol's generic
-      // signature.
-      Type subjectType = source->getStoredType();
-      subjectType = inProtocol->getGenericSignature()
-        ->getCanonicalTypeInContext(subjectType);
-
-      assert(hasConformanceInSignature(inProtocol->getRequirementSignature(),
-                                       subjectType, conformingProto) &&
-             "missing explicit conformance in requirement signature");
-
-      // Record this step.
-      path.push_back({subjectType, conformingProto});
-      return;
-    }
-
-    // Get the generic signature builder for the protocol.
-    // Get a generic signature for the protocol's signature.
-    auto inProtoSig = inProtocol->getGenericSignature();
-    auto &inProtoSigBuilder =
-        replacementBuilder ? *replacementBuilder
-                           : *inProtoSig->getGenericSignatureBuilder();
-
-    // Retrieve the stored type, but erase all of the specific associated
-    // type declarations; we don't want any details of the enclosing context
-    // to sneak in here.
-    Type storedType = eraseAssociatedTypes(source->getStoredType());
-
-    // Dig out the potential archetype for this stored type.
-    auto equivClass =
-      inProtoSigBuilder.resolveEquivalenceClass(
-                               storedType,
-                               ArchetypeResolutionKind::CompleteWellFormed);
-
-    // Find the conformance of this potential archetype to the protocol in
-    // question.
-    auto conforms = equivClass->conformsTo.find(conformingProto);
-    assert(conforms != equivClass->conformsTo.end());
-
-    // Compute the root type, canonicalizing it w.r.t. the protocol context.
-    auto conformsSource = getBestRequirementSource(inProtoSigBuilder,
-                                                   conforms->second);
-    assert(conformsSource != source || !requirementSignatureProto);
-    Type localRootType = conformsSource->getRootType();
-    localRootType = inProtoSig->getCanonicalTypeInContext(localRootType);
-
-    // Build the path according to the requirement signature.
-    buildConformanceAccessPath(path, inProtocol->getRequirementSignature(),
-                               conformsSource, conformingProto, localRootType,
-                               inProtocol);
-
-    // We're done.
-    return;
-  }
-
-  // If we have a superclass or concrete requirement, the conformance
-  // we need is stored in it.
-  if (source->kind == RequirementSource::Superclass ||
-      source->kind == RequirementSource::Concrete) {
-    auto conformance = source->getProtocolConformance();
-    (void)conformance;
-    assert(conformance.getRequirement() == conformingProto);
-    path.push_back({source->getAffectedType(), conformingProto});
-    return;
-  }
-
-  // If we still have a parent, keep going.
-  if (source->parent) {
-    buildConformanceAccessPath(path, reqs, source->parent, conformingProto,
-                               rootType, requirementSignatureProto);
-    return;
-  }
-
-  // We are at an explicit or inferred requirement.
-  assert(source->kind == RequirementSource::Explicit ||
-         source->kind == RequirementSource::Inferred);
-
-  // Skip trivial path elements. These occur when querying a requirement
-  // signature.
-  if (!path.empty() && conformingProto == path.back().second &&
-      rootType->isEqual(conformingProto->getSelfInterfaceType()))
-    return;
-
-  assert(hasConformanceInSignature(reqs, rootType, conformingProto) &&
-         "missing explicit conformance in signature");
-
-  // Add the root of the path, which starts at this explicit requirement.
-  path.push_back({rootType, conformingProto});
-}
-
 ConformanceAccessPath
 GenericSignatureImpl::getConformanceAccessPath(Type type,
                                                ProtocolDecl *protocol) const {
   assert(type->isTypeParameter() && "not a type parameter");
 
-  // Resolve this type to a potential archetype.
+  // Look up the equivalence class for this type.
   auto &builder = *getGenericSignatureBuilder();
   auto equivClass =
     builder.resolveEquivalenceClass(
                                   type,
                                   ArchetypeResolutionKind::CompleteWellFormed);
+
+  assert(!equivClass->concreteType &&
+         "Concrete types don't have conformance access paths");
 
   auto cached = equivClass->conformanceAccessPathCache.find(protocol);
   if (cached != equivClass->conformanceAccessPathCache.end())
@@ -994,17 +779,117 @@ GenericSignatureImpl::getConformanceAccessPath(Type type,
   auto conforms = equivClass->conformsTo.find(protocol);
   assert(conforms != equivClass->conformsTo.end());
 
-  // Canonicalize the root type.
-  auto source = getBestRequirementSource(builder, conforms->second);
-  Type rootType = source->getRootType()->getCanonicalType(this);
+  // Look at every requirement source for this conformance. If all sources are
+  // explicit, leave these three values empty. Otherwise, they are computed
+  // from the 'best' derived requirement source for this conformance.
+  Type shortestParentType;
+  Type shortestSubjectType;
+  ProtocolDecl *shortestParentProto = nullptr;
 
-  // Build the path.
+  auto isShortestPath = [&](Type parentType,
+                            Type subjectType,
+                            ProtocolDecl *parentProto) -> bool {
+    if (!shortestParentType)
+      return true;
+
+    int cmpParentTypes = compareDependentTypes(parentType, shortestParentType);
+    if (cmpParentTypes != 0)
+      return cmpParentTypes < 0;
+
+    int cmpSubjectTypes = compareDependentTypes(subjectType, shortestSubjectType);
+    if (cmpSubjectTypes != 0)
+      return cmpSubjectTypes < 0;
+
+    int cmpParentProtos = TypeDecl::compare(parentProto, shortestParentProto);
+    return cmpParentProtos < 0;
+  };
+
+  auto recordShortestParentType = [&](Type parentType,
+                                      Type subjectType,
+                                      ProtocolDecl *parentProto) {
+    if (isShortestPath(parentType, subjectType, parentProto)) {
+      shortestParentType = parentType;
+      shortestSubjectType = subjectType;
+      shortestParentProto = parentProto;
+    }
+  };
+
+  for (auto constraint : conforms->second) {
+    auto *source = constraint.source;
+
+    switch (source->kind) {
+    case RequirementSource::Explicit:
+    case RequirementSource::Inferred:
+      // This is not a derived source, so it contributes nothing to the
+      // "shortest parent type" computation.
+      break;
+
+    case RequirementSource::ProtocolRequirement:
+    case RequirementSource::InferredProtocolRequirement: {
+      if (source->parent->kind == RequirementSource::RequirementSignatureSelf) {
+        // This is a top-level requirement in the requirement signature that is
+        // currently being computed. This is not a derived source, so it
+        // contributes nothing to the "shortest parent type" computation.
+        break;
+      }
+
+      auto constraintType = constraint.getSubjectDependentType({ });
+
+      // Skip self-recursive sources.
+      bool derivedViaConcrete = false;
+      if (source->getMinimalConformanceSource(builder, constraintType, protocol,
+                                              derivedViaConcrete) != source)
+        break;
+
+
+      // If we have a derived conformance requirement like T[.P].X : Q, we can
+      // recursively compute the conformance access path for T : P, and append
+      // the path element (Self.X : Q).
+      auto parentType = source->parent->getAffectedType()->getCanonicalType();
+      auto subjectType = source->getStoredType()->getCanonicalType();
+
+      auto *parentProto = source->getProtocolDecl();
+
+      // We might have multiple candidate parent types and protocols for the
+      // recursive step, so pick the shortest one.
+      recordShortestParentType(parentType, subjectType, parentProto);
+
+      break;
+    }
+
+    default:
+      // There should be no other way of testifying to a conformance on a
+      // dependent type.
+      llvm_unreachable("Bad requirement source for conformance on dependent type");
+    }
+  }
+
   SmallVector<ConformanceAccessPath::Entry, 2> path;
-  buildConformanceAccessPath(path, getRequirements(), source, protocol,
-                             rootType, nullptr);
 
-  // Return the path; we're done!
+  if (!shortestParentType) {
+    // All requirement sources were explicit. This means we can recover the
+    // conformance directly from the generic signature; canonicalize the
+    // dependent type and add it as an initial path element.
+    auto rootType = equivClass->getAnchor(builder, { });
+    assert(hasConformanceInSignature(getRequirements(), rootType, protocol));
+    path.emplace_back(rootType, protocol);
+  } else {
+    // This conformance comes from a derived source.
+    //
+    // To recover this the conformance, we recursively recover the conformance
+    // of the parent type to the parent protocol first.
+    auto parentPath = getConformanceAccessPath(
+        shortestParentType, shortestParentProto);
+    for (auto entry : parentPath)
+      path.push_back(entry);
+
+    // Then, we add the subject type from the parent protocol's requirement
+    // signature.
+    path.emplace_back(shortestSubjectType, protocol);
+  }
+
   ConformanceAccessPath result(getASTContext().AllocateCopy(path));
+
   equivClass->conformanceAccessPathCache.insert({protocol, result});
   return result;
 }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -470,9 +470,6 @@ struct GenericSignatureBuilder::Implementation {
   /// Whether there were any errors.
   bool HadAnyError = false;
 
-  /// FIXME: Hack to work around a small number of minimization bugs.
-  bool HadAnyRedundantConstraints = false;
-
 #ifndef NDEBUG
   /// Whether we've already finalized the builder.
   bool finalized = false;
@@ -5870,7 +5867,6 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
     case ConstraintRelation::Redundant:
       // If this requirement is not derived or inferred (but has a useful
       // location) complain that it is redundant.
-      Impl->HadAnyRedundantConstraints = true;
       if (constraint.source->shouldDiagnoseRedundancy(true) &&
           representativeConstraint &&
           representativeConstraint->source->shouldDiagnoseRedundancy(false)) {
@@ -7204,10 +7200,7 @@ GenericSignature GenericSignatureBuilder::computeGenericSignature(
   // will produce the same thing.
   //
   // We cannot do this when there were errors.
-  // FIXME: The HadAnyRedundantConstraints bit is a hack because we are
-  // over-minimizing.
-  if (allowBuilderToMove && !Impl->HadAnyError &&
-      !Impl->HadAnyRedundantConstraints) {
+  if (allowBuilderToMove && !Impl->HadAnyError) {
     // Register this generic signature builder as the canonical builder for the
     // given signature.
     Context.registerGenericSignatureBuilder(sig, std::move(*this));

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5302,9 +5302,8 @@ static void expandSameTypeConstraints(GenericSignatureBuilder &builder,
 }
 
 void
-GenericSignatureBuilder::finalize(SourceLoc loc,
-                              TypeArrayView<GenericTypeParamType> genericParams,
-                              bool allowConcreteGenericParams) {
+GenericSignatureBuilder::finalize(TypeArrayView<GenericTypeParamType> genericParams,
+                                  bool allowConcreteGenericParams) {
   // Process any delayed requirements that we can handle now.
   processDelayedRequirements();
 
@@ -7188,11 +7187,10 @@ static void collectRequirements(GenericSignatureBuilder &builder,
 }
 
 GenericSignature GenericSignatureBuilder::computeGenericSignature(
-                                          SourceLoc loc,
                                           bool allowConcreteGenericParams,
                                           bool allowBuilderToMove) && {
   // Finalize the builder, producing any necessary diagnostics.
-  finalize(loc, getGenericParams(), allowConcreteGenericParams);
+  finalize(getGenericParams(), allowConcreteGenericParams);
 
   // Collect the requirements placed on the generic parameter types.
   SmallVector<Requirement, 4> requirements;
@@ -7258,9 +7256,7 @@ void GenericSignatureBuilder::verifyGenericSignature(ASTContext &context,
     // Form a generic signature from the result.
     auto newSig =
       std::move(builder).computeGenericSignature(
-                                      SourceLoc(),
-                                      /*allowConcreteGenericParams=*/true,
-                                      /*allowBuilderToMove=*/true);
+                                      /*allowConcreteGenericParams=*/true);
 
     // The new signature should be equal.
     if (!newSig->isEqual(sig)) {
@@ -7294,9 +7290,7 @@ void GenericSignatureBuilder::verifyGenericSignature(ASTContext &context,
     // Form a generic signature from the result.
     auto newSig =
       std::move(builder).computeGenericSignature(
-                                      SourceLoc(),
-                                      /*allowConcreteGenericParams=*/true,
-                                      /*allowBuilderToMove=*/true);
+                                      /*allowConcreteGenericParams=*/true);
 
     // If the removed requirement is satisfied by the new generic signature,
     // it is redundant. Complain.
@@ -7474,7 +7468,7 @@ AbstractGenericSignatureRequest::evaluate(
     builder.addRequirement(req, source, nullptr);
 
   return std::move(builder).computeGenericSignature(
-      SourceLoc(), /*allowConcreteGenericParams=*/true);
+      /*allowConcreteGenericParams=*/true);
 }
 
 GenericSignature
@@ -7605,5 +7599,5 @@ InferredGenericSignatureRequest::evaluate(
     builder.addRequirement(req, source, parentModule);
   
   return std::move(builder).computeGenericSignature(
-      SourceLoc(), allowConcreteGenericParams);
+      allowConcreteGenericParams);
 }

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -257,7 +257,6 @@ SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       auto errorIndex = convention.completionHandlerErrorParamIndex();
 
       FuncDecl *resumeIntrinsic;
-      Type replacementTypes[] = {resumeType};
 
       SILBasicBlock *returnBB = nullptr;
       if (errorIndex) {

--- a/lib/SILOptimizer/Differentiation/Thunk.cpp
+++ b/lib/SILOptimizer/Differentiation/Thunk.cpp
@@ -76,7 +76,7 @@ CanGenericSignature buildThunkSignature(SILFunction *fn, bool inheritGenericSig,
   builder.addRequirement(newRequirement, source, nullptr);
 
   auto genericSig = std::move(builder).computeGenericSignature(
-      SourceLoc(), /*allowConcreteGenericParams=*/true);
+      /*allowConcreteGenericParams=*/true);
   genericEnv = genericSig->getGenericEnvironment();
 
   newArchetype =

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2270,7 +2270,6 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
 
   // Check the result.
   auto specializedSig = std::move(Builder).computeGenericSignature(
-      attr->getLocation(),
       /*allowConcreteGenericParams=*/true);
   attr->setSpecializedSignature(specializedSig);
 
@@ -4329,7 +4328,7 @@ bool resolveDifferentiableAttrDerivativeGenericSignature(
 
     // Compute generic signature for derivative functions.
     derivativeGenSig = std::move(builder).computeGenericSignature(
-        attr->getLocation(), /*allowConcreteGenericParams=*/true);
+        /*allowConcreteGenericParams=*/true);
   }
 
   attr->setDerivativeGenericSignature(derivativeGenSig);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -938,8 +938,7 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
           nullptr);
 
   auto reqSignature = std::move(builder).computeGenericSignature(
-                        SourceLoc(),
-                        /*allowConcreteGenericPArams=*/false,
+                        /*allowConcreteGenericParams=*/false,
                         /*allowBuilderToMove=*/false);
   return reqSignature->getRequirements();
 }

--- a/validation-test/compiler_crashers_2_fixed/0207-sr7371.swift
+++ b/validation-test/compiler_crashers_2_fixed/0207-sr7371.swift
@@ -1,6 +1,4 @@
-// RUN: not --crash %target-swift-frontend -emit-ir %s
-// rdar://problem/65571199
-// UNSUPPORTED: asan
+// RUN: %target-swift-frontend -emit-ir %s
 
 public protocol TypedParserResultTransferType {
     // Remove type constraint


### PR DESCRIPTION
A new implementation from "first principles". The idea is that for a given conformance, we either have an explicit source
which forms the root of the requirement path, or a derived source, which we 'factor' into a parent type/parent protocol
pair, and a requirement signature requirement.

We recursively compute the conformance access path of the parent type and parent protocol, and append the path element for the requirement.

This fixes a long-standing crasher, and eliminates two hacks, the 'usesRequirementSource' flag in RequirementSource, and the 'HadAnyRedundantConstraints' flag in GenericSignatureBuilder.

Fixes https://bugs.swift.org/browse/SR-7371 / rdar://problem/39239511