### PR TITLE
Add more defined features to make _Concurrency model parse with older compilers

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -39,5 +39,6 @@ LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
 LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
 LANGUAGE_FEATURE(Actors, 0, "actors", langOpts.EnableExperimentalConcurrency)
 LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)
+LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol", true)
 
 #undef LANGUAGE_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -41,5 +41,6 @@ LANGUAGE_FEATURE(Actors, 0, "actors", langOpts.EnableExperimentalConcurrency)
 LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)
 LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol", true)
 LANGUAGE_FEATURE(GlobalActors, 0, "Global actors", langOpts.EnableExperimentalConcurrency)
+LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type", true)
 
 #undef LANGUAGE_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -40,5 +40,6 @@ LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
 LANGUAGE_FEATURE(Actors, 0, "actors", langOpts.EnableExperimentalConcurrency)
 LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)
 LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol", true)
+LANGUAGE_FEATURE(GlobalActors, 0, "Global actors", langOpts.EnableExperimentalConcurrency)
 
 #undef LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2562,6 +2562,21 @@ static bool usesFeatureRethrowsProtocol(Decl *decl) {
   return usesFeatureRethrowsProtocol(decl, checked);
 }
 
+static bool usesFeatureGlobalActors(Decl *decl) {
+  if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
+    if (nominal->getAttrs().hasAttribute<GlobalActorAttr>())
+      return true;
+  }
+
+  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
+    if (auto nominal = ext->getExtendedNominal())
+      if (usesFeatureGlobalActors(nominal))
+        return true;
+  }
+
+  return false;
+}
+
 /// Determine the set of "new" features used on a given declaration.
 ///
 /// Note: right now, all features we check for are "new". At some point, we'll

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -87,6 +87,14 @@ extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
 extension OldSchool: UnsafeConcurrentValue { }
 // CHECK-NEXT: }
 
+// CHECK: #if compiler(>=5.3) && $GlobalActors
+// CHECK-NEXT: @globalActor public struct SomeGlobalActor
+@globalActor
+public struct SomeGlobalActor {
+  public static let shared = MyActor()
+}
+
+
 // CHECK: #if compiler(>=5.3) && $AsyncAwait
 // CHECK-NEXT: func runSomethingSomewhere
 // CHECK-NEXT: #endif

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -67,6 +67,16 @@ public class OldSchool: MP {
   public func takeClass() async { }
 }
 
+// CHECK: #if compiler(>=5.3) && $RethrowsProtocol
+// CHECK-NEXT: @rethrows public protocol RP
+@rethrows public protocol RP {
+  func f() throws
+}
+
+// CHECK: #if compiler(>=5.3) && $RethrowsProtocol
+// CHECK-NEXT: public func acceptsRP
+public func acceptsRP<T: RP>(_: T) { }
+
 // CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
 // CHECK: extension Array : FeatureTest.MP where Element : FeatureTest.MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }


### PR DESCRIPTION
Extend the set of features with support for `#if`-based module interface printing to cover everything that's needed for the `_Concurrency` module to be parsed by older compilers:
* `$RethrowsProtocol`, which is used by `AsyncSequence`
* `$GlobalActors`
* `$BuiltinJob`, which is used in the implementation

Fixes rdar://73327624