### PR TITLE
[Frontend] Allow missing files when allowing compiler errors

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -139,6 +139,8 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.VerifyGenericSignaturesInModule = A->getValue();
   }
 
+  Opts.AllowModuleWithCompilerErrors |= Args.hasArg(OPT_experimental_allow_module_with_compiler_errors);
+
   computeDumpScopeMapLocations();
 
   Optional<FrontendInputsAndOutputs> inputsAndOutputs =
@@ -159,6 +161,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   } else {
     HaveNewInputsAndOutputs = true;
     Opts.InputsAndOutputs = std::move(inputsAndOutputs).getValue();
+    if (Opts.AllowModuleWithCompilerErrors)
+      Opts.InputsAndOutputs.setShouldRecoverMissingInputs();
   }
 
   if (Args.hasArg(OPT_parse_sil) || Opts.InputsAndOutputs.shouldTreatAsSIL()) {
@@ -230,7 +234,6 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.EnableIncrementalDependencyVerifier |= Args.hasArg(OPT_verify_incremental_dependencies);
   Opts.UseSharedResourceFolder = !Args.hasArg(OPT_use_static_resource_dir);
   Opts.DisableBuildingInterface = Args.hasArg(OPT_disable_building_interface);
-  Opts.AllowModuleWithCompilerErrors = Args.hasArg(OPT_experimental_allow_module_with_compiler_errors);
 
   computeImportObjCHeaderOptions();
   computeImplicitImportModuleNames(OPT_import_module, /*isTestable=*/false);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -655,7 +655,7 @@ CompilerInstance::getRecordedBufferID(const InputFile &input,
 
   // Recover by dummy buffer if requested.
   if (!buffers.hasValue() && shouldRecover &&
-      input.getType() == file_types::TY_Swift && !input.isPrimary()) {
+      input.getType() == file_types::TY_Swift) {
     buffers = ModuleBuffers(llvm::MemoryBuffer::getMemBuffer(
         "// missing file\n", input.getFileName()));
   }

--- a/test/Frontend/allow-errors-missing.swift
+++ b/test/Frontend/allow-errors-missing.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t/singlemissing.swiftmodule -experimental-allow-module-with-compiler-errors missing.swift 2>&1 | %FileCheck -check-prefix=CHECK-SINGLEMISSING %s
+// CHECK-SINGLEMISSING: error opening input file 'missing.swift'
+// RUN: llvm-bcanalyzer %t/singlemissing.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/multimissingwmo.swiftmodule -experimental-allow-module-with-compiler-errors -whole-module-optimization missing.swift missing2.swift 2>&1 | %FileCheck -check-prefix=CHECK-MULTIMISSINGWMO %s
+// CHECK-MULTIMISSINGWMO-DAG: error opening input file 'missing.swift'
+// CHECK-MULTIMISSINGWMO-DAG: error opening input file 'missing2.swift'
+// RUN: llvm-bcanalyzer %t/multimissingwmo.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/singlemissingwmo.swiftmodule -experimental-allow-module-with-compiler-errors -whole-module-optimization %s missing.swift  2>&1 | %FileCheck -check-prefix=CHECK-SINGLEMISSINGWMO %s
+// CHECK-SINGLEMISSINGWMO: error opening input file 'missing.swift'
+// RUN: llvm-bcanalyzer %t/singlemissingwmo.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/nonprimarymissing.swiftmodule -experimental-allow-module-with-compiler-errors -primary-file %s missing.swift 2>&1 | %FileCheck -check-prefix=CHECK-NONPRIMARYMISSING %s
+// CHECK-NONPRIMARYMISSING: error opening input file 'missing.swift'
+// RUN: llvm-bcanalyzer %t/nonprimarymissing.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/primarymissing.swiftmodule -experimental-allow-module-with-compiler-errors -primary-file missing.swift %s 2>&1 | %FileCheck -check-prefix=CHECK-PRIMARYMISSING %s
+// CHECK-PRIMARYMISSING: error opening input file 'missing.swift'
+// RUN: llvm-bcanalyzer %t/primarymissing.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
+
+func foo() -> Int { return 0 }
+
+// CHECK-BC-NOT: UnknownCode


### PR DESCRIPTION
As with other compilation errors, we want to generate the swiftmodule
regardless.