### PR TITLE
[5.4] Narrowly Fix a Crash in Availability Checking of Defer Bodies

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3278,7 +3278,7 @@ public:
 bool swift::diagnoseTypeReprAvailability(const TypeRepr *T,
                                          const ExportContext &where,
                                          DeclAvailabilityFlags flags) {
-  if (!T)
+  if (!T || where.isImplicit())
     return false;
   TypeReprAvailabilityWalker walker(where, flags);
   const_cast<TypeRepr*>(T)->walk(walker);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -147,11 +147,7 @@ static void computeExportContextBits(ASTContext &Ctx, Decl *D,
   if (D->isSPI())
     *spi = true;
 
-  // Defer bodies are desugared to an implicit closure expression. We need to
-  // dilute the meaning of "implicit" to make sure we're still checking
-  // availability inside of defer statements.
-  const auto isDeferBody = isa<FuncDecl>(D) && cast<FuncDecl>(D)->isDeferBody();
-  if (D->isImplicit() && !isDeferBody)
+  if (D->isImplicit())
     *implicit = true;
 
   if (D->getAttrs().getDeprecated(Ctx))

--- a/test/Sema/availability.swift
+++ b/test/Sema/availability.swift
@@ -195,32 +195,3 @@ struct VarToFunc {
   }
 }
 
-struct DeferBody {
-  func foo() {
-    enum No: Error {
-      case no
-    }
-
-    defer {
-      do {
-        throw No.no
-      } catch No.no {
-      } catch {
-      }
-    }
-    _ = ()
-  }
-
-  func bar() {
-    @available(*, unavailable)
-    enum No: Error { // expected-note 2 {{'No' has been explicitly marked unavailable here}}
-      case no
-    }
-    do {
-      throw No.no
-      // expected-error@-1 {{'No' is unavailable}}
-    } catch No.no {} catch _ {}
-    // expected-error@-1 {{'No' is unavailable}}
-  }
-}
-

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -357,12 +357,3 @@ public struct PrivateInlinableCrash {
     // expected-error@-2 {{initializer 'init()' is private and cannot be referenced from an '@inlinable' function}}
   }
 }
-
-// Just make sure we don't crash.
-private func deferBodyTestCall() {} // expected-note {{global function 'deferBodyTestCall()' is not '@usableFromInline' or public}}
-@inlinable public func deferBodyTest() {
-  defer {
-    deferBodyTestCall() // expected-error {{global function 'deferBodyTestCall()' is private and cannot be referenced from an '@inlinable' function}}
-  }
-  _ = ()
-}

--- a/validation-test/compiler_crashers_2_fixed/rdar74484150.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar74484150.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+func foo() {
+  enum No: Error {
+    case no
+  }
+
+  defer {
+    do {
+      throw No.no
+    } catch No.no {
+    } catch {
+    }
+  }
+  _ = ()
+}


### PR DESCRIPTION
NIO exposed an issue in the new availability walkers where an implicit
check was not being performed. They were able to get this to crash by
using a defer statement - the body of which contains implicit
declarations that got run through the walker. This exposed a wider hole
in availability checking of defer statements. Namely, that it wasn't
happening.

This is a narrow fix (as opposed to the broader fix in
#36102) that is safer to take for
Swift 5.4.

rdar://74484150