### PR TITLE
GSB: New algorithm for identifying redundant non-same-type requirements

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -675,6 +675,7 @@ private:
   Constraint<T> checkConstraintList(
                            TypeArrayView<GenericTypeParamType> genericParams,
                            std::vector<Constraint<T>> &constraints,
+                           RequirementKind kind,
                            llvm::function_ref<bool(const Constraint<T> &)>
                              isSuitableRepresentative,
                            llvm::function_ref<
@@ -700,6 +701,7 @@ private:
   Constraint<T> checkConstraintList(
                            TypeArrayView<GenericTypeParamType> genericParams,
                            std::vector<Constraint<T>> &constraints,
+                           RequirementKind kind,
                            llvm::function_ref<bool(const Constraint<T> &)>
                              isSuitableRepresentative,
                            llvm::function_ref<

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -638,7 +638,13 @@ public:
   /// Process any delayed requirements that can be handled now.
   void processDelayedRequirements();
 
+  class ExplicitRequirement;
+
+  bool isRedundantExplicitRequirement(ExplicitRequirement req) const;
+
 private:
+  void computeRedundantRequirements();
+
   /// Describes the relationship between a given constraint and
   /// the canonical constraint of the equivalence class.
   enum class ConstraintRelation {
@@ -1205,6 +1211,10 @@ public:
   /// signature, because the information can be re-derived by following the
   /// path.
   bool isDerivedRequirement() const;
+
+  /// Same as above, but we consider RequirementSignatureSelf to not be
+  /// derived.
+  bool isDerivedNonRootRequirement() const;
 
   /// Whether we should diagnose a redundant constraint based on this
   /// requirement source.

--- a/test/Generics/rdar62903491.swift
+++ b/test/Generics/rdar62903491.swift
@@ -1,0 +1,96 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol P {
+  associatedtype X : P
+}
+
+// Anything that mentions 'T : P' minimizes to 'U : P'.
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
+// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+func oneProtocol1<T, U>(_: T, _: U) where T : P, U : P, T.X == U, U.X == T {}
+// CHECK-LABEL: oneProtocol1
+// CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
+// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+func oneProtocol2<T, U>(_: T, _: U) where U : P, T : P, T.X == U, U.X == T {}
+// CHECK-LABEL: oneProtocol2
+// CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
+// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+func oneProtocol3<T, U>(_: T, _: U) where T : P, T.X == U, U : P, U.X == T {}
+// CHECK-LABEL: oneProtocol3
+// CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
+// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+func oneProtocol4<T, U>(_: T, _: U) where U : P, T.X == U, T : P, U.X == T {}
+// CHECK-LABEL: oneProtocol4
+// CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
+
+func oneProtocol5<T, U>(_: T, _: U) where T : P, T.X == U, U.X == T {}
+// CHECK-LABEL: oneProtocol5
+// CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
+
+func oneProtocol6<T, U>(_: T, _: U) where T.X == U, U.X == T, T : P {}
+// CHECK-LABEL: oneProtocol6
+// CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
+
+// Anything that mentions 'U : P' but not 'T : P' minimizes to 'U : P'.
+
+// FIXME: Need to emit warning here too
+func oneProtocol7<T, U>(_: T, _: U) where U : P, T.X == U, U.X == T {}
+// CHECK-LABEL: oneProtocol7
+// CHECK: Generic signature: <T, U where T == U.X, U : P, U == T.X>
+
+// FIXME: Need to emit warning here too
+func oneProtocol8<T, U>(_: T, _: U) where T.X == U, U.X == T, U : P {}
+// CHECK-LABEL: oneProtocol8
+// CHECK: Generic signature: <T, U where T == U.X, U : P, U == T.X>
+
+protocol P1 {
+  associatedtype X : P2
+}
+
+protocol P2 {
+  associatedtype Y : P1
+}
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
+// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+func twoProtocols1<T, U>(_: T, _: U) where T : P1, U : P2, T.X == U, U.Y == T {}
+// CHECK-LABEL: twoProtocols1
+// CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
+// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+func twoProtocols2<T, U>(_: T, _: U) where U : P2, T : P1, T.X == U, U.Y == T {}
+// CHECK-LABEL: twoProtocols2
+// CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
+// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+func twoProtocols3<T, U>(_: T, _: U) where T : P1, T.X == U, U : P2, U.Y == T {}
+// CHECK-LABEL: twoProtocols3
+// CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
+// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+func twoProtocols4<T, U>(_: T, _: U) where U : P2, T.X == U, T : P1, U.Y == T {}
+// CHECK-LABEL: twoProtocols4
+// CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
+// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+func twoProtocols5<T, U>(_: T, _: U) where T : P1, T.X == U, U.Y == T, U : P2 {}
+// CHECK-LABEL: twoProtocols5
+// CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
+
+// expected-warning@+2 {{redundant conformance constraint 'T': 'P1'}}
+// expected-note@+1 {{conformance constraint 'T': 'P1' implied here}}
+func twoProtocols6<T, U>(_: T, _: U) where U : P2, T.X == U, U.Y == T, T : P1 {}
+// CHECK-LABEL: twoProtocols6
+// CHECK: Generic signature: <T, U where T == U.Y, U : P2, U == T.X>

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -378,22 +378,6 @@ typealias NotAnInt = Double
 extension X11 where NotAnInt == Int { }
 // expected-error@-1{{generic signature requires types 'NotAnInt' (aka 'Double') and 'Int' to be the same}}
 
-
-struct X12<T> { }
-
-protocol P12 {
-  associatedtype A
-  associatedtype B
-}
-
-func testP12a<T: P12>(_: T) where T.A == X12<Int>, T.A == X12<T.B>, T.B == Int { }
-// expected-warning@-1{{redundant same-type constraint 'T.B' == 'Int'}}
-// expected-note@-2{{same-type constraint 'T.B' == 'Int' written here}}
-
-func testP12b<T: P12>(_: T) where T.B == Int, T.A == X12<T.B>, X12<T.B> == T.A { }
-// expected-warning@-1{{redundant same-type constraint 'T.A' == 'X12<Int>'}}
-// expected-note@-2{{same-type constraint 'T.A' == 'X12<Int>' written here}}
-
 // rdar://45307061 - dropping delayed same-type constraints when merging
 // equivalence classes
 

--- a/test/Generics/same_type_minimize_concrete.swift
+++ b/test/Generics/same_type_minimize_concrete.swift
@@ -1,0 +1,60 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
+
+struct G<T> { }
+
+protocol P {
+  associatedtype A
+  associatedtype B
+}
+
+// FIXME: We minimize the signatures correctly, but the warnings are
+// slightly bogus.
+
+// expected-warning@+2 {{redundant same-type constraint 'T.B' == 'Int'}}
+// expected-note@+1 {{same-type constraint 'T.B' == 'Int' written here}}
+func test1<T: P>(_: T) where T.A == G<Int>, T.A == G<T.B>, T.B == Int { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+// expected-warning@+2 {{redundant same-type constraint 'T.A' == 'G<Int>'}}
+// expected-note@+1 {{same-type constraint 'T.A' == 'G<Int>' written here}}
+func test2<T: P>(_: T) where T.A == G<Int>, T.B == Int, T.A == G<T.B> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+// expected-warning@+2 {{redundant same-type constraint 'T.B' == 'Int'}}
+// expected-note@+1 {{same-type constraint 'T.B' == 'Int' written here}}
+func test3<T: P>(_: T) where T.A == G<T.B>, T.A == G<Int>, T.B == Int { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+func test4<T: P>(_: T) where T.A == G<T.B>, T.B == Int, T.A == G<Int> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+// expected-warning@+2 {{redundant same-type constraint 'T.A' == 'G<Int>'}}
+// expected-note@+1 {{same-type constraint 'T.A' == 'G<Int>' written here}}
+func test5<T: P>(_: T) where T.B == Int, T.A == G<Int>, T.A == G<T.B> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+// expected-warning@+2 {{redundant same-type constraint 'T.A' == 'G<Int>'}}
+// expected-note@+1 {{same-type constraint 'T.A' == 'G<Int>' written here}}
+func test6<T: P>(_: T) where T.B == Int, T.A == G<T.B>, T.A == G<Int> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+func test7<T: P>(_: T) where T.B == Int, T.A == G<T.B> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+func test8<T: P>(_: T) where T.A == G<T.B>, T.B == Int { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+func test9<T: P>(_: T) where T.B == Int, T.A == G<Int> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+func test10<T: P>(_: T) where T.A == G<Int>, T.B == Int { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+func test11<T: P>(_: T) where T.A == G<T.B>, T.A == G<Int> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+func test12<T: P>(_: T) where T.A == G<Int>, T.A == G<T.B> { }
+// CHECK: Generic signature: <T where T : P, T.A == G<Int>, T.B == Int>
+
+// CHECK-NOT: Generic signature

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -76,14 +76,10 @@ protocol Gamma {
   associatedtype Delta: Alpha
 }
 
-// FIXME: Redundancy diagnostics are an indication that we're getting
-// the minimization wrong. The errors prove it :D
 struct Epsilon<T: Alpha, // expected-note{{conformance constraint 'U': 'Gamma' implied here}}
-// expected-warning@-1{{redundant conformance constraint 'T': 'Alpha'}}
                U: Gamma> // expected-warning{{redundant conformance constraint 'U': 'Gamma'}}
-// expected-note@-1{{conformance constraint 'T': 'Alpha' implied here}}
-  where T.Beta == U, // expected-error{{'Beta' is not a member type of type 'T'}}
-        U.Delta == T {} // expected-error{{'Delta' is not a member type of type 'U'}}
+  where T.Beta == U,
+        U.Delta == T {}
 
 // -----
 


### PR DESCRIPTION
Generic signature minimization needs to diagnose and remove any redundant requirements, that is, requirements that can be proven from some subset of the remaining requirements.

For each requirement on an equivalence class, we record a set of RequirementSources; a RequirementSource is a "proof" that the equivalence class satisfies the requirement.

A RequirementSource is either "explicit" -- meaning it corresponds to a generic requirement written by the user -- or it is "derived", meaning it can be proven from some other explicit requirement.

The most naive formulation of the minimization problem is that we say that an explicit requirement is redundant if there is a derived source for the same requirement. However, this is not sufficient, for example:

```
protocol P {
  associatedtype A : P where A.A == Self
}
```

In the signature <T where T : P>, the explicit requirement T : P also has a derived source T.A.A : P. However, this source is "self-derived", meaning that in order to obtain the witness table for T.A.A : P, we first have to obtain the witness table for T.A.

The GenericSignatureBuilder handled this kind of 'self-derived' requirement correctly, by removing it from the list of sources.  This was implemented in the removeSelfDerived() function.

After removeSelfDerived() was called, any remaining derived requirement sources were assumed to obsolete any explicit source for the same requirement.

However, even this was not sufficient -- namely, it only handled the case where a explicit requirement would imply a derived source for itself, and not a cycle involving multiple explicit sources that would imply each other.

For example, the following generic signature would be misdiagnosed with *both* conformance requirements as redundant, resulting in an invalid generic signature:

```
protocol P {
  associatedtype T : P
}

func f<T : P, U : P>(_: T, _: U) where T.X == U, U.X == T {}
```

In the above example, T : P has an explicit requirement source, as well as a derived source (U : P)(U.X : P). Similarly, U : P has an explicit requirement source, as well as a derived source (T : P)(T.X : P). Since neither of the derived sources were "self-derived" according to our definition, we would diagnose *both* explicit sources as redundant. But of course, after dropping them, we are left with the following generic signature:

```
func f<T, U>(_: T, _: U) where T.X == U, U.X == T {}
```

This is no longer valid -- since neither T nor U have a conformance requirement, the nested types T.X and U.X referenced from our same-type requirements are no longer valid.

The new algorithm abandons the "self-derived" concept. Instead, we build a directed graph where the vertices are explicit requirements, and the edges are implications where one explicit requirement implies another. In the above example, each of the explicit conformance requirements implies the other. This means a correct minimization must pick exactly one of the two -- not zero, and not both.

The set of minimized requirements is formally defined as the minimum set of requirements whose transitive closure is the entire graph.

We compute this set by first building the graph of strongly connected components using Tarjan's algorithm. The graph of SCCs is a directed acyclic graph, which means we can compute the root set of the DAG. Finally, we pick a suitable representative requirement from each SCC in the root set, using the lexshort order on subject types.

Fixes rdar://problem/rdar62903491.

# Next steps

This PR drops in the new algorithm and uses it in a couple of places without refactoring much else. The old removeSelfDerived() code is still part of some load-bearing hacks in computing conformance access paths and minimizing same-type requirements. There will be more code deleted in this area eventually.