### PR TITLE
Adjust to llvm change that requires suspend.async to specify the index of the async context

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -387,7 +387,7 @@ llvm::CallInst *IRGenFunction::emitSuspendAsyncCall(ArrayRef<llvm::Value *> args
 
   auto *calleeContext = Builder.CreateExtractValue(id,
       (unsigned)AsyncFunctionArgumentIndex::Context);
-  llvm::Constant *projectFn = cast<llvm::Constant>(args[1])->stripPointerCasts();
+  llvm::Constant *projectFn = cast<llvm::Constant>(args[2])->stripPointerCasts();
   // Get the caller context from the callee context.
   llvm::Value *context = Builder.CreateCall(projectFn, {calleeContext});
   context = Builder.CreateBitCast(context, IGM.SwiftContextPtrTy);
@@ -2548,6 +2548,7 @@ public:
     auto &Builder = IGF.Builder;
     // Setup the suspend point.
     SmallVector<llvm::Value *, 8> arguments;
+    arguments.push_back(IGM.getInt32(2)); // Index of swiftasync context.
     arguments.push_back(currentResumeFn);
     auto resumeProjFn = IGF.getOrCreateResumePrjFn();
     arguments.push_back(

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2519,6 +2519,7 @@ void IRGenFunction::emitSuspensionPoint(llvm::Value *toExecutor,
 
   // Setup the suspend point.
   SmallVector<llvm::Value *, 8> arguments;
+  arguments.push_back(IGM.getInt32(2)); // swiftasync context index
   arguments.push_back(asyncResume);
   auto resumeProjFn = getOrCreateResumeFromSuspensionFn();
   arguments.push_back(

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -687,6 +687,7 @@ void IRGenFunction::emitAwaitAsyncContinuation(
   {
     // Setup the suspend point.
     SmallVector<llvm::Value *, 8> arguments;
+    arguments.push_back(IGM.getInt32(2)); // swiftasync context index
     arguments.push_back(AsyncCoroutineCurrentResume);
     auto resumeProjFn = getOrCreateResumePrjFn();
     arguments.push_back(

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -88,7 +88,7 @@ bb0:
 // CHECK:   unreachable
 
 // CHECK: await.async.maybe.resume:
-// CHECK:   call { i8*, i8*, i8* } (i8*, i8*, ...) @llvm.coro.suspend.async{{.*}}({{.*}} @__swift_async_resume_project_context
+// CHECK:   call { i8*, i8*, i8* } (i32, i8*, i8*, ...) @llvm.coro.suspend.async{{.*}}({{.*}} @__swift_async_resume_project_context
 //  Abort if we are the first to arrive at the continuation point we must wait
 //  on the await to arrive.
 // CHECK:   [[first_at_sync_pt:%.*]] = cmpxchg {{(i64|i32)}}* [[synchronization_addr_before_await]], {{(i64|i32)}} 0, {{(i64|i32)}} 1 release acquire

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -26,8 +26,8 @@ final actor MyActor {
 // CHECK-arm64e: [[SIGNED_INT:%[0-9]+]]      = call i64 @llvm.ptrauth.sign.i64(i64 [[RESUME_INT]], i32 0, i64 [[PTRAUTH_BLEND]])
 // CHECK-arm64e: [[SIGNED_RESUME:%[0-9]+]]   = inttoptr i64 [[SIGNED_INT]] to i8*
 // CHECK: [[CAST_ACTOR:%[0-9]+]] = bitcast %T4test7MyActorC* [[ACTOR]] to %swift.executor*
-// CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
-// CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[SIGNED_RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
+// CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 2, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
+// CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 2, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[SIGNED_RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
 sil @test_simple : $@convention(method) @async (@guaranteed MyActor) -> () {
 bb0(%0 : $MyActor):
   hop_to_executor %0 : $MyActor


### PR DESCRIPTION

This is to adjust to:
https://reviews.llvm.org/D97333
https://github.com/apple/llvm-project/pull/2553