### PR TITLE
[AutoDiff] Rename 'move(along:)' to 'move(by:)'.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2869,16 +2869,16 @@ WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
       (/*propName*/ Identifier, /*propType*/ Type, /*nominalName*/ Identifier,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_immutable_wrapper_implicit_noderivative_fixit,none,
-      "synthesis of the 'Differentiable.move(along:)' requirement for %1 "
+      "synthesis of the 'Differentiable.move(by:)' requirement for %1 "
       "requires 'wrappedValue' in property wrapper %0 to be mutable or have a "
-      "non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute"
+      "non-mutating 'move(by:)'; add an explicit '@noDerivative' attribute"
       "%select{|, or conform %1 to 'AdditiveArithmetic'}2",
       (/*wrapperType*/ Identifier, /*nominalName*/ Identifier,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_let_property_implicit_noderivative_fixit,none,
-      "synthesis of the 'Differentiable.move(along:)' requirement for %0 "
+      "synthesis of the 'Differentiable.move(by:)' requirement for %0 "
       "requires all stored properties not marked with `@noDerivative` to be "
-      "mutable or have a non-mutating 'move(along:)'; use 'var' instead, or "
+      "mutable or have a non-mutating 'move(by:)'; use 'var' instead, or "
       "add an explicit '@noDerivative' attribute "
       "%select{|, or conform %0 to 'AdditiveArithmetic'}1",
       (/*nominalName*/ Identifier, /*nominalCanDeriveAdditiveArithmetic*/ bool))

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -228,9 +228,9 @@ IDENTIFIER(AtomicStoreOrdering)
 IDENTIFIER(AtomicUpdateOrdering)
 
 // Differentiable programming
-IDENTIFIER(along)
+IDENTIFIER(by)
 IDENTIFIER(differential)
-IDENTIFIER(direction)
+IDENTIFIER(offset)
 IDENTIFIER(move)
 IDENTIFIER(pullback)
 IDENTIFIER(TangentVector)

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -329,10 +329,10 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
       return getRequirement(KnownProtocolKind::AdditiveArithmetic);
     }
 
-    // Differentiable.move(along:)
+    // Differentiable.move(by:)
     if (name.isCompoundName() && name.getBaseName() == ctx.Id_move) {
       auto argumentNames = name.getArgumentNames();
-      if (argumentNames.size() == 1 && argumentNames[0] == ctx.Id_along)
+      if (argumentNames.size() == 1 && argumentNames[0] == ctx.Id_by)
         return getRequirement(KnownProtocolKind::Differentiable);
     }
 

--- a/stdlib/public/Differentiation/AnyDifferentiable.swift
+++ b/stdlib/public/Differentiation/AnyDifferentiable.swift
@@ -23,7 +23,7 @@ import Swift
 
 internal protocol _AnyDifferentiableBox {
   // `Differentiable` requirements.
-  mutating func _move(along direction: AnyDerivative)
+  mutating func _move(by offset: AnyDerivative)
 
   /// The underlying base value, type-erased to `Any`.
   var _typeErasedBase: Any { get }
@@ -50,14 +50,11 @@ internal struct _ConcreteDifferentiableBox<T: Differentiable>: _AnyDifferentiabl
     return (self as? _ConcreteDifferentiableBox<U>)?._base
   }
 
-  mutating func _move(along direction: AnyDerivative) {
-    guard
-      let directionBase =
-        direction.base as? T.TangentVector
-    else {
-      _derivativeTypeMismatch(T.self, type(of: direction.base))
+  mutating func _move(by offset: AnyDerivative) {
+    guard let offsetBase = offset.base as? T.TangentVector else {
+      _derivativeTypeMismatch(T.self, type(of: offset.base))
     }
-    _base.move(along: directionBase)
+    _base.move(by: offsetBase)
   }
 }
 
@@ -100,8 +97,8 @@ public struct AnyDifferentiable: Differentiable {
 
   public typealias TangentVector = AnyDerivative
 
-  public mutating func move(along direction: TangentVector) {
-    _box._move(along: direction)
+  public mutating func move(by offset: TangentVector) {
+    _box._move(by: offset)
   }
 }
 
@@ -121,7 +118,7 @@ internal protocol _AnyDerivativeBox {
   func _subtracting(_ x: _AnyDerivativeBox) -> _AnyDerivativeBox
 
   // `Differentiable` requirements.
-  mutating func _move(along direction: _AnyDerivativeBox)
+  mutating func _move(by offset: _AnyDerivativeBox)
 
   /// The underlying base value, type-erased to `Any`.
   var _typeErasedBase: Any { get }
@@ -215,19 +212,16 @@ where T: Differentiable, T.TangentVector == T {
 
   // `Differentiable` requirements.
   @inlinable
-  mutating func _move(along direction: _AnyDerivativeBox) {
-    if direction._isOpaqueZero() {
+  mutating func _move(by offset: _AnyDerivativeBox) {
+    if offset._isOpaqueZero() {
       return
     }
     // The case where `self._isOpaqueZero()` returns true is handled in
-    // `AnyDerivative.move(along:)`.
-    guard
-      let directionBase =
-        direction._unboxed(to: T.TangentVector.self)
-    else {
-      _derivativeTypeMismatch(T.self, type(of: direction._typeErasedBase))
+    // `AnyDerivative.move(by:)`.
+    guard let offsetBase = offset._unboxed(to: T.TangentVector.self) else {
+      _derivativeTypeMismatch(T.self, type(of: offset._typeErasedBase))
     }
-    _base.move(along: directionBase)
+    _base.move(by: offsetBase)
   }
 }
 
@@ -362,12 +356,12 @@ public struct AnyDerivative: Differentiable & AdditiveArithmetic {
 
   // `Differentiable` requirements.
   @inlinable
-  public mutating func move(along direction: TangentVector) {
+  public mutating func move(by offset: TangentVector) {
     if _box._isOpaqueZero() {
-      _box = direction._box
+      _box = offset._box
       return
     }
-    _box._move(along: direction._box)
+    _box._move(by: offset._box)
   }
 }
 

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -72,14 +72,14 @@ where Element: Differentiable {
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
 
-  public mutating func move(along direction: TangentVector) {
+  public mutating func move(by offset: TangentVector) {
     precondition(
-      base.count == direction.base.count, """
-        Count mismatch: \(base.count) ('self') and \(direction.base.count) \
+      base.count == offset.base.count, """
+        Count mismatch: \(base.count) ('self') and \(offset.base.count) \
         ('direction')
         """)
     for i in base.indices {
-      base[i].move(along: direction.base[i])
+      base[i].move(by: offset.base[i])
     }
   }
 }
@@ -172,9 +172,9 @@ extension Array: Differentiable where Element: Differentiable {
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
 
-  public mutating func move(along direction: TangentVector) {
+  public mutating func move(by offset: TangentVector) {
     var view = DifferentiableView(self)
-    view.move(along: direction)
+    view.move(by: offset)
     self = view.base
   }
 }

--- a/stdlib/public/Differentiation/Differentiable.swift
+++ b/stdlib/public/Differentiation/Differentiable.swift
@@ -32,15 +32,15 @@ public protocol Differentiable {
   associatedtype TangentVector: Differentiable & AdditiveArithmetic
     where TangentVector.TangentVector == TangentVector
 
-  /// Moves `self` along the given direction. In Riemannian geometry, this is
+  /// Moves `self` by the given offset. In Riemannian geometry, this is
   /// equivalent to exponential map, which moves `self` on the geodesic surface
-  /// along the given tangent vector.
-  mutating func move(along direction: TangentVector)
+  /// by the given tangent vector.
+  mutating func move(by offset: TangentVector)
 }
 
 public extension Differentiable where TangentVector == Self {
   @_alwaysEmitIntoClient
-  mutating func move(along direction: TangentVector) {
-    self += direction
+  mutating func move(by offset: TangentVector) {
+    self += offset
   }
 }

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -42,8 +42,8 @@ extension ${Self}: Differentiable {
   public typealias TangentVector = ${Self}
 
   ${Availability(bits)}
-  public mutating func move(along direction: TangentVector) {
-    self += direction
+  public mutating func move(by offset: TangentVector) {
+    self += offset
   }
 }
 

--- a/stdlib/public/Differentiation/OptionalDifferentiation.swift
+++ b/stdlib/public/Differentiation/OptionalDifferentiation.swift
@@ -44,16 +44,16 @@ extension Optional: Differentiable where Wrapped: Differentiable {
       }
     }
 
-    public mutating func move(along direction: TangentVector) {
-      if let value = direction.value {
-        self.value?.move(along: value)
+    public mutating func move(by offset: TangentVector) {
+      if let value = offset.value {
+        self.value?.move(by: value)
       }
     }
   }
 
-  public mutating func move(along direction: TangentVector) {
-    if let value = direction.value {
-      self?.move(along: value)
+  public mutating func move(by offset: TangentVector) {
+    if let value = offset.value {
+      self?.move(by: value)
     }
   }
 }

--- a/test/AutoDiff/SILGen/sil_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness.swift
@@ -82,7 +82,7 @@ func generic_vjp<T: Differentiable>(_ x: T, _ y: Float) -> (
 
 public struct Foo: Differentiable {
   public typealias TangentVector = DummyTangentVector
-  public mutating func move(along _: TangentVector) {}
+  public mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse)
   public var x: Float

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -20,7 +20,7 @@ struct DummyTangentVector: Differentiable & AdditiveArithmetic {
 
 class Super: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 
   var base: Float
   // FIXME(TF-648): Dummy to make `Super.TangentVector` be nontrivial.

--- a/test/AutoDiff/SILGen/witness_table.swift
+++ b/test/AutoDiff/SILGen/witness_table.swift
@@ -26,7 +26,7 @@ struct DummyTangentVector: Differentiable & AdditiveArithmetic {
 
 struct Struct: Protocol {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse, wrt: (self, x, y))
   @differentiable(reverse, wrt: x)

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -464,7 +464,7 @@ struct StructTangentVectorNotStruct: Differentiable {
     static func +(_: Self, _: Self) -> Self { fatalError() }
     static func -(_: Self, _: Self) -> Self { fatalError() }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -488,7 +488,7 @@ struct StructOriginalPropertyNotDifferentiable: Differentiable {
   struct TangentVector: Differentiable & AdditiveArithmetic {
     var nondiff: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -509,7 +509,7 @@ struct StructTangentVectorPropertyNotFound: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var y: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -532,7 +532,7 @@ struct StructTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -555,7 +555,7 @@ final class ClassTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -578,7 +578,7 @@ struct StructTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -601,7 +601,7 @@ final class ClassTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}

--- a/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
@@ -144,7 +144,7 @@ struct StructTangentVectorNotStruct: Differentiable {
     static func +(_: Self, _: Self) -> Self { fatalError() }
     static func -(_: Self, _: Self) -> Self { fatalError() }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -168,7 +168,7 @@ struct StructOriginalPropertyNotDifferentiable: Differentiable {
   struct TangentVector: Differentiable & AdditiveArithmetic {
     var nondiff: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -189,7 +189,7 @@ struct StructTangentVectorPropertyNotFound: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var y: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -212,7 +212,7 @@ struct StructTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -235,7 +235,7 @@ final class ClassTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // SR-13464: Missing support for classes in forward-mode AD
@@ -261,7 +261,7 @@ struct StructTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -284,7 +284,7 @@ final class ClassTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // SR-13464: Missing support for classes in forward-mode AD

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/b.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/b.swift
@@ -3,7 +3,7 @@ import a
 
 extension Struct: Differentiable {
   public struct TangentVector: Differentiable & AdditiveArithmetic {}
-  public mutating func move(along _: TangentVector) {}
+  public mutating func move(by _: TangentVector) {}
 
   @usableFromInline
   @derivative(of: method, wrt: x)

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -31,14 +31,14 @@ func testEmpty() {
 
 protocol DifferentiableWithNonmutatingMoveAlong: Differentiable {}
 extension DifferentiableWithNonmutatingMoveAlong {
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 }
 
 class EmptyWithInheritedNonmutatingMoveAlong: DifferentiableWithNonmutatingMoveAlong {
   typealias TangentVector = Empty.TangentVector
   static func proof_that_i_have_nonmutating_move_along() {
     let empty = EmptyWithInheritedNonmutatingMoveAlong()
-    empty.move(along: .init())
+    empty.move(by: .init())
   }
 }
 
@@ -57,17 +57,17 @@ class ImmutableStoredProperties<T: Differentiable & AnyObject>: Differentiable {
   // expected-warning @+1 {{stored property 'nondiff' has no derivative because 'Int' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let nondiff: Int
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let diff: Float
 
-  let letClass: Empty // No error on class-bound differentiable `let` with a non-mutating 'move(along:)'.
+  let letClass: Empty // No error on class-bound differentiable `let` with a non-mutating 'move(by:)'.
 
   let letClassWithInheritedNonmutatingMoveAlong: EmptyWithInheritedNonmutatingMoveAlong
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
-  let letClassGeneric: T // Error due to lack of non-mutating 'move(along:)'.
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  let letClassGeneric: T // Error due to lack of non-mutating 'move(by:)'.
 
-  let letClassWrappingGeneric: EmptyWrapper<T> // No error on class-bound differentiable `let` with a non-mutating 'move(along:)'.
+  let letClassWrappingGeneric: EmptyWrapper<T> // No error on class-bound differentiable `let` with a non-mutating 'move(by:)'.
 
   init(letClassGeneric: T) {
     okay = 0
@@ -91,7 +91,7 @@ class MutableStoredPropertiesWithInitialValue: Differentiable {
 }
 // Test class with both an empty constructor and memberwise initializer.
 class AllMixedStoredPropertiesHaveInitialValue: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let x = Float(1)
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
@@ -120,7 +120,7 @@ class Simple: Differentiable {
 func testSimple() {
   let simple = Simple(w: 1, b: 1)
   let tangent = Simple.TangentVector(w: 1, b: 1)
-  simple.move(along: tangent)
+  simple.move(by: tangent)
 }
 
 // Test type with mixed members.
@@ -136,7 +136,7 @@ class Mixed: Differentiable {
 func testMixed(_ simple: Simple, _ simpleTangent: Simple.TangentVector) {
   let mixed = Mixed(simple: simple, float: 1)
   let tangent = Mixed.TangentVector(simple: simpleTangent, float: 1)
-  mixed.move(along: tangent)
+  mixed.move(by: tangent)
 }
 
 // Test type with manual definition of vector space types to `Self`.
@@ -181,7 +181,7 @@ where T: Differentiable, T == T.TangentVector {
 func testGenericVectorSpacesEqualSelf() {
   let genericSame = GenericVectorSpacesEqualSelf<Double>(w: 1, b: 1)
   let tangent = GenericVectorSpacesEqualSelf.TangentVector(w: 1, b: 1)
-  genericSame.move(along: tangent)
+  genericSame.move(by: tangent)
 }
 
 // Test nested type.
@@ -266,11 +266,11 @@ class HasCustomMethod: Differentiable {
     self.generic = generic
   }
 
-  func move(along direction: TangentVector) {
+  func move(by offset: TangentVector) {
     print("Hello world")
-    simple.move(along: direction.simple)
-    mixed.move(along: direction.mixed)
-    generic.move(along: direction.generic)
+    simple.move(by: offset.simple)
+    mixed.move(by: offset.mixed)
+    generic.move(by: offset.generic)
   }
 }
 
@@ -556,7 +556,7 @@ class SR_12793: Differentiable {
 
   // Test usage of synthesized `TangentVector` type.
   // This should not produce an error: "reference to invalid associated type 'TangentVector'".
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // Test property wrappers.
@@ -585,7 +585,7 @@ struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 class WrappedProperties: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(by:)'; add an explicit '@noDerivative' attribute}}
   @ImmutableWrapper var immutableInt: Generic<Int> = Generic()
 
   // expected-warning @+1 {{stored property 'mutableInt' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
@@ -606,7 +606,7 @@ class WrappedProperties: Differentiable {
 // Test derived conformances in disallowed contexts.
 
 extension OtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
 
 extension GenericOtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -13,23 +13,23 @@ func testEmpty() {
 
 struct EmptyWithConcreteNonmutatingMoveAlong: Differentiable {
   typealias TangentVector = Empty.TangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
   static func proof_that_i_have_nonmutating_move_along() {
     let empty = Self()
-    empty.move(along: .init())
+    empty.move(by: .init())
   }
 }
 
 protocol DifferentiableWithNonmutatingMoveAlong: Differentiable {}
 extension DifferentiableWithNonmutatingMoveAlong {
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 }
 
 struct EmptyWithInheritedNonmutatingMoveAlong: DifferentiableWithNonmutatingMoveAlong {
   typealias TangentVector = Empty.TangentVector
   static func proof_that_i_have_nonmutating_move_along() {
     let empty = Self()
-    empty.move(along: .init())
+    empty.move(by: .init())
   }
 }
 
@@ -51,14 +51,14 @@ struct ImmutableStoredProperties: Differentiable {
   // expected-warning @+1 {{stored property 'nondiff' has no derivative because 'Int' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let nondiff: Int
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let diff: Float
 
   let nonmutatingMoveAlongStruct: EmptyWithConcreteNonmutatingMoveAlong
 
   let inheritedNonmutatingMoveAlongStruct: EmptyWithInheritedNonmutatingMoveAlong
   
-  let diffClass: EmptyClass // No error on class-bound `let` with a non-mutating `move(along:)`.
+  let diffClass: EmptyClass // No error on class-bound `let` with a non-mutating `move(by:)`.
 }
 func testImmutableStoredProperties() {
   _ = ImmutableStoredProperties.TangentVector(
@@ -73,7 +73,7 @@ struct MutableStoredPropertiesWithInitialValue: Differentiable {
 }
 // Test struct with both an empty constructor and memberwise initializer.
 struct AllMixedStoredPropertiesHaveInitialValue: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let x = Float(1)
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
@@ -94,7 +94,7 @@ struct Simple: AdditiveArithmetic, Differentiable {
 }
 func testSimple() {
   var simple = Simple(w: 1, b: 1)
-  simple.move(along: simple)
+  simple.move(by: simple)
 }
 
 // Test type with mixed members.
@@ -104,7 +104,7 @@ struct Mixed: AdditiveArithmetic, Differentiable {
 }
 func testMixed(_ simple: Simple) {
   var mixed = Mixed(simple: simple, float: 1)
-  mixed.move(along: mixed)
+  mixed.move(by: mixed)
 }
 
 // Test type with manual definition of vector space types to `Self`.
@@ -122,7 +122,7 @@ where T: Differentiable, T == T.TangentVector {
 }
 func testGenericVectorSpacesEqualSelf() {
   var genericSame = GenericVectorSpacesEqualSelf<Double>(w: 1, b: 1)
-  genericSame.move(along: genericSame)
+  genericSame.move(by: genericSame)
 }
 
 // Test nested type.
@@ -136,7 +136,7 @@ func testNested(
   _ genericSame: GenericVectorSpacesEqualSelf<Double>
 ) {
   var nested = Nested(simple: simple, mixed: mixed, generic: genericSame)
-  nested.move(along: nested)
+  nested.move(by: nested)
 }
 
 // Test type that does not conform to `AdditiveArithmetic` but whose members do.
@@ -174,11 +174,11 @@ struct HasCustomMethod: Differentiable {
   var simple: Simple
   var mixed: Mixed
   var generic: GenericVectorSpacesEqualSelf<Double>
-  mutating func move(along direction: TangentVector) {
+  mutating func move(by offset: TangentVector) {
     print("Hello world")
-    simple.move(along: direction.simple)
-    mixed.move(along: direction.mixed)
-    generic.move(along: direction.generic)
+    simple.move(by: offset.simple)
+    mixed.move(by: offset.mixed)
+    generic.move(by: offset.generic)
   }
 }
 
@@ -374,7 +374,7 @@ struct SR_12793: Differentiable {
 
   // Test usage of synthesized `TangentVector` type.
   // This should not produce an error: "reference to invalid associated type 'TangentVector'".
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // Test property wrappers.
@@ -400,7 +400,7 @@ struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 struct WrappedProperties: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(by:)'; add an explicit '@noDerivative' attribute}}
   @ImmutableWrapper var immutableInt: Generic<Int>
 
   // expected-warning @+1 {{stored property 'mutableInt' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
@@ -421,7 +421,7 @@ struct WrappedProperties: Differentiable {
 // Verify that cross-file derived conformances are disallowed.
 
 extension OtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
 
 extension GenericOtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -401,8 +401,8 @@ where T: Differentiable & AdditiveArithmetic {
     fatalError()
   }
   typealias TangentVector = Struct<T.TangentVector>
-  mutating func move(along direction: TangentVector) {
-    x.move(along: direction.x)
+  mutating func move(by offset: TangentVector) {
+    x.move(by: offset.x)
   }
 }
 
@@ -740,7 +740,7 @@ func vjpMultipleSemanticResults(x: inout Float) -> (
 
 struct InoutParameters: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 }
 
 extension InoutParameters {

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -53,7 +53,7 @@ func dupe_attributes(arg1: Float, arg2: Float) -> Float { return arg1 }
 
 struct ComputedPropertyDupeAttributes<T: Differentiable>: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var value: T
 
@@ -85,7 +85,7 @@ protocol WrtOnlySelfProtocol: Differentiable {
 
 class Class: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 }
 @differentiable(reverse, wrt: x)
 func invalidDiffWrtClass(_ x: Class) -> Class {
@@ -144,7 +144,7 @@ struct InstanceMethod {
 // Test instance methods for a `Differentiable` type.
 struct DifferentiableInstanceMethod: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse) // ok
   func noParams() -> Float {
@@ -155,7 +155,7 @@ struct DifferentiableInstanceMethod: Differentiable {
 // Test subscript methods.
 struct SubscriptMethod: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse) // ok
   subscript(implicitGetter x: Float) -> Float {
@@ -245,7 +245,7 @@ protocol ProtocolRequirementsRefined: ProtocolRequirements {
 
 struct InternalDiffAttrConformance: ProtocolRequirements {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var x: Float
   var y: Float
@@ -283,7 +283,7 @@ struct InternalDiffAttrConformance: ProtocolRequirements {
 // expected-error @+1 {{does not conform to protocol 'ProtocolRequirements'}}
 public struct PublicDiffAttrConformance: ProtocolRequirements {
   public typealias TangentVector = DummyTangentVector
-  public mutating func move(along _: TangentVector) {}
+  public mutating func move(by _: TangentVector) {}
 
   var x: Float
   var y: Float
@@ -366,7 +366,7 @@ protocol TF285: Differentiable {
 
 struct TF285MissingOneDiffAttr: TF285 {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   // Requirement is missing the required `@differentiable(reverse, wrt: (x, y))` attribute.
   // Since `TF285MissingOneDiffAttr.foo` is internal, the attribute is implicitly created.
@@ -414,7 +414,7 @@ func infer2(_ fn: @differentiable(reverse) (Float) -> Float, x: Float) -> Float 
 
 struct DiffableStruct: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var a: Float
 
@@ -437,7 +437,7 @@ struct NonDiffableStruct {
 
 struct NumberWrtStruct: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var a, b: Float
 
@@ -579,7 +579,7 @@ extension ProtocolRequirementUnsupported {
 
 class Super: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 
   var base: Float
 
@@ -644,7 +644,7 @@ class Sub: Super {
 
 final class FinalClass: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 
   var base: Float
 
@@ -669,7 +669,7 @@ func swap(x: inout Float, y: inout Float) {}
 
 struct InoutParameters: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 }
 
 extension InoutParameters {
@@ -694,7 +694,7 @@ extension InoutParameters {
 
 struct Accessors: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var stored: Float
   var computed: Float {

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -183,7 +183,7 @@ extension Vector: Differentiable where T: Differentiable {
     static func - (lhs: Self, rhs: Self) -> Self { fatalError() }
     typealias TangentVector = Self
   }
-  mutating func move(along direction: TangentVector) { fatalError() }
+  mutating func move(by offset: TangentVector) { fatalError() }
 }
 
 // expected-note@+1 2 {{found this candidate}}

--- a/test/AutoDiff/Sema/transpose_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/transpose_attr_type_checking.swift
@@ -402,7 +402,7 @@ struct level1 {
     static func + (_: Self, _: Self) -> Self { Self() }
     static func - (_: Self, _: Self) -> Self { Self() }
     typealias TangentVector = Self
-    mutating func move(along: TangentVector) {}
+    mutating func move(by: TangentVector) {}
     func foo(x: Float) -> Float {
       return x
     }
@@ -483,7 +483,7 @@ where T: Differentiable & AdditiveArithmetic {
   static func + (_: Self, _: Self) -> Self { Self() }
   static func - (_: Self, _: Self) -> Self { Self() }
   typealias TangentVector = Self
-  mutating func move(along: TangentVector) {}
+  mutating func move(by: TangentVector) {}
 }
 
 // Test computed properties.

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -58,7 +58,7 @@ struct InstanceMethod : Differentiable {
     static func +(_: Self, _: Self) -> Self { fatalError() }
     static func -(_: Self, _: Self) -> Self { fatalError() }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // CHECK: @differentiable(reverse, wrt: x where T : Differentiable)

--- a/test/AutoDiff/stdlib/anydifferentiable.swift
+++ b/test/AutoDiff/stdlib/anydifferentiable.swift
@@ -15,9 +15,9 @@ struct Generic<T: Differentiable & Equatable>: Differentiable, Equatable {
 
 extension AnyDerivative {
   // This exists only to faciliate testing.
-  func moved(along direction: TangentVector) -> Self {
+  func moved(along offset: TangentVector) -> Self {
     var result = self
-    result.move(along: direction)
+    result.move(by: offset)
     return result
   }
 }
@@ -26,14 +26,14 @@ TypeErasureTests.test("AnyDifferentiable operations") {
   do {
     var any = AnyDifferentiable(Vector(x: 1, y: 1))
     let tan = AnyDerivative(Vector.TangentVector(x: 1, y: 1))
-    any.move(along: tan)
+    any.move(by: tan)
     expectEqual(Vector(x: 2, y: 2), any.base as? Vector)
   }
 
   do {
     var any = AnyDifferentiable(Generic<Float>(x: 1))
     let tan = AnyDerivative(Generic<Float>.TangentVector(x: 1))
-    any.move(along: tan)
+    any.move(by: tan)
     expectEqual(Generic<Float>(x: 2), any.base as? Generic<Float>)
   }
 }

--- a/test/AutoDiff/stdlib/differentiable_protocol.swift
+++ b/test/AutoDiff/stdlib/differentiable_protocol.swift
@@ -39,7 +39,7 @@ extension Wrapper: AdditiveArithmetic where T: AdditiveArithmetic {
 }
 extension Wrapper: Differentiable where T: Differentiable {
   typealias TangentVector = Wrapper<T.TangentVector>
-  mutating func move(along direction: TangentVector) {
-    value.move(along: direction.value)
+  mutating func move(by offset: TangentVector) {
+    value.move(by: offset.value)
   }
 }

--- a/test/AutoDiff/stdlib/optional.swift
+++ b/test/AutoDiff/stdlib/optional.swift
@@ -7,35 +7,35 @@ import StdlibUnittest
 var OptionalDifferentiationTests = TestSuite("OptionalDifferentiation")
 
 OptionalDifferentiationTests.test("Optional operations") {
-  // Differentiable.move(along:)
+  // Differentiable.move(by:)
   do {
     var some: Float? = 2
-    some.move(along: .init(3))
+    some.move(by: .init(3))
     expectEqual(5, some)
 
     var none: Float? = nil
-    none.move(along: .init(3))
+    none.move(by: .init(3))
     expectEqual(nil, none)
   }
 }
 
 OptionalDifferentiationTests.test("Optional.TangentVector operations") {
-  // Differentiable.move(along:)
+  // Differentiable.move(by:)
   do {
     var some: Optional<Float>.TangentVector = .init(2)
-    some.move(along: .init(3))
+    some.move(by: .init(3))
     expectEqual(5, some.value)
 
     var none: Optional<Float>.TangentVector = .init(nil)
-    none.move(along: .init(3))
+    none.move(by: .init(3))
     expectEqual(nil, none.value)
 
     var nestedSome: Optional<Optional<Float>>.TangentVector = .init(.init(2))
-    nestedSome.move(along: .init(.init(3)))
+    nestedSome.move(by: .init(.init(3)))
     expectEqual(.init(5), nestedSome.value)
 
     var nestedNone: Optional<Optional<Float>>.TangentVector = .init(.init(nil))
-    nestedNone.move(along: .init(.init(3)))
+    nestedNone.move(by: .init(.init(3)))
     expectEqual(.init(nil), nestedNone.value)
   }
 

--- a/test/AutoDiff/validation-test/class_differentiation.swift
+++ b/test/AutoDiff/validation-test/class_differentiation.swift
@@ -535,7 +535,7 @@ ClassTests.test("LetProperties") {
   let bar = Bar()
   let grad = gradient(at: bar) { bar in (bar.x.x * bar.x.x).value }
   expectEqual(Bar.TangentVector(x: .init(x: 6.0)), grad)
-  bar.move(along: grad)
+  bar.move(by: grad)
   expectEqual(8.0, bar.x.x)
 }
 

--- a/test/AutoDiff/validation-test/differentiable_property.swift
+++ b/test/AutoDiff/validation-test/differentiable_property.swift
@@ -43,9 +43,9 @@ struct Space {
 
 extension Space : Differentiable {
   typealias TangentVector = TangentSpace
-  mutating func move(along direction: TangentSpace) {
-    x.move(along: direction.x)
-    y.move(along: direction.y)
+  mutating func move(by offset: TangentSpace) {
+    x.move(by: offset.x)
+    y.move(by: offset.y)
   }
 }
 
@@ -113,9 +113,9 @@ struct ProductSpaceOtherTangent {
 
 extension ProductSpaceOtherTangent : Differentiable {
   typealias TangentVector = ProductSpaceOtherTangentTangentSpace
-  mutating func move(along direction: ProductSpaceOtherTangentTangentSpace) {
-    x.move(along: direction.x)
-    y.move(along: direction.y)
+  mutating func move(by offset: ProductSpaceOtherTangentTangentSpace) {
+    x.move(by: offset.x)
+    y.move(by: offset.y)
   }
 }
 

--- a/test/AutoDiff/validation-test/separate_tangent_type.swift
+++ b/test/AutoDiff/validation-test/separate_tangent_type.swift
@@ -28,9 +28,9 @@ struct DifferentiableSubset : Differentiable {
     var w: Tracked<Float>
     var b: Tracked<Float>
   }
-  mutating func move(along v: TangentVector) {
-    w.move(along: v.w)
-    b.move(along: v.b)
+  mutating func move(by v: TangentVector) {
+    w.move(by: v.w)
+    b.move(by: v.b)
   }
 }
 


### PR DESCRIPTION
Rename `move(along:)` to `move(by:)` based on the proposal feedback. The main argument for the change is that tangent vectors specify both a direction and a magnitude, whereas `along:` does not indicate that `self` is being moved by the specified magnitude.