### PR TITLE
Remove a Bogus Assertion

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -818,7 +818,6 @@ Type TypeBase::replaceCovariantResultType(Type newResultType,
 
     auto loadedTy = getWithoutSpecifierType();
     if (auto objectType = loadedTy->getOptionalObjectType()) {
-      assert(!newResultType->getOptionalObjectType());
       newResultType = OptionalType::get(
           objectType->replaceCovariantResultType(newResultType, uncurryLevel));
     }

--- a/validation-test/compiler_crashers_2_fixed/rdar74557857.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar74557857.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend -typecheck %s
+
+extension Optional {
+  init?() {
+    self.init(nilLiteral: Void())
+  }
+}


### PR DESCRIPTION
The self type in this routine is absolutely allowed to resolve to an
Optional.

rdar://74557857