### PR TITLE
Use Member Operators in StdlibUnitTest

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
+++ b/stdlib/private/StdlibUnittest/StdlibCoreExtras.swift
@@ -128,14 +128,14 @@ public struct TypeIdentifier : Hashable, Comparable {
   internal var objectID : ObjectIdentifier {
     return ObjectIdentifier(value)
   }
-}
 
-public func < (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
-  return lhs.objectID < rhs.objectID
-}
+  public static func < (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
+    return lhs.objectID < rhs.objectID
+  }
 
-public func == (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
-  return lhs.objectID == rhs.objectID
+  public static func == (lhs: TypeIdentifier, rhs: TypeIdentifier) -> Bool {
+    return lhs.objectID == rhs.objectID
+  }
 }
 
 extension TypeIdentifier

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -3034,15 +3034,15 @@ struct Pair<T : Comparable> : Comparable {
 
   var first: T
   var second: T
-}
 
-func == <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
-  return lhs.first == rhs.first && lhs.second == rhs.second
-}
+  static func == <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
+    return lhs.first == rhs.first && lhs.second == rhs.second
+  }
 
-func < <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
-  return [lhs.first, lhs.second].lexicographicallyPrecedes(
-    [rhs.first, rhs.second])
+  static func < <T>(lhs: Pair<T>, rhs: Pair<T>) -> Bool {
+    return [lhs.first, lhs.second].lexicographicallyPrecedes(
+      [rhs.first, rhs.second])
+  }
 }
 
 public func expectEqualsUnordered<


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ 

This function used to consider operators defined at top-level scope to be "member operators" as long as the shadow of their generic signature lined up. This allowed Swift 2-style conformances to protocols with operators. A side effect of this change was that the Equatable instance for every RawRepresentable type picked up the free

```
public func == <T: RawRepresentable>(lhs: T, rhs: T) -> Bool
  where T.RawValue: Equatable {
  return lhs.rawValue == rhs.rawValue
}
```

definition in the standard library. This would normally be fine (and probably even a code size win, by sheer coincidence) but performing a string comparison is going to be less performant than a switch on the enum's tag.

Teach swift::isMemberOperator to ignore... non-member operators.