### PR TITLE
[Concurrency] Ensure we get the right context for captured variables. 

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -77,10 +77,6 @@ public:
     /// Access to the declaration is unsafe in a concurrent context.
     Unsafe,
 
-    /// The declaration is a local entity whose capture could introduce
-    /// data races. The context in which the local was defined is provided.
-    LocalCapture,
-
     /// References to this entity are allowed from anywhere, but doing so
     /// may cross an actor boundary if it is not on \c self.
     CrossActorSelf,
@@ -117,12 +113,6 @@ private:
 public:
   Kind getKind() const { return kind; }
 
-  /// Retrieve the declaration context in which a local was defined.
-  DeclContext *getLocalContext() const {
-    assert(kind == LocalCapture);
-    return data.localContext;
-  }
-
   /// Retrieve the actor class that the declaration is within.
   ClassDecl *getActorClass() const {
     assert(kind == ActorSelf || kind == CrossActorSelf);
@@ -151,13 +141,6 @@ public:
       ClassDecl *actorClass, bool isCrossActor) {
     ActorIsolationRestriction result(isCrossActor? CrossActorSelf : ActorSelf);
     result.data.actorClass = actorClass;
-    return result;
-  }
-
-  /// Access is restricted to code running within the given local context.
-  static ActorIsolationRestriction forLocalCapture(DeclContext *dc) {
-    ActorIsolationRestriction result(LocalCapture);
-    result.data.localContext = dc;
     return result;
   }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -413,7 +413,6 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
     // FIXME: Consider whether to limit @objc on global-actor-qualified
     // declarations.
   case ActorIsolationRestriction::Unrestricted:
-  case ActorIsolationRestriction::LocalCapture:
   case ActorIsolationRestriction::Unsafe:
     return false;
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2755,7 +2755,6 @@ bool ConformanceChecker::checkActorIsolation(
   }
 
   case ActorIsolationRestriction::Unsafe:
-  case ActorIsolationRestriction::LocalCapture:
     break;
 
   case ActorIsolationRestriction::Unrestricted:

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -139,12 +139,28 @@ extension MyActor {
     }
 
     // Concurrent closures might run... concurrently.
-    acceptConcurrentClosure {
+    var otherLocalVar = 12
+    acceptConcurrentClosure { [otherLocalVar] in
+      defer {
+        _ = otherLocalVar
+      }
+
       _ = self.text[0] // expected-error{{actor-isolated property 'text' cannot be referenced from a concurrent closure}}
       _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be referenced from a concurrent closure}}
       _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
       localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
       _ = localConstant
+
+      _ = otherLocalVar
+    }
+    otherLocalVar = 17
+
+    acceptConcurrentClosure { [weak self, otherLocalVar] in
+      defer {
+        _ = self?.actorIndependentVar
+      }
+
+      _ = otherLocalVar
     }
 
     // Escaping closures might run concurrently.


### PR DESCRIPTION
The declaration context of an explicitly-captured value is the context
of the original, captured declaration itself... not the closure in which
the value is captured. Account for this in data race checking, by tracking
the effective capture context for such variables. This eliminates some
erroneous complains about accesses to explicitly-captured variables in
concurrent code.

Part of rdar://74281361.