### PR TITLE
Revert "[5.4][CodeCompletion][Sema] Don't filter out any viable solutions when solving for code completion"

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2784,7 +2784,7 @@ private:
   void
   filterSolutions(SmallVectorImpl<Solution> &solutions,
                   bool minimize = false) {
-    if (solutions.size() < 2 || isForCodeCompletion())
+    if (solutions.size() < 2)
       return;
 
     if (auto best = findBestSolution(solutions, minimize)) {

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -46,8 +46,6 @@
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_ERROR | %FileCheck %s --check-prefix=POINT_MEMBER
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=MULTICLOSURE_FUNCBUILDER_FIXME | %FileCheck %s --check-prefix=NORESULTS
 // RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=REGULAR_MULTICLOSURE_APPLIED | %FileCheck %s --check-prefix=POINT_MEMBER
-// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=BEST_SOLUTION_FILTER | %FileCheck %s --check-prefix=BEST_SOLUTION_FILTER
-// RUN: %swift-ide-test -code-completion  -source-filename %s -code-completion-token=BEST_SOLUTION_FILTER2 | %FileCheck %s --check-prefix=BEST_SOLUTION_FILTER
 
 
 struct A {
@@ -440,23 +438,3 @@ takesClosureOfPoint { p in
     if p.#^REGULAR_MULTICLOSURE_APPLIED^# {}
   }
 }
-
-enum Enum123 {
-    case enumElem
-}
-struct Struct123: Equatable {
-    var structMem = Enum123.enumElem
-}
-func testNoBestSolutionFilter() {
-  let a = Struct123();
-  let b = [Struct123]().first(where: { $0 == a && 1 + 90 * 5 / 8 == 45 * -10 })?.structMem != .#^BEST_SOLUTION_FILTER^#
-  let c = min(10.3, 10 / 10.4) < 6 + 5 / (10 - 3) ? true : Optional(a)?.structMem != .#^BEST_SOLUTION_FILTER2^#
-}
-
-// BEST_SOLUTION_FILTER: Begin completions
-// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Convertible]: enumElem[#Enum123#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Enum123#})[#(into: inout Hasher) -> Void#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#Enum123?#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<Enum123>#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#Enum123#})[#Optional<Enum123>#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER: End completions


### PR DESCRIPTION
Reverts apple/swift#35746

- **Explanation**:
    The fix for the changes in apple/swift#35746 (which addressed enum cases being missing in completion results in certain cases) triggered a significant performance regression when performing completion in result builder bodies . Completing at the position show in the the SwiftUI example below now takes almost a minute compared to < 1s prior to the change:

   ```
   import SwiftUI
   struct MyView : View {
       var body: some View {
           VStack {
               HStack {
                   Text("hi")
                   Text("hi")
               }
               HStack {
                   Text("hi")
                   Text("hi")
               }
               HStack {
                   Text("hi")
                   Text("hi")
               }
               HStack {
                   Text("hi")
                   Text("hi")
               }
           }.#^COMPLETE^#
       }
   }
   ```
This performance issue has a much greater negative impact on the code completion experience than the issue the original change was fixing (missing enum member completions after != comparisons where the LHS expression had optional enum type and involved an overloaded function or operator with both generic and non-generic overloads), so this change simply reverts it.

- **Scope of issue**: This has a large performance impact on completion performance in result builder closures/bodies that quickly grows from a second or two to multiple minutes as the number of elements increases.
- **Origination**: My changes to fix missing completions in apple/swift#35746
- **Risk**: Low. The original change (and this revert) only affect code completion behavior with no impact on the compiler itself. 
- **Reviewer**: @xedin (Pavel Yaskevich)
- **Testing**: The existing regression suite, and verifying the performance of the example above was in the normal range and didn't grow noticeably with additional HStack entries.

Resolves rdar://problem/74432972