### PR TITLE
Fix compilation failure introduced by swift_job_run migration

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -103,7 +103,7 @@ void swift::donateThreadToGlobalExecutorUntil(bool (*condition)(void *),
   while (!condition(conditionContext)) {
     auto job = claimNextFromJobQueue();
     if (!job) return;
-    job->run(ExecutorRef::generic());
+    swift_job_run(job, ExecutorRef::generic());
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Since Ci tested platforms started using libdispatch executor, `SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR` case is not tested, so this compilation failure was missed. SwiftWasm uses `SWIFT_STDLIB_SINGLE_THREADED_RUNTIME`, so we caught this.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
