### PR TITLE
[AutoDiff] Remove 'withoutDerivative(at:in:)' and 'withDerivative(_:)'.

### DIFF
--- a/benchmark/single-source/Differentiation.swift
+++ b/benchmark/single-source/Differentiation.swift
@@ -40,7 +40,7 @@ public func run_DifferentiationIdentity(N: Int) {
     x
   }
   for _ in 0..<1000*N {
-    blackHole(valueWithGradient(at: 1, in: f))
+    blackHole(valueWithGradient(at: 1, of: f))
   }
 }
 
@@ -50,7 +50,7 @@ public func run_DifferentiationSquare(N: Int) {
     x * x
   }
   for _ in 0..<1000*N {
-    blackHole(valueWithGradient(at: 1, in: f))
+    blackHole(valueWithGradient(at: 1, of: f))
   }
 }
 
@@ -66,7 +66,7 @@ public func run_DifferentiationArraySum(N: Int) {
     return result
   }
   for _ in 0..<N {
-    blackHole(valueWithGradient(at: onesArray, in: sum))
+    blackHole(valueWithGradient(at: onesArray, of: sum))
   }
 }
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2869,16 +2869,16 @@ WARNING(differentiable_nondiff_type_implicit_noderivative_fixit,none,
       (/*propName*/ Identifier, /*propType*/ Type, /*nominalName*/ Identifier,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_immutable_wrapper_implicit_noderivative_fixit,none,
-      "synthesis of the 'Differentiable.move(along:)' requirement for %1 "
+      "synthesis of the 'Differentiable.move(by:)' requirement for %1 "
       "requires 'wrappedValue' in property wrapper %0 to be mutable or have a "
-      "non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute"
+      "non-mutating 'move(by:)'; add an explicit '@noDerivative' attribute"
       "%select{|, or conform %1 to 'AdditiveArithmetic'}2",
       (/*wrapperType*/ Identifier, /*nominalName*/ Identifier,
        /*nominalCanDeriveAdditiveArithmetic*/ bool))
 WARNING(differentiable_let_property_implicit_noderivative_fixit,none,
-      "synthesis of the 'Differentiable.move(along:)' requirement for %0 "
+      "synthesis of the 'Differentiable.move(by:)' requirement for %0 "
       "requires all stored properties not marked with `@noDerivative` to be "
-      "mutable or have a non-mutating 'move(along:)'; use 'var' instead, or "
+      "mutable or have a non-mutating 'move(by:)'; use 'var' instead, or "
       "add an explicit '@noDerivative' attribute "
       "%select{|, or conform %0 to 'AdditiveArithmetic'}1",
       (/*nominalName*/ Identifier, /*nominalCanDeriveAdditiveArithmetic*/ bool))

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -228,9 +228,9 @@ IDENTIFIER(AtomicStoreOrdering)
 IDENTIFIER(AtomicUpdateOrdering)
 
 // Differentiable programming
-IDENTIFIER(along)
+IDENTIFIER(by)
 IDENTIFIER(differential)
-IDENTIFIER(direction)
+IDENTIFIER(offset)
 IDENTIFIER(move)
 IDENTIFIER(pullback)
 IDENTIFIER(TangentVector)

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -329,10 +329,10 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
       return getRequirement(KnownProtocolKind::AdditiveArithmetic);
     }
 
-    // Differentiable.move(along:)
+    // Differentiable.move(by:)
     if (name.isCompoundName() && name.getBaseName() == ctx.Id_move) {
       auto argumentNames = name.getArgumentNames();
-      if (argumentNames.size() == 1 && argumentNames[0] == ctx.Id_along)
+      if (argumentNames.size() == 1 && argumentNames[0] == ctx.Id_by)
         return getRequirement(KnownProtocolKind::Differentiable);
     }
 

--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
@@ -325,41 +325,41 @@ where T: Differentiable & FloatingPoint, T == T.TangentVector {
 // Differential operators for `${Self}<T>`.
 
 public func gradient<T, R: FloatingPoint>(
-  at x: T, in f: @differentiable(reverse) (T) -> ${Self}<R>
+  at x: T, of f: @differentiable(reverse) (T) -> ${Self}<R>
 ) -> T.TangentVector where R.TangentVector == R {
-  return pullback(at: x, in: f)(1)
+  return pullback(at: x, of: f)(1)
 }
 
 public func gradient<T, U, R: FloatingPoint>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> ${Self}<R>
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> ${Self}<R>
 ) -> (T.TangentVector, U.TangentVector) where R.TangentVector == R {
-  return pullback(at: x, y, in: f)(1)
+  return pullback(at: x, y, of: f)(1)
 }
 
 public func derivative<T: FloatingPoint, R>(
-  at x: ${Self}<T>, in f: @differentiable(reverse) (${Self}<T>) -> R
+  at x: ${Self}<T>, of f: @differentiable(reverse) (${Self}<T>) -> R
 ) -> R.TangentVector where T.TangentVector == T {
-  return differential(at: x, in: f)(1)
+  return differential(at: x, of: f)(1)
 }
 
 public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
   at x: ${Self}<T>, _ y: ${Self}<U>,
-  in f: @differentiable(reverse) (${Self}<T>, ${Self}<U>) -> R
+  of f: @differentiable(reverse) (${Self}<T>, ${Self}<U>) -> R
 ) -> R.TangentVector where T.TangentVector == T, U.TangentVector == U {
-  return differential(at: x, y, in: f)(1, 1)
+  return differential(at: x, y, of: f)(1, 1)
 }
 
 public func valueWithGradient<T, R: FloatingPoint>(
-  at x: T, in f: @differentiable(reverse) (T) -> ${Self}<R>
+  at x: T, of f: @differentiable(reverse) (T) -> ${Self}<R>
 ) -> (value: ${Self}<R>, gradient: T.TangentVector) {
-  let (y, pullback) = valueWithPullback(at: x, in: f)
+  let (y, pullback) = valueWithPullback(at: x, of: f)
   return (y, pullback(1))
 }
 
 public func valueWithDerivative<T: FloatingPoint, R>(
-  at x: ${Self}<T>, in f: @differentiable(reverse) (${Self}<T>) -> R
+  at x: ${Self}<T>, of f: @differentiable(reverse) (${Self}<T>) -> R
 ) -> (value: R, derivative: R.TangentVector) {
-  let (y, differential) = valueWithDifferential(at: x, in: f)
+  let (y, differential) = valueWithDifferential(at: x, of: f)
   return (y, differential(1))
 }
 

--- a/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
+++ b/stdlib/private/DifferentiationUnittest/DifferentiationUnittest.swift.gyb
@@ -34,6 +34,38 @@ public func withLeakChecking(
     file: file, line: line)
 }
 
+@inlinable
+@_semantics("autodiff.nonvarying")
+public func withoutDerivative<T, R>(at x: T, in body: (T) -> R) -> R
+{
+  body(x)
+}
+
+public extension Differentiable {
+  /// Applies the given closure to the derivative of `self`.
+  ///
+  /// Returns `self` like an identity function. When the return value is used in
+  /// a context where it is differentiated with respect to, applies the given
+  /// closure to the derivative of the return value.
+  @inlinable
+  @differentiable(reverse, wrt: self)
+  func withDerivative(_ body: @escaping (inout TangentVector) -> Void) -> Self {
+    return self
+  }
+
+  @inlinable
+  @derivative(of: withDerivative)
+  internal func _vjpWithDerivative(
+    _ body: @escaping (inout TangentVector) -> Void
+  ) -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+    return (self, { grad in
+      var grad = grad
+      body(&grad)
+      return grad
+    })
+  }
+}
+
 public extension TestSuite {
   /// Execute test function and check expected leak count.
   func testWithLeakChecking(

--- a/stdlib/public/Differentiation/AnyDifferentiable.swift
+++ b/stdlib/public/Differentiation/AnyDifferentiable.swift
@@ -23,7 +23,7 @@ import Swift
 
 internal protocol _AnyDifferentiableBox {
   // `Differentiable` requirements.
-  mutating func _move(along direction: AnyDerivative)
+  mutating func _move(by offset: AnyDerivative)
 
   /// The underlying base value, type-erased to `Any`.
   var _typeErasedBase: Any { get }
@@ -50,14 +50,11 @@ internal struct _ConcreteDifferentiableBox<T: Differentiable>: _AnyDifferentiabl
     return (self as? _ConcreteDifferentiableBox<U>)?._base
   }
 
-  mutating func _move(along direction: AnyDerivative) {
-    guard
-      let directionBase =
-        direction.base as? T.TangentVector
-    else {
-      _derivativeTypeMismatch(T.self, type(of: direction.base))
+  mutating func _move(by offset: AnyDerivative) {
+    guard let offsetBase = offset.base as? T.TangentVector else {
+      _derivativeTypeMismatch(T.self, type(of: offset.base))
     }
-    _base.move(along: directionBase)
+    _base.move(by: offsetBase)
   }
 }
 
@@ -100,8 +97,8 @@ public struct AnyDifferentiable: Differentiable {
 
   public typealias TangentVector = AnyDerivative
 
-  public mutating func move(along direction: TangentVector) {
-    _box._move(along: direction)
+  public mutating func move(by offset: TangentVector) {
+    _box._move(by: offset)
   }
 }
 
@@ -121,7 +118,7 @@ internal protocol _AnyDerivativeBox {
   func _subtracting(_ x: _AnyDerivativeBox) -> _AnyDerivativeBox
 
   // `Differentiable` requirements.
-  mutating func _move(along direction: _AnyDerivativeBox)
+  mutating func _move(by offset: _AnyDerivativeBox)
 
   /// The underlying base value, type-erased to `Any`.
   var _typeErasedBase: Any { get }
@@ -215,19 +212,16 @@ where T: Differentiable, T.TangentVector == T {
 
   // `Differentiable` requirements.
   @inlinable
-  mutating func _move(along direction: _AnyDerivativeBox) {
-    if direction._isOpaqueZero() {
+  mutating func _move(by offset: _AnyDerivativeBox) {
+    if offset._isOpaqueZero() {
       return
     }
     // The case where `self._isOpaqueZero()` returns true is handled in
-    // `AnyDerivative.move(along:)`.
-    guard
-      let directionBase =
-        direction._unboxed(to: T.TangentVector.self)
-    else {
-      _derivativeTypeMismatch(T.self, type(of: direction._typeErasedBase))
+    // `AnyDerivative.move(by:)`.
+    guard let offsetBase = offset._unboxed(to: T.TangentVector.self) else {
+      _derivativeTypeMismatch(T.self, type(of: offset._typeErasedBase))
     }
-    _base.move(along: directionBase)
+    _base.move(by: offsetBase)
   }
 }
 
@@ -362,12 +356,12 @@ public struct AnyDerivative: Differentiable & AdditiveArithmetic {
 
   // `Differentiable` requirements.
   @inlinable
-  public mutating func move(along direction: TangentVector) {
+  public mutating func move(by offset: TangentVector) {
     if _box._isOpaqueZero() {
-      _box = direction._box
+      _box = offset._box
       return
     }
-    _box._move(along: direction._box)
+    _box._move(by: offset._box)
   }
 }
 

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -72,14 +72,14 @@ where Element: Differentiable {
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
 
-  public mutating func move(along direction: TangentVector) {
+  public mutating func move(by offset: TangentVector) {
     precondition(
-      base.count == direction.base.count, """
-        Count mismatch: \(base.count) ('self') and \(direction.base.count) \
+      base.count == offset.base.count, """
+        Count mismatch: \(base.count) ('self') and \(offset.base.count) \
         ('direction')
         """)
     for i in base.indices {
-      base[i].move(along: direction.base[i])
+      base[i].move(by: offset.base[i])
     }
   }
 }
@@ -172,9 +172,9 @@ extension Array: Differentiable where Element: Differentiable {
   public typealias TangentVector =
     Array<Element.TangentVector>.DifferentiableView
 
-  public mutating func move(along direction: TangentVector) {
+  public mutating func move(by offset: TangentVector) {
     var view = DifferentiableView(self)
-    view.move(along: direction)
+    view.move(by: offset)
     self = view.base
   }
 }

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -351,7 +351,7 @@ extension Array where Element: Differentiable {
     var values: [Result] = []
     var pullbacks: [(Result.TangentVector) -> Element.TangentVector] = []
     for x in self {
-      let (y, pb) = valueWithPullback(at: x, in: body)
+      let (y, pb) = valueWithPullback(at: x, of: body)
       values.append(y)
       pullbacks.append(pb)
     }
@@ -372,7 +372,7 @@ extension Array where Element: Differentiable {
     var values: [Result] = []
     var differentials: [(Element.TangentVector) -> Result.TangentVector] = []
     for x in self {
-      let (y, df) = valueWithDifferential(at: x, in: body)
+      let (y, df) = valueWithDifferential(at: x, of: body)
       values.append(y)
       differentials.append(df)
     }
@@ -411,7 +411,7 @@ extension Array where Element: Differentiable {
     var result = initialResult
     for element in self {
       let (y, pb) =
-        valueWithPullback(at: result, element, in: nextPartialResult)
+        valueWithPullback(at: result, element, of: nextPartialResult)
       result = y
       pullbacks.append(pb)
     }
@@ -447,7 +447,7 @@ extension Array where Element: Differentiable {
     var result = initialResult
     for element in self {
       let (y, df) =
-        valueWithDifferential(at: result, element, in: nextPartialResult)
+        valueWithDifferential(at: result, element, of: nextPartialResult)
       result = y
       differentials.append(df)
     }

--- a/stdlib/public/Differentiation/Differentiable.swift
+++ b/stdlib/public/Differentiation/Differentiable.swift
@@ -32,15 +32,15 @@ public protocol Differentiable {
   associatedtype TangentVector: Differentiable & AdditiveArithmetic
     where TangentVector.TangentVector == TangentVector
 
-  /// Moves `self` along the given direction. In Riemannian geometry, this is
+  /// Moves `self` by the given offset. In Riemannian geometry, this is
   /// equivalent to exponential map, which moves `self` on the geodesic surface
-  /// along the given tangent vector.
-  mutating func move(along direction: TangentVector)
+  /// by the given tangent vector.
+  mutating func move(by offset: TangentVector)
 }
 
 public extension Differentiable where TangentVector == Self {
   @_alwaysEmitIntoClient
-  mutating func move(along direction: TangentVector) {
-    self += direction
+  mutating func move(by offset: TangentVector) {
+    self += offset
   }
 }

--- a/stdlib/public/Differentiation/DifferentialOperators.swift
+++ b/stdlib/public/Differentiation/DifferentialOperators.swift
@@ -20,14 +20,14 @@ import Swift
 
 @inlinable
 public func valueWithDifferential<T, R>(
-  at x: T, in f: @differentiable(reverse) (T) -> R
+  at x: T, of f: @differentiable(reverse) (T) -> R
 ) -> (value: R, differential: (T.TangentVector) -> R.TangentVector) {
   return Builtin.applyDerivative_jvp(f, x)
 }
 
 @inlinable
 public func valueWithDifferential<T, U, R>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
 ) -> (value: R,
       differential: (T.TangentVector, U.TangentVector) -> R.TangentVector) {
   return Builtin.applyDerivative_jvp_arity2(f, x, y)
@@ -35,7 +35,7 @@ public func valueWithDifferential<T, U, R>(
 
 @inlinable
 public func valueWithDifferential<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> (value: R,
       differential: (T.TangentVector, U.TangentVector, V.TangentVector)
         -> (R.TangentVector)) {
@@ -46,14 +46,14 @@ public func valueWithDifferential<T, U, V, R>(
 
 @inlinable
 public func valueWithPullback<T, R>(
-  at x: T, in f: @differentiable(reverse) (T) -> R
+  at x: T, of f: @differentiable(reverse) (T) -> R
 ) -> (value: R, pullback: (R.TangentVector) -> T.TangentVector) {
   return Builtin.applyDerivative_vjp(f, x)
 }
 
 @inlinable
 public func valueWithPullback<T, U, R>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
 ) -> (value: R,
       pullback: (R.TangentVector) -> (T.TangentVector, U.TangentVector)) {
   return Builtin.applyDerivative_vjp_arity2(f, x, y)
@@ -61,7 +61,7 @@ public func valueWithPullback<T, U, R>(
 
 @inlinable
 public func valueWithPullback<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> (value: R,
       pullback: (R.TangentVector)
         -> (T.TangentVector, U.TangentVector, V.TangentVector)) {
@@ -72,23 +72,23 @@ public func valueWithPullback<T, U, V, R>(
 
 @inlinable
 public func differential<T, R>(
-  at x: T, in f: @differentiable(reverse) (T) -> R
+  at x: T, of f: @differentiable(reverse) (T) -> R
 ) -> (T.TangentVector) -> R.TangentVector {
-  return valueWithDifferential(at: x, in: f).1
+  return valueWithDifferential(at: x, of: f).1
 }
 
 @inlinable
 public func differential<T, U, R>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
 ) -> (T.TangentVector, U.TangentVector) -> R.TangentVector {
-  return valueWithDifferential(at: x, y, in: f).1
+  return valueWithDifferential(at: x, y, of: f).1
 }
 
 @inlinable
 public func differential<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> (T.TangentVector, U.TangentVector, V.TangentVector) -> (R.TangentVector) {
-  return valueWithDifferential(at: x, y, z, in: f).1
+  return valueWithDifferential(at: x, y, z, of: f).1
 }
 
 
@@ -96,21 +96,21 @@ public func differential<T, U, V, R>(
 
 @inlinable
 public func pullback<T, R>(
-  at x: T, in f: @differentiable(reverse) (T) -> R
+  at x: T, of f: @differentiable(reverse) (T) -> R
 ) -> (R.TangentVector) -> T.TangentVector {
   return Builtin.applyDerivative_vjp(f, x).1
 }
 
 @inlinable
 public func pullback<T, U, R>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
 ) -> (R.TangentVector) -> (T.TangentVector, U.TangentVector) {
   return Builtin.applyDerivative_vjp_arity2(f, x, y).1
 }
 
 @inlinable
 public func pullback<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> (R.TangentVector)
     -> (T.TangentVector, U.TangentVector, V.TangentVector) {
   return Builtin.applyDerivative_vjp_arity3(f, x, y, z).1
@@ -120,87 +120,87 @@ public func pullback<T, U, V, R>(
 
 @inlinable
 public func derivative<T: FloatingPoint, R>(
-  at x: T, in f: @differentiable(reverse) (T) -> R
+  at x: T, of f: @differentiable(reverse) (T) -> R
 ) ->  R.TangentVector
   where T.TangentVector == T {
-  return differential(at: x, in: f)(T(1))
+  return differential(at: x, of: f)(T(1))
 }
 
 @inlinable
 public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
 ) -> R.TangentVector
   where T.TangentVector == T,
         U.TangentVector == U {
-  return differential(at: x, y, in: f)(T(1), U(1))
+  return differential(at: x, y, of: f)(T(1), U(1))
 }
 
 @inlinable
 public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> R.TangentVector
   where T.TangentVector == T,
         U.TangentVector == U,
         V.TangentVector == V {
-  return differential(at: x, y, z, in: f)(T(1), U(1), V(1))
+  return differential(at: x, y, z, of: f)(T(1), U(1), V(1))
 }
 
 // Gradient
 
 @inlinable
 public func gradient<T, R>(
-  at x: T, in f: @differentiable(reverse) (T) -> R
+  at x: T, of f: @differentiable(reverse) (T) -> R
 ) -> T.TangentVector
   where R : FloatingPoint, R.TangentVector == R {
-  return pullback(at: x, in: f)(R(1))
+  return pullback(at: x, of: f)(R(1))
 }
 
 @inlinable
 public func gradient<T, U, R>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
 ) -> (T.TangentVector, U.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-  return pullback(at: x, y, in: f)(R(1))
+  return pullback(at: x, y, of: f)(R(1))
 }
 
 @inlinable
 public func gradient<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-  return pullback(at: x, y, z, in: f)(R(1))
+  return pullback(at: x, y, z, of: f)(R(1))
 }
 
 // Value with derivative
 
 @inlinable
 public func valueWithDerivative<T: FloatingPoint, R>(
-  at x: T, in f: @escaping @differentiable(reverse) (T) -> R
+  at x: T, of f: @escaping @differentiable(reverse) (T) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector == T {
-  let (y, differential) = valueWithDifferential(at: x, in: f)
+  let (y, differential) = valueWithDifferential(at: x, of: f)
   return (y, differential(T(1)))
 }
 
 @inlinable
 public func valueWithDerivative<T: FloatingPoint, U: FloatingPoint, R>(
-  at x: T, _ y: U, in f: @escaping @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @escaping @differentiable(reverse) (T, U) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector == T,
         U.TangentVector == U {
-  let (y, differential) = valueWithDifferential(at: x, y, in: f)
+  let (y, differential) = valueWithDifferential(at: x, y, of: f)
   return (y, differential(T(1), U(1)))
 }
 
 @inlinable
 public func valueWithDerivative<
   T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
-  at x: T, _ y: U, _ z: V, in f: @escaping @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @escaping @differentiable(reverse) (T, U, V) -> R
 ) -> (value: R, derivative: R.TangentVector)
   where T.TangentVector == T,
         U.TangentVector == U,
         V.TangentVector == V {
-  let (y, differential) = valueWithDifferential(at: x, y, z, in: f)
+  let (y, differential) = valueWithDifferential(at: x, y, z, of: f)
   return (y, differential(T(1), U(1), V(1)))
 }
 
@@ -208,29 +208,29 @@ public func valueWithDerivative<
 
 @inlinable
 public func valueWithGradient<T, R>(
-  at x: T, in f: @differentiable(reverse) (T) -> R
+  at x: T, of f: @differentiable(reverse) (T) -> R
 ) -> (value: R, gradient: T.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-  let (y, pullback) = valueWithPullback(at: x, in: f)
+  let (y, pullback) = valueWithPullback(at: x, of: f)
   return (y, pullback(R(1)))
 }
 
 @inlinable
 public func valueWithGradient<T, U, R>(
-  at x: T, _ y: U, in f: @differentiable(reverse) (T, U) -> R
+  at x: T, _ y: U, of f: @differentiable(reverse) (T, U) -> R
 ) -> (value: R, gradient: (T.TangentVector, U.TangentVector))
   where R : FloatingPoint, R.TangentVector == R {
-  let (y, pullback) = valueWithPullback(at: x, y, in: f)
+  let (y, pullback) = valueWithPullback(at: x, y, of: f)
   return (y, pullback(R(1)))
 }
 
 @inlinable
 public func valueWithGradient<T, U, V, R>(
-  at x: T, _ y: U, _ z: V, in f: @differentiable(reverse) (T, U, V) -> R
+  at x: T, _ y: U, _ z: V, of f: @differentiable(reverse) (T, U, V) -> R
 ) -> (value: R,
       gradient: (T.TangentVector, U.TangentVector, V.TangentVector))
   where R : FloatingPoint, R.TangentVector == R {
-  let (y, pullback) = valueWithPullback(at: x, y, z, in: f)
+  let (y, pullback) = valueWithPullback(at: x, y, z, of: f)
   return (y, pullback(R(1)))
 }
 
@@ -241,7 +241,7 @@ public func derivative<T: FloatingPoint, R>(
   of f: @escaping @differentiable(reverse) (T) -> R
 ) -> (T) -> R.TangentVector
   where T.TangentVector == T {
-  return { x in derivative(at: x, in: f) }
+  return { x in derivative(at: x, of: f) }
 }
 
 @inlinable 
@@ -250,7 +250,7 @@ public func derivative<T: FloatingPoint, U: FloatingPoint, R>(
 ) -> (T, U) -> R.TangentVector
   where T.TangentVector == T,
         U.TangentVector == U {
-  return { (x, y) in derivative(at: x, y, in: f) }
+  return { (x, y) in derivative(at: x, y, of: f) }
 }
 
 @inlinable
@@ -260,7 +260,7 @@ public func derivative<T: FloatingPoint, U: FloatingPoint, V: FloatingPoint, R>(
   where T.TangentVector == T,
         U.TangentVector == U,
         V.TangentVector == V {
-  return { (x, y, z) in derivative(at: x, y, z, in: f) }
+  return { (x, y, z) in derivative(at: x, y, z, of: f) }
 }
 
 // Gradient (curried)
@@ -270,7 +270,7 @@ public func gradient<T, R>(
   of f: @escaping @differentiable(reverse) (T) -> R
 ) -> (T) -> T.TangentVector
   where R : FloatingPoint, R.TangentVector == R {
-  return { x in gradient(at: x, in: f) }
+  return { x in gradient(at: x, of: f) }
 }
 
 @inlinable
@@ -278,7 +278,7 @@ public func gradient<T, U, R>(
   of f: @escaping @differentiable(reverse) (T, U) -> R
 ) -> (T, U) -> (T.TangentVector, U.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-  return { x, y in gradient(at: x, y, in: f) }
+  return { x, y in gradient(at: x, y, of: f) }
 }
 
 @inlinable
@@ -286,5 +286,5 @@ public func gradient<T, U, V, R>(
   of f: @escaping @differentiable(reverse) (T, U, V) -> R
 ) -> (T, U, V) -> (T.TangentVector, U.TangentVector, V.TangentVector)
   where R : FloatingPoint, R.TangentVector == R {
-  return { x, y, z in gradient(at: x, y, z, in: f) }
+  return { x, y, z in gradient(at: x, y, z, of: f) }
 }

--- a/stdlib/public/Differentiation/DifferentiationUtilities.swift
+++ b/stdlib/public/Differentiation/DifferentiationUtilities.swift
@@ -31,42 +31,6 @@ public func withoutDerivative<T>(at x: T) -> T {
   x
 }
 
-/// Applies the given closure `body` to `x`. When used in a context where `x` is
-/// being differentiated with respect to, this function will not produce any
-/// derivative at `x`.
-// FIXME: Support throws-rethrows.
-@inlinable
-@inline(__always)
-@_semantics("autodiff.nonvarying")
-public func withoutDerivative<T, R>(at x: T, in body: (T) -> R) -> R {
-  body(x)
-}
-
-public extension Differentiable {
-  /// Applies the given closure to the derivative of `self`.
-  ///
-  /// Returns `self` like an identity function. When the return value is used in
-  /// a context where it is differentiated with respect to, applies the given
-  /// closure to the derivative of the return value.
-  @inlinable
-  @differentiable(reverse, wrt: self)
-  func withDerivative(_ body: @escaping (inout TangentVector) -> Void) -> Self {
-    return self
-  }
-
-  @inlinable
-  @derivative(of: withDerivative)
-  internal func _vjpWithDerivative(
-    _ body: @escaping (inout TangentVector) -> Void
-  ) -> (value: Self, pullback: (TangentVector) -> TangentVector) {
-    return (self, { grad in
-      var grad = grad
-      body(&grad)
-      return grad
-    })
-  }
-}
-
 //===----------------------------------------------------------------------===//
 // Diagnostics
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -42,8 +42,8 @@ extension ${Self}: Differentiable {
   public typealias TangentVector = ${Self}
 
   ${Availability(bits)}
-  public mutating func move(along direction: TangentVector) {
-    self += direction
+  public mutating func move(by offset: TangentVector) {
+    self += offset
   }
 }
 

--- a/stdlib/public/Differentiation/OptionalDifferentiation.swift
+++ b/stdlib/public/Differentiation/OptionalDifferentiation.swift
@@ -44,16 +44,16 @@ extension Optional: Differentiable where Wrapped: Differentiable {
       }
     }
 
-    public mutating func move(along direction: TangentVector) {
-      if let value = direction.value {
-        self.value?.move(along: value)
+    public mutating func move(by offset: TangentVector) {
+      if let value = offset.value {
+        self.value?.move(by: value)
       }
     }
   }
 
-  public mutating func move(along direction: TangentVector) {
-    if let value = direction.value {
-      self?.move(along: value)
+  public mutating func move(by offset: TangentVector) {
+    if let value = offset.value {
+      self?.move(by: value)
     }
   }
 }

--- a/test/AutoDiff/IRGen/loadable_by_address.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address.swift
@@ -71,9 +71,9 @@ func large2small(_ foo: Large) -> Float {
 LBATests.test("Correctness") {
   let one = Large.TangentVector(a: 1, b: 1, c: 1, d: 1)
   expectEqual(one,
-              pullback(at: Large(a: 0, b: 0, c: 0, d: 0, e: 0), in: large2large)(one))
+              pullback(at: Large(a: 0, b: 0, c: 0, d: 0, e: 0), of: large2large)(one))
   expectEqual(Large.TangentVector(a: 1, b: 0, c: 0, d: 0),
-              gradient(at: Large(a: 0, b: 0, c: 0, d: 0, e: 0), in: large2small))
+              gradient(at: Large(a: 0, b: 0, c: 0, d: 0, e: 0), of: large2small))
 }
 
 runAllTests()

--- a/test/AutoDiff/SILGen/sil_differentiability_witness.swift
+++ b/test/AutoDiff/SILGen/sil_differentiability_witness.swift
@@ -82,7 +82,7 @@ func generic_vjp<T: Differentiable>(_ x: T, _ y: Float) -> (
 
 public struct Foo: Differentiable {
   public typealias TangentVector = DummyTangentVector
-  public mutating func move(along _: TangentVector) {}
+  public mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse)
   public var x: Float

--- a/test/AutoDiff/SILGen/vtable.swift
+++ b/test/AutoDiff/SILGen/vtable.swift
@@ -20,7 +20,7 @@ struct DummyTangentVector: Differentiable & AdditiveArithmetic {
 
 class Super: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 
   var base: Float
   // FIXME(TF-648): Dummy to make `Super.TangentVector` be nontrivial.

--- a/test/AutoDiff/SILGen/witness_table.swift
+++ b/test/AutoDiff/SILGen/witness_table.swift
@@ -26,7 +26,7 @@ struct DummyTangentVector: Differentiable & AdditiveArithmetic {
 
 struct Struct: Protocol {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse, wrt: (self, x, y))
   @differentiable(reverse, wrt: x)

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -762,7 +762,7 @@ public func hasImplicitlyDifferentiatedClosureDefaultArgument(_ f: @differentiab
 public func fragileFuncWithGradient() {
   // expected-error @+2 {{function is not differentiable}}
   // expected-note @+1 {{differentiated functions in '@inlinable' functions must be marked '@differentiable' or have a public '@derivative'}}
-  _ = gradient(at: 0, in: implicitlyDifferentiableFromFragile)
+  _ = gradient(at: 0, of: implicitlyDifferentiableFromFragile)
 }
 
 @inlinable

--- a/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_diagnostics.swift
@@ -464,7 +464,7 @@ struct StructTangentVectorNotStruct: Differentiable {
     static func +(_: Self, _: Self) -> Self { fatalError() }
     static func -(_: Self, _: Self) -> Self { fatalError() }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -488,7 +488,7 @@ struct StructOriginalPropertyNotDifferentiable: Differentiable {
   struct TangentVector: Differentiable & AdditiveArithmetic {
     var nondiff: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -509,7 +509,7 @@ struct StructTangentVectorPropertyNotFound: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var y: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -532,7 +532,7 @@ struct StructTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -555,7 +555,7 @@ final class ClassTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -578,7 +578,7 @@ struct StructTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -601,7 +601,7 @@ final class ClassTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}

--- a/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/forward_mode_diagnostics.swift
@@ -144,7 +144,7 @@ struct StructTangentVectorNotStruct: Differentiable {
     static func +(_: Self, _: Self) -> Self { fatalError() }
     static func -(_: Self, _: Self) -> Self { fatalError() }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -168,7 +168,7 @@ struct StructOriginalPropertyNotDifferentiable: Differentiable {
   struct TangentVector: Differentiable & AdditiveArithmetic {
     var nondiff: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -189,7 +189,7 @@ struct StructTangentVectorPropertyNotFound: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var y: Float
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -212,7 +212,7 @@ struct StructTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -235,7 +235,7 @@ final class ClassTangentPropertyWrongType: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Double
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // SR-13464: Missing support for classes in forward-mode AD
@@ -261,7 +261,7 @@ struct StructTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // expected-error @+2 {{function is not differentiable}}
@@ -284,7 +284,7 @@ final class ClassTangentPropertyNotStored: Differentiable {
   struct TangentVector: Differentiable, AdditiveArithmetic {
     var x: Float { 0 }
   }
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // SR-13464: Missing support for classes in forward-mode AD

--- a/test/AutoDiff/SILOptimizer/generics.swift
+++ b/test/AutoDiff/SILOptimizer/generics.swift
@@ -6,7 +6,7 @@ import _Differentiation
 func identity<T : Differentiable>(_ x: T) -> T {
   return x
 }
-_ = gradient(at: Float(1), in: { x in identity(x) })
+_ = gradient(at: Float(1), of: { x in identity(x) })
 
 // Test PullbackCloner local buffer allocation.
 // Verify that local buffers are immediately set to zero.
@@ -21,7 +21,7 @@ _ = gradient(at: Float(1), in: { x in identity(x) })
 // Test TF-201: differentiate direct references to generic function.
 // This involves reabstraction thunk differentiation.
 
-_ = gradient(at: Float(1), in: identity)
+_ = gradient(at: Float(1), of: identity)
 
 protocol DifferentiableAdditiveArithmetic: Differentiable & AdditiveArithmetic {
   @differentiable(reverse)
@@ -31,7 +31,7 @@ extension Float: DifferentiableAdditiveArithmetic {}
 func generic<T: DifferentiableAdditiveArithmetic>(_ x: T) -> T {
   x + x + x
 }
-_ = gradient(at: Float(10), in: generic)
+_ = gradient(at: Float(10), of: generic)
 
 struct Wrapper<Scalar : Differentiable> : Differentiable {
   var value: Scalar
@@ -40,13 +40,13 @@ struct Wrapper<Scalar : Differentiable> : Differentiable {
 func generic<T>(_ x: Wrapper<T>) -> T {
   return x.value
 }
-_ = gradient(at: Wrapper<Float>(1), in: generic)
+_ = gradient(at: Wrapper<Float>(1), of: generic)
 
 func generic2<T: Differentiable, U: Differentiable>(_ x: T, _ y: Float, _ z: U) -> T {
   return x
 }
 func foo<T>(_ x: Wrapper<T>) {
-  _ = gradient(at: Float(1), 2, x, in: generic2)
+  _ = gradient(at: Float(1), 2, x, of: generic2)
 }
 
 // Test case where associated derivative function's requirements are met.
@@ -61,7 +61,7 @@ extension Wrapper where Scalar : Numeric {
     return mean() // ok
   }
 }
-_ = pullback(at: Wrapper<Float>(1), in: { $0.variance() })
+_ = pullback(at: Wrapper<Float>(1), of: { $0.variance() })
 
 // Tests TF-277.
 protocol Layer : Differentiable {
@@ -149,11 +149,11 @@ extension TF_508_Struct : Differentiable where Scalar : Differentiable {
 func TF_508() {
   let x = TF_508_Struct<Float>()
   // Test conformance requirement with dependent member type.
-  _ = pullback(at: x, in: { (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
+  _ = pullback(at: x, of: { (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
     return x + x
   })
   // Test same-type requirement with dependent member type.
-  _ = pullback(at: x, in: { (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
+  _ = pullback(at: x, of: { (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
     return x - x
   })
 }

--- a/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/b.swift
+++ b/test/AutoDiff/Sema/DerivativeRegistrationCrossModule/Inputs/b.swift
@@ -3,7 +3,7 @@ import a
 
 extension Struct: Differentiable {
   public struct TangentVector: Differentiable & AdditiveArithmetic {}
-  public mutating func move(along _: TangentVector) {}
+  public mutating func move(by _: TangentVector) {}
 
   @usableFromInline
   @derivative(of: method, wrt: x)

--- a/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/class_differentiable.swift
@@ -31,14 +31,14 @@ func testEmpty() {
 
 protocol DifferentiableWithNonmutatingMoveAlong: Differentiable {}
 extension DifferentiableWithNonmutatingMoveAlong {
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 }
 
 class EmptyWithInheritedNonmutatingMoveAlong: DifferentiableWithNonmutatingMoveAlong {
   typealias TangentVector = Empty.TangentVector
   static func proof_that_i_have_nonmutating_move_along() {
     let empty = EmptyWithInheritedNonmutatingMoveAlong()
-    empty.move(along: .init())
+    empty.move(by: .init())
   }
 }
 
@@ -57,17 +57,17 @@ class ImmutableStoredProperties<T: Differentiable & AnyObject>: Differentiable {
   // expected-warning @+1 {{stored property 'nondiff' has no derivative because 'Int' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let nondiff: Int
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let diff: Float
 
-  let letClass: Empty // No error on class-bound differentiable `let` with a non-mutating 'move(along:)'.
+  let letClass: Empty // No error on class-bound differentiable `let` with a non-mutating 'move(by:)'.
 
   let letClassWithInheritedNonmutatingMoveAlong: EmptyWithInheritedNonmutatingMoveAlong
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
-  let letClassGeneric: T // Error due to lack of non-mutating 'move(along:)'.
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  let letClassGeneric: T // Error due to lack of non-mutating 'move(by:)'.
 
-  let letClassWrappingGeneric: EmptyWrapper<T> // No error on class-bound differentiable `let` with a non-mutating 'move(along:)'.
+  let letClassWrappingGeneric: EmptyWrapper<T> // No error on class-bound differentiable `let` with a non-mutating 'move(by:)'.
 
   init(letClassGeneric: T) {
     okay = 0
@@ -91,7 +91,7 @@ class MutableStoredPropertiesWithInitialValue: Differentiable {
 }
 // Test class with both an empty constructor and memberwise initializer.
 class AllMixedStoredPropertiesHaveInitialValue: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let x = Float(1)
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
@@ -120,7 +120,7 @@ class Simple: Differentiable {
 func testSimple() {
   let simple = Simple(w: 1, b: 1)
   let tangent = Simple.TangentVector(w: 1, b: 1)
-  simple.move(along: tangent)
+  simple.move(by: tangent)
 }
 
 // Test type with mixed members.
@@ -136,7 +136,7 @@ class Mixed: Differentiable {
 func testMixed(_ simple: Simple, _ simpleTangent: Simple.TangentVector) {
   let mixed = Mixed(simple: simple, float: 1)
   let tangent = Mixed.TangentVector(simple: simpleTangent, float: 1)
-  mixed.move(along: tangent)
+  mixed.move(by: tangent)
 }
 
 // Test type with manual definition of vector space types to `Self`.
@@ -181,7 +181,7 @@ where T: Differentiable, T == T.TangentVector {
 func testGenericVectorSpacesEqualSelf() {
   let genericSame = GenericVectorSpacesEqualSelf<Double>(w: 1, b: 1)
   let tangent = GenericVectorSpacesEqualSelf.TangentVector(w: 1, b: 1)
-  genericSame.move(along: tangent)
+  genericSame.move(by: tangent)
 }
 
 // Test nested type.
@@ -266,11 +266,11 @@ class HasCustomMethod: Differentiable {
     self.generic = generic
   }
 
-  func move(along direction: TangentVector) {
+  func move(by offset: TangentVector) {
     print("Hello world")
-    simple.move(along: direction.simple)
-    mixed.move(along: direction.mixed)
-    generic.move(along: direction.generic)
+    simple.move(by: offset.simple)
+    mixed.move(by: offset.mixed)
+    generic.move(by: offset.generic)
   }
 }
 
@@ -556,7 +556,7 @@ class SR_12793: Differentiable {
 
   // Test usage of synthesized `TangentVector` type.
   // This should not produce an error: "reference to invalid associated type 'TangentVector'".
-  func move(along direction: TangentVector) {}
+  func move(by offset: TangentVector) {}
 }
 
 // Test property wrappers.
@@ -585,7 +585,7 @@ struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 class WrappedProperties: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(by:)'; add an explicit '@noDerivative' attribute}}
   @ImmutableWrapper var immutableInt: Generic<Int> = Generic()
 
   // expected-warning @+1 {{stored property 'mutableInt' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
@@ -606,7 +606,7 @@ class WrappedProperties: Differentiable {
 // Test derived conformances in disallowed contexts.
 
 extension OtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring class 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
 
 extension GenericOtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring generic class 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable.swift
@@ -13,23 +13,23 @@ func testEmpty() {
 
 struct EmptyWithConcreteNonmutatingMoveAlong: Differentiable {
   typealias TangentVector = Empty.TangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
   static func proof_that_i_have_nonmutating_move_along() {
     let empty = Self()
-    empty.move(along: .init())
+    empty.move(by: .init())
   }
 }
 
 protocol DifferentiableWithNonmutatingMoveAlong: Differentiable {}
 extension DifferentiableWithNonmutatingMoveAlong {
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 }
 
 struct EmptyWithInheritedNonmutatingMoveAlong: DifferentiableWithNonmutatingMoveAlong {
   typealias TangentVector = Empty.TangentVector
   static func proof_that_i_have_nonmutating_move_along() {
     let empty = Self()
-    empty.move(along: .init())
+    empty.move(by: .init())
   }
 }
 
@@ -51,14 +51,14 @@ struct ImmutableStoredProperties: Differentiable {
   // expected-warning @+1 {{stored property 'nondiff' has no derivative because 'Int' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let nondiff: Int
 
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'ImmutableStoredProperties' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let diff: Float
 
   let nonmutatingMoveAlongStruct: EmptyWithConcreteNonmutatingMoveAlong
 
   let inheritedNonmutatingMoveAlongStruct: EmptyWithInheritedNonmutatingMoveAlong
   
-  let diffClass: EmptyClass // No error on class-bound `let` with a non-mutating `move(along:)`.
+  let diffClass: EmptyClass // No error on class-bound `let` with a non-mutating `move(by:)`.
 }
 func testImmutableStoredProperties() {
   _ = ImmutableStoredProperties.TangentVector(
@@ -73,7 +73,7 @@ struct MutableStoredPropertiesWithInitialValue: Differentiable {
 }
 // Test struct with both an empty constructor and memberwise initializer.
 struct AllMixedStoredPropertiesHaveInitialValue: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(along:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'AllMixedStoredPropertiesHaveInitialValue' requires all stored properties not marked with `@noDerivative` to be mutable or have a non-mutating 'move(by:)'; use 'var' instead, or add an explicit '@noDerivative' attribute}} {{3-3=@noDerivative }}
   let x = Float(1)
   var y = Float(1)
   // Memberwise initializer should be `init(y:)` since `x` is immutable.
@@ -94,7 +94,7 @@ struct Simple: AdditiveArithmetic, Differentiable {
 }
 func testSimple() {
   var simple = Simple(w: 1, b: 1)
-  simple.move(along: simple)
+  simple.move(by: simple)
 }
 
 // Test type with mixed members.
@@ -104,7 +104,7 @@ struct Mixed: AdditiveArithmetic, Differentiable {
 }
 func testMixed(_ simple: Simple) {
   var mixed = Mixed(simple: simple, float: 1)
-  mixed.move(along: mixed)
+  mixed.move(by: mixed)
 }
 
 // Test type with manual definition of vector space types to `Self`.
@@ -122,7 +122,7 @@ where T: Differentiable, T == T.TangentVector {
 }
 func testGenericVectorSpacesEqualSelf() {
   var genericSame = GenericVectorSpacesEqualSelf<Double>(w: 1, b: 1)
-  genericSame.move(along: genericSame)
+  genericSame.move(by: genericSame)
 }
 
 // Test nested type.
@@ -136,7 +136,7 @@ func testNested(
   _ genericSame: GenericVectorSpacesEqualSelf<Double>
 ) {
   var nested = Nested(simple: simple, mixed: mixed, generic: genericSame)
-  nested.move(along: nested)
+  nested.move(by: nested)
 }
 
 // Test type that does not conform to `AdditiveArithmetic` but whose members do.
@@ -174,11 +174,11 @@ struct HasCustomMethod: Differentiable {
   var simple: Simple
   var mixed: Mixed
   var generic: GenericVectorSpacesEqualSelf<Double>
-  mutating func move(along direction: TangentVector) {
+  mutating func move(by offset: TangentVector) {
     print("Hello world")
-    simple.move(along: direction.simple)
-    mixed.move(along: direction.mixed)
-    generic.move(along: direction.generic)
+    simple.move(by: offset.simple)
+    mixed.move(by: offset.mixed)
+    generic.move(by: offset.generic)
   }
 }
 
@@ -374,7 +374,7 @@ struct SR_12793: Differentiable {
 
   // Test usage of synthesized `TangentVector` type.
   // This should not produce an error: "reference to invalid associated type 'TangentVector'".
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // Test property wrappers.
@@ -400,7 +400,7 @@ struct Generic<T> {}
 extension Generic: Differentiable where T: Differentiable {}
 
 struct WrappedProperties: Differentiable {
-  // expected-warning @+1 {{synthesis of the 'Differentiable.move(along:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(along:)'; add an explicit '@noDerivative' attribute}}
+  // expected-warning @+1 {{synthesis of the 'Differentiable.move(by:)' requirement for 'WrappedProperties' requires 'wrappedValue' in property wrapper 'ImmutableWrapper' to be mutable or have a non-mutating 'move(by:)'; add an explicit '@noDerivative' attribute}}
   @ImmutableWrapper var immutableInt: Generic<Int>
 
   // expected-warning @+1 {{stored property 'mutableInt' has no derivative because 'Generic<Int>' does not conform to 'Differentiable'; add an explicit '@noDerivative' attribute}}
@@ -421,7 +421,7 @@ struct WrappedProperties: Differentiable {
 // Verify that cross-file derived conformances are disallowed.
 
 extension OtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring struct 'OtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}
 
 extension GenericOtherFileNonconforming: Differentiable {}
-// expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(along:)' for protocol 'Differentiable'}}
+// expected-error @-1 {{extension outside of file declaring generic struct 'GenericOtherFileNonconforming' prevents automatic synthesis of 'move(by:)' for protocol 'Differentiable'}}

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -401,8 +401,8 @@ where T: Differentiable & AdditiveArithmetic {
     fatalError()
   }
   typealias TangentVector = Struct<T.TangentVector>
-  mutating func move(along direction: TangentVector) {
-    x.move(along: direction.x)
+  mutating func move(by offset: TangentVector) {
+    x.move(by: offset.x)
   }
 }
 
@@ -740,7 +740,7 @@ func vjpMultipleSemanticResults(x: inout Float) -> (
 
 struct InoutParameters: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 }
 
 extension InoutParameters {

--- a/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/differentiable_attr_type_checking.swift
@@ -53,7 +53,7 @@ func dupe_attributes(arg1: Float, arg2: Float) -> Float { return arg1 }
 
 struct ComputedPropertyDupeAttributes<T: Differentiable>: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var value: T
 
@@ -85,7 +85,7 @@ protocol WrtOnlySelfProtocol: Differentiable {
 
 class Class: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 }
 @differentiable(reverse, wrt: x)
 func invalidDiffWrtClass(_ x: Class) -> Class {
@@ -144,7 +144,7 @@ struct InstanceMethod {
 // Test instance methods for a `Differentiable` type.
 struct DifferentiableInstanceMethod: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse) // ok
   func noParams() -> Float {
@@ -155,7 +155,7 @@ struct DifferentiableInstanceMethod: Differentiable {
 // Test subscript methods.
 struct SubscriptMethod: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   @differentiable(reverse) // ok
   subscript(implicitGetter x: Float) -> Float {
@@ -245,7 +245,7 @@ protocol ProtocolRequirementsRefined: ProtocolRequirements {
 
 struct InternalDiffAttrConformance: ProtocolRequirements {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var x: Float
   var y: Float
@@ -283,7 +283,7 @@ struct InternalDiffAttrConformance: ProtocolRequirements {
 // expected-error @+1 {{does not conform to protocol 'ProtocolRequirements'}}
 public struct PublicDiffAttrConformance: ProtocolRequirements {
   public typealias TangentVector = DummyTangentVector
-  public mutating func move(along _: TangentVector) {}
+  public mutating func move(by _: TangentVector) {}
 
   var x: Float
   var y: Float
@@ -366,7 +366,7 @@ protocol TF285: Differentiable {
 
 struct TF285MissingOneDiffAttr: TF285 {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   // Requirement is missing the required `@differentiable(reverse, wrt: (x, y))` attribute.
   // Since `TF285MissingOneDiffAttr.foo` is internal, the attribute is implicitly created.
@@ -414,7 +414,7 @@ func infer2(_ fn: @differentiable(reverse) (Float) -> Float, x: Float) -> Float 
 
 struct DiffableStruct: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var a: Float
 
@@ -437,7 +437,7 @@ struct NonDiffableStruct {
 
 struct NumberWrtStruct: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var a, b: Float
 
@@ -579,7 +579,7 @@ extension ProtocolRequirementUnsupported {
 
 class Super: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 
   var base: Float
 
@@ -644,7 +644,7 @@ class Sub: Super {
 
 final class FinalClass: Differentiable {
   typealias TangentVector = DummyTangentVector
-  func move(along _: TangentVector) {}
+  func move(by _: TangentVector) {}
 
   var base: Float
 
@@ -669,7 +669,7 @@ func swap(x: inout Float, y: inout Float) {}
 
 struct InoutParameters: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 }
 
 extension InoutParameters {
@@ -694,7 +694,7 @@ extension InoutParameters {
 
 struct Accessors: Differentiable {
   typealias TangentVector = DummyTangentVector
-  mutating func move(along _: TangentVector) {}
+  mutating func move(by _: TangentVector) {}
 
   var stored: Float
   var computed: Float {

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -183,7 +183,7 @@ extension Vector: Differentiable where T: Differentiable {
     static func - (lhs: Self, rhs: Self) -> Self { fatalError() }
     typealias TangentVector = Self
   }
-  mutating func move(along direction: TangentVector) { fatalError() }
+  mutating func move(by offset: TangentVector) { fatalError() }
 }
 
 // expected-note@+1 2 {{found this candidate}}

--- a/test/AutoDiff/Sema/transpose_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/transpose_attr_type_checking.swift
@@ -402,7 +402,7 @@ struct level1 {
     static func + (_: Self, _: Self) -> Self { Self() }
     static func - (_: Self, _: Self) -> Self { Self() }
     typealias TangentVector = Self
-    mutating func move(along: TangentVector) {}
+    mutating func move(by: TangentVector) {}
     func foo(x: Float) -> Float {
       return x
     }
@@ -483,7 +483,7 @@ where T: Differentiable & AdditiveArithmetic {
   static func + (_: Self, _: Self) -> Self { Self() }
   static func - (_: Self, _: Self) -> Self { Self() }
   typealias TangentVector = Self
-  mutating func move(along: TangentVector) {}
+  mutating func move(by: TangentVector) {}
 }
 
 // Test computed properties.

--- a/test/AutoDiff/Serialization/differentiable_attr.swift
+++ b/test/AutoDiff/Serialization/differentiable_attr.swift
@@ -58,7 +58,7 @@ struct InstanceMethod : Differentiable {
     static func +(_: Self, _: Self) -> Self { fatalError() }
     static func -(_: Self, _: Self) -> Self { fatalError() }
   }
-  mutating func move(along direction: TangentVector) {}
+  mutating func move(by offset: TangentVector) {}
 }
 
 // CHECK: @differentiable(reverse, wrt: x where T : Differentiable)

--- a/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
@@ -9,4 +9,4 @@ func foo(x: Float?) -> Float {
    _ = withoutDerivative(at: x ?? 0)
    return 0
 }
-gradient(at: 0, in: foo)
+gradient(at: 0, of: foo)

--- a/test/AutoDiff/compiler_crashers_fixed/sr12493-differentiable-function-extract-subst-function-type.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12493-differentiable-function-extract-subst-function-type.swift
@@ -17,6 +17,6 @@ func exampleVJP_1(_ x0: Float) -> (Float, (Float) -> (Float)) {
 
 func bar() {
   let f = differentiableFunction(from: exampleVJP_1)
-  let pb = pullback(at: 10, in: f)
+  let pb = pullback(at: 10, of: f)
   _ = pb(1)
 }

--- a/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr12641-silgen-immutable-address-use-verification-failure.swift
@@ -19,7 +19,7 @@ public func f(_ c: Class) -> Resilient {
   return Resilient(x: 0)
 }
 
-_ = pullback(at: Class(Resilient(x: 10)), in: f)
+_ = pullback(at: Class(Resilient(x: 10)), of: f)
 
 // swift/lib/SIL/Verifier/SILVerifier.cpp:456: bool (anonymous namespace)::ImmutableAddressUseVerifier::isConsumingOrMutatingArgumentConvention(swift::SILArgumentConvention): Assertion `conv.isIndirectConvention() && "Expect an indirect convention"' failed.
 // Stack dump:

--- a/test/AutoDiff/stdlib/anydifferentiable.swift
+++ b/test/AutoDiff/stdlib/anydifferentiable.swift
@@ -112,7 +112,7 @@ TypeErasureTests.test("AnyDifferentiable differentiation") {
   do {
     let x: Float = 3
     let v = AnyDerivative(Float(2))
-    let 𝛁x = pullback(at: x, in: { AnyDifferentiable($0) })(v)
+    let 𝛁x = pullback(at: x, of: { AnyDifferentiable($0) })(v)
     let expectedVJP: Float = 2
     expectEqual(expectedVJP, 𝛁x)
   }
@@ -120,7 +120,7 @@ TypeErasureTests.test("AnyDifferentiable differentiation") {
   do {
     let x = Vector(x: 4, y: 5)
     let v = AnyDerivative(Vector.TangentVector(x: 2, y: 2))
-    let 𝛁x = pullback(at: x, in: { AnyDifferentiable($0) })(v)
+    let 𝛁x = pullback(at: x, of: { AnyDifferentiable($0) })(v)
     let expectedVJP = Vector.TangentVector(x: 2, y: 2)
     expectEqual(expectedVJP, 𝛁x)
   }
@@ -128,7 +128,7 @@ TypeErasureTests.test("AnyDifferentiable differentiation") {
   do {
     let x = Generic<Double>(x: 4)
     let v = AnyDerivative(Generic<Double>.TangentVector(x: 2))
-    let 𝛁x = pullback(at: x, in: { AnyDifferentiable($0) })(v)
+    let 𝛁x = pullback(at: x, of: { AnyDifferentiable($0) })(v)
     let expectedVJP = Generic<Double>.TangentVector(x: 2)
     expectEqual(expectedVJP, 𝛁x)
   }
@@ -147,7 +147,7 @@ TypeErasureTests.test("AnyDerivative differentiation") {
     let v = AnyDerivative(Float(1))
     let expectedVJP: Float = 3
 
-    let (𝛁x, 𝛁y) = pullback(at: x, y, in: tripleSum)(v)
+    let (𝛁x, 𝛁y) = pullback(at: x, y, of: tripleSum)(v)
     expectEqual(expectedVJP, 𝛁x.base as? Float)
     expectEqual(expectedVJP, 𝛁y.base as? Float)
   }
@@ -158,7 +158,7 @@ TypeErasureTests.test("AnyDerivative differentiation") {
     let v = AnyDerivative(Vector.TangentVector(x: 1, y: 1))
     let expectedVJP = Vector.TangentVector(x: 3, y: 3)
 
-    let (𝛁x, 𝛁y) = pullback(at: x, y, in: tripleSum)(v)
+    let (𝛁x, 𝛁y) = pullback(at: x, y, of: tripleSum)(v)
     expectEqual(expectedVJP, 𝛁x.base as? Vector.TangentVector)
     expectEqual(expectedVJP, 𝛁y.base as? Vector.TangentVector)
   }
@@ -169,7 +169,7 @@ TypeErasureTests.test("AnyDerivative differentiation") {
     let v = AnyDerivative(Generic<Double>.TangentVector(x: 1))
     let expectedVJP = Generic<Double>.TangentVector(x: 3)
 
-    let (𝛁x, 𝛁y) = pullback(at: x, y, in: tripleSum)(v)
+    let (𝛁x, 𝛁y) = pullback(at: x, y, of: tripleSum)(v)
     expectEqual(expectedVJP, 𝛁x.base as? Generic<Double>.TangentVector)
     expectEqual(expectedVJP, 𝛁y.base as? Generic<Double>.TangentVector)
   }
@@ -184,7 +184,7 @@ TypeErasureTests.test("AnyDerivative differentiation") {
   do {
     let x: Float = 3
     let v = AnyDerivative(Float(1))
-    let 𝛁x = pullback(at: x, in: { x in typeErased(x) })(v)
+    let 𝛁x = pullback(at: x, of: { x in typeErased(x) })(v)
     let expectedVJP: Float = 2
     expectEqual(expectedVJP, 𝛁x)
   }
@@ -192,7 +192,7 @@ TypeErasureTests.test("AnyDerivative differentiation") {
   do {
     let x = Vector.TangentVector(x: 4, y: 5)
     let v = AnyDerivative(Vector.TangentVector(x: 1, y: 1))
-    let 𝛁x = pullback(at: x, in: { x in typeErased(x) })(v)
+    let 𝛁x = pullback(at: x, of: { x in typeErased(x) })(v)
     let expectedVJP = Vector.TangentVector(x: 2, y: 2)
     expectEqual(expectedVJP, 𝛁x)
   }
@@ -200,7 +200,7 @@ TypeErasureTests.test("AnyDerivative differentiation") {
   do {
     let x = Generic<Double>.TangentVector(x: 4)
     let v = AnyDerivative(Generic<Double>.TangentVector(x: 1))
-    let 𝛁x = pullback(at: x, in: { x in typeErased(x) })(v)
+    let 𝛁x = pullback(at: x, of: { x in typeErased(x) })(v)
     let expectedVJP = Generic<Double>.TangentVector(x: 2)
     expectEqual(expectedVJP, 𝛁x)
   }

--- a/test/AutoDiff/stdlib/anydifferentiable.swift
+++ b/test/AutoDiff/stdlib/anydifferentiable.swift
@@ -15,9 +15,9 @@ struct Generic<T: Differentiable & Equatable>: Differentiable, Equatable {
 
 extension AnyDerivative {
   // This exists only to faciliate testing.
-  func moved(along direction: TangentVector) -> Self {
+  func moved(along offset: TangentVector) -> Self {
     var result = self
-    result.move(along: direction)
+    result.move(by: offset)
     return result
   }
 }
@@ -26,14 +26,14 @@ TypeErasureTests.test("AnyDifferentiable operations") {
   do {
     var any = AnyDifferentiable(Vector(x: 1, y: 1))
     let tan = AnyDerivative(Vector.TangentVector(x: 1, y: 1))
-    any.move(along: tan)
+    any.move(by: tan)
     expectEqual(Vector(x: 2, y: 2), any.base as? Vector)
   }
 
   do {
     var any = AnyDifferentiable(Generic<Float>(x: 1))
     let tan = AnyDerivative(Generic<Float>.TangentVector(x: 1))
-    any.move(along: tan)
+    any.move(by: tan)
     expectEqual(Generic<Float>(x: 2), any.base as? Generic<Float>)
   }
 }

--- a/test/AutoDiff/stdlib/collection_higher_order_functions.swift
+++ b/test/AutoDiff/stdlib/collection_higher_order_functions.swift
@@ -15,19 +15,19 @@ CollectionHOFTests.test("differentiableMap(_:)") {
   func double(_ array: [Float]) -> [Float] {
     array.differentiableMap { $0 * $0 }
   }
-  expectEqual([], pullback(at: array, in: double)([]))
-  expectEqual([0], pullback(at: array, in: double)([0]))
-  expectEqual([2], pullback(at: array, in: double)([1]))
-  expectEqual([2, 4, 6, 8, 10], pullback(at: array, in: double)([1, 1, 1, 1, 1]))
+  expectEqual([], pullback(at: array, of: double)([]))
+  expectEqual([0], pullback(at: array, of: double)([0]))
+  expectEqual([2], pullback(at: array, of: double)([1]))
+  expectEqual([2, 4, 6, 8, 10], pullback(at: array, of: double)([1, 1, 1, 1, 1]))
 }
 
 CollectionHOFTests.test("differentiableReduce(_:_:)") {
   func product(_ array: [Float]) -> Float {
     array.differentiableReduce(1) { $0 * $1 }
   }
-  expectEqual([1], gradient(at: [0], in: product))
-  expectEqual([1], gradient(at: [1], in: product))
-  expectEqual([120, 60, 40, 30, 24], gradient(at: array, in: product))
+  expectEqual([1], gradient(at: [0], of: product))
+  expectEqual([1], gradient(at: [1], of: product))
+  expectEqual([120, 60, 40, 30, 24], gradient(at: array, of: product))
 }
 
 runAllTests()

--- a/test/AutoDiff/stdlib/differentiable_protocol.swift
+++ b/test/AutoDiff/stdlib/differentiable_protocol.swift
@@ -39,7 +39,7 @@ extension Wrapper: AdditiveArithmetic where T: AdditiveArithmetic {
 }
 extension Wrapper: Differentiable where T: Differentiable {
   typealias TangentVector = Wrapper<T.TangentVector>
-  mutating func move(along direction: TangentVector) {
-    value.move(along: direction.value)
+  mutating func move(by offset: TangentVector) {
+    value.move(by: offset.value)
   }
 }

--- a/test/AutoDiff/stdlib/differential_operators.swift.gyb
+++ b/test/AutoDiff/stdlib/differential_operators.swift.gyb
@@ -33,23 +33,23 @@ func exampleVJP_${arity}(${params}) -> (value: Float, pullback: (Float) -> ${pb_
 % expectedGradients = '(' + ', '.join([str(g) for g in expectedGradientValues]) + ')'
 
 DifferentialOperatorTestSuite.test("valueWithPullback_${arity}") {
-  let (value, pb) = valueWithPullback(at: ${args}, in: exampleDiffFunc_${arity})
+  let (value, pb) = valueWithPullback(at: ${args}, of: exampleDiffFunc_${arity})
   expectEqual(${expectedValue}, value)
   expectEqual(${expectedGradients}, pb(1))
 }
 
 DifferentialOperatorTestSuite.test("pullback_${arity}") {
-  let pb = pullback(at: ${args}, in: exampleDiffFunc_${arity})
+  let pb = pullback(at: ${args}, of: exampleDiffFunc_${arity})
   expectEqual(${expectedGradients}, pb(1))
 }
 
 DifferentialOperatorTestSuite.test("gradient_${arity}") {
-  let grad = gradient(at: ${args}, in: exampleDiffFunc_${arity})
+  let grad = gradient(at: ${args}, of: exampleDiffFunc_${arity})
   expectEqual(${expectedGradients}, grad)
 }
 
 DifferentialOperatorTestSuite.test("valueWithGradient_${arity}") {
-  let (value, grad) = valueWithGradient(at: ${args}, in: exampleDiffFunc_${arity})
+  let (value, grad) = valueWithGradient(at: ${args}, of: exampleDiffFunc_${arity})
   expectEqual(${expectedValue}, value)
   expectEqual(${expectedGradients}, grad)
 }

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -35,68 +35,68 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
 %end
 
 FloatingPointDerivativeTests.test("${Self}.+") {
-  expectEqual((1, 1), gradient(at: ${Self}(4), ${Self}(5), in: +))
-  expectEqual((10, 10), pullback(at: ${Self}(4), ${Self}(5), in: +)(${Self}(10)))
+  expectEqual((1, 1), gradient(at: ${Self}(4), ${Self}(5), of: +))
+  expectEqual((10, 10), pullback(at: ${Self}(4), ${Self}(5), of: +)(${Self}(10)))
 
-  expectEqual(2, derivative(at: ${Self}(4), ${Self}(5), in: +))
-  expectEqual(20, differential(at: ${Self}(4), ${Self}(5), in: +)(${Self}(10), ${Self}(10)))
+  expectEqual(2, derivative(at: ${Self}(4), ${Self}(5), of: +))
+  expectEqual(20, differential(at: ${Self}(4), ${Self}(5), of: +)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.-") {
-  expectEqual((1, -1), gradient(at: ${Self}(4), ${Self}(5), in: -))
-  expectEqual((10, -10), pullback(at: ${Self}(4), ${Self}(5), in: -)(${Self}(10)))
+  expectEqual((1, -1), gradient(at: ${Self}(4), ${Self}(5), of: -))
+  expectEqual((10, -10), pullback(at: ${Self}(4), ${Self}(5), of: -)(${Self}(10)))
 
-  expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), in: -))
-  expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), in: -)(${Self}(5), ${Self}(10)))
+  expectEqual(0, derivative(at: ${Self}(4), ${Self}(5), of: -))
+  expectEqual(-5, differential(at: ${Self}(4), ${Self}(5), of: -)(${Self}(5), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.*") {
-  expectEqual((5, 4), gradient(at: ${Self}(4), ${Self}(5), in: *))
-  expectEqual((50, 40), pullback(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10)))
+  expectEqual((5, 4), gradient(at: ${Self}(4), ${Self}(5), of: *))
+  expectEqual((50, 40), pullback(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10)))
 
-  expectEqual(9, derivative(at: ${Self}(4), ${Self}(5), in: *))
-  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
+  expectEqual(9, derivative(at: ${Self}(4), ${Self}(5), of: *))
+  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}./") {
   do {
-    let (dx, dy) = gradient(at: ${Self}(4), ${Self}(5), in: /)
+    let (dx, dy) = gradient(at: ${Self}(4), ${Self}(5), of: /)
     expectEqual(0.2, dx)
     expectEqual(-0.16, dy)
   }
   do {
-    let (dx, dy) = pullback(at: ${Self}(4), ${Self}(5), in: /)(${Self}(10))
+    let (dx, dy) = pullback(at: ${Self}(4), ${Self}(5), of: /)(${Self}(10))
     expectEqual(2, dx)
     expectEqualWithTolerance(-1.6, dy)
   }
 
-  expectEqualWithTolerance(0.04, derivative(at: ${Self}(4), ${Self}(5), in: /))
-  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), in: *)(${Self}(10), ${Self}(10)))
+  expectEqualWithTolerance(0.04, derivative(at: ${Self}(4), ${Self}(5), of: /))
+  expectEqual(90, differential(at: ${Self}(4), ${Self}(5), of: *)(${Self}(10), ${Self}(10)))
 }
 
 FloatingPointDerivativeTests.test("${Self}.squareRoot") {
-  expectEqual(0.5, gradient(at: 1, in: { $0.squareRoot() }))
-  expectEqual(0.25, gradient(at: 4, in: { $0.squareRoot() }))
+  expectEqual(0.5, gradient(at: 1, of: { $0.squareRoot() }))
+  expectEqual(0.25, gradient(at: 4, of: { $0.squareRoot() }))
 }
 
 FloatingPointDerivativeTests.test("${Self}.addingProduct") {
-  expectEqual((1, 2, 3), gradient(at: ${Self}(10), 3, 2, in: { $0.addingProduct($1, $2) }))
+  expectEqual((1, 2, 3), gradient(at: ${Self}(10), 3, 2, of: { $0.addingProduct($1, $2) }))
 }
 
 FloatingPointDerivativeTests.test("${Self}.minimum") {
-  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), ${Self}(2), in : { ${Self}.minimum($0, $1) }))
-  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), ${Self}(1), in : { ${Self}.minimum($0, $1) }))
-  expectEqual((0.0, 1.0), gradient(at: ${Self}(2), ${Self}(1), in : { ${Self}.minimum($0, $1) }))
-  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), .nan, in : { ${Self}.minimum($0, $1) }))
-  expectEqual((0.0, 1.0), gradient(at: .nan, ${Self}(1), in : { ${Self}.minimum($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), ${Self}(2), of: { ${Self}.minimum($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), ${Self}(1), of: { ${Self}.minimum($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: ${Self}(2), ${Self}(1), of: { ${Self}.minimum($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), .nan, of: { ${Self}.minimum($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: .nan, ${Self}(1), of: { ${Self}.minimum($0, $1) }))
 }
 
 FloatingPointDerivativeTests.test("${Self}.maximum") {
-  expectEqual((0.0, 1.0), gradient(at: ${Self}(1), ${Self}(2), in : { ${Self}.maximum($0, $1) }))
-  expectEqual((0.0, 1.0), gradient(at: ${Self}(1), ${Self}(1), in : { ${Self}.maximum($0, $1) }))
-  expectEqual((1.0, 0.0), gradient(at: ${Self}(2), ${Self}(1), in : { ${Self}.maximum($0, $1) }))
-  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), .nan, in : { ${Self}.maximum($0, $1) }))
-  expectEqual((0.0, 1.0), gradient(at: .nan, ${Self}(1), in : { ${Self}.maximum($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: ${Self}(1), ${Self}(2), of: { ${Self}.maximum($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: ${Self}(1), ${Self}(1), of: { ${Self}.maximum($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(2), ${Self}(1), of: { ${Self}.maximum($0, $1) }))
+  expectEqual((1.0, 0.0), gradient(at: ${Self}(1), .nan, of: { ${Self}.maximum($0, $1) }))
+  expectEqual((0.0, 1.0), gradient(at: .nan, ${Self}(1), of: { ${Self}.maximum($0, $1) }))
 }
 
 %if Self == 'Float80':

--- a/test/AutoDiff/stdlib/optional.swift
+++ b/test/AutoDiff/stdlib/optional.swift
@@ -7,35 +7,35 @@ import StdlibUnittest
 var OptionalDifferentiationTests = TestSuite("OptionalDifferentiation")
 
 OptionalDifferentiationTests.test("Optional operations") {
-  // Differentiable.move(along:)
+  // Differentiable.move(by:)
   do {
     var some: Float? = 2
-    some.move(along: .init(3))
+    some.move(by: .init(3))
     expectEqual(5, some)
 
     var none: Float? = nil
-    none.move(along: .init(3))
+    none.move(by: .init(3))
     expectEqual(nil, none)
   }
 }
 
 OptionalDifferentiationTests.test("Optional.TangentVector operations") {
-  // Differentiable.move(along:)
+  // Differentiable.move(by:)
   do {
     var some: Optional<Float>.TangentVector = .init(2)
-    some.move(along: .init(3))
+    some.move(by: .init(3))
     expectEqual(5, some.value)
 
     var none: Optional<Float>.TangentVector = .init(nil)
-    none.move(along: .init(3))
+    none.move(by: .init(3))
     expectEqual(nil, none.value)
 
     var nestedSome: Optional<Optional<Float>>.TangentVector = .init(.init(2))
-    nestedSome.move(along: .init(.init(3)))
+    nestedSome.move(by: .init(.init(3)))
     expectEqual(.init(5), nestedSome.value)
 
     var nestedNone: Optional<Optional<Float>>.TangentVector = .init(.init(nil))
-    nestedNone.move(along: .init(.init(3)))
+    nestedNone.move(by: .init(.init(3)))
     expectEqual(.init(nil), nestedNone.value)
   }
 

--- a/test/AutoDiff/stdlib/simd.swift
+++ b/test/AutoDiff/stdlib/simd.swift
@@ -15,7 +15,7 @@ SIMDTests.test("init(repeating:)") {
   func foo1(x: Float) -> SIMD4<Float> {
     return SIMD4<Float>(repeating: 2 * x)
   }
-  let (val1, pb1) = valueWithPullback(at: 5, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: 5, of: foo1)
   expectEqual(SIMD4<Float>(10, 10, 10, 10), val1)
   expectEqual(8, pb1(g))
 }
@@ -29,7 +29,7 @@ SIMDTests.test("Sum") {
   func foo1(x: SIMD4<Float>) -> Float {
     return x.sum()
   }
-  let (val1, pb1) = valueWithPullback(at: a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, of: foo1)
   expectEqual(10, val1)
   expectEqual(SIMD4<Float>(3, 3, 3, 3), pb1(3))
 }
@@ -42,7 +42,7 @@ SIMDTests.test("Identity") {
   func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
     return x
   }
-  let (val1, pb1) = valueWithPullback(at: a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, of: foo1)
   expectEqual(a, val1)
   expectEqual(g, pb1(g))
 }
@@ -54,7 +54,7 @@ SIMDTests.test("Negate") {
   func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
     return -x
   }
-  let (val1, pb1) = valueWithPullback(at: a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, of: foo1)
   expectEqual(-a, val1)
   expectEqual(-g, pb1(g))
 }
@@ -66,7 +66,7 @@ SIMDTests.test("Subscript") {
     return x[3]
   }
 
-  let (val1, pb1) = valueWithPullback(at: a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, of: foo1)
   expectEqual(4, val1)
   expectEqual(SIMD4<Float>(0, 0, 0, 7), pb1(7))
 }
@@ -84,7 +84,7 @@ SIMDTests.test("SubscriptSetter") {
     return result
   }
 
-  let (val1, pb1) = valueWithPullback(at: a, 5, in: { subscriptSet($0, index: 2, newScalar: $1) })
+  let (val1, pb1) = valueWithPullback(at: a, 5, of: { subscriptSet($0, index: 2, newScalar: $1) })
   expectEqual(SIMD4<Float>(1, 2, 5, 4), val1)
   expectEqual((SIMD4<Float>(1, 1, 0, 1), 1), pb1(ones))
 
@@ -95,7 +95,7 @@ SIMDTests.test("SubscriptSetter") {
     }
     return result
   }
-  let (val2, pb2) = valueWithPullback(at: a, in: doubled)
+  let (val2, pb2) = valueWithPullback(at: a, of: doubled)
   expectEqual(SIMD4<Float>(2, 4, 6, 8), val2)
   expectEqual(SIMD4<Float>(2, 2, 2, 2), pb2(ones))
 }
@@ -108,7 +108,7 @@ SIMDTests.test("Addition") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x + y
   }
-  let (val1, pb1) = valueWithPullback(at: a, a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, a, of: foo1)
   expectEqual(SIMD4<Float>(2, 4, 6, 8), val1)
   expectEqual((g, g), pb1(g))
 
@@ -116,7 +116,7 @@ SIMDTests.test("Addition") {
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x + y
   }
-  let (val2, pb2) = valueWithPullback(at: a, 5, in: foo2)
+  let (val2, pb2) = valueWithPullback(at: a, 5, of: foo2)
   expectEqual(SIMD4<Float>(6, 7, 8, 9), val2)
   expectEqual((g, 4), pb2(g))
 
@@ -124,7 +124,7 @@ SIMDTests.test("Addition") {
   func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y + x
   }
-  let (val3, pb3) = valueWithPullback(at: a, 5, in: foo3)
+  let (val3, pb3) = valueWithPullback(at: a, 5, of: foo3)
   expectEqual(SIMD4<Float>(6, 7, 8, 9), val3)
   expectEqual((g, 4), pb3(g))
 }
@@ -137,7 +137,7 @@ SIMDTests.test("Subtraction") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x - y
   }
-  let (val1, pb1) = valueWithPullback(at: a, a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, a, of: foo1)
   expectEqual(SIMD4<Float>(0, 0, 0, 0), val1)
   expectEqual((g, -g), pb1(g))
 
@@ -145,7 +145,7 @@ SIMDTests.test("Subtraction") {
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x - y
   }
-  let (val2, pb2) = valueWithPullback(at: a, 5, in: foo2)
+  let (val2, pb2) = valueWithPullback(at: a, 5, of: foo2)
   expectEqual(SIMD4<Float>(-4, -3, -2, -1), val2)
   expectEqual((g, -4), pb2(g))
 
@@ -153,7 +153,7 @@ SIMDTests.test("Subtraction") {
   func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y - x
   }
-  let (val3, pb3) = valueWithPullback(at: a, 5, in: foo3)
+  let (val3, pb3) = valueWithPullback(at: a, 5, of: foo3)
   expectEqual(SIMD4<Float>(4, 3, 2, 1), val3)
   expectEqual((-g, 4), pb3(g))
 }
@@ -166,7 +166,7 @@ SIMDTests.test("Multiplication") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x * y
   }
-  let (val1, pb1) = valueWithPullback(at: a, a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, a, of: foo1)
   expectEqual(a * a, val1)
   expectEqual((a, a), pb1(g))
 
@@ -174,7 +174,7 @@ SIMDTests.test("Multiplication") {
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x * y
   }
-  let (val2, pb2) = valueWithPullback(at: a, 5, in: foo2)
+  let (val2, pb2) = valueWithPullback(at: a, 5, of: foo2)
   expectEqual(a * 5, val2)
   expectEqual((SIMD4<Float>(5, 5, 5, 5), 10), pb2(g))
 
@@ -182,7 +182,7 @@ SIMDTests.test("Multiplication") {
   func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y * x
   }
-  let (val3, pb3) = valueWithPullback(at: a, 5, in: foo3)
+  let (val3, pb3) = valueWithPullback(at: a, 5, of: foo3)
   expectEqual(a * 5, val3)
   expectEqual((SIMD4<Float>(5, 5, 5, 5), 10), pb3(g))
 }
@@ -197,7 +197,7 @@ SIMDTests.test("Division") {
   }
   let dlhs1 = g / a
   let drhs1 = -1 / a
-  let (val1, pb1) = valueWithPullback(at: a, a, in: foo1)
+  let (val1, pb1) = valueWithPullback(at: a, a, of: foo1)
   expectEqual(a / a, val1)
   expectEqual((dlhs1, drhs1), pb1(g))
 
@@ -207,7 +207,7 @@ SIMDTests.test("Division") {
   }
   let dlhs2 = g / 5
   let drhs2 = (-a / 25 * g).sum()
-  let (val2, pb2) = valueWithPullback(at: a, 5, in: foo2)
+  let (val2, pb2) = valueWithPullback(at: a, 5, of: foo2)
   expectEqual(a / 5, val2)
   expectEqual((dlhs2, drhs2), pb2(g))
 
@@ -217,7 +217,7 @@ SIMDTests.test("Division") {
   }
   let dlhs3 = (g / a).sum()
   let drhs3 = -5 / (a*a) * g
-  let (val3, pb3) = valueWithPullback(at: 5, a, in: foo3)
+  let (val3, pb3) = valueWithPullback(at: 5, a, of: foo3)
   expectEqual(5 / a, val3)
   expectEqual((dlhs3, drhs3), pb3(g))
 }
@@ -235,7 +235,7 @@ SIMDTests.test("Generics") {
     return SIMDType.init(repeating: x)
   }
   func simd3Init(x: Double) -> SIMD3<Double> { testInit(x: x) }
-  let (val1, pb1) = valueWithPullback(at: 10, in: simd3Init)
+  let (val1, pb1) = valueWithPullback(at: 10, of: simd3Init)
   expectEqual(SIMD3<Double>(10, 10, 10), val1)
   expectEqual(3, pb1(g))
 
@@ -252,7 +252,7 @@ SIMDTests.test("Generics") {
   func simd3Add(lhs: SIMD3<Double>, rhs: SIMD3<Double>) -> SIMD3<Double> {
     return testAddition(lhs: lhs, rhs: rhs)
   }
-  let (val2, pb2) = valueWithPullback(at: a, a, in: simd3Add)
+  let (val2, pb2) = valueWithPullback(at: a, a, of: simd3Add)
   expectEqual(SIMD3<Double>(2, 4, 6), val2)
   expectEqual((g, g), pb2(g))
 
@@ -269,7 +269,7 @@ SIMDTests.test("Generics") {
   func simd3Subtract(lhs: Double, rhs: SIMD3<Double>) -> SIMD3<Double> {
     return testSubtraction(lhs: lhs, rhs: rhs)
   }
-  let (val3, pb3) = valueWithPullback(at: 5, a, in: simd3Subtract)
+  let (val3, pb3) = valueWithPullback(at: 5, a, of: simd3Subtract)
   expectEqual(SIMD3<Double>(4, 3, 2), val3)
   expectEqual((3, SIMD3<Double>(-1, -1, -1)), pb3(g))
 
@@ -286,7 +286,7 @@ SIMDTests.test("Generics") {
   func simd3Multiply(lhs: SIMD3<Double>, rhs: Double) -> SIMD3<Double> {
     return testMultiplication(lhs: lhs, rhs: rhs)
   }
-  let (val4, pb4) = valueWithPullback(at: a, 5, in: simd3Multiply)
+  let (val4, pb4) = valueWithPullback(at: a, 5, of: simd3Multiply)
   expectEqual(SIMD3<Double>(5, 10, 15), val4)
   expectEqual((SIMD3<Double>(5, 5, 5), 6), pb4(g))
 
@@ -302,7 +302,7 @@ SIMDTests.test("Generics") {
     return x.sum()
   }
   func simd3Sum(x: SIMD3<Double>) -> Double { testSum(x: x) }
-  let (val5, pb5) = valueWithPullback(at: a, in: simd3Sum)
+  let (val5, pb5) = valueWithPullback(at: a, of: simd3Sum)
   expectEqual(6, val5)
   expectEqual(SIMD3<Double>(7, 7, 7), pb5(7))
   */

--- a/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
+++ b/test/AutoDiff/stdlib/tgmath_derivatives.swift.gyb
@@ -56,7 +56,7 @@ func checkGradient<T: BinaryFloatingPoint & Differentiable>(
   ulps: T = 192)
 where T == T.TangentVector {
   let eps = T(0.01)
-  let grad = gradient(at: x, y, in: f)
+  let grad = gradient(at: x, y, of: f)
   let (dfdx, dfdy) = computeDividedDifference(f, x, y, eps: eps)
   expectEqualWithTolerance(TestLiteralType(dfdx), grad.0, ulps: ulps)
   expectEqualWithTolerance(TestLiteralType(dfdy), grad.1, ulps: ulps)
@@ -69,7 +69,7 @@ func checkDerivative<T: BinaryFloatingPoint & Differentiable>(
   ulps: T = 192)
 where T == T.TangentVector {
   let eps = T(0.01)
-  let deriv = derivative(at: x, y, in: f)
+  let deriv = derivative(at: x, y, of: f)
   let (dfdx, dfdy) = computeDividedDifference(f, x, y, eps: eps)
   expectEqualWithTolerance(TestLiteralType(dfdx + dfdy), deriv, ulps: ulps)
 }
@@ -82,37 +82,37 @@ where T == T.TangentVector {
 %end
 
 DerivativeTests.test("${op}_${T}") {
-  expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, in: exp))
-  expectEqualWithTolerance(2.772588722239781145, ${op}(at: 2 as ${T}, in: exp2))
-  expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, in: expm1))
-  expectEqualWithTolerance(0.5, ${op}(at: 2 as ${T}, in: log))
-  expectEqualWithTolerance(0.21714724095162590833, ${op}(at: 2 as ${T}, in: log10))
-  expectEqualWithTolerance(0.7213475204444817278, ${op}(at: 2 as ${T}, in: log2))
-  expectEqualWithTolerance(0.33333333333333333334, ${op}(at: 2 as ${T}, in: log1p))
-  expectEqualWithTolerance(5.774399204041917612, ${op}(at: 2 as ${T}, in: tan))
-  expectEqualWithTolerance(-0.9092974268256816954, ${op}(at: 2 as ${T}, in: cos))
-  expectEqualWithTolerance(-0.416146836547142387, ${op}(at: 2 as ${T}, in: sin))
-  expectEqualWithTolerance(1.154700538379251529, ${op}(at: 0.5 as ${T}, in: asin))
-  expectEqualWithTolerance(-1.154700538379251529, ${op}(at: 0.5 as ${T}, in: acos))
-  expectEqualWithTolerance(0.8, ${op}(at: 0.5 as ${T}, in: atan))
-  expectEqualWithTolerance(3.7621956910836314597, ${op}(at: 2 as ${T}, in: sinh))
-  expectEqualWithTolerance(3.6268604078470187677, ${op}(at: 2 as ${T}, in: cosh))
-  expectEqualWithTolerance(0.07065082485316446565, ${op}(at: 2 as ${T}, in: tanh))
-  expectEqualWithTolerance(0.44721359549995793928, ${op}(at: 2 as ${T}, in: asinh))
-  expectEqualWithTolerance(0.5773502691896257645, ${op}(at: 2 as ${T}, in: acosh))
-  expectEqualWithTolerance(1.3333333333333333334, ${op}(at: 0.5 as ${T}, in: atanh))
-  expectEqualWithTolerance(0.020666985354092053575, ${op}(at: 2 as ${T}, in: erf))
-  expectEqualWithTolerance(-0.020666985354092053575, ${op}(at: 2 as ${T}, in: erfc))
-  expectEqualWithTolerance(0.35355339059327376222, ${op}(at: 2 as ${T}, in: { sqrt($0) }))
-  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { ceil($0) }))
-  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { floor($0) }))
-  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { round($0) }))
-  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, in: { trunc($0) }))
+  expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, of: exp))
+  expectEqualWithTolerance(2.772588722239781145, ${op}(at: 2 as ${T}, of: exp2))
+  expectEqualWithTolerance(7.3890560989306502274, ${op}(at: 2 as ${T}, of: expm1))
+  expectEqualWithTolerance(0.5, ${op}(at: 2 as ${T}, of: log))
+  expectEqualWithTolerance(0.21714724095162590833, ${op}(at: 2 as ${T}, of: log10))
+  expectEqualWithTolerance(0.7213475204444817278, ${op}(at: 2 as ${T}, of: log2))
+  expectEqualWithTolerance(0.33333333333333333334, ${op}(at: 2 as ${T}, of: log1p))
+  expectEqualWithTolerance(5.774399204041917612, ${op}(at: 2 as ${T}, of: tan))
+  expectEqualWithTolerance(-0.9092974268256816954, ${op}(at: 2 as ${T}, of: cos))
+  expectEqualWithTolerance(-0.416146836547142387, ${op}(at: 2 as ${T}, of: sin))
+  expectEqualWithTolerance(1.154700538379251529, ${op}(at: 0.5 as ${T}, of: asin))
+  expectEqualWithTolerance(-1.154700538379251529, ${op}(at: 0.5 as ${T}, of: acos))
+  expectEqualWithTolerance(0.8, ${op}(at: 0.5 as ${T}, of: atan))
+  expectEqualWithTolerance(3.7621956910836314597, ${op}(at: 2 as ${T}, of: sinh))
+  expectEqualWithTolerance(3.6268604078470187677, ${op}(at: 2 as ${T}, of: cosh))
+  expectEqualWithTolerance(0.07065082485316446565, ${op}(at: 2 as ${T}, of: tanh))
+  expectEqualWithTolerance(0.44721359549995793928, ${op}(at: 2 as ${T}, of: asinh))
+  expectEqualWithTolerance(0.5773502691896257645, ${op}(at: 2 as ${T}, of: acosh))
+  expectEqualWithTolerance(1.3333333333333333334, ${op}(at: 0.5 as ${T}, of: atanh))
+  expectEqualWithTolerance(0.020666985354092053575, ${op}(at: 2 as ${T}, of: erf))
+  expectEqualWithTolerance(-0.020666985354092053575, ${op}(at: 2 as ${T}, of: erfc))
+  expectEqualWithTolerance(0.35355339059327376222, ${op}(at: 2 as ${T}, of: { sqrt($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, of: { ceil($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, of: { floor($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, of: { round($0) }))
+  expectEqualWithTolerance(0, ${op}(at: 2 as ${T}, of: { trunc($0) }))
 
   // Differential operator specific tests.
 
   // fma
-  let dfma = ${op}(at: 4 as ${T}, 5 as ${T}, 6 as ${T}, in: fma)
+  let dfma = ${op}(at: 4 as ${T}, 5 as ${T}, 6 as ${T}, of: fma)
 %if op == 'gradient':
   expectEqualWithTolerance(5, dfma.0)
   expectEqualWithTolerance(4, dfma.1)
@@ -149,7 +149,7 @@ DerivativeTests.test("${op}_${T}") {
       let y = ${T}(b)
       let expectedDx =  y * pow(x, y - 1)
       let expectedDy = ${T}.zero
-      let dpow = ${op}(at: x, y, in: pow)
+      let dpow = ${op}(at: x, y, of: pow)
 %if op == 'gradient':
       expectEqualWithTolerance(TestLiteralType(expectedDx), dpow.0)
       expectEqualWithTolerance(TestLiteralType(expectedDy), dpow.1)
@@ -171,7 +171,7 @@ DerivativeTests.test("${op}_${T}") {
       expectedValues = (dx: ${T}.zero, dy: ${T}.zero)
     }
     if let (expectedDx, expectedDy) = expectedValues {
-      let dpow = ${op}(at: 0.0, y, in: pow)
+      let dpow = ${op}(at: 0.0, y, of: pow)
 %if op == 'gradient':
       expectEqualWithTolerance(TestLiteralType(expectedDx), dpow.0)
       expectEqualWithTolerance(TestLiteralType(expectedDy), dpow.1)

--- a/test/AutoDiff/validation-test/Inputs/cross_module_derivative_attr/main/main.swift
+++ b/test/AutoDiff/validation-test/Inputs/cross_module_derivative_attr/main/main.swift
@@ -6,7 +6,7 @@ import module1
 var Tests = TestSuite("CrossModuleDerivativeAttr")
 
 Tests.test("CrossFile") {
-  let grad = gradient(at: 0, in: fCrossFile)
+  let grad = gradient(at: 0, of: fCrossFile)
   expectEqual(10, grad)
 }
 

--- a/test/AutoDiff/validation-test/address_only_tangentvector.swift
+++ b/test/AutoDiff/validation-test/address_only_tangentvector.swift
@@ -32,14 +32,14 @@ AddressOnlyTangentVectorTests.test("LoadableClassAddressOnlyTangentVector") {
     var x = s.stored
     return x
   }
-  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), in: projection))
+  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), of: projection))
 
   @differentiable(reverse)
   func tuple<T: Differentiable>(_ s: LoadableClass<T>) -> T {
     var tuple = (s, (s, s))
     return tuple.1.0.stored
   }
-  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), in: tuple))
+  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), of: tuple))
 
   @differentiable(reverse)
   func conditional<T: Differentiable>(_ s: LoadableClass<T>) -> T {
@@ -47,7 +47,7 @@ AddressOnlyTangentVectorTests.test("LoadableClassAddressOnlyTangentVector") {
     if false {}
     return tuple.1.0.stored
   }
-  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), in: conditional))
+  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), of: conditional))
 
   @differentiable(reverse)
   func loop<T: Differentiable>(_ array: [LoadableClass<T>]) -> T {
@@ -57,14 +57,14 @@ AddressOnlyTangentVectorTests.test("LoadableClassAddressOnlyTangentVector") {
     }
     return result[0].stored
   }
-  expectEqual([.init(stored: 1)], gradient(at: [LoadableClass<Float>(10)], in: loop))
+  expectEqual([.init(stored: 1)], gradient(at: [LoadableClass<Float>(10)], of: loop))
 
   @differentiable(reverse)
   func arrayLiteral<T: Differentiable>(_ s: LoadableClass<T>) -> T {
     var result: [[LoadableClass<T>]] = [[s, s]]
     return result[0][1].stored
   }
-  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), in: arrayLiteral))
+  expectEqual(.init(stored: 1), gradient(at: LoadableClass<Float>(10), of: arrayLiteral))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -25,7 +25,7 @@ ArrayAutoDiffTests.test("ArrayIdentity") {
     return x
   }
 
-  let backprop = pullback(at: [5, 6, 7, 8], in: arrayIdentity)
+  let backprop = pullback(at: [5, 6, 7, 8], of: arrayIdentity)
   expectEqual(
     FloatArrayTan([1, 2, 3, 4]),
     backprop(FloatArrayTan([1, 2, 3, 4])))
@@ -38,7 +38,7 @@ ArrayAutoDiffTests.test("ArraySubscript") {
 
   expectEqual(
     FloatArrayTan([1, 1, 1, 0, 0, 0]),
-    gradient(at: [2, 3, 4, 5, 6, 7], in: sumFirstThree))
+    gradient(at: [2, 3, 4, 5, 6, 7], of: sumFirstThree))
 }
 
 ArrayAutoDiffTests.test("ArrayLiteral") {
@@ -46,7 +46,7 @@ ArrayAutoDiffTests.test("ArrayLiteral") {
     func twoElementLiteral(_ x: Float, _ y: Float) -> [Float] {
       return [x, y]
     }
-    let pb = pullback(at: 1, 1, in: twoElementLiteral)
+    let pb = pullback(at: 1, 1, of: twoElementLiteral)
     expectEqual((1, 2), pb(FloatArrayTan([Float(1), Float(2)])))
   }
 
@@ -57,7 +57,7 @@ ArrayAutoDiffTests.test("ArrayLiteral") {
       result = result * y
       return [result, result]
     }
-    let pb = pullback(at: 3, 4, in: twoElementLiteralAddress)
+    let pb = pullback(at: 3, 4, of: twoElementLiteralAddress)
     expectEqual((8, 6), pb(FloatArrayTan([1, 1])))
   }
 
@@ -66,7 +66,7 @@ ArrayAutoDiffTests.test("ArrayLiteral") {
     func twoElementLiteralFunctionResult(_ x: Float, _ y: Float) -> [Float] {
       return [x * y, x * y]
     }
-    let pb = pullback(at: 3, 4, in: twoElementLiteralFunctionResult)
+    let pb = pullback(at: 3, 4, of: twoElementLiteralFunctionResult)
     expectEqual((8, 6), pb(FloatArrayTan([1, 1])))
   }
 
@@ -76,7 +76,7 @@ ArrayAutoDiffTests.test("ArrayLiteral") {
       let array = [x * y, x * y]
       return [array[0], array[1]]
     }
-    let pb = pullback(at: 3, 4, in: twoElementLiterals)
+    let pb = pullback(at: 3, 4, of: twoElementLiterals)
     expectEqual((8, 6), pb(FloatArrayTan([1, 1])))
   }
 }
@@ -86,7 +86,7 @@ ArrayAutoDiffTests.test("ArrayLiteralIndirect") {
     func twoElementLiteralIndirect<T: Differentiable>(_ x: T, _ y: T) -> [T] {
       return [x, y]
     }
-    let pb = pullback(at: Float(1), 1, in: { twoElementLiteralIndirect($0, $1) })
+    let pb = pullback(at: Float(1), 1, of: { twoElementLiteralIndirect($0, $1) })
     expectEqual((1, 2), pb(FloatArrayTan([1, 2])))
   }
 
@@ -97,7 +97,7 @@ ArrayAutoDiffTests.test("ArrayLiteralIndirect") {
       result = result + [y]
       return result
     }
-    let pb = pullback(at: Float(1), 1, in: { twoElementLiteralIndirectVar($0, $1) })
+    let pb = pullback(at: Float(1), 1, of: { twoElementLiteralIndirectVar($0, $1) })
     expectEqual((1, 2), pb(FloatArrayTan([1, 2])))
   }
 }
@@ -125,9 +125,9 @@ ArrayAutoDiffTests.test("ArrayLiteralStruct") {
       let array = structElementLiteral(s)
       return array[0] * array[1]
     }
-    expectEqual(TV(x: 1, y: 0), gradient(at: s, in: { s in structGeneric(s) }))
-    expectEqual(TV(x: 4, y: 3), gradient(at: s, in: structConcrete1))
-    expectEqual(TV(x: 4, y: 3), gradient(at: s, in: structConcrete2))
+    expectEqual(TV(x: 1, y: 0), gradient(at: s, of: { s in structGeneric(s) }))
+    expectEqual(TV(x: 4, y: 3), gradient(at: s, of: structConcrete1))
+    expectEqual(TV(x: 4, y: 3), gradient(at: s, of: structConcrete2))
   }
 
   do {
@@ -146,9 +146,9 @@ ArrayAutoDiffTests.test("ArrayLiteralStruct") {
       let array = structElementAddressLiteral(s)
       return array[0] * array[1]
     }
-    expectEqual(TV(x: 1, y: 0), gradient(at: s, in: { s in structGeneric(s) }))
-    expectEqual(TV(x: 4, y: 3), gradient(at: s, in: structConcrete1))
-    expectEqual(TV(x: 4, y: 3), gradient(at: s, in: structConcrete2))
+    expectEqual(TV(x: 1, y: 0), gradient(at: s, of: { s in structGeneric(s) }))
+    expectEqual(TV(x: 4, y: 3), gradient(at: s, of: structConcrete1))
+    expectEqual(TV(x: 4, y: 3), gradient(at: s, of: structConcrete2))
   }
 
   do {
@@ -168,9 +168,9 @@ ArrayAutoDiffTests.test("ArrayLiteralStruct") {
       let array = structElementAddressLiteral2(s)
       return array[0] * array[1]
     }
-    expectEqual(TV(x: 1, y: 0), gradient(at: s, in: { s in structGeneric(s) }))
-    expectEqual(TV(x: 4, y: 3), gradient(at: s, in: structConcrete1))
-    expectEqual(TV(x: 4, y: 3), gradient(at: s, in: structConcrete2))
+    expectEqual(TV(x: 1, y: 0), gradient(at: s, of: { s in structGeneric(s) }))
+    expectEqual(TV(x: 4, y: 3), gradient(at: s, of: structConcrete1))
+    expectEqual(TV(x: 4, y: 3), gradient(at: s, of: structConcrete2))
   }
 
   // TF-978: Test array literal initialized with `apply` indirect results.
@@ -179,7 +179,7 @@ ArrayAutoDiffTests.test("ArrayLiteralStruct") {
     func applyIndirectResult<T>(_ x: T, _ y: T) -> [Struct<T>] {
       return [Struct(x: x, y: y), Struct(x: x, y: y)]
     }
-    let pb = pullback(at: Float(3), 4, in: { applyIndirectResult($0, $1) })
+    let pb = pullback(at: Float(3), 4, of: { applyIndirectResult($0, $1) })
     let v = TV(x: 1, y: 1)
     expectEqual((2, 2), pb(.init([v, v])))
   }
@@ -191,7 +191,7 @@ ArrayAutoDiffTests.test("ArrayLiteralTuple") {
       var tuple = (x, y)
       return [tuple.0, tuple.1]
     }
-    let pb = pullback(at: Float(3), 4, in: { tupleElementGeneric($0, $1) })
+    let pb = pullback(at: Float(3), 4, of: { tupleElementGeneric($0, $1) })
     // FIXME(TF-977): Fix incorrect derivative for array literal with
     // `tuple_element_addr` elements.
     // expectEqual((1, 1), pb(FloatArrayTan([1, 1])))
@@ -207,7 +207,7 @@ ArrayAutoDiffTests.test("ArrayLiteralNested") {
       let result = [[[[x, y]]]]
       return result[0][0][0]
     }
-    let pb = pullback(at: 3, 4, in: { nested0($0, $1) })
+    let pb = pullback(at: 3, 4, of: { nested0($0, $1) })
     expectEqual((1, 1), pb(FloatArrayTan([1, 1, 1, 1])))
   }
 
@@ -218,7 +218,7 @@ ArrayAutoDiffTests.test("ArrayLiteralNested") {
       var result = [[x, y], [x, y]]
       return result[0] + result[1]
     }
-    let pb = pullback(at: 3, 4, in: { nested1($0, $1) })
+    let pb = pullback(at: 3, 4, of: { nested1($0, $1) })
     expectEqual((2, 2), pb(FloatArrayTan([1, 1, 1, 1])))
   }
 
@@ -234,7 +234,7 @@ ArrayAutoDiffTests.test("ArrayLiteralNested") {
       var nested = [result, [], result]
       return nested[0][1] + result[3]
     }
-    let (value, pb) = valueWithPullback(at: 3, 4, in: { nested2($0, $1) })
+    let (value, pb) = valueWithPullback(at: 3, 4, of: { nested2($0, $1) })
     expectEqual([3, 4], value)
     expectEqual((1, 1), pb(FloatArrayTan([1, 1])))
   }
@@ -251,7 +251,7 @@ ArrayAutoDiffTests.test("ArrayLiteralControlFlow") {
       var result3 = bool ? (bool ? result2 : result) : result2
       return result3
     }
-    let pb = pullback(at: 3, 4, in: { controlFlow($0, $1) })
+    let pb = pullback(at: 3, 4, of: { controlFlow($0, $1) })
     expectEqual((8, 6), pb(FloatArrayTan([1, 1])))
   }
 
@@ -266,7 +266,7 @@ ArrayAutoDiffTests.test("ArrayLiteralControlFlow") {
       var result3 = bool ? (bool ? result2 : result) : result2
       return result3
     }
-    let pb = pullback(at: 3, 4, in: { controlFlowAddress($0, $1) })
+    let pb = pullback(at: 3, 4, of: { controlFlowAddress($0, $1) })
     expectEqual((8, 6), pb(FloatArrayTan([1, 1])))
   }
 
@@ -278,7 +278,7 @@ ArrayAutoDiffTests.test("ArrayLiteralControlFlow") {
       var result3 = bool ? (bool ? result2 : result) : result2
       return result3
     }
-    let pb = pullback(at: Float(3), 4, in: { controlFlowGeneric($0, $1) })
+    let pb = pullback(at: Float(3), 4, of: { controlFlowGeneric($0, $1) })
     expectEqual((1, 1), pb(FloatArrayTan([1, 1])))
   }
 
@@ -292,7 +292,7 @@ ArrayAutoDiffTests.test("ArrayLiteralControlFlow") {
       var result3 = bool ? (bool ? result2 + [[y]] : result2 + [[y]]) : result2 + [[y]]
       return result3[0] + [result3[1][0]]
     }
-    let pb = pullback(at: 3, 4, in: { controlFlowNestedLiteral($0, $1) })
+    let pb = pullback(at: 3, 4, of: { controlFlowNestedLiteral($0, $1) })
     expectEqual((1, 1), pb(FloatArrayTan([1, 1])))
   }
 }
@@ -312,7 +312,7 @@ ArrayAutoDiffTests.test("ExpressibleByArrayLiteralIndirect") {
     return [x, y]
   }
 
-  let (gradX, gradY) = pullback(at: Float(1), Float(1), in: {
+  let (gradX, gradY) = pullback(at: Float(1), Float(1), of: {
     x, y in testArrayUninitializedIntrinsic(x, y)
   })(Indirect<Float>.TangentVector(x: 1))
   expectEqual(1, gradX)
@@ -327,13 +327,13 @@ ArrayAutoDiffTests.test("Array.+") {
 
   expectEqual(
     (.init([1, 1]), .init([1, 0])),
-    gradient(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating))
+    gradient(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating))
   expectEqual(
     (.init([1, 1, 1, 0]), .init([0, 0])),
-    gradient(at: [0, 0, 0, 0], [0, 0], in: sumFirstThreeConcatenating))
+    gradient(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating))
   expectEqual(
     (.init([]), .init([1, 1, 1, 0])),
-    gradient(at: [], [0, 0, 0, 0], in: sumFirstThreeConcatenating))
+    gradient(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating))
 
   func identity(_ array: [Float]) -> [Float] {
     var results: [Float] = []
@@ -343,7 +343,7 @@ ArrayAutoDiffTests.test("Array.+") {
     return results
   }
   let v = FloatArrayTan([4, -5, 6])
-  expectEqual(v, pullback(at: [1, 2, 3], in: identity)(v))
+  expectEqual(v, pullback(at: [1, 2, 3], of: identity)(v))
 }
 
 ArrayAutoDiffTests.test("Array.+=") {
@@ -355,13 +355,13 @@ ArrayAutoDiffTests.test("Array.+=") {
 
   expectEqual(
     (.init([1, 1]), .init([1, 0])),
-    gradient(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating))
+    gradient(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating))
   expectEqual(
     (.init([1, 1, 1, 0]), .init([0, 0])),
-    gradient(at: [0, 0, 0, 0], [0, 0], in: sumFirstThreeConcatenating))
+    gradient(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating))
   expectEqual(
     (.init([]), .init([1, 1, 1, 0])),
-    gradient(at: [], [0, 0, 0, 0], in: sumFirstThreeConcatenating))
+    gradient(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating))
 
   func identity(_ array: [Float]) -> [Float] {
     var results: [Float] = []
@@ -371,7 +371,7 @@ ArrayAutoDiffTests.test("Array.+=") {
     return results
   }
   let v = FloatArrayTan([4, -5, 6])
-  expectEqual(v, pullback(at: [1, 2, 3], in: identity)(v))
+  expectEqual(v, pullback(at: [1, 2, 3], of: identity)(v))
 }
 
 ArrayAutoDiffTests.test("Array.append") {
@@ -383,7 +383,7 @@ ArrayAutoDiffTests.test("Array.append") {
   do {
     let v = FloatArrayTan([1, 2, 3, 4])
     expectEqual((.init([1, 2, 3]), 4),
-                pullback(at: [0, 0, 0], 0, in: appending)(v))
+                pullback(at: [0, 0, 0], 0, of: appending)(v))
   }
 
   func identity(_ array: [Float]) -> [Float] {
@@ -395,7 +395,7 @@ ArrayAutoDiffTests.test("Array.append") {
   }
   do {
     let v = FloatArrayTan([4, -5, 6])
-    expectEqual(v, pullback(at: [1, 2, 3], in: identity)(v))
+    expectEqual(v, pullback(at: [1, 2, 3], of: identity)(v))
   }
 }
 
@@ -407,7 +407,7 @@ ArrayAutoDiffTests.test("Array.init(repeating:count:)") {
   expectEqual(Float(10), gradient(at: .zero) { x in
     repeating(x).differentiableReduce(0, {$0 + $1})
   })
-  expectEqual(Float(20), pullback(at: .zero, in: { x in
+  expectEqual(Float(20), pullback(at: .zero, of: { x in
     repeating(x).differentiableReduce(0, {$0 + $1})
   })(2))
 }
@@ -418,7 +418,7 @@ ArrayAutoDiffTests.test("Array.DifferentiableView.init") {
     return Array<Float>.DifferentiableView(x)
   }
 
-  let backprop = pullback(at: [5, 6, 7, 8], in: constructView)
+  let backprop = pullback(at: [5, 6, 7, 8], of: constructView)
   expectEqual(
     FloatArrayTan([1, 2, 3, 4]),
     backprop(FloatArrayTan([1, 2, 3, 4])))
@@ -432,7 +432,7 @@ ArrayAutoDiffTests.test("Array.DifferentiableView.base") {
 
   let backprop = pullback(
     at: Array<Float>.DifferentiableView([5, 6, 7, 8]),
-    in: accessBase)
+    of: accessBase)
   expectEqual(
     FloatArrayTan([1, 2, 3, 4]),
     backprop(FloatArrayTan([1, 2, 3, 4])))

--- a/test/AutoDiff/validation-test/class_differentiation.swift
+++ b/test/AutoDiff/validation-test/class_differentiation.swift
@@ -535,7 +535,7 @@ ClassTests.test("LetProperties") {
   let bar = Bar()
   let grad = gradient(at: bar) { bar in (bar.x.x * bar.x.x).value }
   expectEqual(Bar.TangentVector(x: .init(x: 6.0)), grad)
-  bar.move(along: grad)
+  bar.move(by: grad)
   expectEqual(8.0, bar.x.x)
 }
 

--- a/test/AutoDiff/validation-test/class_differentiation.swift
+++ b/test/AutoDiff/validation-test/class_differentiation.swift
@@ -49,13 +49,13 @@ ClassTests.test("TrivialMember") {
     }
   }
   // Test class initializer differentiation.
-  expectEqual(10, pullback(at: 3, in: { C($0) })(.init(float: 10)))
-  expectEqual(10, pullback(at: 3, in: { C(convenience: $0) })(.init(float: 10)))
+  expectEqual(10, pullback(at: 3, of: { C($0) })(.init(float: 10)))
+  expectEqual(10, pullback(at: 3, of: { C(convenience: $0) })(.init(float: 10)))
   // Test class method differentiation.
-  expectEqual((.init(float: 3), 10), gradient(at: C(10), 3, in: { c, x in c.method(x) }))
-  expectEqual(.init(float: 0), gradient(at: C(10), in: { c in c.testNoDerivative() }))
+  expectEqual((.init(float: 3), 10), gradient(at: C(10), 3, of: { c, x in c.method(x) }))
+  expectEqual(.init(float: 0), gradient(at: C(10), of: { c in c.testNoDerivative() }))
   expectEqual((.init(float: 20), .init(float: 10)),
-              gradient(at: C(10), C(20), in: { c1, c2 in C.controlFlow(c1, c2, true) }))
+              gradient(at: C(10), C(20), of: { c1, c2 in C.controlFlow(c1, c2, true) }))
 }
 
 ClassTests.test("NontrivialMember") {
@@ -85,11 +85,11 @@ ClassTests.test("NontrivialMember") {
     }
   }
   // Test class initializer differentiation.
-  expectEqual(10, pullback(at: 3, in: { C($0) })(.init(float: 10)))
+  expectEqual(10, pullback(at: 3, of: { C($0) })(.init(float: 10)))
   // Test class method differentiation.
-  expectEqual((.init(float: 3), 10), gradient(at: C(10), 3, in: { c, x in c.method(x) }))
+  expectEqual((.init(float: 3), 10), gradient(at: C(10), 3, of: { c, x in c.method(x) }))
   expectEqual((.init(float: 20), .init(float: 10)),
-              gradient(at: C(10), C(20), in: { c1, c2 in C.controlFlow(c1, c2, true) }))
+              gradient(at: C(10), C(20), of: { c1, c2 in C.controlFlow(c1, c2, true) }))
 }
 
 ClassTests.test("GenericNontrivialMember") {
@@ -108,8 +108,8 @@ ClassTests.test("GenericNontrivialMember") {
     }
   }
   // Test class initializer differentiation.
-  expectEqual(10, pullback(at: 3, in: { C<Float>($0) })(.init(x: 10)))
-  expectEqual(10, pullback(at: 3, in: { C<Float>(convenience: $0) })(.init(x: 10)))
+  expectEqual(10, pullback(at: 3, of: { C<Float>($0) })(.init(x: 10)))
+  expectEqual(10, pullback(at: 3, of: { C<Float>(convenience: $0) })(.init(x: 10)))
 }
 
 // TF-1149: Test class with loadable type but address-only `TangentVector` type.
@@ -129,10 +129,10 @@ ClassTests.test("AddressOnlyTangentVector") {
     }
   }
   // Test class initializer differentiation.
-  expectEqual(10, pullback(at: 3, in: { C<Float>($0) })(.init(stored: 10)))
+  expectEqual(10, pullback(at: 3, of: { C<Float>($0) })(.init(stored: 10)))
   // Test class method differentiation.
   expectEqual((.init(stored: Float(1)), 0),
-              gradient(at: C<Float>(3), 3, in: { c, x in c.method(x) }))
+              gradient(at: C<Float>(3), 3, of: { c, x in c.method(x) }))
 }
 
 // TF-1175: Test whether class-typed arguments are not marked active.
@@ -159,8 +159,8 @@ ClassTests.test("ClassArgumentActivity") {
     return c.x
   }
   // FIXME(TF-1175): Find a robust solution so that derivatives are correct.
-  // expectEqual((100, 20), valueWithGradient(at: 10, in: squared))
-  expectEqual((100, 1), valueWithGradient(at: 10, in: squared))
+  // expectEqual((100, 20), valueWithGradient(at: 10, of: squared))
+  expectEqual((100, 1), valueWithGradient(at: 10, of: squared))
 }
 
 ClassTests.test("FinalClassMethods") {
@@ -414,7 +414,7 @@ ClassTests.test("ClassMethods - generic") {
   func classValueWithGradient<T: Differentiable & FloatingPoint>(
     _ c: Super<T>
   ) -> (T, T) where T == T.TangentVector {
-    let (x,y) =  valueWithGradient(at: Tracked<T>(1), in: {
+    let (x,y) =  valueWithGradient(at: Tracked<T>(1), of: {
         c.f($0) })
     return (x.value, y.value)
   }
@@ -474,7 +474,7 @@ ClassTests.test("ClassMethods - closure captures") {
     m.coefficient += 1
     return result
   }
-  expectEqual(10, gradient(at: 1, in: f1))
+  expectEqual(10, gradient(at: 1, of: f1))
 
   func f2(_ x: Tracked<Float>) -> Tracked<Float> {
     let m = Multiplier(10)
@@ -482,7 +482,7 @@ ClassTests.test("ClassMethods - closure captures") {
     m.coefficient += 1
     return result
   }
-  expectEqual(11, gradient(at: 1, in: f2))
+  expectEqual(11, gradient(at: 1, of: f2))
 
   func f3(_ x: Tracked<Float>) -> Tracked<Float> {
     let m = Multiplier(10)
@@ -490,7 +490,7 @@ ClassTests.test("ClassMethods - closure captures") {
     m.coefficient += 1
     return result
   }
-  expectEqual(10, gradient(at: 1, in: f3))
+  expectEqual(10, gradient(at: 1, of: f3))
 }
 
 ClassTests.test("ClassProperties") {

--- a/test/AutoDiff/validation-test/control_flow.swift
+++ b/test/AutoDiff/validation-test/control_flow.swift
@@ -20,8 +20,8 @@ ControlFlowTests.test("Conditionals") {
     }
     return x + x
   }
-  expectEqual(8, gradient(at: 4, in: cond1))
-  expectEqual(2, gradient(at: -10, in: cond1))
+  expectEqual(8, gradient(at: 4, of: cond1))
+  expectEqual(2, gradient(at: -10, of: cond1))
 
   func cond2(_ x: Float) -> Float {
     let y: Float
@@ -34,9 +34,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y
   }
-  expectEqual(8, gradient(at: 4, in: cond2))
-  expectEqual(2, gradient(at: -10, in: cond2))
-  expectEqual(0, gradient(at: -1337, in: cond2))
+  expectEqual(8, gradient(at: 4, of: cond2))
+  expectEqual(2, gradient(at: -10, of: cond2))
+  expectEqual(0, gradient(at: -1337, of: cond2))
 
   func cond2_var(_ x: Float) -> Float {
     var y: Float = x
@@ -51,9 +51,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y
   }
-  expectEqual(8, gradient(at: 4, in: cond2_var))
-  expectEqual(2, gradient(at: -10, in: cond2_var))
-  expectEqual(0, gradient(at: -1337, in: cond2_var))
+  expectEqual(8, gradient(at: 4, of: cond2_var))
+  expectEqual(2, gradient(at: -10, of: cond2_var))
+  expectEqual(0, gradient(at: -1337, of: cond2_var))
 
   func cond3(_ x: Float, _ y: Float) -> Float {
     if x > 0 {
@@ -61,8 +61,8 @@ ControlFlowTests.test("Conditionals") {
     }
     return y - x
   }
-  expectEqual((5, 4), gradient(at: 4, 5, in: cond3))
-  expectEqual((-1, 1), gradient(at: -3, -2, in: cond3))
+  expectEqual((5, 4), gradient(at: 4, 5, of: cond3))
+  expectEqual((-1, 1), gradient(at: -3, -2, of: cond3))
 
   func cond4_var(_ x: Float) -> Float {
     var outer = x
@@ -76,7 +76,7 @@ ControlFlowTests.test("Conditionals") {
     }
     return outer
   }
-  expectEqual((9, 6), valueWithGradient(at: 3, in: cond4_var))
+  expectEqual((9, 6), valueWithGradient(at: 3, of: cond4_var))
 
   func cond_tuple(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -86,9 +86,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y.0 + y.0 - y.1 + y.0
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_tuple))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_tuple))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_tuple))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_tuple))
 
   func cond_tuple2(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -102,9 +102,9 @@ ControlFlowTests.test("Conditionals") {
     let y1 = y.1
     return y0_double - y1 + y.0
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_tuple2))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple2))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple2))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_tuple2))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_tuple2))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_tuple2))
 
   func cond_tuple_var(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -121,9 +121,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y.0 + y.1 - z.0 + z.1
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_tuple_var))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_tuple_var))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_tuple_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_tuple_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_tuple_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_tuple_var))
 
   func cond_nestedtuple_var(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -140,9 +140,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y.0 + y.1 - z.0.0 + z.0.1
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_nestedtuple_var))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_nestedtuple_var))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_nestedtuple_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_nestedtuple_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_nestedtuple_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_nestedtuple_var))
 
   struct FloatPair : Differentiable {
     var first, second: Float
@@ -169,9 +169,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y.first + y.first - y.second + y.first
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_struct))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_struct))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_struct))
 
   func cond_struct2(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -185,9 +185,9 @@ ControlFlowTests.test("Conditionals") {
     let y1 = y.second
     return y0_double - y1 + y.first
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct2))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct2))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct2))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_struct2))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_struct2))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_struct2))
 
   func cond_struct_var(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -204,9 +204,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y.first + y.second - z.first + z.second
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_struct_var))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_struct_var))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_struct_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_struct_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_struct_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_struct_var))
 
   func cond_nestedstruct_var(_ x: Float) -> Float {
     // Convoluted function returning `x + x`.
@@ -223,9 +223,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y.first + y.second - z.first.first + z.first.second
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: cond_nestedstruct_var))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: cond_nestedstruct_var))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: cond_nestedstruct_var))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: cond_nestedstruct_var))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: cond_nestedstruct_var))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: cond_nestedstruct_var))
 
   func guard1(_ x: Float, _ y: Float) -> Float {
     guard x > 0 else {
@@ -233,8 +233,8 @@ ControlFlowTests.test("Conditionals") {
     }
     return y * y
   }
-  expectEqual((0, 10), gradient(at: 4, 5, in: guard1))
-  expectEqual((-6, 0), gradient(at: -3, -2, in: guard1))
+  expectEqual((0, 10), gradient(at: 4, 5, of: guard1))
+  expectEqual((-6, 0), gradient(at: -3, -2, of: guard1))
 
   func guard2(_ x: Float, _ y: Float) -> Float {
     guard x > 0 else {
@@ -247,10 +247,10 @@ ControlFlowTests.test("Conditionals") {
     }
     return y * y
   }
-  expectEqual((0, 10), gradient(at: 4, 5, in: guard2))
-  expectEqual((5, -1337), gradient(at: -1337, 5, in: guard2))
-  expectEqual((-2674, 0), gradient(at: -1337, -5, in: guard2))
-  expectEqual((2, -3), gradient(at: -3, 2, in: guard2))
+  expectEqual((0, 10), gradient(at: 4, 5, of: guard2))
+  expectEqual((5, -1337), gradient(at: -1337, 5, of: guard2))
+  expectEqual((-2674, 0), gradient(at: -1337, -5, of: guard2))
+  expectEqual((2, -3), gradient(at: -3, 2, of: guard2))
 
   func guard2_var(_ x: Float, _ y: Float) -> Float {
     var z = y
@@ -267,10 +267,10 @@ ControlFlowTests.test("Conditionals") {
     }
     return z * y
   }
-  expectEqual((0, 10), gradient(at: 4, 5, in: guard2_var))
-  expectEqual((5, -1337), gradient(at: -1337, 5, in: guard2_var))
-  expectEqual((-2674, 0), gradient(at: -1337, -5, in: guard2_var))
-  expectEqual((2, -3), gradient(at: -3, 2, in: guard2_var))
+  expectEqual((0, 10), gradient(at: 4, 5, of: guard2_var))
+  expectEqual((5, -1337), gradient(at: -1337, 5, of: guard2_var))
+  expectEqual((-2674, 0), gradient(at: -1337, -5, of: guard2_var))
+  expectEqual((2, -3), gradient(at: -3, 2, of: guard2_var))
 
   func guard3(_ x: Float, _ y: Float) -> Float {
     guard x > 0 else {
@@ -278,9 +278,9 @@ ControlFlowTests.test("Conditionals") {
     }
     return y * y
   }
-  expectEqual((0, 10), gradient(at: 4, 5, in: guard3))
+  expectEqual((0, 10), gradient(at: 4, 5, of: guard3))
   expectCrash {
-    _ = gradient(at: -3, -2, in: guard3)
+    _ = gradient(at: -3, -2, of: guard3)
   }
 
   func cond_empty(_ x: Float) -> Float {
@@ -289,8 +289,8 @@ ControlFlowTests.test("Conditionals") {
     }
     return x * x
   }
-  expectEqual(4, gradient(at: 2, in: cond_empty))
-  expectEqual(-6, gradient(at: -3, in: cond_empty))
+  expectEqual(4, gradient(at: 2, of: cond_empty))
+  expectEqual(-6, gradient(at: -3, of: cond_empty))
 
   func cond_generic<T : Differentiable & FloatingPoint>(
     _ x: T, _ y: T
@@ -300,8 +300,8 @@ ControlFlowTests.test("Conditionals") {
     }
     return y
   }
-  expectEqual((1, 0), gradient(at: 4, 5, in: { x, y in cond_generic(x, y) }))
-  expectEqual((0, 1), gradient(at: -4, 5, in: { x, y in cond_generic(x, y) }))
+  expectEqual((1, 0), gradient(at: 4, 5, of: { x, y in cond_generic(x, y) }))
+  expectEqual((0, 1), gradient(at: -4, 5, of: { x, y in cond_generic(x, y) }))
 }
 
 ControlFlowTests.test("NestedConditionals") {
@@ -315,9 +315,9 @@ ControlFlowTests.test("NestedConditionals") {
     }
     return x * -x
   }
-  expectEqual(23, gradient(at: 11, in: nested1))
-  expectEqual(8, gradient(at: 4, in: nested1))
-  expectEqual(20, gradient(at: -10, in: nested1))
+  expectEqual(23, gradient(at: 11, of: nested1))
+  expectEqual(8, gradient(at: 4, of: nested1))
+  expectEqual(20, gradient(at: -10, of: nested1))
 
   func nested2(_ x: Float, _ y: Float) -> Float {
     if x > 0 {
@@ -329,9 +329,9 @@ ControlFlowTests.test("NestedConditionals") {
     }
     return -y
   }
-  expectEqual((20, 4), gradient(at: 4, 20, in: nested2))
-  expectEqual((1, 1), gradient(at: 4, 5, in: nested2))
-  expectEqual((0, -1), gradient(at: -3, -2, in: nested2))
+  expectEqual((20, 4), gradient(at: 4, 20, of: nested2))
+  expectEqual((1, 1), gradient(at: 4, 5, of: nested2))
+  expectEqual((0, -1), gradient(at: -3, -2, of: nested2))
 
   func nested3(_ x: Float, _ y: Float) -> Float {
     if x > 0 {
@@ -348,10 +348,10 @@ ControlFlowTests.test("NestedConditionals") {
     }
     return -y
   }
-  expectEqual((40, 8), gradient(at: 4, 20, in: nested3))
-  expectEqual((0, -1), gradient(at: 4, 21, in: nested3))
-  expectEqual((1, 1), gradient(at: 4, 5, in: nested3))
-  expectEqual((0, -1), gradient(at: -3, -2, in: nested3))
+  expectEqual((40, 8), gradient(at: 4, 20, of: nested3))
+  expectEqual((0, -1), gradient(at: 4, 21, of: nested3))
+  expectEqual((1, 1), gradient(at: 4, 5, of: nested3))
+  expectEqual((0, -1), gradient(at: -3, -2, of: nested3))
 
   func nested3_var(_ x: Float, _ y: Float) -> Float {
     var w = y
@@ -373,10 +373,10 @@ ControlFlowTests.test("NestedConditionals") {
     w = -w
     return w
   }
-  expectEqual((40, 8), gradient(at: 4, 20, in: nested3))
-  expectEqual((0, -1), gradient(at: 4, 21, in: nested3))
-  expectEqual((1, 1), gradient(at: 4, 5, in: nested3))
-  expectEqual((0, -1), gradient(at: -3, -2, in: nested3))
+  expectEqual((40, 8), gradient(at: 4, 20, of: nested3))
+  expectEqual((0, -1), gradient(at: 4, 21, of: nested3))
+  expectEqual((1, 1), gradient(at: 4, 5, of: nested3))
+  expectEqual((0, -1), gradient(at: -3, -2, of: nested3))
 
   // TF-781: nested if derivative correctness.
   do {
@@ -424,11 +424,11 @@ ControlFlowTests.test("Recursion") {
     }
     return x * factorial(x - 1)
   }
-  expectEqual(0, gradient(at: 1, in: factorial))
-  expectEqual(1, gradient(at: 2, in: factorial))
-  expectEqual(5, gradient(at: 3, in: factorial))
-  expectEqual(26, gradient(at: 4, in: factorial))
-  expectEqual(154, gradient(at: 5, in: factorial))
+  expectEqual(0, gradient(at: 1, of: factorial))
+  expectEqual(1, gradient(at: 2, of: factorial))
+  expectEqual(5, gradient(at: 3, of: factorial))
+  expectEqual(26, gradient(at: 4, of: factorial))
+  expectEqual(154, gradient(at: 5, of: factorial))
 
   func factorial_var1(_ x: Float) -> Float {
     var y: Float = x
@@ -440,11 +440,11 @@ ControlFlowTests.test("Recursion") {
     }
     return y
   }
-  expectEqual(0, gradient(at: 1, in: factorial_var1))
-  expectEqual(1, gradient(at: 2, in: factorial_var1))
-  expectEqual(5, gradient(at: 3, in: factorial_var1))
-  expectEqual(26, gradient(at: 4, in: factorial_var1))
-  expectEqual(154, gradient(at: 5, in: factorial_var1))
+  expectEqual(0, gradient(at: 1, of: factorial_var1))
+  expectEqual(1, gradient(at: 2, of: factorial_var1))
+  expectEqual(5, gradient(at: 3, of: factorial_var1))
+  expectEqual(26, gradient(at: 4, of: factorial_var1))
+  expectEqual(154, gradient(at: 5, of: factorial_var1))
 
   func factorial_var2(_ x: Float) -> Float {
     // Next line is the only difference with `factorial_var1`.
@@ -457,11 +457,11 @@ ControlFlowTests.test("Recursion") {
     }
     return y
   }
-  expectEqual(0, gradient(at: 1, in: factorial_var2))
-  expectEqual(1, gradient(at: 2, in: factorial_var2))
-  expectEqual(5, gradient(at: 3, in: factorial_var2))
-  expectEqual(26, gradient(at: 4, in: factorial_var2))
-  expectEqual(154, gradient(at: 5, in: factorial_var2))
+  expectEqual(0, gradient(at: 1, of: factorial_var2))
+  expectEqual(1, gradient(at: 2, of: factorial_var2))
+  expectEqual(5, gradient(at: 3, of: factorial_var2))
+  expectEqual(26, gradient(at: 4, of: factorial_var2))
+  expectEqual(154, gradient(at: 5, of: factorial_var2))
 
   func product(_ x: Float, count: Int) -> Float {
     precondition(count > 0)
@@ -470,9 +470,9 @@ ControlFlowTests.test("Recursion") {
     }
     return x * product(x, count: count - 1)
   }
-  expectEqual(300, gradient(at: 10, in: { x in product(x, count: 3) }))
-  expectEqual(-20, gradient(at: -10, in: { x in product(x, count: 2) }))
-  expectEqual(1, gradient(at: 100, in: { x in product(x, count: 1) }))
+  expectEqual(300, gradient(at: 10, of: { x in product(x, count: 3) }))
+  expectEqual(-20, gradient(at: -10, of: { x in product(x, count: 2) }))
+  expectEqual(1, gradient(at: 100, of: { x in product(x, count: 1) }))
 }
 
 ControlFlowTests.test("Enums") {
@@ -494,10 +494,10 @@ ControlFlowTests.test("Enums") {
     case let .b(b1, b2): return x * b1 * b2
     }
   }
-  expectEqual(10, gradient(at: 2, in: { x in enum_notactive1(.a(10), x) }))
-  expectEqual(10, gradient(at: 2, in: { x in Enum.a(10).enum_notactive1(x) }))
-  expectEqual(20, gradient(at: 2, in: { x in enum_notactive1(.b(4, 5), x) }))
-  expectEqual(20, gradient(at: 2, in: { x in Enum.b(4, 5).enum_notactive1(x) }))
+  expectEqual(10, gradient(at: 2, of: { x in enum_notactive1(.a(10), x) }))
+  expectEqual(10, gradient(at: 2, of: { x in Enum.a(10).enum_notactive1(x) }))
+  expectEqual(20, gradient(at: 2, of: { x in enum_notactive1(.b(4, 5), x) }))
+  expectEqual(20, gradient(at: 2, of: { x in Enum.b(4, 5).enum_notactive1(x) }))
 
   func enum_notactive2(_ e: Enum, _ x: Float) -> Float {
     var y = x
@@ -517,10 +517,10 @@ ControlFlowTests.test("Enums") {
     }
     return x + y
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: { x in enum_notactive2(.a(10), x) }))
-  expectEqual((20, 2), valueWithGradient(at: 10, in: { x in enum_notactive2(.b(4, 5), x) }))
-  expectEqual((-20, 2), valueWithGradient(at: -10, in: { x in enum_notactive2(.a(10), x) }))
-  expectEqual((-2674, 2), valueWithGradient(at: -1337, in: { x in enum_notactive2(.b(4, 5), x) }))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((20, 2), valueWithGradient(at: 10, of: { x in enum_notactive2(.b(4, 5), x) }))
+  expectEqual((-20, 2), valueWithGradient(at: -10, of: { x in enum_notactive2(.a(10), x) }))
+  expectEqual((-2674, 2), valueWithGradient(at: -1337, of: { x in enum_notactive2(.b(4, 5), x) }))
 
   func optional_notactive1(_ optional: Float?, _ x: Float) -> Float {
     if let y = optional {
@@ -528,8 +528,8 @@ ControlFlowTests.test("Enums") {
     }
     return x + x
   }
-  expectEqual(2, gradient(at: 2, in: { x in optional_notactive1(nil, x) }))
-  expectEqual(10, gradient(at: 2, in: { x in optional_notactive1(10, x) }))
+  expectEqual(2, gradient(at: 2, of: { x in optional_notactive1(nil, x) }))
+  expectEqual(10, gradient(at: 2, of: { x in optional_notactive1(10, x) }))
 
   struct Dense : Differentiable {
     var w1: Float
@@ -565,8 +565,8 @@ ControlFlowTests.test("Enums") {
   }
   do {
     let ind: Indirect = .e(10, .a(3))
-    expectEqual(120, gradient(at: 2, in: { x in enum_indirect_notactive1(ind, x) }))
-    expectEqual(120, gradient(at: 2, in: { x in enum_indirect_notactive1(.indirect(ind), x) }))
+    expectEqual(120, gradient(at: 2, of: { x in enum_indirect_notactive1(ind, x) }))
+    expectEqual(120, gradient(at: 2, of: { x in enum_indirect_notactive1(.indirect(ind), x) }))
   }
 }
 
@@ -578,8 +578,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  expectEqual((8, 12), valueWithGradient(at: 2, in: for_loop))
-  expectEqual((27, 27), valueWithGradient(at: 3, in: for_loop))
+  expectEqual((8, 12), valueWithGradient(at: 2, of: for_loop))
+  expectEqual((27, 27), valueWithGradient(at: 3, of: for_loop))
 
   func for_loop_nonactive_initial_value(_ x: Float) -> Float {
     var result: Float = 1
@@ -588,8 +588,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  expectEqual((4, 4), valueWithGradient(at: 2, in: for_loop_nonactive_initial_value))
-  expectEqual((9, 6), valueWithGradient(at: 3, in: for_loop_nonactive_initial_value))
+  expectEqual((4, 4), valueWithGradient(at: 2, of: for_loop_nonactive_initial_value))
+  expectEqual((9, 6), valueWithGradient(at: 3, of: for_loop_nonactive_initial_value))
 
   func while_loop(_ x: Float) -> Float {
     var result = x
@@ -600,8 +600,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  expectEqual((8, 12), valueWithGradient(at: 2, in: while_loop))
-  expectEqual((27, 27), valueWithGradient(at: 3, in: while_loop))
+  expectEqual((8, 12), valueWithGradient(at: 2, of: while_loop))
+  expectEqual((27, 27), valueWithGradient(at: 3, of: while_loop))
 
   func while_loop_nonactive_initial_value(_ x: Float) -> Float {
     var result: Float = 1
@@ -612,8 +612,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  expectEqual((4, 4), valueWithGradient(at: 2, in: while_loop_nonactive_initial_value))
-  expectEqual((9, 6), valueWithGradient(at: 3, in: while_loop_nonactive_initial_value))
+  expectEqual((4, 4), valueWithGradient(at: 2, of: while_loop_nonactive_initial_value))
+  expectEqual((9, 6), valueWithGradient(at: 3, of: while_loop_nonactive_initial_value))
 
   func repeat_while_loop(_ x: Float) -> Float {
     var result = x
@@ -626,10 +626,10 @@ ControlFlowTests.test("Loops") {
   }
   // FIXME(TF-584): Investigate incorrect (too big) gradient values for
   // repeat-while loops.
-  // expectEqual((8, 12), valueWithGradient(at: 2, in: repeat_while_loop))
-  // expectEqual((27, 27), valueWithGradient(at: 3, in: repeat_while_loop))
-  expectEqual((8, 18), valueWithGradient(at: 2, in: repeat_while_loop))
-  expectEqual((27, 36), valueWithGradient(at: 3, in: repeat_while_loop))
+  // expectEqual((8, 12), valueWithGradient(at: 2, of: repeat_while_loop))
+  // expectEqual((27, 27), valueWithGradient(at: 3, of: repeat_while_loop))
+  expectEqual((8, 18), valueWithGradient(at: 2, of: repeat_while_loop))
+  expectEqual((27, 36), valueWithGradient(at: 3, of: repeat_while_loop))
 
   func repeat_while_loop_nonactive_initial_value(_ x: Float) -> Float {
     var result: Float = 1
@@ -642,10 +642,10 @@ ControlFlowTests.test("Loops") {
   }
   // FIXME(TF-584): Investigate incorrect (too big) gradient values for
   // repeat-while loops.
-  // expectEqual((4, 4), valueWithGradient(at: 2, in: repeat_while_loop_nonactive_initial_value))
-  // expectEqual((9, 6), valueWithGradient(at: 3, in: repeat_while_loop_nonactive_initial_value))
-  expectEqual((4, 5), valueWithGradient(at: 2, in: repeat_while_loop_nonactive_initial_value))
-  expectEqual((9, 7), valueWithGradient(at: 3, in: repeat_while_loop_nonactive_initial_value))
+  // expectEqual((4, 4), valueWithGradient(at: 2, of: repeat_while_loop_nonactive_initial_value))
+  // expectEqual((9, 6), valueWithGradient(at: 3, of: repeat_while_loop_nonactive_initial_value))
+  expectEqual((4, 5), valueWithGradient(at: 2, of: repeat_while_loop_nonactive_initial_value))
+  expectEqual((9, 7), valueWithGradient(at: 3, of: repeat_while_loop_nonactive_initial_value))
 
   func loop_continue(_ x: Float) -> Float {
     var result = x
@@ -657,8 +657,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  expectEqual((64, 192), valueWithGradient(at: 2, in: loop_continue))
-  expectEqual((729, 1458), valueWithGradient(at: 3, in: loop_continue))
+  expectEqual((64, 192), valueWithGradient(at: 2, of: loop_continue))
+  expectEqual((729, 1458), valueWithGradient(at: 3, of: loop_continue))
 
   func loop_break(_ x: Float) -> Float {
     var result = x
@@ -670,8 +670,8 @@ ControlFlowTests.test("Loops") {
     }
     return result
   }
-  expectEqual((64, 192), valueWithGradient(at: 2, in: loop_break))
-  expectEqual((729, 1458), valueWithGradient(at: 3, in: loop_break))
+  expectEqual((64, 192), valueWithGradient(at: 2, of: loop_break))
+  expectEqual((729, 1458), valueWithGradient(at: 3, of: loop_break))
 
   func nested_loop1(_ x: Float) -> Float {
     var outer = x
@@ -688,8 +688,8 @@ ControlFlowTests.test("Loops") {
     }
     return outer
   }
-  expectEqual((20, 22), valueWithGradient(at: 2, in: nested_loop1))
-  expectEqual((104, 66), valueWithGradient(at: 4, in: nested_loop1))
+  expectEqual((20, 22), valueWithGradient(at: 2, of: nested_loop1))
+  expectEqual((104, 66), valueWithGradient(at: 4, of: nested_loop1))
 
   func nested_loop2(_ x: Float, count: Int) -> Float {
     var outer = x
@@ -712,10 +712,10 @@ ControlFlowTests.test("Loops") {
     }
     return outer
   }
-  expectEqual((6, 5), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 1) }))
-  expectEqual((20, 22), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 2) }))
-  expectEqual((52, 80), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 3) }))
-  expectEqual((24, 28), valueWithGradient(at: 2, in: { x in nested_loop2(x, count: 4) }))
+  expectEqual((6, 5), valueWithGradient(at: 2, of: { x in nested_loop2(x, count: 1) }))
+  expectEqual((20, 22), valueWithGradient(at: 2, of: { x in nested_loop2(x, count: 2) }))
+  expectEqual((52, 80), valueWithGradient(at: 2, of: { x in nested_loop2(x, count: 3) }))
+  expectEqual((24, 28), valueWithGradient(at: 2, of: { x in nested_loop2(x, count: 4) }))
 
   // SR13945: Loops in methods caused a runtime segfault.
   struct SR13945 {
@@ -727,8 +727,8 @@ ControlFlowTests.test("Loops") {
       return result
     }
   }
-  expectEqual((0, 0), valueWithGradient(at: 0, in: { SR13945().loopInMethod($0) }))
-  expectEqual((1, 4), valueWithGradient(at: 1, in: { SR13945().loopInMethod($0) }))
+  expectEqual((0, 0), valueWithGradient(at: 0, of: { SR13945().loopInMethod($0) }))
+  expectEqual((1, 4), valueWithGradient(at: 1, of: { SR13945().loopInMethod($0) }))
 }
 
 ControlFlowTests.test("BranchingCastInstructions") {
@@ -739,8 +739,8 @@ ControlFlowTests.test("BranchingCastInstructions") {
     }
     return x * x
   }
-  expectEqual((6, 2), valueWithGradient(at: 3, in: { typeCheckOperator($0, Int.self) }))
-  expectEqual((9, 6), valueWithGradient(at: 3, in: { typeCheckOperator($0, Float.self) }))
+  expectEqual((6, 2), valueWithGradient(at: 3, of: { typeCheckOperator($0, Int.self) }))
+  expectEqual((9, 6), valueWithGradient(at: 3, of: { typeCheckOperator($0, Float.self) }))
 
   // checked_cast_addr_br
   func conditionalCast<T: Differentiable>(_ x: T) -> T {
@@ -749,7 +749,7 @@ ControlFlowTests.test("BranchingCastInstructions") {
     }
     return x
   }
-  expectEqual((3, 1), valueWithGradient(at: Float(3), in: conditionalCast))
+  expectEqual((3, 1), valueWithGradient(at: Float(3), of: conditionalCast))
 }
 
 ControlFlowTests.test("ThrowingCalls") {
@@ -761,14 +761,14 @@ ControlFlowTests.test("ThrowingCalls") {
     try! throwing()
     return x
   }
-  expectEqual(10, pullback(at: 3, in: testThrowing)(10))
+  expectEqual(10, pullback(at: 3, of: testThrowing)(10))
 
   @differentiable(reverse)
   func testThrowingGeneric<T: Differentiable>(_ x: T) -> T {
     try! throwing()
     return x
   }
-  expectEqual(10, pullback(at: 3, in: testThrowingGeneric)(10))
+  expectEqual(10, pullback(at: 3, of: testThrowingGeneric)(10))
 
   func rethrowing(_ body: () throws -> Void) rethrows -> Void {}
 
@@ -777,14 +777,14 @@ ControlFlowTests.test("ThrowingCalls") {
     rethrowing({}) // non-active `try_apply`
     return x
   }
-  expectEqual(10, pullback(at: 3, in: testRethrowingIdentity)(10))
+  expectEqual(10, pullback(at: 3, of: testRethrowingIdentity)(10))
 
   @differentiable(reverse)
   func testRethrowingIdentityGeneric<T: Differentiable>(_ x: T) -> T {
     rethrowing({}) // non-active `try_apply`
     return x
   }
-  expectEqual(10, pullback(at: 3, in: testRethrowingIdentityGeneric)(10))
+  expectEqual(10, pullback(at: 3, of: testRethrowingIdentityGeneric)(10))
 
   @differentiable(reverse)
   func testComplexControlFlow(_ x: Float) -> Float {
@@ -798,7 +798,7 @@ ControlFlowTests.test("ThrowingCalls") {
     rethrowing({})
     return x
   }
-  expectEqual(10, pullback(at: 3, in: testComplexControlFlow)(10))
+  expectEqual(10, pullback(at: 3, of: testComplexControlFlow)(10))
 
   @differentiable(reverse)
   func testComplexControlFlowGeneric<T: Differentiable>(_ x: T) -> T {
@@ -812,7 +812,7 @@ ControlFlowTests.test("ThrowingCalls") {
     rethrowing({})
     return x
   }
-  expectEqual(10, pullback(at: 3, in: testComplexControlFlowGeneric)(10))
+  expectEqual(10, pullback(at: 3, of: testComplexControlFlowGeneric)(10))
 
   // Test `Array.map(_:)`, which is rethrowing.
   func testArrayMap(_ x: [Float]) -> [Float] {
@@ -820,7 +820,7 @@ ControlFlowTests.test("ThrowingCalls") {
     _blackHole(max)
     return x
   }
-  expectEqual([10, 10], pullback(at: [2, 3], in: testArrayMap)([10, 10]))
+  expectEqual([10, 10], pullback(at: [2, 3], of: testArrayMap)([10, 10]))
 
   // Test `Bool.&&(_:)`, which is rethrowing.
   func testBooleanShortCircuitingOperations(_ x: Float, bool: Bool) -> Float {
@@ -829,8 +829,8 @@ ControlFlowTests.test("ThrowingCalls") {
     }
     return x + x
   }
-  expectEqual(6, gradient(at: 3, in: { x in testBooleanShortCircuitingOperations(x, bool: true) }))
-  expectEqual(2, gradient(at: 3, in: { x in testBooleanShortCircuitingOperations(x, bool: false) }))
+  expectEqual(6, gradient(at: 3, of: { x in testBooleanShortCircuitingOperations(x, bool: true) }))
+  expectEqual(2, gradient(at: 3, of: { x in testBooleanShortCircuitingOperations(x, bool: false) }))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/derivative_registration.swift
+++ b/test/AutoDiff/validation-test/derivative_registration.swift
@@ -15,7 +15,7 @@ func _vjpUnary(x: Tracked<Float>) -> (value: Tracked<Float>, pullback: (Tracked<
   return (value: x, pullback: { v in v })
 }
 DerivativeRegistrationTests.testWithLeakChecking("UnaryFreeFunction") {
-  expectEqual(1, gradient(at: 3.0, in: unary))
+  expectEqual(1, gradient(at: 3.0, of: unary))
 }
 
 @_semantics("autodiff.opaque")
@@ -28,7 +28,7 @@ func _vjpMultiply(_ x: Tracked<Float>, _ y: Tracked<Float>)
   return (x * y, { v in (v * y, v * x) })
 }
 DerivativeRegistrationTests.testWithLeakChecking("BinaryFreeFunction") {
-  expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, in: { x, y in multiply(x, y) }))
+  expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, of: { x, y in multiply(x, y) }))
 }
 
 struct Wrapper : Differentiable {
@@ -49,7 +49,7 @@ extension Wrapper {
 }
 DerivativeRegistrationTests.testWithLeakChecking("Initializer") {
   let v = Wrapper.TangentVector(float: 1)
-  let (𝛁x, 𝛁y) = pullback(at: 3, 4, in: { x, y in Wrapper(x, y) })(v)
+  let (𝛁x, 𝛁y) = pullback(at: 3, 4, of: { x, y in Wrapper(x, y) })(v)
   expectEqual(4, 𝛁x)
   expectEqual(3, 𝛁y)
 }
@@ -67,7 +67,7 @@ extension Wrapper {
   }
 }
 DerivativeRegistrationTests.testWithLeakChecking("StaticMethod") {
-  expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, in: { x, y in Wrapper.multiply(x, y) }))
+  expectEqual((3.0, 2.0), gradient(at: 2.0, 3.0, of: { x, y in Wrapper.multiply(x, y) }))
 }
 
 extension Wrapper {
@@ -147,7 +147,7 @@ DerivativeRegistrationTests.testWithLeakChecking("SubscriptSetter") {
 
   let x: Tracked<Float> = 2
   let wrapper = Wrapper(float: 3)
-  let (𝛁wrapper, 𝛁x) = pullback(at: wrapper, x, in: testSubscriptSet)(.init(float: 10))
+  let (𝛁wrapper, 𝛁x) = pullback(at: wrapper, x, of: testSubscriptSet)(.init(float: 10))
   expectEqual(Wrapper.TangentVector(float: 100), 𝛁wrapper)
   expectEqual(200, 𝛁x)
 }
@@ -192,7 +192,7 @@ DerivativeRegistrationTests.testWithLeakChecking("ComputedPropertySetter") {
   }
   let x: Tracked<Float> = 2
   let wrapper = Wrapper(float: 3)
-  let (𝛁wrapper, 𝛁x) = pullback(at: wrapper, x, in: testComputedPropertySet)(.init(float: 10))
+  let (𝛁wrapper, 𝛁x) = pullback(at: wrapper, x, of: testComputedPropertySet)(.init(float: 10))
   expectEqual(Wrapper.TangentVector(float: 100), 𝛁wrapper)
   expectEqual(200, 𝛁x)
 }
@@ -232,7 +232,7 @@ public func dNonCanonicalizedGenSigComparison<T: RefinesDifferentiable>(_ t: T)
   (t, { _ in T.TangentVector.zero })
 }
 DerivativeRegistrationTests.testWithLeakChecking("NonCanonicalizedGenericSignatureComparison") {
-  let dx = gradient(at: Float(0), in: nonCanonicalizedGenSigComparison)
+  let dx = gradient(at: Float(0), of: nonCanonicalizedGenSigComparison)
   // Expect that we use the custom registered derivative, not a generated derivative (which would
   // give a gradient of 1).
   expectEqual(0, dx)

--- a/test/AutoDiff/validation-test/differentiable_property.swift
+++ b/test/AutoDiff/validation-test/differentiable_property.swift
@@ -43,9 +43,9 @@ struct Space {
 
 extension Space : Differentiable {
   typealias TangentVector = TangentSpace
-  mutating func move(along direction: TangentSpace) {
-    x.move(along: direction.x)
-    y.move(along: direction.y)
+  mutating func move(by offset: TangentSpace) {
+    x.move(by: offset.x)
+    y.move(by: offset.y)
   }
 }
 
@@ -113,9 +113,9 @@ struct ProductSpaceOtherTangent {
 
 extension ProductSpaceOtherTangent : Differentiable {
   typealias TangentVector = ProductSpaceOtherTangentTangentSpace
-  mutating func move(along direction: ProductSpaceOtherTangentTangentSpace) {
-    x.move(along: direction.x)
-    y.move(along: direction.y)
+  mutating func move(by offset: ProductSpaceOtherTangentTangentSpace) {
+    x.move(by: offset.x)
+    y.move(by: offset.y)
   }
 }
 

--- a/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
+++ b/test/AutoDiff/validation-test/differentiable_protocol_requirements.swift
@@ -104,7 +104,7 @@ struct TestFunctionsOfX: FunctionsOfX {
 }
 
 @inline(never)  // Prevent specialization, to test all witness code.
-func derivatives<F: FunctionsOfX>(at x: Tracked<Float>, in: F.Type)
+func derivatives<F: FunctionsOfX>(at x: Tracked<Float>, of: F.Type)
   -> (Tracked<Float>, Tracked<Float>, Tracked<Float>, Tracked<Float>)
 {
   let dxdx = gradient(at: x) { x in F(x: x).x }
@@ -117,7 +117,7 @@ func derivatives<F: FunctionsOfX>(at x: Tracked<Float>, in: F.Type)
 ProtocolRequirementAutodiffTests.testWithLeakChecking("constructor, accessor, subscript") {
   expectEqual(
     (1.0, 4.0, 5.0, 5.0),
-    derivatives(at: 2.0, in: TestFunctionsOfX.self))
+    derivatives(at: 2.0, of: TestFunctionsOfX.self))
 }
 
 // MARK: - Test witness method SIL type computation.

--- a/test/AutoDiff/validation-test/forward_mode_array.swift
+++ b/test/AutoDiff/validation-test/forward_mode_array.swift
@@ -18,26 +18,26 @@ ForwardModeTests.test("Array.+") {
     return c[0] + c[1] + c[2]
   }
 
-  expectEqual(3, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1]), .init([1, 1])))
-  expectEqual(0, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([0, 0]), .init([0, 1])))
-  expectEqual(1, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([0, 1]), .init([0, 1])))
-  expectEqual(1, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 0]), .init([0, 1])))
-  expectEqual(1, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([0, 0]), .init([1, 1])))
-  expectEqual(2, differential(at: [0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1]), .init([0, 1])))
+  expectEqual(3, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1]), .init([1, 1])))
+  expectEqual(0, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 0]), .init([0, 1])))
+  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 1]), .init([0, 1])))
+  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 0]), .init([0, 1])))
+  expectEqual(1, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([0, 0]), .init([1, 1])))
+  expectEqual(2, differential(at: [0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1]), .init([0, 1])))
 
   expectEqual(
     3,
-    differential(at: [0, 0, 0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1, 1, 1]), .init([1, 1])))
+    differential(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1, 1, 1]), .init([1, 1])))
   expectEqual(
     3,
-    differential(at: [0, 0, 0, 0], [0, 0], in: sumFirstThreeConcatenating)(.init([1, 1, 1, 0]), .init([0, 0])))
+    differential(at: [0, 0, 0, 0], [0, 0], of: sumFirstThreeConcatenating)(.init([1, 1, 1, 0]), .init([0, 0])))
 
   expectEqual(
     3,
-    differential(at: [], [0, 0, 0, 0], in: sumFirstThreeConcatenating)(.init([]), .init([1, 1, 1, 1])))
+    differential(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating)(.init([]), .init([1, 1, 1, 1])))
   expectEqual(
     0,
-    differential(at: [], [0, 0, 0, 0], in: sumFirstThreeConcatenating)(.init([]), .init([0, 0, 0, 1])))
+    differential(at: [], [0, 0, 0, 0], of: sumFirstThreeConcatenating)(.init([]), .init([0, 0, 0, 1])))
 }
 
 ForwardModeTests.test("Array.init(repeating:count:)") {
@@ -48,7 +48,7 @@ ForwardModeTests.test("Array.init(repeating:count:)") {
   expectEqual(Float(10), derivative(at: .zero) { x in
     repeating(x).differentiableReduce(0, {$0 + $1})
   })
-  expectEqual(Float(20), differential(at: .zero, in: { x in
+  expectEqual(Float(20), differential(at: .zero, of: { x in
     repeating(x).differentiableReduce(0, {$0 + $1})
   })(2))
 }
@@ -59,7 +59,7 @@ ForwardModeTests.test("Array.DifferentiableView.init") {
     return Array<Float>.DifferentiableView(x)
   }
 
-  let forward = differential(at: [5, 6, 7, 8], in: constructView)
+  let forward = differential(at: [5, 6, 7, 8], of: constructView)
   expectEqual(
     FloatArrayTan([1, 2, 3, 4]),
     forward(FloatArrayTan([1, 2, 3, 4])))
@@ -73,7 +73,7 @@ ForwardModeTests.test("Array.DifferentiableView.base") {
 
   let forward = differential(
     at: Array<Float>.DifferentiableView([5, 6, 7, 8]),
-    in: accessBase)
+    of: accessBase)
   expectEqual(
     FloatArrayTan([1, 2, 3, 4]),
     forward(FloatArrayTan([1, 2, 3, 4])))
@@ -86,12 +86,12 @@ ForwardModeTests.test("Array.differentiableMap") {
   func multiplyMap(_ a: [Float]) -> [Float] {
     return a.differentiableMap({ x in 3 * x })
   }
-  expectEqual([3, 3, 3], differential(at: x, in: multiplyMap)(tan))
+  expectEqual([3, 3, 3], differential(at: x, of: multiplyMap)(tan))
 
   func squareMap(_ a: [Float]) -> [Float] {
     return a.differentiableMap({ x in x * x })
   }
-  expectEqual([2, 4, 6], differential(at: x, in: squareMap)(tan))
+  expectEqual([2, 4, 6], differential(at: x, of: squareMap)(tan))
 }
 
 ForwardModeTests.test("Array.differentiableReduce") {
@@ -101,17 +101,17 @@ ForwardModeTests.test("Array.differentiableReduce") {
   func sumReduce(_ a: [Float]) -> Float {
     return a.differentiableReduce(0, { $0 + $1 })
   }
-  expectEqual(1 + 1 + 1, differential(at: x, in: sumReduce)(tan))
+  expectEqual(1 + 1 + 1, differential(at: x, of: sumReduce)(tan))
 
   func productReduce(_ a: [Float]) -> Float {
     return a.differentiableReduce(1, { $0 * $1 })
   }
-  expectEqual(x[1] * x[2] + x[0] * x[2] + x[0] * x[1], differential(at: x, in: productReduce)(tan))
+  expectEqual(x[1] * x[2] + x[0] * x[2] + x[0] * x[1], differential(at: x, of: productReduce)(tan))
 
   func sumOfSquaresReduce(_ a: [Float]) -> Float {
     return a.differentiableReduce(0, { $0 + $1 * $1 })
   }
-  expectEqual(2 * x[0] + 2 * x[1] + 2 * x[2], differential(at: x, in: sumOfSquaresReduce)(tan))
+  expectEqual(2 * x[0] + 2 * x[1] + 2 * x[2], differential(at: x, of: sumOfSquaresReduce)(tan))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode_inout.swift
+++ b/test/AutoDiff/validation-test/forward_mode_inout.swift
@@ -19,7 +19,7 @@ ForwardModeInoutTests.test("Float.+=") {
     result += y
     return result
   }
-  expectEqual(20, differential(at: 4, 5, in: mutatingAddWrapper)(10, 10))
+  expectEqual(20, differential(at: 4, 5, of: mutatingAddWrapper)(10, 10))
 }
 
 ForwardModeInoutTests.test("Float.-=") {
@@ -28,8 +28,8 @@ ForwardModeInoutTests.test("Float.-=") {
     result -= y
     return result
   }
-  expectEqual(0, differential(at: 4, 5, in: mutatingSubtractWrapper)(10, 10))
-  expectEqual(10, differential(at: 4, 5, in: mutatingSubtractWrapper)(20, 10))
+  expectEqual(0, differential(at: 4, 5, of: mutatingSubtractWrapper)(10, 10))
+  expectEqual(10, differential(at: 4, 5, of: mutatingSubtractWrapper)(20, 10))
 }
 
 ForwardModeInoutTests.test("Float.*=") {
@@ -38,7 +38,7 @@ ForwardModeInoutTests.test("Float.*=") {
     result *= y
     return result
   }
-  expectEqual(22, differential(at: 4, 5, in: mutatingMultiplyWrapper)(2, 3))
+  expectEqual(22, differential(at: 4, 5, of: mutatingMultiplyWrapper)(2, 3))
 }
 
 ForwardModeInoutTests.test("Float./=") {
@@ -47,7 +47,7 @@ ForwardModeInoutTests.test("Float./=") {
     result /= y
     return result
   }
-  expectEqual(-1, differential(at: 2, 3, in: mutatingDivideWrapper)(3, 9))
+  expectEqual(-1, differential(at: 2, 3, of: mutatingDivideWrapper)(3, 9))
 }
 
 // Simplest possible `inout` parameter differentiation.
@@ -61,8 +61,8 @@ ForwardModeInoutTests.test("InoutIdentity") {
     inoutIdentity(&result)
     return result
   }
-  expectEqual(1, derivative(at: 10, in: identity))
-  expectEqual(10, differential(at: 10, in: identity)(10))
+  expectEqual(1, derivative(at: 10, of: identity))
+  expectEqual(10, differential(at: 10, of: identity)(10))
 
   func inoutIdentityGeneric<T: Differentiable>(_ x: inout T) {}
 
@@ -71,8 +71,8 @@ ForwardModeInoutTests.test("InoutIdentity") {
     inoutIdentityGeneric(&result)
     return result
   }
-  expectEqual(1, derivative(at: 10.0, in: identityGeneric))
-  expectEqual(10, differential(at: 10.0, in: identityGeneric)(10))
+  expectEqual(1, derivative(at: 10.0, of: identityGeneric))
+  expectEqual(10, differential(at: 10.0, of: identityGeneric)(10))
 }
 
 ForwardModeInoutTests.test("MultipleInoutParams") {
@@ -88,7 +88,7 @@ ForwardModeInoutTests.test("MultipleInoutParams") {
     swap(&p1, &p2)
     return p2
   }
-  expectEqual(1, differential(at: 1, 1, in: first)(1, 2))
+  expectEqual(1, differential(at: 1, 1, of: first)(1, 2))
 
   func second<T: Differentiable>(_ x: T, _ y: T) -> T {
     var p1 = x
@@ -96,7 +96,7 @@ ForwardModeInoutTests.test("MultipleInoutParams") {
     swap(&p1, &p2)
     return p1
   }
-  expectEqual(2, differential(at: 1, 1, in: second)(1, 2))
+  expectEqual(2, differential(at: 1, 1, of: second)(1, 2))
 }
 
 ForwardModeInoutTests.test("StructMutatingMethod") {
@@ -117,7 +117,7 @@ ForwardModeInoutTests.test("StructMutatingMethod") {
     mut.add(y)
     return mut.x
   }
-  expectEqual(1, derivative(at: 1, in: identity))
+  expectEqual(1, derivative(at: 1, of: identity))
 
   func identity2(_ y: Float) -> Float {
     var mut = Mut(x: 0.0)
@@ -125,14 +125,14 @@ ForwardModeInoutTests.test("StructMutatingMethod") {
     mut.addMut(mut2)
     return mut.x
   }
-  expectEqual(1, derivative(at: 1, in: identity2))
+  expectEqual(1, derivative(at: 1, of: identity2))
 
   func double(_ y: Float) -> Float {
     var mut = Mut(x: y)
     mut.add(y)
     return mut.x
   }
-  expectEqual(2, derivative(at: 1, in: double))
+  expectEqual(2, derivative(at: 1, of: double))
 
   func double2(_ y: Float) -> Float {
     var mut = Mut(x: y)
@@ -140,14 +140,14 @@ ForwardModeInoutTests.test("StructMutatingMethod") {
     mut.addMut(mut2)
     return mut.x
   }
-  expectEqual(2, derivative(at: 1, in: double2))
+  expectEqual(2, derivative(at: 1, of: double2))
 
   func square(_ y: Float) -> Float {
     var mut = Mut(x: 0.0)
     mut.add(y * y)
     return mut.x
   }
-  expectEqual(6, derivative(at: 3, in: square))
+  expectEqual(6, derivative(at: 3, of: square))
 
   func square2(_ y: Float) -> Float {
     var mut = Mut(x: 0.0)
@@ -155,7 +155,7 @@ ForwardModeInoutTests.test("StructMutatingMethod") {
     mut.addMut(mut2)
     return mut.x
   }
-  expectEqual(6, derivative(at: 3, in: square2))
+  expectEqual(6, derivative(at: 3, of: square2))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/forward_mode_simd.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simd.swift
@@ -15,7 +15,7 @@ ForwardModeTests.test("init(repeating:)") {
   func foo1(x: Float) -> SIMD4<Float> {
     return SIMD4<Float>(repeating: 2 * x)
   }
-  let (val1, df1) = valueWithDifferential(at: 5, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: 5, of: foo1)
   expectEqual(SIMD4<Float>(10, 10, 10, 10), val1)
   expectEqual(SIMD4<Float>(6, 6, 6, 6), df1(3))
 }
@@ -27,7 +27,7 @@ ForwardModeTests.test("Identity") {
   func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
     return x
   }
-  let (val1, df1) = valueWithDifferential(at: a, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
   expectEqual(a, val1)
   expectEqual(g, df1(.init(g)))
 }
@@ -39,7 +39,7 @@ ForwardModeTests.test("Negate") {
   func foo1(x: SIMD4<Float>) -> SIMD4<Float> {
     return -x
   }
-  let (val1, df1) = valueWithDifferential(at: a, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
   expectEqual(-a, val1)
   expectEqual(-g, df1(.init(g)))
 }
@@ -51,7 +51,7 @@ ForwardModeTests.test("subscript") {
     return x[3]
   }
 
-  let (val1, df1) = valueWithDifferential(at: a, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: a, of: foo1)
   expectEqual(4, val1)
   expectEqual(4, df1(a))
 }
@@ -64,7 +64,7 @@ ForwardModeTests.test("Addition") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x + y
   }
-  let (val1, df1) = valueWithDifferential(at: a, a, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
   expectEqual(SIMD4<Float>(2, 4, 6, 8), val1)
   expectEqual(a + g, df1(a, g))
 
@@ -72,7 +72,7 @@ ForwardModeTests.test("Addition") {
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x + y
   }
-  let (val2, df2) = valueWithDifferential(at: a, 5, in: foo2)
+  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
   expectEqual(SIMD4<Float>(6, 7, 8, 9), val2)
   expectEqual(g + 1, df2(g, 1))
 
@@ -80,7 +80,7 @@ ForwardModeTests.test("Addition") {
   func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y + x
   }
-  let (val3, df3) = valueWithDifferential(at: a, 5, in: foo3)
+  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
   expectEqual(SIMD4<Float>(6, 7, 8, 9), val3)
   expectEqual(2 + g, df3(g, 2))
 }
@@ -93,7 +93,7 @@ ForwardModeTests.test("Subtraction") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x - y
   }
-  let (val1, df1) = valueWithDifferential(at: a, a, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
   expectEqual(SIMD4<Float>(0, 0, 0, 0), val1)
   expectEqual(g - a, df1(g, a))
 
@@ -101,7 +101,7 @@ ForwardModeTests.test("Subtraction") {
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x - y
   }
-  let (val2, df2) = valueWithDifferential(at: a, 5, in: foo2)
+  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
   expectEqual(SIMD4<Float>(-4, -3, -2, -1), val2)
   expectEqual(g - 1, df2(g, 1))
 
@@ -109,7 +109,7 @@ ForwardModeTests.test("Subtraction") {
   func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y - x
   }
-  let (val3, df3) = valueWithDifferential(at: a, 5, in: foo3)
+  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
   expectEqual(SIMD4<Float>(4, 3, 2, 1), val3)
   expectEqual(2 - g, df3(g, 2))
 }
@@ -124,7 +124,7 @@ ForwardModeTests.test("Multiplication") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x * y
   }
-  let (val1, df1) = valueWithDifferential(at: a, a2, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: a, a2, of: foo1)
   expectEqual(a * a2, val1)
   expectEqual(a * g2 + g * a2, df1(g, g2))
 
@@ -132,7 +132,7 @@ ForwardModeTests.test("Multiplication") {
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x * y
   }
-  let (val2, df2) = valueWithDifferential(at: a, 5, in: foo2)
+  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
   expectEqual(a * 5, val2)
   expectEqual(a * 2 + g * 5, df2(g, 2))
 
@@ -140,7 +140,7 @@ ForwardModeTests.test("Multiplication") {
   func foo3(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return y * x
   }
-  let (val3, df3) = valueWithDifferential(at: a, 5, in: foo3)
+  let (val3, df3) = valueWithDifferential(at: a, 5, of: foo3)
   expectEqual(a * 5, val3)
   expectEqual(a * 3 + g * 5, df3(g, 3))
 }
@@ -153,7 +153,7 @@ ForwardModeTests.test("Division") {
   func foo1(x: SIMD4<Float>, y: SIMD4<Float>) -> SIMD4<Float> {
     return x / y
   }
-  let (val1, df1) = valueWithDifferential(at: a, a, in: foo1)
+  let (val1, df1) = valueWithDifferential(at: a, a, of: foo1)
   expectEqual(a / a, val1)
   expectEqual((g * a - a * g) / (a * a)/* == 0 */, df1(g, g))
 
@@ -161,7 +161,7 @@ ForwardModeTests.test("Division") {
   func foo2(x: SIMD4<Float>, y: Float) -> SIMD4<Float> {
     return x / y
   }
-  let (val2, df2) = valueWithDifferential(at: a, 5, in: foo2)
+  let (val2, df2) = valueWithDifferential(at: a, 5, of: foo2)
   expectEqual(a / 5, val2)
   expectEqual((g * 5 - a * 2) / (5 * 5), df2(g, 2))
 
@@ -169,7 +169,7 @@ ForwardModeTests.test("Division") {
   func foo3(x: Float, y: SIMD4<Float>) -> SIMD4<Float> {
     return x / y
   }
-  let (val3, df3) = valueWithDifferential(at: 5, a, in: foo3)
+  let (val3, df3) = valueWithDifferential(at: 5, a, of: foo3)
   expectEqual(5 / a, val3)
   expectEqual((3 * a - 5 * g) / (a * a), df3(3, g))
 }
@@ -189,7 +189,7 @@ ForwardModeTests.test("Generics") {
     return SIMDType.init(repeating: x)
   }
   func simd3Init(x: Double) -> SIMD3<Double> { testInit(x: x) }
-  let (val1, df1) = valueWithDifferential(at: 10, in: simd3Init)
+  let (val1, df1) = valueWithDifferential(at: 10, of: simd3Init)
   expectEqual(SIMD3<Double>(10, 10, 10), val1)
   expectEqual(SIMD3<Double>(5, 5, 5), df1(5))
   */
@@ -207,7 +207,7 @@ ForwardModeTests.test("Generics") {
   func simd3Add(lhs: SIMD3<Double>, rhs: SIMD3<Double>) -> SIMD3<Double> {
     return testAddition(lhs: lhs, rhs: rhs)
   }
-  let (val2, df2) = valueWithDifferential(at: a, a, in: simd3Add)
+  let (val2, df2) = valueWithDifferential(at: a, a, of: simd3Add)
   expectEqual(SIMD3<Double>(2, 4, 6), val2)
   expectEqual(g + a, df2(g, a))
 
@@ -224,7 +224,7 @@ ForwardModeTests.test("Generics") {
   func simd3Subtract(lhs: Double, rhs: SIMD3<Double>) -> SIMD3<Double> {
     return testSubtraction(lhs: lhs, rhs: rhs)
   }
-  let (val3, df3) = valueWithDifferential(at: 5, a, in: simd3Subtract)
+  let (val3, df3) = valueWithDifferential(at: 5, a, of: simd3Subtract)
   expectEqual(SIMD3<Double>(4, 3, 2), val3)
   expectEqual(2 - g, df3(2, g))
 
@@ -241,7 +241,7 @@ ForwardModeTests.test("Generics") {
   func simd3Multiply(lhs: SIMD3<Double>, rhs: Double) -> SIMD3<Double> {
     return testMultipication(lhs: lhs, rhs: rhs)
   }
-  let (val4, df4) = valueWithDifferential(at: a, 5, in: simd3Multiply)
+  let (val4, df4) = valueWithDifferential(at: a, 5, of: simd3Multiply)
   expectEqual(SIMD3<Double>(5, 10, 15), val4)
   expectEqual(a * 3 + g * 5 , df4(g, 3))
 }

--- a/test/AutoDiff/validation-test/forward_mode_simple.swift
+++ b/test/AutoDiff/validation-test/forward_mode_simple.swift
@@ -14,7 +14,7 @@ ForwardModeTests.test("Identity") {
   func func_to_diff(x: Float) -> Float {
     return x
   }
-  let (y, differential) = valueWithDifferential(at: 4, in: func_to_diff)
+  let (y, differential) = valueWithDifferential(at: 4, of: func_to_diff)
   expectEqual(4, y)
   expectEqual(1, differential(1))
 }
@@ -23,7 +23,7 @@ ForwardModeTests.test("Unary") {
   func func_to_diff(x: Float) -> Float {
     return x * x
   }
-  let (y, differential) = valueWithDifferential(at: 4, in: func_to_diff)
+  let (y, differential) = valueWithDifferential(at: 4, of: func_to_diff)
   expectEqual(16, y)
   expectEqual(8, differential(1))
 }
@@ -32,7 +32,7 @@ ForwardModeTests.test("Binary") {
   func func_to_diff(x: Float, y: Float) -> Float {
     return x * y
   }
-  let (y, differential) = valueWithDifferential(at: 4, 5, in: func_to_diff)
+  let (y, differential) = valueWithDifferential(at: 4, 5, of: func_to_diff)
   expectEqual(20, y)
   expectEqual(9, differential(1, 1))
 }
@@ -43,7 +43,7 @@ ForwardModeTests.test("BinaryWithLets") {
     let b = a
     return b * -y
   }
-  let (y, differential) = valueWithDifferential(at: 4, 5, in: func_to_diff)
+  let (y, differential) = valueWithDifferential(at: 4, 5, of: func_to_diff)
   expectEqual(-45, y)
   expectEqual(-19, differential(1, 1))
 }
@@ -93,7 +93,7 @@ ForwardModeTests.test("UnaryWithVars") {
     return d
   }
 
-  let (y, differential) = valueWithDifferential(at: 4, in: unary)
+  let (y, differential) = valueWithDifferential(at: 4, of: unary)
   expectEqual(22, y)
   expectEqual(4, differential(1))
 }
@@ -111,7 +111,7 @@ ForwardModeTests.test("StructInit") {
     return A(x: 2 * x)
   }
 
-  let (y, differential) = valueWithDifferential(at: 4, in: structInit)
+  let (y, differential) = valueWithDifferential(at: 4, of: structInit)
   expectEqual(A(x: 8), y)
   expectEqual(A(x: 2), differential(1))
 }
@@ -123,7 +123,7 @@ ForwardModeTests.test("StructExtract") {
 
   let (y, differential) = valueWithDifferential(
     at: A(x: 4),
-    in: structExtract)
+    of: structExtract)
   expectEqual(8, y)
   expectEqual(2, differential(A(x: 1)))
 }
@@ -138,7 +138,7 @@ ForwardModeTests.test("LocalStructVariable") {
 
   let (y, differential) = valueWithDifferential(
     at: A(x: 4),
-    in: structExtract)
+    of: structExtract)
   expectEqual(A(x: 18), y)
   expectEqual(A(x: 4), differential(A(x: 1)))
 }
@@ -204,7 +204,7 @@ ForwardModeTests.testWithLeakChecking("TrackedIdentity") {
   func identity(x: Tracked<Float>) -> Tracked<Float> {
     return x
   }
-  let (y, differential) = valueWithDifferential(at: 4, in: identity)
+  let (y, differential) = valueWithDifferential(at: 4, of: identity)
   expectEqual(4, y)
   expectEqual(1, differential(1))
 }
@@ -213,7 +213,7 @@ ForwardModeTests.testWithLeakChecking("TrackedAddition") {
   func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
     return x + y
   }
-  let (y, differential) = valueWithDifferential(at: 4, 5, in: add)
+  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
   expectEqual(9, y)
   expectEqual(2, differential(1, 1))
 }
@@ -222,7 +222,7 @@ ForwardModeTests.testWithLeakChecking("TrackedDivision") {
   func divide(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
     return x / y
   }
-  let (y, differential) = valueWithDifferential(at: 10, 5, in: divide)
+  let (y, differential) = valueWithDifferential(at: 10, 5, of: divide)
   expectEqual(2, y)
   expectEqual(-0.2, differential(1, 1))
 }
@@ -231,7 +231,7 @@ ForwardModeTests.testWithLeakChecking("TrackedMultipleMultiplication") {
   func add(x: Tracked<Float>, y: Tracked<Float>) -> Tracked<Float> {
     return x * y * x
   }
-  let (y, differential) = valueWithDifferential(at: 4, 5, in: add)
+  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
   expectEqual(80, y)
   // 2yx+xx
   expectEqual(56, differential(1, 1))
@@ -245,7 +245,7 @@ ForwardModeTests.testWithLeakChecking("TrackedWithLets") {
     return c
   }
   // (3x^2+2xy-y^2)/x^2+1
-  let (y, differential) = valueWithDifferential(at: 4, 5, in: add)
+  let (y, differential) = valueWithDifferential(at: 4, 5, of: add)
   expectEqual(25.25, y)
   expectEqual(4.9375, differential(1, 1))
 }
@@ -260,7 +260,7 @@ ForwardModeTests.test("TupleLet") {
       let tuple = (2 * x, x)
       return tuple.0
     }
-    let (value, derivative) = valueWithDerivative(at: 4, in: tupleLet)
+    let (value, derivative) = valueWithDerivative(at: 4, of: tupleLet)
     expectEqual(8, value)
     expectEqual(2, derivative)
   }
@@ -272,7 +272,7 @@ ForwardModeTests.test("TupleVar") {
       var tuple = (2 * x, x)
       return tuple.0
     }
-    let (value, derivative) = valueWithDerivative(at: 4, in: tupleVar)
+    let (value, derivative) = valueWithDerivative(at: 4, of: tupleVar)
     expectEqual(8, value)
     expectEqual(2, derivative)
   }
@@ -283,7 +283,7 @@ ForwardModeTests.test("TupleVar") {
       var tuple = (2 * x, 1)
       return tuple.0
     }
-    let (value, derivative) = valueWithDerivative(at: 4, in: TF_964)
+    let (value, derivative) = valueWithDerivative(at: 4, of: TF_964)
     expectEqual(8, value)
     expectEqual(2, derivative)
   }
@@ -295,7 +295,7 @@ ForwardModeTests.test("TupleMutation") {
     tuple.0 = tuple.0 * x
     return x * tuple.0
   }
-  expectEqual(27, derivative(at: 3, in: foo))
+  expectEqual(27, derivative(at: 3, of: foo))
 
   func fifthPower(_ x: Float) -> Float {
     var tuple = (x, x)
@@ -303,7 +303,7 @@ ForwardModeTests.test("TupleMutation") {
     tuple.1 = tuple.0 * x
     return tuple.0 * tuple.1
   }
-  expectEqual(405, derivative(at: 3, in: fifthPower))
+  expectEqual(405, derivative(at: 3, of: fifthPower))
 
   func nested(_ x: Float) -> Float {
     var tuple = ((x, x), x)
@@ -311,13 +311,13 @@ ForwardModeTests.test("TupleMutation") {
     tuple.0.1 = tuple.0.0 * x
     return tuple.0.0 * tuple.0.1
   }
-  expectEqual(405, derivative(at: 3, in: nested))
+  expectEqual(405, derivative(at: 3, of: nested))
 
   func generic<T: Differentiable & AdditiveArithmetic>(_ x: T) -> T {
     var tuple = (x, x)
     return tuple.0
   }
-  expectEqual(1, derivative(at: 3.0, in: generic))
+  expectEqual(1, derivative(at: 3.0, of: generic))
 
   // FIXME(TF-1033): Fix forward-mode ownership error for tuple with non-active
   // initial values.
@@ -330,7 +330,7 @@ ForwardModeTests.test("TupleMutation") {
     tuple.1 = x
     return tuple.0
   }
-  expectEqual(1, derivative(at: 3.0, in: genericInitialNonactive))
+  expectEqual(1, derivative(at: 3.0, of: genericInitialNonactive))
   */
 }
 
@@ -341,7 +341,7 @@ ForwardModeTests.test("TupleNonDifferentiableElements") {
     let tuple = (2 * x, 1)
     return tuple.0
   }
-  expectEqual((8, 2), valueWithDerivative(at: 4, in: tupleLet))
+  expectEqual((8, 2), valueWithDerivative(at: 4, of: tupleLet))
 
   func tupleVar(_ x: Tracked<Float>) -> Tracked<Float> {
     var tuple = (x, 1)
@@ -349,7 +349,7 @@ ForwardModeTests.test("TupleNonDifferentiableElements") {
     tuple.1 = 1
     return tuple.0
   }
-  expectEqual((3, 1), valueWithDerivative(at: 3, in: tupleVar))
+  expectEqual((3, 1), valueWithDerivative(at: 3, of: tupleVar))
 
   @differentiable(reverse)
   func nested(_ x: Tracked<Float>) -> Tracked<Float> {
@@ -362,7 +362,7 @@ ForwardModeTests.test("TupleNonDifferentiableElements") {
     return tuple.1.1 * tuple.2
   }
   // FIXME(SR-12911): Fix runtime segfault.
-  // expectEqual((16, 8), valueWithDerivative(at: 4, in: nested))
+  // expectEqual((16, 8), valueWithDerivative(at: 4, of: nested))
 
   struct Wrapper<T> {
     @differentiable(reverse where T : Differentiable)
@@ -378,7 +378,7 @@ ForwardModeTests.test("TupleNonDifferentiableElements") {
     let w = Wrapper<Tracked<Float>>()
     return w.baz(x)
   }
-  expectEqual((3, 1), valueWithDerivative(at: 3, in: wrapper))
+  expectEqual((3, 1), valueWithDerivative(at: 3, of: wrapper))
 }
 
 //===----------------------------------------------------------------------===//
@@ -484,7 +484,7 @@ extension Tensor where Scalar : Numeric {
     return mean() // ok
   }
 }
-_ = differential(at: Tensor<Float>(1), in: { $0.variance() })
+_ = differential(at: Tensor<Float>(1), of: { $0.variance() })
 
 // Tests TF-508: differentiation requirements with dependent member types.
 protocol TF_508_Proto {
@@ -537,12 +537,12 @@ extension TF_508_Struct : Differentiable where Scalar : Differentiable {
 // func TF_508() {
 //   let x = TF_508_Struct<Float>()
 //   // Test conformance requirement with dependent member type.
-//   _ = differential(at: x, in: {
+//   _ = differential(at: x, of: {
 //     (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
 //     return x + x
 //   })
 //   // Test same-type requirement with dependent member type.
-//   _ = differential(at: x, in: {
+//   _ = differential(at: x, of: {
 //     (x: TF_508_Struct<Float>) -> TF_508_Struct<Float> in
 //     return x - x
 //   })
@@ -661,7 +661,7 @@ ForwardModeTests.testWithLeakChecking("TrackedDifferentiableFuncType") {
   func valAndDeriv(
     f: @escaping @differentiable(reverse) (Tracked<Float>) -> Tracked<Float>
   ) -> (Tracked<Float>, Tracked<Float>) {
-    let (y, diff) = valueWithDifferential(at: 5, in: f)
+    let (y, diff) = valueWithDifferential(at: 5, of: f)
     return (y, diff(1))
   }
 
@@ -936,7 +936,7 @@ struct TestFunctionsOfX: FunctionsOfX {
 }
 
 @inline(never)  // Prevent specialization, to test all witness code.
-func derivatives<F: FunctionsOfX>(at x: Float, in: F.Type)
+func derivatives<F: FunctionsOfX>(at x: Float, of: F.Type)
   -> (Float, Float, Float, Float)
 {
   let dxdx = derivative(at: x) { x in F(x: x).x }
@@ -949,7 +949,7 @@ func derivatives<F: FunctionsOfX>(at x: Float, in: F.Type)
 ForwardModeTests.test("constructor, accessor, subscript") {
   expectEqual(
     (1.0, 4.0, 5.0, 5.0),
-    derivatives(at: 2.0, in: TestFunctionsOfX.self))
+    derivatives(at: 2.0, of: TestFunctionsOfX.self))
 }
 
 // MARK: - Test witness method SIL type computation.
@@ -1029,37 +1029,37 @@ ForwardModeTests.test("Arithmetics") {
   func foo1(x: Float, y: Float) -> Float {
     return x * y
   }
-  expectEqual(7, derivative(at: 3, 4, in: foo1))
+  expectEqual(7, derivative(at: 3, 4, of: foo1))
   func foo2(x: Float, y: Float) -> Float {
     return -x * y
   }
-  expectEqual(-7, derivative(at: 3, 4, in: foo2))
+  expectEqual(-7, derivative(at: 3, 4, of: foo2))
   func foo3(x: Float, y: Float) -> Float {
     return -x + y
   }
-  expectEqual(0, derivative(at: 3, 4, in: foo3))
+  expectEqual(0, derivative(at: 3, 4, of: foo3))
 }
 
 ForwardModeTests.test("Fanout") {
   func foo1(x: Float) -> Float {
      x - x
   }
-  expectEqual(0, derivative(at: 100, in: foo1))
+  expectEqual(0, derivative(at: 100, of: foo1))
   func foo2(x: Float) -> Float {
      x + x
   }
-  expectEqual(2, derivative(at: 100, in: foo2))
+  expectEqual(2, derivative(at: 100, of: foo2))
   func foo3(x: Float, y: Float) -> Float {
     x + x + x * y
   }
-  expectEqual(7, derivative(at: 3, 2, in: foo3))
+  expectEqual(7, derivative(at: 3, 2, of: foo3))
 }
 
 ForwardModeTests.test("FunctionCall") {
   func foo(_ x: Float, _ y: Float) -> Float {
     return 3 * x + { $0 * 3 }(3) * y
   }
-  expectEqual(12, derivative(at: 3, 4, in: foo))
+  expectEqual(12, derivative(at: 3, 4, of: foo))
   expectEqual(3, derivative(at: 3) { x in foo(x, 4) })
 }
 
@@ -1067,8 +1067,8 @@ ForwardModeTests.test("ResultSelection") {
   func tuple(_ x: Float, _ y: Float) -> (Float, Float) {
     return (x + 1, y + 2)
   }
-  expectEqual(1, derivative(at: 3, 3, in: { x, y in tuple(x, y).0 }))
-  expectEqual(1, derivative(at: 3, 3, in: { x, y in tuple(x, y).1 }))
+  expectEqual(1, derivative(at: 3, 3, of: { x, y in tuple(x, y).0 }))
+  expectEqual(1, derivative(at: 3, 3, of: { x, y in tuple(x, y).1 }))
 
   // FIXME(SR-12175): Fix forward-mode differentiation tangent buffer crash.
   /*
@@ -1077,8 +1077,8 @@ ForwardModeTests.test("ResultSelection") {
   }
   func tupleGenericFirst<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).0 }
   func tupleGenericSecond<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).1 }
-  expectEqual(1, derivative(at: 3, 3, in: tupleGenericFirst))
-  expectEqual(1, derivative(at: 3, 3, in: tupleGenericSecond))
+  expectEqual(1, derivative(at: 3, 3, of: tupleGenericFirst))
+  expectEqual(1, derivative(at: 3, 3, of: tupleGenericSecond))
   */
 }
 
@@ -1094,8 +1094,8 @@ ForwardModeTests.test("MultipleResults") {
     // Note: both results (tuple elements) are active.
     return z.0 * z.1
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply))
-  expectEqual((10, 5), gradient(at: 5, 10, in: multiply))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply))
+  expectEqual((10, 5), gradient(at: 5, 10, of: multiply))
 
   // Test function with multiple `inout` parameters.
   func swap(_ x: inout Float, _ y: inout Float) {
@@ -1106,8 +1106,8 @@ ForwardModeTests.test("MultipleResults") {
     swap(&tuple.0, &tuple.1)
     return tuple.0 * tuple.1
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swap))
-  expectEqual((10, 5), gradient(at: 5, 10, in: multiply_swap))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swap))
+  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swap))
 
   // Test function with multiple `inout` parameters.
   func swapGeneric<T>(_ x: inout T, _ y: inout T) {
@@ -1118,8 +1118,8 @@ ForwardModeTests.test("MultipleResults") {
     swapGeneric(&tuple.0, &tuple.1)
     return tuple.0 * tuple.1
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swapGeneric))
-  expectEqual((10, 5), gradient(at: 5, 10, in: multiply_swapGeneric))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapGeneric))
+  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swapGeneric))
 
   // Test function with multiple `inout` parameters and a formal result.
   func swapAndReturnProduct(_ x: inout Float, _ y: inout Float) -> Float {
@@ -1134,8 +1134,8 @@ ForwardModeTests.test("MultipleResults") {
     let result = swapAndReturnProduct(&x2, &y2)
     return result
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swapAndReturnProduct))
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swapAndReturnProduct))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
 }
 */
 
@@ -1144,7 +1144,7 @@ ForwardModeTests.test("CaptureLocal") {
   func foo(_ x: Float) -> Float {
     return z * x
   }
-  expectEqual(10, derivative(at: 0, in: foo))
+  expectEqual(10, derivative(at: 0, of: foo))
 }
 
 var globalVar: Float = 10
@@ -1153,7 +1153,7 @@ ForwardModeTests.test("CaptureGlobal") {
     globalVar += 20
     return globalVar * x
   }
-  expectEqual(30, derivative(at: 0, in: foo))
+  expectEqual(30, derivative(at: 0, of: foo))
 }
 
 ForwardModeTests.test("Mutation") {
@@ -1163,7 +1163,7 @@ ForwardModeTests.test("Mutation") {
     a = a * x
     return a * x
   }
-  expectEqual(4 * 27, derivative(at: 3, in: fourthPower))
+  expectEqual(4 * 27, derivative(at: 3, of: fourthPower))
 }
 
 // Tests TF-21.
@@ -1175,7 +1175,7 @@ ForwardModeTests.test("StructMemberwiseInitializer") {
     }
   }
 
-  let derivFoo = differential(at: Float(4), in: { input -> Foo in
+  let derivFoo = differential(at: Float(4), of: { input -> Foo in
     let foo = Foo(stored: input)
     let foo2 = foo + foo
     return Foo(stored: foo2.stored)
@@ -1204,7 +1204,7 @@ ForwardModeTests.test("StructMemberwiseInitializer") {
     }
   }
 
-  let derivCustom = differential(at: Float(4), in: { input -> Custom in
+  let derivCustom = differential(at: Float(4), of: { input -> Custom in
     let foo = Custom(x: input)
     return foo + foo
   })(1)
@@ -1231,8 +1231,8 @@ ForwardModeTests.test("StructConstantStoredProperty") {
     let model = TF_319(x: 10)
     return model.applied(to: input)
   }
-  expectEqual(6, derivative(at: 10, in: { TF_319(x: $0).applied(to: 3) }))
-  expectEqual(20, derivative(at: 3, in: testStructInit))
+  expectEqual(6, derivative(at: 10, of: { TF_319(x: $0).applied(to: 3) }))
+  expectEqual(20, derivative(at: 3, of: testStructInit))
 }
 
 ForwardModeTests.test("StructMutation") {
@@ -1246,7 +1246,7 @@ ForwardModeTests.test("StructMutation") {
     let point = Point(x: input, y: input, z: input)
     return point + point
   }
-  expectEqual(Point(x: 2, y: 2, z: 2), differential(at: 4, in: double)(1))
+  expectEqual(Point(x: 2, y: 2, z: 2), differential(at: 4, of: double)(1))
 
   func fifthPower(_ input: Float) -> Float {
     var point = Point(x: input, y: input, z: input)
@@ -1254,7 +1254,7 @@ ForwardModeTests.test("StructMutation") {
     point.y = point.x * input
     return point.x * point.y
   }
-  expectEqual(405, derivative(at: 3, in: fifthPower))
+  expectEqual(405, derivative(at: 3, of: fifthPower))
 
   func mix(_ input: Float) -> Float {
     var tuple = (point: Point(x: input, y: input, z: input), float: input)
@@ -1262,7 +1262,7 @@ ForwardModeTests.test("StructMutation") {
     tuple.point.y = tuple.point.x * input
     return tuple.point.x * tuple.point.y
   }
-  expectEqual(405, derivative(at: 3, in: mix))
+  expectEqual(405, derivative(at: 3, of: mix))
 
   // Test TF-282.
   struct Add : Differentiable {
@@ -1283,7 +1283,7 @@ ForwardModeTests.test("StructGeneric") {
     var z: T
   }
 
-  let deriv = differential(at: Float(3), in: { input -> Generic<Float> in
+  let deriv = differential(at: Float(3), of: { input -> Generic<Float> in
     var generic = Generic(x: input, y: input, z: input)
     return generic
   })(1)
@@ -1295,7 +1295,7 @@ ForwardModeTests.test("StructGeneric") {
     generic.y = generic.x * input
     return generic.x * generic.y
   }
-  expectEqual(405, derivative(at: 3, in: fifthPower))
+  expectEqual(405, derivative(at: 3, of: fifthPower))
 }
 
 ForwardModeTests.test("SubsetIndices") {
@@ -1386,7 +1386,7 @@ ForwardModeTests.test("ApplyNonActiveIndirectResult") {
     y = x
     return y
   }
-  expectEqual(1.0, derivative(at: 2, in: applyNonactiveArgumentActiveIndirectResult))
+  expectEqual(1.0, derivative(at: 2, of: applyNonactiveArgumentActiveIndirectResult))
 }
 
 ForwardModeTests.test("SR-13530") {
@@ -1397,7 +1397,7 @@ ForwardModeTests.test("SR-13530") {
     precondition(x >= 0)
     return x
   }
-  expectEqual(1, derivative(at: 2, in: SR_13530))
+  expectEqual(1, derivative(at: 2, of: SR_13530))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/inout_parameters.swift
+++ b/test/AutoDiff/validation-test/inout_parameters.swift
@@ -21,8 +21,8 @@ InoutParameterAutoDiffTests.test("Float.+=") {
     result += y
     return result
   }
-  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingAddWrapper))
-  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingAddWrapper)(10))
+  expectEqual((1, 1), gradient(at: 4, 5, of: mutatingAddWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, of: mutatingAddWrapper)(10))
 }
 
 InoutParameterAutoDiffTests.test("Float.-=") {
@@ -31,8 +31,8 @@ InoutParameterAutoDiffTests.test("Float.-=") {
     result += y
     return result
   }
-  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingSubtractWrapper))
-  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingSubtractWrapper)(10))
+  expectEqual((1, 1), gradient(at: 4, 5, of: mutatingSubtractWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, of: mutatingSubtractWrapper)(10))
 }
 
 InoutParameterAutoDiffTests.test("Float.*=") {
@@ -41,8 +41,8 @@ InoutParameterAutoDiffTests.test("Float.*=") {
     result += y
     return result
   }
-  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingMultiplyWrapper))
-  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingMultiplyWrapper)(10))
+  expectEqual((1, 1), gradient(at: 4, 5, of: mutatingMultiplyWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, of: mutatingMultiplyWrapper)(10))
 }
 
 InoutParameterAutoDiffTests.test("Float./=") {
@@ -51,8 +51,8 @@ InoutParameterAutoDiffTests.test("Float./=") {
     result += y
     return result
   }
-  expectEqual((1, 1), gradient(at: 4, 5, in: mutatingDivideWrapper))
-  expectEqual((10, 10), pullback(at: 4, 5, in: mutatingDivideWrapper)(10))
+  expectEqual((1, 1), gradient(at: 4, 5, of: mutatingDivideWrapper))
+  expectEqual((10, 10), pullback(at: 4, 5, of: mutatingDivideWrapper)(10))
 }
 
 // Simplest possible `inout` parameter differentiation.
@@ -66,8 +66,8 @@ InoutParameterAutoDiffTests.test("InoutIdentity") {
     inoutIdentity(&result)
     return result
   }
-  expectEqual(1, gradient(at: 10, in: identity))
-  expectEqual(10, pullback(at: 10, in: identity)(10))
+  expectEqual(1, gradient(at: 10, of: identity))
+  expectEqual(10, pullback(at: 10, of: identity)(10))
 }
 
 extension Float {
@@ -88,7 +88,7 @@ InoutParameterAutoDiffTests.test("ControlFlow") {
     }
     return result
   }
-  expectEqual([1, 1, 1], gradient(at: [1, 2, 3], in: sum))
+  expectEqual([1, 1, 1], gradient(at: [1, 2, 3], of: sum))
 
   func product(_ array: [Float]) -> Float {
     var result: Float = 1
@@ -97,7 +97,7 @@ InoutParameterAutoDiffTests.test("ControlFlow") {
     }
     return result
   }
-  expectEqual([20, 15, 12], gradient(at: [3, 4, 5], in: product))
+  expectEqual([20, 15, 12], gradient(at: [3, 4, 5], of: product))
 
   func productCustom(_ array: [Float]) -> Float {
     var result: Float = 1
@@ -106,7 +106,7 @@ InoutParameterAutoDiffTests.test("ControlFlow") {
     }
     return result
   }
-  expectEqual([20, 15, 12], gradient(at: [3, 4, 5], in: productCustom))
+  expectEqual([20, 15, 12], gradient(at: [3, 4, 5], of: productCustom))
 }
 
 InoutParameterAutoDiffTests.test("SetAccessor") {
@@ -135,8 +135,8 @@ InoutParameterAutoDiffTests.test("SetAccessor") {
     s.computed *= x
     return s.x
   }
-  expectEqual((9, 6), valueWithGradient(at: 3, in: squared))
-  expectEqual((16, 8), valueWithGradient(at: 4, in: squared))
+  expectEqual((9, 6), valueWithGradient(at: 3, of: squared))
+  expectEqual((16, 8), valueWithGradient(at: 4, of: squared))
 
   // `quadrupled` implemented using a `set` accessor.
   func quadrupled(_ x: Float) -> Float {
@@ -144,10 +144,10 @@ InoutParameterAutoDiffTests.test("SetAccessor") {
     s.doubled *= 4 * x
     return s.x
   }
-  print(valueWithGradient(at: 3, in: quadrupled))
-  print(valueWithGradient(at: 4, in: quadrupled))
-  expectEqual((12, 4), valueWithGradient(at: 3, in: quadrupled))
-  expectEqual((16, 4), valueWithGradient(at: 4, in: quadrupled))
+  print(valueWithGradient(at: 3, of: quadrupled))
+  print(valueWithGradient(at: 4, of: quadrupled))
+  expectEqual((12, 4), valueWithGradient(at: 3, of: quadrupled))
+  expectEqual((16, 4), valueWithGradient(at: 4, of: quadrupled))
 }
 
 // Test differentiation wrt `inout` parameters that have a class type.
@@ -170,8 +170,8 @@ InoutParameterAutoDiffTests.test("InoutClassParameter") {
       squaredViaMutation(&c)
       return c.x
     }
-    expectEqual((100, 20), valueWithGradient(at: 10, in: squared))
-    expectEqual(200, pullback(at: 10, in: squared)(10))
+    expectEqual((100, 20), valueWithGradient(at: 10, of: squared))
+    expectEqual(200, pullback(at: 10, of: squared)(10))
   }
 
   do {
@@ -185,10 +185,10 @@ InoutParameterAutoDiffTests.test("InoutClassParameter") {
       return c.x
     }
     // FIXME(TF-1080): Fix incorrect class property `modify` accessor derivative values.
-    // expectEqual((100, 20), valueWithGradient(at: 10, in: squared))
-    // expectEqual(200, pullback(at: 10, in: squared)(10))
-    expectEqual((100, 1), valueWithGradient(at: 10, in: squared))
-    expectEqual(10, pullback(at: 10, in: squared)(10))
+    // expectEqual((100, 20), valueWithGradient(at: 10, of: squared))
+    // expectEqual(200, pullback(at: 10, of: squared)(10))
+    expectEqual((100, 1), valueWithGradient(at: 10, of: squared))
+    expectEqual(10, pullback(at: 10, of: squared)(10))
   }
 }
 
@@ -233,18 +233,18 @@ InoutParameterAutoDiffTests.test("non-wrt inout parameter") {
   let s = SR_13305_Struct()
 
   do {
-    let (value, (dx, dy)) = valueWithGradient(at: 2, 3, in: { foo(s, $0, $1) })
+    let (value, (dx, dy)) = valueWithGradient(at: 2, 3, of: { foo(s, $0, $1) })
     expectEqual(6, value)
     expectEqual((3, 2), (dx, dy))
   }
-  expectEqual((value: 6, gradient: 3), valueWithGradient(at: 2, in: { foo(s, $0, 3) }))
+  expectEqual((value: 6, gradient: 3), valueWithGradient(at: 2, of: { foo(s, $0, 3) }))
 
   do {
-    let (value, (dx, dy)) = valueWithGradient(at: 2, 3, in: { fooGeneric(s, $0, $1) })
+    let (value, (dx, dy)) = valueWithGradient(at: 2, 3, of: { fooGeneric(s, $0, $1) })
     expectEqual(2, value)
     expectEqual((1, 0), (dx, dy))
   }
-  expectEqual((value: 2, gradient: 1), valueWithGradient(at: 2, in: { fooGeneric(s, $0, 3) }))
+  expectEqual((value: 2, gradient: 1), valueWithGradient(at: 2, of: { fooGeneric(s, $0, 3) }))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/method.swift
+++ b/test/AutoDiff/validation-test/method.swift
@@ -73,8 +73,8 @@ MethodTests.testWithLeakChecking(
   func f(_ p: Parameter) -> Tracked<Float> {
     return 100 * p.squared()
   }
-  expectEqual(Parameter(x: 4 * 100), gradient(at: Parameter(x: 2), in: f))
-  expectEqual(Parameter(x: 40 * 100), gradient(at: Parameter(x: 20), in: f))
+  expectEqual(Parameter(x: 4 * 100), gradient(at: Parameter(x: 2), of: f))
+  expectEqual(Parameter(x: 40 * 100), gradient(at: Parameter(x: 20), of: f))
 }
 
 MethodTests.testWithLeakChecking(
@@ -83,24 +83,24 @@ MethodTests.testWithLeakChecking(
   // This is our current syntax for taking gradients of instance methods
   // directly. If/when we develop nicer syntax for this, change this test.
   func g(p: Parameter) -> Tracked<Float> { p.squared() }
-  expectEqual(Parameter(x: 4), gradient(at: Parameter(x: 2), in: g))
-  expectEqual(Parameter(x: 40), gradient(at: Parameter(x: 20), in: g))
+  expectEqual(Parameter(x: 4), gradient(at: Parameter(x: 2), of: g))
+  expectEqual(Parameter(x: 40), gradient(at: Parameter(x: 20), of: g))
 }
 
 MethodTests.testWithLeakChecking("instance method with generated adjoint, wrt only self") {
   func f(_ p: Parameter) -> Tracked<Float> {
     return 100 * p.multiplied(with: 200)
   }
-  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 1), in: f))
-  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 2), in: f))
+  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 1), of: f))
+  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 2), of: f))
 }
 
 MethodTests.testWithLeakChecking("instance method with generated adjoint, wrt only non-self") {
   func f(_ other: Tracked<Float>) -> Tracked<Float> {
     return 100 * Parameter(x: 200).multiplied(with: other)
   }
-  expectEqual(100 * 200, gradient(at: 1, in: f))
-  expectEqual(100 * 200, gradient(at: 2, in: f))
+  expectEqual(100 * 200, gradient(at: 1, of: f))
+  expectEqual(100 * 200, gradient(at: 2, of: f))
 }
 
 MethodTests.testWithLeakChecking(
@@ -118,39 +118,39 @@ MethodTests.testWithLeakChecking(
   func f(_ p: Parameter) -> Tracked<Float> {
     return 100 * Parameter.squared(p: p)
   }
-  expectEqual(Parameter(x: 4 * 100), gradient(at: Parameter(x: 2), in: f))
-  expectEqual(Parameter(x: 40 * 100), gradient(at: Parameter(x: 20), in: f))
+  expectEqual(Parameter(x: 4 * 100), gradient(at: Parameter(x: 2), of: f))
+  expectEqual(Parameter(x: 40 * 100), gradient(at: Parameter(x: 20), of: f))
 }
 
 MethodTests.testWithLeakChecking(
   "static method with generated adjoint, differentiated directly"
 ) {
-  expectEqual(Parameter(x: 4), gradient(at: Parameter(x: 2), in: Parameter.squared))
-  expectEqual(Parameter(x: 40), gradient(at: Parameter(x: 20), in: Parameter.squared))
+  expectEqual(Parameter(x: 4), gradient(at: Parameter(x: 2), of: Parameter.squared))
+  expectEqual(Parameter(x: 40), gradient(at: Parameter(x: 20), of: Parameter.squared))
 }
 
 MethodTests.testWithLeakChecking("static method with generated adjoint, wrt only first param") {
   func f(_ p: Parameter) -> Tracked<Float> {
     return 100 * (p * Parameter(x: 200))
   }
-  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 1), in: f))
-  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 2), in: f))
+  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 1), of: f))
+  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 2), of: f))
 }
 
 MethodTests.testWithLeakChecking("static method with generated adjoint, wrt only second param") {
   func f(_ p: Parameter) -> Tracked<Float> {
     return 100 * (Parameter(x: 200) * p)
   }
-  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 1), in: f))
-  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 2), in: f))
+  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 1), of: f))
+  expectEqual(Parameter(x: 100 * 200), gradient(at: Parameter(x: 2), of: f))
 }
 
 MethodTests.testWithLeakChecking("static method with generated adjoint, wrt all params") {
   func g(a: Parameter, b: Parameter) -> Tracked<Float> { a * b }
   expectEqual((Parameter(x: 100), Parameter(x: 200)),
-              gradient(at: Parameter(x: 200), Parameter(x: 100), in: g))
+              gradient(at: Parameter(x: 200), Parameter(x: 100), of: g))
   expectEqual((Parameter(x: 200), Parameter(x: 100)),
-              gradient(at: Parameter(x: 100), Parameter(x: 200), in: g))
+              gradient(at: Parameter(x: 100), Parameter(x: 200), of: g))
 }
 
 // ==== Tests with custom adjoint ====
@@ -314,69 +314,69 @@ MethodTests.testWithLeakChecking(
   func f(_ p: CustomParameter) -> Tracked<Float> {
     return 100 * p.squared()
   }
-  expectEqual(CustomParameter(x: 4 * 100), gradient(at: CustomParameter(x: 2), in: f))
-  expectEqual(CustomParameter(x: 10 * 100), gradient(at: CustomParameter(x: 20), in: f))
+  expectEqual(CustomParameter(x: 4 * 100), gradient(at: CustomParameter(x: 2), of: f))
+  expectEqual(CustomParameter(x: 10 * 100), gradient(at: CustomParameter(x: 20), of: f))
 }
 
 MethodTests.testWithLeakChecking("instance method with generated adjoint, differentated directly") {
   // This is our current syntax for taking gradients of instance methods
   // directly. If/when we develop nicer syntax for this, change this test.
   func g(p: CustomParameter) -> Tracked<Float> { p.squared() }
-  expectEqual(CustomParameter(x: 4), gradient(at: CustomParameter(x: 2), in: g))
-  expectEqual(CustomParameter(x: 10), gradient(at: CustomParameter(x: 20), in: g))
+  expectEqual(CustomParameter(x: 4), gradient(at: CustomParameter(x: 2), of: g))
+  expectEqual(CustomParameter(x: 10), gradient(at: CustomParameter(x: 20), of: g))
 }
 
 MethodTests.testWithLeakChecking("static method with custom adjoint, called from differentated func") {
   func f(_ p: CustomParameter) -> Tracked<Float> {
     return 100 * CustomParameter.squared(p: p)
   }
-  expectEqual(CustomParameter(x: 4 * 100), gradient(at: CustomParameter(x: 2), in: f))
-  expectEqual(CustomParameter(x: 10 * 100), gradient(at: CustomParameter(x: 20), in: f))
+  expectEqual(CustomParameter(x: 4 * 100), gradient(at: CustomParameter(x: 2), of: f))
+  expectEqual(CustomParameter(x: 10 * 100), gradient(at: CustomParameter(x: 20), of: f))
 }
 
 MethodTests.testWithLeakChecking("static method with custom adjoint, differentiated directly") {
   expectEqual(
-    CustomParameter(x: 4), gradient(at: CustomParameter(x: 2), in: CustomParameter.squared))
+    CustomParameter(x: 4), gradient(at: CustomParameter(x: 2), of: CustomParameter.squared))
   expectEqual(
-    CustomParameter(x: 10), gradient(at: CustomParameter(x: 20), in: CustomParameter.squared))
+    CustomParameter(x: 10), gradient(at: CustomParameter(x: 20), of: CustomParameter.squared))
 }
 
 MethodTests.testWithLeakChecking("instance method with custom adjoint, wrt only self") {
   func f(_ p: CustomParameter) -> Tracked<Float> {
     return 100 * p.multiplied_constOther(with: 200)
   }
-  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 1), in: f))
-  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 2), in: f))
+  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 1), of: f))
+  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 2), of: f))
 }
 
 MethodTests.testWithLeakChecking("instance method with custom adjoint, wrt only non-self") {
   func f(_ other: Tracked<Float>) -> Tracked<Float> {
     return 100 * CustomParameter(x: 200).multiplied_constSelf(with: other)
   }
-  expectEqual(100 * 10, gradient(at: 1, in: f))
-  expectEqual(100 * 10, gradient(at: 2, in: f))
+  expectEqual(100 * 10, gradient(at: 1, of: f))
+  expectEqual(100 * 10, gradient(at: 2, of: f))
 }
 
 MethodTests.testWithLeakChecking("instance method with custom adjoint, wrt self and non-self") {
   func g(p: CustomParameter, o: Tracked<Float>) -> Tracked<Float> { p.multiplied(with: o) }
-  expectEqual((CustomParameter(x: 5), 10), gradient(at: CustomParameter(x: 100), 5, in: g))
-  expectEqual((CustomParameter(x: 10), 5), gradient(at: CustomParameter(x: 5), 100, in: g))
+  expectEqual((CustomParameter(x: 5), 10), gradient(at: CustomParameter(x: 100), 5, of: g))
+  expectEqual((CustomParameter(x: 10), 5), gradient(at: CustomParameter(x: 5), 100, of: g))
 }
 
 MethodTests.testWithLeakChecking("static method with custom adjoint, wrt only lhs") {
   func f(_ p: CustomParameter) -> Tracked<Float> {
     return 100 * CustomParameter.multiply_constLhs(CustomParameter(x: 200), p)
   }
-  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 1), in: f))
-  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 2), in: f))
+  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 1), of: f))
+  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 2), of: f))
 }
 
 MethodTests.testWithLeakChecking("static method with custom adjoint, wrt only rhs") {
   func f(_ p: CustomParameter) -> Tracked<Float> {
     return 100 * CustomParameter.multiply_constLhs(CustomParameter(x: 200), p)
   }
-  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 1), in: f))
-  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 2), in: f))
+  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 1), of: f))
+  expectEqual(CustomParameter(x: 100 * 10), gradient(at: CustomParameter(x: 2), of: f))
 }
 
 MethodTests.testWithLeakChecking("static method with custom adjoint, wrt all") {
@@ -384,9 +384,9 @@ MethodTests.testWithLeakChecking("static method with custom adjoint, wrt all") {
     return CustomParameter.multiply(a, b)
   }
   expectEqual((CustomParameter(x: 5), CustomParameter(x: 10)),
-              gradient(at: CustomParameter(x: 100), CustomParameter(x: 5), in: f))
+              gradient(at: CustomParameter(x: 100), CustomParameter(x: 5), of: f))
   expectEqual((CustomParameter(x: 10), CustomParameter(x: 5)),
-              gradient(at: CustomParameter(x: 5), CustomParameter(x: 100), in: f))
+              gradient(at: CustomParameter(x: 5), CustomParameter(x: 100), of: f))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/optional.swift
+++ b/test/AutoDiff/validation-test/optional.swift
@@ -28,8 +28,8 @@ OptionalTests.test("Let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_let), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_let), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_let), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_let), .init(0.0))
 
   @differentiable(reverse)
   func optional_let_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -38,8 +38,8 @@ OptionalTests.test("Let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_let_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_let_tracked), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_let_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_let_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_let_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
@@ -51,9 +51,9 @@ OptionalTests.test("Let") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_let_nonresilient_tracked), .init(20.0))
+    gradient(at: 10, of: optional_let_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_let_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, of: optional_let_nonresilient_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_let_nested(_ nestedMaybeX: Float??) -> Float {
@@ -65,8 +65,8 @@ OptionalTests.test("Let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_let_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_let_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: 10, of: optional_let_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, of: optional_let_nested), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_let_nested_tracked(_ nestedMaybeX: Tracked<Float>??) -> Tracked<
@@ -81,9 +81,9 @@ OptionalTests.test("Let") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_let_nested_tracked), .init(.init(20.0)))
+    gradient(at: 10, of: optional_let_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_let_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, of: optional_let_nested_tracked), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_let_nested_nonresilient_tracked(
@@ -98,10 +98,10 @@ OptionalTests.test("Let") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_let_nested_nonresilient_tracked),
+    gradient(at: 10, of: optional_let_nested_nonresilient_tracked),
     .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_let_nested_nonresilient_tracked),
+    gradient(at: nil, of: optional_let_nested_nonresilient_tracked),
     .init(.init(0.0)))
 
   @differentiable(reverse)
@@ -113,16 +113,16 @@ OptionalTests.test("Let") {
     }
     return defaultValue
   }
-  expectEqual(gradient(at: 10, 20, in: optional_let_generic), (.init(1.0), 0.0))
+  expectEqual(gradient(at: 10, 20, of: optional_let_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_let_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, of: optional_let_generic), (.init(0.0), 1.0))
 
   expectEqual(
     gradient(
       at: Tracked<Float>.init(10), Tracked<Float>.init(20),
-      in: optional_let_generic), (.init(1.0), 0.0))
+      of: optional_let_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, Tracked<Float>.init(20), in: optional_let_generic),
+    gradient(at: nil, Tracked<Float>.init(20), of: optional_let_generic),
     (.init(0.0), 1.0))
 
   @differentiable(reverse)
@@ -139,10 +139,10 @@ OptionalTests.test("Let") {
   }
 
   expectEqual(
-    gradient(at: 10.0, 20.0, in: optional_let_nested_generic),
+    gradient(at: 10.0, 20.0, of: optional_let_nested_generic),
     (.init(.init(1.0)), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_let_nested_generic),
+    gradient(at: nil, 20, of: optional_let_nested_generic),
     (.init(.init(0.0)), 1.0))
 }
 
@@ -154,8 +154,8 @@ OptionalTests.test("Switch") {
     case let .some(x): return x * x
     }
   }
-  expectEqual(gradient(at: 10, in: optional_switch), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_switch), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_switch), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_switch), .init(0.0))
 
   @differentiable(reverse)
   func optional_switch_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -164,8 +164,8 @@ OptionalTests.test("Switch") {
     case let .some(x): return x * x
     }
   }
-  expectEqual(gradient(at: 10, in: optional_switch_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_switch_tracked), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_switch_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_switch_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_switch_nonresilient_tracked(
@@ -177,9 +177,9 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(
-    gradient(at: 10, in: optional_switch_nonresilient_tracked), .init(20.0))
+    gradient(at: 10, of: optional_switch_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_switch_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, of: optional_switch_nonresilient_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_switch_nested(_ nestedMaybeX: Float??) -> Float {
@@ -192,8 +192,8 @@ OptionalTests.test("Switch") {
       }
     }
   }
-  expectEqual(gradient(at: 10, in: optional_switch_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_switch_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: 10, of: optional_switch_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, of: optional_switch_nested), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_switch_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
@@ -209,9 +209,9 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(
-    gradient(at: 10, in: optional_switch_nested_tracked), .init(.init(20.0)))
+    gradient(at: 10, of: optional_switch_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_switch_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, of: optional_switch_nested_tracked), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_switch_nested_nonresilient_tracked(
@@ -227,10 +227,10 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(
-    gradient(at: 10, in: optional_switch_nested_nonresilient_tracked),
+    gradient(at: 10, of: optional_switch_nested_nonresilient_tracked),
     .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_switch_nested_nonresilient_tracked),
+    gradient(at: nil, of: optional_switch_nested_nonresilient_tracked),
     .init(.init(0.0)))
 
   @differentiable(reverse)
@@ -243,9 +243,9 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(
-    gradient(at: 10, 20, in: optional_switch_generic), (.init(1.0), 0.0))
+    gradient(at: 10, 20, of: optional_switch_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_switch_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, of: optional_switch_generic), (.init(0.0), 1.0))
 
   @differentiable(reverse)
   func optional_switch_nested_generic<T: Differentiable>(
@@ -261,10 +261,10 @@ OptionalTests.test("Switch") {
     }
   }
   expectEqual(
-    gradient(at: 10, 20, in: optional_switch_nested_generic),
+    gradient(at: 10, 20, of: optional_switch_nested_generic),
     (.init(.init(1.0)), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_switch_nested_generic),
+    gradient(at: nil, 20, of: optional_switch_nested_generic),
     (.init(.init(0.0)), 1.0))
 }
 
@@ -277,8 +277,8 @@ OptionalTests.test("Optional binding: if let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var1), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var1), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_var1), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_var1), .init(0.0))
 
   @differentiable(reverse)
   func optional_var1_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -288,8 +288,8 @@ OptionalTests.test("Optional binding: if let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var1_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var1_tracked), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_var1_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_var1_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_var1_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
@@ -302,9 +302,9 @@ OptionalTests.test("Optional binding: if let") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_var1_nonresilient_tracked), .init(20.0))
+    gradient(at: 10, of: optional_var1_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_var1_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, of: optional_var1_nonresilient_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_var1_nested(_ nestedMaybeX: Float??) -> Float {
@@ -317,8 +317,8 @@ OptionalTests.test("Optional binding: if let") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var1_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_var1_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: 10, of: optional_var1_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, of: optional_var1_nested), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_var1_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
@@ -334,9 +334,9 @@ OptionalTests.test("Optional binding: if let") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_var1_nested_tracked), .init(.init(20.0)))
+    gradient(at: 10, of: optional_var1_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_var1_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, of: optional_var1_nested_tracked), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_var1_nested_nonresilient_tracked(
@@ -352,10 +352,10 @@ OptionalTests.test("Optional binding: if let") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_var1_nested_nonresilient_tracked),
+    gradient(at: 10, of: optional_var1_nested_nonresilient_tracked),
     .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_var1_nested_nonresilient_tracked),
+    gradient(at: nil, of: optional_var1_nested_nonresilient_tracked),
     .init(.init(0.0)))
 
   @differentiable(reverse)
@@ -369,9 +369,9 @@ OptionalTests.test("Optional binding: if let") {
     return defaultValue
   }
   expectEqual(
-    gradient(at: 10, 20, in: optional_var1_generic), (.init(1.0), 0.0))
+    gradient(at: 10, 20, of: optional_var1_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_var1_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, of: optional_var1_generic), (.init(0.0), 1.0))
 
   @differentiable(reverse)
   func optional_var1_nested_generic<T: Differentiable>(
@@ -387,10 +387,10 @@ OptionalTests.test("Optional binding: if let") {
     return defaultValue
   }
   expectEqual(
-    gradient(at: 10, 20, in: optional_var1_nested_generic),
+    gradient(at: 10, 20, of: optional_var1_nested_generic),
     (.init(.init(1.0)), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_var1_nested_generic),
+    gradient(at: nil, 20, of: optional_var1_nested_generic),
     (.init(.init(0.0)), 1.0))
 }
 
@@ -402,8 +402,8 @@ OptionalTests.test("Optional binding: if var") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var2), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var2), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_var2), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_var2), .init(0.0))
 
   @differentiable(reverse)
   func optional_var2_tracked(_ maybeX: Tracked<Float>?) -> Tracked<Float> {
@@ -412,8 +412,8 @@ OptionalTests.test("Optional binding: if var") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var2_tracked), .init(20.0))
-  expectEqual(gradient(at: nil, in: optional_var2_tracked), .init(0.0))
+  expectEqual(gradient(at: 10, of: optional_var2_tracked), .init(20.0))
+  expectEqual(gradient(at: nil, of: optional_var2_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_var2_nonresilient_tracked(_ maybeX: NonresilientTracked<Float>?)
@@ -425,9 +425,9 @@ OptionalTests.test("Optional binding: if var") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_var2_nonresilient_tracked), .init(20.0))
+    gradient(at: 10, of: optional_var2_nonresilient_tracked), .init(20.0))
   expectEqual(
-    gradient(at: nil, in: optional_var2_nonresilient_tracked), .init(0.0))
+    gradient(at: nil, of: optional_var2_nonresilient_tracked), .init(0.0))
 
   @differentiable(reverse)
   func optional_var2_nested(_ nestedMaybeX: Float??) -> Float {
@@ -439,8 +439,8 @@ OptionalTests.test("Optional binding: if var") {
     }
     return 10
   }
-  expectEqual(gradient(at: 10, in: optional_var2_nested), .init(.init(20.0)))
-  expectEqual(gradient(at: nil, in: optional_var2_nested), .init(.init(0.0)))
+  expectEqual(gradient(at: 10, of: optional_var2_nested), .init(.init(20.0)))
+  expectEqual(gradient(at: nil, of: optional_var2_nested), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_var2_nested_tracked(_ nestedMaybeX: Tracked<Float>??)
@@ -455,9 +455,9 @@ OptionalTests.test("Optional binding: if var") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_var2_nested_tracked), .init(.init(20.0)))
+    gradient(at: 10, of: optional_var2_nested_tracked), .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_var2_nested_tracked), .init(.init(0.0)))
+    gradient(at: nil, of: optional_var2_nested_tracked), .init(.init(0.0)))
 
   @differentiable(reverse)
   func optional_var2_nested_nonresilient_tracked(
@@ -472,10 +472,10 @@ OptionalTests.test("Optional binding: if var") {
     return 10
   }
   expectEqual(
-    gradient(at: 10, in: optional_var2_nested_nonresilient_tracked),
+    gradient(at: 10, of: optional_var2_nested_nonresilient_tracked),
     .init(.init(20.0)))
   expectEqual(
-    gradient(at: nil, in: optional_var2_nested_nonresilient_tracked),
+    gradient(at: nil, of: optional_var2_nested_nonresilient_tracked),
     .init(.init(0.0)))
 
   @differentiable(reverse)
@@ -488,9 +488,9 @@ OptionalTests.test("Optional binding: if var") {
     return defaultValue
   }
   expectEqual(
-    gradient(at: 10, 20, in: optional_var2_generic), (.init(1.0), 0.0))
+    gradient(at: 10, 20, of: optional_var2_generic), (.init(1.0), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_var2_generic), (.init(0.0), 1.0))
+    gradient(at: nil, 20, of: optional_var2_generic), (.init(0.0), 1.0))
 
   @differentiable(reverse)
   func optional_var2_nested_generic<T: Differentiable>(
@@ -505,10 +505,10 @@ OptionalTests.test("Optional binding: if var") {
     return defaultValue
   }
   expectEqual(
-    gradient(at: 10, 20, in: optional_var2_nested_generic),
+    gradient(at: 10, 20, of: optional_var2_nested_generic),
     (.init(.init(1.0)), 0.0))
   expectEqual(
-    gradient(at: nil, 20, in: optional_var2_nested_generic),
+    gradient(at: nil, 20, of: optional_var2_nested_generic),
     (.init(.init(0.0)), 1.0))
 }
 

--- a/test/AutoDiff/validation-test/optional_property.swift
+++ b/test/AutoDiff/validation-test/optional_property.swift
@@ -85,24 +85,24 @@ struct StructGeneric<T: Differentiable>: Differentiable {
 
 OptionalTests.test("Optional struct stored properties") {
   expectEqual(
-    valueWithGradient(at: Struct(stored: 3, optional: 4), in: { $0.method() }),
+    valueWithGradient(at: Struct(stored: 3, optional: 4), of: { $0.method() }),
     (12, .init(stored: 4, optional: .init(3))))
   expectEqual(
-    valueWithGradient(at: Struct(stored: 3, optional: nil), in: { $0.method() }),
+    valueWithGradient(at: Struct(stored: 3, optional: nil), of: { $0.method() }),
     (3, .init(stored: 1, optional: .init(0))))
 
   expectEqual(
-    valueWithGradient(at: StructTracked(stored: 3, optional: 4), in: { $0.method() }),
+    valueWithGradient(at: StructTracked(stored: 3, optional: 4), of: { $0.method() }),
     (12, .init(stored: 4, optional: .init(3))))
   expectEqual(
-    valueWithGradient(at: StructTracked(stored: 3, optional: nil), in: { $0.method() }),
+    valueWithGradient(at: StructTracked(stored: 3, optional: nil), of: { $0.method() }),
     (3, .init(stored: 1, optional: .init(0))))
 
   expectEqual(
-    valueWithGradient(at: StructGeneric<Float>(stored: 3, optional: 4), in: { $0.method() }),
+    valueWithGradient(at: StructGeneric<Float>(stored: 3, optional: 4), of: { $0.method() }),
     (4, .init(stored: 0, optional: .init(1))))
   expectEqual(
-    valueWithGradient(at: StructGeneric<Float>(stored: 3, optional: nil), in: { $0.method() }),
+    valueWithGradient(at: StructGeneric<Float>(stored: 3, optional: nil), of: { $0.method() }),
     (3, .init(stored: 1, optional: .init(0))))
 }
 
@@ -182,24 +182,24 @@ struct ClassGeneric<T: Differentiable>: Differentiable {
 
 OptionalTests.test("Optional class stored properties") {
   expectEqual(
-    valueWithGradient(at: Class(stored: 3, optional: 4), in: { $0.method() }),
+    valueWithGradient(at: Class(stored: 3, optional: 4), of: { $0.method() }),
     (12, .init(stored: 4, optional: .init(3))))
   expectEqual(
-    valueWithGradient(at: Class(stored: 3, optional: nil), in: { $0.method() }),
+    valueWithGradient(at: Class(stored: 3, optional: nil), of: { $0.method() }),
     (3, .init(stored: 1, optional: .init(0))))
 
   expectEqual(
-    valueWithGradient(at: ClassTracked(stored: 3, optional: 4), in: { $0.method() }),
+    valueWithGradient(at: ClassTracked(stored: 3, optional: 4), of: { $0.method() }),
     (12, .init(stored: 4, optional: .init(3))))
   expectEqual(
-    valueWithGradient(at: ClassTracked(stored: 3, optional: nil), in: { $0.method() }),
+    valueWithGradient(at: ClassTracked(stored: 3, optional: nil), of: { $0.method() }),
     (3, .init(stored: 1, optional: .init(0))))
 
   expectEqual(
-    valueWithGradient(at: ClassGeneric<Tracked<Float>>(stored: 3, optional: 4), in: { $0.method() }),
+    valueWithGradient(at: ClassGeneric<Tracked<Float>>(stored: 3, optional: 4), of: { $0.method() }),
     (4, .init(stored: 0, optional: .init(1))))
   expectEqual(
-    valueWithGradient(at: ClassGeneric<Tracked<Float>>(stored: 3, optional: nil), in: { $0.method() }),
+    valueWithGradient(at: ClassGeneric<Tracked<Float>>(stored: 3, optional: nil), of: { $0.method() }),
     (3, .init(stored: 1, optional: .init(0))))
 }
 

--- a/test/AutoDiff/validation-test/property_wrappers.swift
+++ b/test/AutoDiff/validation-test/property_wrappers.swift
@@ -36,7 +36,7 @@ PropertyWrapperTests.test("SimpleStruct") {
   func getter(_ s: Struct) -> Tracked<Float> {
     return s.x
   }
-  expectEqual(.init(x: 1, y: 0, z: 0), gradient(at: Struct(), in: getter))
+  expectEqual(.init(x: 1, y: 0, z: 0), gradient(at: Struct(), of: getter))
 
   func setter(_ s: Struct, _ x: Tracked<Float>) -> Tracked<Float> {
     var s = s
@@ -44,7 +44,7 @@ PropertyWrapperTests.test("SimpleStruct") {
     return s.x
   }
   expectEqual((.init(x: 60, y: 0, z: 20), 300),
-              gradient(at: Struct(), 2, in: setter))
+              gradient(at: Struct(), 2, of: setter))
 
   // TODO(SR-12640): Support `modify` accessors.
   /*
@@ -54,7 +54,7 @@ PropertyWrapperTests.test("SimpleStruct") {
     return s.x
   }
   expectEqual((.init(x: 60, y: 0, z: 20), 300),
-              gradient(at: Struct(), 2, in: modify))
+              gradient(at: Struct(), 2, of: modify))
   */
 }
 
@@ -70,13 +70,13 @@ PropertyWrapperTests.test("GenericStruct") {
     return s.y
   }
   expectEqual(.init(x: 0, y: 1, z: 0),
-              gradient(at: GenericStruct<Tracked<Float>>(y: 20), in: getter))
+              gradient(at: GenericStruct<Tracked<Float>>(y: 20), of: getter))
 
   func getter2<T>(_ s: GenericStruct<T>) -> Tracked<Float> {
     return s.x * s.z
   }
   expectEqual(.init(x: 30, y: 0, z: 10),
-              gradient(at: GenericStruct<Tracked<Float>>(y: 20), in: getter2))
+              gradient(at: GenericStruct<Tracked<Float>>(y: 20), of: getter2))
 
   func setter<T>(_ s: GenericStruct<T>, _ x: Tracked<Float>) -> Tracked<Float> {
     var s = s
@@ -84,7 +84,7 @@ PropertyWrapperTests.test("GenericStruct") {
     return s.x
   }
   expectEqual((.init(x: 60, y: 0, z: 20), 300),
-              gradient(at: GenericStruct<Tracked<Float>>(y: 20), 2, in: setter))
+              gradient(at: GenericStruct<Tracked<Float>>(y: 20), 2, of: setter))
 
   // TODO(SR-12640): Support `modify` accessors.
   /*
@@ -94,7 +94,7 @@ PropertyWrapperTests.test("GenericStruct") {
     return s.x
   }
   expectEqual((.init(x: 60, y: 0, z: 20), 300),
-              gradient(at: GenericStruct<Tracked<Float>>(y: 1), 2, in: modify))
+              gradient(at: GenericStruct<Tracked<Float>>(y: 1), 2, of: modify))
   */
 }
 
@@ -114,7 +114,7 @@ PropertyWrapperTests.test("SimpleClass") {
   func getter(_ c: Class) -> Tracked<Float> {
     return c.x
   }
-  expectEqual(.init(x: 1, y: 0, z: 0), gradient(at: Class(), in: getter))
+  expectEqual(.init(x: 1, y: 0, z: 0), gradient(at: Class(), of: getter))
 
   func setter(_ c: Class, _ x: Tracked<Float>) -> Tracked<Float> {
     var c = c
@@ -125,10 +125,10 @@ PropertyWrapperTests.test("SimpleClass") {
   // This is relevant for `Class.x.setter`, which has type
   // `$@convention(method) (@in Tracked<Float>, @guaranteed Class) -> ()`.
   expectEqual((.init(x: 1, y: 0, z: 0), 0),
-              gradient(at: Class(), 2, in: setter))
+              gradient(at: Class(), 2, of: setter))
   /*
   expectEqual((.init(x: 60, y: 0, z: 20), 300),
-              gradient(at: Class(), 2, in: setter))
+              gradient(at: Class(), 2, of: setter))
   */
 
   // TODO(SR-12640): Support `modify` accessors.
@@ -139,7 +139,7 @@ PropertyWrapperTests.test("SimpleClass") {
     return c.x
   }
   expectEqual((.init(x: 60, y: 0, z: 20), 300),
-              gradient(at: Class(), 2, in: modify))
+              gradient(at: Class(), 2, of: modify))
   */
 }
 
@@ -215,7 +215,7 @@ PropertyWrapperTests.test("RealPropertyWrappers") {
     return s.x * s.y
   }
   expectEqual(.init(x: 4, y: 3),
-              gradient(at: RealPropertyWrappers(x: 3, y: 4), in: multiply))
+              gradient(at: RealPropertyWrappers(x: 3, y: 4), of: multiply))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/reabstraction.swift
+++ b/test/AutoDiff/validation-test/reabstraction.swift
@@ -8,7 +8,7 @@ var ReabstractionE2ETests = TestSuite("ReabstractionE2E")
 
 ReabstractionE2ETests.test("diff param concrete => generic") {
   func grad<T: Differentiable>(_ f: @differentiable(reverse) (T) -> Float, at x: T) -> T.TangentVector {
-    gradient(at: x, in: f)
+    gradient(at: x, of: f)
   }
   func inner(_ x: Float) -> Float {
     7 * x * x
@@ -38,7 +38,7 @@ ReabstractionE2ETests.test("diff param and nondiff param concrete => generic") {
 
 ReabstractionE2ETests.test("result concrete => generic") {
   func grad<T: Differentiable>(_ f: @differentiable(reverse) (Float) -> T, at x: Float, seed: T.TangentVector) -> Float {
-    pullback(at: x, in: f)(seed)
+    pullback(at: x, of: f)(seed)
   }
   func inner(_ x: Float) -> Float {
     7 * x * x
@@ -69,7 +69,7 @@ ReabstractionE2ETests.test("diff param generic => concrete") {
   }
   let transformed: @differentiable(reverse) (Float) -> Float = inner
   expectEqual(Float(7 * 3 * 3), transformed(3))
-  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, of: transformed))
 }
 #endif
 
@@ -100,7 +100,7 @@ ReabstractionE2ETests.test("result generic => concrete") {
   }
   let transformed: @differentiable(reverse) (Float) -> Float = inner
   expectEqual(Float(7 * 3 * 3), transformed(3))
-  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, of: transformed))
 }
 #endif
 
@@ -112,7 +112,7 @@ ReabstractionE2ETests.test("diff param concrete => generic => concrete") {
   }
   let transformed = id(inner)
   expectEqual(Float(7 * 3 * 3), transformed(3))
-  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, of: transformed))
 }
 
 ReabstractionE2ETests.test("nondiff param concrete => generic => concrete") {
@@ -145,7 +145,7 @@ ReabstractionE2ETests.test("result concrete => generic => concrete") {
   }
   let transformed = id(inner)
   expectEqual(Float(7 * 3 * 3), transformed(3))
-  expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: transformed))
+  expectEqual(Float(7 * 2 * 3), gradient(at: 3, of: transformed))
 }
 
 ReabstractionE2ETests.test("@differentiable(reverse) function => opaque generic => concrete") {
@@ -155,7 +155,7 @@ ReabstractionE2ETests.test("@differentiable(reverse) function => opaque generic 
   // TODO(TF-1122): Actually using `id` causes a segfault at runtime.
   // let transformed = id(inner)
   // expectEqual(Float(7 * 3 * 3), transformed(3))
-  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: id(inner)))
+  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, of: id(inner)))
 }
 
 ReabstractionE2ETests.test("@differentiable(reverse) function => opaque Any => concrete") {
@@ -166,7 +166,7 @@ ReabstractionE2ETests.test("@differentiable(reverse) function => opaque Any => c
   // let transformed = id(inner)
   // let casted = transformed as! @differentiable(reverse) (Float) -> Float
   // expectEqual(Float(7 * 3 * 3), casted(3))
-  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: casted))
+  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, of: casted))
 }
 
 ReabstractionE2ETests.test("access @differentiable(reverse) function using KeyPath") {
@@ -179,7 +179,7 @@ ReabstractionE2ETests.test("access @differentiable(reverse) function using KeyPa
   // TODO(TF-1122): Actually using `kp` causes a segfault at runtime.
   // let extracted = container[keyPath: kp]
   // expectEqual(Float(7 * 3 * 3), extracted(3))
-  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, in: extracted))
+  // expectEqual(Float(7 * 2 * 3), gradient(at: 3, of: extracted))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/repeated_calls.swift
+++ b/test/AutoDiff/validation-test/repeated_calls.swift
@@ -13,7 +13,7 @@ RepeatedCallsTests.testWithLeakChecking("Repeat") {
   func mul4(_ x: Tracked<Float>) -> Tracked<Float> {
     return mul2(mul2(x))
   }
-  expectEqual(4, gradient(at: 0, in: mul4))
+  expectEqual(4, gradient(at: 0, of: mul4))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/separate_tangent_type.swift
+++ b/test/AutoDiff/validation-test/separate_tangent_type.swift
@@ -28,9 +28,9 @@ struct DifferentiableSubset : Differentiable {
     var w: Tracked<Float>
     var b: Tracked<Float>
   }
-  mutating func move(along v: TangentVector) {
-    w.move(along: v.w)
-    b.move(along: v.b)
+  mutating func move(by v: TangentVector) {
+    w.move(by: v.w)
+    b.move(by: v.b)
   }
 }
 

--- a/test/AutoDiff/validation-test/simple_math.swift
+++ b/test/AutoDiff/validation-test/simple_math.swift
@@ -17,37 +17,37 @@ SimpleMathTests.test("Arithmetics") {
   func foo1(x: Float, y: Float) -> Float {
     return x * y
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: foo1))
+  expectEqual((4, 3), gradient(at: 3, 4, of: foo1))
   func foo2(x: Float, y: Float) -> Float {
     return -x * y
   }
-  expectEqual((-4, -3), gradient(at: 3, 4, in: foo2))
+  expectEqual((-4, -3), gradient(at: 3, 4, of: foo2))
   func foo3(x: Float, y: Float) -> Float {
     return -x + y
   }
-  expectEqual((-1, 1), gradient(at: 3, 4, in: foo3))
+  expectEqual((-1, 1), gradient(at: 3, 4, of: foo3))
 }
 
 SimpleMathTests.test("Fanout") {
   func foo1(x: Float) -> Float {
      x - x
   }
-  expectEqual(0, gradient(at: 100, in: foo1))
+  expectEqual(0, gradient(at: 100, of: foo1))
   func foo2(x: Float) -> Float {
      x + x
   }
-  expectEqual(2, gradient(at: 100, in: foo2))
+  expectEqual(2, gradient(at: 100, of: foo2))
   func foo3(x: Float, y: Float) -> Float {
     x + x + x * y
   }
-  expectEqual((4, 3), gradient(at: 3, 2, in: foo3))
+  expectEqual((4, 3), gradient(at: 3, 2, of: foo3))
 }
 
 SimpleMathTests.test("FunctionCall") {
   func foo(_ x: Float, _ y: Float) -> Float {
     return 3 * x + { $0 * 3 }(3) * y
   }
-  expectEqual((3, 9), gradient(at: 3, 4, in: foo))
+  expectEqual((3, 9), gradient(at: 3, 4, of: foo))
   expectEqual(3, gradient(at: 3) { x in foo(x, 4) })
 }
 
@@ -55,16 +55,16 @@ SimpleMathTests.test("ResultSelection") {
   func tuple(_ x: Float, _ y: Float) -> (Float, Float) {
     return (x + 1, y + 2)
   }
-  expectEqual((1, 0), gradient(at: 3, 3, in: { x, y in tuple(x, y).0 }))
-  expectEqual((0, 1), gradient(at: 3, 3, in: { x, y in tuple(x, y).1 }))
+  expectEqual((1, 0), gradient(at: 3, 3, of: { x, y in tuple(x, y).0 }))
+  expectEqual((0, 1), gradient(at: 3, 3, of: { x, y in tuple(x, y).1 }))
 
   func tupleGeneric<T>(_ x: T, _ y: T) -> (T, T) {
     return (x, y)
   }
   func tupleGenericFirst<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).0 }
   func tupleGenericSecond<T>(_ x: T, _ y: T) -> T { tupleGeneric(x, y).1 }
-  expectEqual((1, 0), gradient(at: 3, 3, in: tupleGenericFirst))
-  expectEqual((0, 1), gradient(at: 3, 3, in: tupleGenericSecond))
+  expectEqual((1, 0), gradient(at: 3, 3, of: tupleGenericFirst))
+  expectEqual((0, 1), gradient(at: 3, 3, of: tupleGenericSecond))
 }
 
 SimpleMathTests.test("MultipleResults") {
@@ -77,8 +77,8 @@ SimpleMathTests.test("MultipleResults") {
     // Note: both results (tuple elements) are active.
     return z.0 * z.1
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply))
-  expectEqual((10, 5), gradient(at: 5, 10, in: multiply))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply))
+  expectEqual((10, 5), gradient(at: 5, 10, of: multiply))
 
   // Test function with multiple `inout` parameters.
   func swap(_ x: inout Float, _ y: inout Float) {
@@ -89,8 +89,8 @@ SimpleMathTests.test("MultipleResults") {
     swap(&tuple.0, &tuple.1)
     return tuple.0 * tuple.1
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swap))
-  expectEqual((10, 5), gradient(at: 5, 10, in: multiply_swap))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swap))
+  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swap))
 
   // Test function with multiple `inout` parameters.
   func swapGeneric<T>(_ x: inout T, _ y: inout T) {
@@ -101,8 +101,8 @@ SimpleMathTests.test("MultipleResults") {
     swapGeneric(&tuple.0, &tuple.1)
     return tuple.0 * tuple.1
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swapGeneric))
-  expectEqual((10, 5), gradient(at: 5, 10, in: multiply_swapGeneric))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapGeneric))
+  expectEqual((10, 5), gradient(at: 5, 10, of: multiply_swapGeneric))
 
   // Test function with multiple `inout` parameters and a formal result.
   func swapAndReturnProduct(_ x: inout Float, _ y: inout Float) -> Float {
@@ -117,8 +117,8 @@ SimpleMathTests.test("MultipleResults") {
     let result = swapAndReturnProduct(&x2, &y2)
     return result
   }
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swapAndReturnProduct))
-  expectEqual((4, 3), gradient(at: 3, 4, in: multiply_swapAndReturnProduct))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
+  expectEqual((4, 3), gradient(at: 3, 4, of: multiply_swapAndReturnProduct))
 }
 
 SimpleMathTests.test("CaptureLocal") {
@@ -126,7 +126,7 @@ SimpleMathTests.test("CaptureLocal") {
   func foo(_ x: Float) -> Float {
     return z * x
   }
-  expectEqual(10, gradient(at: 0, in: foo))
+  expectEqual(10, gradient(at: 0, of: foo))
 }
 
 var globalVar: Float = 10
@@ -135,7 +135,7 @@ SimpleMathTests.test("CaptureGlobal") {
     globalVar += 20
     return globalVar * x
   }
-  expectEqual(30, gradient(at: 0, in: foo))
+  expectEqual(30, gradient(at: 0, of: foo))
 }
 
 SimpleMathTests.test("Mutation") {
@@ -145,7 +145,7 @@ SimpleMathTests.test("Mutation") {
     a = a * x
     return a * x
   }
-  expectEqual(4 * 27, gradient(at: 3, in: fourthPower))
+  expectEqual(4 * 27, gradient(at: 3, of: fourthPower))
 }
 
 SimpleMathTests.test("Tuple") {
@@ -154,7 +154,7 @@ SimpleMathTests.test("Tuple") {
     var tuple = (1, 1, ((x, 1), 1))
     return tuple.2.0.0
   }
-  expectEqual(1, gradient(at: 3, in: nested))
+  expectEqual(1, gradient(at: 3, of: nested))
 }
 
 SimpleMathTests.test("TupleMutation") {
@@ -163,7 +163,7 @@ SimpleMathTests.test("TupleMutation") {
     tuple.0 = tuple.0 * x
     return x * tuple.0
   }
-  expectEqual(27, gradient(at: 3, in: foo))
+  expectEqual(27, gradient(at: 3, of: foo))
 
   func fifthPower(_ x: Float) -> Float {
     var tuple = (x, x)
@@ -171,7 +171,7 @@ SimpleMathTests.test("TupleMutation") {
     tuple.1 = tuple.0 * x
     return tuple.0 * tuple.1
   }
-  expectEqual(405, gradient(at: 3, in: fifthPower))
+  expectEqual(405, gradient(at: 3, of: fifthPower))
 
   func nested(_ x: Float) -> Float {
     var tuple = ((x, x), x)
@@ -179,13 +179,13 @@ SimpleMathTests.test("TupleMutation") {
     tuple.0.1 = tuple.0.0 * x
     return tuple.0.0 * tuple.0.1
   }
-  expectEqual(405, gradient(at: 3, in: nested))
+  expectEqual(405, gradient(at: 3, of: nested))
 
   func generic<T: Differentiable & AdditiveArithmetic>(_ x: T) -> T {
     var tuple = (x, x)
     return tuple.0
   }
-  expectEqual(1, gradient(at: 3.0, in: generic))
+  expectEqual(1, gradient(at: 3.0, of: generic))
 
   // FIXME(TF-1033): Fix forward-mode ownership error for tuple with non-active
   // initial values.
@@ -198,7 +198,7 @@ SimpleMathTests.test("TupleMutation") {
     tuple.1 = x
     return tuple.0
   }
-  expectEqual(1, gradient(at: 3.0, in: genericInitialNonactive))
+  expectEqual(1, gradient(at: 3.0, of: genericInitialNonactive))
   */
 }
 
@@ -209,7 +209,7 @@ SimpleMathTests.test("TupleNonDifferentiableElements") {
     let tuple = (2 * x, 1)
     return tuple.0
   }
-  expectEqual((8, 2), valueWithGradient(at: 4, in: tupleLet))
+  expectEqual((8, 2), valueWithGradient(at: 4, of: tupleLet))
 
   func tupleVar(_ x: Tracked<Float>) -> Tracked<Float> {
     var tuple = (x, 1)
@@ -217,7 +217,7 @@ SimpleMathTests.test("TupleNonDifferentiableElements") {
     tuple.1 = 1
     return tuple.0
   }
-  expectEqual((3, 1), valueWithGradient(at: 3, in: tupleVar))
+  expectEqual((3, 1), valueWithGradient(at: 3, of: tupleVar))
 
   func nested(_ x: Tracked<Float>) -> Tracked<Float> {
     // Convoluted function computing `x * x`.
@@ -228,7 +228,7 @@ SimpleMathTests.test("TupleNonDifferentiableElements") {
     tuple.2 = x
     return tuple.1.1 * tuple.2
   }
-  expectEqual((16, 8), valueWithGradient(at: 4, in: nested))
+  expectEqual((16, 8), valueWithGradient(at: 4, of: nested))
 
   struct Wrapper<T> {
     @differentiable(reverse where T : Differentiable)
@@ -244,7 +244,7 @@ SimpleMathTests.test("TupleNonDifferentiableElements") {
     let w = Wrapper<Tracked<Float>>()
     return w.baz(x)
   }
-  expectEqual((3, 1), valueWithGradient(at: 3, in: wrapper))
+  expectEqual((3, 1), valueWithGradient(at: 3, of: wrapper))
 }
 
 // Tests TF-21.
@@ -257,9 +257,9 @@ SimpleMathTests.test("StructMemberwiseInitializer") {
   }
 
   // Test direct `init` reference.
-  expectEqual(10, pullback(at: 4, in: Foo.init)(.init(stored: 10)))
+  expectEqual(10, pullback(at: 4, of: Foo.init)(.init(stored: 10)))
 
-  let 𝛁foo = pullback(at: Float(4), in: { input -> Foo in
+  let 𝛁foo = pullback(at: Float(4), of: { input -> Foo in
     let foo = Foo(stored: input)
     let foo2 = foo + foo
     return Foo(stored: foo2.stored)
@@ -288,7 +288,7 @@ SimpleMathTests.test("StructMemberwiseInitializer") {
     }
   }
 
-  let 𝛁custom = pullback(at: Float(4), in: { input -> Custom in
+  let 𝛁custom = pullback(at: Float(4), of: { input -> Custom in
     let foo = Custom(x: input)
     return foo + foo
   })(Custom.TangentVector(x: 1))
@@ -316,8 +316,8 @@ SimpleMathTests.test("StructConstantStoredProperty") {
     return model.applied(to: input)
   }
   expectEqual(TF_319.TangentVector(x: 6),
-              gradient(at: TF_319(x: 10), in: { $0.applied(to: 3) }))
-  expectEqual(20, gradient(at: 3, in: testStructInit))
+              gradient(at: TF_319(x: 10), of: { $0.applied(to: 3) }))
+  expectEqual(20, gradient(at: 3, of: testStructInit))
 }
 
 SimpleMathTests.test("StructMutation") {
@@ -331,7 +331,7 @@ SimpleMathTests.test("StructMutation") {
     let point = Point(x: input, y: input, z: input)
     return point + point
   }
-  expectEqual(6, pullback(at: 4, in: double)(Point(x: 1, y: 1, z: 1)))
+  expectEqual(6, pullback(at: 4, of: double)(Point(x: 1, y: 1, z: 1)))
 
   func fifthPower(_ input: Float) -> Float {
     var point = Point(x: input, y: input, z: input)
@@ -339,7 +339,7 @@ SimpleMathTests.test("StructMutation") {
     point.y = point.x * input
     return point.x * point.y
   }
-  expectEqual(405, gradient(at: 3, in: fifthPower))
+  expectEqual(405, gradient(at: 3, of: fifthPower))
 
   func mix(_ input: Float) -> Float {
     var tuple = (point: Point(x: input, y: input, z: input), float: input)
@@ -347,7 +347,7 @@ SimpleMathTests.test("StructMutation") {
     tuple.point.y = tuple.point.x * input
     return tuple.point.x * tuple.point.y
   }
-  expectEqual(405, gradient(at: 3, in: mix))
+  expectEqual(405, gradient(at: 3, of: mix))
 
   // Test TF-282.
   struct Add : Differentiable {
@@ -370,7 +370,7 @@ SimpleMathTests.test("StructGeneric") {
     var z: T
   }
 
-  let 𝛁generic = pullback(at: Float(3), in: { input -> Generic<Float> in
+  let 𝛁generic = pullback(at: Float(3), of: { input -> Generic<Float> in
     var generic = Generic(x: input, y: input, z: input)
     return generic
   })(Generic<Float>.TangentVector(x: 1, y: 1, z: 1))
@@ -382,7 +382,7 @@ SimpleMathTests.test("StructGeneric") {
     generic.y = generic.x * input
     return generic.x * generic.y
   }
-  expectEqual(405, gradient(at: 3, in: fifthPower))
+  expectEqual(405, gradient(at: 3, of: fifthPower))
 }
 
 SimpleMathTests.test("StructWithNoDerivativeProperty") {
@@ -432,7 +432,7 @@ SimpleMathTests.test("Adjoint value accumulation for aggregate lhs and concrete 
   func doubled(_ model: SmallTestModel) -> Float{
     return model() + model.stored
   }
-  let grads = gradient(at: SmallTestModel(), in: doubled)
+  let grads = gradient(at: SmallTestModel(), of: doubled)
   expectEqual(2.0, grads.stored)
 }
 

--- a/test/AutoDiff/validation-test/subset_parameters_thunk.swift
+++ b/test/AutoDiff/validation-test/subset_parameters_thunk.swift
@@ -31,10 +31,10 @@ SubsetParameterThunkTests.test("InoutParametersDirect") {
   let x: Float = 3
   let y: Double = 4
   let z: Float = 5
-  expectEqual((2, 3, 4), gradient(at: x, y, z, in: inoutDirectCaller))
-  expectEqual((3, 4), gradient(at: y, z, in: { y, z in inoutDirectCaller(x, y, z) }))
-  expectEqual((2, 4), gradient(at: x, z, in: { x, z in inoutDirectCaller(x, y, z) }))
-  expectEqual((2, 3), gradient(at: x, y, in: { x, y in inoutDirectCaller(x, y, z) }))
+  expectEqual((2, 3, 4), gradient(at: x, y, z, of: inoutDirectCaller))
+  expectEqual((3, 4), gradient(at: y, z, of: { y, z in inoutDirectCaller(x, y, z) }))
+  expectEqual((2, 4), gradient(at: x, z, of: { x, z in inoutDirectCaller(x, y, z) }))
+  expectEqual((2, 3), gradient(at: x, y, of: { x, y in inoutDirectCaller(x, y, z) }))
 }
 
 func inoutIndirect<T: Differentiable, U: Differentiable, V: Differentiable>(
@@ -68,10 +68,10 @@ SubsetParameterThunkTests.test("InoutParametersIndirect") {
   let x: Float = 3
   let y: Double = 4
   let z: Float = 5
-  expectEqual((0, 1, 0), gradient(at: x, y, z, in: inoutIndirectCaller))
-  expectEqual((1, 0), gradient(at: y, z, in: { y, z in inoutIndirectCaller(x, y, z) }))
-  expectEqual((0, 0), gradient(at: x, z, in: { x, z in inoutIndirectCaller(x, y, z) }))
-  expectEqual((0, 1), gradient(at: x, y, in: { x, y in inoutIndirectCaller(x, y, z) }))
+  expectEqual((0, 1, 0), gradient(at: x, y, z, of: inoutIndirectCaller))
+  expectEqual((1, 0), gradient(at: y, z, of: { y, z in inoutIndirectCaller(x, y, z) }))
+  expectEqual((0, 0), gradient(at: x, z, of: { x, z in inoutIndirectCaller(x, y, z) }))
+  expectEqual((0, 1), gradient(at: x, y, of: { x, y in inoutIndirectCaller(x, y, z) }))
 }
 
 runAllTests()

--- a/test/AutoDiff/validation-test/superset_adjoint.swift
+++ b/test/AutoDiff/validation-test/superset_adjoint.swift
@@ -43,7 +43,7 @@ SupersetVJPTests.testWithLeakChecking("SubsetOfSubset") {
   func foo(_ x: Tracked<Float>, _ y: Tracked<Float>, _ z: Tracked<Float>) -> Tracked<Float> {
     withoutDerivative(at: 0)
   }
-  expectEqual(0, gradient(at: 0, in: { x in foo(x, 0, 0) }))
+  expectEqual(0, gradient(at: 0, of: { x in foo(x, 0, 0) }))
 }
 
 SupersetVJPTests.test("ApplySubset") {


### PR DESCRIPTION
These APIs are not included in the initial proposal. This PR moves them to `DifferentiationUnittests`.