### PR TITLE
[NFC] Allow errors to be conditionally emitted as warnings

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -636,7 +636,7 @@ namespace swift {
 
     /// Figure out the Behavior for the given diagnostic, taking current
     /// state such as fatality into account.
-    DiagnosticBehavior determineBehavior(DiagID id);
+    DiagnosticBehavior determineBehavior(const Diagnostic &diag);
 
     bool hadAnyError() const { return anyErrorOccurred; }
     bool hasFatalErrorOccurred() const { return fatalErrorOccurred; }
@@ -1105,7 +1105,7 @@ namespace swift {
                                        Engine.TentativeDiagnostics.end());
 
       for (auto &diagnostic : diagnostics) {
-        auto behavior = Engine.state.determineBehavior(diagnostic.getID());
+        auto behavior = Engine.state.determineBehavior(diagnostic);
         if (behavior == DiagnosticBehavior::Fatal ||
             behavior == DiagnosticBehavior::Error)
           return true;

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -23,6 +23,7 @@
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/TypeLoc.h"
 #include "swift/Localization/LocalizationFormat.h"
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Allocator.h"
@@ -627,8 +628,8 @@ namespace swift {
     /// Track the previous emitted Behavior, useful for notes
     DiagnosticBehavior previousBehavior = DiagnosticBehavior::Unspecified;
 
-    /// Track settable, per-diagnostic state that we store
-    std::vector<DiagnosticBehavior> perDiagnosticBehavior;
+    /// Track which diagnostics should be ignored.
+    llvm::BitVector ignoredDiagnostics;
 
   public:
     DiagnosticState();
@@ -660,9 +661,9 @@ namespace swift {
       fatalErrorOccurred = false;
     }
 
-    /// Set per-diagnostic behavior
-    void setDiagnosticBehavior(DiagID id, DiagnosticBehavior behavior) {
-      perDiagnosticBehavior[(unsigned)id] = behavior;
+    /// Set whether a diagnostic should be ignored.
+    void setIgnoredDiagnostic(DiagID id, bool ignored) {
+      ignoredDiagnostics[(unsigned)id] = ignored;
     }
 
   private:
@@ -808,7 +809,7 @@ namespace swift {
     }
 
     void ignoreDiagnostic(DiagID id) {
-      state.setDiagnosticBehavior(id, DiagnosticBehavior::Ignore);
+      state.setIgnoredDiagnostic(id, true);
     }
 
     void resetHadAnyError() {

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -344,15 +344,16 @@ namespace swift {
     }
   };
 
-  /// Describes the current behavior to take with a diagnostic
+  /// Describes the current behavior to take with a diagnostic.
+  /// Ordered from most severe to least.
   enum class DiagnosticBehavior : uint8_t {
-    Unspecified,
-    Ignore,
-    Note,
-    Remark,
-    Warning,
-    Error,
+    Unspecified = 0,
     Fatal,
+    Error,
+    Warning,
+    Remark,
+    Note,
+    Ignore,
   };
 
   struct DiagnosticFormatOptions {
@@ -405,6 +406,7 @@ namespace swift {
     SourceLoc Loc;
     bool IsChildNote = false;
     const swift::Decl *Decl = nullptr;
+    DiagnosticBehavior BehaviorLimit = DiagnosticBehavior::Unspecified;
 
     friend DiagnosticEngine;
 
@@ -432,10 +434,12 @@ namespace swift {
     bool isChildNote() const { return IsChildNote; }
     SourceLoc getLoc() const { return Loc; }
     const class Decl *getDecl() const { return Decl; }
+    DiagnosticBehavior getBehaviorLimit() const { return BehaviorLimit; }
 
     void setLoc(SourceLoc loc) { Loc = loc; }
     void setIsChildNote(bool isChildNote) { IsChildNote = isChildNote; }
     void setDecl(const class Decl *decl) { Decl = decl; }
+    void setBehaviorLimit(DiagnosticBehavior limit){ BehaviorLimit = limit; }
 
     /// Returns true if this object represents a particular diagnostic.
     ///
@@ -504,6 +508,11 @@ namespace swift {
     
     /// Flush the active diagnostic to the diagnostic output engine.
     void flush();
+
+    /// Prevent the diagnostic from behaving more severely than \p limit. For
+    /// instance, if \c DiagnosticBehavior::Warning is passed, an error will be
+    /// emitted as a warning, but a note will still be emitted as a note.
+    InFlightDiagnostic &limitBehavior(DiagnosticBehavior limit);
 
     /// Add a token-based range to the currently-active diagnostic.
     InFlightDiagnostic &highlight(SourceRange R);

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4364,38 +4364,20 @@ ERROR(non_concurrent_type_member,none,
       "%select{stored property %1|associated value %1}0 of "
       "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",
       (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
-WARNING(non_concurrent_type_member_warn,none,
-      "%select{stored property %1|associated value %1}0 of "
-      "'ConcurrentValue'-conforming %2 %3 has non-concurrent-value type %4",
-      (bool, DeclName, DescriptiveDeclKind, DeclName, Type))
 ERROR(concurrent_value_class_mutable_property,none,
-      "stored property %0 of 'ConcurrentValue'-conforming %1 %2 is mutable",
-      (DeclName, DescriptiveDeclKind, DeclName))
-WARNING(concurrent_value_class_mutable_property_warn,none,
       "stored property %0 of 'ConcurrentValue'-conforming %1 %2 is mutable",
       (DeclName, DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_outside_source_file,none,
       "conformance to 'ConcurrentValue' must occur in the same source file as "
       "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
       (DescriptiveDeclKind, DeclName))
-WARNING(concurrent_value_outside_source_file_warn,none,
-      "conformance to 'ConcurrentValue' must occur in the same source file as "
-      "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
-      (DescriptiveDeclKind, DeclName))
 ERROR(concurrent_value_nonfinal_class,none,
-      "non-final class %0 cannot conform to `ConcurrentValue`; "
-      "use `UnsafeConcurrentValue`", (DeclName))
-WARNING(concurrent_value_nonfinal_class_warn,none,
       "non-final class %0 cannot conform to `ConcurrentValue`; "
       "use `UnsafeConcurrentValue`", (DeclName))
 ERROR(concurrent_value_inherit,none,
       "`ConcurrentValue` class %1 cannot inherit from another class"
       "%select{| other than 'NSObject'}0",
       (bool, DeclName))
-WARNING(concurrent_value_inherit_warn,none,
-        "`ConcurrentValue` class %1 cannot inherit from another class"
-        "%select{| other than 'NSObject'}0",
-        (bool, DeclName))
 
 ERROR(actorindependent_let,none,
       "'@actorIndependent' is meaningless on 'let' declarations because "

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -136,9 +136,8 @@ static constexpr EducationalNotes<LocalDiagID::NumDiags> _EducationalNotes = Edu
 static constexpr auto educationalNotes = _EducationalNotes.value;
 
 DiagnosticState::DiagnosticState() {
-  // Initialize our per-diagnostic state to default
-  perDiagnosticBehavior.resize(LocalDiagID::NumDiags,
-                               DiagnosticBehavior::Unspecified);
+  // Initialize our ignored diagnostics to default
+  ignoredDiagnostics.resize(LocalDiagID::NumDiags);
 }
 
 static CharSourceRange toCharSourceRange(SourceManager &SM, SourceRange SR) {
@@ -826,8 +825,7 @@ DiagnosticBehavior DiagnosticState::determineBehavior(DiagID id) {
 
   // We determine how to handle a diagnostic based on the following rules
   //   1) If current state dictates a certain behavior, follow that
-  //   2) If the user provided a behavior for this specific diagnostic, follow
-  //      that
+  //   2) If the user ignored this specific diagnostic, follow that
   //   3) If the user provided a behavior for this diagnostic's kind, follow
   //      that
   //   4) Otherwise remap the diagnostic kind
@@ -846,11 +844,9 @@ DiagnosticBehavior DiagnosticState::determineBehavior(DiagID id) {
     if (!showDiagnosticsAfterFatalError && !isNote)
       return set(DiagnosticBehavior::Ignore);
 
-  //   2) If the user provided a behavior for this specific diagnostic, follow
-  //      that
-
-  if (perDiagnosticBehavior[(unsigned)id] != DiagnosticBehavior::Unspecified)
-    return set(perDiagnosticBehavior[(unsigned)id]);
+  //   2) If the user ignored this specific diagnostic, follow that
+  if (ignoredDiagnostics[(unsigned)diag.getID()])
+    return set(DiagnosticBehavior::Ignore);
 
   //   3) If the user provided a behavior for this diagnostic's kind, follow
   //      that

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -807,7 +807,7 @@ llvm::cl::opt<bool> AssertOnError("swift-diagnostics-assert-on-error",
 llvm::cl::opt<bool> AssertOnWarning("swift-diagnostics-assert-on-warning",
                                     llvm::cl::init(false));
 
-DiagnosticBehavior DiagnosticState::determineBehavior(DiagID id) {
+DiagnosticBehavior DiagnosticState::determineBehavior(const Diagnostic &diag) {
   auto set = [this](DiagnosticBehavior lvl) {
     if (lvl == DiagnosticBehavior::Fatal) {
       fatalErrorOccurred = true;
@@ -830,7 +830,7 @@ DiagnosticBehavior DiagnosticState::determineBehavior(DiagID id) {
   //      that
   //   4) Otherwise remap the diagnostic kind
 
-  auto diagInfo = storedDiagnosticInfos[(unsigned)id];
+  auto diagInfo = storedDiagnosticInfos[(unsigned)diag.getID()];
   bool isNote = diagInfo.kind == DiagnosticKind::Note;
 
   //   1) If current state dictates a certain behavior, follow that
@@ -907,7 +907,7 @@ static AccessLevel getBufferAccessLevel(const Decl *decl) {
 
 Optional<DiagnosticInfo>
 DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
-  auto behavior = state.determineBehavior(diagnostic.getID());
+  auto behavior = state.determineBehavior(diagnostic);
   if (behavior == DiagnosticBehavior::Ignore)
     return None;
 


### PR DESCRIPTION
Sometimes, the same diagnostic should be emitted as an error in some situations and a warning in others; for instance, this is often done for backwards compatibility in older language modes. Previously, the warning and error had to be two separate diagnostics with their own IDs and their own entries in the diagnostic tables.

This PR adds an `InFlightDiagnostic::limitBehavior()` method which can be used to "demote" an error to a warning. More broadly, it can actually be used to transform any kind of diagnostic to a less "severe" behavior:

Fatal error → Error → Warning → Remark → Note → Ignored (no diagnostic)

This will allow us to avoid adding and maintaining redundant warnings. To test it, I have converted some recently-added code in TypeCheckConcurrency.cpp to use the feature.

As part of this work, I have also removed `DiagnosticEngine::ignoreDiagnostic()`. This feature has apparently never been used, and it was implemented using a very general mechanism that would require some work to reconcile with `limitBehavior()`. Since there are currently no examples of how `ignoreDiagnostic()` is supposed to be used, I chose to remove it rather than try to work on code I cannot test.