### PR TITLE
[Concurrency] Taks APIs fully implemented via ActiveTask internal TL

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -107,6 +107,10 @@ void swift_task_dealloc(AsyncTask *task, void *ptr);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_cancel(AsyncTask *task);
 
+/// Get 'active' AsyncTask, depending on platform this may use thread local storage.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+AsyncTask* swift_task_get_active();
+
 /// Escalate the priority of a task and all of its child tasks.
 ///
 /// This can be called from any thread.

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -134,6 +134,11 @@ SWIFT_RUNTIME_DECLARE_THREAD_LOCAL(
 
 } // end anonymous namespace
 
+AsyncTask*
+swift::swift_task_get_active() {
+  return ActiveTask::get();
+}
+
 void swift::swift_job_run(Job *job, ExecutorRef executor) {
   ExecutorTrackingInfo trackingInfo;
   trackingInfo.enterAndShadow(executor);

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -70,10 +70,13 @@ extension Task {
   /// - Returns: the value bound to the key, or its default value it if was not
   ///            bound in the current (or any parent) tasks.
   public static func local<Key>(_ keyPath: KeyPath<TaskLocalValues, Key>)
-    async -> Key.Value where Key: TaskLocalKey {
-    let task = Builtin.getCurrentAsyncTask()
+    -> Key.Value where Key: TaskLocalKey {
+    guard let task = Task.unsafeCurrent else {
+      return Key.defaultValue
+    }
 
-    let value = _taskLocalValueGet(task, keyType: Key.self, inheritance: Key.inherit.rawValue)
+    let value = _taskLocalValueGet(
+      task._task, keyType: Key.self, inheritance: Key.inherit.rawValue)
     guard let rawValue = value else {
       return Key.defaultValue
     }

--- a/test/Concurrency/Runtime/async_task_equals_hashCode.swift
+++ b/test/Concurrency/Runtime/async_task_equals_hashCode.swift
@@ -1,27 +1,57 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -parse-as-library) | %FileCheck %s --dump-input=always
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library) | %FileCheck %s --dump-input=always
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// REQUIRES: OS=macosx
-// REQUIRES: CPU=x86_64
 
-import Dispatch
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #endif
 
+func simple() async {
+  print("\(#function) -----------------------")
+  let one = await Task.current()
+  let two = await Task.current()
+  print("same equal: \(one == two)") // CHECK: same equal: true
+  print("hashes equal: \(one.hashValue == two.hashValue)") // CHECK: hashes equal: true
+
+  async let x = Task.current()
+  let three = await x
+
+  print("parent/child equal: \(three == two)") // CHECK: parent/child equal: false
+  print("parent/child hashes equal: \(three.hashValue == two.hashValue)") // CHECK: parent/child hashes equal: false
+}
+
+func unsafe() async {
+  print("\(#function) -----------------------")
+  let one = Task.unsafeCurrent!
+  let two = Task.unsafeCurrent!
+  print("unsafe same equal: \(one == two)") // CHECK: same equal: true
+  print("unsafe hashes equal: \(one.hashValue == two.hashValue)") // CHECK: hashes equal: true
+
+  async let x = Task.unsafeCurrent!
+  let three = await x
+
+  print("unsafe parent/child equal: \(three == two)") // CHECK: parent/child equal: false
+  print("unsafe parent/child hashes equal: \(three.hashValue == two.hashValue)") // CHECK: parent/child hashes equal: false
+
+  print("unsafe.task parent/child equal: \(three.task == two.task)") // CHECK: parent/child equal: false
+  print("unsafe.task parent/child hashes equal: \(three.task.hashValue == two.task.hashValue)") // CHECK: parent/child hashes equal: false
+}
+
+func unsafeSync() {
+  print("\(#function) -----------------------")
+  let one = Task.unsafeCurrent!
+  let two = Task.unsafeCurrent!
+  print("unsafe same equal: \(one == two)") // CHECK: same equal: true
+  print("unsafe hashes equal: \(one.hashValue == two.hashValue)") // CHECK: hashes equal: true
+}
+
 @main struct Main {
   static func main() async {
-    let one = await Task.__unsafeCurrentAsync().task // FIXME: replace with Task.current
-    let two = await Task.__unsafeCurrentAsync().task // FIXME: replace with Task.current
-    print("same equal: \(one == two)") // CHECK: same equal: true
-    print("hashes equal: \(one.hashValue == two.hashValue)") // CHECK: hashes equal: true
-
-    async let x = Task.__unsafeCurrentAsync().task // FIXME: replace with Task.current
-
-    let three = await x
-    print("parent/child equal: \(three == two)") // CHECK: parent/child equal: false
-    print("parent/child hashes equal: \(three.hashValue == two.hashValue)") // CHECK: parent/child hashes equal: false
+    await simple()
+    await unsafe()
+    unsafeSync()
   }
 }

--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library) | %FileCheck %s --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+@main struct Main {
+  static func main() async {
+    let handle = Task.runDetached {
+      while (!Task.isCancelled) { // no need for await here, yay
+        print("waiting")
+      }
+
+      print("done")
+    }
+
+    handle.cancel()
+
+    // CHECK: done
+    await handle.get()
+  }
+}

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -13,28 +13,26 @@ import WinSDK
 #error("Unsupported platform")
 #endif
 
-// FIXME: use `Task.currentPriority` once unsafeCurrent works in all these
-
 func test_detach() async {
-  let a1 = await Task.__unsafeCurrentAsync().task.priority
+  let a1 = Task.currentPriority
   print("a1: \(a1)") // CHECK: a1: default
 
   // Note: remember to detach using a higher priority, otherwise a lower one
   // might be escalated by the get() and we could see `default` in the detached
   // task.
   await Task.runDetached(priority: .userInitiated) {
-    let a2 = await Task.__unsafeCurrentAsync().task.priority
+    let a2 = Task.currentPriority
     print("a2: \(a2)") // CHECK: a2: userInitiated
   }.get()
 
-  let a3 = await Task.__unsafeCurrentAsync().task.priority
+  let a3 = Task.currentPriority
   print("a3: \(a3)") // CHECK: a3: default
 }
 
 func test_multiple_lo_indirectly_escalated() async {
   @concurrent
   func loopUntil(priority: Task.Priority) async {
-    while (await Task.__unsafeCurrentAsync().task.priority != priority) {
+    while (Task.currentPriority != priority) {
 #if os(Windows)
       Sleep(1)
 #else

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -16,7 +16,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
       await group.add { () async -> Int in
         sleep(1)
         print("  inside group.add { \(n) }")
-        let cancelled = await Task.__unsafeCurrentAsync().isCancelled
+        let cancelled = Task.isCancelled
         print("  inside group.add { \(n) } (canceled: \(cancelled))")
         return n
       }
@@ -25,7 +25,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
     group.cancelAll()
 
     // return immediately; the group should wait on the tasks anyway
-    let c = await Task.__unsafeCurrentAsync().isCancelled
+    let c = Task.isCancelled
     print("return immediately 0 (canceled: \(c))")
     return 0
   }

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
@@ -15,14 +15,14 @@ func test_skipCallingNext() async {
       print("group.add { \(n) }")
       await group.add { () async -> Int in
         sleep(1)
-        let c = await Task.__unsafeCurrentAsync().isCancelled
+        let c = Task.isCancelled
         print("  inside group.add { \(n) } (canceled: \(c))")
         return n
       }
     }
 
     // return immediately; the group should wait on the tasks anyway
-    let c = await Task.__unsafeCurrentAsync().isCancelled
+    let c = Task.isCancelled
     print("return immediately 0 (canceled: \(c))")
     return 0
   }

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -31,7 +31,7 @@ func test_taskGroup_throws() async {
         print("error caught in group: \(error)")
 
         await group.add { () async -> Int in
-          let c = await Task.__unsafeCurrentAsync().isCancelled
+          let c = Task.isCancelled
           print("task 3 (cancelled: \(c))")
           return 3
         }

--- a/test/Concurrency/Runtime/task_locals_async_let.swift
+++ b/test/Concurrency/Runtime/task_locals_async_let.swift
@@ -26,7 +26,7 @@ func printTaskLocal<Key>(
   _ expected: Key.Value? = nil,
   file: String = #file, line: UInt = #line
 ) async throws -> Key.Value? where Key: TaskLocalKey {
-  let value = await Task.local(key)
+  let value = Task.local(key)
   print("\(Key.self): \(value) at \(file):\(line)")
   if let expected = expected {
     assert("\(expected)" == "\(value)",

--- a/test/Concurrency/Runtime/task_locals_basic.swift
+++ b/test/Concurrency/Runtime/task_locals_basic.swift
@@ -53,7 +53,7 @@ func printTaskLocal<Key>(
   _ expected: Key.Value? = nil,
   file: String = #file, line: UInt = #line
 ) async throws where Key: TaskLocalKey {
-  let value = await Task.local(key)
+  let value = Task.local(key)
   print("\(Key.self): \(value) at \(file):\(line)")
   if let expected = expected {
     assert("\(expected)" == "\(value)",

--- a/test/Concurrency/Runtime/task_locals_groups.swift
+++ b/test/Concurrency/Runtime/task_locals_groups.swift
@@ -26,7 +26,7 @@ func printTaskLocal<Key>(
   _ expected: Key.Value? = nil,
   file: String = #file, line: UInt = #line
 ) async throws where Key: TaskLocalKey {
-  let value = await Task.local(key)
+  let value = Task.local(key)
   print("\(Key.self): \(value) at \(file):\(line)")
   if let expected = expected {
     assert("\(expected)" == "\(value)",
@@ -52,7 +52,7 @@ func groups() async {
         try! await printTaskLocal(\.number) // CHECK: NumberKey: 1 {{.*}}
       }
       try! await printTaskLocal(\.number) // CHECK: NumberKey: 0 {{.*}}
-      return await Task.local(\.number) // 0
+      return Task.local(\.number) // 0
     }
 
     return try! await group.next()!
@@ -67,7 +67,7 @@ func groups() async {
       try! await printTaskLocal(\.number) // CHECK: NumberKey: 2 {{.*}}
       await group.add {
         try! await printTaskLocal(\.number) // CHECK: NumberKey: 2 {{.*}}
-        return await Task.local(\.number)
+        return Task.local(\.number)
       }
       try! await printTaskLocal(\.number) // CHECK: NumberKey: 2 {{.*}}
 

--- a/test/Concurrency/Runtime/task_locals_inherit_never.swift
+++ b/test/Concurrency/Runtime/task_locals_inherit_never.swift
@@ -18,7 +18,7 @@ func printTaskLocal<Key>(
   _ expected: Key.Value? = nil,
   file: String = #file, line: UInt = #line
 ) async where Key: TaskLocalKey {
-  let value = await Task.local(key)
+  let value = Task.local(key)
   print("\(Key.self): \(value) at \(file):\(line)")
   if let expected = expected {
     assert("\(expected)" == "\(value)",


### PR DESCRIPTION
Supersedes #36119 (or follows up to, your call)

Relates to rdar://70546948
Resolves the final step of Task APIs being 1:1 with the end goal shape we are pitching in the proposal [pitch #3](https://forums.swift.org/t/pitch-3-structured-concurrency/44496/33) right now