### PR TITLE
[NFC; Incremental] Rename BasicSourceFileInfo.InterfaceHash

### DIFF
--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -98,7 +98,9 @@ struct BasicDeclLocs {
 
 struct BasicSourceFileInfo {
   StringRef FilePath;
-  Fingerprint InterfaceHash = Fingerprint::ZERO();
+  /// Used for completion; factors in hashes from type-bodies in order to be sensitive to changes in
+  /// the intefaces of top-level type members.
+  Fingerprint InterfaceHashIncludingTypeMembers = Fingerprint::ZERO();
   llvm::sys::TimePoint<> LastModified = {};
   uint64_t FileSize = 0;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1553,7 +1553,7 @@ Fingerprint ModuleDecl::getFingerprint() const {
   StableHasher hasher = StableHasher::defaultHasher();
   SmallVector<Fingerprint, 16> FPs;
   collectBasicSourceFileInfo([&](const BasicSourceFileInfo &bsfi) {
-    FPs.emplace_back(bsfi.InterfaceHash);
+    FPs.emplace_back(bsfi.InterfaceHashIncludingTypeMembers);
   });
   
   // Sort the fingerprints lexicographically so we have a stable hash despite

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -262,10 +262,10 @@ bool BasicSourceFileInfo::populate(const SourceFile *SF) {
   FileSize = stat->getSize();
 
   if (SF->hasInterfaceHash()) {
-    InterfaceHash = SF->getInterfaceHashIncludingTypeMembers();
+    InterfaceHashIncludingTypeMembers = SF->getInterfaceHashIncludingTypeMembers();
   } else {
     // FIXME: Parse the file with EnableInterfaceHash option.
-    InterfaceHash = Fingerprint::ZERO();
+    InterfaceHashIncludingTypeMembers = Fingerprint::ZERO();
   }
 
   return false;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -974,7 +974,7 @@ void ModuleFile::collectBasicSourceFileInfo(
   while (Cursor < End) {
     // FilePath (byte offset in 'SourceLocsTextData').
     auto fileID = endian::readNext<uint32_t, little, unaligned>(Cursor);
-    // InterfaceHash (fixed length string).
+    // InterfaceHashIncludingTypeMembers (fixed length string).
     auto fpStr = StringRef{reinterpret_cast<const char *>(Cursor),
                            Fingerprint::DIGEST_LENGTH};
     Cursor += Fingerprint::DIGEST_LENGTH;
@@ -991,7 +991,7 @@ void ModuleFile::collectBasicSourceFileInfo(
     BasicSourceFileInfo info;
     info.FilePath = filePath;
     if (auto fingerprint = Fingerprint::fromString(fpStr))
-      info.InterfaceHash = fingerprint.getValue();
+      info.InterfaceHashIncludingTypeMembers = fingerprint.getValue();
     else {
       llvm::errs() << "Unconvertable fingerprint '" << fpStr << "'\n";
       abort();

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -803,7 +803,7 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
         return;
 
       auto fileID = FWriter.getTextOffset(absolutePath);
-      auto fingerprintStr = info.InterfaceHash.getRawValue();
+      auto fingerprintStr = info.InterfaceHashIncludingTypeMembers.getRawValue();
       auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
                            info.LastModified.time_since_epoch())
                            .count();
@@ -812,7 +812,7 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
       endian::Writer writer(out, little);
       // FilePath.
       writer.write<uint32_t>(fileID);
-      // InterfaceHash (fixed length string).
+      // InterfaceHashIncludingTypeMembers (fixed length string).
       assert(fingerprintStr.size() == Fingerprint::DIGEST_LENGTH);
       out << fingerprintStr;
       // LastModified (nanoseconds since epoch).

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2518,7 +2518,7 @@ static void printModuleMetadata(ModuleDecl *MD) {
   });
   MD->collectBasicSourceFileInfo([&](const BasicSourceFileInfo &info) {
     OS << "filepath=" << info.FilePath << "; ";
-    OS << "hash=" << info.InterfaceHash.getRawValue() << "; ";
+    OS << "hash=" << info.InterfaceHashIncludingTypeMembers.getRawValue() << "; ";
     OS << "mtime=" << info.LastModified << "; ";
     OS << "size=" << info.FileSize;
     OS << "\n";


### PR DESCRIPTION
In preparation for incremental imports, before adding another `InterfaceHash` variable here, rename this one to be more descriptive.