### PR TITLE
[Incremental Imports] Keep top-level type-body hashes away from swiftmodule hashes

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -879,8 +879,10 @@ public:
   }
 
   /// Read a swiftdeps file at \p path and return a SourceFileDepGraph if
-  /// successful.
-  Optional<SourceFileDepGraph> static loadFromPath(StringRef);
+  /// successful. If \p allowSwiftModule is true, try to load the information
+  /// from a swiftmodule file if appropriate.
+  Optional<SourceFileDepGraph> static loadFromPath(
+      StringRef, bool allowSwiftModule = false);
 
   /// Read a swiftdeps file from \p buffer and return a SourceFileDepGraph if
   /// successful.

--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -99,6 +99,10 @@ struct BasicDeclLocs {
 struct BasicSourceFileInfo {
   StringRef FilePath;
   Fingerprint InterfaceHash = Fingerprint::ZERO();
+  /// Does *not* include the type-body hashes of the top level types.
+  /// Just the `SourceFile` hashes.
+  /// Used for incremental imports.
+  Fingerprint InterfaceHashWithoutTypeMembers = Fingerprint::ZERO();
   llvm::sys::TimePoint<> LastModified = {};
   uint64_t FileSize = 0;
 

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -42,11 +42,16 @@ using namespace fine_grained_dependencies;
 // MARK: Emitting and reading SourceFileDepGraph
 //==============================================================================
 
-Optional<SourceFileDepGraph> SourceFileDepGraph::loadFromPath(StringRef path) {
+Optional<SourceFileDepGraph>
+SourceFileDepGraph::loadFromPath(StringRef path, const bool allowSwiftModule) {
+  const bool treatAsModule =
+      allowSwiftModule &&
+      path.endswith(file_types::getExtension(file_types::TY_SwiftModuleFile));
   auto bufferOrError = llvm::MemoryBuffer::getFile(path);
   if (!bufferOrError)
     return None;
-  return loadFromBuffer(*bufferOrError.get());
+  return treatAsModule ? loadFromSwiftModuleBuffer(*bufferOrError.get())
+                       : loadFromBuffer(*bufferOrError.get());
 }
 
 Optional<SourceFileDepGraph>

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1553,7 +1553,9 @@ Fingerprint ModuleDecl::getFingerprint() const {
   StableHasher hasher = StableHasher::defaultHasher();
   SmallVector<Fingerprint, 16> FPs;
   collectBasicSourceFileInfo([&](const BasicSourceFileInfo &bsfi) {
-    FPs.emplace_back(bsfi.InterfaceHash);
+    // For incremental imports, the hash must be insensitive to type-body
+    // changes, so use the one without type members.
+    FPs.emplace_back(bsfi.InterfaceHashWithoutTypeMembers);
   });
   
   // Sort the fingerprints lexicographically so we have a stable hash despite

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -263,9 +263,11 @@ bool BasicSourceFileInfo::populate(const SourceFile *SF) {
 
   if (SF->hasInterfaceHash()) {
     InterfaceHash = SF->getInterfaceHashIncludingTypeMembers();
+    InterfaceHashWithoutTypeMembers = SF->getInterfaceHash();
   } else {
     // FIXME: Parse the file with EnableInterfaceHash option.
     InterfaceHash = Fingerprint::ZERO();
+    InterfaceHashWithoutTypeMembers = Fingerprint::ZERO();
   }
 
   return false;

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -803,7 +803,10 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
         return;
 
       auto fileID = FWriter.getTextOffset(absolutePath);
-      auto fingerprintStr = info.InterfaceHash.getRawValue();
+      auto fingerprintStrWithoutTypeMembers =
+        info.InterfaceHashWithoutTypeMembers.getRawValue();
+      auto fingerprintStrIncludingTypeMembers =
+        info.InterfaceHash.getRawValue();
       auto timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
                            info.LastModified.time_since_epoch())
                            .count();
@@ -812,9 +815,15 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
       endian::Writer writer(out, little);
       // FilePath.
       writer.write<uint32_t>(fileID);
-      // InterfaceHash (fixed length string).
-      assert(fingerprintStr.size() == Fingerprint::DIGEST_LENGTH);
-      out << fingerprintStr;
+
+      // InterfaceHashWithoutTypeMembers (fixed length string).
+      assert(fingerprintStrWithoutTypeMembers.size() == Fingerprint::DIGEST_LENGTH);
+      out << fingerprintStrWithoutTypeMembers;
+
+      // InterfaceHashIncludingTypeMembers (fixed length string).
+      assert(fingerprintStrIncludingTypeMembers.size() == Fingerprint::DIGEST_LENGTH);
+      out << fingerprintStrIncludingTypeMembers;
+
       // LastModified (nanoseconds since epoch).
       writer.write<uint64_t>(timestamp);
       // FileSize (num of bytes).

--- a/test/Incremental/CrossModule/Inputs/module-fingerprint/C2.swift
+++ b/test/Incremental/CrossModule/Inputs/module-fingerprint/C2.swift
@@ -1,4 +1,6 @@
 public func fromC(parameter: Int = 0) {}
 
 struct S {
+  public func member() {}
 }
+public func other() {}

--- a/test/Incremental/CrossModule/module-fingerprint.swift
+++ b/test/Incremental/CrossModule/module-fingerprint.swift
@@ -13,9 +13,9 @@
 // RUN: %target-swift-ide-test -print-module-metadata -module-to-print B -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-CLEAN-B
 // RUN: %target-swift-ide-test -print-module-metadata -module-to-print A -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-CLEAN-A
 
-// CHECK-CLEAN-C: fingerprint=6e60fd224d614a59568a348e0ac9b55a
-// CHECK-CLEAN-B: fingerprint=bfa14052e1df9253b7bf7e0eb7cfc505
-// CHECK-CLEAN-A: fingerprint=a939d89f07c766a4607c5fe1a1715cf5
+// CHECK-CLEAN-C: fingerprint=7957733a8ee9bc44f726a516108786eb
+// CHECK-CLEAN-B: fingerprint=17bb71bdc7972a93446d524f47044156
+// CHECK-CLEAN-A: fingerprint=048332944f6e149f2e8bed309d47283d
 
 //
 // Now change C and ensure that B rebuilds but A does not
@@ -32,6 +32,25 @@
 // RUN: %target-swift-ide-test -print-module-metadata -module-to-print B -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL-B
 // RUN: %target-swift-ide-test -print-module-metadata -module-to-print A -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL-A
 
-// CHECK-INCREMENTAL-C: fingerprint=3e68d59b74032e18401ec978cdb11cf3
-// CHECK-INCREMENTAL-B: fingerprint=bfa14052e1df9253b7bf7e0eb7cfc505
-// CHECK-INCREMENTAL-A: fingerprint=a939d89f07c766a4607c5fe1a1715cf5
+// CHECK-INCREMENTAL-C: fingerprint=263f083edcaaf08536f657d10082dacc
+// CHECK-INCREMENTAL-B: fingerprint=17bb71bdc7972a93446d524f47044156
+// CHECK-INCREMENTAL-A: fingerprint=048332944f6e149f2e8bed309d47283d
+
+//
+// Now change a top-level type of C and ensure that C's fingerprint does not change
+//
+
+// RUN: cp %S/Inputs/module-fingerprint/C2.swift %t/C.swift
+
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/C.swiftmodule -enable-experimental-cross-module-incremental-build -module-name C -I %t -output-file-map %t/C.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle C.swift
+// RUN: touch %t/C.swiftmodule
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/B.swiftmodule -enable-experimental-cross-module-incremental-build -module-name B -I %t -output-file-map %t/B.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle B.swift
+// RUN: cd %t && %target-swiftc_driver -c -incremental -emit-dependencies -emit-module -emit-module-path %t/A.swiftmodule -enable-experimental-cross-module-incremental-build -module-name A -I %t -output-file-map %t/A.json -working-directory %t -driver-show-incremental -driver-show-job-lifecycle A.swift
+
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print C -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL2-C
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print B -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL2-B
+// RUN: %target-swift-ide-test -print-module-metadata -module-to-print A -enable-swiftsourceinfo -I %t -source-filename %s | %FileCheck %s --check-prefix=CHECK-INCREMENTAL2-A
+
+// CHECK-INCREMENTAL2-C: fingerprint=263f083edcaaf08536f657d10082dacc
+// CHECK-INCREMENTAL2-B: fingerprint=17bb71bdc7972a93446d524f47044156
+// CHECK-INCREMENTAL2-A: fingerprint=048332944f6e149f2e8bed309d47283d

--- a/test/Serialization/sourceinfo.swift
+++ b/test/Serialization/sourceinfo.swift
@@ -6,5 +6,5 @@ import MyModule
 // RUN: %target-swiftc_driver -emit-module -module-name MyModule -o %t/Modules/MyModule.swiftmodule %S/Inputs/SourceInfo/File1.swift %S/Inputs/SourceInfo/File2.swift
 // RUN: %target-swift-ide-test -print-module-metadata -module-to-print MyModule -enable-swiftsourceinfo -I %t/Modules -source-filename %s | %FileCheck %s
 
-// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File1.swift; hash=9da710e9b2de1fff2915639236b8929c; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=35
-// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File2.swift; hash=22b75a7717318d48f7a979906f35195e; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=57
+// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File1.swift; hash=9da710e9b2de1fff2915639236b8929c; hashWithoutTypeMembers=bef81a9bfc04156da679d8d579125d39; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=35
+// CHECK: filepath=SOURCE_DIR{{[/\\]}}test{{[/\\]}}Serialization{{[/\\]}}Inputs{{[/\\]}}SourceInfo{{[/\\]}}File2.swift; hash=22b75a7717318d48f7a979906f35195e; hashWithoutTypeMembers=7a22dbe5fc611122201f7d6b53094531; mtime={{[0-9]{4}-[0-9]{2}-[0-9]{2} .*}}; size=57

--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
   }
 
   case ActionType::BinaryToYAML: {
-    auto fg = SourceFileDepGraph::loadFromPath(options::InputFilename);
+    auto fg = SourceFileDepGraph::loadFromPath(options::InputFilename, true);
     if (!fg) {
       llvm::errs() << "Failed to read dependency file\n";
       return 1;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2519,6 +2519,7 @@ static void printModuleMetadata(ModuleDecl *MD) {
   MD->collectBasicSourceFileInfo([&](const BasicSourceFileInfo &info) {
     OS << "filepath=" << info.FilePath << "; ";
     OS << "hash=" << info.InterfaceHash.getRawValue() << "; ";
+    OS << "hashWithoutTypeMembers=" << info.InterfaceHashWithoutTypeMembers.getRawValue() << "; ";
     OS << "mtime=" << info.LastModified << "; ";
     OS << "size=" << info.FileSize;
     OS << "\n";


### PR DESCRIPTION
(At present includes https://github.com/apple/swift/pull/36133, but I'll rebase after landing it.)

Add `InterfaceHashWithoutTypeMembers` to `BasicSourceFileInfo` and use it when computing swiftmodule hashes.
