### PR TITLE
[cowarrayopt] Instead of always recomputing the loop we are analyzing exiting blocks when checking for dominance, use a cache.

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -105,6 +105,7 @@ class COWArrayOpt {
   RCIdentityFunctionInfo *RCIA;
   SILFunction *Function;
   SILLoop *Loop;
+  Optional<SmallVector<SILBasicBlock *, 8>> LoopExitingBlocks;
   SILBasicBlock *Preheader;
   DominanceInfo *DomTree;
   bool HasChanged = false;
@@ -195,6 +196,16 @@ private:
       return inst->getOperand(0);
     return cast<SingleValueInstruction>(inst);
   }
+
+  ArrayRef<SILBasicBlock *> getLoopExitingBlocks() const {
+    if (!LoopExitingBlocks) {
+      auto *self = const_cast<COWArrayOpt *>(this);
+      self->LoopExitingBlocks.emplace();
+      Loop->getExitingBlocks(*self->LoopExitingBlocks);
+    }
+    return *LoopExitingBlocks;
+  }
+
 };
 } // end anonymous namespace
 
@@ -990,9 +1001,7 @@ bool COWArrayOpt::hoistMakeMutable(ArraySemanticsCall MakeMutable,
 }
 
 bool COWArrayOpt::dominatesExitingBlocks(SILBasicBlock *BB) {
-  llvm::SmallVector<SILBasicBlock *, 8> ExitingBlocks;
-  Loop->getExitingBlocks(ExitingBlocks);
-  for (SILBasicBlock *Exiting : ExitingBlocks) {
+  for (SILBasicBlock *Exiting : getLoopExitingBlocks()) {
     if (!DomTree->dominates(BB, Exiting))
       return false;
   }


### PR DESCRIPTION
Saves a bunch of compile time when compiling the stdlib. Specifically, when
compiling the iOS 32 bit stdlib + sil-verify-all, this shaves off ~20% of the
compile time.
