### PR TITLE
[Concurrency] Make Job/AsyncTask minimally compatible with dispatch object layout

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -1333,6 +1333,26 @@ public:
 };
 using ClassMetadata = TargetClassMetadata<InProcess>;
 
+/// The structure of class metadata that's compatible with dispatch objects.
+/// This includes Swift heap metadata, followed by the vtable entries that
+/// dispatch expects to see, with padding to place them at the expected offsets.
+template <typename Runtime>
+struct TargetDispatchClassMetadata : public TargetHeapMetadata<Runtime> {
+  using DummyVTableCall = void (*)(void);
+
+  TargetDispatchClassMetadata(MetadataKind Kind,
+                              DummyVTableCall DummyVTableEntry)
+      : TargetHeapMetadata<Runtime>(Kind), DummyVTableEntry(DummyVTableEntry) {}
+
+  TargetPointer<Runtime, void> Opaque;
+#if SWIFT_OBJC_INTEROP
+  TargetPointer<Runtime, void> OpaqueObjC[3];
+#endif
+
+  TargetSignedPointer<Runtime, DummyVTableCall> DummyVTableEntry;
+};
+using DispatchClassMetadata = TargetDispatchClassMetadata<InProcess>;
+
 /// The structure of metadata for heap-allocated local variables.
 /// This is non-type metadata.
 template <typename Runtime>

--- a/include/swift/ABI/MetadataKind.def
+++ b/include/swift/ABI/MetadataKind.def
@@ -89,6 +89,10 @@ METADATAKIND(ErrorObject,
 METADATAKIND(Task,
              2 | MetadataKindIsNonType | MetadataKindIsRuntimePrivate)
 
+/// A non-task async job.
+METADATAKIND(Job,
+             3 | MetadataKindIsNonType | MetadataKindIsRuntimePrivate)
+
 // getEnumeratedMetadataKind assumes that all the enumerated values here
 // will be <= LastEnumeratedMetadataKind.
 

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -265,11 +265,8 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
 
   if (Builtin.ID == BuiltinValueKind::ConvertTaskToJob) {
     auto task = args.claimNext();
-    // The job object starts immediately past the heap-object header.
-    auto bytes = IGF.Builder.CreateBitCast(task, IGF.IGM.Int8PtrTy);
-    auto offset = IGF.IGM.RefCountedStructSize;
-    bytes = IGF.Builder.CreateInBoundsGEP(bytes, IGF.IGM.getSize(offset));
-    auto job = IGF.Builder.CreateBitCast(bytes, IGF.IGM.SwiftJobPtrTy);
+    // The job object starts at the beginning of the task.
+    auto job = IGF.Builder.CreateBitCast(task, IGF.IGM.SwiftJobPtrTy);
     out.add(job);
     return;
   }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -619,8 +619,10 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   SwiftTaskGroupPtrTy = Int8PtrTy; // we pass it opaquely (TaskGroup*)
   SwiftExecutorPtrTy = SwiftExecutorTy->getPointerTo(DefaultAS);
   SwiftJobTy = createStructType(*this, "swift.job", {
+    RefCountedStructTy,   // object header
+    Int8PtrTy, Int8PtrTy, // SchedulerPrivate
     SizeTy,               // flags
-    Int8PtrTy             // execution function pointer
+    FunctionPtrTy,        // RunJob/ResumeTask
   });
   SwiftJobPtrTy = SwiftJobTy->getPointerTo();
 

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -86,7 +86,7 @@ static DelayedJob *DelayedJobQueue = nullptr;
 
 /// Get the next-in-queue storage slot.
 static Job *&nextInQueue(Job *cur) {
-  return reinterpret_cast<Job*&>(cur->SchedulerPrivate);
+  return reinterpret_cast<Job*&>(&cur->SchedulerPrivate[NextWaitingTaskIndex]);
 }
 
 /// Insert a job into the cooperative global queue.

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -145,6 +145,11 @@ void AsyncTask::completeFuture(AsyncContext *context, ExecutorRef executor) {
 }
 
 SWIFT_CC(swift)
+static void destroyJob(SWIFT_CONTEXT HeapObject *obj) {
+  assert(false && "A non-task job should never be destroyed as heap metadata.");
+}
+
+SWIFT_CC(swift)
 static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   auto task = static_cast<AsyncTask*>(obj);
 
@@ -165,8 +170,27 @@ static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   free(task);
 }
 
+static void dummyVTableFunction(void) {
+  abort();
+}
+
+FullMetadata<DispatchClassMetadata> swift::jobHeapMetadata = {
+  {
+    {
+      &destroyJob
+    },
+    {
+      /*value witness table*/ nullptr
+    }
+  },
+  {
+    MetadataKind::Job,
+    dummyVTableFunction
+  }
+};
+
 /// Heap metadata for an asynchronous task.
-static FullMetadata<HeapMetadata> taskHeapMetadata = {
+static FullMetadata<DispatchClassMetadata> taskHeapMetadata = {
   {
     {
       &destroyTask
@@ -176,7 +200,8 @@ static FullMetadata<HeapMetadata> taskHeapMetadata = {
     }
   },
   {
-    MetadataKind::Task
+    MetadataKind::Task,
+    dummyVTableFunction
   }
 };
 

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -853,10 +853,8 @@ func globalStringTablePointerUse(_ str: String) -> Builtin.RawPointer {
 
 // CHECK-LABEL: define {{.*}}convertTaskToJob
 // CHECK:      call %swift.refcounted* @swift_retain(%swift.refcounted* returned %0)
-// CHECK-NEXT: [[T0:%.*]] = bitcast %swift.refcounted* %0 to i8*
-// CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds i8, i8* [[T0]], i64 16
-// CHECK-NEXT: [[T2:%.*]] = bitcast i8* [[T1]] to %swift.job*
-// CHECK-NEXT: ret %swift.job* [[T2]]
+// CHECK-NEXT: [[T0:%.*]] = bitcast %swift.refcounted* %0 to %swift.job*
+// CHECK-NEXT: ret %swift.job* [[T0]]
 func convertTaskToJob(_ task: Builtin.NativeObject) -> Builtin.Job {
   return Builtin.convertTaskToJob(task)
 }


### PR DESCRIPTION
Create a `TargetDispatchClassMetadata` for Swift metadata that also has a dispatch-compatible vtable. Dispatch leaves room for ObjC class metadata so the two regions don't overlap. (The vtable currently consists of a single dummy entry; this will be filled out later.)

Rearrange the `Job` and `AsyncTask` hierarchy so that `AsyncTask` inherits only from `Job`, which in turn inherits from `HeapObject`. This gives all `Job` instances a dispatch-compatible `isa` field. It also gives them a refcount word, which is wasted on instances that aren't `AsyncTask` instances. Maybe we can find some use for that space in the future.

rdar://75227953