### PR TITLE
[Concurrency] Ensure we do implicit-async from @actorIndependent & global-actors contexts

### DIFF
--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -21,7 +21,7 @@ actor BankAccount {
   // expected-note@+1 {{calls to instance method 'balance()' from outside of its actor context are implicitly asynchronous}}
   func balance() -> Int { return curBalance }
 
-  // expected-note@+1 {{calls to instance method 'deposit' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@+1 2{{calls to instance method 'deposit' from outside of its actor context are implicitly asynchronous}}
   func deposit(_ amount : Int) -> Int {
     guard amount >= 0 else { return 0 }
 
@@ -125,14 +125,12 @@ func anotherAsyncFunc() async {
 
 }
 
-// expected-note@+2 {{add 'async' to function 'regularFunc()' to make it asynchronous}} {{19-19= async}}
-// expected-note@+1 {{add '@asyncHandler' to function 'regularFunc()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
 func regularFunc() {
   let a = BankAccount(initialDeposit: 34)
 
   _ = a.deposit //expected-error{{actor-isolated instance method 'deposit' can only be referenced inside the actor}}
 
-  _ = a.deposit(1)  // expected-error{{'async' in a function that does not support concurrency}}
+  _ = a.deposit(1)  // expected-error{{actor-isolated instance method 'deposit' can only be referenced inside the actor}}
 }
 
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -20,7 +20,7 @@ func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
 actor MySuperActor {
   var superState: Int = 25 // expected-note {{mutable state is only available within the actor instance}}
 
-  func superMethod() { } // expected-note 3 {{calls to instance method 'superMethod()' from outside of its actor context are implicitly asynchronous}}
+  func superMethod() { } // expected-note 2 {{calls to instance method 'superMethod()' from outside of its actor context are implicitly asynchronous}}
   func superAsyncMethod() async { }
 
   subscript (index: Int) -> String { // expected-note 3{{subscript declared here}}
@@ -35,7 +35,7 @@ actor MyActor: MySuperActor {
   class func synchronousClass() { }
   static func synchronousStatic() { }
 
-  func synchronous() -> String { text.first ?? "nothing" } // expected-note 21{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+  func synchronous() -> String { text.first ?? "nothing" } // expected-note 20{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
   func asynchronous() async -> String { synchronous() }
 }
 
@@ -45,7 +45,6 @@ extension MyActor {
     set { }
   }
 
-  // expected-note@+1 {{add 'async' to function 'actorIndependentFunc(otherActor:)' to make it asynchronous}} {{67-67= async}}
   @actorIndependent func actorIndependentFunc(otherActor: MyActor) -> Int {
     _ = immutable
     _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from an '@actorIndependent' context}}
@@ -65,8 +64,11 @@ extension MyActor {
     _ = otherActor.actorIndependentVar
     otherActor.actorIndependentVar = 17
 
+    // async promotion
+    _ = synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from an '@actorIndependent' context}}
+
     // Global actors
-    syncGlobalActorFunc() /// expected-error{{'async' in a function that does not support concurrency}}
+    syncGlobalActorFunc() /// expected-error{{global function 'syncGlobalActorFunc()' isolated to global actor 'SomeGlobalActor' can not be referenced from an '@actorIndependent' context}}
     _ = syncGlobalActorFunc // expected-error{{global function 'syncGlobalActorFunc()' isolated to global actor 'SomeGlobalActor' can not be referenced from an '@actorIndependent' context}}
 
     // Global data is okay if it is immutable.
@@ -232,7 +234,7 @@ struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
-@SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note{{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
+@SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note 2{{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
 @SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
 @SomeOtherGlobalActor func syncOtherGlobalActorFunc() { }
@@ -260,20 +262,24 @@ extension MyActor {
     await asyncOtherGlobalActorFunc()
 
     _ = immutable
-    _ = synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from context of global actor 'SomeGlobalActor'}}
+    _ = synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
+    _ = await synchronous()
     _ = text[0] // expected-error{{actor-isolated property 'text' can not be referenced from context of global actor 'SomeGlobalActor'}}
 
     // Accesses on 'self' are only okay for immutable and asynchronous, because
     // we are outside of the actor instance.
     _ = self.immutable
-    _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' can not be referenced from context of global actor 'SomeGlobalActor'}}
+    _ = self.synchronous() // expected-error{{call is 'async' but is not marked with 'await'}}
+    _ = await self.synchronous()
+
     _ = await self.asynchronous()
     _ = self.text[0] // expected-error{{actor-isolated property 'text' can not be referenced from context of global actor 'SomeGlobalActor'}}
     _ = self[0] // expected-error{{actor-isolated subscript 'subscript(_:)' can not be referenced from context of global actor 'SomeGlobalActor'}}
 
     // Accesses on 'super' are not okay; we're outside of the actor.
     _ = super.superState // expected-error{{actor-isolated property 'superState' can not be referenced from context of global actor 'SomeGlobalActor'}}
-    super.superMethod() // expected-error{{actor-isolated instance method 'superMethod()' can not be referenced from context of global actor 'SomeGlobalActor'}}
+    super.superMethod() // expected-error{{call is 'async' but is not marked with 'await'}}
+    await super.superMethod()
     await super.superAsyncMethod()
     _ = super[0] // expected-error{{actor-isolated subscript 'subscript(_:)' can not be referenced from context of global actor 'SomeGlobalActor'}}
 
@@ -288,16 +294,14 @@ extension MyActor {
 }
 
 struct GenericStruct<T> {
-  @GenericGlobalActor<T> func f() { } // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  @GenericGlobalActor<T> func f() { } // expected-note 2{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
   @GenericGlobalActor<T> func g() {
     f() // okay
   }
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'h()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'h()' to make it asynchronous}} {{39-39= async}}
   @GenericGlobalActor<String> func h() {
-    f() // expected-error{{'async' in a function that does not support concurrency}}
+    f() // expected-error{{instance method 'f()' isolated to global actor 'GenericGlobalActor<T>' can not be referenced from different global actor 'GenericGlobalActor<String>'}}
     _ = f // expected-error{{instance method 'f()' isolated to global actor 'GenericGlobalActor<T>' can not be referenced from different global actor 'GenericGlobalActor<String>'}}
   }
 }
@@ -472,9 +476,7 @@ class SomeClassInActor {
 
 extension SomeClassInActor.ID {
   func f(_ object: SomeClassInActor) { // expected-note{{add '@MainActor' to make instance method 'f' part of global actor 'MainActor'}}
-    // expected-note@-1{{add 'async' to function 'f' to make it asynchronous}}
-    // expected-note@-2{{add '@asyncHandler' to function 'f' to create an implicit asynchronous context}}
-    object.inActor() // expected-error{{'async' in a function that does not support concurrency}}
+    object.inActor() // expected-error{{instance method 'inActor()' isolated to global actor 'MainActor' can not be referenced from this context}}
   }
 }
 

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -5,21 +5,18 @@ actor MyActor {
   let immutable: Int = 17
   var text: [String] = []
 
-  func synchronous() -> String { text.first ?? "nothing" } // expected-note 2 {{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+  func synchronous() -> String { text.first ?? "nothing" }
   func asynchronous() async -> String { synchronous() }
 
   func testAsyncLetIsolation() async {
     async let x = self.synchronous()
-    // expected-error @-1{{actor-isolated instance method 'synchronous()' cannot be referenced from 'async let' initializer}}
 
     async let y = await self.asynchronous()
 
     async let z = synchronous()
-    // expected-error @-1{{actor-isolated instance method 'synchronous()' cannot be referenced from 'async let' initializer}}
 
     var localText = text
-    async let w = localText.removeLast()
-    // expected-error@-1{{mutation of captured var 'localText' in concurrently-executing code}}
+    async let w = localText.removeLast() // expected-error{{mutation of captured var 'localText' in concurrently-executing code}}
 
     _ = await x
     _ = await y

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -56,11 +56,9 @@ func referenceAsyncGlobalActor() {
 }
 
 
-// expected-note@+3 {{add '@asyncHandler' to function 'callGlobalActor()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+2 {{add 'async' to function 'callGlobalActor()' to make it asynchronous}} {{23-23= async}}
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'callGlobalActor()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func callGlobalActor() {
-  syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+  syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 }
 
 func fromClosure() {
@@ -70,40 +68,36 @@ func fromClosure() {
     x()
   }()
 
-  // expected-error@+2 {{'async' in a function that does not support concurrency}}
   // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
   let _ = { syncGlobActorFn() }()
 }
 
 class Taylor {
-  init() { // expected-note {{add 'async' to function 'init()' to make it asynchronous}} {{9-9= async}}
-    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+  init() {
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn
   }
 
   deinit {
-    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn
   }
 
-  // expected-note@+3 2 {{add '@SomeGlobalActor' to make instance method 'method1()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
-  // expected-note@+2 {{add '@asyncHandler' to function 'method1()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'method1()' to make it asynchronous}} {{17-17= async}}
+  // expected-note@+1 2 {{add '@SomeGlobalActor' to make instance method 'method1()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
   func method1() {
-    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn
   }
 
-  // expected-note@+2 2 {{add '@SomeGlobalActor' to make instance method 'cannotBeHandler()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
-  // expected-note@+1 {{add 'async' to function 'cannotBeHandler()' to make it asynchronous}}
+  // expected-note@+1 2 {{add '@SomeGlobalActor' to make instance method 'cannotBeHandler()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
   func cannotBeHandler() -> Int {
-    syncGlobActorFn() // expected-error {{'async' in a function that does not support concurrency}}
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -43,24 +43,20 @@ protocol P2 {
 }
 
 class C1: P1 {
-  func method() { } // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+  func method() { } // expected-note 2 {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{38-38= async}}
   @OtherGlobalActor func testMethod() {
-    method() // expected-error {{'async' in a function that does not support concurrency}}
+    method() // expected-error {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
     _ = method  // expected-error {{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
   }
 }
 
 class C2: P2 {
-  func method1() { }  // expected-note{{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
+  func method1() { }  // expected-note 2{{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
   func method2() { }
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{38-38= async}}
   @OtherGlobalActor func testMethod() {
-    method1() // expected-error{{'async' in a function that does not support concurrency}}
+    method1() // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
     _ = method1 // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
     method2() // okay
   }
@@ -70,19 +66,19 @@ class C2: P2 {
 // Global actor inference for classes and extensions
 // ----------------------------------------------------------------------
 @SomeGlobalActor class C3 {
-  func method1() { }  // expected-note {{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
+  func method1() { }  // expected-note 2{{calls to instance method 'method1()' from outside of its actor context are implicitly asynchronous}}
 }
 
 extension C3 {
-  func method2() { }  // expected-note {{calls to instance method 'method2()' from outside of its actor context are implicitly asynchronous}}
+  func method2() { }  // expected-note 2{{calls to instance method 'method2()' from outside of its actor context are implicitly asynchronous}}
 }
 
 class C4: C3 {
-  func method3() { }  // expected-note {{calls to instance method 'method3()' from outside of its actor context are implicitly asynchronous}}
+  func method3() { }  // expected-note 2{{calls to instance method 'method3()' from outside of its actor context are implicitly asynchronous}}
 }
 
 extension C4 {
-  func method4() { }  // expected-note {{calls to instance method 'method4()' from outside of its actor context are implicitly asynchronous}}
+  func method4() { }  // expected-note 2{{calls to instance method 'method4()' from outside of its actor context are implicitly asynchronous}}
 }
 
 class C5 {
@@ -90,29 +86,27 @@ class C5 {
 }
 
 @SomeGlobalActor extension C5 {
-  func method2() { }  // expected-note {{calls to instance method 'method2()' from outside of its actor context are implicitly asynchronous}}
+  func method2() { }  // expected-note 2{{calls to instance method 'method2()' from outside of its actor context are implicitly asynchronous}}
 }
 
-// expected-note@+2 5 {{add '@asyncHandler' to function 'testGlobalActorInference(c3:c4:c5:)' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+1 5 {{add 'async' to function 'testGlobalActorInference(c3:c4:c5:)' to make it asynchronous}} {{72-72= async}}
 @OtherGlobalActor func testGlobalActorInference(c3: C3, c4: C4, c5: C5) {
   // Propagation via class annotation
-  c3.method1() // expected-error{{'async' in a function that does not support concurrency}}
-  c3.method2() // expected-error{{'async' in a function that does not support concurrency}}
+  c3.method1() // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+  c3.method2() // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
   
   _ = c3.method1  // expected-error{{instance method 'method1()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
   _ = c3.method2  // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
 
   // Propagation via subclassing
-  c4.method3() // expected-error{{'async' in a function that does not support concurrency}}
-  c4.method4() // expected-error{{'async' in a function that does not support concurrency}}
+  c4.method3() // expected-error{{instance method 'method3()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
+  c4.method4() // expected-error{{instance method 'method4()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
 
   _ = c4.method3  // expected-error{{instance method 'method3()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
   _ = c4.method4  // expected-error{{instance method 'method4()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
 
   // Propagation in an extension.
   c5.method1() // OK: no propagation
-  c5.method2() // expected-error{{'async' in a function that does not support concurrency}}
+  c5.method2() // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
 
   _ = c5.method1  // OK
   _ = c5.method2 // expected-error{{instance method 'method2()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'OtherGlobalActor'}}
@@ -150,15 +144,13 @@ actor GenericSuper<T> {
 }
 
 actor GenericSub<T> : GenericSuper<[T]> {
-  override func method() { }  // expected-note{{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+  override func method() { }  // expected-note 2{{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
   @GenericGlobalActor<T> override func method2() { } // expected-error{{global actor 'GenericGlobalActor<T>'-isolated instance method 'method2()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
   @actorIndependent override func method3() { } // expected-error{{actor-independent instance method 'method3()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}
 
-  // expected-note@+2 {{add '@asyncHandler' to function 'testMethod()' to create an implicit asynchronous context}} {{3-3=@asyncHandler }}
-  // expected-note@+1 {{add 'async' to function 'testMethod()' to make it asynchronous}} {{38-38= async}}
   @OtherGlobalActor func testMethod() {
-    method() // expected-error{{'async' in a function that does not support concurrency}}
+    method() // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[T]>' can not be referenced from different global actor 'OtherGlobalActor'}}
     _ = method  // expected-error{{instance method 'method()' isolated to global actor 'GenericGlobalActor<[T]>' can not be referenced from different global actor 'OtherGlobalActor'}}
   }
 }
@@ -231,9 +223,7 @@ func bar() async {
   foo() // expected-error{{call is 'async' but is not marked with 'await'}}
 }
 
-// expected-note@+3 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
-// expected-note@+2 {{add '@asyncHandler' to function 'barSync()' to create an implicit asynchronous context}} {{1-1=@asyncHandler }}
-// expected-note@+1 {{add 'async' to function 'barSync()' to make it asynchronous}} {{15-15= async}}
+// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func barSync() {
-  foo() // expected-error {{'async' in a function that does not support concurrency}}
+  foo() // expected-error {{global function 'foo()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 }


### PR DESCRIPTION
We weren't allowing implicit "async" promotions for cross-actor references
from functions defined within an actor that were @actorIndependent
or part of a global actor. Ensure we do promotion there.

... and because these lead to misleading diagnostics in a lot of places,
don't do implicit "async" promotion if we're not in an async context
already. We still need to improve the diagnostics here.
