### PR TITLE
C++ Interop: cleanup operator tests (NFC)

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
@@ -1,5 +1,5 @@
 #include "member-out-of-line.h"
 
-IntBox IntBox::operator+(IntBox rhs) const {
-  return IntBox{.value = value + rhs.value};
+LoadableIntWrapper LoadableIntWrapper::operator+(LoadableIntWrapper rhs) const {
+  return LoadableIntWrapper{.value = value + rhs.value};
 }

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -1,9 +1,9 @@
 #ifndef TEST_INTEROP_CXX_OPERATORS_INPUTS_MEMBER_OUT_OF_LINE_H
 #define TEST_INTEROP_CXX_OPERATORS_INPUTS_MEMBER_OUT_OF_LINE_H
 
-struct IntBox {
+struct LoadableIntWrapper {
   int value;
-  IntBox operator+(IntBox rhs) const;
+  LoadableIntWrapper operator+(LoadableIntWrapper rhs) const;
 };
 
 #endif

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -1,76 +1,76 @@
 #ifndef TEST_INTEROP_CXX_OPERATORS_INPUTS_NON_MEMBER_INLINE_H
 #define TEST_INTEROP_CXX_OPERATORS_INPUTS_NON_MEMBER_INLINE_H
 
-struct IntBox {
+struct LoadableIntWrapper {
   int value;
 };
 
-inline IntBox operator+(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value + rhs.value};
+inline LoadableIntWrapper operator+(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value + rhs.value};
 }
 
-inline IntBox operator-(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value - rhs.value};
+inline LoadableIntWrapper operator-(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value - rhs.value};
 }
 
-inline IntBox operator*(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value * rhs.value};
+inline LoadableIntWrapper operator*(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value * rhs.value};
 }
 
-inline IntBox operator/(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value / rhs.value};
+inline LoadableIntWrapper operator/(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value / rhs.value};
 }
 
-inline IntBox operator%(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value % rhs.value};
+inline LoadableIntWrapper operator%(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value % rhs.value};
 }
 
-inline IntBox operator&(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value & rhs.value};
+inline LoadableIntWrapper operator&(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value & rhs.value};
 }
 
-inline IntBox operator|(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value | rhs.value};
+inline LoadableIntWrapper operator|(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value | rhs.value};
 }
 
-inline IntBox operator<<(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value << rhs.value};
+inline LoadableIntWrapper operator<<(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value << rhs.value};
 }
 
-inline IntBox operator>>(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value >> rhs.value};
+inline LoadableIntWrapper operator>>(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value >> rhs.value};
 }
 
-inline bool operator<(IntBox lhs, IntBox rhs) { return lhs.value < rhs.value; }
+inline bool operator<(LoadableIntWrapper lhs, LoadableIntWrapper rhs) { return lhs.value < rhs.value; }
 
-inline bool operator>(IntBox lhs, IntBox rhs) { return lhs.value > rhs.value; }
+inline bool operator>(LoadableIntWrapper lhs, LoadableIntWrapper rhs) { return lhs.value > rhs.value; }
 
-inline bool operator==(IntBox lhs, IntBox rhs) {
+inline bool operator==(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
   return lhs.value == rhs.value;
 }
 
-inline bool operator!=(IntBox lhs, IntBox rhs) {
+inline bool operator!=(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
   return lhs.value != rhs.value;
 }
 
-inline bool operator<=(IntBox lhs, IntBox rhs) {
+inline bool operator<=(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
   return lhs.value == rhs.value;
 }
 
-inline bool operator>=(IntBox lhs, IntBox rhs) {
+inline bool operator>=(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
   return lhs.value != rhs.value;
 }
 
-struct BoolBox {
+struct LoadableBoolWrapper {
   bool value;
 };
 
-inline BoolBox operator&&(BoolBox lhs, BoolBox rhs) {
-  return BoolBox{.value = lhs.value && rhs.value};
+inline LoadableBoolWrapper operator&&(LoadableBoolWrapper lhs, LoadableBoolWrapper rhs) {
+  return LoadableBoolWrapper{.value = lhs.value && rhs.value};
 }
 
-inline BoolBox operator||(BoolBox lhs, BoolBox rhs) {
-  return BoolBox{.value = lhs.value || rhs.value};
+inline LoadableBoolWrapper operator||(LoadableBoolWrapper lhs, LoadableBoolWrapper rhs) {
+  return LoadableBoolWrapper{.value = lhs.value || rhs.value};
 }
 
 // Make sure that we don't crash on templated operators

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.cpp
@@ -1,5 +1,5 @@
 #include "non-member-out-of-line.h"
 
-IntBox operator+(IntBox lhs, IntBox rhs) {
-  return IntBox{.value = lhs.value + rhs.value};
+LoadableIntWrapper operator+(LoadableIntWrapper lhs, LoadableIntWrapper rhs) {
+  return LoadableIntWrapper{.value = lhs.value + rhs.value};
 }

--- a/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-out-of-line.h
@@ -1,10 +1,10 @@
 #ifndef TEST_INTEROP_CXX_OPERATORS_INPUTS_NON_MEMBER_OUT_OF_LINE_H
 #define TEST_INTEROP_CXX_OPERATORS_INPUTS_NON_MEMBER_OUT_OF_LINE_H
 
-struct IntBox {
+struct LoadableIntWrapper {
   int value;
 };
 
-IntBox operator+(IntBox lhs, IntBox rhs);
+LoadableIntWrapper operator+(LoadableIntWrapper lhs, LoadableIntWrapper rhs);
 
 #endif

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -5,7 +5,7 @@
 
 import MemberOutOfLine
 
-public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+public func add(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }
 
-// CHECK: call {{i32|i64}} [[NAME:@_ZNK6IntBoxplES_]](%struct.IntBox* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval\(.*\) align 4}} %{{[0-9]+}})
-// CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.IntBox* nonnull dereferenceable(4), {{i32|\[1 x i32\]|i64|%struct.IntBox\* byval\(%struct.IntBox\) align 4}})
+// CHECK: call {{i32|i64}} [[NAME:@_ZNK18LoadableIntWrapperplES_]](%struct.LoadableIntWrapper* %{{[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\) align 4}} %{{[0-9]+}})
+// CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4), {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4}})

--- a/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
@@ -5,12 +5,12 @@
 
 import MemberOutOfLine
 
-public func add(_ lhs: inout IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+public func add(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }
 
-// CHECK: bb0([[LHS:%.*]] : $*IntBox, [[RHS:%.*]] : $IntBox):
-// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[LHS]] : $*IntBox
-// CHECK:   [[FUNC:%.*]] = function_ref [[NAME:@_ZNK6IntBoxplES_]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
-// CHECK:   apply [[FUNC]]([[ACCESS]], [[RHS]]) : $@convention(c) (@inout IntBox, IntBox) -> IntBox
-// CHECK:   end_access [[ACCESS]] : $*IntBox
+// CHECK: bb0([[LHS:%.*]] : $*LoadableIntWrapper, [[RHS:%.*]] : $LoadableIntWrapper):
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[LHS]] : $*LoadableIntWrapper
+// CHECK:   [[FUNC:%.*]] = function_ref [[NAME:@_ZNK18LoadableIntWrapperplES_]] : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK:   apply [[FUNC]]([[ACCESS]], [[RHS]]) : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK:   end_access [[ACCESS]] : $*LoadableIntWrapper
 
-// CHECK: sil [clang IntBox."+"] [[NAME]] : $@convention(c) (@inout IntBox, IntBox) -> IntBox
+// CHECK: sil [clang LoadableIntWrapper."+"] [[NAME]] : $@convention(c) (@inout LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -15,8 +15,8 @@ import StdlibUnittest
 var OperatorsTestSuite = TestSuite("Operators")
 
 OperatorsTestSuite.test("plus") {
-  var lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
+  var lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs + rhs
 

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -1,20 +1,20 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=NonMemberInline -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
 
-// CHECK:      func + (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func - (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func * (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func / (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func % (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func & (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func | (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func << (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func >> (lhs: IntBox, rhs: IntBox) -> IntBox
-// CHECK-NEXT: func < (lhs: IntBox, rhs: IntBox) -> Bool
-// CHECK-NEXT: func > (lhs: IntBox, rhs: IntBox) -> Bool
-// CHECK-NEXT: func == (lhs: IntBox, rhs: IntBox) -> Bool
-// CHECK-NEXT: func != (lhs: IntBox, rhs: IntBox) -> Bool
-// CHECK-NEXT: func <= (lhs: IntBox, rhs: IntBox) -> Bool
-// CHECK-NEXT: func >= (lhs: IntBox, rhs: IntBox) -> Bool
+// CHECK:      func + (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func - (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func * (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func / (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func % (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func & (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func | (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func << (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func >> (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK-NEXT: func < (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
+// CHECK-NEXT: func > (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
+// CHECK-NEXT: func == (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
+// CHECK-NEXT: func != (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
+// CHECK-NEXT: func <= (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
+// CHECK-NEXT: func >= (lhs: LoadableIntWrapper, rhs: LoadableIntWrapper) -> Bool
 
-// CHECK:      func && (lhs: BoolBox, rhs: BoolBox) -> BoolBox
-// CHECK-NEXT: func || (lhs: BoolBox, rhs: BoolBox) -> BoolBox
+// CHECK:      func && (lhs: LoadableBoolWrapper, rhs: LoadableBoolWrapper) -> LoadableBoolWrapper
+// CHECK-NEXT: func || (lhs: LoadableBoolWrapper, rhs: LoadableBoolWrapper) -> LoadableBoolWrapper

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -2,8 +2,8 @@
 
 import NonMemberInline
 
-var lhs = IntBox(value: 42)
-var rhs = IntBox(value: 23)
+var lhs = LoadableIntWrapper(value: 42)
+var rhs = LoadableIntWrapper(value: 23)
 
 let resultPlus = lhs + rhs
 let resultMinus = lhs - rhs
@@ -21,8 +21,8 @@ let resultExclaimEqual = lhs != rhs
 let resultLessEqual = lhs <= rhs
 let resultGreaterEqual = lhs >= rhs
 
-var lhsBool = BoolBox(value: true)
-var rhsBool = BoolBox(value: false)
+var lhsBool = LoadableBoolWrapper(value: true)
+var rhsBool = LoadableBoolWrapper(value: false)
 
 let resultAmpAmp = lhsBool && rhsBool
 let resultPipePipe = lhsBool && rhsBool

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -8,8 +8,8 @@ import StdlibUnittest
 var OperatorsTestSuite = TestSuite("Operators")
 
 OperatorsTestSuite.test("plus (+)") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs + rhs
 
@@ -17,8 +17,8 @@ OperatorsTestSuite.test("plus (+)") {
 }
 
 OperatorsTestSuite.test("minus (-)") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs - rhs
 
@@ -26,8 +26,8 @@ OperatorsTestSuite.test("minus (-)") {
 }
 
 OperatorsTestSuite.test("star (*)") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs * rhs
 
@@ -35,8 +35,8 @@ OperatorsTestSuite.test("star (*)") {
 }
 
 OperatorsTestSuite.test("slash (/)") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs / rhs
 
@@ -44,8 +44,8 @@ OperatorsTestSuite.test("slash (/)") {
 }
 
 OperatorsTestSuite.test("percent (%)") {
-  let lhs = IntBox(value: 11)
-  let rhs = IntBox(value: 2)
+  let lhs = LoadableIntWrapper(value: 11)
+  let rhs = LoadableIntWrapper(value: 2)
 
   let result = lhs % rhs
 
@@ -53,8 +53,8 @@ OperatorsTestSuite.test("percent (%)") {
 }
 
 OperatorsTestSuite.test("amp (&)") {
-  let lhs = IntBox(value: 6)
-  let rhs = IntBox(value: 5)
+  let lhs = LoadableIntWrapper(value: 6)
+  let rhs = LoadableIntWrapper(value: 5)
 
   let result = lhs & rhs
 
@@ -62,8 +62,8 @@ OperatorsTestSuite.test("amp (&)") {
 }
 
 OperatorsTestSuite.test("pipe (|)") {
-  let lhs = IntBox(value: 6)
-  let rhs = IntBox(value: 5)
+  let lhs = LoadableIntWrapper(value: 6)
+  let rhs = LoadableIntWrapper(value: 5)
 
   let result = lhs | rhs
 
@@ -71,8 +71,8 @@ OperatorsTestSuite.test("pipe (|)") {
 }
 
 OperatorsTestSuite.test("less (<)") {
-  let lhs = IntBox(value: 5)
-  let rhs = IntBox(value: 6)
+  let lhs = LoadableIntWrapper(value: 5)
+  let rhs = LoadableIntWrapper(value: 6)
 
   let result = lhs < rhs
 
@@ -80,8 +80,8 @@ OperatorsTestSuite.test("less (<)") {
 }
 
 OperatorsTestSuite.test("greater (>)") {
-  let lhs = IntBox(value: 5)
-  let rhs = IntBox(value: 6)
+  let lhs = LoadableIntWrapper(value: 5)
+  let rhs = LoadableIntWrapper(value: 6)
 
   let result = lhs > rhs
 
@@ -89,8 +89,8 @@ OperatorsTestSuite.test("greater (>)") {
 }
 
 OperatorsTestSuite.test("less less (<<)") {
-  let lhs = IntBox(value: 2)
-  let rhs = IntBox(value: 4)
+  let lhs = LoadableIntWrapper(value: 2)
+  let rhs = LoadableIntWrapper(value: 4)
 
   let result = lhs << rhs
 
@@ -98,8 +98,8 @@ OperatorsTestSuite.test("less less (<<)") {
 }
 
 OperatorsTestSuite.test("greater greater (>>)") {
-  let lhs = IntBox(value: 512)
-  let rhs = IntBox(value: 8)
+  let lhs = LoadableIntWrapper(value: 512)
+  let rhs = LoadableIntWrapper(value: 8)
 
   let result = lhs >> rhs
 
@@ -107,8 +107,8 @@ OperatorsTestSuite.test("greater greater (>>)") {
 }
 
 OperatorsTestSuite.test("equal equal (==)") {
-  let lhs = IntBox(value: 5)
-  let rhs = IntBox(value: 5)
+  let lhs = LoadableIntWrapper(value: 5)
+  let rhs = LoadableIntWrapper(value: 5)
 
   let result = lhs == rhs
 
@@ -116,8 +116,8 @@ OperatorsTestSuite.test("equal equal (==)") {
 }
 
 OperatorsTestSuite.test("exclaim equal (!=)") {
-  let lhs = IntBox(value: 5)
-  let rhs = IntBox(value: 5)
+  let lhs = LoadableIntWrapper(value: 5)
+  let rhs = LoadableIntWrapper(value: 5)
 
   let result = lhs != rhs
 
@@ -125,8 +125,8 @@ OperatorsTestSuite.test("exclaim equal (!=)") {
 }
 
 OperatorsTestSuite.test("less equal (<=)") {
-  let lhs = IntBox(value: 5)
-  let rhs = IntBox(value: 5)
+  let lhs = LoadableIntWrapper(value: 5)
+  let rhs = LoadableIntWrapper(value: 5)
 
   let result = lhs <= rhs
 
@@ -134,8 +134,8 @@ OperatorsTestSuite.test("less equal (<=)") {
 }
 
 OperatorsTestSuite.test("greater equal (>=)") {
-  let lhs = IntBox(value: 6)
-  let rhs = IntBox(value: 5)
+  let lhs = LoadableIntWrapper(value: 6)
+  let rhs = LoadableIntWrapper(value: 5)
 
   let result = lhs >= rhs
 
@@ -143,8 +143,8 @@ OperatorsTestSuite.test("greater equal (>=)") {
 }
 
 OperatorsTestSuite.test("amp amp (&&)") {
-  let lhs = BoolBox(value: true)
-  let rhs = BoolBox(value: false)
+  let lhs = LoadableBoolWrapper(value: true)
+  let rhs = LoadableBoolWrapper(value: false)
 
   let result = lhs && rhs
 
@@ -152,8 +152,8 @@ OperatorsTestSuite.test("amp amp (&&)") {
 }
 
 OperatorsTestSuite.test("pipe pipe (||)") {
-  let lhs = BoolBox(value: true)
-  let rhs = BoolBox(value: false)
+  let lhs = LoadableBoolWrapper(value: true)
+  let rhs = LoadableBoolWrapper(value: false)
 
   let result = lhs || rhs
 

--- a/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
@@ -2,7 +2,7 @@
 
 import NonMemberOutOfLine
 
-public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+public func add(_ lhs: LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }
 
-// CHECK: call {{i32|i64}} [[NAME:@(_Zpl6IntBoxS_|"\?\?H@YA\?AUIntBox@@U0@0@Z")]]({{i32|\[1 x i32\]|i64}} %{{[0-9]+}}, {{i32|\[1 x i32\]|i64}} %{{[0-9]+}})
+// CHECK: call {{i32|i64}} [[NAME:@(_Zpl18LoadableIntWrapperS_|"\?\?H@YA\?AULoadableIntWrapper@@U0@0@Z")]]({{i32|\[1 x i32\]|i64}} %{{[0-9]+}}, {{i32|\[1 x i32\]|i64}} %{{[0-9]+}})
 // CHECK: declare {{(dso_local )?}}{{i32|i64}} [[NAME]]({{i32|\[1 x i32\]|i64}}, {{i32|\[1 x i32\]|i64}})

--- a/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
@@ -2,9 +2,9 @@
 
 import NonMemberOutOfLine
 
-public func add(_ lhs: IntBox, _ rhs: IntBox) -> IntBox { lhs + rhs }
+public func add(_ lhs: LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs + rhs }
 
-// CHECK: [[COUNTER:%.*]] = function_ref [[NAME:@(_Zpl6IntBoxS_|\?\?H@YA\?AUIntBox@@U0@0@Z)]] : $@convention(c) (IntBox, IntBox) -> IntBox
-// CHECK: apply [[COUNTER]](%0, %1) : $@convention(c) (IntBox, IntBox) -> IntBox
+// CHECK: [[COUNTER:%.*]] = function_ref [[NAME:@(_Zpl18LoadableIntWrapperS_|\?\?H@YA\?AULoadableIntWrapper@@U0@0@Z)]] : $@convention(c) (LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK: apply [[COUNTER]](%0, %1) : $@convention(c) (LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper
 
-// CHECK: sil [serializable] [clang "+"] [[NAME]] : $@convention(c) (IntBox, IntBox) -> IntBox
+// CHECK: sil [serializable] [clang "+"] [[NAME]] : $@convention(c) (LoadableIntWrapper, LoadableIntWrapper) -> LoadableIntWrapper

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -12,8 +12,8 @@ import StdlibUnittest
 var OperatorsTestSuite = TestSuite("Operators")
 
 OperatorsTestSuite.test("plus") {
-  let lhs = IntBox(value: 42)
-  let rhs = IntBox(value: 23)
+  let lhs = LoadableIntWrapper(value: 42)
+  let rhs = LoadableIntWrapper(value: 23)
 
   let result = lhs + rhs
 


### PR DESCRIPTION
Rename the test structures to match the terminology of loadable types vs address-only types.

https://github.com/apple/swift/pull/36075#discussion_r581575708