### PR TITLE
[Deserialization] Output a diagnostic when deserializing an invalid decl

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -776,6 +776,9 @@ NOTE(serialization_compatibility_version_mismatch,none,
      "(this is supported but may expose additional compiler issues)",
      (StringRef, StringRef, StringRef))
 
+ERROR(serialization_invalid_decl,none,
+      "deserialization of invalid declaration %0 from module '%1'",
+      (DeclName, StringRef))
 ERROR(serialization_allowing_invalid_decl,none,
       "allowing deserialization of invalid declaration %0 from module '%1'",
       (DeclName, StringRef))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -439,15 +439,9 @@ bool Decl::isInvalid() const {
   case DeclKind::Constructor:
   case DeclKind::Destructor:
   case DeclKind::Func:
+  case DeclKind::Accessor:
   case DeclKind::EnumElement:
     return cast<ValueDecl>(this)->getInterfaceType()->hasError();
-
-  case DeclKind::Accessor: {
-    auto *AD = cast<AccessorDecl>(this);
-    if (AD->hasInterfaceType() && AD->getInterfaceType()->hasError())
-      return true;
-    return AD->getStorage()->isInvalid();
-  }
   }
 
   llvm_unreachable("Unknown decl kind");

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3242,9 +3242,9 @@ performTopLevelDeclDiagnostics(TopLevelCodeDecl *TLCD) {
 /// Perform diagnostics for func/init/deinit declarations.
 void swift::performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD) {
   // Don't produce these diagnostics for implicitly generated code.
-  if (AFD->getLoc().isInvalid() || AFD->isImplicit() || AFD->isInvalid())
+  if (AFD->getLoc().isInvalid() || AFD->isImplicit())
     return;
-  
+
   // Check for unused variables, as well as variables that are could be
   // declared as constants. Skip local functions though, since they will
   // be checked as part of their parent function or TopLevelCodeDecl.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1248,18 +1248,6 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
 
   // Local function to determine whether we can implicitly infer @objc.
   auto canInferImplicitObjC = [&](bool allowAnyAccess) {
-    if (VD->isInvalid())
-      return false;
-    if (VD->isOperator())
-      return false;
-
-    // Implicitly generated declarations are not @objc, except for constructors.
-    if (!allowImplicit && VD->isImplicit())
-      return false;
-
-    if (!allowAnyAccess && VD->getFormalAccess() <= AccessLevel::FilePrivate)
-      return false;
-
     if (auto accessor = dyn_cast<AccessorDecl>(VD)) {
       switch (accessor->getAccessorKind()) {
       case AccessorKind::DidSet:
@@ -1275,6 +1263,19 @@ Optional<ObjCReason> shouldMarkAsObjC(const ValueDecl *VD, bool allowImplicit) {
         break;
       }
     }
+
+    if (VD->isInvalid())
+      return false;
+    if (VD->isOperator())
+      return false;
+
+    // Implicitly generated declarations are not @objc, except for constructors.
+    if (!allowImplicit && VD->isImplicit())
+      return false;
+
+    if (!allowAnyAccess && VD->getFormalAccess() <= AccessLevel::FilePrivate)
+      return false;
+
     return true;
   };
 


### PR DESCRIPTION
The previous change 47b068d4453776cd0feba754a4e41c416039ea26 was
partially reverted (when not allowing errors) as it output diagnostics
for valid code.

`Decl::isInvalid` had a special case for `AccessorDecl` where if its
interface type hadn't already been computed, it would fallback to
checking whether its storage (ie. its `VarDecl`) was valid. Since the
`VarDecl` isn't fully deserialized when deserializing the
`AccessorDecl`, this sometimes causes `isInvalid` to be true, even
though it isn't actually invalid.

The fallback introduced to `isInvalid` was to prevent a cycle during
typechecking caused by `SimpleDidSetRequest` - during `didSet`
typechecking, the body would be typechecked, which would then check
whether the declaration is valid, calling the typechecking for the
declaration again (and so on).

This change removes the special case from `isInvalid`. The result of
`isInvalid` is then correct for `AccessorDecl`, preventing spurious
diagnostics.

The `isInvalid` check in `performAbstractFuncDeclDiagnostics` has been
removed to prevent the cycle there - it works perfectly fine without it.
The unused variable diagnostics are skipped on seeing an error in the
body anyway. The opaque type matching diagnostics make sense to keep
when the return type is valid.

Removing that check exposes another cycle when computing captures in
body typechecking caused by `shouldMarkAsObjC` checking `isInvalid` as
well. It already checks for `didSet`, so have moved that check above the
`isInvalid` check.

Resolves rdar://74541834