### PR TITLE
[docs] Update the `sphinx-build` options

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -10,7 +10,6 @@ SET(SWIFT_SPHINX_PAPER_SIZE "letter"
   CACHE STRING "Paper size for generated documentation")
 
 SET(SPHINX_ARGS
-  -W
   -D latex_elements.papersize=${SWIFT_SPHINX_PAPER_SIZE}
   -d ${CMAKE_BINARY_DIR}/doctrees)
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ BUILDDIR      = _build
 # Internal variables.
 PAPEROPT_a4     = -D latex_elements.papersize=a4
 PAPEROPT_letter = -D latex_elements.papersize=letter
-ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 


### PR DESCRIPTION
The [`-W` warnings as errors][-W] option can cause external builds to fail:

* e.g. <https://github.com/apple/swift/pull/35161>
* e.g. <https://github.com/apple/swift/pull/35993#issuecomment-785080679>

The `-W` option could either be removed, or replaced with:

* [`-n` nit-picky mode][-n], and/or
* [`-q` standard error mode][-q].

(There's also a [`SPHINXOPTS`][env] environment variable.)

**Note:** The HTML documentation isn't built or tested by swift-ci.

[-W]:  <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W>
[-n]:  <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-n>
[-q]:  <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-q>
[env]: <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#environment-variables>