### PR TITLE
SIL: handle hop_to_executor in the LoadBorrowImmutabilityChecker

### DIFF
--- a/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
+++ b/lib/SIL/Verifier/LoadBorrowImmutabilityChecker.cpp
@@ -98,6 +98,7 @@ bool GatherWritesVisitor::visitUse(Operand *op, AccessUseType useTy) {
   case SILInstructionKind::WitnessMethodInst:
   case SILInstructionKind::ExistentialMetatypeInst:
   case SILInstructionKind::IsUniqueInst:
+  case SILInstructionKind::HopToExecutorInst:
     return true;
 
   // Known writes...

--- a/test/SIL/ownership-verifier/borrow_and_concurrency.sil
+++ b/test/SIL/ownership-verifier/borrow_and_concurrency.sil
@@ -1,0 +1,26 @@
+// RUN: %target-sil-opt -enable-experimental-concurrency -o /dev/null %s 
+
+// REQUIRES: concurrency
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+final actor Storage {
+  @_hasStorage @_hasInitialValue final var resolved: [String] { get set }
+  init()
+}
+
+sil hidden [ossa] @$s3nix3FooV7StorageC3getySSSgSiYF : $@convention(method) @async (@guaranteed Storage) -> () {
+bb0(%0 : @guaranteed $Storage):
+  hop_to_executor %0 : $Storage
+  %2 = ref_element_addr %0 : $Storage, #Storage.resolved
+  %3 = begin_access [read] [dynamic] %2 : $*Array<String>
+  %4 = load_borrow %3 : $*Array<String>
+  end_borrow %4 : $Array<String>
+  end_access %3 : $*Array<String>
+  %r = tuple ()
+  return %r : $()
+}


### PR DESCRIPTION
Fixes a verification failure.

rdar://74660131
