### PR TITLE
[Concurrency] Remove @hasAsyncAlternative feature flag

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1673,10 +1673,6 @@ ERROR(sil_inst_autodiff_invalid_witness_generic_signature,PointsToFirstBadToken,
       (StringRef, StringRef))
 
 // hasAsyncAlternative
-ERROR(requires_has_async_alternative, none,
-      "'%0' support is required to be explicitly enabled using "
-      "-experimental-has-async-alternative-attribute", (StringRef))
-
 ERROR(has_async_alternative_invalid_name, none,
       "argument of '%0' attribute must be an identifier or full function name",
       (StringRef))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -384,9 +384,6 @@ namespace swift {
     ASTVerifierOverrideKind ASTVerifierOverride =
         ASTVerifierOverrideKind::NoOverride;
 
-    /// Allow @hasAsyncAlternative attribute
-    bool EnableExperimentalHasAsyncAlternative = false;
-
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -793,8 +793,4 @@ def new_driver_path
   : Separate<["-"], "new-driver-path">, MetaVarName<"<path>">,
   HelpText<"Path of the new driver to be used">;
 
-def experimental_has_async_alternative_attribute:
-  Flag<["-"], "experimental-has-async-alternative-attribute">,
-  HelpText<"Allow use of @hasAsyncAlternative">;
-
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -713,9 +713,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
-  Opts.EnableExperimentalHasAsyncAlternative |=
-      Args.hasArg(OPT_experimental_has_async_alternative_attribute);
-
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2694,12 +2694,8 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       return false;
     }
 
-    if (!DiscardAttribute) {
-      if (Context.LangOpts.EnableExperimentalHasAsyncAlternative)
-        Attributes.add(attr);
-      else
-        diagnose(Loc, diag::requires_has_async_alternative, AttrName);
-    }
+    if (!DiscardAttribute)
+      Attributes.add(attr);
     break;
   }
   }

--- a/test/attr/attr_hasasyncalternative.swift
+++ b/test/attr/attr_hasasyncalternative.swift
@@ -1,6 +1,6 @@
 // REQUIRES: concurrency
 
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -experimental-has-async-alternative-attribute
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 
 @hasAsyncAlternative
 func func1() {}

--- a/test/attr/attr_hasasyncalternative_disabled.swift
+++ b/test/attr/attr_hasasyncalternative_disabled.swift
@@ -1,6 +1,0 @@
-// REQUIRES: concurrency
-
-// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
-
-@hasAsyncAlternative // expected-error {{'hasAsyncAlternative' support is required to be explicitly enabled using -experimental-has-async-alternative-attribute}}
-func func1() {}


### PR DESCRIPTION
This patch removes the feature flag for @hasAsyncAlternative since it's
already protected by the experimental concurrency flag and will go in
with the concurrency features.

This fixes one of Doug's comments on https://github.com/apple/swift/pull/36027.
