### PR TITLE
Change swiftasynccc IRGen check to use alternate API.

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -549,7 +549,8 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   SwiftCC = llvm::CallingConv::Swift;
 
   bool isAsynCCSupported =
-      clangASTContext.getTargetInfo().isSwiftAsyncCCSupported();
+    clangASTContext.getTargetInfo().checkCallingConvention(clang::CC_SwiftAsync)
+    == clang::TargetInfo::CCCR_OK;
   SwiftAsyncCC = (opts.UseAsyncLowering && isAsynCCSupported)
                      ? llvm::CallingConv::SwiftTail
                      : SwiftCC;


### PR DESCRIPTION
I'm planning to remove the `isSwiftAsyncCCSupported` from upstream, so changing the corresponding call-site.