### PR TITLE
[libSyntax] Don't reference count RawSyntax

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1817,10 +1817,12 @@ bool isKeywordPossibleDeclStart(const Token &Tok);
 
 /// Lex and return a vector of `TokenSyntax` tokens, which include
 /// leading and trailing trivia.
-std::vector<std::pair<RC<syntax::RawSyntax>, syntax::AbsoluteOffsetPosition>>
+std::vector<
+    std::pair<const syntax::RawSyntax *, syntax::AbsoluteOffsetPosition>>
 tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
-                   unsigned BufferID, unsigned Offset = 0,
-                   unsigned EndOffset = 0, DiagnosticEngine *Diags = nullptr);
+                   unsigned BufferID, const RC<SyntaxArena> &Arena,
+                   unsigned Offset = 0, unsigned EndOffset = 0,
+                   DiagnosticEngine *Diags = nullptr);
 } // end namespace swift
 
 #endif

--- a/include/swift/Syntax/AbsoluteRawSyntax.h
+++ b/include/swift/Syntax/AbsoluteRawSyntax.h
@@ -32,11 +32,11 @@ public:
 
   /// Assuming that this index points to the start of \p Raw, advance it so that
   /// it points to the next sibling of \p Raw.
-  SyntaxIndexInTree advancedBy(const RC<RawSyntax> &Raw) const;
+  SyntaxIndexInTree advancedBy(const RawSyntax *Raw) const;
 
   /// Assuming that this index points to the next sibling of \p Raw, reverse it
   /// so that it points to the start of \p Raw.
-  SyntaxIndexInTree reversedBy(const RC<RawSyntax> &Raw) const;
+  SyntaxIndexInTree reversedBy(const RawSyntax *Raw) const;
 
   /// Advance this index to point to its first immediate child.
   SyntaxIndexInTree advancedToFirstChild() const;
@@ -84,14 +84,14 @@ public:
 
   /// Assuming that this identifier points to the start of \p Raw, advance it so
   /// that it points to the next sibling of \p Raw.
-  SyntaxIdentifier advancedBy(const RC<RawSyntax> &Raw) const {
+  SyntaxIdentifier advancedBy(const RawSyntax *Raw) const {
     auto NewIndexInTree = IndexInTree.advancedBy(Raw);
     return SyntaxIdentifier(RootId, NewIndexInTree);
   }
 
   /// Assuming that this identifier points to the next sibling of \p Raw,
   /// reverse it so that it points to the start of \p Raw.
-  SyntaxIdentifier reversedBy(const RC<RawSyntax> &Raw) const {
+  SyntaxIdentifier reversedBy(const RawSyntax *Raw) const {
     auto NewIndexInTree = IndexInTree.reversedBy(Raw);
     return SyntaxIdentifier(RootId, NewIndexInTree);
   }
@@ -138,11 +138,11 @@ public:
 
   /// Assuming that this position points to the start of \p Raw, advance it so
   /// that it points to the next sibling of \p Raw.
-  AbsoluteSyntaxPosition advancedBy(const RC<RawSyntax> &Raw) const;
+  AbsoluteSyntaxPosition advancedBy(const RawSyntax *Raw) const;
 
   /// Assuming that this position points to the next sibling of \p Raw, reverse
   /// it so that it points to the start of \p Raw.
-  AbsoluteSyntaxPosition reversedBy(const RC<RawSyntax> &Raw) const;
+  AbsoluteSyntaxPosition reversedBy(const RawSyntax *Raw) const;
 
   /// Get the position of the node's first immediate child.
   AbsoluteSyntaxPosition advancedToFirstChild() const {
@@ -189,7 +189,7 @@ public:
 
   /// Assuming that this info points to the start of \p Raw, advance it so
   /// that it points to the next sibling of \p Raw.
-  AbsoluteSyntaxInfo advancedBy(const RC<RawSyntax> &Raw) const {
+  AbsoluteSyntaxInfo advancedBy(const RawSyntax *Raw) const {
     auto NewNodeId = NodeId.advancedBy(Raw);
     auto NewPosition = Position.advancedBy(Raw);
     return AbsoluteSyntaxInfo(NewPosition, NewNodeId);
@@ -197,7 +197,7 @@ public:
 
   /// Assuming that this info points to the next sibling of \p Raw, reverse
   /// it so that it points to the start of \p Raw.
-  AbsoluteSyntaxInfo reversedBy(const RC<RawSyntax> &Raw) const {
+  AbsoluteSyntaxInfo reversedBy(const RawSyntax *Raw) const {
     auto NewNodeId = NodeId.reversedBy(Raw);
     auto NewPosition = Position.reversedBy(Raw);
     return AbsoluteSyntaxInfo(NewPosition, NewNodeId);
@@ -214,20 +214,20 @@ public:
 /// A \c RawSyntax node that is enrichted with information of its position
 /// within the syntax tree it lives in.
 struct AbsoluteRawSyntax {
-  const RC<RawSyntax> Raw;
+  const RawSyntax *Raw;
   const AbsoluteSyntaxInfo Info;
 
 public:
-  AbsoluteRawSyntax(const RC<RawSyntax> &Raw, AbsoluteSyntaxInfo Info)
+  AbsoluteRawSyntax(const RawSyntax *Raw, AbsoluteSyntaxInfo Info)
       : Raw(Raw), Info(Info) {}
 
   /// Construct a \c AbsoluteRawSyntax for a \c RawSyntax node that represents
   /// the syntax tree's root.
-  static AbsoluteRawSyntax forRoot(const RC<RawSyntax> &Raw) {
+  static AbsoluteRawSyntax forRoot(const RawSyntax *Raw) {
     return AbsoluteRawSyntax(Raw, AbsoluteSyntaxInfo::forRoot());
   }
 
-  const RC<RawSyntax> &getRaw() const { return Raw; }
+  const RawSyntax *getRaw() const { return Raw; }
 
   AbsoluteSyntaxInfo getInfo() const { return Info; }
 
@@ -245,7 +245,7 @@ public:
   ///  - the \p NewRaw as the backing storage
   ///  - the \p NewRootId as the RootId
   AbsoluteRawSyntax
-  replacingSelf(const RC<RawSyntax> &NewRaw,
+  replacingSelf(const RawSyntax *NewRaw,
                 SyntaxIdentifier::RootIdType NewRootId) const {
     SyntaxIdentifier NewNodeId(NewRootId, Info.getNodeId().getIndexInTree());
     AbsoluteSyntaxInfo NewInfo(Info.getPosition(), NewNodeId);

--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -25,8 +25,27 @@
 #include "llvm/Support/YAMLTraits.h"
 #include <forward_list>
 
+namespace swift {
+namespace json {
+
+/// Input to the llvm::yaml / json parser that deserialises to a \c RawSyntax
+/// tree. Contains a \c SyntaxArena in which the tree shall be created.
+class SyntaxInput : public llvm::yaml::Input {
+public:
+  RC<SyntaxArena> Arena;
+
+  SyntaxInput(llvm::StringRef InputContent, const RC<SyntaxArena> &Arena)
+      : llvm::yaml::Input(InputContent), Arena(Arena) {}
+  SyntaxInput(llvm::MemoryBufferRef buffer, const RC<SyntaxArena> &Arena)
+      : llvm::yaml::Input(buffer), Arena(Arena) {}
+};
+} // end namespace json
+} // end namespace swift
+
 namespace llvm {
 namespace yaml {
+
+using swift::json::SyntaxInput;
 
 /// Deserialization traits for SourcePresence.
 template <> struct ScalarEnumerationTraits<swift::SourcePresence> {
@@ -73,16 +92,16 @@ template <> struct SequenceTraits<std::vector<swift::TriviaPiece>> {
 };
 
 /// Deserialization traits for RawSyntax list.
-template <> struct SequenceTraits<std::vector<swift::RC<swift::RawSyntax>>> {
-  static size_t size(IO &in, std::vector<swift::RC<swift::RawSyntax>> &seq) {
+template <> struct SequenceTraits<std::vector<const swift::RawSyntax *>> {
+  static size_t size(IO &in, std::vector<const swift::RawSyntax *> &seq) {
     return seq.size();
   }
-  static swift::RC<swift::RawSyntax> &
-  element(IO &in, std::vector<swift::RC<swift::RawSyntax>> &seq, size_t index) {
+  static const swift::RawSyntax *&
+  element(IO &in, std::vector<const swift::RawSyntax *> &seq, size_t index) {
     if (seq.size() <= index) {
       seq.resize(index + 1);
     }
-    return const_cast<swift::RC<swift::RawSyntax> &>(seq[index]);
+    return const_cast<const swift::RawSyntax *&>(seq[index]);
   }
 };
 
@@ -117,7 +136,7 @@ template <> struct MappingTraits<TokenDescription> {
   }
 };
 
-/// Deserialization traits for RC<RawSyntax>.
+/// Deserialization traits for RawSyntax *.
 /// First it will check whether the node is null.
 /// Then this will be different depending if the raw syntax node is a Token or
 /// not. Token nodes will always have this structure:
@@ -138,10 +157,12 @@ template <> struct MappingTraits<TokenDescription> {
 /// }
 /// ```
 
-template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
-  static void mapping(IO &in, swift::RC<swift::RawSyntax> &value) {
+template <> struct MappingTraits<const swift::RawSyntax *> {
+  static void mapping(IO &in, const swift::RawSyntax *&value) {
     TokenDescription description;
-    auto input = static_cast<Input *>(&in);
+    // RawSyntax trees must always be generated from a SyntaxInput. Otherwise
+    // we don't have an arena to create the nodes in.
+    auto input = static_cast<SyntaxInput *>(&in);
     /// Check whether this is null
     if (input->getCurrentNode()->getType() != Node::NodeKind::NK_Mapping) {
       return;
@@ -164,11 +185,11 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
       unsigned nodeId = std::atoi(nodeIdString.data());
       value = swift::RawSyntax::makeAndCalcLength(
           tokenKind, text, leadingTrivia, trailingTrivia, presence,
-          swift::SyntaxArena::make(), nodeId);
+          input->Arena, nodeId);
     } else {
       swift::SyntaxKind kind;
       in.mapRequired("kind", kind);
-      std::vector<swift::RC<swift::RawSyntax>> layout;
+      std::vector<const swift::RawSyntax *> layout;
       in.mapRequired("layout", layout);
       swift::SourcePresence presence;
       in.mapRequired("presence", presence);
@@ -178,8 +199,8 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
       StringRef nodeIdString;
       in.mapRequired("id", nodeIdString);
       unsigned nodeId = std::atoi(nodeIdString.data());
-      value = swift::RawSyntax::makeAndCalcLength(
-          kind, layout, presence, swift::SyntaxArena::make(), nodeId);
+      value = swift::RawSyntax::makeAndCalcLength(kind, layout, presence,
+                                                  input->Arena, nodeId);
     }
   }
 };
@@ -190,13 +211,17 @@ template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
 namespace swift {
 namespace json {
 class SyntaxDeserializer {
-  llvm::yaml::Input Input;
+  SyntaxInput Input;
 
 public:
-  SyntaxDeserializer(llvm::StringRef InputContent) : Input(InputContent) {}
-  SyntaxDeserializer(llvm::MemoryBufferRef buffer) : Input(buffer) {}
+  SyntaxDeserializer(llvm::StringRef InputContent,
+                     RC<SyntaxArena> Arena = SyntaxArena::make())
+      : Input(InputContent, Arena) {}
+  SyntaxDeserializer(llvm::MemoryBufferRef buffer,
+                     RC<SyntaxArena> Arena = SyntaxArena::make())
+      : Input(buffer, Arena) {}
   llvm::Optional<swift::SourceFileSyntax> getSourceFileSyntax() {
-    swift::RC<swift::RawSyntax> raw;
+    const swift::RawSyntax *raw;
     Input >> raw;
     return swift::makeRoot<swift::SourceFileSyntax>(raw);
   }

--- a/include/swift/Syntax/Serialization/SyntaxSerialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxSerialization.h
@@ -89,14 +89,14 @@ struct ArrayTraits<ArrayRef<syntax::TriviaPiece>> {
 };
 
 /// Serialization traits for RawSyntax list.
-template<>
-struct ArrayTraits<ArrayRef<RC<syntax::RawSyntax>>> {
-  static size_t size(Output &out, ArrayRef<RC<syntax::RawSyntax>> &seq) {
+template <>
+struct ArrayTraits<ArrayRef<const syntax::RawSyntax *>> {
+  static size_t size(Output &out, ArrayRef<const syntax::RawSyntax *> &seq) {
     return seq.size();
   }
-  static RC<syntax::RawSyntax> &
-  element(Output &out, ArrayRef<RC<syntax::RawSyntax>> &seq, size_t index) {
-    return const_cast<RC<syntax::RawSyntax> &>(seq[index]);
+  static const syntax::RawSyntax *&
+  element(Output &out, ArrayRef<const syntax::RawSyntax *> &seq, size_t index) {
+    return const_cast<const syntax::RawSyntax *&>(seq[index]);
   }
 };
 
@@ -128,7 +128,7 @@ struct ObjectTraits<TokenDescription> {
   }
 };
 
-/// Serialization traits for RC<RawSyntax>.
+/// Serialization traits for RawSyntax *.
 /// This will be different depending if the raw syntax node is a Token or not.
 /// Token nodes will always have this structure:
 /// ```
@@ -147,9 +147,9 @@ struct ObjectTraits<TokenDescription> {
 ///   "presence": <"Present" or "Missing">
 /// }
 /// ```
-template<>
-struct ObjectTraits<syntax::RawSyntax> {
-  static void mapping(Output &out, syntax::RawSyntax &value) {
+template <>
+struct ObjectTraits<const syntax::RawSyntax> {
+  static void mapping(Output &out, const syntax::RawSyntax &value) {
     bool dontSerializeIds =
         (bool)out.getUserInfo()[DontSerializeNodeIdsUserInfoKey];
     if (!dontSerializeIds) {
@@ -189,13 +189,13 @@ struct ObjectTraits<syntax::RawSyntax> {
   }
 };
 
-template<>
-struct NullableTraits<RC<syntax::RawSyntax>> {
+template <>
+struct NullableTraits<const syntax::RawSyntax *> {
   using value_type = syntax::RawSyntax;
-  static bool isNull(RC<syntax::RawSyntax> &value) {
+  static bool isNull(const syntax::RawSyntax *&value) {
     return value == nullptr;
   }
-  static syntax::RawSyntax &get(RC<syntax::RawSyntax> &value) {
+  static const syntax::RawSyntax &get(const syntax::RawSyntax *&value) {
     return *value;
   }
 };

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -39,8 +39,9 @@ namespace syntax {
 struct SyntaxVisitor;
 class SourceFileSyntax;
 
-template <typename SyntaxNode> SyntaxNode makeRoot(RC<RawSyntax> Raw) {
-  auto Data = SyntaxData::make(AbsoluteRawSyntax::forRoot(Raw));
+template <typename SyntaxNode>
+SyntaxNode makeRoot(const RawSyntax *Raw) {
+  auto Data = SyntaxData::makeRoot(AbsoluteRawSyntax::forRoot(Raw));
   return SyntaxNode(Data);
 }
 
@@ -66,7 +67,7 @@ public:
   SyntaxKind getKind() const;
 
   /// Get the shared raw syntax.
-  const RC<RawSyntax> &getRaw() const;
+  const RawSyntax *getRaw() const;
 
   /// Get an ID for this node that is stable across incremental parses
   SyntaxNodeId getId() const { return getRaw()->getId(); }

--- a/include/swift/Syntax/SyntaxBuilders.h.gyb
+++ b/include/swift/Syntax/SyntaxBuilders.h.gyb
@@ -34,15 +34,14 @@ class SyntaxArena;
 %     child_count = len(node.children)
 class ${node.name}Builder {
   RC<SyntaxArena> Arena;
-  RC<RawSyntax> Layout[${child_count}] = {
+  const RawSyntax *Layout[${child_count}] = {
 %     for child in node.children:
     nullptr,
 %     end
   };
 
 public:
-  ${node.name}Builder(const RC<SyntaxArena> &Arena = SyntaxArena::make())
-      : Arena(Arena) {}
+  ${node.name}Builder(const RC<SyntaxArena> &Arena) : Arena(Arena) {}
 
 %     for child in node.children:
   ${node.name}Builder &use${child.name}(${child.type_name} ${child.name});

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -46,24 +46,29 @@ class SyntaxArena;
 struct SyntaxFactory {
   /// Make any kind of token.
   static TokenSyntax makeToken(tok Kind,
-      StringRef Text, StringRef LeadingTrivia, StringRef TrailingTrivia,
+      StringRef Text,
+      StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
       SourcePresence Presence,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+      const RC<SyntaxArena> &Arena
   );
 
   /// Collect a list of tokens into a piece of "unknown" syntax.
-  static UnknownSyntax makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static UnknownSyntax makeUnknownSyntax(
+      llvm::ArrayRef<TokenSyntax> Tokens,
+      const RC<SyntaxArena> &Arena
   );
 
-  static Optional<Syntax> createSyntax(SyntaxKind Kind,
+  static Optional<Syntax> createSyntax(
+      SyntaxKind Kind,
       llvm::ArrayRef<Syntax> Elements,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+      const RC<SyntaxArena> &Arena
   );
 
-  static RC<RawSyntax> createRaw(SyntaxKind Kind,
-      llvm::ArrayRef<RC<RawSyntax>> Elements,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static const RawSyntax *createRaw(
+      SyntaxKind Kind,
+      llvm::ArrayRef<const RawSyntax *> Elements,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Count the number of children for a given syntax node kind,
@@ -72,7 +77,7 @@ struct SyntaxFactory {
   static std::pair<unsigned, unsigned> countChildren(SyntaxKind Kind);
 
   static Syntax
-  makeBlankCollectionSyntax(SyntaxKind Kind);
+  makeBlankCollectionSyntax(SyntaxKind Kind, const RC<SyntaxArena> &Arena);
 
 % for node in SYNTAX_NODES:
 %   if node.children:
@@ -86,38 +91,46 @@ struct SyntaxFactory {
 %     end
 %     child_params = ', '.join(child_params)
   static ${node.name} make${node.syntax_kind}(${child_params},
-      const RC<SyntaxArena> &Arena = SyntaxArena::make());
+      const RC<SyntaxArena> &Arena
+  );
 %   elif node.is_syntax_collection():
   static ${node.name} make${node.syntax_kind}(
       const std::vector<${node.collection_element_type}> &elts,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make());
+      const RC<SyntaxArena> &Arena
+  );
 %   end
 
   static ${node.name} makeBlank${node.syntax_kind}(
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+      const RC<SyntaxArena> &Arena
   );
 % end
 
 % for token in SYNTAX_TOKENS:
 %   if token.is_keyword:
-  static TokenSyntax make${token.name}Keyword(StringRef LeadingTrivia,
+  static TokenSyntax make${token.name}Keyword(
+      StringRef LeadingTrivia,
       StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make());
+      const RC<SyntaxArena> &Arena
+  );
 %   elif token.text:
-  static TokenSyntax make${token.name}Token(StringRef LeadingTrivia,
-            StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make());
+  static TokenSyntax make${token.name}Token(
+      StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
+  );
 %   else:
-  static TokenSyntax make${token.name}(StringRef Text,
-            StringRef LeadingTrivia, StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make());
+  static TokenSyntax make${token.name}(
+      StringRef Text,
+      StringRef LeadingTrivia, StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
+  );
 %   end
 % end
 
 #pragma mark - Convenience APIs
 
   static TupleTypeSyntax makeVoidTupleType(
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates an labelled TupleTypeElementSyntax with the provided label,
@@ -125,61 +138,69 @@ struct SyntaxFactory {
   static TupleTypeElementSyntax makeTupleTypeElement(
       llvm::Optional<TokenSyntax> Label,
       llvm::Optional<TokenSyntax> Colon, TypeSyntax Type,
-      llvm::Optional<TokenSyntax> TrailingComma = llvm::None,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+      llvm::Optional<TokenSyntax> TrailingComma,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates an unlabelled TupleTypeElementSyntax with the provided type and
   /// optional trailing comma.
   static TupleTypeElementSyntax
-  makeTupleTypeElement(TypeSyntax Type,
-      llvm::Optional<TokenSyntax> TrailingComma = llvm::None,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  makeTupleTypeElement(
+      TypeSyntax Type,
+      llvm::Optional<TokenSyntax> TrailingComma,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates a TypeIdentifierSyntax with the provided name and leading/trailing
   /// trivia.
-  static TypeSyntax makeTypeIdentifier(StringRef TypeName,
-      StringRef LeadingTrivia = {}, StringRef TrailingTrivia = {},
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static TypeSyntax makeTypeIdentifier(
+      StringRef TypeName,
+      StringRef LeadingTrivia, StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates a GenericParameterSyntax with no inheritance clause and an
   /// optional trailing comma.
   static GenericParameterSyntax
-  makeGenericParameter(TokenSyntax Name,
+  makeGenericParameter(
+      TokenSyntax Name,
       llvm::Optional<TokenSyntax> TrailingComma,
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates a TypeIdentifierSyntax for the `Any` type.
-  static TypeSyntax makeAnyTypeIdentifier(StringRef LeadingTrivia = {},
-      StringRef TrailingTrivia = {},
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static TypeSyntax makeAnyTypeIdentifier(
+      StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates a TypeIdentifierSyntax for the `Self` type.
-  static TypeSyntax makeSelfTypeIdentifier(StringRef LeadingTrivia = {},
-      StringRef TrailingTrivia = {},
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static TypeSyntax makeSelfTypeIdentifier(
+      StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates a TokenSyntax for the `Type` identifier.
-  static TokenSyntax makeTypeToken(StringRef LeadingTrivia = {},
-      StringRef TrailingTrivia = {},
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static TokenSyntax makeTypeToken(
+      StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates a TokenSyntax for the `Protocol` identifier.
-  static TokenSyntax makeProtocolToken(StringRef LeadingTrivia = {},
-      StringRef TrailingTrivia = {},
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static TokenSyntax makeProtocolToken(
+      StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Creates an `==` operator token.
-  static TokenSyntax makeEqualityOperator(StringRef LeadingTrivia = {},
-      StringRef TrailingTrivia = {},
-      const RC<SyntaxArena> &Arena = SyntaxArena::make()
+  static TokenSyntax makeEqualityOperator(
+      StringRef LeadingTrivia,
+      StringRef TrailingTrivia,
+      const RC<SyntaxArena> &Arena
   );
 
   /// Whether a raw node kind `MemberKind` can serve as a member in a syntax
@@ -190,7 +211,7 @@ struct SyntaxFactory {
   /// Whether a raw node `Member` can serve as a member in a syntax collection
   /// of the given syntax collection kind.
   static bool canServeAsCollectionMemberRaw(SyntaxKind CollectionKind,
-                                            const RC<RawSyntax> &Member);
+                                            const RawSyntax *Member);
 
   /// Whether a node `Member` can serve as a member in a syntax collection of
   /// the given syntax collection kind.

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -93,7 +93,8 @@ public:
 %           raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
 %         end
   /// Adds the provided `${child_elt}` to the node's `${child.name}`
-  /// collection.
+  /// collection. The new raw node will be created in the same arena as this
+  /// node.
   /// - param element: The new `${child_elt}` to add to the node's
   ///                  `${child.name}` collection.
   /// - returns: A copy of the receiver with the provided `${child_elt}`
@@ -101,7 +102,8 @@ public:
   ${node.name} add${child_elt}(${child_elt_type} ${child_elt});
 %       end
 
-  /// Returns a copy of the receiver with its `${child.name}` replaced.
+  /// Returns a copy of the receiver with its `${child.name}` replaced. The new
+  /// raw node will be created in the same arena as this node.
   /// - param newChild: The new `${child.name}` to replace the node's
   ///                   current `${child.name}`, if present.
   ${node.name}

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -35,8 +35,9 @@ protected:
 public:
   TokenSyntax(const SyntaxData Data) : Syntax(Data) {}
 
-  static TokenSyntax missingToken(const tok Kind, StringRef Text) {
-    return makeRoot<TokenSyntax>(RawSyntax::missing(Kind, Text));
+  static TokenSyntax missingToken(const tok Kind, StringRef Text,
+                                  const RC<SyntaxArena> &Arena) {
+    return makeRoot<TokenSyntax>(RawSyntax::missing(Kind, Text, Arena));
   }
 
   StringRef getLeadingTrivia() const { return getRaw()->getLeadingTrivia(); }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -321,11 +321,14 @@ std::vector<Token> swift::tokenize(const LangOptions &LangOpts,
   return Tokens;
 }
 
-std::vector<std::pair<RC<syntax::RawSyntax>, syntax::AbsoluteOffsetPosition>>
+std::vector<
+    std::pair<const syntax::RawSyntax *, syntax::AbsoluteOffsetPosition>>
 swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
-                          unsigned BufferID, unsigned Offset,
-                          unsigned EndOffset, DiagnosticEngine *Diags) {
-  std::vector<std::pair<RC<syntax::RawSyntax>, syntax::AbsoluteOffsetPosition>>
+                          unsigned BufferID, const RC<SyntaxArena> &Arena,
+                          unsigned Offset, unsigned EndOffset,
+                          DiagnosticEngine *Diags) {
+  std::vector<
+      std::pair<const syntax::RawSyntax *, syntax::AbsoluteOffsetPosition>>
       Tokens;
   syntax::AbsoluteOffsetPosition RunningPos(0);
 
@@ -340,7 +343,7 @@ swift::tokenizeWithTrivia(const LangOptions &LangOpts, const SourceManager &SM,
                             TrailingTrivia.size();
         auto ThisToken = RawSyntax::make(
             Tok.getKind(), Tok.getRawText(), TextLength, LeadingTrivia,
-            TrailingTrivia, SourcePresence::Present);
+            TrailingTrivia, SourcePresence::Present, Arena);
 
         auto ThisTokenPos =
             RunningPos.advancedBy(ThisToken->getLeadingTriviaLength());

--- a/lib/Syntax/AbsoluteRawSyntax.cpp
+++ b/lib/Syntax/AbsoluteRawSyntax.cpp
@@ -17,8 +17,7 @@ using namespace swift::syntax;
 
 std::atomic<SyntaxIdentifier::RootIdType> SyntaxIdentifier::NextUnusedRootId(0);
 
-SyntaxIndexInTree
-SyntaxIndexInTree::advancedBy(const RC<RawSyntax> &Raw) const {
+SyntaxIndexInTree SyntaxIndexInTree::advancedBy(const RawSyntax *Raw) const {
   auto NewIndexInTree = IndexInTree;
   if (Raw) {
     NewIndexInTree += Raw->getTotalNodes();
@@ -26,8 +25,7 @@ SyntaxIndexInTree::advancedBy(const RC<RawSyntax> &Raw) const {
   return SyntaxIndexInTree(NewIndexInTree);
 }
 
-SyntaxIndexInTree
-SyntaxIndexInTree::reversedBy(const RC<RawSyntax> &Raw) const {
+SyntaxIndexInTree SyntaxIndexInTree::reversedBy(const RawSyntax *Raw) const {
   auto NewIndexInTree = IndexInTree;
   if (Raw) {
     NewIndexInTree -= Raw->getTotalNodes();
@@ -41,7 +39,7 @@ SyntaxIndexInTree SyntaxIndexInTree::advancedToFirstChild() const {
 }
 
 AbsoluteSyntaxPosition
-AbsoluteSyntaxPosition::advancedBy(const RC<RawSyntax> &Raw) const {
+AbsoluteSyntaxPosition::advancedBy(const RawSyntax *Raw) const {
   OffsetType NewOffset = Offset;
   if (Raw) {
     NewOffset += Raw->getTextLength();
@@ -51,7 +49,7 @@ AbsoluteSyntaxPosition::advancedBy(const RC<RawSyntax> &Raw) const {
 }
 
 AbsoluteSyntaxPosition
-AbsoluteSyntaxPosition::reversedBy(const RC<RawSyntax> &Raw) const {
+AbsoluteSyntaxPosition::reversedBy(const RawSyntax *Raw) const {
   OffsetType NewOffset = Offset;
   if (Raw) {
     NewOffset -= Raw->getTextLength();

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -89,7 +89,7 @@ Trivia lexTrivia(StringRef TriviaStr) {
 
 /// If the \p Str is not allocated in \p Arena, copy it to \p Arena and adjust
 /// \p Str to point to the string's copy in \p Arena.
-void copyToArenaIfNecessary(StringRef &Str, const RC<SyntaxArena> Arena) {
+void copyToArenaIfNecessary(StringRef &Str, const RC<SyntaxArena> &Arena) {
   if (Str.empty()) {
     // Empty strings can live wherever they want. Nothing to do.
     return;
@@ -107,11 +107,11 @@ void copyToArenaIfNecessary(StringRef &Str, const RC<SyntaxArena> Arena) {
 // FIXME: If we want thread-safety for tree creation, this needs to be atomic.
 unsigned RawSyntax::NextFreeNodeId = 1;
 
-RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
+RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<const RawSyntax *> Layout,
                      size_t TextLength, SourcePresence Presence,
                      const RC<SyntaxArena> &Arena,
                      llvm::Optional<unsigned> NodeId)
-    : RefCount(0), Arena(Arena),
+    : Arena(Arena.get()),
       Bits({{unsigned(TextLength), unsigned(Presence), false}}) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
   assert(Kind != SyntaxKind::Token &&
@@ -121,6 +121,9 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
   for (auto Child : Layout) {
     if (Child) {
       TotalSubNodeCount += Child->getTotalSubNodeCount() + 1;
+      // If the child is stored in a different arena, it needs to stay alive
+      // as long as this node's arena is alive.
+      Arena->addChildArena(Child->Arena);
     }
   }
 
@@ -136,14 +139,14 @@ RawSyntax::RawSyntax(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
 
   // Initialize layout data.
   std::uninitialized_copy(Layout.begin(), Layout.end(),
-                          getTrailingObjects<RC<RawSyntax>>());
+                          getTrailingObjects<const RawSyntax *>());
 }
 
 RawSyntax::RawSyntax(tok TokKind, StringRef Text, size_t TextLength,
                      StringRef LeadingTrivia, StringRef TrailingTrivia,
                      SourcePresence Presence, const RC<SyntaxArena> &Arena,
                      llvm::Optional<unsigned> NodeId)
-    : RefCount(0), Arena(Arena),
+    : Arena(Arena.get()),
       Bits({{unsigned(TextLength), unsigned(Presence), true}}) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
   copyToArenaIfNecessary(LeadingTrivia, Arena);
@@ -172,35 +175,29 @@ RawSyntax::RawSyntax(tok TokKind, StringRef Text, size_t TextLength,
   Bits.Token.TokenKind = unsigned(TokKind);
 }
 
-RawSyntax::~RawSyntax() {
-  if (!isToken()) {
-    for (auto &child : getLayout())
-      child.~RC<RawSyntax>();
-  }
+const RawSyntax *RawSyntax::make(SyntaxKind Kind,
+                                 ArrayRef<const RawSyntax *> Layout,
+                                 size_t TextLength, SourcePresence Presence,
+                                 const RC<SyntaxArena> &Arena,
+                                 llvm::Optional<unsigned> NodeId) {
+  assert(Arena && "RawSyntax nodes must always be allocated in an arena");
+  auto size = totalSizeToAlloc<const RawSyntax *>(Layout.size());
+  void *data = Arena->Allocate(size, alignof(RawSyntax));
+  return new (data)
+      RawSyntax(Kind, Layout, TextLength, Presence, Arena, NodeId);
 }
 
-RC<RawSyntax> RawSyntax::make(SyntaxKind Kind, ArrayRef<RC<RawSyntax>> Layout,
-                              size_t TextLength, SourcePresence Presence,
-                              const RC<SyntaxArena> &Arena,
-                              llvm::Optional<unsigned> NodeId) {
+const RawSyntax *RawSyntax::make(tok TokKind, StringRef Text, size_t TextLength,
+                                 StringRef LeadingTrivia,
+                                 StringRef TrailingTrivia,
+                                 SourcePresence Presence,
+                                 const RC<SyntaxArena> &Arena,
+                                 llvm::Optional<unsigned> NodeId) {
   assert(Arena && "RawSyntax nodes must always be allocated in an arena");
-  auto size = totalSizeToAlloc<RC<RawSyntax>>(Layout.size());
+  auto size = totalSizeToAlloc<const RawSyntax *>(0);
   void *data = Arena->Allocate(size, alignof(RawSyntax));
-  return RC<RawSyntax>(
-      new (data) RawSyntax(Kind, Layout, TextLength, Presence, Arena, NodeId));
-}
-
-RC<RawSyntax> RawSyntax::make(tok TokKind, StringRef Text, size_t TextLength,
-                              StringRef LeadingTrivia, StringRef TrailingTrivia,
-                              SourcePresence Presence,
-                              const RC<SyntaxArena> &Arena,
-                              llvm::Optional<unsigned> NodeId) {
-  assert(Arena && "RawSyntax nodes must always be allocated in an arena");
-  auto size = totalSizeToAlloc<RC<RawSyntax>>(0);
-  void *data = Arena->Allocate(size, alignof(RawSyntax));
-  return RC<RawSyntax>(new (data)
-                           RawSyntax(TokKind, Text, TextLength, LeadingTrivia,
-                                     TrailingTrivia, Presence, Arena, NodeId));
+  return new (data) RawSyntax(TokKind, Text, TextLength, LeadingTrivia,
+                              TrailingTrivia, Presence, Arena, NodeId);
 }
 
 Trivia RawSyntax::getLeadingTriviaPieces() const {
@@ -211,20 +208,21 @@ Trivia RawSyntax::getTrailingTriviaPieces() const {
   return lexTrivia(getTrailingTrivia());
 }
 
-RC<RawSyntax> RawSyntax::append(RC<RawSyntax> NewLayoutElement) const {
+const RawSyntax *RawSyntax::append(const RawSyntax *NewLayoutElement) const {
   auto Layout = getLayout();
-  std::vector<RC<RawSyntax>> NewLayout;
+  std::vector<const RawSyntax *> NewLayout;
   NewLayout.reserve(Layout.size() + 1);
   std::copy(Layout.begin(), Layout.end(), std::back_inserter(NewLayout));
   NewLayout.push_back(NewLayoutElement);
   return RawSyntax::makeAndCalcLength(getKind(), NewLayout,
-                                      SourcePresence::Present);
+                                      SourcePresence::Present, Arena);
 }
 
-RC<RawSyntax> RawSyntax::replacingChild(CursorIndex Index,
-                                        RC<RawSyntax> NewLayoutElement) const {
+const RawSyntax *
+RawSyntax::replacingChild(CursorIndex Index,
+                          const RawSyntax *NewLayoutElement) const {
   auto Layout = getLayout();
-  std::vector<RC<RawSyntax>> NewLayout;
+  std::vector<const RawSyntax *> NewLayout;
   NewLayout.reserve(Layout.size());
 
   std::copy(Layout.begin(), Layout.begin() + Index,
@@ -235,7 +233,8 @@ RC<RawSyntax> RawSyntax::replacingChild(CursorIndex Index,
   std::copy(Layout.begin() + Index + 1, Layout.end(),
             std::back_inserter(NewLayout));
 
-  return RawSyntax::makeAndCalcLength(getKind(), NewLayout, getPresence());
+  return RawSyntax::makeAndCalcLength(getKind(), NewLayout, getPresence(),
+                                      Arena);
 }
 
 void RawSyntax::print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const {

--- a/lib/Syntax/Syntax.cpp
+++ b/lib/Syntax/Syntax.cpp
@@ -17,7 +17,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-const RC<RawSyntax> &Syntax::getRaw() const { return Data.getRaw(); }
+const RawSyntax *Syntax::getRaw() const { return Data.getRaw(); }
 
 SyntaxKind Syntax::getKind() const {
   return getRaw()->getKind();

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -15,12 +15,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-SyntaxData SyntaxData::make(AbsoluteRawSyntax AbsoluteRaw,
-                            const RC<RefCountedBox<SyntaxData>> &Parent) {
-  return SyntaxData(AbsoluteRaw, Parent);
-}
-
-SyntaxData SyntaxData::replacingSelf(const RC<RawSyntax> &NewRaw) const {
+SyntaxData SyntaxData::replacingSelf(const RawSyntax *NewRaw) const {
   if (hasParent()) {
     auto NewRoot = getParent()->replacingChild(NewRaw, getIndexInParent());
     auto NewRootBox = RefCountedBox<SyntaxData>::make(NewRoot);
@@ -29,7 +24,7 @@ SyntaxData SyntaxData::replacingSelf(const RC<RawSyntax> &NewRaw) const {
     return SyntaxData(NewSelf, NewRootBox);
   } else {
     auto NewSelf = AbsoluteRawSyntax::forRoot(NewRaw);
-    return SyntaxData(NewSelf, /*Parent=*/nullptr);
+    return SyntaxData(NewSelf);
   }
 }
 

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -50,7 +50,7 @@ TokenSyntax SyntaxFactory::makeToken(tok Kind, StringRef Text,
 UnknownSyntax
 SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
                                  const RC<SyntaxArena> &Arena) {
-  std::vector<RC<RawSyntax>> Layout;
+  std::vector<const RawSyntax *> Layout;
   Layout.reserve(Tokens.size());
   for (auto &Token : Tokens) {
     Layout.push_back(Token.getRaw());
@@ -60,11 +60,13 @@ SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
   return makeRoot<UnknownSyntax>(Raw);
 }
 
-Syntax SyntaxFactory::makeBlankCollectionSyntax(SyntaxKind Kind) {
+Syntax SyntaxFactory::makeBlankCollectionSyntax(SyntaxKind Kind,
+                                                const RC<SyntaxArena> &Arena) {
   switch(Kind) {
 % for node in SYNTAX_NODES:
 %   if node.is_syntax_collection():
-  case SyntaxKind::${node.syntax_kind}: return makeBlank${node.syntax_kind}();
+  case SyntaxKind::${node.syntax_kind}:
+    return makeBlank${node.syntax_kind}(Arena);
 %   end
 % end
   default: break;
@@ -111,7 +113,7 @@ bool SyntaxFactory::canServeAsCollectionMemberRaw(SyntaxKind CollectionKind,
 }
 
 bool SyntaxFactory::canServeAsCollectionMemberRaw(SyntaxKind CollectionKind,
-                                                  const RC<RawSyntax> &Member) {
+                                                  const RawSyntax *Member) {
   return canServeAsCollectionMemberRaw(CollectionKind, Member->getKind());
 }
 
@@ -120,15 +122,17 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
   return canServeAsCollectionMemberRaw(CollectionKind, Member.getRaw());
 }
 
-RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
-                                       llvm::ArrayRef<RC<RawSyntax>> Elements,
-                                       const RC<SyntaxArena> &Arena) {
+const RawSyntax *SyntaxFactory::createRaw(
+  SyntaxKind Kind,
+  llvm::ArrayRef<const RawSyntax *> Elements,
+  const RC<SyntaxArena> &Arena
+) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
   case SyntaxKind::${node.syntax_kind}: {
 % if node.children:
 %   child_count = len(node.children)
-    RC<RawSyntax> Layout[${child_count}];
+    const RawSyntax *Layout[${child_count}];
     unsigned I = 0;
 %   for (child_idx, child) in enumerate(node.children):
     // child[${child_idx}] ${child.name}
@@ -168,7 +172,7 @@ RC<RawSyntax> SyntaxFactory::createRaw(SyntaxKind Kind,
 Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
                                              llvm::ArrayRef<Syntax> Elements,
                                              const RC<SyntaxArena> &Arena) {
-  std::vector<RC<RawSyntax>> Layout;
+  std::vector<const RawSyntax *> Layout;
   Layout.reserve(Elements.size());
   for (auto &E : Elements)
     Layout.emplace_back(E.getRaw());
@@ -207,7 +211,7 @@ ${node.name}
 SyntaxFactory::make${node.syntax_kind}(
     const std::vector<${node.collection_element_type}> &elements,
     const RC<SyntaxArena> &Arena) {
-  std::vector<RC<RawSyntax>> layout;
+  std::vector<const RawSyntax *> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
     layout.push_back(element.getRaw());

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -45,7 +45,7 @@ void ${node.name}::validate() const {
                                  tok::${token_kind}, ${choices});
 %       end
 %       if child.node_choices:
-  if (auto &__Child = raw->getChild(Cursor::${child.name}))
+  if (auto __Child = raw->getChild(Cursor::${child.name}))
     assert(${check_child_condition_raw(child)}(__Child));
 %       end
 %     end
@@ -75,26 +75,30 @@ ${child.type_name} ${node.name}::get${child.name}() const {
 %         raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
 %       end
 ${node.name} ${node.name}::add${child_elt}(${child_elt_type} ${child_elt}) {
-  RC<RawSyntax> raw = getRaw()->getChild(Cursor::${child.name});
+  const RawSyntax *raw = getRaw()->getChild(Cursor::${child.name});
   if (raw)
     raw = raw->append(${child_elt}.getRaw());
   else
     raw = RawSyntax::makeAndCalcLength(SyntaxKind::${child_node.syntax_kind},
-      {${child_elt}.getRaw()}, SourcePresence::Present);
+      {${child_elt}.getRaw()}, SourcePresence::Present, raw->getArena());
   return ${node.name}(Data.replacingChild(raw, Cursor::${child.name}));
 }
 %     end
 
 ${node.name} ${node.name}::with${child.name}(
   llvm::Optional<${child.type_name}> New${child.type_name}) {
-  RC<RawSyntax> raw;
+  const RawSyntax *raw;
   if (New${child.type_name}.hasValue()) {
     raw = New${child.type_name}->getRaw();
   } else {
 % if child.is_optional:
     raw = nullptr;
 % else:
-    raw = ${make_missing_child(child)};
+    {
+      // make_missing_child access the 'Arena' variable. Create it.
+      RC<SyntaxArena> Arena = getRaw()->getArena();
+      raw = ${make_missing_child(child)};
+    }
 % end
   }
   return ${node.name}(Data.replacingChild(raw, Cursor::${child.name}));

--- a/lib/SyntaxParse/RawSyntaxTokenCache.cpp
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.cpp
@@ -39,10 +39,11 @@ static bool shouldCacheNode(tok TokKind, size_t TextSize,
   return true;
 }
 
-RC<RawSyntax> RawSyntaxTokenCache::getToken(RC<SyntaxArena> &Arena, tok TokKind,
-                                            size_t TextLength, StringRef Text,
-                                            StringRef LeadingTrivia,
-                                            StringRef TrailingTrivia) {
+const RawSyntax *RawSyntaxTokenCache::getToken(RC<SyntaxArena> &Arena,
+                                               tok TokKind, size_t TextLength,
+                                               StringRef Text,
+                                               StringRef LeadingTrivia,
+                                               StringRef TrailingTrivia) {
   // Determine whether this token is worth to cache.
   if (!shouldCacheNode(TokKind, Text.size(), LeadingTrivia, TrailingTrivia)) {
     // Do not use cache.

--- a/lib/SyntaxParse/RawSyntaxTokenCache.h
+++ b/lib/SyntaxParse/RawSyntaxTokenCache.h
@@ -34,17 +34,17 @@ class RawSyntaxCacheNode : public llvm::FoldingSetNode {
   friend llvm::FoldingSetTrait<RawSyntaxCacheNode>;
 
   /// Associated RawSyntax.
-  RC<syntax::RawSyntax> Obj;
+  const syntax::RawSyntax *Obj;
   /// FoldingSet node identifier of the associated RawSyntax.
   llvm::FoldingSetNodeIDRef IDRef;
 
 public:
-  RawSyntaxCacheNode(RC<syntax::RawSyntax> &Obj,
+  RawSyntaxCacheNode(const syntax::RawSyntax *Obj,
                      const llvm::FoldingSetNodeIDRef IDRef)
       : Obj(Obj), IDRef(IDRef) {}
 
   /// Retrieve assciated RawSyntax.
-  const RC<syntax::RawSyntax> &get() { return Obj; }
+  const syntax::RawSyntax *get() { return Obj; }
 
   // Only allow allocation of Node using the allocator in SyntaxArena.
   void *operator new(size_t Bytes, RC<syntax::SyntaxArena> &Arena,
@@ -61,10 +61,10 @@ class RawSyntaxTokenCache {
   std::vector<RawSyntaxCacheNode *> CacheNodes;
 
 public:
-  RC<syntax::RawSyntax> getToken(RC<syntax::SyntaxArena> &Arena, tok TokKind,
-                                 size_t TextLength, StringRef Text,
-                                 StringRef LeadingTrivia,
-                                 StringRef TrailingTrivia);
+  const syntax::RawSyntax *getToken(RC<syntax::SyntaxArena> &Arena, tok TokKind,
+                                    size_t TextLength, StringRef Text,
+                                    StringRef LeadingTrivia,
+                                    StringRef TrailingTrivia);
 
   ~RawSyntaxTokenCache();
 };

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -27,14 +27,6 @@
 using namespace swift;
 using namespace swift::syntax;
 
-static RC<RawSyntax> transferOpaqueNode(OpaqueSyntaxNode opaqueN) {
-  if (!opaqueN)
-    return nullptr;
-  RC<RawSyntax> raw{(RawSyntax *)opaqueN};
-  raw->Release(); // -1 since it's transfer of ownership.
-  return raw;
-}
-
 SyntaxTreeCreator::SyntaxTreeCreator(SourceManager &SM, unsigned bufferID,
                                      SyntaxParsingCache *syntaxCache,
                                      RC<syntax::SyntaxArena> arena)
@@ -103,7 +95,7 @@ public:
 Optional<SourceFileSyntax>
 SyntaxTreeCreator::realizeSyntaxRoot(OpaqueSyntaxNode rootN,
                                      const SourceFile &SF) {
-  auto raw = transferOpaqueNode(rootN);
+  auto raw = static_cast<const RawSyntax *>(rootN);
   auto rootNode = makeRoot<SourceFileSyntax>(raw);
 
   // Verify the tree if specified.
@@ -138,34 +130,28 @@ OpaqueSyntaxNode SyntaxTreeCreator::recordToken(tok tokenKind,
   auto raw =
       TokenCache->getToken(Arena, tokenKind, range.getByteLength(), tokenText,
                            leadingTriviaText, trailingTriviaText);
-  OpaqueSyntaxNode opaqueN = raw.get();
-  raw.resetWithoutRelease();
-  return opaqueN;
+  return static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw));
 }
 
 OpaqueSyntaxNode
 SyntaxTreeCreator::recordMissingToken(tok kind, SourceLoc loc) {
   auto raw = RawSyntax::missing(kind, getTokenText(kind), Arena);
-  OpaqueSyntaxNode opaqueN = raw.get();
-  raw.resetWithoutRelease();
-  return opaqueN;
+  return static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw));
 }
 
 OpaqueSyntaxNode
 SyntaxTreeCreator::recordRawSyntax(syntax::SyntaxKind kind,
                                    ArrayRef<OpaqueSyntaxNode> elements,
                                    CharSourceRange range) {
-  SmallVector<RC<RawSyntax>, 16> parts;
+  SmallVector<const RawSyntax *, 16> parts;
   parts.reserve(elements.size());
   for (OpaqueSyntaxNode opaqueN : elements) {
-    parts.push_back(transferOpaqueNode(opaqueN));
+    parts.push_back(static_cast<const RawSyntax *>(opaqueN));
   }
   size_t TextLength = range.isValid() ? range.getByteLength() : 0;
   auto raw =
       RawSyntax::make(kind, parts, TextLength, SourcePresence::Present, Arena);
-  OpaqueSyntaxNode opaqueN = raw.get();
-  raw.resetWithoutRelease();
-  return opaqueN;
+  return static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw));
 }
 
 std::pair<size_t, OpaqueSyntaxNode>
@@ -175,15 +161,10 @@ SyntaxTreeCreator::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
   auto cacheLookup = SyntaxCache->lookUp(lexerOffset, kind);
   if (!cacheLookup)
     return {0, nullptr};
-  RC<RawSyntax> raw = cacheLookup->getRaw();
-  OpaqueSyntaxNode opaqueN = raw.get();
+  const RawSyntax *raw = cacheLookup->getRaw();
   size_t length = raw->getTextLength();
-  raw.resetWithoutRelease();
-  return {length, opaqueN};
+  return {length, static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw))};
 }
 
 void SyntaxTreeCreator::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
-  if (!opaqueN)
-    return;
-  static_cast<RawSyntax *>(opaqueN)->Release();
 }

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -291,20 +291,19 @@ struct ByteBasedSourceRangeSet {
 
 int getTokensFromFile(
     unsigned BufferID, LangOptions &LangOpts, SourceManager &SourceMgr,
-    swift::DiagnosticEngine &Diags,
-    std::vector<std::pair<RC<syntax::RawSyntax>,
+    const RC<SyntaxArena> &Arena, swift::DiagnosticEngine &Diags,
+    std::vector<std::pair<const syntax::RawSyntax *,
                           syntax::AbsoluteOffsetPosition>> &Tokens) {
-  Tokens = tokenizeWithTrivia(LangOpts, SourceMgr, BufferID,
-                              /*Offset=*/0, /*EndOffset=*/0,
-                              &Diags);
+  Tokens = tokenizeWithTrivia(LangOpts, SourceMgr, BufferID, Arena,
+                              /*Offset=*/0, /*EndOffset=*/0, &Diags);
   return EXIT_SUCCESS;
 }
 
 int getTokensFromFile(
     const StringRef InputFilename, LangOptions &LangOpts,
-    SourceManager &SourceMgr, DiagnosticEngine &Diags,
-    unsigned int &OutBufferID,
-    std::vector<std::pair<RC<syntax::RawSyntax>,
+    SourceManager &SourceMgr, const RC<SyntaxArena> &Arena,
+    DiagnosticEngine &Diags, unsigned int &OutBufferID,
+    std::vector<std::pair<const syntax::RawSyntax *,
                           syntax::AbsoluteOffsetPosition>> &Tokens) {
   auto Buffer = llvm::MemoryBuffer::getFile(InputFilename);
   if (!Buffer) {
@@ -314,7 +313,8 @@ int getTokensFromFile(
   }
 
   OutBufferID = SourceMgr.addNewSourceBuffer(std::move(Buffer.get()));
-  return getTokensFromFile(OutBufferID, LangOpts, SourceMgr, Diags, Tokens);
+  return getTokensFromFile(OutBufferID, LangOpts, SourceMgr, Arena, Diags,
+                           Tokens);
 }
 
 void anchorForGetMainExecutable() {}
@@ -672,10 +672,12 @@ int doFullLexRoundTrip(const StringRef InputFilename) {
   Diags.addConsumer(DiagPrinter);
 
   unsigned int BufferID;
-  std::vector<std::pair<RC<syntax::RawSyntax>, syntax::AbsoluteOffsetPosition>>
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  std::vector<
+      std::pair<const syntax::RawSyntax *, syntax::AbsoluteOffsetPosition>>
       Tokens;
-  if (getTokensFromFile(InputFilename, LangOpts, SourceMgr, Diags, BufferID,
-                        Tokens) == EXIT_FAILURE) {
+  if (getTokensFromFile(InputFilename, LangOpts, SourceMgr, Arena, Diags,
+                        BufferID, Tokens) == EXIT_FAILURE) {
     return EXIT_FAILURE;
   }
 
@@ -694,9 +696,11 @@ int doDumpRawTokenSyntax(const StringRef InputFile) {
   Diags.addConsumer(DiagPrinter);
 
   unsigned int BufferID;
-  std::vector<std::pair<RC<syntax::RawSyntax>, syntax::AbsoluteOffsetPosition>>
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  std::vector<
+      std::pair<const syntax::RawSyntax *, syntax::AbsoluteOffsetPosition>>
       Tokens;
-  if (getTokensFromFile(InputFile, LangOpts, SourceMgr, Diags, BufferID,
+  if (getTokensFromFile(InputFile, LangOpts, SourceMgr, Arena, Diags, BufferID,
                         Tokens) == EXIT_FAILURE) {
     return EXIT_FAILURE;
   }
@@ -736,7 +740,7 @@ int doSerializeRawTree(const char *MainExecutablePath,
     }
 
     auto SerializeTree = [&ReusedNodeIds](llvm::raw_ostream &os,
-                                          RC<RawSyntax> Root,
+                                          const RawSyntax *Root,
                                           SyntaxParsingCache *SyntaxCache) {
       swift::json::Output::UserInfoMap JsonUserInfo;
       JsonUserInfo[swift::json::OmitNodesUserInfoKey] = &ReusedNodeIds;

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -13,18 +13,20 @@ using namespace swift::syntax;
 #pragma mark - declaration-modifier
 
 DeclModifierSyntax getCannedDeclModifier() {
-  auto Private = SyntaxFactory::makeIdentifier("private", "", "");
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto Set = SyntaxFactory::makeIdentifier("set", "", "");
-  auto RParen = SyntaxFactory::makeRightParenToken("", "");
-  return SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Private = SyntaxFactory::makeIdentifier("private", "", "", Arena);
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto Set = SyntaxFactory::makeIdentifier("set", "", "", Arena);
+  auto RParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+  return SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen, Arena);
 }
 
 TEST(DeclSyntaxTests, DeclModifierMakeAPIs) {
   {
+    RC<SyntaxArena> Arena = SyntaxArena::make();
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankDeclModifier().print(OS);
+    SyntaxFactory::makeBlankDeclModifier(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -36,11 +38,13 @@ TEST(DeclSyntaxTests, DeclModifierMakeAPIs) {
 }
 
 TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
-  auto Private = SyntaxFactory::makeIdentifier("private", "", "");
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto Set = SyntaxFactory::makeIdentifier("set", "", "");
-  auto RParen = SyntaxFactory::makeRightParenToken("", "");
-  auto Mod = SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Private = SyntaxFactory::makeIdentifier("private", "", "", Arena);
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto Set = SyntaxFactory::makeIdentifier("set", "", "", Arena);
+  auto RParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+  auto Mod =
+      SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen, Arena);
 
   ASSERT_EQ(Private.getRaw(), Mod.getName().getRaw());
   ASSERT_EQ(LParen.getRaw(), Mod.getDetailLeftParen()->getRaw());
@@ -49,14 +53,15 @@ TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
 }
 
 TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
-  auto Private = SyntaxFactory::makeIdentifier("private", "", "");
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto Set = SyntaxFactory::makeIdentifier("set", "", "");
-  auto RParen = SyntaxFactory::makeRightParenToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Private = SyntaxFactory::makeIdentifier("private", "", "", Arena);
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto Set = SyntaxFactory::makeIdentifier("set", "", "", Arena);
+  auto RParen = SyntaxFactory::makeRightParenToken("", "", Arena);
 
   SmallString<24> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
-  SyntaxFactory::makeBlankDeclModifier()
+  SyntaxFactory::makeBlankDeclModifier(Arena)
       .withName(Private)
       .withDetailLeftParen(LParen)
       .withDetail(Set)
@@ -68,129 +73,147 @@ TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
 #pragma mark - typealias-decl
 
 TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTypealiasDecl().print(OS);
+    SyntaxFactory::makeBlankTypealiasDecl(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
     SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ");
-    auto Subsequence = SyntaxFactory::makeIdentifier("MyCollection", "", "");
-    auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "");
-    auto ElementParam =
-      SyntaxFactory::makeGenericParameter(None, ElementName, None, None, None);
-    auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "");
-    auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ");
-    auto GenericParams = GenericParameterClauseSyntaxBuilder()
-      .useLeftAngleBracket(LeftAngle)
-      .useRightAngleBracket(RightAngle)
-      .addGenericParameter(ElementParam)
-      .build();
-    auto Assignment = SyntaxFactory::makeEqualToken("", " ");
-    auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", "", "");
-    auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
+    auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ", Arena);
+    auto Subsequence =
+        SyntaxFactory::makeIdentifier("MyCollection", "", "", Arena);
+    auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "", Arena);
+    auto ElementParam = SyntaxFactory::makeGenericParameter(
+        None, ElementName, None, None, None, Arena);
+    auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
+    auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ", Arena);
+    auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
+                             .useLeftAngleBracket(LeftAngle)
+                             .useRightAngleBracket(RightAngle)
+                             .addGenericParameter(ElementParam)
+                             .build();
+    auto Assignment = SyntaxFactory::makeEqualToken("", " ", Arena);
+    auto ElementType =
+        SyntaxFactory::makeTypeIdentifier("Element", "", "", Arena);
+    auto ElementArg =
+        SyntaxFactory::makeGenericArgument(ElementType, None, Arena);
 
     auto GenericArgs =
-        GenericArgumentClauseSyntaxBuilder()
+        GenericArgumentClauseSyntaxBuilder(Arena)
             .useLeftAngleBracket(LeftAngle)
-            .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+            .useRightAngleBracket(
+                SyntaxFactory::makeRightAngleToken("", "", Arena))
             .addArgument(ElementArg)
             .build();
 
-    auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
+    auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
     auto Array_Int =
-        SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
-    auto TypeInit = SyntaxFactory::makeTypeInitializerClause(Assignment,
-                                                             Array_Int);
-    SyntaxFactory::makeTypealiasDecl(None, None, Typealias,
-                                     Subsequence, GenericParams, TypeInit, None)
-      .print(OS);
+        SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs, Arena);
+    auto TypeInit =
+        SyntaxFactory::makeTypeInitializerClause(Assignment, Array_Int, Arena);
+    SyntaxFactory::makeTypealiasDecl(None, None, Typealias, Subsequence,
+                                     GenericParams, TypeInit, None, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str().str(),
               "typealias MyCollection<Element> = Array<Element>");
   }
 }
 
 TEST(DeclSyntaxTests, TypealiasWithAPIs) {
-  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ");
-  auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", "", "");
-  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "");
-  auto ElementParam =
-      SyntaxFactory::makeGenericParameter(None, ElementName, None, None, None);
-  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "");
-  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ");
-  auto GenericParams = GenericParameterClauseSyntaxBuilder()
-    .useLeftAngleBracket(LeftAngle)
-    .useRightAngleBracket(RightAngle)
-    .addGenericParameter(ElementParam)
-    .build();
-  auto Equal = SyntaxFactory::makeEqualToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ", Arena);
+  auto MyCollection =
+      SyntaxFactory::makeIdentifier("MyCollection", "", "", Arena);
+  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "", Arena);
+  auto ElementParam = SyntaxFactory::makeGenericParameter(
+      None, ElementName, None, None, None, Arena);
+  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
+  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ", Arena);
+  auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
+                           .useLeftAngleBracket(LeftAngle)
+                           .useRightAngleBracket(RightAngle)
+                           .addGenericParameter(ElementParam)
+                           .build();
+  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
 
-  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", "", "");
-  auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
-  auto GenericArgs =
-      GenericArgumentClauseSyntaxBuilder()
-          .useLeftAngleBracket(LeftAngle)
-          .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
-          .addArgument(ElementArg)
-          .build();
+  auto ElementType =
+      SyntaxFactory::makeTypeIdentifier("Element", "", "", Arena);
+  auto ElementArg =
+      SyntaxFactory::makeGenericArgument(ElementType, None, Arena);
+  auto GenericArgs = GenericArgumentClauseSyntaxBuilder(Arena)
+                         .useLeftAngleBracket(LeftAngle)
+                         .useRightAngleBracket(
+                             SyntaxFactory::makeRightAngleToken("", "", Arena))
+                         .addArgument(ElementArg)
+                         .build();
 
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
-  auto Array_Int = SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
-  auto Type_Init = SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int);
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
+  auto Array_Int =
+      SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs, Arena);
+  auto Type_Init =
+      SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int, Arena);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTypealiasDecl()
-      .withTypealiasKeyword(Typealias)
-      .withIdentifier(MyCollection)
-      .withGenericParameterClause(GenericParams)
-      .withInitializer(Type_Init)
-      .print(OS);
+    SyntaxFactory::makeBlankTypealiasDecl(Arena)
+        .withTypealiasKeyword(Typealias)
+        .withIdentifier(MyCollection)
+        .withGenericParameterClause(GenericParams)
+        .withInitializer(Type_Init)
+        .print(OS);
     ASSERT_EQ(OS.str().str(),
               "typealias MyCollection<Element> = Array<Element>");
   }
 }
 
 TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   SmallString<64> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ");
-  auto MyCollection = SyntaxFactory::makeIdentifier("MyCollection", "", "");
-  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "");
-  auto ElementParam = SyntaxFactory::makeGenericParameter(ElementName, None);
-  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "");
-  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ");
-  auto GenericParams = GenericParameterClauseSyntaxBuilder()
-    .useLeftAngleBracket(LeftAngle)
-    .useRightAngleBracket(RightAngle)
-    .addGenericParameter(ElementParam)
-    .build();
-  auto Equal = SyntaxFactory::makeEqualToken("", " ");
+  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ", Arena);
+  auto MyCollection =
+      SyntaxFactory::makeIdentifier("MyCollection", "", "", Arena);
+  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "", Arena);
+  auto ElementParam =
+      SyntaxFactory::makeGenericParameter(ElementName, None, Arena);
+  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
+  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ", Arena);
+  auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
+                           .useLeftAngleBracket(LeftAngle)
+                           .useRightAngleBracket(RightAngle)
+                           .addGenericParameter(ElementParam)
+                           .build();
+  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
 
-  auto ElementType = SyntaxFactory::makeTypeIdentifier("Element", "", "");
-  auto ElementArg = SyntaxFactory::makeGenericArgument(ElementType, None);
+  auto ElementType =
+      SyntaxFactory::makeTypeIdentifier("Element", "", "", Arena);
+  auto ElementArg =
+      SyntaxFactory::makeGenericArgument(ElementType, None, Arena);
 
-  auto GenericArgs =
-      GenericArgumentClauseSyntaxBuilder()
-          .useLeftAngleBracket(LeftAngle)
-          .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
-          .addArgument(ElementArg)
-          .build();
+  auto GenericArgs = GenericArgumentClauseSyntaxBuilder(Arena)
+                         .useLeftAngleBracket(LeftAngle)
+                         .useRightAngleBracket(
+                             SyntaxFactory::makeRightAngleToken("", "", Arena))
+                         .addArgument(ElementArg)
+                         .build();
 
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
-  auto Array_Int = SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs);
-  auto Type_Init = SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int);
-  TypealiasDeclSyntaxBuilder()
-    .useTypealiasKeyword(Typealias)
-    .useIdentifier(MyCollection)
-    .useGenericParameterClause(GenericParams)
-    .useInitializer(Type_Init)
-    .build()
-    .print(OS);
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
+  auto Array_Int =
+      SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs, Arena);
+  auto Type_Init =
+      SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int, Arena);
+  TypealiasDeclSyntaxBuilder(Arena)
+      .useTypealiasKeyword(Typealias)
+      .useIdentifier(MyCollection)
+      .useGenericParameterClause(GenericParams)
+      .useInitializer(Type_Init)
+      .build()
+      .print(OS);
   ASSERT_EQ(OS.str().str(),
             "typealias MyCollection<Element> = Array<Element>");
 }
@@ -198,26 +221,28 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
 #pragma mark - parameter
 
 FunctionParameterSyntax getCannedFunctionParameter() {
-  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ");
-  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
-  auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...");
-  auto Equal = SyntaxFactory::makeEqualToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ", Arena);
+  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
+  auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...", Arena);
+  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
 
-  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto One = SyntaxFactory::makePrefixOperatorExpr(Sign,
-    SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
-  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
+  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto One = SyntaxFactory::makePrefixOperatorExpr(
+      Sign, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
+  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
 
   return SyntaxFactory::makeFunctionParameter(None, ExternalName, LocalName,
                                               Colon, Int, NoEllipsis,
-                                              DefaultArg, Comma);
+                                              DefaultArg, Comma, Arena);
 }
 
 TEST(DeclSyntaxTests, FunctionParameterMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -227,30 +252,30 @@ TEST(DeclSyntaxTests, FunctionParameterMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionParameter().print(OS);
+    SyntaxFactory::makeBlankFunctionParameter(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
 
 TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
-  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ");
-  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
-  auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...");
-  auto Equal = SyntaxFactory::makeEqualToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ", Arena);
+  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
+  auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...", Arena);
+  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
 
-  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto One = SyntaxFactory::makePrefixOperatorExpr(Sign,
-    SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
-  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
-  auto Comma = SyntaxFactory::makeCommaToken("", "");
+  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto One = SyntaxFactory::makePrefixOperatorExpr(
+      Sign, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
+  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
 
-  auto Param = SyntaxFactory::makeFunctionParameter(None, ExternalName,
-                                                    LocalName, Colon, Int,
-                                                    NoEllipsis, DefaultArg,
-                                                    Comma);
+  auto Param = SyntaxFactory::makeFunctionParameter(
+      None, ExternalName, LocalName, Colon, Int, NoEllipsis, DefaultArg, Comma,
+      Arena);
 
   ASSERT_EQ(ExternalName.getRaw(), Param.getFirstName()->getRaw());
   ASSERT_EQ(LocalName.getRaw(), Param.getSecondName()->getRaw());
@@ -278,17 +303,18 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
-  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ");
-  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "");
-  auto Colon = SyntaxFactory::makeColonToken(" ", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
-  auto Equal = SyntaxFactory::makeEqualToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ", Arena);
+  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken(" ", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
+  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
 
-  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
-  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One);
-  auto Comma = SyntaxFactory::makeCommaToken("", "");
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
+  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
 
   {
     SmallString<48> Scratch;
@@ -315,12 +341,13 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionParameterWithEllipsis) {
-  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ");
-  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "");
-  auto Colon = SyntaxFactory::makeColonToken(" ", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-  auto Ellipsis = SyntaxFactory::makeEllipsisToken("", " ");
-  auto Comma = SyntaxFactory::makeCommaToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ", Arena);
+  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken(" ", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+  auto Ellipsis = SyntaxFactory::makeEllipsisToken("", " ", Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
 
   {
     SmallString<48> Scratch;
@@ -341,10 +368,11 @@ TEST(DeclSyntaxTests, FunctionParameterWithEllipsis) {
 #pragma mark - parameter-list
 
 TEST(DeclSyntaxTests, FunctionParameterListMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionParameterList().print(OS);
+    SyntaxFactory::makeBlankFunctionParameterList(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -352,7 +380,7 @@ TEST(DeclSyntaxTests, FunctionParameterListMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto Param = getCannedFunctionParameter();
     std::vector<FunctionParameterSyntax> Params { Param, Param, Param };
-    SyntaxFactory::makeFunctionParameterList(Params).print(OS);
+    SyntaxFactory::makeFunctionParameterList(Params, Arena).print(OS);
     ASSERT_EQ(OS.str().str(),
       "with radius: Int = -1, with radius: Int = -1, with radius: Int = -1, ");
   }
@@ -361,28 +389,32 @@ TEST(DeclSyntaxTests, FunctionParameterListMakeAPIs) {
 #pragma mark - function-signature
 
 FunctionSignatureSyntax getCannedFunctionSignature() {
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
   auto Param = getCannedFunctionParameter();
-  auto List = SyntaxFactory::makeBlankFunctionParameterList()
-    .appending(Param)
-    .appending(Param)
-    .appending(Param)
-    .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken("", " ");
-  auto Parameter = SyntaxFactory::makeParameterClause(LParen, List, RParen);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
-  auto Return = SyntaxFactory::makeReturnClause(Arrow, Int);
+  auto List = SyntaxFactory::makeBlankFunctionParameterList(Arena)
+                  .appending(Param)
+                  .appending(Param)
+                  .appending(Param)
+                  .castTo<FunctionParameterListSyntax>();
+  auto RParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
+  auto Parameter =
+      SyntaxFactory::makeParameterClause(LParen, List, RParen, Arena);
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
+  auto Return = SyntaxFactory::makeReturnClause(Arrow, Int, Arena);
 
-  return SyntaxFactory::makeFunctionSignature(Parameter, None, Throws, Return);
+  return SyntaxFactory::makeFunctionSignature(Parameter, None, Throws, Return,
+                                              Arena);
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionSignature().print(OS);
+    SyntaxFactory::makeBlankFunctionSignature(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -397,23 +429,23 @@ TEST(DeclSyntaxTests, FunctionSignatureMakeAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
   auto Param = getCannedFunctionParameter();
-  auto List = SyntaxFactory::makeBlankFunctionParameterList()
-    .appending(Param)
-    .appending(Param)
-    .appending(Param)
-    .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken("", " ");
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
+  auto List = SyntaxFactory::makeBlankFunctionParameterList(Arena)
+                  .appending(Param)
+                  .appending(Param)
+                  .appending(Param)
+                  .castTo<FunctionParameterListSyntax>();
+  auto RParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
 
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
 
   auto Sig = SyntaxFactory::makeFunctionSignature(
-    SyntaxFactory::makeParameterClause(LParen, List, RParen),
-    None, Throws,
-    SyntaxFactory::makeReturnClause(Arrow, Int));
+      SyntaxFactory::makeParameterClause(LParen, List, RParen, Arena), None,
+      Throws, SyntaxFactory::makeReturnClause(Arrow, Int, Arena), Arena);
 
   ASSERT_EQ(LParen.getRaw(), Sig.getInput().getLeftParen().getRaw());
 
@@ -447,27 +479,29 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
   auto Param = getCannedFunctionParameter();
-  auto List = SyntaxFactory::makeBlankFunctionParameterList()
-    .appending(Param)
-    .appending(Param)
-    .appending(Param)
-    .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken("", " ");
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
+  auto List = SyntaxFactory::makeBlankFunctionParameterList(Arena)
+                  .appending(Param)
+                  .appending(Param)
+                  .appending(Param)
+                  .castTo<FunctionParameterListSyntax>();
+  auto RParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
 
-  auto Parameter = SyntaxFactory::makeParameterClause(LParen, List, RParen);
-  auto Return = SyntaxFactory::makeReturnClause(Arrow, Int);
+  auto Parameter =
+      SyntaxFactory::makeParameterClause(LParen, List, RParen, Arena);
+  auto Return = SyntaxFactory::makeReturnClause(Arrow, Int, Arena);
   SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
-  SyntaxFactory::makeBlankFunctionSignature()
-    .withInput(Parameter)
-    .withThrowsOrRethrowsKeyword(Throws)
-    .withOutput(Return)
-    .print(OS);
+  SyntaxFactory::makeBlankFunctionSignature(Arena)
+      .withInput(Parameter)
+      .withThrowsOrRethrowsKeyword(Throws)
+      .withOutput(Return)
+      .print(OS);
   ASSERT_EQ(OS.str().str(),
             "(with radius: Int = -1, "
             "with radius: Int = -1, "
@@ -477,33 +511,35 @@ TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
 #pragma mark - function-declaration
 
 ModifierListSyntax getCannedModifiers() {
-  auto PublicID = SyntaxFactory::makePublicKeyword("", " ");
-  auto NoLParen = TokenSyntax::missingToken(tok::l_paren, "(");
-  auto NoArgument = TokenSyntax::missingToken(tok::identifier, "");
-  auto NoRParen = TokenSyntax::missingToken(tok::r_paren, ")");
-  auto Public =
-      SyntaxFactory::makeDeclModifier(PublicID, NoLParen, NoArgument, NoRParen);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto PublicID = SyntaxFactory::makePublicKeyword("", " ", Arena);
+  auto NoLParen = TokenSyntax::missingToken(tok::l_paren, "(", Arena);
+  auto NoArgument = TokenSyntax::missingToken(tok::identifier, "", Arena);
+  auto NoRParen = TokenSyntax::missingToken(tok::r_paren, ")", Arena);
+  auto Public = SyntaxFactory::makeDeclModifier(PublicID, NoLParen, NoArgument,
+                                                NoRParen, Arena);
 
-  auto StaticKW = SyntaxFactory::makeStaticKeyword("", " ");
-  auto Static =
-      SyntaxFactory::makeDeclModifier(StaticKW, NoLParen, NoArgument, NoRParen);
+  auto StaticKW = SyntaxFactory::makeStaticKeyword("", " ", Arena);
+  auto Static = SyntaxFactory::makeDeclModifier(StaticKW, NoLParen, NoArgument,
+                                                NoRParen, Arena);
 
-  return SyntaxFactory::makeBlankModifierList()
-    .appending(Public)
-    .appending(Static);
+  return SyntaxFactory::makeBlankModifierList(Arena)
+      .appending(Public)
+      .appending(Static);
 }
 
 GenericParameterClauseSyntax getCannedGenericParams() {
-  GenericParameterClauseSyntaxBuilder GB;
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  GenericParameterClauseSyntaxBuilder GB(Arena);
 
-  auto LAngle = SyntaxFactory::makeLeftAngleToken("", "");
-  auto RAngle = SyntaxFactory::makeRightAngleToken("", "");
-  auto TType = SyntaxFactory::makeIdentifier("T", "", "");
-  auto UType = SyntaxFactory::makeIdentifier("U", "", "");
+  auto LAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
+  auto RAngle = SyntaxFactory::makeRightAngleToken("", "", Arena);
+  auto TType = SyntaxFactory::makeIdentifier("T", "", "", Arena);
+  auto UType = SyntaxFactory::makeIdentifier("U", "", "", Arena);
 
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto T = SyntaxFactory::makeGenericParameter(TType, Comma);
-  auto U = SyntaxFactory::makeGenericParameter(UType, None);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto T = SyntaxFactory::makeGenericParameter(TType, Comma, Arena);
+  auto U = SyntaxFactory::makeGenericParameter(UType, None, Arena);
 
   GB.addGenericParameter(T);
   GB.addGenericParameter(U);
@@ -514,41 +550,45 @@ GenericParameterClauseSyntax getCannedGenericParams() {
 }
 
 CodeBlockSyntax getCannedBody() {
-  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "-");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("\n  ", "");
-  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, One);
-  auto ReturnItem = SyntaxFactory::makeCodeBlockItem(Return, None, None);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "-", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("\n  ", "", Arena);
+  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, One, Arena);
+  auto ReturnItem = SyntaxFactory::makeCodeBlockItem(Return, None, None, Arena);
 
-  auto Stmts = SyntaxFactory::makeCodeBlockItemList({ReturnItem});
+  auto Stmts = SyntaxFactory::makeCodeBlockItemList({ReturnItem}, Arena);
 
-  auto LBrace = SyntaxFactory::makeLeftBraceToken("", "");
-  auto RBrace = SyntaxFactory::makeRightBraceToken("\n", "");
+  auto LBrace = SyntaxFactory::makeLeftBraceToken("", "", Arena);
+  auto RBrace = SyntaxFactory::makeRightBraceToken("\n", "", Arena);
 
-  return SyntaxFactory::makeCodeBlock(LBrace, Stmts, RBrace);
+  return SyntaxFactory::makeCodeBlock(LBrace, Stmts, RBrace, Arena);
 }
 
 GenericWhereClauseSyntax getCannedWhereClause() {
-  auto WhereKW = SyntaxFactory::makeWhereKeyword("", " ");
-  auto T = SyntaxFactory::makeTypeIdentifier("T", "", " ");
-  auto EqualEqual = SyntaxFactory::makeEqualityOperator("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ");
-  auto SameType = SyntaxFactory::makeSameTypeRequirement(T, EqualEqual, Int);
-  auto Req = SyntaxFactory::makeGenericRequirement(SameType, None);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto WhereKW = SyntaxFactory::makeWhereKeyword("", " ", Arena);
+  auto T = SyntaxFactory::makeTypeIdentifier("T", "", " ", Arena);
+  auto EqualEqual = SyntaxFactory::makeEqualityOperator("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
+  auto SameType =
+      SyntaxFactory::makeSameTypeRequirement(T, EqualEqual, Int, Arena);
+  auto Req = SyntaxFactory::makeGenericRequirement(SameType, None, Arena);
 
-  auto Requirements = SyntaxFactory::makeBlankGenericRequirementList()
-    .appending(Req);
+  auto Requirements =
+      SyntaxFactory::makeBlankGenericRequirementList(Arena).appending(Req);
 
-  return SyntaxFactory::makeBlankGenericWhereClause()
-    .withWhereKeyword(WhereKW)
-    .withRequirementList(Requirements);
+  return SyntaxFactory::makeBlankGenericWhereClause(Arena)
+      .withWhereKeyword(WhereKW)
+      .withRequirementList(Requirements);
 }
 
 FunctionDeclSyntax getCannedFunctionDecl() {
-  auto NoAttributes = SyntaxFactory::makeBlankAttributeList();
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto FuncKW = SyntaxFactory::makeFuncKeyword("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto NoAttributes = SyntaxFactory::makeBlankAttributeList(Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto FuncKW = SyntaxFactory::makeFuncKeyword("", " ", Arena);
   auto Modifiers = getCannedModifiers();
   auto GenericParams = getCannedGenericParams();
   auto GenericWhere = getCannedWhereClause();
@@ -557,14 +597,15 @@ FunctionDeclSyntax getCannedFunctionDecl() {
 
   return SyntaxFactory::makeFunctionDecl(NoAttributes, Modifiers, FuncKW, Foo,
                                          GenericParams, Signature, GenericWhere,
-                                         Body);
+                                         Body, Arena);
 }
 
 TEST(DeclSyntaxTests, FunctionDeclMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionDecl().print(OS);
+    SyntaxFactory::makeBlankFunctionDecl(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -584,10 +625,11 @@ TEST(DeclSyntaxTests, FunctionDeclMakeAPIs) {
 }
 
 TEST(DeclSyntaxTests, FunctionDeclGetAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionDecl().print(OS);
+    SyntaxFactory::makeBlankFunctionDecl(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -9,11 +9,13 @@ using namespace swift::syntax;
 #pragma mark - integer-literal-expression
 
 TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
-    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("100", "", "");
-    auto Sign = SyntaxFactory::makePrefixOperator("-", "", "");
-    auto Literal = SyntaxFactory::makePrefixOperatorExpr(Sign,
-      SyntaxFactory::makeIntegerLiteralExpr(LiteralToken));
+    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("100", "", "", Arena);
+    auto Sign = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
+    auto Literal = SyntaxFactory::makePrefixOperatorExpr(
+        Sign, SyntaxFactory::makeIntegerLiteralExpr(LiteralToken, Arena),
+        Arena);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -22,9 +24,10 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(Literal.getKind(), SyntaxKind::PrefixOperatorExpr);
   }
   {
-    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("1_000", "", "");
-    auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-    auto Literal = SyntaxFactory::makeIntegerLiteralExpr(LiteralToken);
+    auto LiteralToken =
+        SyntaxFactory::makeIntegerLiteral("1_000", "", "", Arena);
+    auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
+    auto Literal = SyntaxFactory::makeIntegerLiteralExpr(LiteralToken, Arena);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -33,10 +36,12 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   }
   {
     auto Literal =
-        SyntaxFactory::makeBlankPrefixOperatorExpr()
-            .withOperatorToken(TokenSyntax::missingToken(tok::oper_prefix, ""))
+        SyntaxFactory::makeBlankPrefixOperatorExpr(Arena)
+            .withOperatorToken(
+                TokenSyntax::missingToken(tok::oper_prefix, "", Arena))
             .withPostfixExpression(SyntaxFactory::makeIntegerLiteralExpr(
-                SyntaxFactory::makeIntegerLiteral("0", "", "    ")));
+                SyntaxFactory::makeIntegerLiteral("0", "", "    ", Arena),
+                Arena));
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -45,10 +50,11 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   }
   {
     auto LiteralToken =
-        SyntaxFactory::makeIntegerLiteral("1_000_000_000_000", "", "");
-    auto PlusSign = SyntaxFactory::makePrefixOperator("+", "", "");
-    auto OneThousand = SyntaxFactory::makePrefixOperatorExpr(PlusSign,
-      SyntaxFactory::makeIntegerLiteralExpr(LiteralToken));
+        SyntaxFactory::makeIntegerLiteral("1_000_000_000_000", "", "", Arena);
+    auto PlusSign = SyntaxFactory::makePrefixOperator("+", "", "", Arena);
+    auto OneThousand = SyntaxFactory::makePrefixOperatorExpr(
+        PlusSign, SyntaxFactory::makeIntegerLiteralExpr(LiteralToken, Arena),
+        Arena);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -60,19 +66,22 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
 #pragma mark - symbolic-reference
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
-    auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
-    auto Int = SyntaxFactory::makeIdentifier("Int", "", "");
-    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
-    auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
-    GenericArgumentClauseSyntaxBuilder ArgBuilder;
-    ArgBuilder.useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", ""))
-        .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+    auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
+    auto Int = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
+    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None, Arena);
+    auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None, Arena);
+    GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
+    ArgBuilder
+        .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", "", Arena))
+        .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", "", Arena))
         .addArgument(GenericArg);
 
     auto GenericArgs = ArgBuilder.build();
 
-    auto Ref = SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs);
+    auto Ref =
+        SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs, Arena);
 
     ASSERT_EQ(Ref.getIdentifier().getRaw(), Array.getRaw());
 
@@ -90,75 +99,80 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
 }
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
-  auto Int = SyntaxFactory::makeIdentifier("Int", "", "");
-  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
-  auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
-  GenericArgumentClauseSyntaxBuilder ArgBuilder;
-  ArgBuilder.useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", ""))
-      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
+  auto Int = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
+  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None, Arena);
+  auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None, Arena);
+  GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
+  ArgBuilder
+      .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", "", Arena))
+      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", "", Arena))
       .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr().print(OS);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena).print(OS);
     EXPECT_EQ(OS.str().str(), "");
   }
 
   {
-    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
+    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto BlankArgs = SyntaxFactory::makeBlankGenericArgumentClause();
+    auto BlankArgs = SyntaxFactory::makeBlankGenericArgumentClause(Arena);
 
-    SyntaxFactory::makeSymbolicReferenceExpr(Foo, BlankArgs).print(OS);
+    SyntaxFactory::makeSymbolicReferenceExpr(Foo, BlankArgs, Arena).print(OS);
     EXPECT_EQ(OS.str().str(), "foo");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs).print(OS);
+    SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "Array<Int>");
   }
 }
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "");
-  auto Int = SyntaxFactory::makeIdentifier("Int", "", "");
-  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
-  auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None);
-  GenericArgumentClauseSyntaxBuilder ArgBuilder;
-  ArgBuilder.useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", ""))
-      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", ""))
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
+  auto Int = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
+  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None, Arena);
+  auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None, Arena);
+  GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
+  ArgBuilder
+      .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", "", Arena))
+      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", "", Arena))
       .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr()
-      .withIdentifier(Array)
-      .print(OS);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena)
+        .withIdentifier(Array)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "Array");
   }
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr()
-      .withGenericArgumentClause(GenericArgs)
-      .print(OS);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena)
+        .withGenericArgumentClause(GenericArgs)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "<Int>");
   }
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr()
-      .withIdentifier(Array)
-      .withGenericArgumentClause(GenericArgs)
-      .print(OS);
+    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena)
+        .withIdentifier(Array)
+        .withGenericArgumentClause(GenericArgs)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "Array<Int>");
   }
 }
@@ -166,15 +180,17 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
 #pragma mark - function-call-argument
 
 TEST(ExprSyntaxTests, TupleExprElementGetAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
 
   {
-    auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
-                                                       Comma);
+    auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma,
+                                                   Arena);
 
     ASSERT_EQ(X.getRaw(), Arg.getLabel()->getRaw());
     ASSERT_EQ(Colon.getRaw(), Arg.getColon()->getRaw());
@@ -192,52 +208,57 @@ TEST(ExprSyntaxTests, TupleExprElementGetAPIs) {
 }
 
 TEST(ExprSyntaxTests, TupleExprElementMakeAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElement().print(OS);
+    SyntaxFactory::makeBlankTupleExprElement(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElement()
-      .withExpression(SymbolicRef).print(OS);
+    SyntaxFactory::makeBlankTupleExprElement(Arena)
+        .withExpression(SymbolicRef)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "foo");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma)
-      .print(OS);
+    SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "x: foo, ");
   }
 }
 
 TEST(ExprSyntaxTests, TupleExprElementWithAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElement()
-      .withLabel(X)
-      .withColon(Colon)
-      .withExpression(SymbolicRef)
-      .withTrailingComma(Comma)
-      .print(OS);
+    SyntaxFactory::makeBlankTupleExprElement(Arena)
+        .withLabel(X)
+        .withColon(Colon)
+        .withExpression(SymbolicRef)
+        .withTrailingComma(Comma)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "x: foo, ");
   }
 }
@@ -245,72 +266,76 @@ TEST(ExprSyntaxTests, TupleExprElementWithAPIs) {
 #pragma mark - function-call-argument-list
 
 namespace {
-TupleExprElementListSyntax getFullArgumentList() {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "");
-  auto Y = SyntaxFactory::makeIdentifier("y", "", "");
-  auto Z = SyntaxFactory::makeIdentifier("z", "", "");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+TupleExprElementListSyntax getFullArgumentList(const RC<SyntaxArena> &Arena) {
+  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+  auto Y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
+  auto Z = SyntaxFactory::makeIdentifier("z", "", "", Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-  auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
-                                                     Comma);
+  auto Arg =
+      SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma, Arena);
 
-  return SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg)
-    .appending(Arg.withLabel(Y))
-    .appending(Arg.withLabel(Z).withTrailingComma(NoComma))
-    .castTo<TupleExprElementListSyntax>();
+  return SyntaxFactory::makeBlankTupleExprElementList(Arena)
+      .appending(Arg)
+      .appending(Arg.withLabel(Y))
+      .appending(Arg.withLabel(Z).withTrailingComma(NoComma))
+      .castTo<TupleExprElementListSyntax>();
 }
 
-TupleExprElementListSyntax getLabellessArgumentList() {
-  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "");
-  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "");
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
-  auto NoLabel = TokenSyntax::missingToken(tok::identifier, "");
-  auto NoColon = TokenSyntax::missingToken(tok::colon, ":");
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
-  auto Two = SyntaxFactory::makeIntegerLiteralExpr(TwoDigits);
-  auto Three = SyntaxFactory::makeIntegerLiteralExpr(ThreeDigits);
+TupleExprElementListSyntax
+getLabellessArgumentList(const RC<SyntaxArena> &Arena) {
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "", Arena);
+  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "", Arena);
+  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
+  auto NoLabel = TokenSyntax::missingToken(tok::identifier, "", Arena);
+  auto NoColon = TokenSyntax::missingToken(tok::colon, ":", Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+  auto Two = SyntaxFactory::makeIntegerLiteralExpr(TwoDigits, Arena);
+  auto Three = SyntaxFactory::makeIntegerLiteralExpr(ThreeDigits, Arena);
 
-  auto OneArg = SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, One,
-                                                        Comma);
-  auto TwoArg = SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, Two,
-                                                        Comma);
-  auto ThreeArg = SyntaxFactory::makeTupleExprElement(NoLabel, NoColon,
-                                                          Three, NoComma);
+  auto OneArg =
+      SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, One, Comma, Arena);
+  auto TwoArg =
+      SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, Two, Comma, Arena);
+  auto ThreeArg = SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, Three,
+                                                      NoComma, Arena);
 
-  return SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(OneArg)
-    .appending(TwoArg)
-    .appending(ThreeArg)
-    .castTo<TupleExprElementListSyntax>();
+  return SyntaxFactory::makeBlankTupleExprElementList(Arena)
+      .appending(OneArg)
+      .appending(TwoArg)
+      .appending(ThreeArg)
+      .castTo<TupleExprElementListSyntax>();
 }
 } // end anonymous namespace
 
 TEST(ExprSyntaxTests, TupleExprElementListGetAPIs) {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "");
-  auto Y = SyntaxFactory::makeIdentifier("y", "", "");
-  auto Z = SyntaxFactory::makeIdentifier("z", "", "");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+  auto Y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
+  auto Z = SyntaxFactory::makeIdentifier("z", "", "", Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-  auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
-                                                     Comma);
+  auto Arg =
+      SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma, Arena);
 
-  auto ArgList = SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg)
-    .appending(Arg.withLabel(Y))
-    .appending(Arg.withLabel(Z).withTrailingComma(NoComma))
-    .castTo<TupleExprElementListSyntax>();
+  auto ArgList = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+                     .appending(Arg)
+                     .appending(Arg.withLabel(Y))
+                     .appending(Arg.withLabel(Z).withTrailingComma(NoComma))
+                     .castTo<TupleExprElementListSyntax>();
 
   ASSERT_EQ(ArgList.size(), size_t(3));
 
@@ -346,25 +371,26 @@ TEST(ExprSyntaxTests, TupleExprElementListGetAPIs) {
 }
 
 TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     llvm::SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElementList().print(OS);
+    SyntaxFactory::makeBlankTupleExprElementList(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
-    auto X = SyntaxFactory::makeIdentifier("x", "", "");
-    auto Y = SyntaxFactory::makeIdentifier("y", "", "");
-    auto Z = SyntaxFactory::makeIdentifier("z", "", "");
-    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-    auto Colon = SyntaxFactory::makeColonToken("", " ");
-    auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo,
-                                                                llvm::None);
-    auto Comma = SyntaxFactory::makeCommaToken("", " ");
-    auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+    auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+    auto Y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
+    auto Z = SyntaxFactory::makeIdentifier("z", "", "", Arena);
+    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+    auto SymbolicRef =
+        SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+    auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-    auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef,
-                                                       Comma);
+    auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma,
+                                                   Arena);
 
     std::vector<TupleExprElementSyntax> Args {
       Arg, Arg.withLabel(Y), Arg.withLabel(Z).withTrailingComma(NoComma)
@@ -372,7 +398,7 @@ TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
 
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto ArgList = SyntaxFactory::makeTupleExprElementList(Args);
+    auto ArgList = SyntaxFactory::makeTupleExprElementList(Args, Arena);
     ArgList.print(OS);
     ASSERT_EQ(ArgList.size(), size_t(3));
     ASSERT_EQ(OS.str().str(), "x: foo, y: foo, z: foo");
@@ -380,7 +406,8 @@ TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
 }
 
 TEST(ExprSyntaxTests, TupleExprElementListWithAPIs) {
-  auto ArgList = getFullArgumentList();
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ArgList = getFullArgumentList(Arena);
   llvm::SmallString<64> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   ASSERT_EQ(ArgList.size(), size_t(3));
@@ -392,14 +419,16 @@ TEST(ExprSyntaxTests, TupleExprElementListWithAPIs) {
 #pragma mark - function-call-expression
 
 TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto ArgList = getFullArgumentList();
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto ArgList = getFullArgumentList(Arena);
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
 
   auto Call = SyntaxFactory::makeFunctionCallExpr(
-      SymbolicRef, LeftParen, ArgList, RightParen, None, None);
+      SymbolicRef, LeftParen, ArgList, RightParen, None, None, Arena);
 
   {
     auto GottenExpression1 = Call.getCalledExpression();
@@ -426,15 +455,17 @@ TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
 }
 
 TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto ArgList = getFullArgumentList();
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto ArgList = getFullArgumentList(Arena);
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
 
   {
     auto Call = SyntaxFactory::makeFunctionCallExpr(
-        SymbolicRef, LeftParen, ArgList, RightParen, None, None);
+        SymbolicRef, LeftParen, ArgList, RightParen, None, None, Arena);
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     Call.print(OS);
@@ -444,43 +475,46 @@ TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
   {
     llvm::SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionCallExpr().print(OS);
+    SyntaxFactory::makeBlankFunctionCallExpr(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
 
 TEST(ExprSyntaxTests, FunctionCallExprWithAPIs) {
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto ArgList = getFullArgumentList();
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto ArgList = getFullArgumentList(Arena);
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
 
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionCallExpr()
-      .withCalledExpression(SymbolicRef)
-      .withLeftParen(LeftParen)
-      .withRightParen(RightParen)
-      .print(OS);
+    SyntaxFactory::makeBlankFunctionCallExpr(Arena)
+        .withCalledExpression(SymbolicRef)
+        .withLeftParen(LeftParen)
+        .withRightParen(RightParen)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "foo()");
   }
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionCallExpr()
-      .withCalledExpression(SymbolicRef)
-      .withLeftParen(LeftParen)
-      .withArgumentList(getLabellessArgumentList())
-      .withRightParen(RightParen)
-      .print(OS);
+    SyntaxFactory::makeBlankFunctionCallExpr(Arena)
+        .withCalledExpression(SymbolicRef)
+        .withLeftParen(LeftParen)
+        .withArgumentList(getLabellessArgumentList(Arena))
+        .withRightParen(RightParen)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "foo(1, 2, 3)");
   }
 }
 
 TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
-  FunctionCallExprSyntaxBuilder CallBuilder;
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  FunctionCallExprSyntaxBuilder CallBuilder(Arena);
 
   {
     llvm::SmallString<64> Scratch;
@@ -489,8 +523,8 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
     ASSERT_EQ(OS.str().str(), "");
   }
 
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "");
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
 
   {
     llvm::SmallString<64> Scratch;
@@ -501,17 +535,18 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
     ASSERT_EQ(OS.str().str(), "()");
   }
 
-  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "");
-  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "");
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits);
-  auto NoLabel = TokenSyntax::missingToken(tok::identifier, "");
-  auto NoColon = TokenSyntax::missingToken(tok::colon, ":");
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "", Arena);
+  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "", Arena);
+  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
+  auto NoLabel = TokenSyntax::missingToken(tok::identifier, "", Arena);
+  auto NoColon = TokenSyntax::missingToken(tok::colon, ":", Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
 
   {
     llvm::SmallString<64> Scratch;
@@ -521,8 +556,8 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
     ASSERT_EQ(OS.str().str(), "foo()");
   }
 
-  auto OneArg = SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, One,
-                                                        Comma);
+  auto OneArg =
+      SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, One, Comma, Arena);
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);

--- a/unittests/Syntax/StmtSyntaxTests.cpp
+++ b/unittests/Syntax/StmtSyntaxTests.cpp
@@ -8,13 +8,15 @@ using namespace swift::syntax;
 #pragma mark - fallthrough-statement
 
 TEST(StmtSyntaxTests, FallthroughStmtGetAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   llvm::SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "");
+  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "", Arena);
 
-  auto Fallthrough = SyntaxFactory::makeBlankFallthroughStmt()
-    .withFallthroughKeyword(FallthroughKW);
+  auto Fallthrough =
+      SyntaxFactory::makeBlankFallthroughStmt(Arena).withFallthroughKeyword(
+          FallthroughKW);
 
   /// This should be directly shared through reference-counting.
   ASSERT_EQ(FallthroughKW.getRaw(), Fallthrough.getFallthroughKeyword()
@@ -22,26 +24,28 @@ TEST(StmtSyntaxTests, FallthroughStmtGetAPIs) {
 }
 
 TEST(StmtSyntaxTests, FallthroughStmtWithAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   llvm::SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "");
+  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "", Arena);
 
-  SyntaxFactory::makeBlankFallthroughStmt()
-    .withFallthroughKeyword(FallthroughKW)
-    .print(OS);
+  SyntaxFactory::makeBlankFallthroughStmt(Arena)
+      .withFallthroughKeyword(FallthroughKW)
+      .print(OS);
 
   ASSERT_EQ(OS.str().str(), "fallthrough");
 }
 
 TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "", Arena);
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    SyntaxFactory::makeFallthroughStmt(FallthroughKW).print(OS);
+    SyntaxFactory::makeFallthroughStmt(FallthroughKW, Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "fallthrough");
   }
 
@@ -51,7 +55,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 
     auto NewFallthroughKW = FallthroughKW.withLeadingTrivia("  ");
 
-    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
+    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW, Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough");
   }
 
@@ -62,7 +66,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     auto NewFallthroughKW =
         FallthroughKW.withLeadingTrivia("  ").withTrailingTrivia("  ");
 
-    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
+    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW, Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough  ");
   }
 
@@ -70,7 +74,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    SyntaxFactory::makeBlankFallthroughStmt().print(OS);
+    SyntaxFactory::makeBlankFallthroughStmt(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
@@ -78,9 +82,11 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 #pragma mark - break-statement
 
 TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
-  auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ");
-  auto Label = SyntaxFactory::makeIdentifier("sometimesYouNeedTo", "", "");
-  auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ", Arena);
+  auto Label =
+      SyntaxFactory::makeIdentifier("sometimesYouNeedTo", "", "", Arena);
+  auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label, Arena);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(BreakKW.getRaw(), Break.getBreakKeyword().getRaw());
@@ -88,10 +94,11 @@ TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
 }
 
 TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
-  auto BreakKW = SyntaxFactory::makeBreakKeyword("", "");
-  auto Label = SyntaxFactory::makeIdentifier("theRules", "", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto BreakKW = SyntaxFactory::makeBreakKeyword("", "", Arena);
+  auto Label = SyntaxFactory::makeIdentifier("theRules", "", "", Arena);
 
-  auto Break = SyntaxFactory::makeBlankBreakStmt();
+  auto Break = SyntaxFactory::makeBlankBreakStmt(Arena);
 
   {
     llvm::SmallString<48> Scratch;
@@ -123,19 +130,20 @@ TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
 }
 
 TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ");
-    auto Label = SyntaxFactory::makeIdentifier("theBuild", "", "");
-    auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label);
+    auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ", Arena);
+    auto Label = SyntaxFactory::makeIdentifier("theBuild", "", "", Arena);
+    auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label, Arena);
     Break.print(OS);
     ASSERT_EQ(OS.str().str(), "break theBuild"); // don't you dare
   }
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankBreakStmt().print(OS);
+    SyntaxFactory::makeBlankBreakStmt(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
@@ -143,9 +151,10 @@ TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
 #pragma mark - continue-statement
 
 TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
-  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ");
-  auto Label = SyntaxFactory::makeIdentifier("always", "", "");
-  auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ", Arena);
+  auto Label = SyntaxFactory::makeIdentifier("always", "", "", Arena);
+  auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label, Arena);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(ContinueKW.getRaw(), Continue.getContinueKeyword().getRaw());
@@ -153,9 +162,10 @@ TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
 }
 
 TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
-  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", "");
-  auto Label = SyntaxFactory::makeIdentifier("toCare", "", "");
-  auto Continue = SyntaxFactory::makeBlankContinueStmt();
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", "", Arena);
+  auto Label = SyntaxFactory::makeIdentifier("toCare", "", "", Arena);
+  auto Continue = SyntaxFactory::makeBlankContinueStmt(Arena);
 
   {
     llvm::SmallString<48> Scratch;
@@ -187,19 +197,20 @@ TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
 }
 
 TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ");
-    auto Label = SyntaxFactory::makeIdentifier("toLead", "", "");
-    auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label);
+    auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ", Arena);
+    auto Label = SyntaxFactory::makeIdentifier("toLead", "", "", Arena);
+    auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label, Arena);
     Continue.print(OS);
     ASSERT_EQ(OS.str().str(), "continue toLead"); // by example
   }
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankContinueStmt().print(OS);
+    SyntaxFactory::makeBlankContinueStmt(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
@@ -207,34 +218,36 @@ TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
 #pragma mark - return-statement
 
 TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ");
-  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(Minus,
-    SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ", Arena);
+  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(
+      Minus, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt().print(OS);
+    SyntaxFactory::makeBlankReturnStmt(Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne).print(OS);
+    SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne, Arena).print(OS);
     ASSERT_EQ(OS.str().str(), "return -1");
   }
 }
 
 TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ");
-  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(Minus,
-    SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
-  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne);
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ", Arena);
+  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(
+      Minus, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
+  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne, Arena);
 
   ASSERT_EQ(ReturnKW.getRaw(), Return.getReturnKeyword().getRaw());
   auto GottenExpression = Return.getExpression().getValue();
@@ -243,32 +256,36 @@ TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
 }
 
 TEST(StmtSyntaxTests, ReturnStmtWithAPIs) {
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ");
-  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "");
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "");
-  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(Minus,
-    SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ", Arena);
+  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
+  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(
+      Minus, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt().withReturnKeyword(ReturnKW).print(OS);
+    SyntaxFactory::makeBlankReturnStmt(Arena).withReturnKeyword(ReturnKW).print(
+        OS);
     ASSERT_EQ(OS.str().str(), "return ");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt().withExpression(MinusOne).print(OS);
+    SyntaxFactory::makeBlankReturnStmt(Arena).withExpression(MinusOne).print(
+        OS);
     ASSERT_EQ(OS.str().str(), "-1");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt()
-      .withReturnKeyword(ReturnKW)
-      .withExpression(MinusOne).print(OS);
+    SyntaxFactory::makeBlankReturnStmt(Arena)
+        .withReturnKeyword(ReturnKW)
+        .withExpression(MinusOne)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "return -1");
   }
 }

--- a/unittests/Syntax/SyntaxCollectionTests.cpp
+++ b/unittests/Syntax/SyntaxCollectionTests.cpp
@@ -9,30 +9,35 @@ using namespace swift;
 using namespace swift::syntax;
 
 TupleExprElementSyntax getCannedArgument() {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "");
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto SymbolicRef = SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto NoComma = RawSyntax::missing(tok::comma, ",");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto SymbolicRef =
+      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
 
-  return SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma);
+  return SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma,
+                                             Arena);
 }
 
 TEST(SyntaxCollectionTests, empty) {
-  auto Empty = SyntaxFactory::makeBlankTupleExprElementList();
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Empty = SyntaxFactory::makeBlankTupleExprElementList(Arena);
   ASSERT_TRUE(Empty.empty());
   ASSERT_FALSE(Empty.appending(getCannedArgument()).empty());
 }
 
 TEST(SyntaxCollectionTests, size) {
-  auto Empty = SyntaxFactory::makeBlankTupleExprElementList();
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Empty = SyntaxFactory::makeBlankTupleExprElementList(Arena);
   ASSERT_EQ(Empty.size(), size_t(0));
   ASSERT_EQ(Empty.appending(getCannedArgument()).size(), size_t(1));
 }
 
 TEST(SyntaxCollectionTests, subscript) {
-  auto Empty = SyntaxFactory::makeBlankTupleExprElementList();
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Empty = SyntaxFactory::makeBlankTupleExprElementList(Arena);
 #ifndef NDEBUG
   ASSERT_DEATH({ Empty[0]; }, "");
 #endif
@@ -56,12 +61,13 @@ TEST(SyntaxCollectionTests, subscript) {
 }
 
 TEST(SyntaxCollectionTests, appending) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   auto Arg = getCannedArgument();
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
-  auto List = SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg)
-    .appending(Arg)
-    .appending(Arg.withTrailingComma(NoComma));
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+                  .appending(Arg)
+                  .appending(Arg)
+                  .appending(Arg.withTrailingComma(NoComma));
 
   ASSERT_EQ(List.size(), size_t(3));
 
@@ -85,16 +91,17 @@ TEST(SyntaxCollectionTests, appending) {
 }
 
 TEST(SyntaxCollectionTests, removingLast) {
-  ASSERT_DEATH({
-    SyntaxFactory::makeBlankTupleExprElementList().removingLast();
-  }, "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  ASSERT_DEATH(
+      { SyntaxFactory::makeBlankTupleExprElementList(Arena).removingLast(); },
+      "");
   auto Arg = getCannedArgument();
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
-  auto List = SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg)
-    .appending(Arg)
-    .appending(Arg.withTrailingComma(NoComma))
-    .removingLast();
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+                  .appending(Arg)
+                  .appending(Arg)
+                  .appending(Arg.withTrailingComma(NoComma))
+                  .removingLast();
   SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   List.print(OS);
@@ -102,12 +109,13 @@ TEST(SyntaxCollectionTests, removingLast) {
 }
 
 TEST(SyntaxCollectionTests, prepending) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   auto Arg = getCannedArgument();
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
-  auto List = SyntaxFactory::makeBlankTupleExprElementList()
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
                   .prepending(Arg.withTrailingComma(NoComma))
                   .prepending(Arg.withLabel(
-                      SyntaxFactory::makeIdentifier("schwifty", "", "")))
+                      SyntaxFactory::makeIdentifier("schwifty", "", "", Arena)))
                   .prepending(Arg);
 
   ASSERT_EQ(List.size(), size_t(3));
@@ -132,14 +140,15 @@ TEST(SyntaxCollectionTests, prepending) {
 }
 
 TEST(SyntaxCollectionTests, removingFirst) {
-  ASSERT_DEATH({
-    SyntaxFactory::makeBlankTupleExprElementList().removingFirst();
-  }, "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  ASSERT_DEATH(
+      { SyntaxFactory::makeBlankTupleExprElementList(Arena).removingFirst(); },
+      "");
   auto Arg = getCannedArgument();
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
-  auto List = SyntaxFactory::makeBlankTupleExprElementList()
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
                   .appending(Arg.withLabel(
-                      SyntaxFactory::makeIdentifier("schwifty", "", "")))
+                      SyntaxFactory::makeIdentifier("schwifty", "", "", Arena)))
                   .appending(Arg)
                   .appending(Arg.withTrailingComma(NoComma))
                   .removingFirst();
@@ -150,74 +159,78 @@ TEST(SyntaxCollectionTests, removingFirst) {
 }
 
 TEST(SyntaxCollectionTests, inserting) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   auto Arg = getCannedArgument();
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 #ifndef NDEBUG
-  ASSERT_DEATH({
-    SyntaxFactory::makeBlankTupleExprElementList().inserting(1, Arg);
-  }, "");
+  ASSERT_DEATH(
+      {
+        SyntaxFactory::makeBlankTupleExprElementList(Arena).inserting(1, Arg);
+      },
+      "");
 #endif
 
   {
     SmallString<48> InsertedScratch;
     llvm::raw_svector_ostream InsertedOS(InsertedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList()
-      .inserting(0, Arg)
-      .inserting(0, Arg)
-      .inserting(0, Arg)
-      .print(InsertedOS);
+    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+        .inserting(0, Arg)
+        .inserting(0, Arg)
+        .inserting(0, Arg)
+        .print(InsertedOS);
 
     SmallString<48> PrependedScratch;
     llvm::raw_svector_ostream PrependedOS(PrependedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList()
-      .prepending(Arg)
-      .prepending(Arg)
-      .prepending(Arg)
-      .print(PrependedOS);
+    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+        .prepending(Arg)
+        .prepending(Arg)
+        .prepending(Arg)
+        .print(PrependedOS);
     ASSERT_EQ(InsertedOS.str().str(), PrependedOS.str().str());
   }
 
   {
     SmallString<48> InsertedScratch;
     llvm::raw_svector_ostream InsertedOS(InsertedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList()
-      .inserting(0, Arg)
-      .inserting(1, Arg)
-      .inserting(2, Arg)
-      .print(InsertedOS);
+    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+        .inserting(0, Arg)
+        .inserting(1, Arg)
+        .inserting(2, Arg)
+        .print(InsertedOS);
 
     SmallString<48> AppendedScratch;
     llvm::raw_svector_ostream AppendedOS(AppendedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList()
-      .appending(Arg)
-      .appending(Arg)
-      .appending(Arg)
-      .print(AppendedOS);
+    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+        .appending(Arg)
+        .appending(Arg)
+        .appending(Arg)
+        .print(AppendedOS);
     ASSERT_EQ(InsertedOS.str().str(), AppendedOS.str().str());
   }
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElementList()
+    SyntaxFactory::makeBlankTupleExprElementList(Arena)
         .appending(Arg)
         .appending(Arg)
-        .inserting(
-            1, Arg.withLabel(SyntaxFactory::makeIdentifier("schwifty", "", "")))
+        .inserting(1, Arg.withLabel(SyntaxFactory::makeIdentifier(
+                          "schwifty", "", "", Arena)))
         .print(OS);
     ASSERT_EQ(OS.str().str(), "x: foo, schwifty: foo, x: foo, ");
   }
 }
 
 TEST(SyntaxCollectionTests, cleared) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   auto Arg = getCannedArgument();
   SmallString<1> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg)
-    .appending(Arg)
-    .appending(Arg)
-    .cleared();
+  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+                  .appending(Arg)
+                  .appending(Arg)
+                  .appending(Arg)
+                  .cleared();
 
   List.print(OS);
   ASSERT_EQ(OS.str().str(), "");
@@ -226,11 +239,12 @@ TEST(SyntaxCollectionTests, cleared) {
 }
 
 TEST(SyntaxCollectionTests, Iteration) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   auto Arg = getCannedArgument();
-  auto List = SyntaxFactory::makeBlankTupleExprElementList()
-    .appending(Arg)
-    .appending(Arg)
-    .appending(Arg);
+  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+                  .appending(Arg)
+                  .appending(Arg)
+                  .appending(Arg);
 
   auto Element0 = List[0];
   auto Element1 = List[1];
@@ -258,11 +272,12 @@ TEST(SyntaxCollectionTests, Iteration) {
 }
 
 TEST(SyntaxCollectionTests, Removing) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   auto Arg = getCannedArgument();
-  auto List = SyntaxFactory::makeBlankTupleExprElementList()
+  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
                   .appending(Arg)
                   .appending(Arg.withLabel(
-                      SyntaxFactory::makeIdentifier("first", "", "")))
+                      SyntaxFactory::makeIdentifier("first", "", "", Arena)))
                   .appending(Arg)
                   .removing(1);
 

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -12,33 +12,36 @@ using namespace swift::syntax;
 #pragma mark - type-attribute
 
 TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
-  auto At = SyntaxFactory::makeAtSignToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto At = SyntaxFactory::makeAtSignToken("", "", Arena);
   {
-    auto AutoclosureID = SyntaxFactory::makeIdentifier("autoclosure", "", "");
+    auto AutoclosureID =
+        SyntaxFactory::makeIdentifier("autoclosure", "", "", Arena);
     SmallString<24> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Autoclosure = SyntaxFactory::makeBlankAttribute()
-      .withAtSignToken(At)
-      .withAttributeName(AutoclosureID);
+    auto Autoclosure = SyntaxFactory::makeBlankAttribute(Arena)
+                           .withAtSignToken(At)
+                           .withAttributeName(AutoclosureID);
     Autoclosure.print(OS);
     ASSERT_EQ(OS.str().str(), "@autoclosure");
   }
 
   {
-    auto conventionID = SyntaxFactory::makeIdentifier("convention", "", "");
-    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-    auto RightParen = SyntaxFactory::makeRightParenToken("", "");
+    auto conventionID =
+        SyntaxFactory::makeIdentifier("convention", "", "", Arena);
+    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+    auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
 
-    auto Convention = SyntaxFactory::makeBlankAttribute()
-      .withAtSignToken(At)
-      .withAttributeName(conventionID)
-      .withLeftParen(LeftParen)
-      .withRightParen(RightParen);
+    auto Convention = SyntaxFactory::makeBlankAttribute(Arena)
+                          .withAtSignToken(At)
+                          .withAttributeName(conventionID)
+                          .withLeftParen(LeftParen)
+                          .withRightParen(RightParen);
 
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto cID = SyntaxFactory::makeIdentifier("c", "", "");
+      auto cID = SyntaxFactory::makeIdentifier("c", "", "", Arena);
       Convention.withArgument(cID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
@@ -46,8 +49,9 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "");
-      auto swiftArgs = SyntaxFactory::makeTokenList({LeftParen, swiftID, RightParen});
+      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "", Arena);
+      auto swiftArgs =
+          SyntaxFactory::makeTokenList({LeftParen, swiftID, RightParen}, Arena);
       Convention.withArgument(swiftID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
     }
@@ -55,8 +59,9 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto blockID = SyntaxFactory::makeIdentifier("block", "", "");
-      auto blockArgs = SyntaxFactory::makeTokenList({LeftParen, blockID, RightParen});
+      auto blockID = SyntaxFactory::makeIdentifier("block", "", "", Arena);
+      auto blockArgs =
+          SyntaxFactory::makeTokenList({LeftParen, blockID, RightParen}, Arena);
       Convention.withArgument(blockID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
     }
@@ -65,39 +70,42 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "");
-    auto Escaping = SyntaxFactory::makeBlankAttribute()
-      .withAtSignToken(At)
-      .withAttributeName(EscapingID);
+    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "", Arena);
+    auto Escaping = SyntaxFactory::makeBlankAttribute(Arena)
+                        .withAtSignToken(At)
+                        .withAttributeName(EscapingID);
     Escaping.print(OS);
     ASSERT_EQ(OS.str().str(), "@escaping");
   }
 }
 
 TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
-  auto At = SyntaxFactory::makeAtSignToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto At = SyntaxFactory::makeAtSignToken("", "", Arena);
   {
-    auto AutoclosureID = SyntaxFactory::makeIdentifier("autoclosure", "", "");
+    auto AutoclosureID =
+        SyntaxFactory::makeIdentifier("autoclosure", "", "", Arena);
     SmallString<24> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Autoclosure = SyntaxFactory::makeBlankAttribute()
-    .withAtSignToken(At)
-    .withAttributeName(AutoclosureID);
+    auto Autoclosure = SyntaxFactory::makeBlankAttribute(Arena)
+                           .withAtSignToken(At)
+                           .withAttributeName(AutoclosureID);
     Autoclosure.print(OS);
     ASSERT_EQ(OS.str().str(), "@autoclosure");
   }
 
   {
-    auto conventionID = SyntaxFactory::makeIdentifier("convention", "", "");
-    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-    auto RightParen = SyntaxFactory::makeRightParenToken("", "");
+    auto conventionID =
+        SyntaxFactory::makeIdentifier("convention", "", "", Arena);
+    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+    auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
 
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto cID = SyntaxFactory::makeIdentifier("c", "", "");
+      auto cID = SyntaxFactory::makeIdentifier("c", "", "", Arena);
       SyntaxFactory::makeAttribute(At, conventionID, LeftParen, cID, RightParen,
-                                   llvm::None)
+                                   llvm::None, Arena)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
@@ -105,9 +113,9 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "");
+      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "", Arena);
       SyntaxFactory::makeAttribute(At, conventionID, LeftParen, swiftID,
-                                   RightParen, llvm::None)
+                                   RightParen, llvm::None, Arena)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
     }
@@ -115,9 +123,9 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto blockID = SyntaxFactory::makeIdentifier("block", "", "");
+      auto blockID = SyntaxFactory::makeIdentifier("block", "", "", Arena);
       SyntaxFactory::makeAttribute(At, conventionID, LeftParen, blockID,
-                                   RightParen, llvm::None)
+                                   RightParen, llvm::None, Arena)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
     }
@@ -126,82 +134,88 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "");
-    auto Escaping = SyntaxFactory::makeBlankAttribute()
-      .withAtSignToken(At)
-      .withAttributeName(EscapingID);
+    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "", Arena);
+    auto Escaping = SyntaxFactory::makeBlankAttribute(Arena)
+                        .withAtSignToken(At)
+                        .withAttributeName(EscapingID);
     Escaping.print(OS);
     ASSERT_EQ(OS.str().str(), "@escaping");
   }
 }
 
 TEST(TypeSyntaxTests, TupleWithAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType().withLeftParen(
-        SyntaxFactory::makeLeftParenToken("", ""));
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withLeftParen(
+        SyntaxFactory::makeLeftParenToken("", "", Arena));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType().withLeftParen(
-        SyntaxFactory::makeLeftParenToken("  ", " "));
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withLeftParen(
+        SyntaxFactory::makeLeftParenToken("  ", " ", Arena));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "  ( )");
   }
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType().withRightParen(
-        SyntaxFactory::makeRightParenToken("    ", "\n"));
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withRightParen(
+        SyntaxFactory::makeRightParenToken("    ", "\n", Arena));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "(    )\n");
   }
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType().withRightParen(
-        SyntaxFactory::makeRightParenToken("", ""));
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withRightParen(
+        SyntaxFactory::makeRightParenToken("", "", Arena));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Comma = SyntaxFactory::makeCommaToken("", "");
-    auto Foo = SyntaxFactory::makeTypeIdentifier("Foo", "", "  ");
-    auto Void = SyntaxFactory::makeVoidTupleType()
-      .withElements(SyntaxFactory::makeTupleTypeElementList({
-        SyntaxFactory::makeTupleTypeElement(Foo, Comma),
-        SyntaxFactory::makeTupleTypeElement(Foo)
-      }));
+    auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
+    auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+    auto Foo = SyntaxFactory::makeTypeIdentifier("Foo", "", "  ", Arena);
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withElements(
+        SyntaxFactory::makeTupleTypeElementList(
+            {SyntaxFactory::makeTupleTypeElement(Foo, Comma, Arena),
+             SyntaxFactory::makeTupleTypeElement(Foo, NoComma, Arena)},
+            Arena));
     Void.print(OS);
     ASSERT_EQ(OS.str().str(), "(Foo  ,Foo  )");
   }
 }
 
 TEST(TypeSyntaxTests, TupleBuilderAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
 
-    TupleTypeSyntaxBuilder Builder;
-    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", ""));
-    auto Comma = SyntaxFactory::makeCommaToken("", " ");
-    auto IntId = SyntaxFactory::makeIdentifier("Int", "", "");
-    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(IntId, None);
-    auto Int = SyntaxFactory::makeTupleTypeElement(IntType);
-    auto IntWithComma = SyntaxFactory::makeTupleTypeElement(IntType, Comma);
-    auto StringId = SyntaxFactory::makeIdentifier("String", "", "");
-    auto StringType = SyntaxFactory::makeSimpleTypeIdentifier(StringId, None);
-    auto String = SyntaxFactory::makeTupleTypeElement(StringType, Comma);
+    TupleTypeSyntaxBuilder Builder(Arena);
+    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", "", Arena));
+    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+    auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+    auto IntId = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
+    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(IntId, None, Arena);
+    auto Int = SyntaxFactory::makeTupleTypeElement(IntType, NoComma, Arena);
+    auto IntWithComma =
+        SyntaxFactory::makeTupleTypeElement(IntType, Comma, Arena);
+    auto StringId = SyntaxFactory::makeIdentifier("String", "", "", Arena);
+    auto StringType =
+        SyntaxFactory::makeSimpleTypeIdentifier(StringId, None, Arena);
+    auto String = SyntaxFactory::makeTupleTypeElement(StringType, Comma, Arena);
     Builder.addElement(IntWithComma);
     Builder.addElement(String);
     Builder.addElement(Int);
-    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", ""));
+    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", "", Arena));
 
     auto TupleType = Builder.build();
 
@@ -212,22 +226,23 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
 
-    TupleTypeSyntaxBuilder Builder;
-    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", ""));
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-    auto Comma = SyntaxFactory::makeCommaToken("", " ");
-    auto Colon = SyntaxFactory::makeColonToken("", " ");
-    auto xLabel = SyntaxFactory::makeIdentifier("x", {} , {});
-    auto xTypeElt = SyntaxFactory::makeTupleTypeElement(xLabel, Colon,
-                                                        Int, Comma);
-    auto inout = SyntaxFactory::makeInoutKeyword("", " ");
-    auto yLabel = SyntaxFactory::makeIdentifier("y", {} , {});
-    auto yTypeElt = SyntaxFactory::makeTupleTypeElement(yLabel, Colon,
-                                                        Int)
-      .withInOut(inout);
+    TupleTypeSyntaxBuilder Builder(Arena);
+    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", "", Arena));
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+    auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
+    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+    auto xLabel = SyntaxFactory::makeIdentifier("x", {}, {}, Arena);
+    auto xTypeElt =
+        SyntaxFactory::makeTupleTypeElement(xLabel, Colon, Int, Comma, Arena);
+    auto inout = SyntaxFactory::makeInoutKeyword("", " ", Arena);
+    auto yLabel = SyntaxFactory::makeIdentifier("y", {}, {}, Arena);
+    auto yTypeElt =
+        SyntaxFactory::makeTupleTypeElement(yLabel, Colon, Int, NoComma, Arena)
+            .withInOut(inout);
     Builder.addElement(xTypeElt);
     Builder.addElement(yTypeElt);
-    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", ""));
+    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", "", Arena));
 
     auto TupleType = Builder.build();
     TupleType.print(OS);
@@ -237,10 +252,11 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
 }
 
 TEST(TypeSyntaxTests, TupleMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType();
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
@@ -248,18 +264,19 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-    auto Bool = SyntaxFactory::makeTypeIdentifier("Bool", "", "");
-    auto Comma = SyntaxFactory::makeCommaToken("", " ");
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+    auto Bool = SyntaxFactory::makeTypeIdentifier("Bool", "", "", Arena);
+    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
     auto TupleType = SyntaxFactory::makeTupleType(
-        SyntaxFactory::makeLeftParenToken("", ""),
+        SyntaxFactory::makeLeftParenToken("", "", Arena),
         SyntaxFactory::makeTupleTypeElementList(
-            {SyntaxFactory::makeTupleTypeElement(Int, Comma),
-             SyntaxFactory::makeTupleTypeElement(Bool, Comma),
-             SyntaxFactory::makeTupleTypeElement(Int, Comma),
-             SyntaxFactory::makeTupleTypeElement(Bool, Comma),
-             SyntaxFactory::makeTupleTypeElement(Int, None)}),
-        SyntaxFactory::makeRightParenToken("", ""));
+            {SyntaxFactory::makeTupleTypeElement(Int, Comma, Arena),
+             SyntaxFactory::makeTupleTypeElement(Bool, Comma, Arena),
+             SyntaxFactory::makeTupleTypeElement(Int, Comma, Arena),
+             SyntaxFactory::makeTupleTypeElement(Bool, Comma, Arena),
+             SyntaxFactory::makeTupleTypeElement(Int, None, Arena)},
+            Arena),
+        SyntaxFactory::makeRightParenToken("", "", Arena), Arena);
     TupleType.print(OS);
     ASSERT_EQ(OS.str().str(),
               "(Int, Bool, Int, Bool, Int)");
@@ -267,10 +284,11 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
 }
 
 TEST(TypeSyntaxTests, CreateCannedTypes) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<3> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Any = SyntaxFactory::makeAnyTypeIdentifier();
+    auto Any = SyntaxFactory::makeAnyTypeIdentifier("", "", Arena);
     Any.print(OS);
     ASSERT_EQ(OS.str(), "Any");
   }
@@ -278,222 +296,234 @@ TEST(TypeSyntaxTests, CreateCannedTypes) {
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Self = SyntaxFactory::makeSelfTypeIdentifier();
+    auto Self = SyntaxFactory::makeSelfTypeIdentifier("", "", Arena);
     Self.print(OS);
     ASSERT_EQ(OS.str(), "Self");
   }
 }
 
 TEST(TypeSyntaxTests, OptionalTypeMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-    auto Question = SyntaxFactory::makePostfixQuestionMarkToken("", "");
-    auto OptionalInt = SyntaxFactory::makeOptionalType(Int, Question);
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+    auto Question = SyntaxFactory::makePostfixQuestionMarkToken("", "", Arena);
+    auto OptionalInt = SyntaxFactory::makeOptionalType(Int, Question, Arena);
     OptionalInt.print(OS);
     ASSERT_EQ(OS.str(), "Int?");
   }
 }
 
 TEST(TypeSyntaxTests, OptionalTypeWithAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<8> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto StringType = SyntaxFactory::makeTypeIdentifier("String", " ", "");
-    SyntaxFactory::makeBlankOptionalType()
+    auto StringType =
+        SyntaxFactory::makeTypeIdentifier("String", " ", "", Arena);
+    SyntaxFactory::makeBlankOptionalType(Arena)
         .withWrappedType(StringType)
-        .withQuestionMark(SyntaxFactory::makePostfixQuestionMarkToken("", ""))
+        .withQuestionMark(
+            SyntaxFactory::makePostfixQuestionMarkToken("", "", Arena))
         .print(OS);
     ASSERT_EQ(OS.str(), " String?");
   }
 }
 
 TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-    auto Bang = SyntaxFactory::makeExclamationMarkToken("", "");
+    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+    auto Bang = SyntaxFactory::makeExclamationMarkToken("", "", Arena);
     auto IntBang =
-      SyntaxFactory::makeImplicitlyUnwrappedOptionalType(Int, Bang);
+        SyntaxFactory::makeImplicitlyUnwrappedOptionalType(Int, Bang, Arena);
     IntBang.print(OS);
     ASSERT_EQ(OS.str(), "Int!");
   }
 }
 
 TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeWithAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<8> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto StringType = SyntaxFactory::makeTypeIdentifier("String", " ", "");
-    SyntaxFactory::makeBlankImplicitlyUnwrappedOptionalType()
+    auto StringType =
+        SyntaxFactory::makeTypeIdentifier("String", " ", "", Arena);
+    SyntaxFactory::makeBlankImplicitlyUnwrappedOptionalType(Arena)
         .withWrappedType(StringType)
-        .withExclamationMark(SyntaxFactory::makeExclamationMarkToken("", ""))
+        .withExclamationMark(
+            SyntaxFactory::makeExclamationMarkToken("", "", Arena))
         .print(OS);
     ASSERT_EQ(OS.str(), " String!");
   }
 }
 
 TEST(TypeSyntaxTests, MetatypeTypeMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "");
-    auto Dot = SyntaxFactory::makePeriodToken("", "");
-    auto Type = SyntaxFactory::makeTypeToken("", "");
-    SyntaxFactory::makeMetatypeType(Int, Dot, Type)
-      .print(OS);
+    auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "", Arena);
+    auto Dot = SyntaxFactory::makePeriodToken("", "", Arena);
+    auto Type = SyntaxFactory::makeTypeToken("", "", Arena);
+    SyntaxFactory::makeMetatypeType(Int, Dot, Type, Arena).print(OS);
     ASSERT_EQ(OS.str(), "T.Type");
   }
 }
 
 TEST(TypeSyntaxTests, MetatypeTypeWithAPIs) {
-  auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "");
-  auto Dot = SyntaxFactory::makePeriodToken("", "");
-  auto Type = SyntaxFactory::makeTypeToken("", "");
-  auto Protocol = SyntaxFactory::makeProtocolToken("", "");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "", Arena);
+  auto Dot = SyntaxFactory::makePeriodToken("", "", Arena);
+  auto Type = SyntaxFactory::makeTypeToken("", "", Arena);
+  auto Protocol = SyntaxFactory::makeProtocolToken("", "", Arena);
 
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankMetatypeType()
-      .withBaseType(Int)
-      .withPeriod(Dot)
-      .withTypeOrProtocol(Type)
-      .print(OS);
+    SyntaxFactory::makeBlankMetatypeType(Arena)
+        .withBaseType(Int)
+        .withPeriod(Dot)
+        .withTypeOrProtocol(Type)
+        .print(OS);
     ASSERT_EQ(OS.str(), "T.Type");
   }
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankMetatypeType()
-      .withBaseType(Int)
-      .withPeriod(Dot)
-      .withTypeOrProtocol(Protocol)
-      .print(OS);
+    SyntaxFactory::makeBlankMetatypeType(Arena)
+        .withBaseType(Int)
+        .withPeriod(Dot)
+        .withTypeOrProtocol(Protocol)
+        .print(OS);
     ASSERT_EQ(OS.str(), "T.Protocol");
   }
 
 #ifndef NDEBUG
   ASSERT_DEATH(
       {
-        SyntaxFactory::makeBlankMetatypeType()
+        SyntaxFactory::makeBlankMetatypeType(Arena)
             .withBaseType(Int)
             .withPeriod(Dot)
-            .withTypeOrProtocol(SyntaxFactory::makeIdentifier("WRONG", "", ""));
+            .withTypeOrProtocol(
+                SyntaxFactory::makeIdentifier("WRONG", "", "", Arena));
       },
       "");
 #endif
 }
 
 TEST(TypeSyntaxTests, ArrayTypeWithAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
-    auto Double = SyntaxFactory::makeTypeIdentifier("Double", "", "");
-    SyntaxFactory::makeBlankArrayType()
-      .withLeftSquareBracket(LeftSquare)
-      .withElementType(Double)
-      .withRightSquareBracket(RightSquare)
-      .print(OS);
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
+    auto RightSquare =
+        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
+    auto Double = SyntaxFactory::makeTypeIdentifier("Double", "", "", Arena);
+    SyntaxFactory::makeBlankArrayType(Arena)
+        .withLeftSquareBracket(LeftSquare)
+        .withElementType(Double)
+        .withRightSquareBracket(RightSquare)
+        .print(OS);
     ASSERT_EQ(OS.str(), "[Double]");
   }
 }
 
 TEST(TypeSyntaxTests, ArrayTypeMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
-    auto Void = SyntaxFactory::makeVoidTupleType();
-    SyntaxFactory::makeArrayType(LeftSquare, Void, RightSquare)
-      .print(OS);
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
+    auto RightSquare =
+        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
+    SyntaxFactory::makeArrayType(LeftSquare, Void, RightSquare, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str(), "[()]");
   }
 }
 
 TEST(TypeSyntaxTests, DictionaryTypeWithAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
-    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ");
-    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-    auto Colon = SyntaxFactory::makeColonToken("", " ");
-    SyntaxFactory::makeBlankDictionaryType()
-      .withLeftSquareBracket(LeftSquare)
-      .withKeyType(Key)
-      .withColon(Colon)
-      .withValueType(Value)
-      .withRightSquareBracket(RightSquare)
-      .print(OS);
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
+    auto RightSquare =
+        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
+    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ", Arena);
+    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+    SyntaxFactory::makeBlankDictionaryType(Arena)
+        .withLeftSquareBracket(LeftSquare)
+        .withKeyType(Key)
+        .withColon(Colon)
+        .withValueType(Value)
+        .withRightSquareBracket(RightSquare)
+        .print(OS);
 
     ASSERT_EQ(OS.str(), "[String : Int]");
   }
 }
 
 TEST(TypeSyntaxTests, DictionaryTypeMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "");
-    auto RightSquare = SyntaxFactory::makeRightSquareBracketToken("", "");
-    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ");
-    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-    auto Colon = SyntaxFactory::makeColonToken("", " ");
-    SyntaxFactory::makeDictionaryType(LeftSquare,
-                                        Key, Colon, Value,
-                                        RightSquare).print(OS);
+    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
+    auto RightSquare =
+        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
+    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ", Arena);
+    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+    SyntaxFactory::makeDictionaryType(LeftSquare, Key, Colon, Value,
+                                      RightSquare, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str(), "[String : Int]");
   }
 }
 
 TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto Colon = SyntaxFactory::makeColonToken("", " ");
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto RightParen = SyntaxFactory::makeRightParenToken("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-  auto IntArg = SyntaxFactory::makeBlankTupleTypeElement()
-    .withType(Int);
-  auto Async = SyntaxFactory::makeIdentifier("async", "", " ");
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ");
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto RightParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+  auto IntArg = SyntaxFactory::makeBlankTupleTypeElement(Arena).withType(Int);
+  auto Async = SyntaxFactory::makeIdentifier("async", "", " ", Arena);
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
+  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ", Arena);
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto x = SyntaxFactory::makeIdentifier("x", "", "");
-    auto y = SyntaxFactory::makeIdentifier("y", "", "");
-    auto xArg = SyntaxFactory::makeBlankTupleTypeElement()
-      .withName(x)
-      .withColon(Colon)
-      .withType(Int)
-      .withTrailingComma(Comma);
-    auto yArg = SyntaxFactory::makeBlankTupleTypeElement()
-      .withName(y)
-      .withColon(Colon)
-      .withType(Int);
+    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
+    auto xArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+                    .withName(x)
+                    .withColon(Colon)
+                    .withType(Int)
+                    .withTrailingComma(Comma);
+    auto yArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+                    .withName(y)
+                    .withColon(Colon)
+                    .withType(Int);
 
-    auto TypeList = SyntaxFactory::makeTupleTypeElementList({
-      xArg, yArg
-    });
-    SyntaxFactory::makeFunctionType(LeftParen,
-                                    TypeList,
-                                    RightParen,
-                                    Async,
-                                    Throws,
-                                    Arrow,
-                                    Int)
-      .print(OS);
+    auto TypeList =
+        SyntaxFactory::makeTupleTypeElementList({xArg, yArg}, Arena);
+    SyntaxFactory::makeFunctionType(LeftParen, TypeList, RightParen, Async,
+                                    Throws, Arrow, Int, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "(x: Int, y: Int) async throws -> Int");
   }
 
@@ -501,96 +531,82 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto x = SyntaxFactory::makeIdentifier("x", "", "");
-    auto y = SyntaxFactory::makeIdentifier("y", "", "");
-    auto xArg = SyntaxFactory::makeBlankTupleTypeElement()
-      .withName(x)
-      .withColon(Colon)
-      .withType(Int)
-      .withTrailingComma(Comma);
-    auto yArg = SyntaxFactory::makeBlankTupleTypeElement()
-      .withName(y)
-      .withColon(Colon)
-      .withType(Int);
+    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
+    auto xArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+                    .withName(x)
+                    .withColon(Colon)
+                    .withType(Int)
+                    .withTrailingComma(Comma);
+    auto yArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+                    .withName(y)
+                    .withColon(Colon)
+                    .withType(Int);
 
-    auto TypeList = SyntaxFactory::makeTupleTypeElementList({
-      xArg, yArg
-    });
-    SyntaxFactory::makeFunctionType(LeftParen,
-                                    TypeList,
-                                    RightParen,
-                                    None,
-                                    Throws,
-                                    Arrow,
-                                    Int)
-      .print(OS);
+    auto TypeList =
+        SyntaxFactory::makeTupleTypeElementList({xArg, yArg}, Arena);
+    SyntaxFactory::makeFunctionType(LeftParen, TypeList, RightParen, None,
+                                    Throws, Arrow, Int, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "(x: Int, y: Int) throws -> Int");
   }
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto TypeList = SyntaxFactory::makeTupleTypeElementList({
-      IntArg.withTrailingComma(Comma),
-      IntArg
-    });
-    SyntaxFactory::makeFunctionType(LeftParen,
-                                    TypeList,
-                                    RightParen,
-                                    None,
-                                    Rethrows,
-                                    Arrow,
-                                    Int).print(OS);
+    auto TypeList = SyntaxFactory::makeTupleTypeElementList(
+        {IntArg.withTrailingComma(Comma), IntArg}, Arena);
+    SyntaxFactory::makeFunctionType(LeftParen, TypeList, RightParen, None,
+                                    Rethrows, Arrow, Int, Arena)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "(Int, Int) rethrows -> Int");
   }
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList();
-    auto Void = SyntaxFactory::makeVoidTupleType();
-    SyntaxFactory::makeFunctionType(LeftParen,
-                                    TypeList,
-                                    RightParen,
-                                    None,
-                                    TokenSyntax::missingToken(tok::kw_throws,
-                                                              "throws"),
-                                    Arrow,
-                                    Void).print(OS);
+    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList(Arena);
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
+    SyntaxFactory::makeFunctionType(
+        LeftParen, TypeList, RightParen, None,
+        TokenSyntax::missingToken(tok::kw_throws, "throws", Arena), Arrow, Void,
+        Arena)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "() -> ()");
   }
-} 
+}
 
 TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto RightParen = SyntaxFactory::makeRightParenToken("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-  auto IntArg = SyntaxFactory::makeTupleTypeElement(None, None, None, None,
-                                                    Int, None, None, None);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ");
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto RightParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+  auto IntArg = SyntaxFactory::makeTupleTypeElement(None, None, None, None, Int,
+                                                    None, None, None, Arena);
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
+  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ", Arena);
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto x = SyntaxFactory::makeIdentifier("x", "", "");
-    auto y = SyntaxFactory::makeIdentifier("y", "", "");
-    auto Colon = SyntaxFactory::makeColonToken("", " ");
-    auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon,
-                                                    Int, None, None, Comma);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon,
-                                                    Int, None, None, None);
+    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
+    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+    auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon, Int,
+                                                    None, None, Comma, Arena);
+    auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon, Int,
+                                                    None, None, None, Arena);
 
-    SyntaxFactory::makeBlankFunctionType()
-      .withLeftParen(LeftParen)
-      .addArgument(xArg)
-      .addArgument(yArg)
-      .withRightParen(RightParen)
-      .withThrowsOrRethrowsKeyword(Throws)
-      .withArrow(Arrow)
-      .withReturnType(Int)
-      .print(OS);
+    SyntaxFactory::makeBlankFunctionType(Arena)
+        .withLeftParen(LeftParen)
+        .addArgument(xArg)
+        .addArgument(yArg)
+        .withRightParen(RightParen)
+        .withThrowsOrRethrowsKeyword(Throws)
+        .withArrow(Arrow)
+        .withReturnType(Int)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "(x: Int, y: Int) throws -> Int");
 
 
@@ -599,52 +615,53 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionType()
-      .withLeftParen(LeftParen)
-      .withRightParen(RightParen)
-      .addArgument(IntArg.withTrailingComma(Comma))
-      .addArgument(IntArg)
-      .withThrowsOrRethrowsKeyword(Rethrows)
-      .withArrow(Arrow)
-      .withReturnType(Int)
-      .print(OS);
+    SyntaxFactory::makeBlankFunctionType(Arena)
+        .withLeftParen(LeftParen)
+        .withRightParen(RightParen)
+        .addArgument(IntArg.withTrailingComma(Comma))
+        .addArgument(IntArg)
+        .withThrowsOrRethrowsKeyword(Rethrows)
+        .withArrow(Arrow)
+        .withReturnType(Int)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "(Int, Int) rethrows -> Int");
   }
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto Void = SyntaxFactory::makeVoidTupleType();
-    SyntaxFactory::makeBlankFunctionType()
-      .withLeftParen(LeftParen)
-      .withRightParen(RightParen)
-      .withArrow(Arrow)
-      .withReturnType(Void)
-      .print(OS);
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
+    SyntaxFactory::makeBlankFunctionType(Arena)
+        .withLeftParen(LeftParen)
+        .withRightParen(RightParen)
+        .withArrow(Arrow)
+        .withReturnType(Void)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "() -> ()");
   }
 }
 
 TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
-  auto Comma = SyntaxFactory::makeCommaToken("", " ");
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "");
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "");
-  auto RightParen = SyntaxFactory::makeRightParenToken("", " ");
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ");
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ");
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ");
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  auto RightParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
+  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
+  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ", Arena);
+  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    FunctionTypeSyntaxBuilder Builder;
-    auto x = SyntaxFactory::makeIdentifier("x", "", "");
-    auto y = SyntaxFactory::makeIdentifier("y", "", "");
-    auto Colon = SyntaxFactory::makeColonToken("", " ");
-    auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon,
-                                                    Int, None, None, Comma);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon,
-                                                    Int, None, None, None);
+    FunctionTypeSyntaxBuilder Builder(Arena);
+    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
+    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
+    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
+    auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon, Int,
+                                                    None, None, Comma, Arena);
+    auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon, Int,
+                                                    None, None, None, Arena);
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
@@ -661,9 +678,9 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    FunctionTypeSyntaxBuilder Builder;
-    auto IntArg = SyntaxFactory::makeTupleTypeElement(None, None, None, None,
-                                                      Int, None, None, None);
+    FunctionTypeSyntaxBuilder Builder(Arena);
+    auto IntArg = SyntaxFactory::makeTupleTypeElement(
+        None, None, None, None, Int, None, None, None, Arena);
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
       .addArgument(IntArg.withTrailingComma(Comma))
@@ -679,8 +696,8 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    FunctionTypeSyntaxBuilder Builder;
-    auto Void = SyntaxFactory::makeVoidTupleType();
+    FunctionTypeSyntaxBuilder Builder(Arena);
+    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -38,14 +38,14 @@ def make_missing_child(child):
         tok_kind = token.kind if token else "unknown"
         tok_text = token.text if token else ""
         return \
-            'RawSyntax::missing(tok::%s, "%s")' % \
+            'RawSyntax::missing(tok::%s, "%s", Arena)' % \
             (tok_kind, tok_text)
     else:
         missing_kind = "Unknown" if child.syntax_kind == "Syntax" \
                        else child.syntax_kind
         if child.node_choices:
             return make_missing_child(child.node_choices[0])
-        return 'RawSyntax::missing(SyntaxKind::%s)' % missing_kind
+        return 'RawSyntax::missing(SyntaxKind::%s, Arena)' % missing_kind
 
 
 def check_child_condition_raw(child):
@@ -53,7 +53,7 @@ def check_child_condition_raw(child):
     Generates a C++ closure to check whether a given raw syntax node can
     satisfy the requirements of child.
     """
-    result = '[](const RC<RawSyntax> &Raw) {\n'
+    result = '[](const RawSyntax *Raw) {\n'
     result += ' // check %s\n' % child.name
     if child.token_choices:
         result += 'if (!Raw->isToken()) return false;\n'


### PR DESCRIPTION
Instead, only reference count the `SyntaxArena` that the `RawSyntax` nodes live in. The user of `RawSyntax` nodes must guarantee that the `SyntaxArena` stays alive as long as the `RawSyntax` nodes are being accessed.

During parse time, the `SyntaxTreeCreator` holds on to the `SyntaxArena` in which it creates `RawSyntax` nodes. When inspecting a syntax tree, the root `SyntaxData` node keeps the `SyntaxArena` alive. The change should  be mostly invisible to the users of the public libSyntax API.

This change significantly decreases the overall reference-counting  overhead. Since we were not able to free individual `RawSyntax` nodes anyway, performing the reference-counting on the level of the `SyntaxArena` feels natural.

70% of all changes are just adjustments in `unittests/Syntax` The actual logic change is fairly small (<400 LOC).