### PR TITLE
[build] Use CMAKE_SYSTEM_PROCESSOR for better cross-arch compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,7 +797,7 @@ elseif("${SWIFT_HOST_VARIANT_SDK}" MATCHES "(OSX|IOS*|TVOS*|WATCHOS*)")
   #
   # Primary variant is always OSX; even on iOS hosts.
   set(SWIFT_PRIMARY_VARIANT_SDK_default "OSX")
-  set(SWIFT_PRIMARY_VARIANT_ARCH_default "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+  set(SWIFT_PRIMARY_VARIANT_ARCH_default "${CMAKE_SYSTEM_PROCESSOR}")
 
 endif()
 


### PR DESCRIPTION
When trying to cross compile from an Intel Mac to a Arm64 Mac, the usage
of CMAKE_HOST_SYSTEM_PROCESSOR makes the default value for the stdlib to
be x86_64, when it should be arm64, or the arm64 targets for the stdlib
will not be created and the CMake configuration will have a missing
target and not finish successfully.

Using CMAKE_SYSTEM_PROCESSOR uses the override that one can provide from
the command line, and it will correctly configure the compiler and the
stdlib to target Arm64 Macs.