### PR TITLE
Sema: Fix conformance checking for 'rethrows' protocol requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2232,6 +2232,9 @@ NOTE(protocol_witness_settable_conflict,none,
      "candidate is not settable, but protocol requires it", ())
 NOTE(protocol_witness_rethrows_conflict,none,
      "candidate is not 'rethrows', but protocol requires it", ())
+NOTE(protocol_witness_rethrows_by_conformance_conflict,none,
+     "candidate is 'rethrows' via a conformance, "
+     "but the protocol requirement is not from a '@rethrows' protocol", ())
 NOTE(protocol_witness_throws_conflict,none,
      "candidate throws, but protocol does not allow it", ())
 NOTE(protocol_witness_not_objc,none,

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -242,22 +242,19 @@ private:
     ParamDecl *TheParameter;
     Expr *TheExpr;
   };
-  unsigned TheKind : 2;
-  unsigned ParamCount : 2;
+  Kind TheKind;
   PolymorphicEffectKind RethrowingKind;
   SubstitutionMap Substitutions;
 
 public:
   explicit AbstractFunction(Kind kind, Expr *fn)
     : TheKind(kind),
-      ParamCount(1),
       RethrowingKind(PolymorphicEffectKind::None) {
     TheExpr = fn;
   }
 
   explicit AbstractFunction(AbstractFunctionDecl *fn, SubstitutionMap subs)
     : TheKind(Kind::Function),
-      ParamCount(fn->getNumCurryLevels()),
       RethrowingKind(fn->getPolymorphicEffectKind(EffectKind::Throws)),
       Substitutions(subs) {
     TheFunction = fn;
@@ -265,46 +262,31 @@ public:
 
   explicit AbstractFunction(AbstractClosureExpr *closure)
     : TheKind(Kind::Closure),
-      ParamCount(1),
       RethrowingKind(PolymorphicEffectKind::None) {
     TheClosure = closure;
   }
 
   explicit AbstractFunction(ParamDecl *parameter)
     : TheKind(Kind::Parameter),
-      ParamCount(1),
       RethrowingKind(PolymorphicEffectKind::None) {
     TheParameter = parameter;
   }
 
-  Kind getKind() const { return Kind(TheKind); }
-
-  /// Whether the function is marked 'rethrows'.
-  bool isBodyRethrows() const {
-    switch (RethrowingKind) {
-    case PolymorphicEffectKind::None:
-    case PolymorphicEffectKind::Always:
-      return false;
-
-    case PolymorphicEffectKind::ByClosure:
-    case PolymorphicEffectKind::ByConformance:
-    case PolymorphicEffectKind::Invalid:
-      return true;
-    }
-  }
+  Kind getKind() const { return TheKind; }
 
   PolymorphicEffectKind getRethrowingKind() const {
     return RethrowingKind;
   }
 
-  unsigned getNumArgumentsForFullApply() const {
-    return ParamCount;
-  }
-
   Type getType() const {
     switch (getKind()) {
     case Kind::Opaque: return getOpaqueFunction()->getType();
-    case Kind::Function: return getFunction()->getInterfaceType();
+    case Kind::Function: {
+      auto *AFD = getFunction();
+      if (AFD->hasImplicitSelfDecl())
+        return AFD->getMethodInterfaceType();
+      return AFD->getInterfaceType();
+    }
     case Kind::Closure: return getClosure()->getType();
     case Kind::Parameter: return getParameter()->getType();
     }
@@ -339,23 +321,20 @@ public:
   }
 
   static AbstractFunction decomposeApply(ApplyExpr *apply,
-                           SmallVectorImpl<SmallVector<Expr *, 2>> &argLists) {
-    Expr *fn;
-    do {
-      auto *argExpr = apply->getArg();
-      if (auto *tupleExpr = dyn_cast<TupleExpr>(argExpr)) {
-        auto args = tupleExpr->getElements();
-        argLists.emplace_back(args.begin(), args.end());
-      } else if (auto *parenExpr = dyn_cast<ParenExpr>(argExpr)) {
-        argLists.emplace_back();
-        argLists.back().push_back(parenExpr->getSubExpr());
-      } else {
-        argLists.emplace_back();
-        argLists.back().push_back(argExpr);
-      }
+                                         SmallVectorImpl<Expr *> &args) {
+    auto *argExpr = apply->getArg();
+    if (auto *tupleExpr = dyn_cast<TupleExpr>(argExpr)) {
+      auto elts = tupleExpr->getElements();
+      args.append(elts.begin(), elts.end());
+    } else {
+      auto *parenExpr = cast<ParenExpr>(argExpr);
+      args.push_back(parenExpr->getSubExpr());
+    }
 
-      fn = apply->getFn()->getValueProvidingExpr();
-    } while ((apply = dyn_cast<ApplyExpr>(fn)));
+    Expr *fn = apply->getFn()->getValueProvidingExpr();
+
+    if (auto *selfCall = dyn_cast<SelfApplyExpr>(fn))
+      fn = selfCall->getFn()->getValueProvidingExpr();
 
     return decomposeFunction(fn);
   }
@@ -705,6 +684,9 @@ public:
 
   /// Check to see if the given function application throws or is async.
   Classification classifyApply(ApplyExpr *E) {
+    if (isa<SelfApplyExpr>(E))
+      return Classification();
+
     // An apply expression is a potential throw site if the function throws.
     // But if the expression didn't type-check, suppress diagnostics.
     if (!E->getType() || E->getType()->hasError())
@@ -716,16 +698,15 @@ public:
     if (!fnType) return Classification::forInvalidCode();
 
     bool isAsync = fnType->isAsync() || E->implicitlyAsync();
+
     // Decompose the application.
-    SmallVector<SmallVector<Expr *, 2>, 2> argLists;
-    auto fnRef = AbstractFunction::decomposeApply(E, argLists);
+    SmallVector<Expr *, 2> args;
+    auto fnRef = AbstractFunction::decomposeApply(E, args);
 
     // If any of the arguments didn't type check, fail.
-    for (auto argList : argLists) {
-      for (auto *arg : argList) {
-        if (!arg->getType() || arg->getType()->hasError())
-          return Classification::forInvalidCode();
-      }
+    for (auto *arg : args) {
+      if (!arg->getType() || arg->getType()->hasError())
+        return Classification::forInvalidCode();
     }
 
     // If the function doesn't throw at all, we're done here.
@@ -733,31 +714,9 @@ public:
       return isAsync ? Classification::forAsync() : Classification();
     }
 
-    // If we're applying more arguments than the natural argument
-    // count, then this is a call to the opaque value returned from
-    // the function.
-    if (argLists.size() != fnRef.getNumArgumentsForFullApply()) {
-      // Special case: a reference to an operator within a type might be
-      // missing 'self'.
-      // FIXME: The issue here is that this is an ill-formed expression, but
-      // we don't know it from the structure of the expression.
-      if (argLists.size() == 1 && fnRef.getKind() == AbstractFunction::Function &&
-          isa<FuncDecl>(fnRef.getFunction()) &&
-          cast<FuncDecl>(fnRef.getFunction())->isOperator() &&
-          fnRef.getNumArgumentsForFullApply() == 2 &&
-          fnRef.getFunction()->getDeclContext()->isTypeContext()) {
-        // Can only happen with invalid code.
-        assert(fnRef.getFunction()->getASTContext().Diags.hadAnyError());
-        return Classification::forInvalidCode();
-      }
-
-      assert(argLists.size() > fnRef.getNumArgumentsForFullApply() &&
-             "partial application was throwing?");
-      return Classification::forThrow(PotentialThrowReason::forThrowingApply(),
-                                      isAsync);
-    }
-
-    if (fnRef.getRethrowingKind() == PolymorphicEffectKind::ByConformance) {
+    // Handle rethrowing functions.
+    switch (fnRef.getRethrowingKind()) {
+    case PolymorphicEffectKind::ByConformance: {
       auto substitutions = fnRef.getSubstitutions();
       for (auto conformanceRef : substitutions.getConformances()) {
         if (conformanceRef.hasEffect(EffectKind::Throws)) {
@@ -765,37 +724,38 @@ public:
             PotentialThrowReason::forRethrowsConformance(E), isAsync);
         }
       }
+
+      // 'ByConformance' is a superset of 'ByClosure', so check for
+      // closure arguments too.
+      LLVM_FALLTHROUGH;
     }
 
-    // If the function's body is 'rethrows' for the number of
-    // arguments we gave it, apply the rethrows logic.
-    if (fnRef.isBodyRethrows()) {
+    case PolymorphicEffectKind::ByClosure: {
       // We need to walk the original parameter types in parallel
       // because it only counts for 'rethrows' purposes if it lines up
       // with a throwing function parameter in the original type.
-      Type type = fnRef.getType();
-      if (!type) return Classification::forInvalidCode();
+      auto *origType = fnRef.getType()->getAs<AnyFunctionType>();
+      if (!origType)
+        return Classification::forInvalidCode();
 
       // Use the most significant result from the arguments.
       Classification result = isAsync ? Classification::forAsync() 
                                       : Classification();
-      for (auto argList : llvm::reverse(argLists)) {
-        auto fnType = type->getAs<AnyFunctionType>();
-        if (!fnType)
-          return Classification::forInvalidCode();
 
-        auto params = fnType->getParams();
-        if (params.size() != argList.size())
-          return Classification::forInvalidCode();
+      auto params = origType->getParams();
+      if (params.size() != args.size())
+        return Classification::forInvalidCode();
 
-        for (unsigned i = 0, e = params.size(); i < e; ++i) {
-          result.merge(classifyRethrowsArgument(argList[i],
-                                                params[i].getParameterType()));
-        }
-
-        type = fnType->getResult();
+      for (unsigned i = 0, e = params.size(); i < e; ++i) {
+        result.merge(classifyRethrowsArgument(args[i],
+                                              params[i].getParameterType()));
       }
+
       return result;
+    }
+
+    default:
+      break;
     }
 
     // Try to classify the implementation of functions that we have

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -558,25 +558,39 @@ swift::matchWitness(
     if (!funcReq->isMutating() && funcWitness->isMutating())
       return RequirementMatch(witness, MatchKind::MutatingConflict);
 
-    // If the requirement is rethrows, the witness must either be
-    // rethrows or be non-throwing if the requirement is not by conformance
-    // else the witness can be by conformance, throwing or non throwing
-    if (reqAttrs.hasAttribute<RethrowsAttr>() &&
-        !witnessAttrs.hasAttribute<RethrowsAttr>()) {
+    // If the requirement has an explicit 'rethrows' argument, the witness
+    // must be 'rethrows', too.
+    if (reqAttrs.hasAttribute<RethrowsAttr>()) {
       auto reqRethrowingKind =
           funcReq->getPolymorphicEffectKind(EffectKind::Throws);
       auto witnessRethrowingKind =
           funcWitness->getPolymorphicEffectKind(EffectKind::Throws);
-      if (reqRethrowingKind == PolymorphicEffectKind::ByConformance) {
-        switch (witnessRethrowingKind) {
-        case PolymorphicEffectKind::ByConformance:
-        case PolymorphicEffectKind::Always:
-        case PolymorphicEffectKind::None:
+
+      assert(reqRethrowingKind != PolymorphicEffectKind::Always &&
+             reqRethrowingKind != PolymorphicEffectKind::None);
+
+      switch (witnessRethrowingKind) {
+      case PolymorphicEffectKind::None:
+      case PolymorphicEffectKind::Invalid:
+      case PolymorphicEffectKind::ByClosure:
+        break;
+
+      case PolymorphicEffectKind::ByConformance: {
+        // A by-conformance `rethrows` witness cannot witness a
+        // by-conformance `rethrows` requirement unless the protocol
+        // is @rethrows. Otherwise, we don't have enough information
+        // at the call site to assess if the conformance actually
+        // throws or not.
+        auto *proto = cast<ProtocolDecl>(req->getDeclContext());
+        if (reqRethrowingKind == PolymorphicEffectKind::ByConformance &&
+            proto->hasPolymorphicEffect(EffectKind::Throws))
           break;
-        default:
-          return RequirementMatch(witness, MatchKind::RethrowsConflict);
-        }
-      } else if (cast<AbstractFunctionDecl>(witness)->hasThrows()) {
+
+        return RequirementMatch(witness,
+                                MatchKind::RethrowsByConformanceConflict);
+      }
+
+      case PolymorphicEffectKind::Always:
         return RequirementMatch(witness, MatchKind::RethrowsConflict);
       }
     }
@@ -2523,6 +2537,13 @@ diagnoseMatch(ModuleDecl *module, NormalProtocolConformance *conformance,
         diags.diagnose(witness, diag::protocol_witness_rethrows_conflict);
     auto FD = cast<FuncDecl>(witness);
     diag.fixItReplace(FD->getThrowsLoc(), getTokenText(tok::kw_rethrows));
+    break;
+  }
+  case MatchKind::RethrowsByConformanceConflict: {
+    auto witness = match.Witness;
+    auto diag =
+        diags.diagnose(witness,
+                       diag::protocol_witness_rethrows_by_conformance_conflict);
     break;
   }
   case MatchKind::NonObjC:

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -263,8 +263,12 @@ enum class MatchKind : uint8_t {
   /// The witness did not match because of __consuming conflicts.
   ConsumingConflict,
 
-  /// The witness is not rethrows, but the requirement is.
+  /// The witness throws unconditionally, but the requirement rethrows.
   RethrowsConflict,
+
+  /// The witness rethrows via conformance, but the requirement rethrows
+  /// via closure and is not in a '@rethrows' protocol.
+  RethrowsByConformanceConflict,
 
   /// The witness is explicitly @nonobjc but the requirement is @objc.
   NonObjC,
@@ -498,6 +502,7 @@ struct RequirementMatch {
     case MatchKind::NonMutatingConflict:
     case MatchKind::ConsumingConflict:
     case MatchKind::RethrowsConflict:
+    case MatchKind::RethrowsByConformanceConflict:
     case MatchKind::AsyncConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:
@@ -530,6 +535,7 @@ struct RequirementMatch {
     case MatchKind::NonMutatingConflict:
     case MatchKind::ConsumingConflict:
     case MatchKind::RethrowsConflict:
+    case MatchKind::RethrowsByConformanceConflict:
     case MatchKind::AsyncConflict:
     case MatchKind::ThrowsConflict:
     case MatchKind::NonObjC:


### PR DESCRIPTION
A protocol requirement in a non-'@rethrows' protocol cannot be
witnessed by a rethrows-via-conformance witness, because there
is not enough information at a potential call site of the
protocol requirement to determine if the witness uses a
rethrows source or not.