### PR TITLE
Concrete SIMD operations, part 1

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -225,6 +225,7 @@ set(SWIFTLIB_SOURCES
 
 set(SWIFTLIB_GYB_SOURCES
   ${SWIFTLIB_ESSENTIAL_GYB_SOURCES}
+  SIMDConcreteOperations.swift.gyb
   SIMDVectorTypes.swift.gyb
   Tuple.swift.gyb
   )

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -169,6 +169,7 @@
       "FloatingPointTypes.swift",
       "FloatingPointRandom.swift"],
     "Vector": [
+      "SIMDConcreteOperations.swift",
       "SIMDVector.swift",
       "SIMDVectorTypes.swift"]}
   ],

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -126,6 +126,24 @@ extension SIMD${n} where Scalar == ${Scalar} {
       Builtin.cmp_${s}ge_${Builtin}(a._storage._value, b._storage._value)
     )
   }
+    
+  /// The wrapping sum of two vectors.
+  @_alwaysEmitIntoClient
+  public static func &+(a: Self, b: Self) -> Self{
+    Self(Builtin.add_${Builtin}(a._storage._value, b._storage._value))
+  }
+    
+  /// The wrapping difference of two vectors.
+  @_alwaysEmitIntoClient
+  public static func &-(a: Self, b: Self) -> Self{
+    Self(Builtin.sub_${Builtin}(a._storage._value, b._storage._value))
+  }
+    
+  /// The pointwise wrapping product of two vectors.
+  @_alwaysEmitIntoClient
+  public static func &*(a: Self, b: Self) -> Self{
+    Self(Builtin.mul_${Builtin}(a._storage._value, b._storage._value))
+  }
 }
 
 % end
@@ -192,6 +210,30 @@ extension SIMD${n} where Scalar == ${Scalar} {
     SIMDMask<MaskStorage>(
       Builtin.fcmp_oge_${Builtin}(a._storage._value, b._storage._value)
     )
+  }
+    
+  /// The sum of two vectors.
+  @_alwaysEmitIntoClient
+  public static func +(a: Self, b: Self) -> Self{
+    Self(Builtin.fadd_${Builtin}(a._storage._value, b._storage._value))
+  }
+    
+  /// The difference of two vectors.
+  @_alwaysEmitIntoClient
+  public static func -(a: Self, b: Self) -> Self{
+    Self(Builtin.fsub_${Builtin}(a._storage._value, b._storage._value))
+  }
+    
+  /// The pointwise product of two vectors.
+  @_alwaysEmitIntoClient
+  public static func *(a: Self, b: Self) -> Self{
+    Self(Builtin.fmul_${Builtin}(a._storage._value, b._storage._value))
+  }
+    
+  /// The pointwise quotient of two vectors.
+  @_alwaysEmitIntoClient
+  public static func /(a: Self, b: Self) -> Self{
+    Self(Builtin.fdiv_${Builtin}(a._storage._value, b._storage._value))
   }
 }
 %  if bits == 16:

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -1,0 +1,202 @@
+//===--- SIMDConcreteOperations.swift -------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+%{
+from __future__ import division
+from SwiftIntTypes import all_integer_types
+word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+storagescalarCounts = [2,4,8,16,32,64]
+vectorscalarCounts = storagescalarCounts + [3]
+}%
+
+%for int in all_integer_types(word_bits):
+% Scalar = int.stdlib_name
+% for n in vectorscalarCounts:
+%  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
+%  storageN = 4 if n == 3 else n
+%  s = "s" if int.is_signed else "u"
+%  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
+%  if int.is_signed:
+extension SIMDMask where Storage == ${Vector} {
+  @_alwaysEmitIntoClient
+  internal init(_ _builtin: Builtin.Vec${storageN}xInt1) {
+    _storage = ${Vector}(Builtin.sext_Vec${storageN}xInt1_${Builtin}(_builtin))
+  }
+  
+  @_alwaysEmitIntoClient
+  internal static var allTrue: Self {
+    let zero = ${Vector}()
+    return zero .== zero
+  }
+  
+  /// A vector mask that is the boolean negation of the input.
+  @_alwaysEmitIntoClient
+  public static prefix func .!(a: Self) -> Self {
+    a .^ .allTrue
+  }
+    
+  /// A vector mask that is the boolean conjunction of the inputs.
+  @_alwaysEmitIntoClient
+  public static func .&(a: Self, b: Self) -> Self {
+    Self(${Vector}(Builtin.and_${Builtin}(
+      a._storage._storage._value,
+      b._storage._storage._value
+    )))
+  }
+      
+  /// A vector mask that is the exclusive or of the inputs.
+  @_alwaysEmitIntoClient
+  public static func .^(a: Self, b: Self) -> Self {
+    Self(${Vector}(Builtin.xor_${Builtin}(
+      a._storage._storage._value,
+      b._storage._storage._value
+    )))
+  }
+      
+  /// A vector mask that is the boolean disjunction of the inputs.
+  @_alwaysEmitIntoClient
+  public static func .|(a: Self, b: Self) -> Self {
+    Self(${Vector}(Builtin.or_${Builtin}(
+      a._storage._storage._value,
+      b._storage._storage._value
+    )))
+  }
+}
+
+%  end
+extension SIMD${n} where Scalar == ${Scalar} {
+  @_alwaysEmitIntoClient
+  internal init(_ _builtin: Builtin.${Builtin}) {
+    _storage = ${Scalar}.SIMD${storageN}Storage(_builtin)
+  }
+    
+  /// A vector mask with the result of a pointwise equality comparison.
+  @_alwaysEmitIntoClient
+  public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.cmp_eq_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise inequality comparison.
+  @_alwaysEmitIntoClient
+  public static func .!=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.cmp_ne_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise less-than comparison.
+  @_alwaysEmitIntoClient
+  public static func .<(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.cmp_${s}lt_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise less-than-or-equal-to comparison.
+  @_alwaysEmitIntoClient
+  public static func .<=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.cmp_${s}le_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise greater-than comparison.
+  @_alwaysEmitIntoClient
+  public static func .>(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.cmp_${s}gt_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise greater-than-or-equal-to comparison.
+  @_alwaysEmitIntoClient
+  public static func .>=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.cmp_${s}ge_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+}
+
+% end
+%end
+
+%for (Scalar, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
+% for n in vectorscalarCounts:
+%  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
+%  storageN = 4 if n == 3 else n
+%  Builtin = "Vec" + str(storageN) + "xFPIEEE" + str(bits)
+%  if bits == 16:
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+%  end
+extension SIMD${n} where Scalar == ${Scalar} {
+  @_alwaysEmitIntoClient
+  internal init(_ _builtin: Builtin.${Builtin}) {
+    _storage = ${Scalar}.SIMD${storageN}Storage(_builtin)
+  }
+  
+  /// A vector mask with the result of a pointwise equality comparison.
+  @_alwaysEmitIntoClient
+  public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.fcmp_oeq_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise inequality comparison.
+  @_alwaysEmitIntoClient
+  public static func .!=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.fcmp_une_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise less-than comparison.
+  @_alwaysEmitIntoClient
+  public static func .<(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.fcmp_olt_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise less-than-or-equal-to comparison.
+  @_alwaysEmitIntoClient
+  public static func .<=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.fcmp_ole_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise greater-than comparison.
+  @_alwaysEmitIntoClient
+  public static func .>(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.fcmp_ogt_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+  
+  /// A vector mask with the result of a pointwise greater-than-or-equal-to comparison.
+  @_alwaysEmitIntoClient
+  public static func .>=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    SIMDMask<MaskStorage>(
+      Builtin.fcmp_oge_${Builtin}(a._storage._value, b._storage._value)
+    )
+  }
+}
+%  if bits == 16:
+#endif
+%  end
+
+% end
+%end

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -211,30 +211,6 @@ extension SIMD${n} where Scalar == ${Scalar} {
       Builtin.fcmp_oge_${Builtin}(a._storage._value, b._storage._value)
     )
   }
-    
-  /// The sum of two vectors.
-  @_alwaysEmitIntoClient
-  public static func +(a: Self, b: Self) -> Self{
-    Self(Builtin.fadd_${Builtin}(a._storage._value, b._storage._value))
-  }
-    
-  /// The difference of two vectors.
-  @_alwaysEmitIntoClient
-  public static func -(a: Self, b: Self) -> Self{
-    Self(Builtin.fsub_${Builtin}(a._storage._value, b._storage._value))
-  }
-    
-  /// The pointwise product of two vectors.
-  @_alwaysEmitIntoClient
-  public static func *(a: Self, b: Self) -> Self{
-    Self(Builtin.fmul_${Builtin}(a._storage._value, b._storage._value))
-  }
-    
-  /// The pointwise quotient of two vectors.
-  @_alwaysEmitIntoClient
-  public static func /(a: Self, b: Self) -> Self{
-    Self(Builtin.fdiv_${Builtin}(a._storage._value, b._storage._value))
-  }
 }
 %  if bits == 16:
 #endif

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -129,21 +129,36 @@ extension SIMD${n} where Scalar == ${Scalar} {
     
   /// The wrapping sum of two vectors.
   @_alwaysEmitIntoClient
-  public static func &+(a: Self, b: Self) -> Self{
+  public static func &+(a: Self, b: Self) -> Self {
     Self(Builtin.add_${Builtin}(a._storage._value, b._storage._value))
   }
     
   /// The wrapping difference of two vectors.
   @_alwaysEmitIntoClient
-  public static func &-(a: Self, b: Self) -> Self{
+  public static func &-(a: Self, b: Self) -> Self {
     Self(Builtin.sub_${Builtin}(a._storage._value, b._storage._value))
   }
     
   /// The pointwise wrapping product of two vectors.
   @_alwaysEmitIntoClient
-  public static func &*(a: Self, b: Self) -> Self{
+  public static func &*(a: Self, b: Self) -> Self {
     Self(Builtin.mul_${Builtin}(a._storage._value, b._storage._value))
   }
+        
+  /// Updates the left hand side with the wrapping sum of the two
+  /// vectors.
+  @_alwaysEmitIntoClient
+  public static func &+=(a: inout Self, b: Self) { a = a &+ b }
+    
+  /// Updates the left hand side with the wrapping difference of the two
+  /// vectors.
+  @_alwaysEmitIntoClient
+  public static func &-=(a: inout Self, b: Self) { a = a &- b }
+    
+  /// Updates the left hand side with the pointwise wrapping product of two
+  /// vectors.
+  @_alwaysEmitIntoClient
+  public static func &*=(a: inout Self, b: Self) { a = a &* b }
 }
 
 % end

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -152,7 +152,7 @@ extension SIMD {
     }
   }
   
-  /// Returns a vector mask with the result of a pointwise equality comparison.
+  /// A vector mask with the result of a pointwise equality comparison.
   @_transparent
   public static func .==(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
@@ -822,6 +822,8 @@ extension SIMD where Scalar: FloatingPoint {
     return result
   }
   
+  /// A vector formed by rounding each lane of the source vector to an integral
+  /// value according to the specified rounding `rule`.
   @_transparent
   public func rounded(_ rule: FloatingPointRoundingRule) -> Self {
     var result = Self()
@@ -829,19 +831,19 @@ extension SIMD where Scalar: FloatingPoint {
     return result
   }
   
-  /// Returns the least scalar in the vector.
+  /// The least scalar in the vector.
   @_alwaysEmitIntoClient
   public func min() -> Scalar {
     return indices.reduce(into: self[0]) { $0 = Scalar.minimum($0, self[$1]) }
   }
   
-  /// Returns the greatest scalar in the vector.
+  /// The greatest scalar in the vector.
   @_alwaysEmitIntoClient
   public func max() -> Scalar {
     return indices.reduce(into: self[0]) { $0 = Scalar.maximum($0, self[$1]) }
   }
   
-  /// Returns the sum of the scalars in the vector.
+  /// The sum of the scalars in the vector.
   @_alwaysEmitIntoClient
   public func sum() -> Scalar {
     // Implementation note: this eventually be defined to lower to either

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -234,6 +234,11 @@ extension ${Self}: SIMDScalar {
     public init() {
       _value = Builtin.zeroInitializer()
     }
+    
+    @_alwaysEmitIntoClient
+    internal init(_ _builtin: Builtin.Vec${n}x${BuiltinName}) {
+      _value = _builtin
+    }
 
     public subscript(index: Int) -> ${Self} {
       @_transparent
@@ -282,6 +287,11 @@ extension ${Self} : SIMDScalar {
     @_transparent
     public init() {
       _value = Builtin.zeroInitializer()
+    }
+    
+    @_alwaysEmitIntoClient
+    internal init(_ _builtin: Builtin.Vec${n}xFPIEEE${bits}) {
+      _value = _builtin
     }
 
     public subscript(index: Int) -> ${Self} {

--- a/test/stdlib/SIMDConcreteFP.swift.gyb
+++ b/test/stdlib/SIMDConcreteFP.swift.gyb
@@ -1,0 +1,86 @@
+//===--- SIMDConcreteFP.swift.gyb -----------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %empty-directory(%t)
+// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/SIMDConcreteFP.swift
+// RUN: %line-directive %t/SIMDConcreteFP.swift -- %target-build-swift %t/SIMDConcreteFP.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %line-directive %t/SIMDConcreteFP.swift -- %target-run %t/a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+func genericComparisons<T>(
+  _ a: T, _ b: T
+) -> (
+  eq: SIMDMask<T.MaskStorage>,
+  ne: SIMDMask<T.MaskStorage>,
+  lt: SIMDMask<T.MaskStorage>,
+  le: SIMDMask<T.MaskStorage>,
+  gt: SIMDMask<T.MaskStorage>,
+  ge: SIMDMask<T.MaskStorage>
+) where T: SIMD, T.Scalar: Comparable {(
+  eq: a .== b,
+  ne: a .!= b,
+  lt: a .<  b,
+  le: a .<= b,
+  gt: a .>  b,
+  ge: a .>= b
+)}
+
+%for (Scalar, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
+% for n in [2,3,4,8,16,32,64]:
+%  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
+%  storageN = 4 if n == 3 else n
+%  Builtin = "Vec" + str(storageN) + "xFPIEEE" + str(bits)
+var ${Scalar}x${n}_TestSuite = TestSuite("${Scalar}x${n}")
+
+%  if bits == 16:
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+%  end
+${Scalar}x${n}_TestSuite.test("comparisons") {
+%  if bits == 16:
+  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+%  end
+  let a = ${Vector}.random(in: -1 ..< 1)
+  let ap1 = a + ${Vector}(repeating: 1)
+  expectTrue(all(a .== a))
+  expectFalse(any(a .!= a))
+  expectFalse(any(a .== ap1))
+  expectTrue(all(a .!= ap1))
+  expectTrue(all(a .< ap1))
+  expectTrue(all(a .<= ap1))
+  expectFalse(any(a .> ap1))
+  expectFalse(any(a .>= ap1))
+  
+  let b = a.replacing(
+    with: ${Vector}.random(in: -1 ..< 1),
+    where: .random()
+  )
+  let (eq,ne,lt,le,gt,ge) = genericComparisons(a, b)
+  expectEqual(eq, a .== b)
+  expectEqual(ne, a .!= b)
+  expectEqual(lt, a .<  b)
+  expectEqual(le, a .<= b)
+  expectEqual(gt, a .>  b)
+  expectEqual(ge, a .>= b)
+%  if bits == 16:
+  }
+%  end
+}
+%  if bits == 16:
+  #endif
+%  end
+
+% end
+%end
+
+runAllTests()

--- a/test/stdlib/SIMDConcreteIntegers.swift.gyb
+++ b/test/stdlib/SIMDConcreteIntegers.swift.gyb
@@ -1,0 +1,98 @@
+//===--- SIMDConcreteIntegers.swift.gyb -----------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %empty-directory(%t)
+// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/SIMDConcreteIntegers.swift
+// RUN: %line-directive %t/SIMDConcreteIntegers.swift -- %target-build-swift %t/SIMDConcreteIntegers.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %line-directive %t/SIMDConcreteIntegers.swift -- %target-run %t/a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+%{
+from __future__ import division
+from SwiftIntTypes import all_integer_types
+word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+storagescalarCounts = [2,4,8,16,32,64]
+vectorscalarCounts = storagescalarCounts + [3]
+}%
+
+func genericComparisons<T>(
+  _ a: T, _ b: T
+) -> (
+  eq: SIMDMask<T.MaskStorage>,
+  ne: SIMDMask<T.MaskStorage>,
+  lt: SIMDMask<T.MaskStorage>,
+  le: SIMDMask<T.MaskStorage>,
+  gt: SIMDMask<T.MaskStorage>,
+  ge: SIMDMask<T.MaskStorage>
+) where T: SIMD, T.Scalar: Comparable {(
+  eq: a .== b,
+  ne: a .!= b,
+  lt: a .<  b,
+  le: a .<= b,
+  gt: a .>  b,
+  ge: a .>= b
+)}
+
+func genericArithmetic<T>(
+  _ a: T, _ b: T
+) -> (
+  add: T, sub: T, mul: T
+) where T: SIMD, T.Scalar: FixedWidthInteger {(
+  add: a &+ b,
+  sub: a &- b,
+  mul: a &* b
+)}
+
+%for int in all_integer_types(word_bits):
+% Scalar = int.stdlib_name
+% for n in vectorscalarCounts:
+%  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
+%  storageN = 4 if n == 3 else n
+%  s = "s" if int.is_signed else "u"
+%  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
+var ${Scalar}x${n}_TestSuite = TestSuite("${Scalar}x${n}")
+
+${Scalar}x${n}_TestSuite.test("comparisons") {
+  let a = ${Vector}.random(in: ${Scalar}.min ... .max)
+  expectTrue(all(a .== a))
+  expectFalse(any(a .!= a))
+  expectFalse(any(a .== a &+ ${Vector}(repeating: 1)))
+  expectTrue(all(a .!= a &+ ${Vector}(repeating: 1)))
+  
+  let b = a.replacing(
+    with: ${Vector}.random(in: ${Scalar}.min ... .max),
+    where: .random()
+  )
+  let (eq,ne,lt,le,gt,ge) = genericComparisons(a, b)
+  expectEqual(eq, a .== b)
+  expectEqual(ne, a .!= b)
+  expectEqual(lt, a .<  b)
+  expectEqual(le, a .<= b)
+  expectEqual(gt, a .>  b)
+  expectEqual(ge, a .>= b)
+}
+
+${Scalar}x${n}_TestSuite.test("arithmetic") {
+  let a = ${Vector}.random(in: ${Scalar}.min ... .max)
+  let b = ${Vector}.random(in: ${Scalar}.min ... .max)
+  let (add,sub,mul) = genericArithmetic(a, b)
+  expectEqual(add, a &+ b)
+  expectEqual(sub, a &- b)
+  expectEqual(mul, a &* b)
+}
+
+% end
+%end
+
+runAllTests()

--- a/test/stdlib/SIMDConcreteMasks.swift.gyb
+++ b/test/stdlib/SIMDConcreteMasks.swift.gyb
@@ -1,0 +1,67 @@
+//===--- SIMDConcreteMasks.swift.gyb --------------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %empty-directory(%t)
+// RUN: %gyb -DCMAKE_SIZEOF_VOID_P=%target-ptrsize %s -o %t/SIMDConcreteMasks.swift
+// RUN: %line-directive %t/SIMDConcreteMasks.swift -- %target-build-swift %t/SIMDConcreteMasks.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %line-directive %t/SIMDConcreteMasks.swift -- %target-run %t/a.out
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+%{
+from __future__ import division
+from SwiftIntTypes import all_integer_types
+word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
+storagescalarCounts = [2,4,8,16,32,64]
+vectorscalarCounts = storagescalarCounts + [3]
+}%
+
+func genericMaskOps<T>(
+  _ a: SIMDMask<T>, _ b: SIMDMask<T>
+) -> (
+  not: SIMDMask<T>,
+  and: SIMDMask<T>,
+  or: SIMDMask<T>,
+  xor: SIMDMask<T>
+) where T: SIMD, T.Scalar: SignedInteger & FixedWidthInteger {(
+  not: .!a,
+  and: a .& b,
+  or: a .| b,
+  xor: a .^ b
+)}
+
+%for int in all_integer_types(word_bits):
+% Scalar = int.stdlib_name
+% for n in vectorscalarCounts:
+%  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
+%  storageN = 4 if n == 3 else n
+%  s = "s" if int.is_signed else "u"
+%  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
+%  if int.is_signed:
+var ${Scalar}x${n}Mask_TestSuite = TestSuite("${Scalar}x${n}Mask")
+
+${Scalar}x${n}Mask_TestSuite.test("boolean operators") {
+  let a = SIMDMask<${Vector}>.random()
+  let b = SIMDMask<${Vector}>.random()
+  let (not,and,or,xor) = genericMaskOps(a, b)
+  expectEqual(not, .!a)
+  expectEqual(and, a .& b)
+  expectEqual(or, a .| b)
+  expectEqual(xor, a .^ b)
+}
+
+%  end
+% end
+%end
+
+runAllTests()


### PR DESCRIPTION
Adds concrete overloads of the following SIMD operations:

- Comparisons: .==, .!=, .<, .<=, .>, .>=
- Logical operations on masks: .!, .&, .^, .|
- Integer arithmetic: &+, &-, &*, &+=, &-=, &*=

This makes some simple benchmarks 10-100x faster, which is basically a no-brainer, while staying away from the most heavily used operators, so hopefully doesn't impact compilation performance too badly.