### PR TITLE
[build-script] Make swift-driver depend on swiftpm

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -49,7 +49,8 @@ class SwiftDriver(product.Product):
                 libdispatch.LibDispatch,
                 foundation.Foundation,
                 xctest.XCTest,
-                llbuild.LLBuild]
+                llbuild.LLBuild,
+                swiftpm.SwiftPM]
 
     def should_clean(self, host_target):
         return self.args.clean_swift_driver


### PR DESCRIPTION
The swift-driver test suite depends on swiftpm to be able to run its tests. This is made an unconditional dependency because no products currently dynamically request test-specific dependencies.

This could also be implemented as a conditional dependency that's only there if swift-driver testing is requested, but I'm unsure if we want dynamic build orders like that.