### PR TITLE
[NFC, Incremental] Add ability to decode a swiftmodule file to `swift-dependency-tool`

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -879,8 +879,10 @@ public:
   }
 
   /// Read a swiftdeps file at \p path and return a SourceFileDepGraph if
-  /// successful.
-  Optional<SourceFileDepGraph> static loadFromPath(StringRef);
+  /// successful. If \p allowSwiftModule is true, try to load the information
+  /// from a swiftmodule file if appropriate.
+  Optional<SourceFileDepGraph> static loadFromPath(
+      StringRef, bool allowSwiftModule = false);
 
   /// Read a swiftdeps file from \p buffer and return a SourceFileDepGraph if
   /// successful.

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -42,11 +42,16 @@ using namespace fine_grained_dependencies;
 // MARK: Emitting and reading SourceFileDepGraph
 //==============================================================================
 
-Optional<SourceFileDepGraph> SourceFileDepGraph::loadFromPath(StringRef path) {
+Optional<SourceFileDepGraph>
+SourceFileDepGraph::loadFromPath(StringRef path, const bool allowSwiftModule) {
+  const bool treatAsModule =
+      allowSwiftModule &&
+      path.endswith(file_types::getExtension(file_types::TY_SwiftModuleFile));
   auto bufferOrError = llvm::MemoryBuffer::getFile(path);
   if (!bufferOrError)
     return None;
-  return loadFromBuffer(*bufferOrError.get());
+  return treatAsModule ? loadFromSwiftModuleBuffer(*bufferOrError.get())
+                       : loadFromBuffer(*bufferOrError.get());
 }
 
 Optional<SourceFileDepGraph>

--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
   }
 
   case ActionType::BinaryToYAML: {
-    auto fg = SourceFileDepGraph::loadFromPath(options::InputFilename);
+    auto fg = SourceFileDepGraph::loadFromPath(options::InputFilename, true);
     if (!fg) {
       llvm::errs() << "Failed to read dependency file\n";
       return 1;


### PR DESCRIPTION
For testing and debugging incremental imports, it is helpful to be able to decode into YAML the dependency information in a swiftmodule file. Hence, make `swift-dependency-tool` a little smarter so it can do that.