### PR TITLE
[Concurrency] Add support for @GlobalActor(unsafe).

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1663,6 +1663,7 @@ class CustomAttr final : public DeclAttribute,
 
   unsigned hasArgLabelLocs : 1;
   unsigned numArgLabels : 16;
+  mutable unsigned isArgUnsafeBit : 1;
 
   CustomAttr(SourceLoc atLoc, SourceRange range, TypeExpr *type,
              PatternBindingInitializer *initContext, Expr *arg,
@@ -1694,6 +1695,11 @@ public:
 
   Expr *getArg() const { return arg; }
   void setArg(Expr *newArg) { arg = newArg; }
+
+  /// Determine whether the argument is '(unsafe)', a special subexpression
+  /// used by global actors.
+  bool isArgUnsafe() const;
+  void setArgIsUnsafe(bool unsafe) { isArgUnsafeBit = unsafe; }
 
   Expr *getSemanticInit() const { return semanticInit; }
   void setSemanticInit(Expr *expr) { semanticInit = expr; }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4410,7 +4410,9 @@ ERROR(global_actor_on_local_variable,none,
       "local variable %0 cannot have a global actor", (DeclName))
 ERROR(global_actor_on_struct_property,none,
       "stored property %0 of a struct cannot have a global actor", (DeclName))
-
+ERROR(global_actor_non_unsafe_init,none,
+      "global actor attribute %0 argument can only be '(unsafe)'", (Type))
+      
 ERROR(actor_isolation_multiple_attr,none,
       "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",
       (DescriptiveDeclKind, DeclName, StringRef, StringRef))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8159,10 +8159,16 @@ void ClangImporter::Implementation::importAttributes(
       // FIXME: Hard-core @MainActor and @UIActor, because we don't have a
       // point at which to do name lookup for imported entities.
       if (swiftAttr->getAttribute() == "@MainActor" ||
+          swiftAttr->getAttribute() == "@MainActor(unsafe)" ||
           swiftAttr->getAttribute() == "@UIActor") {
+        bool isUnsafe = swiftAttr->getAttribute() == "@MainActor(unsafe)" ||
+            !C.LangOpts.isSwiftVersionAtLeast(6);
         if (Type mainActorType = getMainActorType()) {
           auto typeExpr = TypeExpr::createImplicit(mainActorType, SwiftContext);
           auto attr = CustomAttr::create(SwiftContext, SourceLoc(), typeExpr);
+          attr->setArgIsUnsafe(isUnsafe);
+          if (isUnsafe)
+            attr->setImplicit();
           MappedDecl->getAttrs().add(attr);
         }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2777,8 +2777,11 @@ bool ConformanceChecker::checkActorIsolation(
     break;
   }
 
-  case ActorIsolation::Independent:
   case ActorIsolation::IndependentUnsafe:
+    // The requirement is explicitly unsafe; allow it.
+    return false;
+
+  case ActorIsolation::Independent:
   case ActorIsolation::Unspecified:
     break;
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4396,9 +4396,10 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
 
       case decls_block::Custom_DECL_ATTR: {
         bool isImplicit;
+        bool isArgUnsafe;
         TypeID typeID;
         serialization::decls_block::CustomDeclAttrLayout::readRecord(
-          scratch, isImplicit, typeID);
+          scratch, isImplicit, typeID, isArgUnsafe);
 
         Expected<Type> deserialized = MF.getTypeChecked(typeID);
         if (!deserialized) {
@@ -4412,7 +4413,9 @@ llvm::Error DeclDeserializer::deserializeDeclAttributes() {
             return deserialized.takeError();
         } else {
           auto *TE = TypeExpr::createImplicit(deserialized.get(), ctx);
-          Attr = CustomAttr::create(ctx, SourceLoc(), TE, isImplicit);
+          auto custom = CustomAttr::create(ctx, SourceLoc(), TE, isImplicit);
+          custom->setArgIsUnsafe(isArgUnsafe);
+          Attr = custom;
         }
         break;
       }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 599; // has-async-alternative
+const uint16_t SWIFTMODULE_VERSION_MINOR = 600; // custom attr (unsafe)
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1943,9 +1943,9 @@ namespace decls_block {
   using CustomDeclAttrLayout = BCRecordLayout<
     Custom_DECL_ATTR,
     BCFixed<1>,  // implicit flag
-    TypeIDField // type referenced by this custom attribute
+    TypeIDField, // type referenced by this custom attribute
+    BCFixed<1>   // is the argument (unsafe)
   >;
-
 }
 
 /// Returns the encoding kind for the given decl.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2532,7 +2532,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto theAttr = cast<CustomAttr>(DA);
       CustomDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                        theAttr->isImplicit(),
-                                       S.addTypeRef(theAttr->getType()));
+                                       S.addTypeRef(theAttr->getType()),
+                                       theAttr->isArgUnsafe());
       return;
     }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -77,7 +77,7 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
 func globalAsync() async { }
 
 actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
-  func syncMethod() { } // expected-note 2{{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
+  func syncMethod() { } // expected-note {{calls to instance method 'syncMethod()' from outside of its actor context are implicitly asynchronous}}
 
   func independentMethod() {
     syncMethod() // expected-error{{ctor-isolated instance method 'syncMethod()' can not be referenced from an '@actorIndependent' context}}
@@ -88,7 +88,7 @@ actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
   }
 
   func mainActorMethod() {
-    syncMethod() // expected-error{{actor-isolated instance method 'syncMethod()' can not be referenced from context of global actor 'MainActor'}}
+    syncMethod()
   }
 
   func uiActorMethod() { }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -29,6 +29,12 @@ struct GenericGlobalActor<T> {
 @MainActor func iron() {}
 
 // ----------------------------------------------------------------------
+// Check that @MainActor(blah) doesn't work
+// ----------------------------------------------------------------------
+// expected-error@+1{{global actor attribute 'MainActor' argument can only be '(unsafe)'}}
+@MainActor(blah) func brokenMainActorAttr() { }
+
+// ----------------------------------------------------------------------
 // Global actor inference for protocols
 // ----------------------------------------------------------------------
 
@@ -226,4 +232,37 @@ func bar() async {
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func barSync() {
   foo() // expected-error {{global function 'foo()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+}
+
+
+// ----------------------------------------------------------------------
+// Unsafe global actors
+// ----------------------------------------------------------------------
+protocol UGA {
+  @SomeGlobalActor(unsafe) func req()
+}
+
+struct StructUGA1: UGA {
+  @SomeGlobalActor func req() { }
+}
+
+struct StructUGA2: UGA {
+  @actorIndependent func req() { }
+}
+
+@GenericGlobalActor<String>
+func testUGA<T: UGA>(_ value: T) {
+  value.req()
+}
+
+class UGAClass {
+  @SomeGlobalActor(unsafe) func method() { }
+}
+
+class UGASubclass1: UGAClass {
+  @SomeGlobalActor override func method() { }
+}
+
+class UGASubclass2: UGAClass {
+  override func method() { }
 }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -39,8 +39,8 @@ import _Concurrency
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: @actorIndependent func independentMethod()
 // CHECK-NEXT: @asyncHandler func asyncHandlerMethod()
-// CHECK-NEXT: @MainActor func mainActorMethod()
-// CHECK-NEXT: @MainActor func uiActorMethod()
+// CHECK-NEXT: {{^}}  func mainActorMethod()
+// CHECK-NEXT: {{^}}  func uiActorMethod()
 // CHECK-NEXT: {{^}}  optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}
 


### PR DESCRIPTION
Allow us to tag declarations that are meant to be in a global actor, but
for which we don't yet want to enforce everything. This will be used for
better staging-in of global actor annotations, but for now it's a fancy
way to document @actorIndependent(unsafe).

Stages in the syntax for rdar://74241687 without really implementing it.
