### PR TITLE
[Concurrency] Remove get_active now that getCurrentAsync task uses ActiveTask

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -107,10 +107,6 @@ void swift_task_dealloc(AsyncTask *task, void *ptr);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_cancel(AsyncTask *task);
 
-/// Get 'active' AsyncTask, depending on platform this may use thread local storage.
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-AsyncTask* swift_task_get_active();
-
 /// Escalate the priority of a task and all of its child tasks.
 ///
 /// This can be called from any thread.

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -134,11 +134,6 @@ SWIFT_RUNTIME_DECLARE_THREAD_LOCAL(
 
 } // end anonymous namespace
 
-AsyncTask*
-swift::swift_task_get_active() {
-  return ActiveTask::get();
-}
-
 void swift::swift_job_run(Job *job, ExecutorRef executor) {
   ExecutorTrackingInfo trackingInfo;
   trackingInfo.enterAndShadow(executor);

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -508,12 +508,9 @@ extension Task {
   ///
   /// The returned value must not be accessed from tasks other than the current one.
   public static var unsafeCurrent: UnsafeCurrentTask? {
-    guard let _task = _getActiveAsyncTask() else {
+    guard let _task = Builtin.getCurrentAsyncTask() else {
       return nil
     }
-    // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
-    //        with "destroying a task that never completed" in the task's destroy.
-    //        How do we solve this properly?
     _swiftRetain(_task)
     return UnsafeCurrentTask(_task)
   }
@@ -582,9 +579,6 @@ extension UnsafeCurrentTask: Equatable {
 }
 
 // ==== Internal ---------------------------------------------------------------
-
-@_silgen_name("swift_task_get_active")
-func _getActiveAsyncTask() -> Builtin.NativeObject?
 
 @_silgen_name("swift_task_getJobFlags")
 func getJobFlags(_ task: Builtin.NativeObject) -> Task.JobFlags

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -70,7 +70,7 @@ extension Task {
     handler: @concurrent () -> (),
     operation: () async throws -> T
   ) async rethrows -> T {
-    let task = Builtin.getCurrentAsyncTask()
+    let task = _taskGetCurrent()! // !-safe, task is always available in an async func
 
     guard !_taskIsCancelled(task) else {
       // If the current task is already cancelled, run the handler immediately.

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -65,7 +65,7 @@ extension Task {
     returning returnType: BodyResult.Type = BodyResult.self,
     body: @concurrent @escaping (inout Task.Group<TaskResult>) async throws -> BodyResult
   ) async throws -> BodyResult {
-    let parent = Builtin.getCurrentAsyncTask()
+    let parent = _taskGetCurrent()! // !-safe, task is always available in an async func
 
     // Set up the job flags for a new task.
     var groupFlags = JobFlags()
@@ -77,7 +77,7 @@ extension Task {
 
     let (groupTask, _) =
       Builtin.createAsyncTaskFuture(groupFlags.bits, parent) { () async throws -> BodyResult in
-        let task = Builtin.getCurrentAsyncTask()
+        let task = _taskGetCurrent()! // !-safe, task is always available in an async func
         var group = Task.Group<TaskResult>(task: task)
 
         // This defer handles both return/throw cases in the following way:

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -100,7 +100,7 @@ extension Task {
     boundTo value: Key.Value,
     operation: () async throws -> BodyResult
   ) async rethrows -> BodyResult where Key: TaskLocalKey {
-    let task = Builtin.getCurrentAsyncTask()
+    let task = _taskGetCurrent()! // !-safe, task is always available in an async func
 
     _taskLocalValuePush(task, keyType: Key.self, value: value)
     defer { _taskLocalValuePop(task) }


### PR DESCRIPTION
Remove the workaround get_active since the builtin now does the right thing and uses the ActiveTask thread local.