### PR TITLE
DestroyHoisting: create the correct debug info location kind for inserted destroys

### DIFF
--- a/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyHoisting.cpp
@@ -507,7 +507,7 @@ void DestroyHoisting::insertDestroys(Bits &toInsert, Bits &activeDestroys,
   SILInstruction *insertionPoint =
     (afterInst ? &*std::next(afterInst->getIterator()) : &*inBlock->begin());
   SILBuilder builder(insertionPoint);
-  SILLocation loc = RegularLocation(insertionPoint->getLoc());
+  SILLocation loc = CleanupLocation(insertionPoint->getLoc());
 
   // Insert destroy_addr instructions for all bits in toInsert.
   for (int locIdx = toInsert.find_first(); locIdx >= 0;

--- a/test/SILOptimizer/diagnose_unreachable.swift
+++ b/test/SILOptimizer/diagnose_unreachable.swift
@@ -1,4 +1,8 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
+
+// Rerun with optimizations to check if -O does not make any difference
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s -o /dev/null -verify
+
 func ifFalse() -> Int {
   if false { // expected-note {{always evaluates to false}}
     return 0 // expected-warning {{will never be executed}}
@@ -451,3 +455,18 @@ func f(i: Int?) {
     guard i != nil else { Never.theThing }
     guard i != nil else { test(Never.self) }
 }
+
+extension Collection {
+  // Check that the destroy_addr which is inserted by DestroyHoisting does not
+  // trigger a warning here.
+  func f() -> Index {
+    var lo = startIndex
+    var hi = endIndex
+    while true {
+        formIndex(after: &lo)
+        formIndex(after: &hi)
+        if Bool.random() { return hi }
+    }
+  }
+}
+


### PR DESCRIPTION
Such locations should be cleanup locations and not regular locations.
Otherwise it could trigger a false unreachable-code warning.

rdar://74241814
