### PR TITLE
[Frontend] Lock the swiftmodule when rebuilding from the swiftinterface

### DIFF
--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -290,7 +290,7 @@ bool ModuleInterfaceBuilder::buildSwiftModule(StringRef OutPath,
   // processes are doing the same.
   // FIXME: We should surface the module building step to the build system so
   // we don't need to synchronize here.
-  llvm::LockFileManager Locked(interfacePath);
+  llvm::LockFileManager Locked(OutPath);
   switch (Locked) {
   case llvm::LockFileManager::LFS_Error:{
     // ModuleInterfaceBuilder takes care of correctness and locks are only

--- a/test/APIJSON/access.swift
+++ b/test/APIJSON/access.swift
@@ -5,7 +5,7 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/MyModule.swiftinterface
-// RUN: %target-swift-api-extract -target x86_64-apple-macos11.0 -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+// RUN: %target-swift-api-extract -target x86_64-apple-macos11.0 -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
 
 public func publicFunction()
 internal func internalFunction()

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+// RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5 
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
 
 import Foundation
 

--- a/test/APIJSON/non-objc-class.swift
+++ b/test/APIJSON/non-objc-class.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
 
 import Foundation
 

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
 
 import Foundation
 

--- a/test/APIJSON/struct.swift
+++ b/test/APIJSON/struct.swift
@@ -1,7 +1,7 @@
 // REQUIRES: objc_interop, OS=macosx
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution -module-name MyModule -swift-version 5
-// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule | %FileCheck %s
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t | %FileCheck %s
 
 // Struct has no objc data.
 @available(macOS 10.13, *)

--- a/test/Driver/lock_interface.swift
+++ b/test/Driver/lock_interface.swift
@@ -1,23 +1,29 @@
-// REQUIRES: rdar59977439
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/sdk)
 // RUN: %empty-directory(%t/module-cache-lock)
 // RUN: %empty-directory(%t/module-cache-no-lock)
-// RUN: echo 'public func foo() {}' > %t/Foo.swift
-// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/Foo.swiftinterface %t/Foo.swift -enable-library-evolution
+// RUN: echo 'public func foo() {}' > %t/sdk/Foo.swift
+// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/sdk/Foo.swiftinterface %t/sdk/Foo.swift -enable-library-evolution
+// RUN: chmod a-w %t/sdk
+
 // RUN: touch %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift
 // RUN: echo 'import Foo' > %t/file-01.swift
 // RUN: echo 'import Foo' > %t/file-02.swift
 // RUN: echo 'import Foo' > %t/file-03.swift
-// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t -Xfrontend -Rmodule-interface-rebuild -module-cache-path %t/module-cache &> %t/result.txt
+// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -module-cache-path %t/module-cache &> %t/result.txt
 // RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD < %t/result.txt
 
-// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-interface-lock -module-cache-path %t/module-cache-no-lock &> %t/result.txt
+// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-interface-lock -module-cache-path %t/module-cache-no-lock &> %t/result.txt
 
 // RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD-NO-LOCK < %t/result.txt
+
+// Reset the permissions
+// RUN: chmod a+w %t/sdk
 
 // Ensure we only build Foo module once from the interface
 // CHECK-REBUILD: rebuilding module 'Foo' from interface
 // CHECK-REBUILD-NOT: rebuilding module 'Foo' from interface
+// CHECK-REBUILD-NOT: building module interface without lock file
 
 // CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface
 // CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface


### PR DESCRIPTION
When rebuilding a module interface from the textual interface, lock the destination path of the created swiftmodule instead of the source swiftinterface. The swiftinterface files are likely to be in the SDK and may be on a read-only filesystem.

rdar://60247977

I'm reenabling the test at the same time.