### PR TITLE
[Concurrency] Reorder constructor initializers to avoid warning

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -281,9 +281,9 @@ public:
 
     private:
       explicit TaskLocalItem(const Metadata *keyType, const Metadata *valueType)
-          : keyType(keyType),
-            valueType(valueType),
-            next(0) { }
+          : next(0),
+            keyType(keyType),
+            valueType(valueType) { }
 
     public:
       /// TaskLocalItem which does not by itself store any value, but only points


### PR DESCRIPTION
Small warning fix for `TaskLocalItem`

```
swift/ABI/Task.h:285:13: warning: field 'valueType' will be initialized after field 'next' [-Wreorder-ctor]
            valueType(valueType),
            ^
1 warning generated.
```