### PR TITLE
[ConstraintSystem] Delay inference until let's clear that type variable attempt is successful

### DIFF
--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -135,6 +135,24 @@ private:
   /// equivalence class changes.
   void reintroduceToInference(Constraint *constraint, bool notifyReferencedVars);
 
+  /// Similar to \c introduceToInference(Constraint *, ...) this method is going
+  /// to notify inference that this type variable has been bound to a concrete
+  /// type.
+  ///
+  /// The reason why this can't simplify be a part of \c bindTypeVariable
+  /// is related to the fact that it's sometimes expensive to re-compute
+  /// bindings (i.e. if `DependentMemberType` is involved, because it requires
+  /// a conformance lookup), so inference has to be delayed until its clear that
+  /// type variable has been bound to a valid type and solver can make progress.
+  void
+  introduceToInference(Type fixedType,
+                       SmallPtrSetImpl<TypeVariableType *> &referencedVars);
+
+  /// Opposite of \c introduceToInference(Type, ...)
+  void
+  retractFromInference(Type fixedType,
+                       SmallPtrSetImpl<TypeVariableType *> &referencedVars);
+
   /// Drop all previously collected bindings and re-infer based on the
   /// current set constraints associated with this equivalence class.
   void resetBindingSet();
@@ -148,6 +166,7 @@ private:
   /// This is useful in situations when type variable gets bound and unbound,
   /// or equivalence class changes.
   void notifyReferencingVars() const;
+
   /// }
 
   /// The constraint graph this node belongs to.

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -44,6 +44,7 @@ class Constraint;
 class ConstraintGraph;
 class ConstraintGraphScope;
 class ConstraintSystem;
+class TypeVariableBinding;
 
 /// A single node in the constraint graph, which represents a type variable.
 class ConstraintGraphNode {
@@ -144,11 +145,9 @@ private:
   /// bindings (i.e. if `DependentMemberType` is involved, because it requires
   /// a conformance lookup), so inference has to be delayed until its clear that
   /// type variable has been bound to a valid type and solver can make progress.
-  void
-  introduceToInference(Type fixedType,
-                       SmallPtrSetImpl<TypeVariableType *> &referencedVars);
+  void introduceToInference(Type fixedType);
 
-  /// Opposite of \c introduceToInference(Type, ...)
+  /// Opposite of \c introduceToInference(Type)
   void
   retractFromInference(Type fixedType,
                        SmallPtrSetImpl<TypeVariableType *> &referencedVars);
@@ -211,6 +210,8 @@ private:
   void verify(ConstraintGraph &cg);
 
   friend class ConstraintGraph;
+  friend class ConstraintSystem;
+  friend class TypeVariableBinding;
 };
 
 /// A graph that describes the relationships among the various type variables

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3631,6 +3631,10 @@ public:
 
     /// Indicates that we are applying a fix.
     TMF_ApplyingFix = 0x02,
+
+    /// Indicates that we are attempting a possible type for
+    /// a type variable.
+    TMF_BindingTypeVariable = 0x04,
   };
 
   /// Options that govern how type matching should proceed.
@@ -3702,10 +3706,14 @@ public:
   /// \param type The fixed type to which the type variable will be bound.
   ///
   /// \param updateState Whether to update the state based on this binding.
-  /// False when we're only assigning a type as part of reconstructing 
+  /// False when we're only assigning a type as part of reconstructing
   /// a complete solution from partial solutions.
+  ///
+  /// \param notifyBindingInference Whether to notify binding inference about
+  /// the change to this type variable.
   void assignFixedType(TypeVariableType *typeVar, Type type,
-                       bool updateState = true);
+                       bool updateState = true,
+                       bool notifyBindingInference = true);
 
   /// Determine if the type in question is an Array<T> and, if so, provide the
   /// element type of the array.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1793,7 +1793,15 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
     type = type->reconstituteSugar(/*recursive=*/false);
   }
 
-  cs.addConstraint(ConstraintKind::Bind, TypeVar, type, srcLocator);
+  ConstraintSystem::TypeMatchOptions options;
+
+  options |= ConstraintSystem::TMF_GenerateConstraints;
+
+  auto result =
+      cs.matchTypes(TypeVar, type, ConstraintKind::Bind, options, srcLocator);
+
+  if (result.isFailure())
+    return false;
 
   auto reportHole = [&]() {
     if (cs.isForCodeCompletion()) {
@@ -1825,5 +1833,5 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
       return true;
   }
 
-  return !cs.failedConstraint && !cs.simplify();
+  return !cs.simplify();
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3016,7 +3016,8 @@ ConstraintSystem::matchTypesBindTypeVar(
                : getTypeMatchFailure(locator);
   }
 
-  assignFixedType(typeVar, type);
+  assignFixedType(typeVar, type, /*updateState=*/true,
+                  /*notifyInference=*/!flags.contains(TMF_BindingTypeVariable));
 
   return getTypeMatchSuccess();
 }

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -275,11 +275,13 @@ inference::PotentialBindings &ConstraintGraphNode::getCurrentBindings() {
 
 static bool isUsefulForReferencedVars(Constraint *constraint) {
   switch (constraint->getKind()) {
-  // Don't attempt to propagate information about `Bind`s to referenced
-  // variables since they are adjacent through that binding already, and
-  // there is no useful information in trying to process that kind of
+  // Don't attempt to propagate information about `Bind`s and
+  // `BindOverload`s to referenced variables since they are
+  // adjacent through that binding already, and there is no
+  // useful information in trying to process that kind of
   // constraint.
   case ConstraintKind::Bind:
+  case ConstraintKind::BindOverload:
     return false;
 
   default:

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -335,8 +335,7 @@ void ConstraintGraphNode::reintroduceToInference(Constraint *constraint,
   introduceToInference(constraint, notifyReferencedVars);
 }
 
-void ConstraintGraphNode::introduceToInference(
-    Type fixedType, SmallPtrSetImpl<TypeVariableType *> &referencedVars) {
+void ConstraintGraphNode::introduceToInference(Type fixedType) {
   // Notify all of the type variables that reference this one.
   //
   // Since this type variable has been replaced with a fixed type
@@ -344,6 +343,12 @@ void ConstraintGraphNode::introduceToInference(
   // which means that all of the not-yet-attempted bindings should
   // change as well.
   notifyReferencingVars();
+
+  if (!fixedType->hasTypeVariable())
+    return;
+
+  SmallPtrSet<TypeVariableType *, 4> referencedVars;
+  fixedType->getTypeVariables(referencedVars);
 
   for (auto *referencedVar : referencedVars) {
     auto &node = CG[referencedVar];
@@ -593,8 +598,6 @@ void ConstraintGraph::bindTypeVariable(TypeVariableType *typeVar, Type fixed) {
     otherNode.addReferencedBy(typeVar);
     node.addReferencedVar(otherTypeVar);
   }
-
-  node.introduceToInference(fixed, referencedVars);
 }
 
 void ConstraintGraph::unbindTypeVariable(TypeVariableType *typeVar, Type fixed) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -155,7 +155,8 @@ bool ConstraintSystem::typeVarOccursInType(TypeVariableType *typeVar,
 }
 
 void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
-                                       bool updateState) {
+                                       bool updateState,
+                                       bool notifyBindingInference) {
   assert(!type->hasError() &&
          "Should not be assigning a type involving ErrorType!");
 
@@ -199,6 +200,9 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
   // Notify the constraint graph.
   CG.bindTypeVariable(typeVar, type);
   addTypeVariableConstraintsToWorkList(typeVar);
+
+  if (notifyBindingInference)
+    CG[typeVar].introduceToInference(type);
 }
 
 void ConstraintSystem::addTypeVariableConstraintsToWorkList(


### PR DESCRIPTION
Currently bindings where inferred on every `bindTypeVariable` call,
but that's wasteful because not all binds are always correct. To
avoid unnecessary inference traffic let's wait until re-activated
constraints are simplified and notify binding inference about new
fixed type only if all of them are successful.

This is a follow-up to https://github.com/apple/swift/pull/35903.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
