### PR TITLE
[Frontend][Index] Add a new -index-unit-ouput-path and filelist equivalent to the frontend

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -165,15 +165,15 @@ ERROR(error_mode_requires_one_sil_multi_sib,none,
       ())
 
 ERROR(error_no_output_filename_specified,none,
-      "an output filename was not specified for a mode which requires an "
-      "output filename", ())
+      "an %0 filename was not specified for a mode which requires an "
+      "%0 filename", (StringRef))
 
 ERROR(error_implicit_output_file_is_directory,none,
       "the implicit output file '%0' is a directory; explicitly specify a "
-      "filename using -o", (StringRef))
+      "filename using %1", (StringRef, StringRef))
 
 ERROR(error_if_any_output_files_are_specified_they_all_must_be,none,
-      "if any output files are specified, they all must be", ())
+      "if any %0 files are specified, they all must be", (StringRef))
 
 ERROR(error_primary_file_not_found,none,
       "primary file '%0' was not found in file list '%1'",
@@ -211,6 +211,8 @@ ERROR(error_index_failed_status_check,none,
       "failed file status check: %0", (StringRef))
 ERROR(error_index_inputs_more_than_outputs,none,
       "index output filenames do not match input source files", ())
+WARNING(warn_index_unit_output_path_without_index_store,none,
+      "-index-unit-output-path is ignored without -index-store-path", ())
 
 ERROR(error_wrong_number_of_arguments,none,
       "wrong number of '%0' arguments (expected %1, got %2)",

--- a/include/swift/Basic/PrimarySpecificPaths.h
+++ b/include/swift/Basic/PrimarySpecificPaths.h
@@ -32,16 +32,23 @@ public:
   /// is to be written to stdout, contains "-".
   std::string OutputFilename;
 
+  /// The name to report the main output file as being in the index store.
+  /// This is equivalent to OutputFilename, unless -index-store-output-path
+  /// was specified.
+  std::string IndexUnitOutputFilename;
+
   SupplementaryOutputPaths SupplementaryOutputs;
 
   /// The name of the "main" input file, used by the debug info.
   std::string MainInputFilenameForDebugInfo;
 
   PrimarySpecificPaths(StringRef OutputFilename = StringRef(),
+                       StringRef IndexUnitOutputFilename = StringRef(),
                        StringRef MainInputFilenameForDebugInfo = StringRef(),
                        SupplementaryOutputPaths SupplementaryOutputs =
                            SupplementaryOutputPaths())
       : OutputFilename(OutputFilename),
+        IndexUnitOutputFilename(IndexUnitOutputFilename),
         SupplementaryOutputs(SupplementaryOutputs),
         MainInputFilenameForDebugInfo(MainInputFilenameForDebugInfo) {}
 

--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -185,7 +185,7 @@ struct SupplementaryOutputPaths {
     if (!LdAddCFilePath.empty())
       fn(LdAddCFilePath); 
     if (!ModuleSummaryOutputPath.empty())
-      fn(ModuleSummaryOutputPath); 
+      fn(ModuleSummaryOutputPath);
   }
 
   bool empty() const {

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -188,7 +188,8 @@ private:
   friend struct InterfaceSubContextDelegateImpl;
   void setMainAndSupplementaryOutputs(
       ArrayRef<std::string> outputFiles,
-      ArrayRef<SupplementaryOutputPaths> supplementaryOutputs);
+      ArrayRef<SupplementaryOutputPaths> supplementaryOutputs,
+      ArrayRef<std::string> outputFilesForIndexUnits = None);
 
 public:
   unsigned countOfInputsProducingMainOutputs() const;
@@ -209,12 +210,17 @@ public:
       llvm::function_ref<bool(const InputFile &)> fn) const;
 
   std::vector<std::string> copyOutputFilenames() const;
+  std::vector<std::string> copyIndexUnitOutputFilenames() const;
 
   void forEachOutputFilename(llvm::function_ref<void(StringRef)> fn) const;
 
   /// Gets the name of the specified output filename.
   /// If multiple files are specified, the last one is returned.
   std::string getSingleOutputFilename() const;
+
+  /// Gets the name of the specified output filename to record in the index unit
+  /// output files. If multiple are specified, the last one is returned.
+  std::string getSingleIndexUnitOutputFilename() const;
 
   bool isOutputFilenameStdout() const;
   bool isOutputFileDirectory() const;

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -105,6 +105,12 @@ public:
   /// stream, the result is "-".
   std::string outputFilename() const { return PSPs.OutputFilename; }
 
+  std::string indexUnitOutputFilename() const {
+    if (!PSPs.IndexUnitOutputFilename.empty())
+      return PSPs.IndexUnitOutputFilename;
+    return outputFilename();
+  }
+
   /// If there are explicit primary inputs (i.e. designated with -primary-input
   /// or -primary-filelist), the paths specific to those inputs (other than the
   /// input file path itself) are kept here. If there are no explicit primary

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -626,6 +626,9 @@ def index_ignore_stdlib :
   Flag<["-"], "index-ignore-stdlib">,
   HelpText<"Avoid emitting index data for the standard library.">;
 
+def index_unit_output_path_filelist : Separate<["-"], "index-unit-output-path-filelist">,
+  HelpText<"Specify index unit output paths in a file rather than on the command line">;
+
 def dump_interface_hash : Flag<["-"], "dump-interface-hash">,
    HelpText<"Parse input file(s) and dump interface token hash(es)">,
    ModeOpt;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1123,6 +1123,10 @@ def index_store_path : Separate<["-"], "index-store-path">,
   Flags<[FrontendOption, ArgumentIsPath]>, MetaVarName<"<path>">,
   HelpText<"Store indexing data to <path>">;
 
+def index_unit_output_path : Separate<["-"], "index-unit-output-path">,
+  Flags<[FrontendOption, ArgumentIsPath]>, MetaVarName<"<path>">,
+  HelpText<"Use <path> as the output path in the produced index data.">;
+
 def index_ignore_system_modules : Flag<["-"], "index-ignore-system-modules">,
   Flags<[NoInteractiveOption]>,
   HelpText<"Avoid indexing system modules">;

--- a/lib/Frontend/ArgsToFrontendInputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendInputsConverter.cpp
@@ -187,8 +187,8 @@ ArgsToFrontendInputsConverter::createInputFilesConsumingPrimaries(
 
   if (!Files.empty() && !hasAnyPrimaryFiles) {
     Optional<std::vector<std::string>> userSuppliedNamesOrErr =
-        OutputFilesComputer::getOutputFilenamesFromCommandLineOrFilelist(Args,
-                                                                         Diags);
+        OutputFilesComputer::getOutputFilenamesFromCommandLineOrFilelist(
+          Args, Diags, options::OPT_o, options::OPT_output_filelist);
     if (userSuppliedNamesOrErr && userSuppliedNamesOrErr->size() == 1)
       result.setIsSingleThreadedWMO(true);
   }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -514,8 +514,8 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
     return false;
   }
   Optional<std::vector<std::string>> outputFilenames =
-      OutputFilesComputer::getOutputFilenamesFromCommandLineOrFilelist(Args,
-                                                                       Diags);
+      OutputFilesComputer::getOutputFilenamesFromCommandLineOrFilelist(
+        Args, Diags, options::OPT_o, options::OPT_output_filelist);
 
   std::string nameToStem =
       outputFilenames && outputFilenames->size() == 1 &&
@@ -531,14 +531,17 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
 bool ArgsToFrontendOptionsConverter::
     computeMainAndSupplementaryOutputFilenames() {
   std::vector<std::string> mainOutputs;
+  std::vector<std::string> mainOutputForIndexUnits;
   std::vector<SupplementaryOutputPaths> supplementaryOutputs;
   const bool hadError = ArgsToFrontendOutputsConverter(
                             Args, Opts.ModuleName, Opts.InputsAndOutputs, Diags)
-                            .convert(mainOutputs, supplementaryOutputs);
+                            .convert(mainOutputs, mainOutputForIndexUnits,
+                                     supplementaryOutputs);
   if (hadError)
     return true;
   Opts.InputsAndOutputs.setMainAndSupplementaryOutputs(mainOutputs,
-                                                       supplementaryOutputs);
+                                                       supplementaryOutputs,
+                                                       mainOutputForIndexUnits);
   return false;
 }
 

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -34,15 +34,42 @@ using namespace llvm::opt;
 
 bool ArgsToFrontendOutputsConverter::convert(
     std::vector<std::string> &mainOutputs,
+    std::vector<std::string> &mainOutputsForIndexUnits,
     std::vector<SupplementaryOutputPaths> &supplementaryOutputs) {
 
   Optional<OutputFilesComputer> ofc =
-      OutputFilesComputer::create(Args, Diags, InputsAndOutputs);
+      OutputFilesComputer::create(Args, Diags, InputsAndOutputs, {
+        "output", options::OPT_o, options::OPT_output_filelist, "-o"
+      });
   if (!ofc)
     return true;
   Optional<std::vector<std::string>> mains = ofc->computeOutputFiles();
   if (!mains)
     return true;
+
+  Optional<std::vector<std::string>> indexMains;
+  if (Args.hasArg(options::OPT_index_unit_output_path,
+                  options::OPT_index_unit_output_path_filelist)) {
+
+    if (!Args.hasArg(options::OPT_index_store_path)) {
+      Diags.diagnose(SourceLoc(),
+                     diag::warn_index_unit_output_path_without_index_store);
+    }
+
+    Optional<OutputFilesComputer> iuofc =
+        OutputFilesComputer::create(Args, Diags, InputsAndOutputs, {
+          "index unit output path", options::OPT_index_unit_output_path,
+          options::OPT_index_unit_output_path_filelist,
+          "-index-unit-output-path"
+        });
+    if (!iuofc)
+      return true;
+    indexMains = iuofc->computeOutputFiles();
+    if (!indexMains)
+      return true;
+
+    assert(mains->size() == indexMains->size() && "checks not equivalent?");
+  }
 
   Optional<std::vector<SupplementaryOutputPaths>> supplementaries =
       SupplementaryOutputPathsComputer(Args, Diags, InputsAndOutputs, *mains,
@@ -52,6 +79,8 @@ bool ArgsToFrontendOutputsConverter::convert(
     return true;
 
   mainOutputs = std::move(*mains);
+  if (indexMains)
+    mainOutputsForIndexUnits = std::move(*indexMains);
   supplementaryOutputs = std::move(*supplementaries);
   return false;
 }
@@ -75,22 +104,26 @@ ArgsToFrontendOutputsConverter::readOutputFileList(const StringRef filelistPath,
 
 Optional<std::vector<std::string>>
 OutputFilesComputer::getOutputFilenamesFromCommandLineOrFilelist(
-    const ArgList &args, DiagnosticEngine &diags) {
-  if (const Arg *A = args.getLastArg(options::OPT_output_filelist)) {
-    assert(!args.hasArg(options::OPT_o) &&
-           "don't use -o with -output-filelist");
+    const ArgList &args, DiagnosticEngine &diags, options::ID singleOpt,
+    options::ID filelistOpt) {
+  if (const Arg *A = args.getLastArg(filelistOpt)) {
+    assert(!args.hasArg(singleOpt) &&
+           "don't use -o with -output-filelist or -index-unit-output-path with "
+           " -index-unit-output-filelist");
     return ArgsToFrontendOutputsConverter::readOutputFileList(A->getValue(),
                                                               diags);
   }
-  return args.getAllArgValues(options::OPT_o);
+  return args.getAllArgValues(singleOpt);
 }
 
 Optional<OutputFilesComputer>
 OutputFilesComputer::create(const llvm::opt::ArgList &args,
                             DiagnosticEngine &diags,
-                            const FrontendInputsAndOutputs &inputsAndOutputs) {
+                            const FrontendInputsAndOutputs &inputsAndOutputs,
+                            OutputOptInfo optInfo) {
   Optional<std::vector<std::string>> outputArguments =
-      getOutputFilenamesFromCommandLineOrFilelist(args, diags);
+      getOutputFilenamesFromCommandLineOrFilelist(args, diags, optInfo.SingleID,
+                                                  optInfo.FilelistID);
   if (!outputArguments)
     return None;
   const StringRef outputDirectoryArgument =
@@ -113,7 +146,8 @@ OutputFilesComputer::create(const llvm::opt::ArgList &args,
           inputsAndOutputs.countOfInputsProducingMainOutputs()) {
     diags.diagnose(
         SourceLoc(),
-        diag::error_if_any_output_files_are_specified_they_all_must_be);
+        diag::error_if_any_output_files_are_specified_they_all_must_be,
+        optInfo.PrettyName);
     return None;
   }
 
@@ -125,7 +159,8 @@ OutputFilesComputer::create(const llvm::opt::ArgList &args,
       outputDirectoryArgument, firstInput, requestedAction,
       args.getLastArg(options::OPT_module_name),
       file_types::getExtension(outputType),
-      FrontendOptions::doesActionProduceTextualOutput(requestedAction));
+      FrontendOptions::doesActionProduceTextualOutput(requestedAction),
+      optInfo);
 }
 
 OutputFilesComputer::OutputFilesComputer(
@@ -135,12 +170,13 @@ OutputFilesComputer::OutputFilesComputer(
     const StringRef outputDirectoryArgument, const StringRef firstInput,
     const FrontendOptions::ActionType requestedAction,
     const llvm::opt::Arg *moduleNameArg, const StringRef suffix,
-    const bool hasTextualOutput)
+    const bool hasTextualOutput, OutputOptInfo optInfo)
     : Diags(diags), InputsAndOutputs(inputsAndOutputs),
       OutputFileArguments(outputFileArguments),
       OutputDirectoryArgument(outputDirectoryArgument), FirstInput(firstInput),
       RequestedAction(requestedAction), ModuleNameArg(moduleNameArg),
-      Suffix(suffix), HasTextualOutput(hasTextualOutput) {}
+      Suffix(suffix), HasTextualOutput(hasTextualOutput),
+      OutputInfo(optInfo) {}
 
 Optional<std::vector<std::string>>
 OutputFilesComputer::computeOutputFiles() const {
@@ -189,7 +225,8 @@ OutputFilesComputer::deriveOutputFileFromInput(const InputFile &input) const {
   std::string baseName = determineBaseNameOfOutput(input);
   if (baseName.empty()) {
     // Assuming FrontendOptions::doesActionProduceOutput(RequestedAction)
-    Diags.diagnose(SourceLoc(), diag::error_no_output_filename_specified);
+    Diags.diagnose(SourceLoc(), diag::error_no_output_filename_specified,
+                   OutputInfo.PrettyName);
     return None;
   }
   return deriveOutputFileFromParts("", baseName);
@@ -200,7 +237,7 @@ Optional<std::string> OutputFilesComputer::deriveOutputFileForDirectory(
   std::string baseName = determineBaseNameOfOutput(input);
   if (baseName.empty()) {
     Diags.diagnose(SourceLoc(), diag::error_implicit_output_file_is_directory,
-                   OutputDirectoryArgument);
+                   OutputDirectoryArgument, OutputInfo.SingleOptSpelling);
     return None;
   }
   return deriveOutputFileFromParts(OutputDirectoryArgument, baseName);

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.h
@@ -44,12 +44,20 @@ public:
         Diags(diags) {}
 
   bool convert(std::vector<std::string> &mainOutputs,
+               std::vector<std::string> &mainOutputsForIndexUnits,
                std::vector<SupplementaryOutputPaths> &supplementaryOutputs);
 
   /// Try to read an output file list file.
   /// \returns `None` if it could not open the filelist.
   static Optional<std::vector<std::string>>
   readOutputFileList(StringRef filelistPath, DiagnosticEngine &diags);
+};
+
+struct OutputOptInfo {
+  StringRef PrettyName;
+  options::ID SingleID;
+  options::ID FilelistID;
+  StringRef SingleOptSpelling;
 };
 
 class OutputFilesComputer {
@@ -62,6 +70,7 @@ class OutputFilesComputer {
   const llvm::opt::Arg *const ModuleNameArg;
   const StringRef Suffix;
   const bool HasTextualOutput;
+  const OutputOptInfo OutputInfo;
 
   OutputFilesComputer(DiagnosticEngine &diags,
                       const FrontendInputsAndOutputs &inputsAndOutputs,
@@ -69,19 +78,23 @@ class OutputFilesComputer {
                       StringRef outputDirectoryArgument, StringRef firstInput,
                       FrontendOptions::ActionType requestedAction,
                       const llvm::opt::Arg *moduleNameArg, StringRef suffix,
-                      bool hasTextualOutput);
+                      bool hasTextualOutput,
+                      OutputOptInfo optInfo);
 
 public:
   static Optional<OutputFilesComputer>
   create(const llvm::opt::ArgList &args, DiagnosticEngine &diags,
-         const FrontendInputsAndOutputs &inputsAndOutputs);
+         const FrontendInputsAndOutputs &inputsAndOutputs,
+         OutputOptInfo optInfo);
 
   /// \return the output filenames on the command line or in the output
   /// filelist. If there
   /// were neither -o's nor an output filelist, returns an empty vector.
   static Optional<std::vector<std::string>>
   getOutputFilenamesFromCommandLineOrFilelist(const llvm::opt::ArgList &args,
-                                              DiagnosticEngine &diags);
+                                              DiagnosticEngine &diags,
+                                              options::ID singleOpt,
+                                              options::ID filelistOpt);
 
   Optional<std::vector<std::string>> computeOutputFiles() const;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1665,7 +1665,10 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
     const PrimarySpecificPaths &PSPs =
         opts.InputsAndOutputs.getPrimarySpecificPathsForPrimary(
             PrimarySourceFile->getFilename());
-    (void) index::indexAndRecord(PrimarySourceFile, PSPs.OutputFilename,
+    StringRef OutputFile = PSPs.IndexUnitOutputFilename;
+    if (OutputFile.empty())
+      OutputFile = PSPs.OutputFilename;
+    (void) index::indexAndRecord(PrimarySourceFile, OutputFile,
                                  opts.IndexStorePath, opts.IndexSystemModules,
                                  opts.IndexIgnoreStdlib, isDebugCompilation,
                                  Invocation.getTargetTriple(),
@@ -1674,10 +1677,11 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
     std::string moduleToken =
         Invocation.getModuleOutputPathForAtMostOnePrimary();
     if (moduleToken.empty())
-      moduleToken = opts.InputsAndOutputs.getSingleOutputFilename();
+      moduleToken = opts.InputsAndOutputs.getSingleIndexUnitOutputFilename();
 
     (void) index::indexAndRecord(Instance.getMainModule(),
-                                 opts.InputsAndOutputs.copyOutputFilenames(),
+                                 opts.InputsAndOutputs
+                                   .copyIndexUnitOutputFilenames(),
                                  moduleToken, opts.IndexStorePath,
                                  opts.IndexSystemModules,
                                  opts.IndexIgnoreStdlib,

--- a/test/Index/Store/unit-custom-output-path.swift
+++ b/test/Index/Store/unit-custom-output-path.swift
@@ -1,0 +1,250 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/main.swift
+// RUN: touch %t/second.swift
+
+// 1. Incremental mode (single primary file)
+//
+// A) Run without -index-unit-output-path:
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_without \
+//    RUN:     -primary-file %t/main.swift %t/second.swift \
+//    RUN:     -o %t/main_out.o
+//
+//    Check the unit output is based on -o
+//    RUN: c-index-test core -print-unit %t/idx_without | %FileCheck -check-prefixes=INDEX_WITHOUT %s
+//
+//    INDEX_WITHOUT:      main_out.o-{{.*}}
+//    INDEX_WITHOUT-NEXT: --------
+//    INDEX_WITHOUT:      out-file: {{.*}}main_out.o
+
+//
+// B) Run with a -index-unit-output-path different from the -o value:
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_with \
+//    RUN:     -primary-file %t/main.swift %t/second.swift \
+//    RUN:     -o %t/main_out.o -index-unit-output-path %t/custom_output.o
+//
+//    Run the same command as above again but with different -o value
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_with \
+//    RUN:     -primary-file %t/main.swift %t/second.swift \
+//    RUN:     -o %t/different.o -index-unit-output-path %t/custom_output.o
+//
+//    Check the unit output is based on -index-unit-output-path:
+//    RUN: c-index-test core -print-unit %t/idx_with | %FileCheck -check-prefixes=INDEX_WITH %s
+//
+//    Check no units were produced based on the -o values
+//    RUN: c-index-test core -print-unit %t/idx_with | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
+//
+//    INDEX_WITH:      custom_output.o-{{.*}}
+//    INDEX_WITH-NEXT: --------
+//    INDEX_WITH:      out-file: {{.*}}custom_output.o
+//
+//    INDEX_WITH_NEGATIVE-NOT: main_out.o
+//    INDEX_WITH_NEGATIVE-NOT: different.o
+//
+//    Run with a diferent -index-unit-output-path
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_with \
+//    RUN:     -primary-file %t/main.swift %t/second.swift \
+//    RUN:     -o %t/different.o -index-unit-output-path %t/custom_output_two.o
+//
+//    Check it resulted in a second unit being added to the store
+//    RUN: c-index-test core -print-unit %t/idx_with | %FileCheck -check-prefixes=INDEX_WITH,INDEX_WITH_SECOND %s
+//
+//    INDEX_WITH_SECOND: custom_output_two.o-{{.*}}
+//    INDEX_WITH_SECOND: --------
+//    INDEX_WITH_SECOND: out-file: {{.*}}custom_output_two.o
+//
+// C) Do the above again but with a fresh index store and using file lists.
+//
+//    RUN: echo '%t/main.swift' > %t/filelist
+//    RUN: echo '%t/second.swift' >> %t/filelist
+//
+//    RUN: echo '%t/output.o' > %t/outputlist
+//
+//    RUN: echo '"%t/custom_output.o' > %t/index-outputlist
+//
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_with_list \
+//    RUN:     -primary-file %t/main.swift -filelist %t/filelist \
+//    RUN:     -output-filelist %t/outputlist -index-unit-output-path-filelist %t/index-outputlist
+
+//    RUN: echo '%t/different.o' > %t/outputlist
+
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_with_list \
+//    RUN:     -primary-file %t/main.swift -filelist %t/filelist \
+//    RUN:     -output-filelist %t/outputlist -index-unit-output-path-filelist %t/index-outputlist
+//
+//    RUN: c-index-test core -print-unit %t/idx_with_list | %FileCheck -check-prefixes=INDEX_WITH %s
+//    RUN: c-index-test core -print-unit %t/idx_with_list | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
+
+
+// 2. Batch mode (multiple primary files)
+//
+// A) Run without -index-unit-output-path:
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -enable-batch-mode \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_batch_without \
+//    RUN:     -primary-file %t/main.swift -primary-file %t/second.swift \
+//    RUN:     -o %t/main_out.o -o second_out.o
+//
+//    Check the unit output is based on the -o values
+//    RUN: c-index-test core -print-unit %t/idx_batch_without | %FileCheck -check-prefixes=INDEX_BATCH_WITHOUT %s
+//
+//    INDEX_BATCH_WITHOUT:      main_out.o-{{.*}}
+//    INDEX_BATCH_WITHOUT-NEXT: --------
+//    INDEX_BATCH_WITHOUT:      out-file: {{.*}}main_out.o
+//
+//    INDEX_BATCH_WITHOUT:      second_out.o-{{.*}}
+//    INDEX_BATCH_WITHOUT-NEXT: --------
+//    INDEX_BATCH_WITHOUT:      out-file: {{.*}}second_out.o
+//
+// B) Run with -index-unit-output-path values different from the -o values:
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -enable-batch-mode \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_with \
+//    RUN:     -primary-file %t/main.swift -primary-file %t/second.swift \
+//    RUN:     -o %t/main_out.o -o %t/second_out.o \
+//    RUN:     -index-unit-output-path %t/custom_main.o -index-unit-output-path %t/custom_second.o
+//
+//    Run the same command as above again but with different -o value
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -enable-batch-mode \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_batch_with \
+//    RUN:     -primary-file %t/main.swift -primary-file %t/second.swift \
+//    RUN:     -o %t/different_main.o -o %t/different_second.o \
+//    RUN:     -index-unit-output-path %t/custom_main.o -index-unit-output-path %t/custom_second.o
+//
+//    Check the unit output is based on -index-unit-output-path:
+//    RUN: c-index-test core -print-unit %t/idx_batch_with | %FileCheck -check-prefixes=INDEX_BATCH_WITH %s
+//
+//    Check the unit output is not baed on the -o values:
+//    RUN: c-index-test core -print-unit %t/idx_batch_with | %FileCheck -check-prefixes=INDEX_BATCH_WITH_NEGATIVE %s
+//
+//    INDEX_BATCH_WITH:      custom_main.o-{{.*}}
+//    INDEX_BATCH_WITH-NEXT: --------
+//    INDEX_BATCH_WITH:      out-file: {{.*}}custom_main.o
+//
+//    INDEX_BATCH_WITH:      custom_second.o-{{.*}}
+//    INDEX_BATCH_WITH-NEXT: --------
+//    INDEX_BATCH_WITH:      out-file: {{.*}}custom_second.o
+//
+//    INDEX_BATCH_WITH_NEGATIVE-NOT: different_main.o
+//    INDEX_BATCH_WITH_NEGATIVE-NOT: different_second.o
+//    INDEX_BATCH_WITH_NEGATIVE-NOT: main_out.o
+//    INDEX_BATCH_WITH_NEGATIVE-NOT: second_out.o
+//
+// C) Do the above again but with a fresh index store and using file lists.
+//
+//    RUN: echo '%t/main.swift' > %t/filelist
+//    RUN: echo '%t/second.swift' >> %t/filelist
+//
+//    RUN: echo '%t/main_out.o' > %t/outputlist
+//    RUN: echo '%t/second_out.o' >> %t/outputlist
+//
+//    RUN: echo '"%t/custom_main.o' > %t/index-outputlist
+//    RUN: echo '"%t/custom_second.o' >> %t/index-outputlist
+//
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -enable-batch-mode \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_batch_with_list \
+//    RUN:     -primary-filelist %t/filelist -filelist %t/filelist \
+//    RUN:     -output-filelist %t/outputlist -index-unit-output-path-filelist %t/index-outputlist
+//
+//    RUN: echo '%t/different_main.o' > %t/outputlist
+//    RUN: echo '%t/different_second.o' >> %t/outputlist
+//
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -enable-batch-mode \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_batch_with_list \
+//    RUN:     -primary-filelist %t/filelist -filelist %t/filelist \
+//    RUN:     -output-filelist %t/outputlist -index-unit-output-path-filelist %t/index-outputlist
+//
+//    RUN: c-index-test core -print-unit %t/idx_batch_with_list | %FileCheck -check-prefixes=INDEX_BATCH_WITH %s
+//    RUN: c-index-test core -print-unit %t/idx_batch_with_list | %FileCheck -check-prefixes=INDEX_BATCH_WITH_NEGATIVE %s
+
+
+// 3. Multi-threaded WMO
+//
+// A) Run without -index-unit-output-path:
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -num-threads 2 \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_wmo_without \
+//    RUN:     %t/main.swift %t/second.swift \
+//    RUN:     -o %t/main_out.o -o %t/second_out.o
+//
+//    Check the unit output is based on -o
+//    RUN: c-index-test core -print-unit %t/idx_wmo_without | %FileCheck -check-prefixes=INDEX_WMO_WITHOUT %s
+//
+//    INDEX_WMO_WITHOUT:      main_out.o-{{.*}}
+//    INDEX_WMO_WITHOUT-NEXT: --------
+//    INDEX_WMO_WITHOUT:      out-file: {{.*}}main_out.o
+//
+//    INDEX_WMO_WITHOUT:      second_out.o-{{.*}}
+//    INDEX_WMO_WITHOUT-NEXT: --------
+//    INDEX_WMO_WITHOUT:      out-file: {{.*}}second_out.o
+//
+// B) Run with a -index-unit-output-path different from the -o value
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -num-threads 2 \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_wmo_with \
+//    RUN:     %t/main.swift %t/second.swift \
+//    RUN:     -o %t/main_out.o -o %t/second_out.o \
+//    RUN:     -index-unit-output-path %t/main_custom.o -index-unit-output-path %t/second_custom.o
+//
+//    Run the same command as above again but with different -o values
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib -num-threads 2 \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_wmo_with \
+//    RUN:     %t/main.swift %t/second.swift \
+//    RUN:     -o %t/main_different.o -o %t/second_different.o \
+//    RUN:     -index-unit-output-path %t/main_custom.o -index-unit-output-path %t/second_custom.o
+//
+//    Check the unit output is based on -index-unit-output-path
+//    RUN: c-index-test core -print-unit %t/idx_wmo_with | %FileCheck -check-prefixes=INDEX_WMO_WITH %s
+//    Check no units were produced based on the -o values:
+//    RUN: c-index-test core -print-unit %t/idx_wmo_with | %FileCheck -check-prefixes=INDEX_WMO_WITH_NEGATIVE %s
+//
+//    INDEX_WMO_WITH:      main_custom.o-{{.*}}
+//    INDEX_WMO_WITH-NEXT: --------
+//    INDEX_WMO_WITH:      out-file: {{.*}}main_custom.o
+//
+//    INDEX_WMO_WITH:      second_custom.o-{{.*}}
+//    INDEX_WMO_WITH-NEXT: --------
+//    INDEX_WMO_WITH:      out-file: {{.*}}second_custom.o
+//
+//    INDEX_WMO_WITH_NEGATIVE-NOT: main_out.o
+//    INDEX_WMO_WITH_NEGATIVE-NOT: second_out.o
+//    INDEX_WMO_WITH_NEGATIVE-NOT: main_different.o
+//    INDEX_WMO_WITH_NEGATIVE-NOT: second_different.o
+
+
+// 4. Diagnostics
+//
+// A) Check mismatched -o and -index-unit-output-path errors
+//    RUN: not %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_ignored \
+//    RUN:     -primary-file %t/main.swift %t/second.swift \
+//    RUN:     -o %t/main_out.o -index-unit-output-path %t/custom_output.o -index-unit-output-path %t/custom_output.o 2>&1 \
+//    RUN: | %FileCheck --check-prefixes=ERROR_MISMATCH %s
+//
+//    ERROR_MISMATCH: error: if any index unit output path files are specified, they all must be
+//
+// B) Check mismatched -o and -index-unit-output-path via file lists errors
+//    RUN: echo '%t/main.swift' > %t/filelist
+//    RUN: echo '%t/second.swift' >> %t/filelist
+//
+//    RUN: echo '%t/main_out.o' > %t/outputlist
+//    RUN: echo '%t/second_out.o' >> %t/outputlist
+//
+//    RUN: echo '"%t/custom_main.o' > %t/index-outputlist
+//
+//    RUN: not %target-swift-frontend -typecheck -parse-stdlib -enable-batch-mode \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_ignored \
+//    RUN:     -primary-filelist %t/filelist -filelist %t/filelist \
+//    RUN:     -output-filelist %t/outputlist -index-unit-output-path-filelist %t/index-outputlist 2>&1 \
+//    RUN: | %FileCheck --check-prefixes=ERROR_MISMATCH %s
+//
+// C) Check -index-unit-output-path without -index-store warns
+//    RUN: %target-swift-frontend -typecheck -parse-stdlib \
+//    RUN:     -module-name mod_name \
+//    RUN:     -primary-file %t/main.swift %t/second.swift \
+//    RUN:     -o %t/main_out.o -index-unit-output-path %t/custom_output.o 2>&1 \
+//    RUN: | %FileCheck --check-prefixes=ERROR_IGNORED %s
+//
+//    ERROR_IGNORED: warning: -index-unit-output-path is ignored without -index-store-path
+


### PR DESCRIPTION
These new options mirror -o and -output-filelist and are used instead of those options to supply the output file path(s) to record in the index store. This is intended to allow sharing index data across builds in separate directories (so different -o values) that are otherwise equivalent as far as the index data is concerned (e.g. an ASAN build and a non-ASAN build) by supplying the same -index-unit-output-path for both.

Resolves rdar://problem/74816412