### PR TITLE
Fix rebranch SwiftNameAttr warning regression

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -391,9 +391,7 @@ void ClangImporter::Implementation::addBridgeHeaderTopLevelDecls(
   BridgeHeaderTopLevelDecls.push_back(D);
 }
 
-bool ClangImporter::Implementation::shouldIgnoreBridgeHeaderTopLevelDecl(
-    clang::Decl *D) {
-  // Ignore forward references;
+bool importer::isForwardDeclOfType(const clang::Decl *D) {
   if (auto *ID = dyn_cast<clang::ObjCInterfaceDecl>(D)) {
     if (!ID->isThisDeclarationADefinition())
       return true;
@@ -405,6 +403,11 @@ bool ClangImporter::Implementation::shouldIgnoreBridgeHeaderTopLevelDecl(
       return true;
   }
   return false;
+}
+
+bool ClangImporter::Implementation::shouldIgnoreBridgeHeaderTopLevelDecl(
+    clang::Decl *D) {
+  return importer::isForwardDeclOfType(D);
 }
 
 ClangImporter::ClangImporter(ASTContext &ctx,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1462,6 +1462,10 @@ public:
 
 namespace importer {
 
+/// Whether this is a forward declaration of a type. We ignore forward
+/// declarations in certain cases, and instead process the real declarations.
+bool isForwardDeclOfType(const clang::Decl *decl);
+
 /// Whether we should suppress the import of the given Clang declaration.
 bool shouldSuppressDeclImport(const clang::Decl *decl);
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -2040,7 +2040,12 @@ void importer::finalizeLookupTable(
       auto decl = entry.get<clang::NamedDecl *>();
       auto swiftName = decl->getAttr<clang::SwiftNameAttr>();
 
-      if (swiftName) {
+      if (swiftName
+          // Clang didn't previously attach SwiftNameAttrs to forward
+          // declarations, but this changed and we started diagnosing spurious
+          // warnings on @class declarations. Suppress them.
+          // FIXME: Can we avoid processing these decls in the first place?
+          && !importer::isForwardDeclOfType(decl)) {
         clang::SourceLocation diagLoc = swiftName->getLocation();
         if (!diagLoc.isValid())
           diagLoc = decl->getLocation();

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.apinotes
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.apinotes
@@ -1,4 +1,7 @@
 Name: ImportAsMember
+Classes:
+- Name: IAMPrivateChild
+  SwiftName: IAMPrivateParent.Child
 Globals:
 - Name: IAMStruct1APINoteVar
   SwiftName: Struct1.newApiNoteVar

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember.h
@@ -76,4 +76,9 @@ typedef int IAMBadInnerIntAPINotes;
 // CHECK: ImportAsMember.h:[[@LINE-1]]:{{[0-9]+}}: warning: imported declaration 'IAMBadInnerIntAPINotes' could not be mapped to 'IAMNonexistent.Inner2'
 // CHECK: ImportAsMember.h:[[@LINE-2]]:{{[0-9]+}}: note: please report this issue to the owners of 'ImportAsMember'
 
+@interface IAMPrivateParent @end
+@interface IAMPrivateChild
+- (instancetype)init;
+@end
+
 #endif // IMPORT_AS_MEMBER_H

--- a/test/ClangImporter/Inputs/custom-modules/ImportAsMember_Private.h
+++ b/test/ClangImporter/Inputs/custom-modules/ImportAsMember_Private.h
@@ -1,0 +1,9 @@
+#ifndef IMPORT_AS_MEMBER_PRIVATE_H
+#define IMPORT_AS_MEMBER_PRIVATE_H
+
+#include <ImportAsMember.h>
+
+@class IAMPrivateChild;
+// CHECK-NOT: ImportAsMember_Private.h:[[@LINE-1]]:{{[0-9]+}}: warning: imported declaration 'IAMPrivateChild' could not be mapped to 'IAMPrivateParent.Child'
+
+#endif // IMPORT_AS_MEMBER_PRIVATE_H

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -113,6 +113,16 @@ module ImportAsMember {
   }
 }
 
+// FIXME: This probably ought to be in a module_private.map, but that causes
+// hundreds of clang warnings.
+module ImportAsMember_Private {
+  export *
+
+  module A {
+    header "ImportAsMember_Private.h"
+  }
+}
+
 module ObjCIRExtras {
   header "ObjCIRExtras.h"
   export *

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -1,8 +1,13 @@
 // RUN: %empty-directory(%t.mcp)
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules -module-cache-path %t.mcp %s 2>&1 | %FileCheck %S/Inputs/custom-modules/ImportAsMember.h
+
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules -module-cache-path %t.mcp %s >%t.txt 2>&1
+// RUN: %FileCheck %S/Inputs/custom-modules/ImportAsMember.h <%t.txt
+// RUN: %FileCheck %S/Inputs/custom-modules/ImportAsMember_Private.h <%t.txt
+
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules -module-cache-path %t.mcp %s -verify
 
 import ImportAsMember
+import ImportAsMember_Private
 import ImportAsMemberSubmodules
 
 let _: IAMSOuter.Inner?


### PR DESCRIPTION
A change in the new clang branch seems to have caused it to start applying SwiftNameAttrs to forward declarations. We have apparently always tried to add these forward declarations to the lookup tables in PCH files, but never diagnosed the resulting failures because they did not have SwiftNameAttrs. Now they do, so we started emitting incorrect warnings.

We *probably* don’t need to process these at all, but there’s a risk of unintended behavior changes from that; instead, this PR takes a conservative approach and simply suppresses the warnings like we always have.

Fixes rdar://74710976.
