### PR TITLE
[Concurrency] Fix async-main crash

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4379,6 +4379,9 @@ ERROR(actorindependent_local_var,none,
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "
       "module was not imported", (StringRef))
+ERROR(async_main_no_concurrency,none,
+      "'_Concurrency' module not imported, required for async main", ())
+
 ERROR(enqueue_partial_task_not_in_context,none,
       "'enqueue(partialTask:)' can only be implemented in the definition of "
       "actor class %0", (Type))

--- a/test/Concurrency/async_main_no_concurrency.swift
+++ b/test/Concurrency/async_main_no_concurrency.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library %s
+// RUN: %target-typecheck-verify-swift -parse-as-library -enable-experimental-concurrency -parse-stdlib %s
+
+@main struct Main {
+  // expected-error@+1:22{{'_Concurrency' module not imported, required for async main}}
+  static func main() async {
+  }
+}


### PR DESCRIPTION
The compiler would assert/crash if someone tried to use async-main without enabling concurrency since it would fail to find the concurrency module. `import _Concurrency` in the source file would also work, but is kind of gross.

I've decided to go down the route of just protecting the feature behind a check for enabling concurrency. Once we have, the concurrency module is imported implicitly, and we avoid the crash. Alternatively, we could just recommend that folks import the concurrency module.

Fixes rdar://74821680