### PR TITLE
Platform: link against ComCtl32 when using Common Controls

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -148,6 +148,8 @@ module WinSDK [system] {
     module CommCtrl {
       header "CommCtrl.h"
       export *
+
+      link "ComCtl32.Lib"
     }
 
     module CommDlg {


### PR DESCRIPTION
This adds a missing link directive to the ComCtl32 module.  This allows
use of the module without requiring the user to explicitly add the
linked library to the target when building code against this module.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
