### PR TITLE
swift-autocomplete.bash, rename 'options' for zsh compat

### DIFF
--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -161,8 +161,8 @@ _swift_complete()
     if [[ ${prevWord} == "-Xfrontend" ]] || echo ${COMP_WORDS[@]} | grep --quiet -e '-frontend' ; then
       frontendOption="-frontend"
     fi
-    options=`${tool} ${frontendOption} -help-hidden 2>/dev/null | grep '^  *-[a-zA-Z-]' | sed -E 's/^  *(-[a-zA-Z=-]+).*/\1/'`
-    COMPREPLY=( $(compgen -W "${options}" -- ${currentWord}) )
+    toolOptions=`${tool} ${frontendOption} -help-hidden 2>/dev/null | grep '^  *-[a-zA-Z-]' | sed -E 's/^  *(-[a-zA-Z=-]+).*/\1/'`
+    COMPREPLY=( $(compgen -W "${toolOptions}" -- ${currentWord}) )
   fi
   return 0
 }


### PR DESCRIPTION
Ok, now I can finally use swift auto-complete support.

'options' is the name of a reserved array in zsh