### PR TITLE
[SR-14280][CSSimplify] Increase the score when matching functions with different representations for contextual type

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1068,3 +1068,12 @@ func rdar_74435602(error: Error?) {
     }
   })
 }
+
+// SR-14280
+let _: (@convention(block) () -> Void)? = Bool.random() ? nil : {} // OK
+let _: (@convention(thin) () -> Void)? = Bool.random() ? nil : {} // OK
+let _: (@convention(c) () -> Void)? = Bool.random() ? nil : {} // OK on type checking, diagnostics are deffered to SIL
+
+let _: (@convention(block) () -> Void)? = Bool.random() ? {} : {} // OK
+let _: (@convention(thin) () -> Void)? = Bool.random() ? {} : {} // OK
+let _: (@convention(c) () -> Void)? = Bool.random() ? {} : {} // OK on type checking, diagnostics are deffered to SIL


### PR DESCRIPTION
<!-- What's in this pull request? -->
It does make sense to favor the same representation of contextual type, so increase the score when a function type is matching with different representations to avoid ambiguity. In this example, solver finds both bindings `(@convention(block) () -> Void)?` and `(() -> ())?`. Let me know what you think :) 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves: SR-14280
Resolves: rdar://74877828

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
