### PR TITLE
Update WinSDK module for latest changes

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -401,6 +401,13 @@ module WinSDK [system] {
     link "AdvAPI32.Lib"
   }
 
+  module WinSafer {
+    header "winsafer.h"
+    export *
+
+    link "AdvAPI32.Lib"
+  }
+
   // TODO(compnerd) does it make sense to implicitly export this API surface?
   // It seems to be meant for device drivers.
   module WLANAPI {

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -165,9 +165,6 @@ module WinSDK [system] {
       header "d3d11_2.h"
       header "d3d11_3.h"
       header "d3d11_4.h"
-
-      header "../shared/dxgi1_6.h"
-
       export *
 
       link "d3d11.lib"
@@ -180,6 +177,23 @@ module WinSDK [system] {
 
       link "d3d12.lib"
       link "dxgi.lib"
+    }
+
+    // FIXME(compnerd) DXGI is part of the Direct3D interfaces currently; we
+    // should split it out, but because it is part of the D3D11 interfaces, this
+    // separate module is meant to augment the uncovered portions only.
+    module _DXGI {
+      header "../shared/dxgi1_6.h"
+      export *
+
+      link "dxgi.lib"
+    }
+
+    module D3DCompiler {
+      header "d3dcompiler.h"
+      export *
+
+      link "d3dcompiler.lib"
     }
 
     module XAudio29 {

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -153,7 +153,7 @@ module WinSDK [system] {
     }
   }
 
-  module DirectX {
+  explicit module DirectX {
     module Direct3D12 {
       header "d3d12.h"
       export *
@@ -178,7 +178,7 @@ module WinSDK [system] {
       header "Xinput.h"
       export *
 
-      link "xinputuap.lib"
+      link "xinput.lib"
     }
 
     link "dxguid.lib"

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -184,6 +184,7 @@ module WinSDK [system] {
     // separate module is meant to augment the uncovered portions only.
     module _DXGI {
       header "../shared/dxgi1_6.h"
+      header "dxgidebug.h"
       export *
 
       link "dxgi.lib"

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -139,6 +139,11 @@ module WinSDK [system] {
     }
   }
 
+  module ActiveX {
+    header "OCIdl.h"
+    export *
+  }
+
   module Controls {
     module CommCtrl {
       header "CommCtrl.h"

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -153,6 +153,35 @@ module WinSDK [system] {
     }
   }
 
+  module DirectX {
+    module Direct3D12 {
+      header "d3d12.h"
+      export *
+
+      link "d3d12.lib"
+      link "dxgi.lib"
+    }
+
+    module XAudio29 {
+      header "xaudio2.h"
+      header "xaudio2fx.h"
+      export *
+
+      link "xaudio2.lib"
+    }
+
+    // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was
+    // part of Vista.
+    module XInput14 {
+      header "Xinput.h"
+      export *
+
+      link "xinputuap.lib"
+    }
+
+    link "dxguid.lib"
+  }
+
   // FIXME(compnerd) this is a hack for the HWND typedef for DbgHelp
   module __DirectX {
     header "directmanipulation.h"

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -161,9 +161,13 @@ module WinSDK [system] {
   explicit module DirectX {
     module Direct3D11 {
       header "d3d11.h"
+      header "d3d11_1.h"
+      header "d3d11_2.h"
+      header "d3d11_3.h"
+      header "d3d11_4.h"
       export *
 
-      link "d3d12.lib"
+      link "d3d11.lib"
       link "dxgi.lib"
     }
 

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -159,6 +159,14 @@ module WinSDK [system] {
   }
 
   explicit module DirectX {
+    module Direct3D11 {
+      header "d3d11.h"
+      export *
+
+      link "d3d12.lib"
+      link "dxgi.lib"
+    }
+
     module Direct3D12 {
       header "d3d12.h"
       export *

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -168,6 +168,8 @@ module WinSDK [system] {
       export *
 
       link "xaudio2.lib"
+
+      requires cplusplus
     }
 
     // XInput 1.4 (Windows 10, XBox) is newer than the XInput 9.1.0 which was

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -165,6 +165,9 @@ module WinSDK [system] {
       header "d3d11_2.h"
       header "d3d11_3.h"
       header "d3d11_4.h"
+
+      header "../shared/dxgi1_6.h"
+
       export *
 
       link "d3d11.lib"

--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -372,6 +372,15 @@ module WinSDK [system] {
     link "sensorsapi.lib"
   }
 
+  module UI {
+    module XAML {
+      module Hosting {
+        header "windows.ui.xaml.hosting.desktopwindowxamlsource.h"
+        export *
+      }
+    }
+  }
+
   module User {
     header "WinUser.h"
     export *


### PR DESCRIPTION
This cherry-picks from main changes for the WinSDK module to the 5.4 release branch.  This only impacts the Windows path and should be safe for the platform as it only changes how headers are mapped into the clang importer.