### PR TITLE
[windows][test] Mark two tests that end up deadlocked as unsupported.

### DIFF
--- a/test/Concurrency/Runtime/async_task_equals_hashCode.swift
+++ b/test/Concurrency/Runtime/async_task_equals_hashCode.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
+// UNSUPPORTED: OS=windows-os
 
 #if canImport(Darwin)
 import Darwin

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
+// UNSUPPORTED: OS=windows-msvc
 
 struct Boom: Error {}
 struct IgnoredBoom: Error {}


### PR DESCRIPTION
Two tests seems to end up deadlocked in the Windows CI machines. Mark
them as unsupported for the time being so the CI machines are useful
again.

/cc @compnerd @ktoso 