### PR TITLE
Teach TSan about Swift Task and Actor model

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -150,6 +150,8 @@ void swift::swift_job_run(Job *job, ExecutorRef executor) {
 }
 
 void swift::runJobInExecutorContext(Job *job, ExecutorRef executor) {
+  _swift_tsan_acquire(job);
+
   if (auto task = dyn_cast<AsyncTask>(job)) {
     // Update the active task in the current thread.
     ActiveTask::set(task);
@@ -167,6 +169,8 @@ void swift::runJobInExecutorContext(Job *job, ExecutorRef executor) {
     // There's no extra bookkeeping to do for simple jobs.
     job->runSimpleInFullyEstablishedContext(executor);
   }
+
+  _swift_tsan_release(job);
 }
 
 AsyncTask *swift::swift_task_getCurrent() {
@@ -1427,6 +1431,8 @@ void swift::swift_task_switch(AsyncTask *task, ExecutorRef currentExecutor,
 
 void swift::swift_task_enqueue(Job *job, ExecutorRef executor) {
   assert(job && "no job provided");
+
+  _swift_tsan_release(job);
 
   if (executor.isGeneric())
     return swift_task_enqueueGlobal(job);

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -65,6 +65,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   TaskGroup.swift
   TaskLocal.cpp
   TaskLocal.swift
+  ThreadSanitizer.cpp
   Mutex.cpp
   ${swift_concurrency_objc_sources}
 

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -56,6 +56,11 @@ void donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
                                        void *context);
 #endif
 
+/// release() establishes a happens-before relation with a preceding acquire()
+/// on the same address.
+void _swift_tsan_acquire(void *addr);
+void _swift_tsan_release(void *addr);
+
 // ==== ------------------------------------------------------------------------
 // TODO: this was moved from Task.cpp to share it with TaskGroup.cpp, where else better place to put it?
 

--- a/stdlib/public/Concurrency/ThreadSanitizer.cpp
+++ b/stdlib/public/Concurrency/ThreadSanitizer.cpp
@@ -16,19 +16,34 @@
 
 #include "TaskPrivate.h"
 
+#if defined(_WIN32)
+#define NOMINMAX
+#include <windows.h>
+#else
 #include <dlfcn.h>
+#endif
 
 using TSanFunc = void(void *);
 
+namespace {
+static TSanFunc *loadSymbol(const char *name) {
+#if defined(_WIN32)
+  return (TSanFunc *)GetProcAddress(GetModuleHandle(NULL), name);
+#else
+  return (TSanFunc *)dlsym(RTLD_DEFAULT, name);
+#endif
+}
+}
+
 void swift::_swift_tsan_acquire(void *addr) {
-  static auto ptr = (TSanFunc *)dlsym(RTLD_DEFAULT, "__tsan_acquire");
+  static auto ptr = loadSymbol("__tsan_acquire");
   if (ptr) {
     ptr(addr);
   }
 }
 
 void swift::_swift_tsan_release(void *addr) {
-  static auto ptr = (TSanFunc *)dlsym(RTLD_DEFAULT, "__tsan_release");
+  static auto ptr = loadSymbol("__tsan_release");
   if (ptr) {
     ptr(addr);
   }

--- a/stdlib/public/Concurrency/ThreadSanitizer.cpp
+++ b/stdlib/public/Concurrency/ThreadSanitizer.cpp
@@ -55,3 +55,9 @@ void swift::_swift_tsan_release(void *addr) {
     tsan_release(addr);
   }
 }
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(c)
+void swift_task_set_tsan_hooks(TSanFunc *acquire, TSanFunc *release) {
+  tsan_acquire = acquire;
+  tsan_release = release;
+}

--- a/stdlib/public/Concurrency/ThreadSanitizer.cpp
+++ b/stdlib/public/Concurrency/ThreadSanitizer.cpp
@@ -1,0 +1,35 @@
+//===--- ThreadSanitizer.cpp - Thread Sanitizer support -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Thread Sanitizer support for the Swift Task runtime
+//
+//===----------------------------------------------------------------------===//
+
+#include "TaskPrivate.h"
+
+#include <dlfcn.h>
+
+using TSanFunc = void(void *);
+
+void swift::_swift_tsan_acquire(void *addr) {
+  static auto ptr = (TSanFunc *)dlsym(RTLD_DEFAULT, "__tsan_acquire");
+  if (ptr) {
+    ptr(addr);
+  }
+}
+
+void swift::_swift_tsan_release(void *addr) {
+  static auto ptr = (TSanFunc *)dlsym(RTLD_DEFAULT, "__tsan_release");
+  if (ptr) {
+    ptr(addr);
+  }
+}

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -69,6 +69,12 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
 
 @main struct Main {
   static func main() async {
-    await runTest(numCounters: 10, numWorkers: 100, numIterations: 1000)
+    // Useful for debugging: specify counter/worker/iteration counts
+    let args = CommandLine.arguments
+    let counters = args.count >= 2 ? Int(args[1])! : 10
+    let workers = args.count >= 3 ? Int(args[2])! : 100
+    let iterations = args.count >= 4 ? Int(args[3])! : 1000
+    print("counters: \(counters), workers: \(workers), iterations: \(iterations)")
+    await runTest(numCounters: counters, numWorkers: workers, numIterations: iterations)
   }
 }

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -4,6 +4,8 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 // REQUIRES: tsan_runtime
+// UNSUPPORTED: linux
+// UNSUPPORTED: windows
 
 #if canImport(Darwin)
 import Darwin

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -1,8 +1,9 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library -sanitize=thread)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
+// REQUIRES: tsan_runtime
 
 #if canImport(Darwin)
 import Darwin

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -1,0 +1,74 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+actor Counter {
+  private var value = 0
+  private let scratchBuffer: UnsafeMutableBufferPointer<Int>
+
+  init(maxCount: Int) {
+    scratchBuffer = .allocate(capacity: maxCount)
+    scratchBuffer.initialize(repeating: 0)
+  }
+
+  func next() -> Int {
+    let current = value
+
+    // Make sure we haven't produced this value before
+    assert(scratchBuffer[current] == 0)
+    scratchBuffer[current] = 1
+
+    value = value + 1
+    return current
+  }
+}
+
+
+func worker(identity: Int, counters: [Counter], numIterations: Int) async {
+  for i in 0..<numIterations {
+    let counterIndex = Int.random(in: 0 ..< counters.count)
+    let counter = counters[counterIndex]
+    let nextValue = await counter.next()
+    print("Worker \(identity) calling counter \(counterIndex) produced \(nextValue)")
+  }
+}
+
+func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
+  // Create counter actors.
+  var counters: [Counter] = []
+  for i in 0..<numCounters {
+    counters.append(Counter(maxCount: numWorkers * numIterations))
+  }
+
+  // Create a bunch of worker threads.
+  var workers: [Task.Handle<Void, Error>] = []
+  for i in 0..<numWorkers {
+    workers.append(
+      Task.runDetached { [counters] in
+        usleep(UInt32.random(in: 0..<100) * 1000)
+        await worker(identity: i, counters: counters, numIterations: numIterations)
+      }
+    )
+  }
+
+  // Wait until all of the workers have finished.
+  for worker in workers {
+    try! await worker.get()
+  }
+
+  print("DONE!")
+}
+
+@main struct Main {
+  static func main() async {
+    await runTest(numCounters: 10, numWorkers: 100, numIterations: 1000)
+  }
+}

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -70,6 +70,12 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
 
 @main struct Main {
   static func main() async {
-    await runTest(numCounters: 10, numWorkers: 100, numIterations: 1000)
+    // Useful for debugging: specify counter/worker/iteration counts
+    let args = CommandLine.arguments
+    let counters = args.count >= 2 ? Int(args[1])! : 10
+    let workers = args.count >= 3 ? Int(args[2])! : 100
+    let iterations = args.count >= 4 ? Int(args[3])! : 1000
+    print("counters: \(counters), workers: \(workers), iterations: \(iterations)")
+    await runTest(numCounters: counters, numWorkers: workers, numIterations: iterations)
   }
 }

--- a/test/Sanitizers/tsan/async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/async_let_fibonacci.swift
@@ -1,0 +1,55 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+func fib(_ n: Int) -> Int {
+  var first = 0
+  var second = 1
+  for _ in 0..<n {
+    let temp = first
+    first = second
+    second = temp + first
+  }
+  return first
+}
+
+func asyncFib(_ n: Int) async -> Int {
+  if n == 0 || n == 1 {
+    return n
+  }
+
+  async let first = await asyncFib(n-2)
+  async let second = await asyncFib(n-1)
+
+  // Sleep a random amount of time waiting on the result producing a result.
+  usleep(UInt32.random(in: 0..<100) * 1000)
+
+  let result = await first + second
+
+  // Sleep a random amount of time before producing a result.
+  usleep(UInt32.random(in: 0..<100) * 1000)
+
+  return result
+}
+
+func runFibonacci(_ n: Int) async {
+  let result = await asyncFib(n)
+
+  print()
+  print("Async fib = \(result), sequential fib = \(fib(n))")
+  assert(result == fib(n))
+}
+
+@main struct Main {
+  static func main() async {
+    await runFibonacci(10)
+  }
+}

--- a/test/Sanitizers/tsan/async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/async_let_fibonacci.swift
@@ -1,8 +1,9 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library -sanitize=thread)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
+// REQUIRES: tsan_runtime
 
 #if canImport(Darwin)
 import Darwin

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -1,0 +1,84 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency  %import-libdispatch -parse-as-library)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+import Dispatch
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+enum HomeworkError: Error, Equatable {
+  case dogAteIt(String)
+}
+
+func formGreeting(name: String) async -> String {
+  return "Hello \(name) from async world"
+}
+
+func testSimple(
+  name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
+) async {
+  print("Testing name: \(name), dog: \(dogName), shouldThrow: \(shouldThrow) doSuspend: \(doSuspend)")
+
+  var completed = false
+
+  let taskHandle: Task.Handle<String, Error> = Task.runDetached {
+    let greeting = await formGreeting(name: name)
+
+    // If the intent is to test suspending, wait a bit so the second task
+    // can complete.
+    if doSuspend {
+      print("- Future sleeping")
+      sleep(1)
+    }
+
+    if (shouldThrow) {
+      print("- Future throwing")
+      throw HomeworkError.dogAteIt(dogName + " the dog")
+    }
+
+    print("- Future returning normally")
+    return greeting + "!"
+  }
+
+  // If the intent is not to test suspending, wait a bit so the first task
+  // can complete.
+  if !doSuspend {
+    print("+ Reader sleeping")
+    sleep(1)
+  }
+
+  do {
+    print("+ Reader waiting for the result")
+    let result = try await taskHandle.get()
+    completed = true
+    print("+ Normal return: \(result)")
+    assert(result == "Hello \(name) from async world!")
+  } catch HomeworkError.dogAteIt(let badDog) {
+    completed = true
+    print("+ Error return: HomeworkError.dogAteIt(\(badDog))")
+    assert(badDog == dogName + " the dog")
+  } catch {
+    fatalError("Caught a different exception?")
+  }
+
+  assert(completed)
+  print("Finished test")
+}
+
+
+@main struct Main {
+  static func main() async {
+    await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)
+    await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: true, doSuspend: false)
+    await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: true)
+    await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: true, doSuspend: true)
+
+    print("Done")
+  }
+}

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -1,8 +1,9 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency  %import-libdispatch -parse-as-library)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency  %import-libdispatch -parse-as-library -sanitize=thread)
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
+// REQUIRES: tsan_runtime
 
 import Dispatch
 

--- a/test/Sanitizers/tsan/mainactor.swift
+++ b/test/Sanitizers/tsan/mainactor.swift
@@ -1,0 +1,83 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -enable-experimental-concurrency %import-libdispatch) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+import Dispatch
+
+/// @returns true iff the expected answer is actually the case, i.e., correct.
+/// If the current queue does not match expectations, this function may return
+/// false or just crash the program with non-zero exit code, depending on SDK.
+func checkIfMainQueue(expectedAnswer expected: Bool) -> Bool {
+  if #available(macOS 10.12, iOS 10, tvOS 10, watchOS 3, *) {
+    dispatchPrecondition(condition: expected ? .onQueue(DispatchQueue.main) 
+                                             : .notOnQueue(DispatchQueue.main))
+  }
+  return true
+}
+
+actor A {
+  func onCorrectQueue(_ count : Int) -> Int {
+    if checkIfMainQueue(expectedAnswer: false) {
+      print("on actor instance's queue")
+      return count + 1
+    }
+    print("ERROR: not on actor instance's queue")
+    return -10
+  }
+}
+
+@MainActor func checkAnotherFn(_ count : Int) -> Int {
+  if checkIfMainQueue(expectedAnswer: true) {
+    print("on main queue again!")
+    return count + 1
+  } else {
+    print("ERROR: left the main queue?")
+    return -10
+  }
+}
+
+@MainActor func enterMainActor(_ initialCount : Int) async -> Int {
+  if checkIfMainQueue(expectedAnswer: true) {
+    print("hello from main actor!")
+  } else {
+    print("ERROR: not on correct queue!")
+  }
+
+  // try calling a function on another actor.
+  let count = await A().onCorrectQueue(initialCount)
+
+  guard checkIfMainQueue(expectedAnswer: true) else {
+    print("ERROR: did not switch back to main actor!")
+    return -10
+  }
+
+  return checkAnotherFn(count) + 1
+}
+
+@concurrent func someFunc() async -> Int {
+  // NOTE: the "return" counter is just to make sure we're properly returning values.
+  // the expected number should be equal to the number of "plus-one" expressions.
+  // since there are no loops or duplicate function calls
+  return await enterMainActor(0) + 1
+}
+
+
+// CHECK: starting
+// CHECK-NOT: ERROR
+// CHECK: hello from main actor!
+// CHECK-NOT: ERROR
+// CHECK: on actor instance's queue
+// CHECK-NOT: ERROR
+// CHECK: on main queue again!
+// CHECK-NOT: ERROR
+// CHECK: finished with return counter = 4
+
+@main struct RunIt {
+  static func main() async {
+    print("starting")
+    let result = await someFunc()
+    print("finished with return counter = \(result)")
+  }
+}

--- a/test/Sanitizers/tsan/mainactor.swift
+++ b/test/Sanitizers/tsan/mainactor.swift
@@ -1,8 +1,9 @@
-// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -enable-experimental-concurrency %import-libdispatch) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -enable-experimental-concurrency %import-libdispatch -sanitize=thread) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
+// REQUIRES: tsan_runtime
 
 import Dispatch
 

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftc_driver %s -Xfrontend -enable-experimental-concurrency -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
 // RUN: %target-codesign %t
-// RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %FileCheck %s
+// RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %swift-demangle --simplified | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -1,0 +1,67 @@
+// RUN: %target-swiftc_driver %s -Xfrontend -enable-experimental-concurrency -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
+// RUN: %target-codesign %t
+// RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+// REQUIRES: tsan_runtime
+
+var globalCounterValue = 0
+
+actor Counter {
+  func next() -> Int {
+    let current = globalCounterValue
+    globalCounterValue += 1
+    return current
+  }
+}
+
+func worker(identity: Int, counters: [Counter], numIterations: Int) async {
+  for _ in 0..<numIterations {
+    let counterIndex = Int.random(in: 0 ..< counters.count)
+    let counter = counters[counterIndex]
+    let nextValue = await counter.next()
+    print("Worker \(identity) calling counter \(counterIndex) produced \(nextValue)")
+  }
+}
+
+func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
+  // Create counter actors.
+  var counters: [Counter] = []
+  for _ in 0..<numCounters {
+    counters.append(Counter())
+  }
+
+  // Create a bunch of worker threads.
+  var workers: [Task.Handle<Void, Error>] = []
+  for i in 0..<numWorkers {
+    workers.append(
+      Task.runDetached { [counters] in
+        await worker(identity: i, counters: counters, numIterations: numIterations)
+      }
+    )
+  }
+
+  // Wait until all of the workers have finished.
+  for worker in workers {
+    try! await worker.get()
+  }
+
+  print("DONE!")
+}
+
+@main struct Main {
+  static func main() async {
+    // Useful for debugging: specify counter/worker/iteration counts
+    let args = CommandLine.arguments
+    let counters = args.count >= 2 ? Int(args[1])! : 10
+    let workers = args.count >= 3 ? Int(args[2])! : 10
+    let iterations = args.count >= 4 ? Int(args[3])! : 100
+    print("counters: \(counters), workers: \(workers), iterations: \(iterations)")
+    await runTest(numCounters: counters, numWorkers: workers, numIterations: iterations)
+  }
+}
+
+// CHECK: ThreadSanitizer: {{(Swift access|data)}} race
+// CHECK: Location is global 'globalCounterValue'

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftc_driver %s -Xfrontend -enable-experimental-concurrency -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
 // RUN: %target-codesign %t
-// RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %FileCheck %s
+// RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %swift-demangle --simplified | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -1,0 +1,65 @@
+// RUN: %target-swiftc_driver %s -Xfrontend -enable-experimental-concurrency -parse-as-library %import-libdispatch -target %sanitizers-target-triple -g -sanitize=thread -o %t
+// RUN: %target-codesign %t
+// RUN: env %env-TSAN_OPTIONS="abort_on_error=0" not %target-run %t 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+// REQUIRES: tsan_runtime
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+func fib(_ n: Int) -> Int {
+  var first = 0
+  var second = 1
+  for _ in 0..<n {
+    let temp = first
+    first = second
+    second = temp + first
+  }
+  return first
+}
+
+var racyCounter = 0
+
+func asyncFib(_ n: Int) async -> Int {
+  racyCounter += 1
+  if n == 0 || n == 1 {
+    return n
+  }
+
+  async let first = await asyncFib(n-2)
+  async let second = await asyncFib(n-1)
+
+  // Sleep a random amount of time waiting on the result producing a result.
+  usleep(UInt32.random(in: 0..<100) * 1000)
+
+  let result = await first + second
+
+  // Sleep a random amount of time before producing a result.
+  usleep(UInt32.random(in: 0..<100) * 1000)
+
+  return result
+}
+
+func runFibonacci(_ n: Int) async {
+  let result = await asyncFib(n)
+
+  print()
+  print("Async fib = \(result), sequential fib = \(fib(n))")
+  assert(result == fib(n))
+  print("asyncFib() called around \(racyCounter) times")
+}
+
+@main struct Main {
+  static func main() async {
+    await runFibonacci(10)
+  }
+}
+
+// CHECK: ThreadSanitizer: Swift access race
+// CHECK: Location is global 'racyCounter'


### PR DESCRIPTION
I have identified the following conceptual synchronization points at
which task data and computation can cross thread boundaries.  We need to
model these in TSan to avoid false positives:

Awaiting an async task (`AsyncTask::waitFuture`), which has two cases:
1) The task has completed (`AsyncTask::completeFuture`).  Everything
   that happened during task execution "happened before" before the
   point where we access its result.  We synchronize on the *awaited*
   task.
2) The task is still executing: the current execution is suspended and
   the waiting task is put into the list of "waiters".  Once the awaited
   task completes, the waiters will be scheduled.  In this case, we
   synchronize on the *waiting* task.

Note: there is a similar relationship for task groups which I still have
to investigate.  I will follow-up with an additional patch and tests.

Actor job execution (`swift::runJobInExecutorContext`):
Job scheduling (`swift::swift_task_enqueue`) precedes/happens before job
execution.  Also all job executions (switching actors or suspend/resume)
are serially ordered.

Note: the happens-before edge for schedule->execute isn't strictly
needed in most cases since scheduling calls through to libdispatch's
`dispatch_async_f`, which we already intercept and model in TSan.
However, I am trying to model Swift Task semantics to increase the
chance of things to continue to work in case the "task backend" is
switched out.

rdar://74256733
