### PR TITLE
IRGen: Remove hack

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2425,13 +2425,6 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
     value = llvm::ConstantExpr::getBitCast(value, fnPtr->getType());
   } else {
     value = fnPtr;
-
-    // HACK: the swiftasync argument treatment is currently using
-    // a register that can be clobbered by the linker.  Use nonlazybind
-    // as a workaround.
-    if (fpKind.isSpecial()) {
-      cast<llvm::Function>(value)->addFnAttr(llvm::Attribute::NonLazyBind);
-    }
   }
   FunctionPointer fp = FunctionPointer(fpKind, value, sig);
 


### PR DESCRIPTION
Since llvm-project PR#2557 llvm will no longer use r11 for swiftasync
