### PR TITLE
[stdlib] Fix conversion from Float16 to unsigned integer types

### DIFF
--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1160,11 +1160,19 @@ public struct ${Self}
   public init(_ source: ${FloatType}) {
     _precondition(source.isFinite,
       "${FloatType} value cannot be converted to ${Self} because it is either infinite or NaN")
-%     if not (FloatBits == 16 and signed and bits >= 32): # Float16 is always in-range for 32- and 64-bit signed integer types.
+%     if FloatBits == 16 and signed and bits >= 32:
+    // A Float16 value, if finite, is always in-range for 32- and 64-bit signed
+    // integer types.
+%     else:
     _precondition(source > ${str(lower)}.0,
       "${FloatType} value cannot be converted to ${Self} because the result would be less than ${Self}.min")
+%       if FloatBits == 16 and not signed and bits >= 16:
+    // A Float16 value, if greater than -1 and finite, is always in-range for
+    // 16-, 32-, and 64-bit unsigned integer types.
+%       else:
     _precondition(source < ${str(upper)}.0,
       "${FloatType} value cannot be converted to ${Self} because the result would be greater than ${Self}.max")
+%       end
 %     end
     self._value = Builtin.fpto${u}i_FPIEEE${FloatBits}_${BuiltinName}(source._value)
   }
@@ -1191,10 +1199,16 @@ public struct ${Self}
     // The value passed as `source` must not be infinite, NaN, or exceed the
     // bounds of the integer type; the result of `fptosi` or `fptoui` is
     // undefined if it overflows.
-%     if not (FloatBits == 16 and signed and bits >= 32): # Float16 is always in-range for 32- and 64-bit signed integer types.
-    guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
-%     else:
+%     if FloatBits == 16 and signed and bits >= 32:
+    // A Float16 value, if finite, is always in-range for 32- and 64-bit signed
+    // integer types.
     guard source.isFinite else {
+%     elif FloatBits == 16 and not signed and bits >= 16:
+    // A Float16 value, if greater than -1 and finite, is always in-range for
+    // 16-, 32-, and 64-bit unsigned integer types.
+    guard source > ${str(lower)}.0 && source.isFinite else {
+%     else:
+    guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
 %     end
       return nil
     }

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1160,7 +1160,7 @@ public struct ${Self}
   public init(_ source: ${FloatType}) {
     _precondition(source.isFinite,
       "${FloatType} value cannot be converted to ${Self} because it is either infinite or NaN")
-%     if not (FloatBits == 16 and bits >= 32): # Float16 is always in-range for 32- and 64-bit ints.
+%     if not (FloatBits == 16 and signed and bits >= 32): # Float16 is always in-range for 32- and 64-bit signed integer types.
     _precondition(source > ${str(lower)}.0,
       "${FloatType} value cannot be converted to ${Self} because the result would be less than ${Self}.min")
     _precondition(source < ${str(upper)}.0,
@@ -1191,7 +1191,7 @@ public struct ${Self}
     // The value passed as `source` must not be infinite, NaN, or exceed the
     // bounds of the integer type; the result of `fptosi` or `fptoui` is
     // undefined if it overflows.
-%     if not (FloatBits == 16 and bits >= 32): # Float16 is always in-range for 32- and 64-bit ints.
+%     if not (FloatBits == 16 and signed and bits >= 32): # Float16 is always in-range for 32- and 64-bit signed integer types.
     guard source > ${str(lower)}.0 && source < ${str(upper)}.0 else {
 %     else:
     guard source.isFinite else {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes a think-o, unblocking #36205, which will serve as the test for this change.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-14293](https://bugs.swift.org/browse/SR-14293).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
