### PR TITLE
[ConstraintGraph] Optimize edge contraction

### DIFF
--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1312,12 +1312,36 @@ static bool shouldContractEdge(ConstraintKind kind) {
 }
 
 bool ConstraintGraph::contractEdges() {
+  // Current constraint system doesn't have any closure expressions
+  // associated with it so there is nothing to here.
+  if (CS.ClosureTypes.empty())
+    return false;
+
   SmallVector<Constraint *, 16> constraints;
-  CS.findConstraints(constraints, [&](const Constraint &constraint) {
-    // Track how many constraints did contraction algorithm iterated over.
-    incrementConstraintsPerContractionCounter();
-    return shouldContractEdge(constraint.getKind());
-  });
+  for (const auto &closure : CS.ClosureTypes) {
+    for (const auto &param : closure.second->getParams()) {
+      auto paramTy = param.getPlainType()->getAs<TypeVariableType>();
+      if (!paramTy)
+        continue;
+
+      // This closure is not currently in scope.
+      if (!CS.TypeVariables.count(paramTy))
+        break;
+
+      // Nothing to contract here since outside parameter
+      // is already bound to a concrete type.
+      if (CS.getFixedType(paramTy))
+        continue;
+
+      for (auto *constraint : (*this)[paramTy].getConstraints()) {
+        // Track how many constraints did contraction algorithm iterated over.
+        incrementConstraintsPerContractionCounter();
+
+        if (shouldContractEdge(constraint->getKind()))
+          constraints.push_back(constraint);
+      }
+    }
+  }
 
   bool didContractEdges = false;
   for (auto *constraint : constraints) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1298,24 +1298,23 @@ ConstraintGraph::computeConnectedComponents(
   return cc.getComponents();
 }
 
-
-/// For a given constraint kind, decide if we should attempt to eliminate its
-/// edge in the graph.
-static bool shouldContractEdge(ConstraintKind kind) {
-  switch (kind) {
-  case ConstraintKind::BindParam:
-    return true;
-
-  default:
-    return false;
-  }
-}
-
 bool ConstraintGraph::contractEdges() {
   // Current constraint system doesn't have any closure expressions
   // associated with it so there is nothing to here.
   if (CS.ClosureTypes.empty())
     return false;
+
+  // For a given constraint kind, decide if we should attempt to eliminate its
+  // edge in the graph.
+  auto shouldContractEdge = [](ConstraintKind kind) {
+    switch (kind) {
+    case ConstraintKind::BindParam:
+      return true;
+
+    default:
+      return false;
+    }
+  };
 
   SmallVector<Constraint *, 16> constraints;
   for (const auto &closure : CS.ClosureTypes) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar29358447.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar29358447.swift.gyb
@@ -1,9 +1,0 @@
-// RUN: %scale-test --begin 0 --end 10000 --step 1000 --typecheck --select incrementConstraintsPerContractionCounter %s
-// REQUIRES: asserts,no_asan
-
-let _: [Int] = [
-%for i in range(0, N):
-  1,
-%end
-  1
-]


### PR DESCRIPTION
Previously on every step solver would iterate over all
constraints in attempt to find `BindParam` which could
be contracted. Instead of doing that, let's take advantage
of the fact that all (participating) closures are recorded
in the constraint system during constraint generation, so
it should be possible to check either outer parameter types
are contractable with their inner uses.

In combination with incremental bindings new `contactEdges`
is effectively free.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
