### PR TITLE
[windows][test] Mark the test as unsupported on Windows, but correctly.

### DIFF
--- a/test/Concurrency/Runtime/async_task_equals_hashCode.swift
+++ b/test/Concurrency/Runtime/async_task_equals_hashCode.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// UNSUPPORTED: OS=windows-os
+// UNSUPPORTED: OS=windows-msvc
 
 #if canImport(Darwin)
 import Darwin


### PR DESCRIPTION
Can I blame this on auto-complete?

Continuation of #36214.

