### PR TITLE
Funnel all "get local conformances" queries through a request.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3004,6 +3004,7 @@ class NominalTypeDecl : public GenericTypeDecl, public IterableDeclContext {
   friend class DeclContext;
   friend class IterableDeclContext;
   friend class DirectLookupRequest;
+  friend class LookupAllConformancesInContextRequest;
   friend ArrayRef<ValueDecl *>
   ValueDecl::getSatisfiedProtocolRequirements(bool Sorted) const;
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -734,6 +734,8 @@ class IterableDeclContext {
 
   static IterableDeclContext *castDeclToIterableDeclContext(const Decl *D);
 
+  friend class LookupAllConformancesInContextRequest;
+
   /// Retrieve the \c ASTContext in which this iterable context occurs.
   ASTContext &getASTContext() const;
 

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -955,9 +955,7 @@ bool ConformanceLookupTable::lookupConformance(
 void ConformanceLookupTable::lookupConformances(
        NominalTypeDecl *nominal,
        DeclContext *dc,
-       ConformanceLookupKind lookupKind,
-       SmallVectorImpl<ProtocolDecl *> *protocols,
-       SmallVectorImpl<ProtocolConformance *> *conformances,
+       std::vector<ProtocolConformance *> *conformances,
        SmallVectorImpl<ConformanceDiagnostic> *diagnostics) {
   // We need to expand all implied conformances before we can find
   // those conformances that pertain to this declaration context.
@@ -979,36 +977,6 @@ void ConformanceLookupTable::lookupConformances(
                    [&](ConformanceEntry *entry) {
                      if (entry->isSuperseded())
                        return true;
-
-                     // If we are to filter out this result, do so now.
-                     switch (lookupKind) {
-                     case ConformanceLookupKind::OnlyExplicit:
-                       switch (entry->getKind()) {
-                       case ConformanceEntryKind::Explicit:
-                       case ConformanceEntryKind::Synthesized:
-                         break;
-                       case ConformanceEntryKind::Implied:
-                       case ConformanceEntryKind::Inherited:
-                         return false;
-                       }
-                       break;
-                     case ConformanceLookupKind::NonInherited:
-                       switch (entry->getKind()) {
-                       case ConformanceEntryKind::Explicit:
-                       case ConformanceEntryKind::Synthesized:
-                       case ConformanceEntryKind::Implied:
-                         break;
-                       case ConformanceEntryKind::Inherited:
-                         return false;
-                       }
-                       break;
-                     case ConformanceLookupKind::All:
-                       break;
-                     }
-
-                     // Record the protocol.
-                     if (protocols)
-                       protocols->push_back(entry->getProtocol());
 
                      // Record the conformance.
                      if (conformances) {

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -437,9 +437,7 @@ public:
   /// Look for all of the conformances within the given declaration context.
   void lookupConformances(NominalTypeDecl *nominal,
                           DeclContext *dc,
-                          ConformanceLookupKind lookupKind,
-                          SmallVectorImpl<ProtocolDecl *> *protocols,
-                          SmallVectorImpl<ProtocolConformance *> *conformances,
+                          std::vector<ProtocolConformance *> *conformances,
                           SmallVectorImpl<ConformanceDiagnostic> *diagnostics);
 
   /// Retrieve the complete set of protocols to which this nominal

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -178,9 +178,7 @@ bool IsAsyncHandlerRequest::evaluate(
   // implies @asyncHandler.
   {
     auto idc = cast<IterableDeclContext>(dc->getAsDecl());
-    auto conformances = evaluateOrDefault(
-        dc->getASTContext().evaluator,
-        LookupAllConformancesInContextRequest{idc}, { });
+    auto conformances = idc->getLocalConformances();
 
     for (auto conformance : conformances) {
       auto protocol = conformance->getProtocol();
@@ -2050,9 +2048,7 @@ static Optional<ActorIsolation> getIsolationFromWitnessedRequirements(
 
   // Walk through each of the conformances in this context, collecting any
   // requirements that have actor isolation.
-  auto conformances = evaluateOrDefault(
-      dc->getASTContext().evaluator,
-      LookupAllConformancesInContextRequest{idc}, { });
+  auto conformances = idc->getLocalConformances();
   using IsolatedRequirement =
       std::tuple<ProtocolConformance *, ActorIsolation, ValueDecl *>;
   SmallVector<IsolatedRequirement, 2> isolatedRequirements;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5650,13 +5650,6 @@ diagnoseMissingAppendInterpolationMethod(NominalTypeDecl *typeDecl) {
   }
 }
 
-std::vector<ProtocolConformance *>
-LookupAllConformancesInContextRequest::evaluate(
-    Evaluator &eval, const IterableDeclContext *IDC) const {
-  auto result = IDC->getLocalConformances(ConformanceLookupKind::All);
-  return std::vector<ProtocolConformance *>(result.begin(), result.end());
-}
-
 void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   auto *const dc = idc->getAsGenericContext();
 
@@ -5672,9 +5665,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   const auto defaultAccess = nominal->getFormalAccess();
 
   // Check each of the conformances associated with this context.
-  auto conformances =
-      evaluateOrDefault(dc->getASTContext().evaluator,
-                        LookupAllConformancesInContextRequest{idc}, {});
+  auto conformances = idc->getLocalConformances();
 
   // The conformance checker bundle that checks all conformances in the context.
   auto &Context = dc->getASTContext();

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -274,9 +274,7 @@ static Type inferResultBuilderType(ValueDecl *decl)  {
   auto addConformanceMatches = [&matches](ValueDecl *lookupDecl) {
     DeclContext *dc = lookupDecl->getDeclContext();
     auto idc = cast<IterableDeclContext>(dc->getAsDecl());
-    auto conformances = evaluateOrDefault(
-        dc->getASTContext().evaluator,
-        LookupAllConformancesInContextRequest{idc}, { });
+    auto conformances = idc->getLocalConformances();
 
     for (auto conformance : conformances) {
       auto protocol = conformance->getProtocol();


### PR DESCRIPTION
`LookupAllConformancesInContextRequest` caches the results of performing
lookup of all of the conformances ascribed to a given iterable
declaration context. However, it was only used in a small number of
places, with most clients using a different API
(`getLocalConformances()`) that does not provide
caching, cycle detection, or dependency tracking.

Sink `LookupAllConformancesInContextRequest` lower in the stack, and
reimplement `getLocalConformances()` on top of it. This ensures that
all of the various queries go through the cached request and get the
benefits of the request-evaluator infrastructure.