### PR TITLE
SILGen: Generate an 'apply [nothrow] for calls to 'rethrows' functions

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1655,8 +1655,7 @@ public:
 
   SILBasicBlock *getTryApplyErrorDest(SILLocation loc,
                                       CanSILFunctionType fnTy,
-                                      SILResultInfo exnResult,
-                                      bool isSuppressed);
+                                      SILResultInfo exnResult);
 
   /// Emit a dynamic member reference.
   RValue emitDynamicMemberRefExpr(DynamicMemberRefExpr *e, SGFContext c);

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1455,8 +1455,7 @@ void StmtEmitter::visitFailStmt(FailStmt *S) {
 SILBasicBlock *
 SILGenFunction::getTryApplyErrorDest(SILLocation loc,
                                      CanSILFunctionType fnTy,
-                                     SILResultInfo exnResult,
-                                     bool suppressErrorPath) {
+                                     SILResultInfo exnResult) {
   assert(exnResult.getConvention() == ResultConvention::Owned);
 
   // For now, don't try to re-use destination blocks for multiple
@@ -1470,13 +1469,6 @@ SILGenFunction::getTryApplyErrorDest(SILLocation loc,
 
   if (fnTy->isAsync())
     emitHopToCurrentExecutor(loc);
-
-  // If we're suppressing error paths, just wrap it up as unreachable
-  // and return.
-  if (suppressErrorPath) {
-    B.createUnreachable(loc);
-    return destBB;
-  }
 
   // We don't want to exit here with a dead cleanup on the stack,
   // so push the scope first.

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -612,8 +612,7 @@ class SuperSub : SuperBase {
     // CHECK:   [[REABSTRACT_CVF:%.*]] = convert_function [[REABSTRACT_PA]]
     // CHECK:   [[REABSTRACT_CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[REABSTRACT_CVF]]
     // CHECK:   [[TRY_APPLY_AUTOCLOSURE:%.*]] = function_ref @$ss2qqoiyxxSg_xyKXKtKlF :
-    // CHECK:   try_apply [[TRY_APPLY_AUTOCLOSURE]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}}, normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
-    // CHECK: [[NORMAL_BB]]{{.*}}
+    // CHECK:   apply [nothrow] [[TRY_APPLY_AUTOCLOSURE]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}})
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let f1 = {
       // CHECK: sil private [transparent] [ossa] @[[INNER_FUNC_2]]
@@ -644,8 +643,7 @@ class SuperSub : SuperBase {
     // CHECK:   [[REABSTRACT_CVF:%.*]] = convert_function [[REABSTRACT_PA]]
     // CHECK:   [[REABSTRACT_CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[REABSTRACT_CVF]]
     // CHECK:   [[TRY_APPLY_FUNC:%.*]] = function_ref @$ss2qqoiyxxSg_xyKXKtKlF :
-    // CHECK:   try_apply [[TRY_APPLY_FUNC]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}}, normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
-    // CHECK: [[NORMAL_BB]]{{.*}}
+    // CHECK:   apply [nothrow] [[TRY_APPLY_FUNC]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}})
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func g1() {
       // CHECK: sil private [transparent] [ossa] @[[INNER_FUNC_2]] : $@convention(thin) (@guaranteed SuperSub) -> @error Error {

--- a/test/SILGen/foreach_async.swift
+++ b/test/SILGen/foreach_async.swift
@@ -81,9 +81,7 @@ struct AsyncLazySequence<S: Sequence>: AsyncSequence {
 // CHECK:   [[NEXT_RESULT:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[MUTATION:%.*]] = begin_access
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $AsyncLazySequence<Array<Int>>.Iterator, #AsyncIteratorProtocol.next : <Self where Self : AsyncIteratorProtocol> (inout Self) -> () async throws -> Self.Element? : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error), normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-
-// CHECK: [[NORMAL_BB]]([[VAR:%.*]] : $()):
+// CHECK:   [[VAR:%.*]] = apply [nothrow] [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
@@ -94,9 +92,6 @@ struct AsyncLazySequence<S: Sequence>: AsyncSequence {
 // CHECK: [[NONE_BB]]:
 // CHECK:   funcEnd
 // CHECK    return
-
-// CHECK: [[ERROR_BB]]([[VAR:%.*]] : @owned $Error):
-// CHECK:    unreachable
 // CHECK: } // end sil function '$s13foreach_async13trivialStructyyAA17AsyncLazySequenceVySaySiGGYF'
 func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
   for await x in xx {
@@ -115,9 +110,7 @@ func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK:   [[NEXT_RESULT:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[MUTATION:%.*]] = begin_access
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $AsyncLazySequence<Array<Int>>.Iterator, #AsyncIteratorProtocol.next : <Self where Self : AsyncIteratorProtocol> (inout Self) -> () async throws -> Self.Element? : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error), normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-
-// CHECK: [[NORMAL_BB]]([[VAR:%.*]] : $()):
+// CHECK:   [[VAR:%.*]] = apply [nothrow] [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
@@ -136,9 +129,6 @@ func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK: [[NONE_BB]]:
 // CHECK:   funcEnd
 // CHECK    return
-
-// CHECK: [[ERROR_BB]]([[VAR:%.*]] : @owned $Error):
-// CHECK:    unreachable
 // CHECK: } // end sil function '$s13foreach_async21trivialStructContinueyyAA17AsyncLazySequenceVySaySiGGYF'
 
 func trivialStructContinue(_ xx: AsyncLazySequence<[Int]>) async {
@@ -176,9 +166,7 @@ func trivialStructBreak(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK:   [[NEXT_RESULT:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[MUTATION:%.*]] = begin_access
 // CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $AsyncLazySequence<Array<Int>>.Iterator, #AsyncIteratorProtocol.next : <Self where Self : AsyncIteratorProtocol> (inout Self) -> () async throws -> Self.Element? : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error), normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-
-// CHECK: [[NORMAL_BB]]([[VAR:%.*]] : $()):
+// CHECK:   [[VAR:%.*]] = apply [nothrow] [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 

--- a/test/SILGen/rethrows.swift
+++ b/test/SILGen/rethrows.swift
@@ -59,14 +59,10 @@ func test1() throws {
 // CHECK:       [[T1:%.*]] = convert_function [[T0]] : $@callee_guaranteed () -> Int to $@callee_guaranteed () -> (Int, @error Error)
 // CHECK:       [[T2:%.*]] = convert_escape_to_noescape [[T1]]
 // CHECK:       [[RETHROWER:%.*]] = function_ref @$s8rethrows9rethroweryS2iyKXEKF : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[T2]]) : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
-// CHECK:     [[NORMAL]]([[T0:%.*]] : $Int):
+// CHECK:       [[T0:%.*]] = apply [nothrow] [[RETHROWER]]([[T2]]) : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
 // CHECK-NEXT:  strong_release [[T1]]
 // CHECK-NEXT:  [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT:  return [[RESULT]]
-// CHECK:     [[ERROR]]([[T0:%.*]] : $Error):
-// CHECK-NEXT:  strong_release [[T1]]
-// CHECK-NEXT:  unreachable
 func test2() {
   rethrower(nonthrower)
 }
@@ -77,12 +73,9 @@ func test2() {
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[CVT]]
 // CHECK:       [[T1:%.*]] = convert_function [[T0]] : $@noescape @callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> (Int, @error Error)
 // CHECK:       [[RETHROWER:%.*]] = function_ref @$s8rethrows9rethroweryS2iyKXEKF : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[T1]]) : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
-// CHECK:     [[NORMAL]]({{%.*}} : $Int):
+// CHECK:       {{%.*}} = apply [nothrow] [[RETHROWER]]([[T1]]) : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error
 // CHECK-NEXT:  [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT:  return [[RESULT]]
-// CHECK:     [[ERROR]]([[ERROR:%.*]] : $Error):
-// CHECK-NEXT:  unreachable
 // CHECK-LABEL: // end sil function '$s8rethrows5test3yyF'
 func test3() {
   rethrower { rethrower(nonthrower) }


### PR DESCRIPTION
Previously we would emit a try_apply with an error block containing an
'unreachable', and rely on SIL passes to optimize it out, but there's
no reason not to generate the simpler pattern upfront.
