### PR TITLE
[libSyntax] Miscellaneous minor improvements

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -22,7 +22,7 @@
 
 namespace swift {
 
-typedef void *OpaqueSyntaxNode;
+typedef const void *OpaqueSyntaxNode;
 class SyntaxParsingContext;
 
 /// Represents a raw syntax node formed by the parser.

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -67,8 +67,6 @@ public:
   ParsedRawSyntaxNode recordEmptyRawSyntaxCollection(syntax::SyntaxKind kind,
                                                      SourceLoc loc);
 
-  void discardRecordedNode(ParsedRawSyntaxNode &node);
-
   /// Used for incremental re-parsing.
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,
                                  syntax::SyntaxKind kind);

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -62,13 +62,6 @@ public:
   virtual Optional<syntax::SourceFileSyntax>
   realizeSyntaxRoot(OpaqueSyntaxNode root, const SourceFile &SF) = 0;
 
-  /// Discard raw syntax node.
-  /// 
-  /// FIXME: This breaks invariant that any recorded node will be a part of the
-  /// result SourceFile syntax. This method is a temporary workaround, and
-  /// should be removed when we fully migrate to libSyntax parsing.
-  virtual void discardRecordedNode(OpaqueSyntaxNode node) = 0;
-
   /// Used for incremental re-parsing.
   virtual std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -33,7 +33,7 @@ class SourceFileSyntax;
 enum class SyntaxKind;
 }
 
-typedef void *OpaqueSyntaxNode;
+typedef const void *OpaqueSyntaxNode;
 
 class SyntaxParseActions {
   virtual void _anchor();

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -53,7 +53,7 @@ namespace swift {
   class IRGenOptions;
   class LangOptions;
   class ModuleDecl;
-  typedef void *OpaqueSyntaxNode;
+  typedef const void *OpaqueSyntaxNode;
   class Parser;
   class SerializationOptions;
   class SILOptions;

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -116,7 +116,9 @@ public:
     NewLayout.reserve(OldLayout.size() + 1);
     std::copy(OldLayout.begin(), OldLayout.end(), back_inserter(NewLayout));
     NewLayout.push_back(E.getRaw());
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
+                                            getRaw()->getPresence(),
+                                            getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
   }
 
@@ -126,7 +128,9 @@ public:
   SyntaxCollection<CollectionKind, Element> removingLast() const {
     assert(!empty());
     auto NewLayout = getRaw()->getLayout().drop_back();
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
+                                            getRaw()->getPresence(),
+                                            getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
   }
 
@@ -137,7 +141,9 @@ public:
     std::vector<const RawSyntax *> NewLayout = {E.getRaw()};
     std::copy(OldLayout.begin(), OldLayout.end(),
               std::back_inserter(NewLayout));
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
+                                            getRaw()->getPresence(),
+                                            getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
   }
 
@@ -147,7 +153,9 @@ public:
   SyntaxCollection<CollectionKind, Element> removingFirst() const {
     assert(!empty());
     auto NewLayout = getRaw()->getLayout().drop_front();
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
+                                            getRaw()->getPresence(),
+                                            getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
   }
 
@@ -166,7 +174,9 @@ public:
     NewLayout.push_back(E.getRaw());
     std::copy(OldLayout.begin() + i, OldLayout.end(),
               std::back_inserter(NewLayout));
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
+                                            getRaw()->getPresence(),
+                                            getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
   }
 
@@ -177,13 +187,16 @@ public:
     auto iterator = NewLayout.begin();
     std::advance(iterator, i);
     NewLayout.erase(iterator);
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
+                                            getRaw()->getPresence(),
+                                            getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
   }
 
   /// Return an empty syntax collection of this type.
   SyntaxCollection<CollectionKind, Element> cleared() const {
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, {}, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::makeAndCalcLength(
+        CollectionKind, {}, getRaw()->getPresence(), getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
   }
 

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -73,8 +73,6 @@ private:
                                    ArrayRef<OpaqueSyntaxNode> elements,
                                    CharSourceRange range) override;
 
-  void discardRecordedNode(OpaqueSyntaxNode node) override;
-
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;
 };

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -112,10 +112,6 @@ ParsedRawSyntaxRecorder::recordEmptyRawSyntaxCollection(SyntaxKind kind,
   return ParsedRawSyntaxNode{kind, tok::unknown, range, n};
 }
 
-void ParsedRawSyntaxRecorder::discardRecordedNode(ParsedRawSyntaxNode &node) {
-  SPActions->discardRecordedNode(node.takeOpaqueNode());
-}
-
 ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::lookupNode(size_t lexerOffset, SourceLoc loc,
                                     SyntaxKind kind) {

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -405,12 +405,6 @@ SyntaxParsingContext::~SyntaxParsingContext() {
   // Remove all parts in this context.
   case AccumulationMode::Discard: {
     auto &nodes = getStorage();
-    for (auto i = nodes.begin()+Offset, e = nodes.end(); i != e; ++i) {
-      // FIXME: This should not be needed. This breaks invariant that any
-      // recorded node must be a part of result souce syntax tree.
-      if (i->isRecorded())
-        getRecorder().discardRecordedNode(*i);
-    }
     nodes.erase(nodes.begin()+Offset, nodes.end());
     break;
   }

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -130,13 +130,13 @@ OpaqueSyntaxNode SyntaxTreeCreator::recordToken(tok tokenKind,
   auto raw =
       TokenCache->getToken(Arena, tokenKind, range.getByteLength(), tokenText,
                            leadingTriviaText, trailingTriviaText);
-  return static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw));
+  return static_cast<OpaqueSyntaxNode>(raw);
 }
 
 OpaqueSyntaxNode
 SyntaxTreeCreator::recordMissingToken(tok kind, SourceLoc loc) {
   auto raw = RawSyntax::missing(kind, getTokenText(kind), Arena);
-  return static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw));
+  return static_cast<OpaqueSyntaxNode>(raw);
 }
 
 OpaqueSyntaxNode
@@ -151,7 +151,7 @@ SyntaxTreeCreator::recordRawSyntax(syntax::SyntaxKind kind,
   size_t TextLength = range.isValid() ? range.getByteLength() : 0;
   auto raw =
       RawSyntax::make(kind, parts, TextLength, SourcePresence::Present, Arena);
-  return static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw));
+  return static_cast<OpaqueSyntaxNode>(raw);
 }
 
 std::pair<size_t, OpaqueSyntaxNode>
@@ -163,7 +163,7 @@ SyntaxTreeCreator::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
     return {0, nullptr};
   const RawSyntax *raw = cacheLookup->getRaw();
   size_t length = raw->getTextLength();
-  return {length, static_cast<OpaqueSyntaxNode>(const_cast<RawSyntax *>(raw))};
+  return {length, static_cast<OpaqueSyntaxNode>(raw)};
 }
 
 void SyntaxTreeCreator::discardRecordedNode(OpaqueSyntaxNode opaqueN) {

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -165,6 +165,3 @@ SyntaxTreeCreator::lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) {
   size_t length = raw->getTextLength();
   return {length, static_cast<OpaqueSyntaxNode>(raw)};
 }
-
-void SyntaxTreeCreator::discardRecordedNode(OpaqueSyntaxNode opaqueN) {
-}

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -183,7 +183,8 @@ private:
     auto numValue = serialization::getNumericValue(kind);
     node.kind = numValue;
     assert(node.kind == numValue && "syntax kind value is too large");
-    node.layout_data.nodes = elements.data();
+    node.layout_data.nodes =
+        const_cast<const swiftparse_client_node_t *>(elements.data());
     node.layout_data.nodes_count = elements.size();
     makeCRange(node.range, range);
     node.present = true;
@@ -302,7 +303,7 @@ swiftparse_client_node_t SynParser::parse(const char *source) {
     pConsumer = std::make_unique<SynParserDiagConsumer>(*this, bufID);
     PU.getDiagnosticEngine().addConsumer(*pConsumer);
   }
-  return PU.parse();
+  return const_cast<swiftparse_client_node_t>(PU.parse());
 }
 }
 //===--- C API ------------------------------------------------------------===//

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -197,10 +197,6 @@ private:
     return None;
   }
 
-  void discardRecordedNode(OpaqueSyntaxNode node) override {
-    // FIXME: This method should not be called at all.
-  }
-
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, SyntaxKind kind) override {
     auto NodeLookup = getNodeLookup();


### PR DESCRIPTION
This PR is a collection of minor improvements to libSyntax
- Fix some formatting issues where lines contain more than 80 columns
- Change `OpaqueSyntaxNode` to be a `const void *` pointer instead of `void *` since its data is not supposed to be modified
- Remove `discaredRecordedNode`. Since `RawSyntax` is no longer reference counted, none of the implementations did anything and the comment in there says, we should get rid of it anyway.