### PR TITLE
[libSyntax] Make SyntaxFactory methods instance methods 

### DIFF
--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -53,8 +53,6 @@ const auto NoParent = llvm::None;
 /// Essentially, this is a wrapper around \c SyntaxData that provides
 /// convenience methods based on the node's kind.
 class Syntax {
-  friend struct SyntaxFactory;
-
 protected:
   SyntaxData Data;
 

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -53,7 +53,6 @@ struct SyntaxCollectionIterator {
 /// A generic unbounded collection of syntax nodes
 template <SyntaxKind CollectionKind, typename Element>
 class SyntaxCollection : public Syntax {
-  friend struct SyntaxFactory;
   friend class Syntax;
 
 private:

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -16,17 +16,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the SyntaxFactory, one of the most important client-facing
-// types in lib/Syntax and likely to be very commonly used.
-//
-// Effectively a namespace, SyntaxFactory is never instantiated, but is *the*
-// one-stop shop for making new Syntax nodes. Putting all of these into a
-// collection of static methods provides a single point of API lookup for
-// clients' convenience and also allows the library to hide all of the
-// constructors for all Syntax nodes, as the SyntaxFactory is friend to all.
-//
-//===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_SYNTAX_FACTORY_H
 #define SWIFT_SYNTAX_FACTORY_H
@@ -43,32 +32,31 @@ namespace syntax {
 class SyntaxArena;
 
 /// The Syntax factory - the one-stop shop for making new Syntax nodes.
-struct SyntaxFactory {
+class SyntaxFactory {
+  RC<SyntaxArena> Arena;
+
+public:
+  explicit SyntaxFactory(const RC<SyntaxArena> &Arena) : Arena(Arena) {}
+
   /// Make any kind of token.
-  static TokenSyntax makeToken(tok Kind,
+  TokenSyntax makeToken(tok Kind,
       StringRef Text,
       StringRef LeadingTrivia,
       StringRef TrailingTrivia,
-      SourcePresence Presence,
-      const RC<SyntaxArena> &Arena
+      SourcePresence Presence
   );
 
   /// Collect a list of tokens into a piece of "unknown" syntax.
-  static UnknownSyntax makeUnknownSyntax(
-      llvm::ArrayRef<TokenSyntax> Tokens,
-      const RC<SyntaxArena> &Arena
+  UnknownSyntax makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens);
+
+  Optional<Syntax> createSyntax(
+      SyntaxKind Kind,
+      llvm::ArrayRef<Syntax> Elements
   );
 
-  static Optional<Syntax> createSyntax(
+  const RawSyntax *createRaw(
       SyntaxKind Kind,
-      llvm::ArrayRef<Syntax> Elements,
-      const RC<SyntaxArena> &Arena
-  );
-
-  static const RawSyntax *createRaw(
-      SyntaxKind Kind,
-      llvm::ArrayRef<const RawSyntax *> Elements,
-      const RC<SyntaxArena> &Arena
+      llvm::ArrayRef<const RawSyntax *> Elements
   );
 
   /// Count the number of children for a given syntax node kind,
@@ -76,8 +64,7 @@ struct SyntaxFactory {
   /// between these two numbers is the number of optional children.
   static std::pair<unsigned, unsigned> countChildren(SyntaxKind Kind);
 
-  static Syntax
-  makeBlankCollectionSyntax(SyntaxKind Kind, const RC<SyntaxArena> &Arena);
+  Syntax makeBlankCollectionSyntax(SyntaxKind Kind);
 
 % for node in SYNTAX_NODES:
 %   if node.children:
@@ -90,117 +77,98 @@ struct SyntaxFactory {
 %         child_params.append("%s %s" % (param_type, child.name))
 %     end
 %     child_params = ', '.join(child_params)
-  static ${node.name} make${node.syntax_kind}(${child_params},
-      const RC<SyntaxArena> &Arena
-  );
+  ${node.name} make${node.syntax_kind}(${child_params});
 %   elif node.is_syntax_collection():
-  static ${node.name} make${node.syntax_kind}(
-      const std::vector<${node.collection_element_type}> &elts,
-      const RC<SyntaxArena> &Arena
+  ${node.name} make${node.syntax_kind}(
+      const std::vector<${node.collection_element_type}> &elts
   );
 %   end
 
-  static ${node.name} makeBlank${node.syntax_kind}(
-      const RC<SyntaxArena> &Arena
-  );
+  ${node.name} makeBlank${node.syntax_kind}();
 % end
 
 % for token in SYNTAX_TOKENS:
 %   if token.is_keyword:
-  static TokenSyntax make${token.name}Keyword(
+  TokenSyntax make${token.name}Keyword(
       StringRef LeadingTrivia,
-      StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef TrailingTrivi
   );
 %   elif token.text:
-  static TokenSyntax make${token.name}Token(
+  TokenSyntax make${token.name}Token(
       StringRef LeadingTrivia,
-      StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef TrailingTrivia
   );
 %   else:
-  static TokenSyntax make${token.name}(
+  TokenSyntax make${token.name}(
       StringRef Text,
-      StringRef LeadingTrivia, StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef LeadingTrivia, StringRef TrailingTrivia
   );
 %   end
 % end
 
 #pragma mark - Convenience APIs
 
-  static TupleTypeSyntax makeVoidTupleType(
-      const RC<SyntaxArena> &Arena
-  );
+  TupleTypeSyntax makeVoidTupleType();
 
   /// Creates an labelled TupleTypeElementSyntax with the provided label,
   /// colon, type and optional trailing comma.
-  static TupleTypeElementSyntax makeTupleTypeElement(
+  TupleTypeElementSyntax makeTupleTypeElement(
       llvm::Optional<TokenSyntax> Label,
       llvm::Optional<TokenSyntax> Colon, TypeSyntax Type,
-      llvm::Optional<TokenSyntax> TrailingComma,
-      const RC<SyntaxArena> &Arena
+      llvm::Optional<TokenSyntax> TrailingComma
   );
 
   /// Creates an unlabelled TupleTypeElementSyntax with the provided type and
   /// optional trailing comma.
-  static TupleTypeElementSyntax
+  TupleTypeElementSyntax
   makeTupleTypeElement(
       TypeSyntax Type,
-      llvm::Optional<TokenSyntax> TrailingComma,
-      const RC<SyntaxArena> &Arena
+      llvm::Optional<TokenSyntax> TrailingComma
   );
 
   /// Creates a TypeIdentifierSyntax with the provided name and leading/trailing
   /// trivia.
-  static TypeSyntax makeTypeIdentifier(
+  TypeSyntax makeTypeIdentifier(
       StringRef TypeName,
-      StringRef LeadingTrivia, StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef LeadingTrivia, StringRef TrailingTrivia
   );
 
   /// Creates a GenericParameterSyntax with no inheritance clause and an
   /// optional trailing comma.
-  static GenericParameterSyntax
+  GenericParameterSyntax
   makeGenericParameter(
       TokenSyntax Name,
-      llvm::Optional<TokenSyntax> TrailingComma,
-      const RC<SyntaxArena> &Arena
+      llvm::Optional<TokenSyntax> TrailingComma
   );
 
   /// Creates a TypeIdentifierSyntax for the `Any` type.
-  static TypeSyntax makeAnyTypeIdentifier(
+  TypeSyntax makeAnyTypeIdentifier(
       StringRef LeadingTrivia,
-      StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef TrailingTrivia
   );
 
   /// Creates a TypeIdentifierSyntax for the `Self` type.
-  static TypeSyntax makeSelfTypeIdentifier(
+  TypeSyntax makeSelfTypeIdentifier(
       StringRef LeadingTrivia,
-      StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef TrailingTrivia
   );
 
   /// Creates a TokenSyntax for the `Type` identifier.
-  static TokenSyntax makeTypeToken(
+  TokenSyntax makeTypeToken(
       StringRef LeadingTrivia,
-      StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef TrailingTrivia
   );
 
   /// Creates a TokenSyntax for the `Protocol` identifier.
-  static TokenSyntax makeProtocolToken(
+  TokenSyntax makeProtocolToken(
       StringRef LeadingTrivia,
-      StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef TrailingTrivia
   );
 
   /// Creates an `==` operator token.
-  static TokenSyntax makeEqualityOperator(
+  TokenSyntax makeEqualityOperator(
       StringRef LeadingTrivia,
-      StringRef TrailingTrivia,
-      const RC<SyntaxArena> &Arena
+      StringRef TrailingTrivia
   );
 
   /// Whether a raw node kind `MemberKind` can serve as a member in a syntax

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -16,17 +16,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// This file defines the SyntaxFactory, one of the most important client-facing
-// types in lib/Syntax and likely to be very commonly used.
-//
-// Effectively a namespace, SyntaxFactory is never instantiated, but is *the*
-// one-stop shop for making new Syntax nodes. Putting all of these into a
-// collection of static methods provides a single point of API lookup for
-// clients' convenience and also allows the library to hide all of the
-// constructors for all Syntax nodes, as the SyntaxFactory is friend to all.
-//
-//===----------------------------------------------------------------------===//
 
 #include "swift/Syntax/SyntaxFactory.h"
 #include "swift/Syntax/SyntaxNodes.h"
@@ -41,15 +30,13 @@ using namespace swift::syntax;
 TokenSyntax SyntaxFactory::makeToken(tok Kind, StringRef Text,
                                      StringRef LeadingTrivia,
                                      StringRef TrailingTrivia,
-                                     SourcePresence Presence,
-                                     const RC<SyntaxArena> &Arena) {
+                                     SourcePresence Presence) {
   return makeRoot<TokenSyntax>(RawSyntax::makeAndCalcLength(Kind, Text, 
     LeadingTrivia, TrailingTrivia, Presence, Arena));
 }
 
 UnknownSyntax
-SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
-                                 const RC<SyntaxArena> &Arena) {
+SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens) {
   std::vector<const RawSyntax *> Layout;
   Layout.reserve(Tokens.size());
   for (auto &Token : Tokens) {
@@ -60,13 +47,12 @@ SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens,
   return makeRoot<UnknownSyntax>(Raw);
 }
 
-Syntax SyntaxFactory::makeBlankCollectionSyntax(SyntaxKind Kind,
-                                                const RC<SyntaxArena> &Arena) {
+Syntax SyntaxFactory::makeBlankCollectionSyntax(SyntaxKind Kind) {
   switch(Kind) {
 % for node in SYNTAX_NODES:
 %   if node.is_syntax_collection():
   case SyntaxKind::${node.syntax_kind}:
-    return makeBlank${node.syntax_kind}(Arena);
+    return makeBlank${node.syntax_kind}();
 %   end
 % end
   default: break;
@@ -124,8 +110,7 @@ canServeAsCollectionMember(SyntaxKind CollectionKind, Syntax Member) {
 
 const RawSyntax *SyntaxFactory::createRaw(
   SyntaxKind Kind,
-  llvm::ArrayRef<const RawSyntax *> Elements,
-  const RC<SyntaxArena> &Arena
+  llvm::ArrayRef<const RawSyntax *> Elements
 ) {
   switch (Kind) {
 % for node in SYNTAX_NODES:
@@ -150,14 +135,14 @@ const RawSyntax *SyntaxFactory::createRaw(
 %   end
     if (I != Elements.size())
       return nullptr;
-    return RawSyntax::makeAndCalcLength(Kind, Layout, SourcePresence::Present, 
+    return RawSyntax::makeAndCalcLength(Kind, Layout, SourcePresence::Present,
                                         Arena);
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
       if (!canServeAsCollectionMemberRaw(SyntaxKind::${node.syntax_kind}, E))
         return nullptr;
     }
-    return RawSyntax::makeAndCalcLength(Kind, Elements, SourcePresence::Present, 
+    return RawSyntax::makeAndCalcLength(Kind, Elements, SourcePresence::Present,
                                         Arena);
 % else:
     return nullptr;
@@ -170,14 +155,13 @@ const RawSyntax *SyntaxFactory::createRaw(
 }
 
 Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
-                                             llvm::ArrayRef<Syntax> Elements,
-                                             const RC<SyntaxArena> &Arena) {
+                                             llvm::ArrayRef<Syntax> Elements) {
   std::vector<const RawSyntax *> Layout;
   Layout.reserve(Elements.size());
   for (auto &E : Elements)
     Layout.emplace_back(E.getRaw());
 
-  if (auto Raw = createRaw(Kind, Layout, Arena))
+  if (auto Raw = createRaw(Kind, Layout))
     return makeRoot<Syntax>(Raw);
   else
     return None;
@@ -193,8 +177,7 @@ Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
 %         child_params.append("%s %s" % (param_type, child.name))
 %     child_params = ', '.join(child_params)
 ${node.name}
-SyntaxFactory::make${node.syntax_kind}(${child_params},
-                                       const RC<SyntaxArena> &Arena) {
+SyntaxFactory::make${node.syntax_kind}(${child_params}) {
   auto Raw = RawSyntax::makeAndCalcLength(SyntaxKind::${node.syntax_kind}, {
 %     for child in node.children:
 %       if child.is_optional:
@@ -209,8 +192,7 @@ SyntaxFactory::make${node.syntax_kind}(${child_params},
 %   elif node.is_syntax_collection():
 ${node.name}
 SyntaxFactory::make${node.syntax_kind}(
-    const std::vector<${node.collection_element_type}> &elements,
-    const RC<SyntaxArena> &Arena) {
+    const std::vector<${node.collection_element_type}> &elements) {
   std::vector<const RawSyntax *> layout;
   layout.reserve(elements.size());
   for (auto &element : elements) {
@@ -223,7 +205,7 @@ SyntaxFactory::make${node.syntax_kind}(
 %   end
 
 ${node.name}
-SyntaxFactory::makeBlank${node.syntax_kind}(const RC<SyntaxArena> &Arena) {
+SyntaxFactory::makeBlank${node.syntax_kind}() {
   auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, {
 %   for child in node.children:
 %       if child.is_optional:
@@ -241,99 +223,86 @@ SyntaxFactory::makeBlank${node.syntax_kind}(const RC<SyntaxArena> &Arena) {
 %   if token.is_keyword:
   TokenSyntax
   SyntaxFactory::make${token.name}Keyword(StringRef LeadingTrivia,
-                                          StringRef TrailingTrivia,
-                                          const RC<SyntaxArena> &Arena) {
+                                          StringRef TrailingTrivia) {
     return makeToken(tok::${token.kind}, "${token.text}", LeadingTrivia,
-                     TrailingTrivia, SourcePresence::Present, Arena);
+                     TrailingTrivia, SourcePresence::Present);
   }
 %   elif token.text:
   TokenSyntax
   SyntaxFactory::make${token.name}Token(StringRef LeadingTrivia,
-                                        StringRef TrailingTrivia,
-                                        const RC<SyntaxArena> &Arena) {
+                                        StringRef TrailingTrivia) {
     return makeToken(tok::${token.kind}, "${token.text}", LeadingTrivia,
-                     TrailingTrivia, SourcePresence::Present, Arena);
+                     TrailingTrivia, SourcePresence::Present);
   }
 %   else:
   TokenSyntax
   SyntaxFactory::make${token.name}(StringRef Text,
                                    StringRef LeadingTrivia,
-                                   StringRef TrailingTrivia,
-                                   const RC<SyntaxArena> &Arena) {
+                                   StringRef TrailingTrivia) {
     return makeToken(tok::${token.kind}, Text, LeadingTrivia, TrailingTrivia,
-                     SourcePresence::Present, Arena);
+                     SourcePresence::Present);
   }
 %   end
 % end
 
-TupleTypeSyntax SyntaxFactory::makeVoidTupleType(const RC<SyntaxArena> &Arena) {
-  return makeTupleType(makeLeftParenToken({}, {}, Arena),
-                       makeBlankTupleTypeElementList(Arena),
-                       makeRightParenToken({}, {}, Arena),
-                       Arena);
+TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
+  return makeTupleType(makeLeftParenToken({}, {}),
+                       makeBlankTupleTypeElementList(),
+                       makeRightParenToken({}, {}));
 }
 
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(llvm::Optional<TokenSyntax> Label,
                                     llvm::Optional<TokenSyntax> Colon,
                                     TypeSyntax Type,
-                                    llvm::Optional<TokenSyntax> TrailingComma,
-                                    const RC<SyntaxArena> &Arena) {
+                                    llvm::Optional<TokenSyntax> TrailingComma) {
   return makeTupleTypeElement(None, Label, None, Colon, Type, None, None,
-                              TrailingComma, Arena);
+                              TrailingComma);
 }
 
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
-                                    llvm::Optional<TokenSyntax> TrailingComma,
-                                    const RC<SyntaxArena> &Arena) {
+                                    llvm::Optional<TokenSyntax> TrailingComma) {
   return makeTupleTypeElement(None, None, None, None, Type, None, None,
-                              TrailingComma, Arena);
+                              TrailingComma);
 }
 
 GenericParameterSyntax
 SyntaxFactory::makeGenericParameter(TokenSyntax Name,
-                                    llvm::Optional<TokenSyntax> TrailingComma,
-                                    const RC<SyntaxArena> &Arena) {
-  return makeGenericParameter(None, Name, None, None, TrailingComma, Arena);
+                                    llvm::Optional<TokenSyntax> TrailingComma) {
+  return makeGenericParameter(None, Name, None, None, TrailingComma);
 }
 
 TypeSyntax SyntaxFactory::makeTypeIdentifier(StringRef TypeName,
                                              StringRef LeadingTrivia,
-                                             StringRef TrailingTrivia,
-                                             const RC<SyntaxArena> &Arena) {
+                                             StringRef TrailingTrivia) {
   auto identifier =
-      makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia, Arena);
-  return makeSimpleTypeIdentifier(identifier, None, Arena);
+      makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia);
+  return makeSimpleTypeIdentifier(identifier, None);
 }
 
 TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(StringRef LeadingTrivia,
-                                                StringRef TrailingTrivia,
-                                                const RC<SyntaxArena> &Arena) {
-  return makeTypeIdentifier("Any", LeadingTrivia, TrailingTrivia, Arena);
+                                                StringRef TrailingTrivia) {
+  return makeTypeIdentifier("Any", LeadingTrivia, TrailingTrivia);
 }
 
 TypeSyntax SyntaxFactory::makeSelfTypeIdentifier(StringRef LeadingTrivia,
-                                                 StringRef TrailingTrivia,
-                                                 const RC<SyntaxArena> &Arena) {
-  return makeTypeIdentifier("Self", LeadingTrivia, TrailingTrivia, Arena);
+                                                 StringRef TrailingTrivia) {
+  return makeTypeIdentifier("Self", LeadingTrivia, TrailingTrivia);
 }
 
 TokenSyntax SyntaxFactory::makeTypeToken(StringRef LeadingTrivia,
-                                         StringRef TrailingTrivia,
-                                         const RC<SyntaxArena> &Arena) {
-  return makeIdentifier("Type", LeadingTrivia, TrailingTrivia, Arena);
+                                         StringRef TrailingTrivia) {
+  return makeIdentifier("Type", LeadingTrivia, TrailingTrivia);
 }
 
 TokenSyntax SyntaxFactory::makeProtocolToken(StringRef LeadingTrivia,
-                                             StringRef TrailingTrivia,
-                                             const RC<SyntaxArena> &Arena) {
-  return makeIdentifier("Protocol", LeadingTrivia, TrailingTrivia, Arena);
+                                             StringRef TrailingTrivia) {
+  return makeIdentifier("Protocol", LeadingTrivia, TrailingTrivia);
 }
 
 TokenSyntax SyntaxFactory::makeEqualityOperator(StringRef LeadingTrivia,
-                                                StringRef TrailingTrivia,
-                                                const RC<SyntaxArena> &Arena) {
+                                                StringRef TrailingTrivia) {
   return makeToken(tok::oper_binary_spaced, "==", LeadingTrivia, TrailingTrivia, 
-                   SourcePresence::Present, Arena);
+                   SourcePresence::Present);
 }

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -13,19 +13,21 @@ using namespace swift::syntax;
 #pragma mark - declaration-modifier
 
 DeclModifierSyntax getCannedDeclModifier(const RC<SyntaxArena> &Arena) {
-  auto Private = SyntaxFactory::makeIdentifier("private", "", "", Arena);
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-  auto Set = SyntaxFactory::makeIdentifier("set", "", "", Arena);
-  auto RParen = SyntaxFactory::makeRightParenToken("", "", Arena);
-  return SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen, Arena);
+  SyntaxFactory Factory(Arena);
+  auto Private = Factory.makeIdentifier("private", "", "");
+  auto LParen = Factory.makeLeftParenToken("", "");
+  auto Set = Factory.makeIdentifier("set", "", "");
+  auto RParen = Factory.makeRightParenToken("", "");
+  return Factory.makeDeclModifier(Private, LParen, Set, RParen);
 }
 
 TEST(DeclSyntaxTests, DeclModifierMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
   {
+    SyntaxFactory Factory(Arena);
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankDeclModifier(Arena).print(OS);
+    Factory.makeBlankDeclModifier().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -38,12 +40,12 @@ TEST(DeclSyntaxTests, DeclModifierMakeAPIs) {
 
 TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Private = SyntaxFactory::makeIdentifier("private", "", "", Arena);
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-  auto Set = SyntaxFactory::makeIdentifier("set", "", "", Arena);
-  auto RParen = SyntaxFactory::makeRightParenToken("", "", Arena);
-  auto Mod =
-      SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen, Arena);
+  SyntaxFactory Factory(Arena);
+  auto Private = Factory.makeIdentifier("private", "", "");
+  auto LParen = Factory.makeLeftParenToken("", "");
+  auto Set = Factory.makeIdentifier("set", "", "");
+  auto RParen = Factory.makeRightParenToken("", "");
+  auto Mod = Factory.makeDeclModifier(Private, LParen, Set, RParen);
 
   ASSERT_EQ(Private.getRaw(), Mod.getName().getRaw());
   ASSERT_EQ(LParen.getRaw(), Mod.getDetailLeftParen()->getRaw());
@@ -53,14 +55,15 @@ TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
 
 TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Private = SyntaxFactory::makeIdentifier("private", "", "", Arena);
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-  auto Set = SyntaxFactory::makeIdentifier("set", "", "", Arena);
-  auto RParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Private = Factory.makeIdentifier("private", "", "");
+  auto LParen = Factory.makeLeftParenToken("", "");
+  auto Set = Factory.makeIdentifier("set", "", "");
+  auto RParen = Factory.makeRightParenToken("", "");
 
   SmallString<24> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
-  SyntaxFactory::makeBlankDeclModifier(Arena)
+  Factory.makeBlankDeclModifier()
       .withName(Private)
       .withDetailLeftParen(LParen)
       .withDetail(Set)
@@ -73,49 +76,45 @@ TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
 
 TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTypealiasDecl(Arena).print(OS);
+    Factory.makeBlankTypealiasDecl().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
     SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ", Arena);
-    auto Subsequence =
-        SyntaxFactory::makeIdentifier("MyCollection", "", "", Arena);
-    auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "", Arena);
-    auto ElementParam = SyntaxFactory::makeGenericParameter(
-        None, ElementName, None, None, None, Arena);
-    auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
-    auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ", Arena);
+    auto Typealias = Factory.makeTypealiasKeyword("", " ");
+    auto Subsequence = Factory.makeIdentifier("MyCollection", "", "");
+    auto ElementName = Factory.makeIdentifier("Element", "", "");
+    auto ElementParam =
+        Factory.makeGenericParameter(None, ElementName, None, None, None);
+    auto LeftAngle = Factory.makeLeftAngleToken("", "");
+    auto RightAngle = Factory.makeRightAngleToken("", " ");
     auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
                              .useLeftAngleBracket(LeftAngle)
                              .useRightAngleBracket(RightAngle)
                              .addGenericParameter(ElementParam)
                              .build();
-    auto Assignment = SyntaxFactory::makeEqualToken("", " ", Arena);
-    auto ElementType =
-        SyntaxFactory::makeTypeIdentifier("Element", "", "", Arena);
-    auto ElementArg =
-        SyntaxFactory::makeGenericArgument(ElementType, None, Arena);
+    auto Assignment = Factory.makeEqualToken("", " ");
+    auto ElementType = Factory.makeTypeIdentifier("Element", "", "");
+    auto ElementArg = Factory.makeGenericArgument(ElementType, None);
 
     auto GenericArgs =
         GenericArgumentClauseSyntaxBuilder(Arena)
             .useLeftAngleBracket(LeftAngle)
-            .useRightAngleBracket(
-                SyntaxFactory::makeRightAngleToken("", "", Arena))
+            .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
             .addArgument(ElementArg)
             .build();
 
-    auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
-    auto Array_Int =
-        SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs, Arena);
-    auto TypeInit =
-        SyntaxFactory::makeTypeInitializerClause(Assignment, Array_Int, Arena);
-    SyntaxFactory::makeTypealiasDecl(None, None, Typealias, Subsequence,
-                                     GenericParams, TypeInit, None, Arena)
+    auto Array = Factory.makeIdentifier("Array", "", "");
+    auto Array_Int = Factory.makeSimpleTypeIdentifier(Array, GenericArgs);
+    auto TypeInit = Factory.makeTypeInitializerClause(Assignment, Array_Int);
+    Factory
+        .makeTypealiasDecl(None, None, Typealias, Subsequence, GenericParams,
+                           TypeInit, None)
         .print(OS);
     ASSERT_EQ(OS.str().str(),
               "typealias MyCollection<Element> = Array<Element>");
@@ -124,41 +123,37 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
 
 TEST(DeclSyntaxTests, TypealiasWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ", Arena);
-  auto MyCollection =
-      SyntaxFactory::makeIdentifier("MyCollection", "", "", Arena);
-  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "", Arena);
-  auto ElementParam = SyntaxFactory::makeGenericParameter(
-      None, ElementName, None, None, None, Arena);
-  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
-  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Typealias = Factory.makeTypealiasKeyword("", " ");
+  auto MyCollection = Factory.makeIdentifier("MyCollection", "", "");
+  auto ElementName = Factory.makeIdentifier("Element", "", "");
+  auto ElementParam =
+      Factory.makeGenericParameter(None, ElementName, None, None, None);
+  auto LeftAngle = Factory.makeLeftAngleToken("", "");
+  auto RightAngle = Factory.makeRightAngleToken("", " ");
   auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
                            .useLeftAngleBracket(LeftAngle)
                            .useRightAngleBracket(RightAngle)
                            .addGenericParameter(ElementParam)
                            .build();
-  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
+  auto Equal = Factory.makeEqualToken("", " ");
 
-  auto ElementType =
-      SyntaxFactory::makeTypeIdentifier("Element", "", "", Arena);
-  auto ElementArg =
-      SyntaxFactory::makeGenericArgument(ElementType, None, Arena);
-  auto GenericArgs = GenericArgumentClauseSyntaxBuilder(Arena)
-                         .useLeftAngleBracket(LeftAngle)
-                         .useRightAngleBracket(
-                             SyntaxFactory::makeRightAngleToken("", "", Arena))
-                         .addArgument(ElementArg)
-                         .build();
+  auto ElementType = Factory.makeTypeIdentifier("Element", "", "");
+  auto ElementArg = Factory.makeGenericArgument(ElementType, None);
+  auto GenericArgs =
+      GenericArgumentClauseSyntaxBuilder(Arena)
+          .useLeftAngleBracket(LeftAngle)
+          .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
+          .addArgument(ElementArg)
+          .build();
 
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
-  auto Array_Int =
-      SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs, Arena);
-  auto Type_Init =
-      SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int, Arena);
+  auto Array = Factory.makeIdentifier("Array", "", "");
+  auto Array_Int = Factory.makeSimpleTypeIdentifier(Array, GenericArgs);
+  auto Type_Init = Factory.makeTypeInitializerClause(Equal, Array_Int);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTypealiasDecl(Arena)
+    Factory.makeBlankTypealiasDecl()
         .withTypealiasKeyword(Typealias)
         .withIdentifier(MyCollection)
         .withGenericParameterClause(GenericParams)
@@ -171,41 +166,36 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
 
 TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   SmallString<64> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto Typealias = SyntaxFactory::makeTypealiasKeyword("", " ", Arena);
-  auto MyCollection =
-      SyntaxFactory::makeIdentifier("MyCollection", "", "", Arena);
-  auto ElementName = SyntaxFactory::makeIdentifier("Element", "", "", Arena);
-  auto ElementParam =
-      SyntaxFactory::makeGenericParameter(ElementName, None, Arena);
-  auto LeftAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
-  auto RightAngle = SyntaxFactory::makeRightAngleToken("", " ", Arena);
+  auto Typealias = Factory.makeTypealiasKeyword("", " ");
+  auto MyCollection = Factory.makeIdentifier("MyCollection", "", "");
+  auto ElementName = Factory.makeIdentifier("Element", "", "");
+  auto ElementParam = Factory.makeGenericParameter(ElementName, None);
+  auto LeftAngle = Factory.makeLeftAngleToken("", "");
+  auto RightAngle = Factory.makeRightAngleToken("", " ");
   auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
                            .useLeftAngleBracket(LeftAngle)
                            .useRightAngleBracket(RightAngle)
                            .addGenericParameter(ElementParam)
                            .build();
-  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
+  auto Equal = Factory.makeEqualToken("", " ");
 
-  auto ElementType =
-      SyntaxFactory::makeTypeIdentifier("Element", "", "", Arena);
-  auto ElementArg =
-      SyntaxFactory::makeGenericArgument(ElementType, None, Arena);
+  auto ElementType = Factory.makeTypeIdentifier("Element", "", "");
+  auto ElementArg = Factory.makeGenericArgument(ElementType, None);
 
-  auto GenericArgs = GenericArgumentClauseSyntaxBuilder(Arena)
-                         .useLeftAngleBracket(LeftAngle)
-                         .useRightAngleBracket(
-                             SyntaxFactory::makeRightAngleToken("", "", Arena))
-                         .addArgument(ElementArg)
-                         .build();
+  auto GenericArgs =
+      GenericArgumentClauseSyntaxBuilder(Arena)
+          .useLeftAngleBracket(LeftAngle)
+          .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
+          .addArgument(ElementArg)
+          .build();
 
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
-  auto Array_Int =
-      SyntaxFactory::makeSimpleTypeIdentifier(Array, GenericArgs, Arena);
-  auto Type_Init =
-      SyntaxFactory::makeTypeInitializerClause(Equal, Array_Int, Arena);
+  auto Array = Factory.makeIdentifier("Array", "", "");
+  auto Array_Int = Factory.makeSimpleTypeIdentifier(Array, GenericArgs);
+  auto Type_Init = Factory.makeTypeInitializerClause(Equal, Array_Int);
   TypealiasDeclSyntaxBuilder(Arena)
       .useTypealiasKeyword(Typealias)
       .useIdentifier(MyCollection)
@@ -220,27 +210,28 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
 #pragma mark - parameter
 
 FunctionParameterSyntax getCannedFunctionParameter(const RC<SyntaxArena> &Arena) {
-  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ", Arena);
-  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto ExternalName = Factory.makeIdentifier("with", "", " ");
+  auto LocalName = Factory.makeIdentifier("radius", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", " ");
   auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...", Arena);
-  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
+  auto Equal = Factory.makeEqualToken("", " ");
 
-  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto One = SyntaxFactory::makePrefixOperatorExpr(
-      Sign, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
-  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto Sign = Factory.makePrefixOperator("-", "", "");
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto One = Factory.makePrefixOperatorExpr(
+      Sign, Factory.makeIntegerLiteralExpr(OneDigits));
+  auto DefaultArg = Factory.makeInitializerClause(Equal, One);
+  auto Comma = Factory.makeCommaToken("", " ");
 
-  return SyntaxFactory::makeFunctionParameter(None, ExternalName, LocalName,
-                                              Colon, Int, NoEllipsis,
-                                              DefaultArg, Comma, Arena);
+  return Factory.makeFunctionParameter(None, ExternalName, LocalName, Colon,
+                                       Int, NoEllipsis, DefaultArg, Comma);
 }
 
 TEST(DeclSyntaxTests, FunctionParameterMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -250,30 +241,30 @@ TEST(DeclSyntaxTests, FunctionParameterMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionParameter(Arena).print(OS);
+    Factory.makeBlankFunctionParameter().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
 
 TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ExternalName = SyntaxFactory::makeIdentifier("with", "", " ", Arena);
-  auto LocalName = SyntaxFactory::makeIdentifier("radius", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto ExternalName = Factory.makeIdentifier("with", "", " ");
+  auto LocalName = Factory.makeIdentifier("radius", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", " ");
   auto NoEllipsis = TokenSyntax::missingToken(tok::identifier, "...", Arena);
-  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
+  auto Equal = Factory.makeEqualToken("", " ");
 
-  auto Sign = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto One = SyntaxFactory::makePrefixOperatorExpr(
-      Sign, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
-  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
+  auto Sign = Factory.makePrefixOperator("-", "", "");
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto One = Factory.makePrefixOperatorExpr(
+      Sign, Factory.makeIntegerLiteralExpr(OneDigits));
+  auto DefaultArg = Factory.makeInitializerClause(Equal, One);
+  auto Comma = Factory.makeCommaToken("", "");
 
-  auto Param = SyntaxFactory::makeFunctionParameter(
-      None, ExternalName, LocalName, Colon, Int, NoEllipsis, DefaultArg, Comma,
-      Arena);
+  auto Param = Factory.makeFunctionParameter(
+      None, ExternalName, LocalName, Colon, Int, NoEllipsis, DefaultArg, Comma);
 
   ASSERT_EQ(ExternalName.getRaw(), Param.getFirstName()->getRaw());
   ASSERT_EQ(LocalName.getRaw(), Param.getSecondName()->getRaw());
@@ -302,17 +293,18 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
 
 TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ", Arena);
-  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken(" ", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
-  auto Equal = SyntaxFactory::makeEqualToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto ExternalName = Factory.makeIdentifier("for", "", " ");
+  auto LocalName = Factory.makeIdentifier("integer", "", "");
+  auto Colon = Factory.makeColonToken(" ", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", " ");
+  auto Equal = Factory.makeEqualToken("", " ");
 
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
-  auto DefaultArg = SyntaxFactory::makeInitializerClause(Equal, One, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
+  auto DefaultArg = Factory.makeInitializerClause(Equal, One);
+  auto Comma = Factory.makeCommaToken("", "");
 
   {
     SmallString<48> Scratch;
@@ -340,12 +332,13 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
 
 TEST(DeclSyntaxTests, FunctionParameterWithEllipsis) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ExternalName = SyntaxFactory::makeIdentifier("for", "", " ", Arena);
-  auto LocalName = SyntaxFactory::makeIdentifier("integer", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken(" ", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-  auto Ellipsis = SyntaxFactory::makeEllipsisToken("", " ", Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto ExternalName = Factory.makeIdentifier("for", "", " ");
+  auto LocalName = Factory.makeIdentifier("integer", "", "");
+  auto Colon = Factory.makeColonToken(" ", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", "");
+  auto Ellipsis = Factory.makeEllipsisToken("", " ");
+  auto Comma = Factory.makeCommaToken("", "");
 
   {
     SmallString<48> Scratch;
@@ -367,10 +360,11 @@ TEST(DeclSyntaxTests, FunctionParameterWithEllipsis) {
 
 TEST(DeclSyntaxTests, FunctionParameterListMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionParameterList(Arena).print(OS);
+    Factory.makeBlankFunctionParameterList().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -378,7 +372,7 @@ TEST(DeclSyntaxTests, FunctionParameterListMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto Param = getCannedFunctionParameter(Arena);
     std::vector<FunctionParameterSyntax> Params { Param, Param, Param };
-    SyntaxFactory::makeFunctionParameterList(Params, Arena).print(OS);
+    Factory.makeFunctionParameterList(Params).print(OS);
     ASSERT_EQ(OS.str().str(),
       "with radius: Int = -1, with radius: Int = -1, with radius: Int = -1, ");
   }
@@ -387,31 +381,31 @@ TEST(DeclSyntaxTests, FunctionParameterListMakeAPIs) {
 #pragma mark - function-signature
 
 FunctionSignatureSyntax getCannedFunctionSignature(const RC<SyntaxArena> &Arena) {
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto LParen = Factory.makeLeftParenToken("", "");
   auto Param = getCannedFunctionParameter(Arena);
-  auto List = SyntaxFactory::makeBlankFunctionParameterList(Arena)
+  auto List = Factory.makeBlankFunctionParameterList()
                   .appending(Param)
                   .appending(Param)
                   .appending(Param)
                   .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
-  auto Parameter =
-      SyntaxFactory::makeParameterClause(LParen, List, RParen, Arena);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
-  auto Return = SyntaxFactory::makeReturnClause(Arrow, Int, Arena);
+  auto RParen = Factory.makeRightParenToken("", " ");
+  auto Parameter = Factory.makeParameterClause(LParen, List, RParen);
+  auto Throws = Factory.makeThrowsKeyword("", " ");
+  auto Arrow = Factory.makeArrowToken("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", " ");
+  auto Return = Factory.makeReturnClause(Arrow, Int);
 
-  return SyntaxFactory::makeFunctionSignature(Parameter, None, Throws, Return,
-                                              Arena);
+  return Factory.makeFunctionSignature(Parameter, None, Throws, Return);
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionSignature(Arena).print(OS);
+    Factory.makeBlankFunctionSignature().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -427,22 +421,23 @@ TEST(DeclSyntaxTests, FunctionSignatureMakeAPIs) {
 
 TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto LParen = Factory.makeLeftParenToken("", "");
   auto Param = getCannedFunctionParameter(Arena);
-  auto List = SyntaxFactory::makeBlankFunctionParameterList(Arena)
+  auto List = Factory.makeBlankFunctionParameterList()
                   .appending(Param)
                   .appending(Param)
                   .appending(Param)
                   .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
+  auto RParen = Factory.makeRightParenToken("", " ");
+  auto Throws = Factory.makeThrowsKeyword("", " ");
+  auto Arrow = Factory.makeArrowToken("", " ");
 
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+  auto Int = Factory.makeTypeIdentifier("Int", "", "");
 
-  auto Sig = SyntaxFactory::makeFunctionSignature(
-      SyntaxFactory::makeParameterClause(LParen, List, RParen, Arena), None,
-      Throws, SyntaxFactory::makeReturnClause(Arrow, Int, Arena), Arena);
+  auto Sig = Factory.makeFunctionSignature(
+      Factory.makeParameterClause(LParen, List, RParen), None, Throws,
+      Factory.makeReturnClause(Arrow, Int));
 
   ASSERT_EQ(LParen.getRaw(), Sig.getInput().getLeftParen().getRaw());
 
@@ -477,24 +472,24 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
 
 TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto LParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto LParen = Factory.makeLeftParenToken("", "");
   auto Param = getCannedFunctionParameter(Arena);
-  auto List = SyntaxFactory::makeBlankFunctionParameterList(Arena)
+  auto List = Factory.makeBlankFunctionParameterList()
                   .appending(Param)
                   .appending(Param)
                   .appending(Param)
                   .castTo<FunctionParameterListSyntax>();
-  auto RParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
+  auto RParen = Factory.makeRightParenToken("", " ");
+  auto Throws = Factory.makeThrowsKeyword("", " ");
+  auto Arrow = Factory.makeArrowToken("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", "");
 
-  auto Parameter =
-      SyntaxFactory::makeParameterClause(LParen, List, RParen, Arena);
-  auto Return = SyntaxFactory::makeReturnClause(Arrow, Int, Arena);
+  auto Parameter = Factory.makeParameterClause(LParen, List, RParen);
+  auto Return = Factory.makeReturnClause(Arrow, Int);
   SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
-  SyntaxFactory::makeBlankFunctionSignature(Arena)
+  Factory.makeBlankFunctionSignature()
       .withInput(Parameter)
       .withThrowsOrRethrowsKeyword(Throws)
       .withOutput(Return)
@@ -508,33 +503,33 @@ TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
 #pragma mark - function-declaration
 
 ModifierListSyntax getCannedModifiers(const RC<SyntaxArena> &Arena) {
-  auto PublicID = SyntaxFactory::makePublicKeyword("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto PublicID = Factory.makePublicKeyword("", " ");
   auto NoLParen = TokenSyntax::missingToken(tok::l_paren, "(", Arena);
   auto NoArgument = TokenSyntax::missingToken(tok::identifier, "", Arena);
   auto NoRParen = TokenSyntax::missingToken(tok::r_paren, ")", Arena);
-  auto Public = SyntaxFactory::makeDeclModifier(PublicID, NoLParen, NoArgument,
-                                                NoRParen, Arena);
+  auto Public =
+      Factory.makeDeclModifier(PublicID, NoLParen, NoArgument, NoRParen);
 
-  auto StaticKW = SyntaxFactory::makeStaticKeyword("", " ", Arena);
-  auto Static = SyntaxFactory::makeDeclModifier(StaticKW, NoLParen, NoArgument,
-                                                NoRParen, Arena);
+  auto StaticKW = Factory.makeStaticKeyword("", " ");
+  auto Static =
+      Factory.makeDeclModifier(StaticKW, NoLParen, NoArgument, NoRParen);
 
-  return SyntaxFactory::makeBlankModifierList(Arena)
-      .appending(Public)
-      .appending(Static);
+  return Factory.makeBlankModifierList().appending(Public).appending(Static);
 }
 
 GenericParameterClauseSyntax getCannedGenericParams(const RC<SyntaxArena> &Arena) {
+  SyntaxFactory Factory(Arena);
   GenericParameterClauseSyntaxBuilder GB(Arena);
 
-  auto LAngle = SyntaxFactory::makeLeftAngleToken("", "", Arena);
-  auto RAngle = SyntaxFactory::makeRightAngleToken("", "", Arena);
-  auto TType = SyntaxFactory::makeIdentifier("T", "", "", Arena);
-  auto UType = SyntaxFactory::makeIdentifier("U", "", "", Arena);
+  auto LAngle = Factory.makeLeftAngleToken("", "");
+  auto RAngle = Factory.makeRightAngleToken("", "");
+  auto TType = Factory.makeIdentifier("T", "", "");
+  auto UType = Factory.makeIdentifier("U", "", "");
 
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
-  auto T = SyntaxFactory::makeGenericParameter(TType, Comma, Arena);
-  auto U = SyntaxFactory::makeGenericParameter(UType, None, Arena);
+  auto Comma = Factory.makeCommaToken("", " ");
+  auto T = Factory.makeGenericParameter(TType, Comma);
+  auto U = Factory.makeGenericParameter(UType, None);
 
   GB.addGenericParameter(T);
   GB.addGenericParameter(U);
@@ -545,59 +540,60 @@ GenericParameterClauseSyntax getCannedGenericParams(const RC<SyntaxArena> &Arena
 }
 
 CodeBlockSyntax getCannedBody(const RC<SyntaxArena> &Arena) {
+  SyntaxFactory Factory(Arena);
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "-", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("\n  ", "", Arena);
-  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, One, Arena);
-  auto ReturnItem = SyntaxFactory::makeCodeBlockItem(Return, None, None, Arena);
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
+  auto ReturnKW = Factory.makeReturnKeyword("\n  ", "");
+  auto Return = Factory.makeReturnStmt(ReturnKW, One);
+  auto ReturnItem = Factory.makeCodeBlockItem(Return, None, None);
 
-  auto Stmts = SyntaxFactory::makeCodeBlockItemList({ReturnItem}, Arena);
+  auto Stmts = Factory.makeCodeBlockItemList({ReturnItem});
 
-  auto LBrace = SyntaxFactory::makeLeftBraceToken("", "", Arena);
-  auto RBrace = SyntaxFactory::makeRightBraceToken("\n", "", Arena);
+  auto LBrace = Factory.makeLeftBraceToken("", "");
+  auto RBrace = Factory.makeRightBraceToken("\n", "");
 
-  return SyntaxFactory::makeCodeBlock(LBrace, Stmts, RBrace, Arena);
+  return Factory.makeCodeBlock(LBrace, Stmts, RBrace);
 }
 
 GenericWhereClauseSyntax getCannedWhereClause(const RC<SyntaxArena> &Arena) {
-  auto WhereKW = SyntaxFactory::makeWhereKeyword("", " ", Arena);
-  auto T = SyntaxFactory::makeTypeIdentifier("T", "", " ", Arena);
-  auto EqualEqual = SyntaxFactory::makeEqualityOperator("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", " ", Arena);
-  auto SameType =
-      SyntaxFactory::makeSameTypeRequirement(T, EqualEqual, Int, Arena);
-  auto Req = SyntaxFactory::makeGenericRequirement(SameType, None, Arena);
+  SyntaxFactory Factory(Arena);
+  auto WhereKW = Factory.makeWhereKeyword("", " ");
+  auto T = Factory.makeTypeIdentifier("T", "", " ");
+  auto EqualEqual = Factory.makeEqualityOperator("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", " ");
+  auto SameType = Factory.makeSameTypeRequirement(T, EqualEqual, Int);
+  auto Req = Factory.makeGenericRequirement(SameType, None);
 
-  auto Requirements =
-      SyntaxFactory::makeBlankGenericRequirementList(Arena).appending(Req);
+  auto Requirements = Factory.makeBlankGenericRequirementList().appending(Req);
 
-  return SyntaxFactory::makeBlankGenericWhereClause(Arena)
+  return Factory.makeBlankGenericWhereClause()
       .withWhereKeyword(WhereKW)
       .withRequirementList(Requirements);
 }
 
 FunctionDeclSyntax getCannedFunctionDecl(const RC<SyntaxArena> &Arena) {
-  auto NoAttributes = SyntaxFactory::makeBlankAttributeList(Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto FuncKW = SyntaxFactory::makeFuncKeyword("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto NoAttributes = Factory.makeBlankAttributeList();
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto FuncKW = Factory.makeFuncKeyword("", " ");
   auto Modifiers = getCannedModifiers(Arena);
   auto GenericParams = getCannedGenericParams(Arena);
   auto GenericWhere = getCannedWhereClause(Arena);
   auto Signature = getCannedFunctionSignature(Arena);
   auto Body = getCannedBody(Arena);
 
-  return SyntaxFactory::makeFunctionDecl(NoAttributes, Modifiers, FuncKW, Foo,
-                                         GenericParams, Signature, GenericWhere,
-                                         Body, Arena);
+  return Factory.makeFunctionDecl(NoAttributes, Modifiers, FuncKW, Foo,
+                                  GenericParams, Signature, GenericWhere, Body);
 }
 
 TEST(DeclSyntaxTests, FunctionDeclMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionDecl(Arena).print(OS);
+    Factory.makeBlankFunctionDecl().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
@@ -618,10 +614,11 @@ TEST(DeclSyntaxTests, FunctionDeclMakeAPIs) {
 
 TEST(DeclSyntaxTests, FunctionDeclGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionDecl(Arena).print(OS);
+    Factory.makeBlankFunctionDecl().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -10,12 +10,12 @@ using namespace swift::syntax;
 
 TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
-    auto LiteralToken = SyntaxFactory::makeIntegerLiteral("100", "", "", Arena);
-    auto Sign = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
-    auto Literal = SyntaxFactory::makePrefixOperatorExpr(
-        Sign, SyntaxFactory::makeIntegerLiteralExpr(LiteralToken, Arena),
-        Arena);
+    auto LiteralToken = Factory.makeIntegerLiteral("100", "", "");
+    auto Sign = Factory.makePrefixOperator("-", "", "");
+    auto Literal = Factory.makePrefixOperatorExpr(
+        Sign, Factory.makeIntegerLiteralExpr(LiteralToken));
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -24,10 +24,9 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(Literal.getKind(), SyntaxKind::PrefixOperatorExpr);
   }
   {
-    auto LiteralToken =
-        SyntaxFactory::makeIntegerLiteral("1_000", "", "", Arena);
+    auto LiteralToken = Factory.makeIntegerLiteral("1_000", "", "");
     auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
-    auto Literal = SyntaxFactory::makeIntegerLiteralExpr(LiteralToken, Arena);
+    auto Literal = Factory.makeIntegerLiteralExpr(LiteralToken);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -35,13 +34,11 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(OS.str().str(), "1_000");
   }
   {
-    auto Literal =
-        SyntaxFactory::makeBlankPrefixOperatorExpr(Arena)
-            .withOperatorToken(
-                TokenSyntax::missingToken(tok::oper_prefix, "", Arena))
-            .withPostfixExpression(SyntaxFactory::makeIntegerLiteralExpr(
-                SyntaxFactory::makeIntegerLiteral("0", "", "    ", Arena),
-                Arena));
+    auto Literal = Factory.makeBlankPrefixOperatorExpr()
+                       .withOperatorToken(TokenSyntax::missingToken(
+                           tok::oper_prefix, "", Arena))
+                       .withPostfixExpression(Factory.makeIntegerLiteralExpr(
+                           Factory.makeIntegerLiteral("0", "", "    ")));
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -49,12 +46,10 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(OS.str().str(), "0    ");
   }
   {
-    auto LiteralToken =
-        SyntaxFactory::makeIntegerLiteral("1_000_000_000_000", "", "", Arena);
-    auto PlusSign = SyntaxFactory::makePrefixOperator("+", "", "", Arena);
-    auto OneThousand = SyntaxFactory::makePrefixOperatorExpr(
-        PlusSign, SyntaxFactory::makeIntegerLiteralExpr(LiteralToken, Arena),
-        Arena);
+    auto LiteralToken = Factory.makeIntegerLiteral("1_000_000_000_000", "", "");
+    auto PlusSign = Factory.makePrefixOperator("+", "", "");
+    auto OneThousand = Factory.makePrefixOperatorExpr(
+        PlusSign, Factory.makeIntegerLiteralExpr(LiteralToken));
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -67,21 +62,20 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
-    auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
-    auto Int = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
-    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None, Arena);
-    auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None, Arena);
+    auto Array = Factory.makeIdentifier("Array", "", "");
+    auto Int = Factory.makeIdentifier("Int", "", "");
+    auto IntType = Factory.makeSimpleTypeIdentifier(Int, None);
+    auto GenericArg = Factory.makeGenericArgument(IntType, None);
     GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
-    ArgBuilder
-        .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", "", Arena))
-        .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", "", Arena))
+    ArgBuilder.useLeftAngleBracket(Factory.makeLeftAngleToken("", ""))
+        .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
         .addArgument(GenericArg);
 
     auto GenericArgs = ArgBuilder.build();
 
-    auto Ref =
-        SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs, Arena);
+    auto Ref = Factory.makeSymbolicReferenceExpr(Array, GenericArgs);
 
     ASSERT_EQ(Ref.getIdentifier().getRaw(), Array.getRaw());
 
@@ -100,68 +94,65 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
-  auto Int = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
-  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None, Arena);
-  auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None, Arena);
+  SyntaxFactory Factory(Arena);
+  auto Array = Factory.makeIdentifier("Array", "", "");
+  auto Int = Factory.makeIdentifier("Int", "", "");
+  auto IntType = Factory.makeSimpleTypeIdentifier(Int, None);
+  auto GenericArg = Factory.makeGenericArgument(IntType, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
-  ArgBuilder
-      .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", "", Arena))
-      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", "", Arena))
+  ArgBuilder.useLeftAngleBracket(Factory.makeLeftAngleToken("", ""))
+      .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
       .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena).print(OS);
+    Factory.makeBlankSymbolicReferenceExpr().print(OS);
     EXPECT_EQ(OS.str().str(), "");
   }
 
   {
-    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
+    auto Foo = Factory.makeIdentifier("foo", "", "");
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto BlankArgs = SyntaxFactory::makeBlankGenericArgumentClause(Arena);
+    auto BlankArgs = Factory.makeBlankGenericArgumentClause();
 
-    SyntaxFactory::makeSymbolicReferenceExpr(Foo, BlankArgs, Arena).print(OS);
+    Factory.makeSymbolicReferenceExpr(Foo, BlankArgs).print(OS);
     EXPECT_EQ(OS.str().str(), "foo");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeSymbolicReferenceExpr(Array, GenericArgs, Arena)
-        .print(OS);
+    Factory.makeSymbolicReferenceExpr(Array, GenericArgs).print(OS);
     ASSERT_EQ(OS.str().str(), "Array<Int>");
   }
 }
 
 TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Array = SyntaxFactory::makeIdentifier("Array", "", "", Arena);
-  auto Int = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
-  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None, Arena);
-  auto GenericArg = SyntaxFactory::makeGenericArgument(IntType, None, Arena);
+  SyntaxFactory Factory(Arena);
+  auto Array = Factory.makeIdentifier("Array", "", "");
+  auto Int = Factory.makeIdentifier("Int", "", "");
+  auto IntType = Factory.makeSimpleTypeIdentifier(Int, None);
+  auto GenericArg = Factory.makeGenericArgument(IntType, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
-  ArgBuilder
-      .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken("", "", Arena))
-      .useRightAngleBracket(SyntaxFactory::makeRightAngleToken("", "", Arena))
+  ArgBuilder.useLeftAngleBracket(Factory.makeLeftAngleToken("", ""))
+      .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
       .addArgument(GenericArg);
   auto GenericArgs = ArgBuilder.build();
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena)
-        .withIdentifier(Array)
-        .print(OS);
+    Factory.makeBlankSymbolicReferenceExpr().withIdentifier(Array).print(OS);
     ASSERT_EQ(OS.str().str(), "Array");
   }
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena)
+    Factory.makeBlankSymbolicReferenceExpr()
         .withGenericArgumentClause(GenericArgs)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "<Int>");
@@ -169,7 +160,7 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankSymbolicReferenceExpr(Arena)
+    Factory.makeBlankSymbolicReferenceExpr()
         .withIdentifier(Array)
         .withGenericArgumentClause(GenericArgs)
         .print(OS);
@@ -181,16 +172,15 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
 
 TEST(ExprSyntaxTests, TupleExprElementGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto X = Factory.makeIdentifier("x", "", "");
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = Factory.makeCommaToken("", " ");
 
   {
-    auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma,
-                                                   Arena);
+    auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
 
     ASSERT_EQ(X.getRaw(), Arg.getLabel()->getRaw());
     ASSERT_EQ(Colon.getRaw(), Arg.getColon()->getRaw());
@@ -209,51 +199,48 @@ TEST(ExprSyntaxTests, TupleExprElementGetAPIs) {
 
 TEST(ExprSyntaxTests, TupleExprElementMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto X = Factory.makeIdentifier("x", "", "");
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = Factory.makeCommaToken("", " ");
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElement(Arena).print(OS);
+    Factory.makeBlankTupleExprElement().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElement(Arena)
-        .withExpression(SymbolicRef)
-        .print(OS);
+    Factory.makeBlankTupleExprElement().withExpression(SymbolicRef).print(OS);
     ASSERT_EQ(OS.str().str(), "foo");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma, Arena)
-        .print(OS);
+    Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma).print(OS);
     ASSERT_EQ(OS.str().str(), "x: foo, ");
   }
 }
 
 TEST(ExprSyntaxTests, TupleExprElementWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto X = Factory.makeIdentifier("x", "", "");
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = Factory.makeCommaToken("", " ");
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElement(Arena)
+    Factory.makeBlankTupleExprElement()
         .withLabel(X)
         .withColon(Colon)
         .withExpression(SymbolicRef)
@@ -267,20 +254,19 @@ TEST(ExprSyntaxTests, TupleExprElementWithAPIs) {
 
 namespace {
 TupleExprElementListSyntax getFullArgumentList(const RC<SyntaxArena> &Arena) {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-  auto Y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
-  auto Z = SyntaxFactory::makeIdentifier("z", "", "", Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto X = Factory.makeIdentifier("x", "", "");
+  auto Y = Factory.makeIdentifier("y", "", "");
+  auto Z = Factory.makeIdentifier("z", "", "");
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-  auto Arg =
-      SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma, Arena);
+  auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
 
-  return SyntaxFactory::makeBlankTupleExprElementList(Arena)
+  return Factory.makeBlankTupleExprElementList()
       .appending(Arg)
       .appending(Arg.withLabel(Y))
       .appending(Arg.withLabel(Z).withTrailingComma(NoComma))
@@ -289,26 +275,25 @@ TupleExprElementListSyntax getFullArgumentList(const RC<SyntaxArena> &Arena) {
 
 TupleExprElementListSyntax
 getLabellessArgumentList(const RC<SyntaxArena> &Arena) {
+  SyntaxFactory Factory(Arena);
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "", Arena);
-  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "", Arena);
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto TwoDigits = Factory.makeIntegerLiteral("2", "", "");
+  auto ThreeDigits = Factory.makeIntegerLiteral("3", "", "");
+  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
   auto NoLabel = TokenSyntax::missingToken(tok::identifier, "", Arena);
   auto NoColon = TokenSyntax::missingToken(tok::colon, ":", Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-  auto Two = SyntaxFactory::makeIntegerLiteralExpr(TwoDigits, Arena);
-  auto Three = SyntaxFactory::makeIntegerLiteralExpr(ThreeDigits, Arena);
+  auto Two = Factory.makeIntegerLiteralExpr(TwoDigits);
+  auto Three = Factory.makeIntegerLiteralExpr(ThreeDigits);
 
-  auto OneArg =
-      SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, One, Comma, Arena);
-  auto TwoArg =
-      SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, Two, Comma, Arena);
-  auto ThreeArg = SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, Three,
-                                                      NoComma, Arena);
+  auto OneArg = Factory.makeTupleExprElement(NoLabel, NoColon, One, Comma);
+  auto TwoArg = Factory.makeTupleExprElement(NoLabel, NoColon, Two, Comma);
+  auto ThreeArg =
+      Factory.makeTupleExprElement(NoLabel, NoColon, Three, NoComma);
 
-  return SyntaxFactory::makeBlankTupleExprElementList(Arena)
+  return Factory.makeBlankTupleExprElementList()
       .appending(OneArg)
       .appending(TwoArg)
       .appending(ThreeArg)
@@ -318,20 +303,19 @@ getLabellessArgumentList(const RC<SyntaxArena> &Arena) {
 
 TEST(ExprSyntaxTests, TupleExprElementListGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-  auto Y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
-  auto Z = SyntaxFactory::makeIdentifier("z", "", "", Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto X = Factory.makeIdentifier("x", "", "");
+  auto Y = Factory.makeIdentifier("y", "", "");
+  auto Z = Factory.makeIdentifier("z", "", "");
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-  auto Arg =
-      SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma, Arena);
+  auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
 
-  auto ArgList = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+  auto ArgList = Factory.makeBlankTupleExprElementList()
                      .appending(Arg)
                      .appending(Arg.withLabel(Y))
                      .appending(Arg.withLabel(Z).withTrailingComma(NoComma))
@@ -372,25 +356,24 @@ TEST(ExprSyntaxTests, TupleExprElementListGetAPIs) {
 
 TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     llvm::SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElementList(Arena).print(OS);
+    Factory.makeBlankTupleExprElementList().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
   {
-    auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-    auto Y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
-    auto Z = SyntaxFactory::makeIdentifier("z", "", "", Arena);
-    auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-    auto SymbolicRef =
-        SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+    auto X = Factory.makeIdentifier("x", "", "");
+    auto Y = Factory.makeIdentifier("y", "", "");
+    auto Z = Factory.makeIdentifier("z", "", "");
+    auto Foo = Factory.makeIdentifier("foo", "", "");
+    auto Colon = Factory.makeColonToken("", " ");
+    auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+    auto Comma = Factory.makeCommaToken("", " ");
     auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-    auto Arg = SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma,
-                                                   Arena);
+    auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
 
     std::vector<TupleExprElementSyntax> Args {
       Arg, Arg.withLabel(Y), Arg.withLabel(Z).withTrailingComma(NoComma)
@@ -398,7 +381,7 @@ TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
 
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto ArgList = SyntaxFactory::makeTupleExprElementList(Args, Arena);
+    auto ArgList = Factory.makeTupleExprElementList(Args);
     ArgList.print(OS);
     ASSERT_EQ(ArgList.size(), size_t(3));
     ASSERT_EQ(OS.str().str(), "x: foo, y: foo, z: foo");
@@ -407,6 +390,7 @@ TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
 
 TEST(ExprSyntaxTests, TupleExprElementListWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   auto ArgList = getFullArgumentList(Arena);
   llvm::SmallString<64> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
@@ -420,15 +404,15 @@ TEST(ExprSyntaxTests, TupleExprElementListWithAPIs) {
 
 TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto LeftParen = Factory.makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList(Arena);
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+  auto RightParen = Factory.makeRightParenToken("", "");
 
-  auto Call = SyntaxFactory::makeFunctionCallExpr(
-      SymbolicRef, LeftParen, ArgList, RightParen, None, None, Arena);
+  auto Call = Factory.makeFunctionCallExpr(SymbolicRef, LeftParen, ArgList,
+                                           RightParen, None, None);
 
   {
     auto GottenExpression1 = Call.getCalledExpression();
@@ -456,16 +440,16 @@ TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
 
 TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto LeftParen = Factory.makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList(Arena);
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+  auto RightParen = Factory.makeRightParenToken("", "");
 
   {
-    auto Call = SyntaxFactory::makeFunctionCallExpr(
-        SymbolicRef, LeftParen, ArgList, RightParen, None, None, Arena);
+    auto Call = Factory.makeFunctionCallExpr(SymbolicRef, LeftParen, ArgList,
+                                             RightParen, None, None);
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     Call.print(OS);
@@ -475,24 +459,24 @@ TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
   {
     llvm::SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionCallExpr(Arena).print(OS);
+    Factory.makeBlankFunctionCallExpr().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
 
 TEST(ExprSyntaxTests, FunctionCallExprWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto LeftParen = Factory.makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList(Arena);
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+  auto RightParen = Factory.makeRightParenToken("", "");
 
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionCallExpr(Arena)
+    Factory.makeBlankFunctionCallExpr()
         .withCalledExpression(SymbolicRef)
         .withLeftParen(LeftParen)
         .withRightParen(RightParen)
@@ -502,7 +486,7 @@ TEST(ExprSyntaxTests, FunctionCallExprWithAPIs) {
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionCallExpr(Arena)
+    Factory.makeBlankFunctionCallExpr()
         .withCalledExpression(SymbolicRef)
         .withLeftParen(LeftParen)
         .withArgumentList(getLabellessArgumentList(Arena))
@@ -514,6 +498,7 @@ TEST(ExprSyntaxTests, FunctionCallExprWithAPIs) {
 
 TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   FunctionCallExprSyntaxBuilder CallBuilder(Arena);
 
   {
@@ -523,8 +508,8 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
     ASSERT_EQ(OS.str().str(), "");
   }
 
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-  auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+  auto LeftParen = Factory.makeLeftParenToken("", "");
+  auto RightParen = Factory.makeRightParenToken("", "");
 
   {
     llvm::SmallString<64> Scratch;
@@ -536,17 +521,16 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
   }
 
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto TwoDigits = SyntaxFactory::makeIntegerLiteral("2", "", "", Arena);
-  auto ThreeDigits = SyntaxFactory::makeIntegerLiteral("3", "", "", Arena);
-  auto One = SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena);
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto TwoDigits = Factory.makeIntegerLiteral("2", "", "");
+  auto ThreeDigits = Factory.makeIntegerLiteral("3", "", "");
+  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
   auto NoLabel = TokenSyntax::missingToken(tok::identifier, "", Arena);
   auto NoColon = TokenSyntax::missingToken(tok::colon, ":", Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
 
   {
     llvm::SmallString<64> Scratch;
@@ -556,8 +540,7 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
     ASSERT_EQ(OS.str().str(), "foo()");
   }
 
-  auto OneArg =
-      SyntaxFactory::makeTupleExprElement(NoLabel, NoColon, One, Comma, Arena);
+  auto OneArg = Factory.makeTupleExprElement(NoLabel, NoColon, One, Comma);
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);

--- a/unittests/Syntax/StmtSyntaxTests.cpp
+++ b/unittests/Syntax/StmtSyntaxTests.cpp
@@ -9,14 +9,14 @@ using namespace swift::syntax;
 
 TEST(StmtSyntaxTests, FallthroughStmtGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   llvm::SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "", Arena);
+  auto FallthroughKW = Factory.makeFallthroughKeyword("", "");
 
   auto Fallthrough =
-      SyntaxFactory::makeBlankFallthroughStmt(Arena).withFallthroughKeyword(
-          FallthroughKW);
+      Factory.makeBlankFallthroughStmt().withFallthroughKeyword(FallthroughKW);
 
   /// This should be directly shared through reference-counting.
   ASSERT_EQ(FallthroughKW.getRaw(), Fallthrough.getFallthroughKeyword()
@@ -25,12 +25,13 @@ TEST(StmtSyntaxTests, FallthroughStmtGetAPIs) {
 
 TEST(StmtSyntaxTests, FallthroughStmtWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   llvm::SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
 
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "", Arena);
+  auto FallthroughKW = Factory.makeFallthroughKeyword("", "");
 
-  SyntaxFactory::makeBlankFallthroughStmt(Arena)
+  Factory.makeBlankFallthroughStmt()
       .withFallthroughKeyword(FallthroughKW)
       .print(OS);
 
@@ -39,13 +40,14 @@ TEST(StmtSyntaxTests, FallthroughStmtWithAPIs) {
 
 TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto FallthroughKW = SyntaxFactory::makeFallthroughKeyword("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto FallthroughKW = Factory.makeFallthroughKeyword("", "");
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    SyntaxFactory::makeFallthroughStmt(FallthroughKW, Arena).print(OS);
+    Factory.makeFallthroughStmt(FallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "fallthrough");
   }
 
@@ -55,7 +57,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 
     auto NewFallthroughKW = FallthroughKW.withLeadingTrivia("  ");
 
-    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW, Arena).print(OS);
+    Factory.makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough");
   }
 
@@ -66,7 +68,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     auto NewFallthroughKW =
         FallthroughKW.withLeadingTrivia("  ").withTrailingTrivia("  ");
 
-    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW, Arena).print(OS);
+    Factory.makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough  ");
   }
 
@@ -74,7 +76,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    SyntaxFactory::makeBlankFallthroughStmt(Arena).print(OS);
+    Factory.makeBlankFallthroughStmt().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
@@ -83,10 +85,10 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 
 TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ", Arena);
-  auto Label =
-      SyntaxFactory::makeIdentifier("sometimesYouNeedTo", "", "", Arena);
-  auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label, Arena);
+  SyntaxFactory Factory(Arena);
+  auto BreakKW = Factory.makeBreakKeyword("", " ");
+  auto Label = Factory.makeIdentifier("sometimesYouNeedTo", "", "");
+  auto Break = Factory.makeBreakStmt(BreakKW, Label);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(BreakKW.getRaw(), Break.getBreakKeyword().getRaw());
@@ -95,10 +97,11 @@ TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
 
 TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto BreakKW = SyntaxFactory::makeBreakKeyword("", "", Arena);
-  auto Label = SyntaxFactory::makeIdentifier("theRules", "", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto BreakKW = Factory.makeBreakKeyword("", "");
+  auto Label = Factory.makeIdentifier("theRules", "", "");
 
-  auto Break = SyntaxFactory::makeBlankBreakStmt(Arena);
+  auto Break = Factory.makeBlankBreakStmt();
 
   {
     llvm::SmallString<48> Scratch;
@@ -131,19 +134,20 @@ TEST(StmtSyntaxTests, BreakStmtWithAPIs) {
 
 TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto BreakKW = SyntaxFactory::makeBreakKeyword("", " ", Arena);
-    auto Label = SyntaxFactory::makeIdentifier("theBuild", "", "", Arena);
-    auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label, Arena);
+    auto BreakKW = Factory.makeBreakKeyword("", " ");
+    auto Label = Factory.makeIdentifier("theBuild", "", "");
+    auto Break = Factory.makeBreakStmt(BreakKW, Label);
     Break.print(OS);
     ASSERT_EQ(OS.str().str(), "break theBuild"); // don't you dare
   }
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankBreakStmt(Arena).print(OS);
+    Factory.makeBlankBreakStmt().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
@@ -152,9 +156,10 @@ TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
 
 TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ", Arena);
-  auto Label = SyntaxFactory::makeIdentifier("always", "", "", Arena);
-  auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label, Arena);
+  SyntaxFactory Factory(Arena);
+  auto ContinueKW = Factory.makeContinueKeyword("", " ");
+  auto Label = Factory.makeIdentifier("always", "", "");
+  auto Continue = Factory.makeContinueStmt(ContinueKW, Label);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(ContinueKW.getRaw(), Continue.getContinueKeyword().getRaw());
@@ -163,9 +168,10 @@ TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
 
 TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ContinueKW = SyntaxFactory::makeContinueKeyword("", "", Arena);
-  auto Label = SyntaxFactory::makeIdentifier("toCare", "", "", Arena);
-  auto Continue = SyntaxFactory::makeBlankContinueStmt(Arena);
+  SyntaxFactory Factory(Arena);
+  auto ContinueKW = Factory.makeContinueKeyword("", "");
+  auto Label = Factory.makeIdentifier("toCare", "", "");
+  auto Continue = Factory.makeBlankContinueStmt();
 
   {
     llvm::SmallString<48> Scratch;
@@ -198,19 +204,20 @@ TEST(StmtSyntaxTests, ContinueStmtWithAPIs) {
 
 TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto ContinueKW = SyntaxFactory::makeContinueKeyword("", " ", Arena);
-    auto Label = SyntaxFactory::makeIdentifier("toLead", "", "", Arena);
-    auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label, Arena);
+    auto ContinueKW = Factory.makeContinueKeyword("", " ");
+    auto Label = Factory.makeIdentifier("toLead", "", "");
+    auto Continue = Factory.makeContinueStmt(ContinueKW, Label);
     Continue.print(OS);
     ASSERT_EQ(OS.str().str(), "continue toLead"); // by example
   }
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankContinueStmt(Arena).print(OS);
+    Factory.makeBlankContinueStmt().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 }
@@ -219,35 +226,37 @@ TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
 
 TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ", Arena);
-  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(
-      Minus, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
+  SyntaxFactory Factory(Arena);
+  auto ReturnKW = Factory.makeReturnKeyword("", " ");
+  auto Minus = Factory.makePrefixOperator("-", "", "");
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto MinusOne = Factory.makePrefixOperatorExpr(
+      Minus, Factory.makeIntegerLiteralExpr(OneDigits));
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt(Arena).print(OS);
+    Factory.makeBlankReturnStmt().print(OS);
     ASSERT_EQ(OS.str().str(), "");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne, Arena).print(OS);
+    Factory.makeReturnStmt(ReturnKW, MinusOne).print(OS);
     ASSERT_EQ(OS.str().str(), "return -1");
   }
 }
 
 TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ", Arena);
-  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(
-      Minus, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
-  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne, Arena);
+  SyntaxFactory Factory(Arena);
+  auto ReturnKW = Factory.makeReturnKeyword("", " ");
+  auto Minus = Factory.makePrefixOperator("-", "", "");
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto MinusOne = Factory.makePrefixOperatorExpr(
+      Minus, Factory.makeIntegerLiteralExpr(OneDigits));
+  auto Return = Factory.makeReturnStmt(ReturnKW, MinusOne);
 
   ASSERT_EQ(ReturnKW.getRaw(), Return.getReturnKeyword().getRaw());
   auto GottenExpression = Return.getExpression().getValue();
@@ -257,32 +266,31 @@ TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
 
 TEST(StmtSyntaxTests, ReturnStmtWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto ReturnKW = SyntaxFactory::makeReturnKeyword("", " ", Arena);
-  auto Minus = SyntaxFactory::makePrefixOperator("-", "", "", Arena);
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", "", "", Arena);
-  auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(
-      Minus, SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
+  SyntaxFactory Factory(Arena);
+  auto ReturnKW = Factory.makeReturnKeyword("", " ");
+  auto Minus = Factory.makePrefixOperator("-", "", "");
+  auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto MinusOne = Factory.makePrefixOperatorExpr(
+      Minus, Factory.makeIntegerLiteralExpr(OneDigits));
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt(Arena).withReturnKeyword(ReturnKW).print(
-        OS);
+    Factory.makeBlankReturnStmt().withReturnKeyword(ReturnKW).print(OS);
     ASSERT_EQ(OS.str().str(), "return ");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt(Arena).withExpression(MinusOne).print(
-        OS);
+    Factory.makeBlankReturnStmt().withExpression(MinusOne).print(OS);
     ASSERT_EQ(OS.str().str(), "-1");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankReturnStmt(Arena)
+    Factory.makeBlankReturnStmt()
         .withReturnKeyword(ReturnKW)
         .withExpression(MinusOne)
         .print(OS);

--- a/unittests/Syntax/SyntaxCollectionTests.cpp
+++ b/unittests/Syntax/SyntaxCollectionTests.cpp
@@ -9,34 +9,36 @@ using namespace swift;
 using namespace swift::syntax;
 
 TupleExprElementSyntax getCannedArgument(const RC<SyntaxArena> &Arena) {
-  auto X = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-  auto Foo = SyntaxFactory::makeIdentifier("foo", "", "", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto SymbolicRef =
-      SyntaxFactory::makeSymbolicReferenceExpr(Foo, llvm::None, Arena);
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto X = Factory.makeIdentifier("x", "", "");
+  auto Foo = Factory.makeIdentifier("foo", "", "");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto Comma = Factory.makeCommaToken("", " ");
 
-  return SyntaxFactory::makeTupleExprElement(X, Colon, SymbolicRef, Comma,
-                                             Arena);
+  return Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
 }
 
 TEST(SyntaxCollectionTests, empty) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Empty = SyntaxFactory::makeBlankTupleExprElementList(Arena);
+  SyntaxFactory Factory(Arena);
+  auto Empty = Factory.makeBlankTupleExprElementList();
   ASSERT_TRUE(Empty.empty());
   ASSERT_FALSE(Empty.appending(getCannedArgument(Arena)).empty());
 }
 
 TEST(SyntaxCollectionTests, size) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Empty = SyntaxFactory::makeBlankTupleExprElementList(Arena);
+  SyntaxFactory Factory(Arena);
+  auto Empty = Factory.makeBlankTupleExprElementList();
   ASSERT_EQ(Empty.size(), size_t(0));
   ASSERT_EQ(Empty.appending(getCannedArgument(Arena)).size(), size_t(1));
 }
 
 TEST(SyntaxCollectionTests, subscript) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Empty = SyntaxFactory::makeBlankTupleExprElementList(Arena);
+  SyntaxFactory Factory(Arena);
+  auto Empty = Factory.makeBlankTupleExprElementList();
 #ifndef NDEBUG
   ASSERT_DEATH({ Empty[0]; }, "");
 #endif
@@ -61,9 +63,10 @@ TEST(SyntaxCollectionTests, subscript) {
 
 TEST(SyntaxCollectionTests, appending) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   auto Arg = getCannedArgument(Arena);
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+  auto List = Factory.makeBlankTupleExprElementList()
                   .appending(Arg)
                   .appending(Arg)
                   .appending(Arg.withTrailingComma(NoComma));
@@ -91,12 +94,11 @@ TEST(SyntaxCollectionTests, appending) {
 
 TEST(SyntaxCollectionTests, removingLast) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  ASSERT_DEATH(
-      { SyntaxFactory::makeBlankTupleExprElementList(Arena).removingLast(); },
-      "");
+  SyntaxFactory Factory(Arena);
+  ASSERT_DEATH({ Factory.makeBlankTupleExprElementList().removingLast(); }, "");
   auto Arg = getCannedArgument(Arena);
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+  auto List = Factory.makeBlankTupleExprElementList()
                   .appending(Arg)
                   .appending(Arg)
                   .appending(Arg.withTrailingComma(NoComma))
@@ -109,13 +111,14 @@ TEST(SyntaxCollectionTests, removingLast) {
 
 TEST(SyntaxCollectionTests, prepending) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   auto Arg = getCannedArgument(Arena);
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
-                  .prepending(Arg.withTrailingComma(NoComma))
-                  .prepending(Arg.withLabel(
-                      SyntaxFactory::makeIdentifier("schwifty", "", "", Arena)))
-                  .prepending(Arg);
+  auto List =
+      Factory.makeBlankTupleExprElementList()
+          .prepending(Arg.withTrailingComma(NoComma))
+          .prepending(Arg.withLabel(Factory.makeIdentifier("schwifty", "", "")))
+          .prepending(Arg);
 
   ASSERT_EQ(List.size(), size_t(3));
 
@@ -140,17 +143,17 @@ TEST(SyntaxCollectionTests, prepending) {
 
 TEST(SyntaxCollectionTests, removingFirst) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  ASSERT_DEATH(
-      { SyntaxFactory::makeBlankTupleExprElementList(Arena).removingFirst(); },
-      "");
+  SyntaxFactory Factory(Arena);
+  ASSERT_DEATH({ Factory.makeBlankTupleExprElementList().removingFirst(); },
+               "");
   auto Arg = getCannedArgument(Arena);
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
-                  .appending(Arg.withLabel(
-                      SyntaxFactory::makeIdentifier("schwifty", "", "", Arena)))
-                  .appending(Arg)
-                  .appending(Arg.withTrailingComma(NoComma))
-                  .removingFirst();
+  auto List =
+      Factory.makeBlankTupleExprElementList()
+          .appending(Arg.withLabel(Factory.makeIdentifier("schwifty", "", "")))
+          .appending(Arg)
+          .appending(Arg.withTrailingComma(NoComma))
+          .removingFirst();
   SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   List.print(OS);
@@ -159,20 +162,18 @@ TEST(SyntaxCollectionTests, removingFirst) {
 
 TEST(SyntaxCollectionTests, inserting) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   auto Arg = getCannedArgument(Arena);
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 #ifndef NDEBUG
-  ASSERT_DEATH(
-      {
-        SyntaxFactory::makeBlankTupleExprElementList(Arena).inserting(1, Arg);
-      },
-      "");
+  ASSERT_DEATH({ Factory.makeBlankTupleExprElementList().inserting(1, Arg); },
+               "");
 #endif
 
   {
     SmallString<48> InsertedScratch;
     llvm::raw_svector_ostream InsertedOS(InsertedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+    Factory.makeBlankTupleExprElementList()
         .inserting(0, Arg)
         .inserting(0, Arg)
         .inserting(0, Arg)
@@ -180,7 +181,7 @@ TEST(SyntaxCollectionTests, inserting) {
 
     SmallString<48> PrependedScratch;
     llvm::raw_svector_ostream PrependedOS(PrependedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+    Factory.makeBlankTupleExprElementList()
         .prepending(Arg)
         .prepending(Arg)
         .prepending(Arg)
@@ -191,7 +192,7 @@ TEST(SyntaxCollectionTests, inserting) {
   {
     SmallString<48> InsertedScratch;
     llvm::raw_svector_ostream InsertedOS(InsertedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+    Factory.makeBlankTupleExprElementList()
         .inserting(0, Arg)
         .inserting(1, Arg)
         .inserting(2, Arg)
@@ -199,7 +200,7 @@ TEST(SyntaxCollectionTests, inserting) {
 
     SmallString<48> AppendedScratch;
     llvm::raw_svector_ostream AppendedOS(AppendedScratch);
-    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+    Factory.makeBlankTupleExprElementList()
         .appending(Arg)
         .appending(Arg)
         .appending(Arg)
@@ -210,11 +211,10 @@ TEST(SyntaxCollectionTests, inserting) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankTupleExprElementList(Arena)
+    Factory.makeBlankTupleExprElementList()
         .appending(Arg)
         .appending(Arg)
-        .inserting(1, Arg.withLabel(SyntaxFactory::makeIdentifier(
-                          "schwifty", "", "", Arena)))
+        .inserting(1, Arg.withLabel(Factory.makeIdentifier("schwifty", "", "")))
         .print(OS);
     ASSERT_EQ(OS.str().str(), "x: foo, schwifty: foo, x: foo, ");
   }
@@ -222,10 +222,11 @@ TEST(SyntaxCollectionTests, inserting) {
 
 TEST(SyntaxCollectionTests, cleared) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   auto Arg = getCannedArgument(Arena);
   SmallString<1> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+  auto List = Factory.makeBlankTupleExprElementList()
                   .appending(Arg)
                   .appending(Arg)
                   .appending(Arg)
@@ -239,8 +240,9 @@ TEST(SyntaxCollectionTests, cleared) {
 
 TEST(SyntaxCollectionTests, Iteration) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   auto Arg = getCannedArgument(Arena);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
+  auto List = Factory.makeBlankTupleExprElementList()
                   .appending(Arg)
                   .appending(Arg)
                   .appending(Arg);
@@ -272,13 +274,14 @@ TEST(SyntaxCollectionTests, Iteration) {
 
 TEST(SyntaxCollectionTests, Removing) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   auto Arg = getCannedArgument(Arena);
-  auto List = SyntaxFactory::makeBlankTupleExprElementList(Arena)
-                  .appending(Arg)
-                  .appending(Arg.withLabel(
-                      SyntaxFactory::makeIdentifier("first", "", "", Arena)))
-                  .appending(Arg)
-                  .removing(1);
+  auto List =
+      Factory.makeBlankTupleExprElementList()
+          .appending(Arg)
+          .appending(Arg.withLabel(Factory.makeIdentifier("first", "", "")))
+          .appending(Arg)
+          .removing(1);
 
   ASSERT_EQ(List.size(), static_cast<size_t>(2));
 

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -13,26 +13,25 @@ using namespace swift::syntax;
 
 TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto At = SyntaxFactory::makeAtSignToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto At = Factory.makeAtSignToken("", "");
   {
-    auto AutoclosureID =
-        SyntaxFactory::makeIdentifier("autoclosure", "", "", Arena);
+    auto AutoclosureID = Factory.makeIdentifier("autoclosure", "", "");
     SmallString<24> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Autoclosure = SyntaxFactory::makeBlankAttribute(Arena)
-                           .withAtSignToken(At)
-                           .withAttributeName(AutoclosureID);
+    auto Autoclosure =
+        Factory.makeBlankAttribute().withAtSignToken(At).withAttributeName(
+            AutoclosureID);
     Autoclosure.print(OS);
     ASSERT_EQ(OS.str().str(), "@autoclosure");
   }
 
   {
-    auto conventionID =
-        SyntaxFactory::makeIdentifier("convention", "", "", Arena);
-    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-    auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+    auto conventionID = Factory.makeIdentifier("convention", "", "");
+    auto LeftParen = Factory.makeLeftParenToken("", "");
+    auto RightParen = Factory.makeRightParenToken("", "");
 
-    auto Convention = SyntaxFactory::makeBlankAttribute(Arena)
+    auto Convention = Factory.makeBlankAttribute()
                           .withAtSignToken(At)
                           .withAttributeName(conventionID)
                           .withLeftParen(LeftParen)
@@ -41,7 +40,7 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto cID = SyntaxFactory::makeIdentifier("c", "", "", Arena);
+      auto cID = Factory.makeIdentifier("c", "", "");
       Convention.withArgument(cID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
@@ -49,9 +48,8 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "", Arena);
-      auto swiftArgs =
-          SyntaxFactory::makeTokenList({LeftParen, swiftID, RightParen}, Arena);
+      auto swiftID = Factory.makeIdentifier("swift", "", "");
+      auto swiftArgs = Factory.makeTokenList({LeftParen, swiftID, RightParen});
       Convention.withArgument(swiftID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
     }
@@ -59,9 +57,8 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto blockID = SyntaxFactory::makeIdentifier("block", "", "", Arena);
-      auto blockArgs =
-          SyntaxFactory::makeTokenList({LeftParen, blockID, RightParen}, Arena);
+      auto blockID = Factory.makeIdentifier("block", "", "");
+      auto blockArgs = Factory.makeTokenList({LeftParen, blockID, RightParen});
       Convention.withArgument(blockID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
     }
@@ -70,10 +67,10 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "", Arena);
-    auto Escaping = SyntaxFactory::makeBlankAttribute(Arena)
-                        .withAtSignToken(At)
-                        .withAttributeName(EscapingID);
+    auto EscapingID = Factory.makeIdentifier("escaping", "", "");
+    auto Escaping =
+        Factory.makeBlankAttribute().withAtSignToken(At).withAttributeName(
+            EscapingID);
     Escaping.print(OS);
     ASSERT_EQ(OS.str().str(), "@escaping");
   }
@@ -81,31 +78,31 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
 
 TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto At = SyntaxFactory::makeAtSignToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto At = Factory.makeAtSignToken("", "");
   {
-    auto AutoclosureID =
-        SyntaxFactory::makeIdentifier("autoclosure", "", "", Arena);
+    auto AutoclosureID = Factory.makeIdentifier("autoclosure", "", "");
     SmallString<24> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Autoclosure = SyntaxFactory::makeBlankAttribute(Arena)
-                           .withAtSignToken(At)
-                           .withAttributeName(AutoclosureID);
+    auto Autoclosure =
+        Factory.makeBlankAttribute().withAtSignToken(At).withAttributeName(
+            AutoclosureID);
     Autoclosure.print(OS);
     ASSERT_EQ(OS.str().str(), "@autoclosure");
   }
 
   {
-    auto conventionID =
-        SyntaxFactory::makeIdentifier("convention", "", "", Arena);
-    auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-    auto RightParen = SyntaxFactory::makeRightParenToken("", "", Arena);
+    auto conventionID = Factory.makeIdentifier("convention", "", "");
+    auto LeftParen = Factory.makeLeftParenToken("", "");
+    auto RightParen = Factory.makeRightParenToken("", "");
 
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto cID = SyntaxFactory::makeIdentifier("c", "", "", Arena);
-      SyntaxFactory::makeAttribute(At, conventionID, LeftParen, cID, RightParen,
-                                   llvm::None, Arena)
+      auto cID = Factory.makeIdentifier("c", "", "");
+      Factory
+          .makeAttribute(At, conventionID, LeftParen, cID, RightParen,
+                         llvm::None)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
@@ -113,9 +110,10 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto swiftID = SyntaxFactory::makeIdentifier("swift", "", "", Arena);
-      SyntaxFactory::makeAttribute(At, conventionID, LeftParen, swiftID,
-                                   RightParen, llvm::None, Arena)
+      auto swiftID = Factory.makeIdentifier("swift", "", "");
+      Factory
+          .makeAttribute(At, conventionID, LeftParen, swiftID, RightParen,
+                         llvm::None)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
     }
@@ -123,9 +121,10 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
-      auto blockID = SyntaxFactory::makeIdentifier("block", "", "", Arena);
-      SyntaxFactory::makeAttribute(At, conventionID, LeftParen, blockID,
-                                   RightParen, llvm::None, Arena)
+      auto blockID = Factory.makeIdentifier("block", "", "");
+      Factory
+          .makeAttribute(At, conventionID, LeftParen, blockID, RightParen,
+                         llvm::None)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
     }
@@ -134,10 +133,10 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto EscapingID = SyntaxFactory::makeIdentifier("escaping", "", "", Arena);
-    auto Escaping = SyntaxFactory::makeBlankAttribute(Arena)
-                        .withAtSignToken(At)
-                        .withAttributeName(EscapingID);
+    auto EscapingID = Factory.makeIdentifier("escaping", "", "");
+    auto Escaping =
+        Factory.makeBlankAttribute().withAtSignToken(At).withAttributeName(
+            EscapingID);
     Escaping.print(OS);
     ASSERT_EQ(OS.str().str(), "@escaping");
   }
@@ -145,49 +144,49 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
 
 TEST(TypeSyntaxTests, TupleWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withLeftParen(
-        SyntaxFactory::makeLeftParenToken("", "", Arena));
+    auto Void = Factory.makeVoidTupleType().withLeftParen(
+        Factory.makeLeftParenToken("", ""));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withLeftParen(
-        SyntaxFactory::makeLeftParenToken("  ", " ", Arena));
+    auto Void = Factory.makeVoidTupleType().withLeftParen(
+        Factory.makeLeftParenToken("  ", " "));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "  ( )");
   }
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withRightParen(
-        SyntaxFactory::makeRightParenToken("    ", "\n", Arena));
+    auto Void = Factory.makeVoidTupleType().withRightParen(
+        Factory.makeRightParenToken("    ", "\n"));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "(    )\n");
   }
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withRightParen(
-        SyntaxFactory::makeRightParenToken("", "", Arena));
+    auto Void = Factory.makeVoidTupleType().withRightParen(
+        Factory.makeRightParenToken("", ""));
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Comma = SyntaxFactory::makeCommaToken("", "", Arena);
+    auto Comma = Factory.makeCommaToken("", "");
     auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-    auto Foo = SyntaxFactory::makeTypeIdentifier("Foo", "", "  ", Arena);
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena).withElements(
-        SyntaxFactory::makeTupleTypeElementList(
-            {SyntaxFactory::makeTupleTypeElement(Foo, Comma, Arena),
-             SyntaxFactory::makeTupleTypeElement(Foo, NoComma, Arena)},
-            Arena));
+    auto Foo = Factory.makeTypeIdentifier("Foo", "", "  ");
+    auto Void = Factory.makeVoidTupleType().withElements(
+        Factory.makeTupleTypeElementList(
+            {Factory.makeTupleTypeElement(Foo, Comma),
+             Factory.makeTupleTypeElement(Foo, NoComma)}));
     Void.print(OS);
     ASSERT_EQ(OS.str().str(), "(Foo  ,Foo  )");
   }
@@ -195,27 +194,26 @@ TEST(TypeSyntaxTests, TupleWithAPIs) {
 
 TEST(TypeSyntaxTests, TupleBuilderAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
 
     TupleTypeSyntaxBuilder Builder(Arena);
-    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", "", Arena));
-    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+    Builder.useLeftParen(Factory.makeLeftParenToken("", ""));
+    auto Comma = Factory.makeCommaToken("", " ");
     auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-    auto IntId = SyntaxFactory::makeIdentifier("Int", "", "", Arena);
-    auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(IntId, None, Arena);
-    auto Int = SyntaxFactory::makeTupleTypeElement(IntType, NoComma, Arena);
-    auto IntWithComma =
-        SyntaxFactory::makeTupleTypeElement(IntType, Comma, Arena);
-    auto StringId = SyntaxFactory::makeIdentifier("String", "", "", Arena);
-    auto StringType =
-        SyntaxFactory::makeSimpleTypeIdentifier(StringId, None, Arena);
-    auto String = SyntaxFactory::makeTupleTypeElement(StringType, Comma, Arena);
+    auto IntId = Factory.makeIdentifier("Int", "", "");
+    auto IntType = Factory.makeSimpleTypeIdentifier(IntId, None);
+    auto Int = Factory.makeTupleTypeElement(IntType, NoComma);
+    auto IntWithComma = Factory.makeTupleTypeElement(IntType, Comma);
+    auto StringId = Factory.makeIdentifier("String", "", "");
+    auto StringType = Factory.makeSimpleTypeIdentifier(StringId, None);
+    auto String = Factory.makeTupleTypeElement(StringType, Comma);
     Builder.addElement(IntWithComma);
     Builder.addElement(String);
     Builder.addElement(Int);
-    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", "", Arena));
+    Builder.useRightParen(Factory.makeRightParenToken("", ""));
 
     auto TupleType = Builder.build();
 
@@ -227,22 +225,20 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     llvm::raw_svector_ostream OS { Scratch };
 
     TupleTypeSyntaxBuilder Builder(Arena);
-    Builder.useLeftParen(SyntaxFactory::makeLeftParenToken("", "", Arena));
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
+    Builder.useLeftParen(Factory.makeLeftParenToken("", ""));
+    auto Int = Factory.makeTypeIdentifier("Int", "", "");
+    auto Comma = Factory.makeCommaToken("", " ");
     auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-    auto xLabel = SyntaxFactory::makeIdentifier("x", {}, {}, Arena);
-    auto xTypeElt =
-        SyntaxFactory::makeTupleTypeElement(xLabel, Colon, Int, Comma, Arena);
-    auto inout = SyntaxFactory::makeInoutKeyword("", " ", Arena);
-    auto yLabel = SyntaxFactory::makeIdentifier("y", {}, {}, Arena);
-    auto yTypeElt =
-        SyntaxFactory::makeTupleTypeElement(yLabel, Colon, Int, NoComma, Arena)
-            .withInOut(inout);
+    auto Colon = Factory.makeColonToken("", " ");
+    auto xLabel = Factory.makeIdentifier("x", {}, {});
+    auto xTypeElt = Factory.makeTupleTypeElement(xLabel, Colon, Int, Comma);
+    auto inout = Factory.makeInoutKeyword("", " ");
+    auto yLabel = Factory.makeIdentifier("y", {}, {});
+    auto yTypeElt = Factory.makeTupleTypeElement(yLabel, Colon, Int, NoComma)
+                        .withInOut(inout);
     Builder.addElement(xTypeElt);
     Builder.addElement(yTypeElt);
-    Builder.useRightParen(SyntaxFactory::makeRightParenToken("", "", Arena));
+    Builder.useRightParen(Factory.makeRightParenToken("", ""));
 
     auto TupleType = Builder.build();
     TupleType.print(OS);
@@ -253,10 +249,11 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
 
 TEST(TypeSyntaxTests, TupleMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<2> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
+    auto Void = Factory.makeVoidTupleType();
     Void.print(OS);
     ASSERT_EQ(OS.str(), "()");
   }
@@ -264,19 +261,18 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
   {
     SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-    auto Bool = SyntaxFactory::makeTypeIdentifier("Bool", "", "", Arena);
-    auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
-    auto TupleType = SyntaxFactory::makeTupleType(
-        SyntaxFactory::makeLeftParenToken("", "", Arena),
-        SyntaxFactory::makeTupleTypeElementList(
-            {SyntaxFactory::makeTupleTypeElement(Int, Comma, Arena),
-             SyntaxFactory::makeTupleTypeElement(Bool, Comma, Arena),
-             SyntaxFactory::makeTupleTypeElement(Int, Comma, Arena),
-             SyntaxFactory::makeTupleTypeElement(Bool, Comma, Arena),
-             SyntaxFactory::makeTupleTypeElement(Int, None, Arena)},
-            Arena),
-        SyntaxFactory::makeRightParenToken("", "", Arena), Arena);
+    auto Int = Factory.makeTypeIdentifier("Int", "", "");
+    auto Bool = Factory.makeTypeIdentifier("Bool", "", "");
+    auto Comma = Factory.makeCommaToken("", " ");
+    auto TupleType =
+        Factory.makeTupleType(Factory.makeLeftParenToken("", ""),
+                              Factory.makeTupleTypeElementList(
+                                  {Factory.makeTupleTypeElement(Int, Comma),
+                                   Factory.makeTupleTypeElement(Bool, Comma),
+                                   Factory.makeTupleTypeElement(Int, Comma),
+                                   Factory.makeTupleTypeElement(Bool, Comma),
+                                   Factory.makeTupleTypeElement(Int, None)}),
+                              Factory.makeRightParenToken("", ""));
     TupleType.print(OS);
     ASSERT_EQ(OS.str().str(),
               "(Int, Bool, Int, Bool, Int)");
@@ -285,10 +281,11 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
 
 TEST(TypeSyntaxTests, CreateCannedTypes) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<3> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Any = SyntaxFactory::makeAnyTypeIdentifier("", "", Arena);
+    auto Any = Factory.makeAnyTypeIdentifier("", "");
     Any.print(OS);
     ASSERT_EQ(OS.str(), "Any");
   }
@@ -296,7 +293,7 @@ TEST(TypeSyntaxTests, CreateCannedTypes) {
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS { Scratch };
-    auto Self = SyntaxFactory::makeSelfTypeIdentifier("", "", Arena);
+    auto Self = Factory.makeSelfTypeIdentifier("", "");
     Self.print(OS);
     ASSERT_EQ(OS.str(), "Self");
   }
@@ -304,12 +301,13 @@ TEST(TypeSyntaxTests, CreateCannedTypes) {
 
 TEST(TypeSyntaxTests, OptionalTypeMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-    auto Question = SyntaxFactory::makePostfixQuestionMarkToken("", "", Arena);
-    auto OptionalInt = SyntaxFactory::makeOptionalType(Int, Question, Arena);
+    auto Int = Factory.makeTypeIdentifier("Int", "", "");
+    auto Question = Factory.makePostfixQuestionMarkToken("", "");
+    auto OptionalInt = Factory.makeOptionalType(Int, Question);
     OptionalInt.print(OS);
     ASSERT_EQ(OS.str(), "Int?");
   }
@@ -317,15 +315,14 @@ TEST(TypeSyntaxTests, OptionalTypeMakeAPIs) {
 
 TEST(TypeSyntaxTests, OptionalTypeWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<8> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto StringType =
-        SyntaxFactory::makeTypeIdentifier("String", " ", "", Arena);
-    SyntaxFactory::makeBlankOptionalType(Arena)
+    auto StringType = Factory.makeTypeIdentifier("String", " ", "");
+    Factory.makeBlankOptionalType()
         .withWrappedType(StringType)
-        .withQuestionMark(
-            SyntaxFactory::makePostfixQuestionMarkToken("", "", Arena))
+        .withQuestionMark(Factory.makePostfixQuestionMarkToken("", ""))
         .print(OS);
     ASSERT_EQ(OS.str(), " String?");
   }
@@ -333,13 +330,13 @@ TEST(TypeSyntaxTests, OptionalTypeWithAPIs) {
 
 TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-    auto Bang = SyntaxFactory::makeExclamationMarkToken("", "", Arena);
-    auto IntBang =
-        SyntaxFactory::makeImplicitlyUnwrappedOptionalType(Int, Bang, Arena);
+    auto Int = Factory.makeTypeIdentifier("Int", "", "");
+    auto Bang = Factory.makeExclamationMarkToken("", "");
+    auto IntBang = Factory.makeImplicitlyUnwrappedOptionalType(Int, Bang);
     IntBang.print(OS);
     ASSERT_EQ(OS.str(), "Int!");
   }
@@ -347,15 +344,14 @@ TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeMakeAPIs) {
 
 TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<8> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto StringType =
-        SyntaxFactory::makeTypeIdentifier("String", " ", "", Arena);
-    SyntaxFactory::makeBlankImplicitlyUnwrappedOptionalType(Arena)
+    auto StringType = Factory.makeTypeIdentifier("String", " ", "");
+    Factory.makeBlankImplicitlyUnwrappedOptionalType()
         .withWrappedType(StringType)
-        .withExclamationMark(
-            SyntaxFactory::makeExclamationMarkToken("", "", Arena))
+        .withExclamationMark(Factory.makeExclamationMarkToken("", ""))
         .print(OS);
     ASSERT_EQ(OS.str(), " String!");
   }
@@ -363,28 +359,30 @@ TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeWithAPIs) {
 
 TEST(TypeSyntaxTests, MetatypeTypeMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "", Arena);
-    auto Dot = SyntaxFactory::makePeriodToken("", "", Arena);
-    auto Type = SyntaxFactory::makeTypeToken("", "", Arena);
-    SyntaxFactory::makeMetatypeType(Int, Dot, Type, Arena).print(OS);
+    auto Int = Factory.makeTypeIdentifier("T", "", "");
+    auto Dot = Factory.makePeriodToken("", "");
+    auto Type = Factory.makeTypeToken("", "");
+    Factory.makeMetatypeType(Int, Dot, Type).print(OS);
     ASSERT_EQ(OS.str(), "T.Type");
   }
 }
 
 TEST(TypeSyntaxTests, MetatypeTypeWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Int = SyntaxFactory::makeTypeIdentifier("T", "", "", Arena);
-  auto Dot = SyntaxFactory::makePeriodToken("", "", Arena);
-  auto Type = SyntaxFactory::makeTypeToken("", "", Arena);
-  auto Protocol = SyntaxFactory::makeProtocolToken("", "", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Int = Factory.makeTypeIdentifier("T", "", "");
+  auto Dot = Factory.makePeriodToken("", "");
+  auto Type = Factory.makeTypeToken("", "");
+  auto Protocol = Factory.makeProtocolToken("", "");
 
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankMetatypeType(Arena)
+    Factory.makeBlankMetatypeType()
         .withBaseType(Int)
         .withPeriod(Dot)
         .withTypeOrProtocol(Type)
@@ -394,7 +392,7 @@ TEST(TypeSyntaxTests, MetatypeTypeWithAPIs) {
   {
     SmallString<4> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankMetatypeType(Arena)
+    Factory.makeBlankMetatypeType()
         .withBaseType(Int)
         .withPeriod(Dot)
         .withTypeOrProtocol(Protocol)
@@ -405,11 +403,10 @@ TEST(TypeSyntaxTests, MetatypeTypeWithAPIs) {
 #ifndef NDEBUG
   ASSERT_DEATH(
       {
-        SyntaxFactory::makeBlankMetatypeType(Arena)
+        Factory.makeBlankMetatypeType()
             .withBaseType(Int)
             .withPeriod(Dot)
-            .withTypeOrProtocol(
-                SyntaxFactory::makeIdentifier("WRONG", "", "", Arena));
+            .withTypeOrProtocol(Factory.makeIdentifier("WRONG", "", ""));
       },
       "");
 #endif
@@ -417,14 +414,14 @@ TEST(TypeSyntaxTests, MetatypeTypeWithAPIs) {
 
 TEST(TypeSyntaxTests, ArrayTypeWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
-    auto RightSquare =
-        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
-    auto Double = SyntaxFactory::makeTypeIdentifier("Double", "", "", Arena);
-    SyntaxFactory::makeBlankArrayType(Arena)
+    auto LeftSquare = Factory.makeLeftSquareBracketToken("", "");
+    auto RightSquare = Factory.makeRightSquareBracketToken("", "");
+    auto Double = Factory.makeTypeIdentifier("Double", "", "");
+    Factory.makeBlankArrayType()
         .withLeftSquareBracket(LeftSquare)
         .withElementType(Double)
         .withRightSquareBracket(RightSquare)
@@ -435,32 +432,31 @@ TEST(TypeSyntaxTests, ArrayTypeWithAPIs) {
 
 TEST(TypeSyntaxTests, ArrayTypeMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
-    auto RightSquare =
-        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
-    SyntaxFactory::makeArrayType(LeftSquare, Void, RightSquare, Arena)
-        .print(OS);
+    auto LeftSquare = Factory.makeLeftSquareBracketToken("", "");
+    auto RightSquare = Factory.makeRightSquareBracketToken("", "");
+    auto Void = Factory.makeVoidTupleType();
+    Factory.makeArrayType(LeftSquare, Void, RightSquare).print(OS);
     ASSERT_EQ(OS.str(), "[()]");
   }
 }
 
 TEST(TypeSyntaxTests, DictionaryTypeWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
-    auto RightSquare =
-        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
-    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ", Arena);
-    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-    SyntaxFactory::makeBlankDictionaryType(Arena)
+    auto LeftSquare = Factory.makeLeftSquareBracketToken("", "");
+    auto RightSquare = Factory.makeRightSquareBracketToken("", "");
+    auto Key = Factory.makeTypeIdentifier("String", "", " ");
+    auto Value = Factory.makeTypeIdentifier("Int", "", "");
+    auto Colon = Factory.makeColonToken("", " ");
+    Factory.makeBlankDictionaryType()
         .withLeftSquareBracket(LeftSquare)
         .withKeyType(Key)
         .withColon(Colon)
@@ -474,17 +470,16 @@ TEST(TypeSyntaxTests, DictionaryTypeWithAPIs) {
 
 TEST(TypeSyntaxTests, DictionaryTypeMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
+  SyntaxFactory Factory(Arena);
   {
     SmallString<16> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto LeftSquare = SyntaxFactory::makeLeftSquareBracketToken("", "", Arena);
-    auto RightSquare =
-        SyntaxFactory::makeRightSquareBracketToken("", "", Arena);
-    auto Key = SyntaxFactory::makeTypeIdentifier("String", "", " ", Arena);
-    auto Value = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-    SyntaxFactory::makeDictionaryType(LeftSquare, Key, Colon, Value,
-                                      RightSquare, Arena)
+    auto LeftSquare = Factory.makeLeftSquareBracketToken("", "");
+    auto RightSquare = Factory.makeRightSquareBracketToken("", "");
+    auto Key = Factory.makeTypeIdentifier("String", "", " ");
+    auto Value = Factory.makeTypeIdentifier("Int", "", "");
+    auto Colon = Factory.makeColonToken("", " ");
+    Factory.makeDictionaryType(LeftSquare, Key, Colon, Value, RightSquare)
         .print(OS);
     ASSERT_EQ(OS.str(), "[String : Int]");
   }
@@ -492,37 +487,38 @@ TEST(TypeSyntaxTests, DictionaryTypeMakeAPIs) {
 
 TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
-  auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-  auto RightParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-  auto IntArg = SyntaxFactory::makeBlankTupleTypeElement(Arena).withType(Int);
-  auto Async = SyntaxFactory::makeIdentifier("async", "", " ", Arena);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ", Arena);
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Comma = Factory.makeCommaToken("", " ");
+  auto Colon = Factory.makeColonToken("", " ");
+  auto LeftParen = Factory.makeLeftParenToken("", "");
+  auto RightParen = Factory.makeRightParenToken("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", "");
+  auto IntArg = Factory.makeBlankTupleTypeElement().withType(Int);
+  auto Async = Factory.makeIdentifier("async", "", " ");
+  auto Throws = Factory.makeThrowsKeyword("", " ");
+  auto Rethrows = Factory.makeRethrowsKeyword("", " ");
+  auto Arrow = Factory.makeArrowToken("", " ");
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
-    auto xArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+    auto x = Factory.makeIdentifier("x", "", "");
+    auto y = Factory.makeIdentifier("y", "", "");
+    auto xArg = Factory.makeBlankTupleTypeElement()
                     .withName(x)
                     .withColon(Colon)
                     .withType(Int)
                     .withTrailingComma(Comma);
-    auto yArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+    auto yArg = Factory.makeBlankTupleTypeElement()
                     .withName(y)
                     .withColon(Colon)
                     .withType(Int);
 
-    auto TypeList =
-        SyntaxFactory::makeTupleTypeElementList({xArg, yArg}, Arena);
-    SyntaxFactory::makeFunctionType(LeftParen, TypeList, RightParen, Async,
-                                    Throws, Arrow, Int, Arena)
+    auto TypeList = Factory.makeTupleTypeElementList({xArg, yArg});
+    Factory
+        .makeFunctionType(LeftParen, TypeList, RightParen, Async, Throws, Arrow,
+                          Int)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "(x: Int, y: Int) async throws -> Int");
   }
@@ -531,32 +527,33 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
-    auto xArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+    auto x = Factory.makeIdentifier("x", "", "");
+    auto y = Factory.makeIdentifier("y", "", "");
+    auto xArg = Factory.makeBlankTupleTypeElement()
                     .withName(x)
                     .withColon(Colon)
                     .withType(Int)
                     .withTrailingComma(Comma);
-    auto yArg = SyntaxFactory::makeBlankTupleTypeElement(Arena)
+    auto yArg = Factory.makeBlankTupleTypeElement()
                     .withName(y)
                     .withColon(Colon)
                     .withType(Int);
 
-    auto TypeList =
-        SyntaxFactory::makeTupleTypeElementList({xArg, yArg}, Arena);
-    SyntaxFactory::makeFunctionType(LeftParen, TypeList, RightParen, None,
-                                    Throws, Arrow, Int, Arena)
+    auto TypeList = Factory.makeTupleTypeElementList({xArg, yArg});
+    Factory
+        .makeFunctionType(LeftParen, TypeList, RightParen, None, Throws, Arrow,
+                          Int)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "(x: Int, y: Int) throws -> Int");
   }
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto TypeList = SyntaxFactory::makeTupleTypeElementList(
-        {IntArg.withTrailingComma(Comma), IntArg}, Arena);
-    SyntaxFactory::makeFunctionType(LeftParen, TypeList, RightParen, None,
-                                    Rethrows, Arrow, Int, Arena)
+    auto TypeList = Factory.makeTupleTypeElementList(
+        {IntArg.withTrailingComma(Comma), IntArg});
+    Factory
+        .makeFunctionType(LeftParen, TypeList, RightParen, None, Rethrows,
+                          Arrow, Int)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "(Int, Int) rethrows -> Int");
   }
@@ -564,12 +561,13 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto TypeList = SyntaxFactory::makeBlankTupleTypeElementList(Arena);
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
-    SyntaxFactory::makeFunctionType(
-        LeftParen, TypeList, RightParen, None,
-        TokenSyntax::missingToken(tok::kw_throws, "throws", Arena), Arrow, Void,
-        Arena)
+    auto TypeList = Factory.makeBlankTupleTypeElementList();
+    auto Void = Factory.makeVoidTupleType();
+    Factory
+        .makeFunctionType(
+            LeftParen, TypeList, RightParen, None,
+            TokenSyntax::missingToken(tok::kw_throws, "throws", Arena), Arrow,
+            Void)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "() -> ()");
   }
@@ -577,28 +575,29 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
 
 TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-  auto RightParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-  auto IntArg = SyntaxFactory::makeTupleTypeElement(None, None, None, None, Int,
-                                                    None, None, None, Arena);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ", Arena);
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Comma = Factory.makeCommaToken("", " ");
+  auto LeftParen = Factory.makeLeftParenToken("", "");
+  auto RightParen = Factory.makeRightParenToken("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", "");
+  auto IntArg = Factory.makeTupleTypeElement(None, None, None, None, Int, None,
+                                             None, None);
+  auto Throws = Factory.makeThrowsKeyword("", " ");
+  auto Rethrows = Factory.makeRethrowsKeyword("", " ");
+  auto Arrow = Factory.makeArrowToken("", " ");
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
-    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-    auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon, Int,
-                                                    None, None, Comma, Arena);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon, Int,
-                                                    None, None, None, Arena);
+    auto x = Factory.makeIdentifier("x", "", "");
+    auto y = Factory.makeIdentifier("y", "", "");
+    auto Colon = Factory.makeColonToken("", " ");
+    auto xArg = Factory.makeTupleTypeElement(None, x, None, Colon, Int, None,
+                                             None, Comma);
+    auto yArg = Factory.makeTupleTypeElement(None, y, None, Colon, Int, None,
+                                             None, None);
 
-    SyntaxFactory::makeBlankFunctionType(Arena)
+    Factory.makeBlankFunctionType()
         .withLeftParen(LeftParen)
         .addArgument(xArg)
         .addArgument(yArg)
@@ -615,7 +614,7 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeBlankFunctionType(Arena)
+    Factory.makeBlankFunctionType()
         .withLeftParen(LeftParen)
         .withRightParen(RightParen)
         .addArgument(IntArg.withTrailingComma(Comma))
@@ -630,8 +629,8 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
-    SyntaxFactory::makeBlankFunctionType(Arena)
+    auto Void = Factory.makeVoidTupleType();
+    Factory.makeBlankFunctionType()
         .withLeftParen(LeftParen)
         .withRightParen(RightParen)
         .withArrow(Arrow)
@@ -643,25 +642,26 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
 
 TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
-  auto Comma = SyntaxFactory::makeCommaToken("", " ", Arena);
-  auto Int = SyntaxFactory::makeTypeIdentifier("Int", "", "", Arena);
-  auto LeftParen = SyntaxFactory::makeLeftParenToken("", "", Arena);
-  auto RightParen = SyntaxFactory::makeRightParenToken("", " ", Arena);
-  auto Throws = SyntaxFactory::makeThrowsKeyword("", " ", Arena);
-  auto Rethrows = SyntaxFactory::makeRethrowsKeyword("", " ", Arena);
-  auto Arrow = SyntaxFactory::makeArrowToken("", " ", Arena);
+  SyntaxFactory Factory(Arena);
+  auto Comma = Factory.makeCommaToken("", " ");
+  auto Int = Factory.makeTypeIdentifier("Int", "", "");
+  auto LeftParen = Factory.makeLeftParenToken("", "");
+  auto RightParen = Factory.makeRightParenToken("", " ");
+  auto Throws = Factory.makeThrowsKeyword("", " ");
+  auto Rethrows = Factory.makeRethrowsKeyword("", " ");
+  auto Arrow = Factory.makeArrowToken("", " ");
 
   {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     FunctionTypeSyntaxBuilder Builder(Arena);
-    auto x = SyntaxFactory::makeIdentifier("x", "", "", Arena);
-    auto y = SyntaxFactory::makeIdentifier("y", "", "", Arena);
-    auto Colon = SyntaxFactory::makeColonToken("", " ", Arena);
-    auto xArg = SyntaxFactory::makeTupleTypeElement(None, x, None, Colon, Int,
-                                                    None, None, Comma, Arena);
-    auto yArg = SyntaxFactory::makeTupleTypeElement(None, y, None, Colon, Int,
-                                                    None, None, None, Arena);
+    auto x = Factory.makeIdentifier("x", "", "");
+    auto y = Factory.makeIdentifier("y", "", "");
+    auto Colon = Factory.makeColonToken("", " ");
+    auto xArg = Factory.makeTupleTypeElement(None, x, None, Colon, Int, None,
+                                             None, Comma);
+    auto yArg = Factory.makeTupleTypeElement(None, y, None, Colon, Int, None,
+                                             None, None);
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
@@ -679,8 +679,8 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     FunctionTypeSyntaxBuilder Builder(Arena);
-    auto IntArg = SyntaxFactory::makeTupleTypeElement(
-        None, None, None, None, Int, None, None, None, Arena);
+    auto IntArg = Factory.makeTupleTypeElement(None, None, None, None, Int,
+                                               None, None, None);
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
       .addArgument(IntArg.withTrailingComma(Comma))
@@ -697,7 +697,7 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     FunctionTypeSyntaxBuilder Builder(Arena);
-    auto Void = SyntaxFactory::makeVoidTupleType(Arena);
+    auto Void = Factory.makeVoidTupleType();
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)


### PR DESCRIPTION
This saves us from passing in the SyntaxArena every time a new node is created.

As discussed [here](https://github.com/apple/swift/pull/36165#discussion_r583231810).