### PR TITLE
[libSyntax] Re-enable the UnknownSyntaxTests

### DIFF
--- a/unittests/Syntax/CMakeLists.txt
+++ b/unittests/Syntax/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_swift_unittest(SwiftSyntaxTests
   DeclSyntaxTests.cpp
   ExprSyntaxTests.cpp
-  GenericSyntaxTests.cpp
   StmtSyntaxTests.cpp
   SyntaxCollectionTests.cpp
   TriviaTests.cpp

--- a/unittests/Syntax/UnknownSyntaxTests.cpp
+++ b/unittests/Syntax/UnknownSyntaxTests.cpp
@@ -9,45 +9,46 @@ using llvm::SmallString;
 using namespace swift;
 using namespace swift::syntax;
 
-/*
-SymbolicReferenceExprSyntax getCannedSymbolicRef() {
-  // First, make a symbolic reference to an 'Array<Int>'
-  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {});
-  auto Int = SyntaxFactory::makeIdentifier("Int", {}, {});
-  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None);
-  auto IntArg = SyntaxFactory::makeGenericArgument(IntType, None);
-  GenericArgumentClauseSyntaxBuilder ArgBuilder;
-  ArgBuilder
-    .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}))
-    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}))
-    .addArgumentsMember(IntArg);
 
-  return SyntaxFactory::makeSymbolicReferenceExpr(Array, ArgBuilder.build());
+SymbolicReferenceExprSyntax getCannedSymbolicRef(const RC<SyntaxArena> &Arena) {
+  // First, make a symbolic reference to an 'Array<Int>'
+  auto Array = SyntaxFactory::makeIdentifier("Array", {}, {}, Arena);
+  auto Int = SyntaxFactory::makeIdentifier("Int", {}, {}, Arena);
+  auto IntType = SyntaxFactory::makeSimpleTypeIdentifier(Int, None, Arena);
+  auto IntArg = SyntaxFactory::makeGenericArgument(IntType, None, Arena);
+  GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
+  ArgBuilder
+    .useLeftAngleBracket(SyntaxFactory::makeLeftAngleToken({}, {}, Arena))
+    .useRightAngleBracket(SyntaxFactory::makeRightAngleToken({}, {}, Arena))
+    .addArgument(IntArg);
+
+  return SyntaxFactory::makeSymbolicReferenceExpr(Array, ArgBuilder.build(), Arena);
 }
 
-FunctionCallExprSyntax getCannedFunctionCall() {
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto RParen = SyntaxFactory::makeRightParenToken({}, {});
+FunctionCallExprSyntax getCannedFunctionCall(const RC<SyntaxArena> &Arena) {
+  auto LParen = SyntaxFactory::makeLeftParenToken({}, {}, Arena);
+  auto RParen = SyntaxFactory::makeRightParenToken({}, {}, Arena);
 
-  auto Label = SyntaxFactory::makeIdentifier("elements", {}, {});
-  auto Colon = SyntaxFactory::makeColonToken({}, Trivia::spaces(1));
-  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
-  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "");
+  auto Label = SyntaxFactory::makeIdentifier("elements", {}, {}, Arena);
+  auto Colon = SyntaxFactory::makeColonToken({}, " ", Arena);
+  auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {}, Arena);
+  auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
   auto One = SyntaxFactory::makePrefixOperatorExpr(NoSign,
-    SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
-  auto NoComma = TokenSyntax::missingToken(tok::comma, ",");
+    SyntaxFactory::makeIntegerLiteralExpr(OneDigits, Arena), Arena);
+  auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
   auto Arg = SyntaxFactory::makeTupleExprElement(Label, Colon, One,
-                                                     NoComma);
-  auto Args = SyntaxFactory::makeTupleExprElementList({ Arg });
+                                                     NoComma, Arena);
+  auto Args = SyntaxFactory::makeTupleExprElementList({ Arg }, Arena);
 
-  return SyntaxFactory::makeFunctionCallExpr(getCannedSymbolicRef(), LParen,
-                                             Args, RParen, None);
+  return SyntaxFactory::makeFunctionCallExpr(getCannedSymbolicRef(Arena), LParen,
+                                             Args, RParen, None, None, Arena);
 }
 
 TEST(UnknownSyntaxTests, UnknownSyntaxMakeAPIs) {
+  RC<SyntaxArena> Arena = SyntaxArena::make();
   {
-    auto SymbolicRef = getCannedSymbolicRef();
+    auto SymbolicRef = getCannedSymbolicRef(Arena);
 
     // Print the known symbolic reference. It should print as "Array<Int>".
     SmallString<48> KnownScratch;
@@ -57,7 +58,7 @@ TEST(UnknownSyntaxTests, UnknownSyntaxMakeAPIs) {
 
     // Wrap that symbolic reference as an UnknownSyntax. This has the same
     // RawSyntax layout but with the Unknown Kind.
-    auto Unknown = make<UnknownSyntax>(SymbolicRef.getRaw());
+    auto Unknown = makeRoot<UnknownSyntax>(SymbolicRef.getRaw());
 
     // Print the unknown syntax. It should also print as "Array<Int>".
     SmallString<48> UnknownScratch;
@@ -69,7 +70,8 @@ TEST(UnknownSyntaxTests, UnknownSyntaxMakeAPIs) {
 }
 
 TEST(UnknownSyntaxTests, UnknownSyntaxGetAPIs) {
-  auto Call = getCannedFunctionCall();
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto Call = getCannedFunctionCall(Arena);
 
   // Function call child 0 -> layout child 0 -> called expression
   {
@@ -82,23 +84,23 @@ TEST(UnknownSyntaxTests, UnknownSyntaxGetAPIs) {
 
     // Wrap that call as an UnknownExprSyntax. This has the same
     // RawSyntax layout but with the UnknownExpr Kind.;
-    auto Unknown = make<UnknownExprSyntax>(Call.getRaw());
+    auto Unknown = makeRoot<UnknownExprSyntax>(Call.getRaw());
 
-    ASSERT_EQ(Unknown.getNumChildren(), size_t(3));
+    ASSERT_EQ(Unknown.getNumChildren(), size_t(6));
 
     // Get the second child from the unknown call, which is the argument list.
     // This should print the same as the known one: "elements: 1"
     SmallString<48> UnknownScratch;
     llvm::raw_svector_ostream UnknownOS(UnknownScratch);
     auto ExprGottenFromUnknown = Unknown.getChild(0)
-      .castTo<SymbolicReferenceExprSyntax>();
+      ->castTo<SymbolicReferenceExprSyntax>();
     ExprGottenFromUnknown.print(UnknownOS);
 
     ASSERT_EQ(KnownOS.str().str(), UnknownOS.str().str());
 
     auto ExprGottenFromUnknown2 = Unknown.getChild(0);
     ASSERT_TRUE(ExprGottenFromUnknown
-                .hasSameIdentityAs(ExprGottenFromUnknown2));
+                .hasSameIdentityAs(*ExprGottenFromUnknown2));
   }
 
   // Function call child 1 -> layout child 2 -> function call argument list
@@ -112,44 +114,45 @@ TEST(UnknownSyntaxTests, UnknownSyntaxGetAPIs) {
 
     // Wrap that symbolic reference as an UnknownSyntax. This has the same
     // RawSyntax layout but with the Unknown Kind.
-    auto Unknown = make<UnknownSyntax>(Call.getRaw());
+    auto Unknown = makeRoot<UnknownSyntax>(Call.getRaw());
 
-    ASSERT_EQ(Unknown.getNumChildren(), size_t(3));
+    ASSERT_EQ(Unknown.getNumChildren(), size_t(6));
 
-    // Get the second child from the unknown call, which is the argument list.
+    // Get the third child from the unknown call, which is the argument list.
     // This should print the same as the known one: "elements: 1"
     SmallString<48> UnknownScratch;
     llvm::raw_svector_ostream UnknownOS(UnknownScratch);
-    auto ArgsGottenFromUnknown = Unknown.getChild(1)
-      .castTo<TupleExprElementListSyntax>();
+    auto ArgsGottenFromUnknown = Unknown.getChild(2)
+      ->castTo<TupleExprElementListSyntax>();
     ArgsGottenFromUnknown.print(UnknownOS);
 
     ASSERT_EQ(KnownOS.str().str(), UnknownOS.str().str());
 
-    auto ArgsGottenFromUnknown2 = Unknown.getChild(1);
+    auto ArgsGottenFromUnknown2 = Unknown.getChild(2);
     ASSERT_TRUE(ArgsGottenFromUnknown
-                  .hasSameIdentityAs(ArgsGottenFromUnknown2));
+                  .hasSameIdentityAs(*ArgsGottenFromUnknown2));
   }
 }
 
 TEST(UnknownSyntaxTests, EmbedUnknownExpr) {
-  auto SymbolicRef = getCannedSymbolicRef();
-  auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
-  auto RParen = SyntaxFactory::makeRightParenToken({}, {});
-  auto EmptyArgs = SyntaxFactory::makeBlankTupleExprElementList();
+  RC<SyntaxArena> Arena = SyntaxArena::make();
+  auto SymbolicRef = getCannedSymbolicRef(Arena);
+  auto LParen = SyntaxFactory::makeLeftParenToken({}, {}, Arena);
+  auto RParen = SyntaxFactory::makeRightParenToken({}, {}, Arena);
+  auto EmptyArgs = SyntaxFactory::makeBlankTupleExprElementList(Arena);
 
   SmallString<48> KnownScratch;
   llvm::raw_svector_ostream KnownOS(KnownScratch);
   auto CallWithKnownExpr = SyntaxFactory::makeFunctionCallExpr(SymbolicRef,
                                                                LParen,
                                                                EmptyArgs,
-                                                               RParen, None);
+                                                               RParen, None, None, Arena);
   CallWithKnownExpr.print(KnownOS);
 
   // Let's make a function call expression where the called expression is
   // actually unknown. It should print the same and have the same structure
   // as one with a known called expression.
-  auto UnknownSymbolicRef = make<UnknownExprSyntax>(SymbolicRef.getRaw())
+  auto UnknownSymbolicRef = makeRoot<UnknownExprSyntax>(SymbolicRef.getRaw())
                               .castTo<ExprSyntax>();
 
   SmallString<48> UnknownScratch;
@@ -163,12 +166,3 @@ TEST(UnknownSyntaxTests, EmbedUnknownExpr) {
   ASSERT_EQ(KnownOS.str().str(), UnknownOS.str().str());
 }
 
-TEST(UnknownSyntaxTests, EmbedUnknownDecl) {
-  // TODO
-}
-
-TEST(UnknownSyntaxTests, EmbedUnknownStmt) {
-  // TODO
-}
-
-*/


### PR DESCRIPTION
These appear to have been commented out for years for no particular reason.