### PR TITLE
[Parser] Pass token to TokenReceiver by reference

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -87,7 +87,7 @@ namespace swift {
 class ConsumeTokenReceiver {
 public:
   /// This is called when a token is consumed.
-  virtual void receive(Token Tok) {}
+  virtual void receive(const Token &Tok) {}
 
   /// This is called to update the kind of a token whose start location is Loc.
   virtual void registerTokenKindChange(SourceLoc Loc, tok NewKind) {};
@@ -488,9 +488,7 @@ public:
       std::vector<Token> delayedTokens;
       DelayedTokenReceiver(ConsumeTokenReceiver *&receiver):
         savedConsumer(receiver, this) {}
-      void receive(Token tok) override {
-        delayedTokens.push_back(tok);
-      }
+      void receive(const Token &tok) override { delayedTokens.push_back(tok); }
       Optional<std::vector<Token>> finalize() override {
         llvm_unreachable("Cannot finalize a DelayedTokenReciever");
       }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -476,7 +476,8 @@ public:
     TokenKindChangeMap[Loc.getOpaquePointerValue()] = NewKind;
   }
 
-  void receive(Token Tok) override {
+  void receive(const Token &TokParam) override {
+    Token Tok = TokParam;
     // We filter out all tokens without valid location
     if(Tok.getLoc().isInvalid())
       return;


### PR DESCRIPTION
Small peformance improvement: `Token` is larger than a pointer and not modified in the performance-criticial `TokenReceivers` (I don’t count `TokenRecorder` as performance-critical), so we can pass it by reference.