### PR TITLE
Implement decodeImmediate for VecElementArguments

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1864,7 +1864,6 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
   case IITDescriptor::HalfVecArgument:
   case IITDescriptor::VarArg:
   case IITDescriptor::Token:
-  case IITDescriptor::VecElementArgument:
   case IITDescriptor::VecOfAnyPtrsToElt:
   case IITDescriptor::VecOfBitcastsToInt:
   case IITDescriptor::Subdivide2Argument:
@@ -1891,6 +1890,15 @@ Type IntrinsicTypeDecoder::decodeImmediate() {
     Type eltType = decodeImmediate();
     if (!eltType) return Type();
     return makeVector(eltType, D.Vector_Width.getKnownMinValue());
+  }
+  
+  // The element type of a vector type.
+  case IITDescriptor::VecElementArgument: {
+    Type argType = getTypeArgument(D.getArgumentNumber());
+    if (!argType) return Type();
+    auto vecType = argType->getAs<BuiltinVectorType>();
+    if (!vecType) return Type();
+    return vecType->getElementType();
   }
 
   // A pointer to an immediate type.

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -158,12 +158,16 @@ func cast_test(_ ptr: inout Builtin.RawPointer, i8: inout Builtin.Int8,
   d = Builtin.bitcast_Int64_FPIEEE64(i64)   // CHECK: bitcast
 }
 
-func intrinsic_test(_ i32: inout Builtin.Int32, i16: inout Builtin.Int16) {
+func intrinsic_test(_ i32: inout Builtin.Int32, i16: inout Builtin.Int16,
+                    _ v8i16: Builtin.Vec8xInt16) {
+  // CHECK: intrinsic_test
   i32 = Builtin.int_bswap_Int32(i32) // CHECK: llvm.bswap.i32(
 
   i16 = Builtin.int_bswap_Int16(i16) // CHECK: llvm.bswap.i16(
   
   var x = Builtin.int_sadd_with_overflow_Int16(i16, i16) // CHECK: call { i16, i1 } @llvm.sadd.with.overflow.i16(
+  
+  i16 = Builtin.int_vector_reduce_smin_Vec8xInt16(v8i16) // CHECK: llvm.vector.reduce.smin.v8i16(
   
   Builtin.int_trap() // CHECK: llvm.trap()
 }


### PR DESCRIPTION
This simply hadn't been wired up yet, which prevented us from being able to use certain intrinsics from the Builtin module (like vector_reduce_smin and friends).
