### PR TITLE
[Concurrency] remove unimplemented Task APIs: yield, startingOn

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -12,5 +12,5 @@
 
 import Swift
 
-// TODO: just a placeholder; proposal and complete types soon
-public protocol ExecutorRef {}
+// TODO: Custom Executors proposal will define these types
+//       https://forums.swift.org/t/support-custom-executors-in-swift-concurrency/44425/38

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -392,12 +392,9 @@ extension Task {
   @discardableResult
   public static func runDetached<T>(
     priority: Priority = .default,
-    startingOn executor: ExecutorRef? = nil,
     operation: @concurrent @escaping () async -> T
     // TODO: Allow inheriting task-locals?
   ) -> Handle<T, Never> {
-    assert(executor == nil, "Custom executor support is not implemented yet.") // FIXME
-
     // Set up the job flags for a new task.
     var flags = JobFlags()
     flags.kind = .task
@@ -448,11 +445,8 @@ extension Task {
   @discardableResult
   public static func runDetached<T, Failure>(
     priority: Priority = .default,
-    startingOn executor: ExecutorRef? = nil,
     operation: @concurrent @escaping () async throws -> T
   ) -> Handle<T, Failure> {
-    assert(executor == nil, "Custom executor support is not implemented yet.") // FIXME
-
     // Set up the job flags for a new task.
     var flags = JobFlags()
     flags.kind = .task
@@ -476,22 +470,6 @@ public func _runAsyncHandler(operation: @escaping () async -> ()) {
   Task.runDetached(
     operation: unsafeBitCast(operation, to: ConcurrentFunctionType.self)
   )
-}
-
-// ==== Voluntary Suspension -----------------------------------------------------
-
-extension Task {
-
-  /// Explicitly suspend the current task, potentially giving up execution actor
-  /// of current actor/task, allowing other tasks to execute.
-  ///
-  /// This is not a perfect cure for starvation;
-  /// if the task is the highest-priority task in the system, it might go
-  /// immediately back to executing.
-  @available(*, deprecated, message: "Not implemented yet.")
-  public static func yield() async {
-    fatalError("\(#function) not implemented yet.")
-  }
 }
 
 // ==== UnsafeCurrentTask ------------------------------------------------------


### PR DESCRIPTION
Remove two Task APIs which are not implemented.

Rather than leaving landmines, let's remove them for now until we're able to implement them.

- yield
- tasks picking a `startingOn` executor