### PR TITLE
[SE-0302] Minor semantic tweaks to bring implementation closer to the proposal

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4360,11 +4360,11 @@ WARNING(concurrent_value_outside_source_file_warn,none,
       "conformance to 'ConcurrentValue' must occur in the same source file as "
       "%0 %1; use 'UnsafeConcurrentValue' for retroactive conformance",
       (DescriptiveDeclKind, DeclName))
-ERROR(concurrent_value_open_class,none,
-      "open class %0 cannot conform to `ConcurrentValue`; "
+ERROR(concurrent_value_nonfinal_class,none,
+      "non-final class %0 cannot conform to `ConcurrentValue`; "
       "use `UnsafeConcurrentValue`", (DeclName))
-WARNING(concurrent_value_open_class_warn,none,
-      "open class %0 cannot conform to `ConcurrentValue`; "
+WARNING(concurrent_value_nonfinal_class_warn,none,
+      "non-final class %0 cannot conform to `ConcurrentValue`; "
       "use `UnsafeConcurrentValue`", (DeclName))
 ERROR(concurrent_value_inherit,none,
       "`ConcurrentValue` class %1 cannot inherit from another class"

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2483,11 +2483,11 @@ bool swift::checkConcurrentValueConformance(
   }
 
   if (classDecl) {
-    // An open class cannot conform to `ConcurrentValue`.
-    if (classDecl->getFormalAccess() == AccessLevel::Open) {
+    // An non-final class cannot conform to `ConcurrentValue`.
+    if (!classDecl->isFinal()) {
       classDecl->diagnose(
-          asWarning ? diag::concurrent_value_open_class_warn
-                    : diag::concurrent_value_open_class,
+          asWarning ? diag::concurrent_value_nonfinal_class_warn
+                    : diag::concurrent_value_nonfinal_class,
           classDecl->getName());
 
       if (!asWarning)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -768,7 +768,20 @@ static bool isConcurrentValueType(const DeclContext *dc, Type type) {
 
     bool visitFunctionType(FunctionType *type) {
       // Concurrent function types meet the requirements.
-      return type->isConcurrent();
+      if (type->isConcurrent())
+        return true;
+
+      // C and thin function types meeting the requirements because they
+      // cannot have captures.
+      switch (type->getExtInfo().getRepresentation()) {
+      case FunctionTypeRepresentation::Block:
+      case FunctionTypeRepresentation::Swift:
+        return false;
+
+      case FunctionTypeRepresentation::CFunctionPointer:
+      case FunctionTypeRepresentation::Thin:
+        return true;
+      }
     }
 
     bool visitProtocolCompositionType(ProtocolCompositionType *type) {

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -215,21 +215,19 @@ enum E2<T> {
 
 extension E2: ConcurrentValue where T: ConcurrentValue { }
 
-class C1: ConcurrentValue {
+final class C1: ConcurrentValue {
   let nc: NotConcurrent? = nil // expected-error{{stored property 'nc' of 'ConcurrentValue'-conforming class 'C1' has non-concurrent-value type 'NotConcurrent?'}}
   var x: Int = 0 // expected-error{{stored property 'x' of 'ConcurrentValue'-conforming class 'C1' is mutable}}
   let i: Int = 0
 }
 
-class C2: ConcurrentValue {
+final class C2: ConcurrentValue {
   let x: Int = 0
 }
 
-class C3: C2 {
-  var y: Int = 0 // expected-error{{stored property 'y' of 'ConcurrentValue'-conforming class 'C3' is mutable}}
-}
+class C3 { }
 
-class C4: C2, UnsafeConcurrentValue {
+class C4: C3, UnsafeConcurrentValue {
   var y: Int = 0 // okay
 }
 
@@ -241,17 +239,9 @@ class C6: C5 {
   var y: Int = 0 // still okay, it's unsafe
 }
 
-class C7<T>: ConcurrentValue { }
+final class C7<T>: ConcurrentValue { }
 
-class C8: C7<Int> { } // okay
-
-open class C9: ConcurrentValue { } // expected-error{{open class 'C9' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
-
-public class C10: ConcurrentValue { }
-// expected-note@-1{{superclass is declared here}}
-open class C11: C10 { }
-// expected-error@-1{{superclass 'C10' of open class must be open}}
-// expected-error@-2{{open class 'C11' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class C9: ConcurrentValue { } // expected-error{{non-final class 'C9' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 
 // ----------------------------------------------------------------------
 // UnsafeConcurrentValue disabling checking

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -5,17 +5,17 @@
 
 import Foundation
 
-class A: NSObject, ConcurrentValue {
+final class A: NSObject, ConcurrentValue {
   let x: Int = 5
 }
 
-class B: NSObject, ConcurrentValue {
+final class B: NSObject, ConcurrentValue {
   var x: Int = 5 // expected-error{{stored property 'x' of 'ConcurrentValue'-conforming class 'B' is mutable}}
 }
 
 class C { }
 
-class D: NSObject, ConcurrentValue {
+final class D: NSObject, ConcurrentValue {
   let c: C = C() // expected-error{{stored property 'c' of 'ConcurrentValue'-conforming class 'D' has non-concurrent-value type 'C'}}
 }
 

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -80,10 +80,16 @@ public enum PublicEnum {
   case some
 }
 
+struct HasFunctions {
+  var tfp: @convention(thin) () -> Void
+  var cfp: @convention(c) () -> Void
+}
+
 func testCV(
   c1: C1, c2: C2, s1: S1, e1: E1, e2: E2, gs1: GS1<Int>, gs2: GS2<Int>,
   bc: Bitcode, ps: PublicStruct, pe: PublicEnum,
-  fps: FrozenPublicStruct, fpe: FrozenPublicEnum
+  fps: FrozenPublicStruct, fpe: FrozenPublicEnum,
+  hf: HasFunctions
 ) {
   acceptCV(c1) // expected-error{{'C1' conform to 'ConcurrentValue'}}
   acceptCV(c2)
@@ -103,4 +109,7 @@ func testCV(
   // Public is okay when also @frozen.
   acceptCV(fps)
   acceptCV(fpe)
+
+  // Thin and C function types are ConcurrentValue.
+  acceptCV(hf)
 }

--- a/test/Constraints/ErrorBridging.swift
+++ b/test/Constraints/ErrorBridging.swift
@@ -75,7 +75,7 @@ func throwErrorCode() throws {
   throw FictionalServerError.meltedDown // expected-error{{thrown error code type 'FictionalServerError.Code' does not conform to 'Error'; construct an 'FictionalServerError' instance}}{{29-29=(}}{{40-40=)}}
 }
 
-class MyErrorClass { }
+class MyErrorClass { } // expected-warning{{non-final class 'MyErrorClass' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 extension MyErrorClass: Error { }
 
 class MyClass { }

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -346,7 +346,7 @@ extension Int: JSONLeaf { }
 extension Array: JSON where Element: JSON { }
 
 protocol SR13035Error: Error {}
-class ChildError: SR13035Error {}
+class ChildError: SR13035Error {} // expected-warning{{non-final class 'ChildError' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 
 protocol AnyC {
   func foo()

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -1013,14 +1013,14 @@ func testOptionalTryNeverFailsAddressOnlyVar<T>(_ obj: T) {
   var copy = try? obj // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{initialization of variable 'copy' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
-class SomeErrorClass : Error { }
+class SomeErrorClass : Error { } // expected-warning{{non-final class 'SomeErrorClass' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 
 // CHECK-LABEL: sil_vtable SomeErrorClass
 // CHECK-NEXT:   #SomeErrorClass.init!allocator: {{.*}} : @$s6errors14SomeErrorClassCACycfC
 // CHECK-NEXT:   #SomeErrorClass.deinit!deallocator: @$s6errors14SomeErrorClassCfD
 // CHECK-NEXT: }
 
-class OtherErrorSub : OtherError { }
+class OtherErrorSub : OtherError { } // expected-warning{{non-final class 'OtherErrorSub' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 
 // CHECK-LABEL: sil_vtable OtherErrorSub {
 // CHECK-NEXT:  #OtherError.init!allocator: {{.*}} : @$s6errors13OtherErrorSubCACycfC [override]

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -145,7 +145,7 @@ B(foo: 0) // expected-warning{{unused}}
 
 // rdar://problem/33040113 - Provide fix-it for missing "try" when calling throwing Swift function
 
-class E_33040113 : Error {}
+class E_33040113 : Error {} // expected-warning{{non-final class 'E_33040113' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 func rdar33040113() throws -> Int {
     throw E_33040113()
 }

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -33,7 +33,7 @@ actor A7 {
 }
 
 // A non-actor can conform to the Actor protocol, if it does it properly.
-class C1: Actor {
+class C1: Actor { // expected-error{{non-final class 'C1' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
   func enqueue(partialTask: PartialAsyncTask) { }
 }
 
@@ -55,8 +55,9 @@ extension BA2 {
   @actorIndependent func enqueue(partialTask: PartialAsyncTask) { }
 }
 
-// No synthesis for non-actores.
+// No synthesis for non-actors.
 class C2: Actor { // expected-error{{type 'C2' does not conform to protocol 'Actor'}}
+  // expected-error@-1{{non-final class 'C2' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 }
 
 // Make sure the conformances actually happen.

--- a/test/decl/protocol/special/Error.swift
+++ b/test/decl/protocol/special/Error.swift
@@ -34,13 +34,13 @@ enum EmptyErrorDomain: Error {}
 struct ErrorStruct : Error {
 }
 
-class ErrorClass : Error {
+class ErrorClass : Error { // expected-warning{{non-final class 'ErrorClass' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 }
 
 struct ErrorStruct2 { }
 
 extension ErrorStruct2 : Error { }
 
-class ErrorClass2 { }
+class ErrorClass2 { } // expected-warning{{non-final class 'ErrorClass2' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 
 extension ErrorClass2 : Error { }

--- a/test/decl/protocol/special/coding/enum_coding_key.swift
+++ b/test/decl/protocol/special/coding/enum_coding_key.swift
@@ -45,6 +45,7 @@ struct StructKey : CodingKey { // expected-error {{type 'StructKey' does not con
 
 // Classes conforming to CodingKey should not get implict derived conformance.
 class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform to protocol 'CodingKey'}}
+  // expected-warning@-1{{non-final class 'ClassKey' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 }
 
 // Types which are valid for CodingKey derived conformance should not get that

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -212,7 +212,7 @@ func sr_6400_3(error: Error) {
 }
 
 class SR_6400_A {}
-class SR_6400_B: SR_6400_FakeApplicationDelegate & Error {}
+class SR_6400_B: SR_6400_FakeApplicationDelegate & Error {} // expected-warning{{non-final class 'SR_6400_B' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 
 func sr_6400_4() {
   do {


### PR DESCRIPTION
Two minor tweaks for ConcurrentValue types:
* Thin and C function types conform to ConcurrentValue (because they have no captures)
* Replace "non-open class" check with "final class" check for ConcurrentValue conformance