### PR TITLE
[Concurrency] Tune overloading to to allow sync overloads in async contexts

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -775,9 +775,11 @@ enum ScoreKind {
   SK_Hole,
   /// A reference to an @unavailable declaration.
   SK_Unavailable,
-  /// A reference to an async function in a synchronous context, or
-  /// vice versa.
-  SK_AsyncSyncMismatch,
+  /// A reference to an async function in a synchronous context.
+  SK_AsyncInSyncMismatch,
+  /// Synchronous function in an asynchronous context or a conversion of
+  /// a synchronous function to an asynchronous one.
+  SK_SyncInAsync,
   /// A use of the "forward" scan for trailing closures.
   SK_ForwardTrailingClosure,
   /// A use of a disfavored overload.

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -40,8 +40,11 @@ static StringRef getScoreKindName(ScoreKind kind) {
   case SK_Unavailable:
     return "use of an unavailable declaration";
 
-  case SK_AsyncSyncMismatch:
-    return "async/synchronous mismatch";
+  case SK_AsyncInSyncMismatch:
+    return "async-in-synchronous mismatch";
+
+  case SK_SyncInAsync:
+    return "sync-in-asynchronous";
 
   case SK_ForwardTrailingClosure:
     return "forward scan when matching a trailing closure";

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1983,6 +1983,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       if (recordFix(fix))
         return getTypeMatchFailure(locator);
     }
+
+    increaseScore(SK_SyncInAsync);
   }
 
   // A @concurrent function can be a subtype of a non-@concurrent function.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -711,7 +711,7 @@ bool DisjunctionStep::shouldStopAt(const DisjunctionChoice &choice) const {
   auto delta = LastSolvedChoice->second - getCurrentScore();
   bool hasUnavailableOverloads = delta.Data[SK_Unavailable] > 0;
   bool hasFixes = delta.Data[SK_Fix] > 0;
-  bool hasAsyncMismatch = delta.Data[SK_AsyncSyncMismatch] > 0;
+  bool hasAsyncMismatch = delta.Data[SK_AsyncInSyncMismatch] > 0;
   auto isBeginningOfPartition = choice.isBeginningOfPartition();
 
   // Attempt to short-circuit evaluation of this disjunction only

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2820,8 +2820,10 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // If we're choosing an asynchronous declaration within a synchronous
     // context, or vice-versa, increase the async/async mismatch score.
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      if (func->isAsyncContext() != isAsynchronousContext(useDC))
-        increaseScore(SK_AsyncSyncMismatch);
+      if (func->isAsyncContext() != isAsynchronousContext(useDC)) {
+        increaseScore(
+            func->isAsyncContext() ? SK_AsyncInSyncMismatch : SK_SyncInAsync);
+      }
     }
 
     // If we're binding to an init member, the 'throws' need to line up

--- a/test/Constraints/async.swift
+++ b/test/Constraints/async.swift
@@ -115,3 +115,26 @@ struct FunctionTypes {
     asyncNonThrowing = syncThrowing    // expected-error{{invalid conversion}}
   }
 }
+
+// Overloading when there is conversion from sync to async.
+func bar(_ f: (Int) -> Int) -> Int {
+  return f(2)
+}
+
+func bar(_ f: (Int) async -> Int) async -> Int {
+  return await f(2)
+}
+
+func incrementSync(_ x: Int) -> Int {
+  return x + 1
+}
+
+func incrementAsync(_ x: Int) async -> Int {
+  return x + 1
+}
+
+func testAsyncWithConversions() async {
+  _ = bar(incrementSync)
+  _ = bar { -$0 }
+  _ = bar(incrementAsync) // expected-error{{call is 'async' but is not marked with 'await'}}
+}


### PR DESCRIPTION
The existing overloading rules strongly prefer async functions within
async contexts, and synchronous functions in synchronous contexts.
However, when there are other differences in the
signature, particularly parameters of function type that differ in
async vs. synchronous, the overloading rule would force the use of the
synchronous function even in cases where the synchronous function
would be better. An example:

    func f(_: (Int) -> Int) { }
    func f(_: (Int) async -> Int) async { }

    func g(_ x: Int) -> Int { -x }

    func h() async {
      f(g) // currently selects async f, want to select synchronous f
    }

Effect the semantics change by splitting the "sync/async mismatch"
score in the constraint system into an "async in sync mismatch" score
that is mostly disqualifying (because the call will always fail) and a
less-important score for "sync used in an async context", which also
includes conversion from a synchronous function to an asynchronous
one. This way, only synchronous functions are still considered within
a synchronous context, but we get more natural overloading behavior
within an asynchronous context. The end result is intended to be
equivalent to what one would get with reasync:

    func f(_: (Int) async -> Int) async { ... }

Addresses rdar://74289867.
