### PR TITLE
[Concurrency] Test showing that runDetached leaks

### DIFF
--- a/test/Concurrency/Runtime/async_task_detached.swift
+++ b/test/Concurrency/Runtime/async_task_detached.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+class X {
+  init() {
+    print("X: init")
+  }
+  deinit {
+    print("X: deinit")
+  }
+}
+
+func test_detach() async {
+  for _ in 1...3 {
+    let x = X()
+    let h = Task.runDetached {
+      print("inside: \(x)")
+    }
+    await h.get()
+  }
+  // CHECK: X: init
+  // CHECK: inside: main.X
+  // CHECK: X: deinit
+}
+
+
+@main struct Main {
+  static func main() async {
+    await test_detach()
+  }
+}


### PR DESCRIPTION
Detaching currently leaks and this is a simple reproducer for it.

rdar://74973364