### PR TITLE
[libSyntax] Add a unsafe but fast SyntaxDataRef version of SyntaxData

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -450,6 +450,7 @@ public:
   /// Get a child based on a particular node's "Cursor", indicating
   /// the position of the terms in the production of the Swift grammar.
   const RawSyntax *getChild(CursorIndex Index) const {
+    assert(Index < getNumChildren() && "Index out of bounds");
     return getLayout()[Index];
   }
 

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -56,10 +56,10 @@ class Syntax {
   friend struct SyntaxFactory;
 
 protected:
-  SyntaxData Data;
+  RC<const SyntaxData> Data;
 
 public:
-  explicit Syntax(const SyntaxData Data) : Data(Data) {}
+  explicit Syntax(const RC<const SyntaxData> &Data) : Data(Data) {}
 
   virtual ~Syntax() {}
 
@@ -86,9 +86,7 @@ public:
   }
 
   /// Get the Data for this Syntax node.
-  const SyntaxData &getData() const {
-    return Data;
-  }
+  const RC<const SyntaxData> &getData() const { return Data; }
 
   /// Cast this Syntax node to a more specific type, asserting it's of the
   /// right kind.
@@ -113,7 +111,7 @@ public:
 
   /// Returns the child index of this node in its parent,
   /// if it has one, otherwise 0.
-  CursorIndex getIndexInParent() const { return getData().getIndexInParent(); }
+  CursorIndex getIndexInParent() const { return getData()->getIndexInParent(); }
 
   /// Return the number of bytes this node takes when spelled out in the source
   size_t getTextLength() const { return getRaw()->getTextLength(); }
@@ -157,8 +155,8 @@ public:
   SWIFT_DEBUG_DUMP;
 
   bool hasSameIdentityAs(const Syntax &Other) const {
-    return Data.getAbsoluteRaw().getNodeId() ==
-           Other.Data.getAbsoluteRaw().getNodeId();
+    return Data->getAbsoluteRaw().getNodeId() ==
+           Other.Data->getAbsoluteRaw().getNodeId();
   }
 
   static bool kindof(SyntaxKind Kind) {
@@ -180,23 +178,23 @@ public:
 
   /// Get the offset at which the leading trivia of this node starts.
   AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const {
-    return Data.getAbsolutePositionBeforeLeadingTrivia();
+    return Data->getAbsolutePositionBeforeLeadingTrivia();
   }
 
   /// Get the offset at which the actual content (i.e. non-triva) of this node
   /// starts.
   AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
-    return Data.getAbsolutePositionAfterLeadingTrivia();
+    return Data->getAbsolutePositionAfterLeadingTrivia();
   }
 
   /// Get the offset at which the trailing trivia of this node starts.
   AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const {
-    return Data.getAbsoluteEndPositionBeforeTrailingTrivia();
+    return Data->getAbsoluteEndPositionBeforeTrailingTrivia();
   }
 
   /// Get the offset at which the trailing trivia of this node starts.
   AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const {
-    return Data.getAbsoluteEndPositionAfterTrailingTrivia();
+    return Data->getAbsoluteEndPositionAfterTrailingTrivia();
   }
 
   // TODO: hasSameStructureAs ?

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -57,8 +57,8 @@ class SyntaxCollection : public Syntax {
   friend class Syntax;
 
 private:
-  static SyntaxData makeData(std::initializer_list<Element> &Elements,
-                             const RC<SyntaxArena> &Arena) {
+  static RC<const SyntaxData> makeData(std::initializer_list<Element> &Elements,
+                                       const RC<SyntaxArena> &Arena) {
     std::vector<const RawSyntax *> List;
     List.reserve(Elements.size());
     for (auto &Elt : Elements)
@@ -69,7 +69,7 @@ private:
   }
 
 public:
-  SyntaxCollection(const SyntaxData Data) : Syntax(Data) {}
+  SyntaxCollection(const RC<const SyntaxData> &Data) : Syntax(Data) {}
 
   SyntaxCollection(std::initializer_list<Element> list):
     SyntaxCollection(SyntaxCollection::makeData(list)) {}
@@ -105,7 +105,7 @@ public:
   Element operator[](const size_t Index) const {
     assert(Index < size());
     assert(!empty());
-    return Element(*Data.getChild(Index));
+    return Element(Data->getChild(Index));
   }
 
   /// Return a new collection with the given element added to the end.
@@ -119,7 +119,7 @@ public:
     auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
                                             getRaw()->getPresence(),
                                             getRaw()->getArena());
-    return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
+    return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   /// Return a new collection with an element removed from the end.
@@ -131,7 +131,7 @@ public:
     auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
                                             getRaw()->getPresence(),
                                             getRaw()->getArena());
-    return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
+    return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   /// Return a new collection with the given element appended to the front.
@@ -144,7 +144,7 @@ public:
     auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
                                             getRaw()->getPresence(),
                                             getRaw()->getArena());
-    return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
+    return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   /// Return a new collection with an element removed from the end.
@@ -156,7 +156,7 @@ public:
     auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
                                             getRaw()->getPresence(),
                                             getRaw()->getArena());
-    return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
+    return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   /// Return a new collection with the Element inserted at index i.
@@ -177,7 +177,7 @@ public:
     auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
                                             getRaw()->getPresence(),
                                             getRaw()->getArena());
-    return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
+    return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   /// Return a new collection with the element removed at index i.
@@ -190,14 +190,14 @@ public:
     auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
                                             getRaw()->getPresence(),
                                             getRaw()->getArena());
-    return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
+    return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   /// Return an empty syntax collection of this type.
   SyntaxCollection<CollectionKind, Element> cleared() const {
     auto Raw = RawSyntax::makeAndCalcLength(
         CollectionKind, {}, getRaw()->getPresence(), getRaw()->getArena());
-    return SyntaxCollection<CollectionKind, Element>(Data.replacingSelf(Raw));
+    return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   static bool kindof(SyntaxKind Kind) {

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -53,42 +53,253 @@ namespace syntax {
 
 /// The class for holding parented syntax.
 ///
-/// This structure should not contain significant public
-/// API or internal modification API.
+/// \c SyntaxDataRef is designed for efficiency, not memory safety.
+/// It *does not* retain the \c RawSyntax that backs the syntax node, the \c
+/// SyntaxArena in which the \c RawSyntax node lives nor the parent \c
+/// SyntaxDataRef node. It is the user's responsibility to ensure these values
+/// outlive the \c SyntaxDataRef.
 ///
-/// It is essentially a wrapper around \c AbsoluteRawSyntax that also keeps
-/// track of the parent.
-class SyntaxData : public llvm::ThreadSafeRefCountedBase<SyntaxData> {
-  const AbsoluteRawSyntax AbsoluteRaw;
-  RC<const SyntaxData> Parent;
+/// Always use \c SyntaxData if performance is not a concern and memory safety
+/// should be guaranteed.
+class SyntaxDataRef {
+  friend class SyntaxData;
 
+protected:
+  /// The \c AbsoluteRawSyntaxNode that provides the majority of this node's
+  /// data. The underlying \c RawSyntax node is *not* retained by the \c
+  /// SyntaxDataRef. It is the user's responsibility to ensure that the \c
+  /// RawSyntax's \c SyntaxArena outlives this \c SyntaxDataRef.
+  ///
+  /// In \c SyntaxData, the backing \c SyntaxArena is retained via the \c Arena
+  /// property, lifiting the responsibility to guarantee the \c RawSyntax node
+  /// stays alive from the user.
+  const AbsoluteRawSyntax AbsoluteRaw;
+
+  /// The parent of this node. The parent is *not* retained by the \c
+  /// SyntaxDataRef. It is the user's responsibility to ensure that the parent
+  /// always outlives the child.
+  ///
+  /// If this is a \c SyntaxData object, \c Parent is guaranteed to also be a
+  /// \c SyntaxData object, which is manually retained when \c this is created
+  /// and released when \c this is destroyed.
+  const SyntaxDataRef *Parent;
+
+#ifndef NDEBUG
+  /// In debug builds, a flag that specifies if this instance is a \c
+  /// SyntaxDataRef or a \c SyntaxData object.
+  bool IsRef = true;
+#endif
+
+  /// Creates an empty \c SyntaxDataRef variable to which values can later be
+  /// stored.
+  SyntaxDataRef() : AbsoluteRaw() {}
+
+  /// Creates a \c SyntaxDataRef. \p AbsoluteRaw must not be null. If \p Parent
+  /// is a \c nullptr, this node represents the root of a tree.
+  SyntaxDataRef(const AbsoluteRawSyntax &AbsoluteRaw,
+                const SyntaxDataRef *Parent)
+      : AbsoluteRaw(AbsoluteRaw), Parent(Parent) {
+    assert(!AbsoluteRaw.isNull() &&
+           "SyntaxDataRef must always have a value. Use default constructor to "
+           "create a SyntaxDataRef to be populated later.");
+  }
+
+public:
+  SyntaxDataRef(const SyntaxDataRef &DataRef) = default;
+  SyntaxDataRef(SyntaxDataRef &&DataRef) = default;
+
+  // MARK: - Retrieving underlying data
+
+  /// Whether this is a null node created by the default constructor, and will
+  /// be populated later.
+  bool isNull() const { return AbsoluteRaw.isNull(); }
+
+  const AbsoluteRawSyntax &getAbsoluteRaw() const {
+    assert(!isNull() && "Cannot get AbsoluteRaw of a null SyntaxDataRef");
+    return AbsoluteRaw;
+  }
+
+  /// Returns the raw syntax node for this syntax node.
+  const RawSyntax *getRaw() const { return getAbsoluteRaw().getRaw(); }
+
+  // MARK: - Retrieving related nodes
+
+  const SyntaxDataRef *getParentRef() const {
+    assert(!isNull() && "Cannot get Parent of a null SyntaxDataRef");
+    return Parent;
+  }
+
+  /// Returns true if this syntax node has a parent.
+  bool hasParent() const { return getParentRef() != nullptr; }
+
+  /// Returns the number of children this SyntaxData has.
+  size_t getNumChildren() const { return getRaw()->getLayout().size(); }
+
+  /// Returns the child index of this node in its parent, if it has a parent,
+  /// otherwise 0.
+  AbsoluteSyntaxPosition::IndexInParentType getIndexInParent() const {
+    return getAbsoluteRaw().getPosition().getIndexInParent();
+  }
+
+  // MARK: - Retrieving source locations
+
+  /// Get the offset at which the leading trivia of this node starts.
+  AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const {
+    return getAbsoluteRaw().getPosition();
+  }
+
+  /// Get the offset at which the content of this node (excluding leading
+  /// trivia) starts.
+  AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
+    if (auto FirstToken = getAbsoluteRaw().getFirstToken()) {
+      return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
+          FirstToken->getRaw()->getLeadingTriviaLength());
+    } else {
+      return getAbsolutePositionBeforeLeadingTrivia();
+    }
+  }
+
+  /// Get the offset at which the content (excluding trailing trivia) of this
+  /// node ends.
+  AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const {
+    if (auto LastToken = getAbsoluteRaw().getLastToken()) {
+      return getAbsoluteEndPositionAfterTrailingTrivia().advancedBy(
+          -LastToken->getRaw()->getTrailingTriviaLength());
+    } else {
+      return getAbsoluteEndPositionAfterTrailingTrivia();
+    }
+  }
+
+  /// Get the offset at chiwh the trailing trivia of this node ends.
+  AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const {
+    return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
+        getRaw()->getTextLength());
+  }
+
+  // MARK: - Getting the node's kind
+
+  /// Returns which kind of syntax node this is.
+  SyntaxKind getKind() const { return getRaw()->getKind(); }
+
+  /// Returns true if the data node represents type syntax.
+  bool isType() const { return getRaw()->isType(); }
+
+  /// Returns true if the data node represents statement syntax.
+  bool isStmt() const { return getRaw()->isStmt(); }
+
+  /// Returns true if the data node represents declaration syntax.
+  bool isDecl() const { return getRaw()->isDecl(); }
+
+  /// Returns true if the data node represents expression syntax.
+  bool isExpr() const { return getRaw()->isExpr(); }
+
+  /// Returns true if the data node represents pattern syntax.
+  bool isPattern() const { return getRaw()->isPattern(); }
+
+  /// Returns true if this syntax is of some "unknown" kind.
+  bool isUnknown() const { return getRaw()->isUnknown(); }
+
+  // MARK: - Miscellaneous
+
+  /// Dump a debug description of the syntax data for debugging to
+  /// standard error.
+  void dump(llvm::raw_ostream &OS) const;
+
+  SWIFT_DEBUG_DUMP;
+};
+
+class SyntaxData final : public SyntaxDataRef {
   /// If this node is the root of a Syntax tree (i.e. \c Parent is \c nullptr ),
   /// the arena in which this node's \c RawSyntax node has been allocated.
   /// This keeps this \c RawSyntax nodes referenced by this tree alive.
+  /// If \c Parent has a value, this is always \c nullptr.
   RC<SyntaxArena> Arena;
 
-  /// Create a intermediate node with a parent.
-  SyntaxData(AbsoluteRawSyntax AbsoluteRaw, const RC<const SyntaxData> &Parent)
-      : AbsoluteRaw(AbsoluteRaw), Parent(Parent), Arena(nullptr) {}
+  mutable std::atomic<int> RefCount{0};
 
-  /// Create a new root node
-  SyntaxData(AbsoluteRawSyntax AbsoluteRaw)
-      : AbsoluteRaw(AbsoluteRaw), Parent(nullptr),
-        Arena(AbsoluteRaw.getRaw()->getArena()) {}
+  /// Create a non-root node with a \p Parent.
+  SyntaxData(const AbsoluteRawSyntax &AbsoluteRaw,
+             const RC<const SyntaxData> &Parent)
+      : SyntaxDataRef(AbsoluteRaw, Parent.get()), Arena(nullptr) {
+    assert(
+        Parent != nullptr &&
+        "Use SyntaxData(AbsoluteRawSyntax) or makeRoot to create a root node.");
+    assert(!Parent->IsRef &&
+           "Cannot create a SyntaxData as a child of a SyntaxDataRef");
+    Parent->Retain();
+#ifndef NDEBUG
+    IsRef = false;
+#endif
+  }
+
+  /// Create a new root node.
+  SyntaxData(const AbsoluteRawSyntax &AbsoluteRaw)
+      : SyntaxDataRef(AbsoluteRaw, nullptr),
+        Arena(AbsoluteRaw.getRaw()->getArena()) {
+#ifndef NDEBUG
+    IsRef = false;
+#endif
+  }
 
 public:
-  /// With a new \c RawSyntax node, create a new node from this one and
-  /// recursively rebuild the parental chain up to the root.
-  RC<const SyntaxData> replacingSelf(const RawSyntax *NewRaw) const;
-
-  /// Replace a child in the raw syntax and recursively rebuild the
-  /// parental chain up to the root.
-  template <typename CursorType>
-  RC<const SyntaxData> replacingChild(const RawSyntax *RawChild,
-                                      CursorType ChildCursor) const {
-    auto NewRaw = AbsoluteRaw.getRaw()->replacingChild(ChildCursor, RawChild);
-    return replacingSelf(NewRaw);
+  SyntaxData(const SyntaxData &DataRef)
+      : SyntaxDataRef(DataRef.AbsoluteRaw, DataRef.Parent),
+        Arena(DataRef.Arena) {
+    if (auto Parent = getParent()) {
+      assert(!Parent->IsRef &&
+             "Parent of a SyntaxData node should always be a SyntaxData node");
+      Parent->Retain();
+    }
   }
+
+  ~SyntaxData() {
+    assert(RefCount == 0 &&
+           "Destruction occured when there are still references to this.");
+    if (auto Parent = getParent()) {
+      Parent->Release();
+    }
+  }
+
+  /// Make a new \c SyntaxData node for the tree's root.
+  static RC<const SyntaxData> makeRoot(const AbsoluteRawSyntax &AbsoluteRaw) {
+    return RC<const SyntaxData>(new SyntaxData(AbsoluteRaw));
+  }
+
+  void Retain() const { RefCount.fetch_add(1, std::memory_order_relaxed); }
+
+  void Release() const {
+    int NewRefCount = RefCount.fetch_sub(1, std::memory_order_acq_rel) - 1;
+    assert(NewRefCount >= 0 && "Reference count was already zero.");
+    if (NewRefCount == 0) {
+      delete this;
+    }
+  }
+
+  // MARK: - Retrieving related nodes
+
+  /// Return the parent syntax if there is one, otherwise return \c nullptr.
+  RC<const SyntaxData> getParent() const {
+    if (auto ParentRef = getParentRef()) {
+      assert(!ParentRef->IsRef &&
+             "Parent of a SyntaxData node should always be a SyntaxData node");
+      return RC<const SyntaxData>(static_cast<const SyntaxData *>(ParentRef));
+    } else {
+      return nullptr;
+    }
+  }
+
+  /// Gets the child at the index specified by the provided cursor if there is
+  /// one, otherwise returns \c nullptr.
+  template <typename CursorType>
+  RC<const SyntaxData> getChild(CursorType Cursor) const {
+    return getChild(
+        (AbsoluteSyntaxPosition::IndexInParentType)cursorIndex(Cursor));
+  }
+
+  /// Gets the child at the specified \p Index  if there is one, otherwise
+  /// returns \c nullptr.
+  RC<const SyntaxData>
+  getChild(AbsoluteSyntaxPosition::IndexInParentType Index) const;
 
   /// Get the node immediately before this current node that does contain a
   /// non-missing token. Return \c nullptr if we cannot find such node.
@@ -106,86 +317,20 @@ public:
   /// this node does not contain non-missing tokens.
   RC<const SyntaxData> getLastToken() const;
 
-  /// Make a new \c SyntaxData node for the tree's root.
-  static RC<const SyntaxData> makeRoot(AbsoluteRawSyntax AbsoluteRaw) {
-    return RC<const SyntaxData>(new SyntaxData(AbsoluteRaw));
-  }
+  // MARK: - Modifying node
 
-  const AbsoluteRawSyntax &getAbsoluteRaw() const { return AbsoluteRaw; }
+  /// With a new \c RawSyntax node, create a new node from this one and
+  /// recursively rebuild the parental chain up to the root.
+  RC<const SyntaxData> replacingSelf(const RawSyntax *NewRaw) const;
 
-  /// Returns the raw syntax node for this syntax node.
-  const RawSyntax *getRaw() const { return AbsoluteRaw.getRaw(); }
-
-  /// Returns the kind of syntax node this is.
-  SyntaxKind getKind() const { return AbsoluteRaw.getRaw()->getKind(); }
-
-  /// Return the parent syntax if there is one.
-  RC<const SyntaxData> getParent() const { return Parent; }
-
-  /// Returns true if this syntax node has a parent.
-  bool hasParent() const {
-    return Parent != nullptr;
-  }
-
-  /// Returns the child index of this node in its parent, if it has a parent,
-  /// otherwise 0.
-  AbsoluteSyntaxPosition::IndexInParentType getIndexInParent() const {
-    return AbsoluteRaw.getPosition().getIndexInParent();
-  }
-
-  /// Returns the number of children this SyntaxData represents.
-  size_t getNumChildren() const {
-    return AbsoluteRaw.getRaw()->getLayout().size();
-  }
-
-  /// Gets the child at the index specified by the provided cursor.
+  /// Replace a child in the raw syntax and recursively rebuild the
+  /// parental chain up to the root.
   template <typename CursorType>
-  RC<const SyntaxData> getChild(CursorType Cursor) const {
-    return getChild(
-        (AbsoluteSyntaxPosition::IndexInParentType)cursorIndex(Cursor));
+  RC<const SyntaxData> replacingChild(const RawSyntax *RawChild,
+                                      CursorType ChildCursor) const {
+    auto NewRaw = AbsoluteRaw.getRaw()->replacingChild(ChildCursor, RawChild);
+    return replacingSelf(NewRaw);
   }
-
-  /// Gets the child at the specified \p Index.
-  RC<const SyntaxData>
-  getChild(AbsoluteSyntaxPosition::IndexInParentType Index) const;
-
-  /// Get the offset at which the leading trivia of this node starts.
-  AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const;
-
-  /// Get the offset at which the content (excluding trailing trivia) of this
-  /// node ends.
-  AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const;
-
-  /// Get the offset at which the content of this node (excluding leading
-  /// trivia) starts.
-  AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const;
-
-  /// Get the offset at chiwh the trailing trivia of this node ends.
-  AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const;
-
-  /// Returns true if the data node represents type syntax.
-  bool isType() const;
-
-  /// Returns true if the data node represents statement syntax.
-  bool isStmt() const;
-
-  /// Returns true if the data node represents declaration syntax.
-  bool isDecl() const;
-
-  /// Returns true if the data node represents expression syntax.
-  bool isExpr() const;
-
-  /// Returns true if the data node represents pattern syntax.
-  bool isPattern() const;
-
-  /// Returns true if this syntax is of some "unknown" kind.
-  bool isUnknown() const;
-
-  /// Dump a debug description of the syntax data for debugging to
-  /// standard error.
-  void dump(llvm::raw_ostream &OS) const;
-
-  SWIFT_DEBUG_DUMP;
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -51,20 +51,6 @@
 namespace swift {
 namespace syntax {
 
-/// A reference counted box that can contain any type.
-template <typename T>
-class RefCountedBox final
-    : public llvm::ThreadSafeRefCountedBase<RefCountedBox<T>> {
-public:
-  const T Data;
-
-  RefCountedBox(const T Data) : Data(Data) {}
-
-  static RC<RefCountedBox<T>> make(const T &Data) {
-    return RC<RefCountedBox<T>>{new RefCountedBox(Data)};
-  }
-};
-
 /// The class for holding parented syntax.
 ///
 /// This structure should not contain significant public
@@ -72,9 +58,9 @@ public:
 ///
 /// It is essentially a wrapper around \c AbsoluteRawSyntax that also keeps
 /// track of the parent.
-class SyntaxData {
+class SyntaxData : public llvm::ThreadSafeRefCountedBase<SyntaxData> {
   const AbsoluteRawSyntax AbsoluteRaw;
-  RC<RefCountedBox<SyntaxData>> Parent;
+  RC<const SyntaxData> Parent;
 
   /// If this node is the root of a Syntax tree (i.e. \c Parent is \c nullptr ),
   /// the arena in which this node's \c RawSyntax node has been allocated.
@@ -82,8 +68,7 @@ class SyntaxData {
   RC<SyntaxArena> Arena;
 
   /// Create a intermediate node with a parent.
-  SyntaxData(AbsoluteRawSyntax AbsoluteRaw,
-             const RC<RefCountedBox<SyntaxData>> &Parent)
+  SyntaxData(AbsoluteRawSyntax AbsoluteRaw, const RC<const SyntaxData> &Parent)
       : AbsoluteRaw(AbsoluteRaw), Parent(Parent), Arena(nullptr) {}
 
   /// Create a new root node
@@ -94,36 +79,36 @@ class SyntaxData {
 public:
   /// With a new \c RawSyntax node, create a new node from this one and
   /// recursively rebuild the parental chain up to the root.
-  SyntaxData replacingSelf(const RawSyntax *NewRaw) const;
+  RC<const SyntaxData> replacingSelf(const RawSyntax *NewRaw) const;
 
   /// Replace a child in the raw syntax and recursively rebuild the
   /// parental chain up to the root.
   template <typename CursorType>
-  SyntaxData replacingChild(const RawSyntax *RawChild,
-                            CursorType ChildCursor) const {
+  RC<const SyntaxData> replacingChild(const RawSyntax *RawChild,
+                                      CursorType ChildCursor) const {
     auto NewRaw = AbsoluteRaw.getRaw()->replacingChild(ChildCursor, RawChild);
     return replacingSelf(NewRaw);
   }
 
   /// Get the node immediately before this current node that does contain a
-  /// non-missing token. Return \c None if we cannot find such node.
-  Optional<SyntaxData> getPreviousNode() const;
+  /// non-missing token. Return \c nullptr if we cannot find such node.
+  RC<const SyntaxData> getPreviousNode() const;
 
   /// Get the node immediately after this current node that does contain a
-  /// non-missing token. Return \c None if we cannot find such node.
-  Optional<SyntaxData> getNextNode() const;
+  /// non-missing token. Return \c nullptr if we cannot find such node.
+  RC<const SyntaxData> getNextNode() const;
 
-  /// Get the first non-missing token node in this tree. Return \c None if
+  /// Get the first non-missing token node in this tree. Return \c nullptr if
   /// this node does not contain non-missing tokens.
-  Optional<SyntaxData> getFirstToken() const;
+  RC<const SyntaxData> getFirstToken() const;
 
-  /// Get the last non-missing token node in this tree. Return \c None if
+  /// Get the last non-missing token node in this tree. Return \c nullptr if
   /// this node does not contain non-missing tokens.
-  Optional<SyntaxData> getLastToken() const;
+  RC<const SyntaxData> getLastToken() const;
 
   /// Make a new \c SyntaxData node for the tree's root.
-  static SyntaxData makeRoot(AbsoluteRawSyntax AbsoluteRaw) {
-    return SyntaxData(AbsoluteRaw);
+  static RC<const SyntaxData> makeRoot(AbsoluteRawSyntax AbsoluteRaw) {
+    return RC<const SyntaxData>(new SyntaxData(AbsoluteRaw));
   }
 
   const AbsoluteRawSyntax &getAbsoluteRaw() const { return AbsoluteRaw; }
@@ -135,13 +120,7 @@ public:
   SyntaxKind getKind() const { return AbsoluteRaw.getRaw()->getKind(); }
 
   /// Return the parent syntax if there is one.
-  Optional<SyntaxData> getParent() const {
-    if (Parent) {
-      return Parent->Data;
-    } else {
-      return None;
-    }
-  }
+  RC<const SyntaxData> getParent() const { return Parent; }
 
   /// Returns true if this syntax node has a parent.
   bool hasParent() const {
@@ -161,13 +140,13 @@ public:
 
   /// Gets the child at the index specified by the provided cursor.
   template <typename CursorType>
-  Optional<SyntaxData> getChild(CursorType Cursor) const {
+  RC<const SyntaxData> getChild(CursorType Cursor) const {
     return getChild(
         (AbsoluteSyntaxPosition::IndexInParentType)cursorIndex(Cursor));
   }
 
   /// Gets the child at the specified \p Index.
-  Optional<SyntaxData>
+  RC<const SyntaxData>
   getChild(AbsoluteSyntaxPosition::IndexInParentType Index) const;
 
   /// Get the offset at which the leading trivia of this node starts.

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -69,7 +69,7 @@ public:
   };
 %     end
 
-  ${node.name}(const SyntaxData Data) : ${node.base_type}(Data) {
+  ${node.name}(const RC<const SyntaxData> &Data) : ${node.base_type}(Data) {
 %     if node.requires_validation():
       this->validate();
 %     end

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -33,7 +33,7 @@ protected:
     assert(getRaw()->isToken());
   }
 public:
-  TokenSyntax(const SyntaxData Data) : Syntax(Data) {}
+  TokenSyntax(const RC<const SyntaxData> &Data) : Syntax(Data) {}
 
   static TokenSyntax missingToken(const tok Kind, StringRef Text,
                                   const RC<SyntaxArena> &Arena) {
@@ -50,12 +50,12 @@ public:
 
   TokenSyntax withLeadingTrivia(StringRef Trivia) const {
     auto NewRaw = getRaw()->withLeadingTrivia(Trivia);
-    return TokenSyntax(getData().replacingSelf(NewRaw));
+    return TokenSyntax(getData()->replacingSelf(NewRaw));
   }
 
   TokenSyntax withTrailingTrivia(StringRef Trivia) const {
     auto NewRaw = getRaw()->withTrailingTrivia(Trivia);
-    return TokenSyntax(getData().replacingSelf(NewRaw));
+    return TokenSyntax(getData()->replacingSelf(NewRaw));
   }
 
   /* TODO: If we really need them.

--- a/include/swift/Syntax/UnknownSyntax.h
+++ b/include/swift/Syntax/UnknownSyntax.h
@@ -29,7 +29,7 @@ namespace syntax {
 class UnknownSyntax : public Syntax {
   void validate() const;
 public:
-  UnknownSyntax(const SyntaxData Data) : Syntax(Data) {}
+  UnknownSyntax(const RC<const SyntaxData> &Data) : Syntax(Data) {}
 
   static bool classof(const Syntax *S) {
     return S->isUnknown();

--- a/lib/Parse/SyntaxParsingCache.cpp
+++ b/lib/Parse/SyntaxParsingCache.cpp
@@ -41,7 +41,7 @@ bool SyntaxParsingCache::nodeCanBeReused(const Syntax &Node, size_t NodeStart,
   // StructDecl inside and `private struc Foo {}` parses as two CodeBlockItems
   // one for `private` and one for `struc Foo {}`
   size_t NextLeafNodeLength = 0;
-  if (auto NextNode = Node.getData().getNextNode()) {
+  if (auto NextNode = Node.getData()->getNextNode()) {
     auto NextLeafNode = NextNode->getFirstToken();
     auto NextRawNode = NextLeafNode->getRaw();
     assert(NextRawNode->isPresent());

--- a/lib/Syntax/Syntax.cpp
+++ b/lib/Syntax/Syntax.cpp
@@ -17,7 +17,7 @@
 using namespace swift;
 using namespace swift::syntax;
 
-const RawSyntax *Syntax::getRaw() const { return Data.getRaw(); }
+const RawSyntax *Syntax::getRaw() const { return Data->getRaw(); }
 
 SyntaxKind Syntax::getKind() const {
   return getRaw()->getKind();
@@ -36,21 +36,21 @@ void Syntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   getRaw()->dump(OS, 0);
 }
 
-bool Syntax::isType() const { return Data.isType(); }
+bool Syntax::isType() const { return Data->isType(); }
 
-bool Syntax::isDecl() const { return Data.isDecl(); }
+bool Syntax::isDecl() const { return Data->isDecl(); }
 
-bool Syntax::isStmt() const { return Data.isStmt(); }
+bool Syntax::isStmt() const { return Data->isStmt(); }
 
-bool Syntax::isExpr() const { return Data.isExpr(); }
+bool Syntax::isExpr() const { return Data->isExpr(); }
 
 bool Syntax::isToken() const {
   return getRaw()->isToken();
 }
 
-bool Syntax::isPattern() const { return Data.isPattern(); }
+bool Syntax::isPattern() const { return Data->isPattern(); }
 
-bool Syntax::isUnknown() const { return Data.isUnknown(); }
+bool Syntax::isUnknown() const { return Data->isUnknown(); }
 
 bool Syntax::isPresent() const {
   return getRaw()->isPresent();
@@ -61,19 +61,19 @@ bool Syntax::isMissing() const {
 }
 
 llvm::Optional<Syntax> Syntax::getParent() const {
-  auto ParentData = getData().getParent();
+  auto ParentData = getData()->getParent();
   if (!ParentData) {
     return None;
   }
-  return Syntax(*ParentData);
+  return Syntax(ParentData);
 }
 
-size_t Syntax::getNumChildren() const { return Data.getNumChildren(); }
+size_t Syntax::getNumChildren() const { return Data->getNumChildren(); }
 
 llvm::Optional<Syntax> Syntax::getChild(const size_t N) const {
-  auto ChildData = Data.getChild(N);
+  auto ChildData = Data->getChild(N);
   if (!ChildData) {
     return None;
   }
-  return Syntax(*ChildData);
+  return Syntax(ChildData);
 }

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -28,7 +28,7 @@ using namespace swift::syntax;
 %   if node.requires_validation():
 void ${node.name}::validate() const {
 #ifndef NDEBUG
-  auto raw = Data.getRaw();
+  auto raw = getData()->getRaw();
   if (isMissing()) return;
   assert(raw->getLayout().size() == ${len(node.children)});
 %     for child in node.children:
@@ -56,14 +56,14 @@ void ${node.name}::validate() const {
 %   for child in node.children:
 %     if child.is_optional:
 llvm::Optional<${child.type_name}> ${node.name}::get${child.name}() const {
-  auto ChildData = Data.getChild(Cursor::${child.name});
+  auto ChildData = Data->getChild(Cursor::${child.name});
   if (!ChildData)
     return llvm::None;
-  return ${child.type_name}(*ChildData);
+  return ${child.type_name}(ChildData);
 }
 %     else:
 ${child.type_name} ${node.name}::get${child.name}() const {
-  return ${child.type_name}(*Data.getChild(Cursor::${child.name}));
+  return ${child.type_name}(Data->getChild(Cursor::${child.name}));
 }
 %     end
 
@@ -81,7 +81,7 @@ ${node.name} ${node.name}::add${child_elt}(${child_elt_type} ${child_elt}) {
   else
     raw = RawSyntax::makeAndCalcLength(SyntaxKind::${child_node.syntax_kind},
       {${child_elt}.getRaw()}, SourcePresence::Present, raw->getArena());
-  return ${node.name}(Data.replacingChild(raw, Cursor::${child.name}));
+  return ${node.name}(Data->replacingChild(raw, Cursor::${child.name}));
 }
 %     end
 
@@ -101,7 +101,7 @@ ${node.name} ${node.name}::with${child.name}(
     }
 % end
   }
-  return ${node.name}(Data.replacingChild(raw, Cursor::${child.name}));
+  return ${node.name}(Data->replacingChild(raw, Cursor::${child.name}));
 }
 
 %   end

--- a/lib/Syntax/UnknownSyntax.cpp
+++ b/lib/Syntax/UnknownSyntax.cpp
@@ -16,4 +16,4 @@
 using namespace swift;
 using namespace swift::syntax;
 
-void UnknownSyntax::validate() const { assert(Data.getRaw()->isUnknown()); }
+void UnknownSyntax::validate() const { assert(Data->getRaw()->isUnknown()); }


### PR DESCRIPTION
In contrast to `SyntaxData`, `SyntaxDataRef` is not memory-safe, but designed to be fast. In particular, the following guarantees from `SyntaxData` are being dropped:
 - `SyntaxDataRef` does not retain the `SyntaxArena` containing its `RawSyntax`. The user of `SyntaxDataRef` has to make sure the arena stays alive while the `SyntaxDataRef` is being used. However, that's usually pretty easily done by just retaining the `SyntaxArena` of the tree's root node.
 - The parent of a `SyntaxDataRef` must outlive the child node. This is the more tricky constraint, but if a tree is just walked top to bottom with nodes stored on the stack, this is given by the way the stack is being unrolled.