### PR TITLE
SIL: some improvements/fixes around assign_by_wrapper

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3642,7 +3642,9 @@ assign_by_wrapper
 ``````````````````
 ::
 
-  sil-instruction ::= 'assign_by_wrapper' sil-operand 'to' sil-operand ',' 'init' sil-operand ',' 'set' sil-operand
+  sil-instruction ::= 'assign_by_wrapper' sil-operand 'to' mode? sil-operand ',' 'init' sil-operand ',' 'set' sil-operand
+
+  mode ::= '[initialization]' | '[assign]' | '[assign_wrapped_value]'
 
   assign_by_wrapper %0 : $S to %1 : $*T, init %2 : $F, set %3 : $G
   // $S can be a value or address type
@@ -3653,13 +3655,22 @@ assign_by_wrapper
 Similar to the `assign`_ instruction, but the assignment is done via a
 delegate.
 
-In case of an initialization, the function ``%2`` is called with ``%0`` as
-argument. The result is stored to ``%1``. In case ``%2`` is an address type,
-it is simply passed as a first out-argument to ``%2``.
+Initially the instruction is created with no mode. Once the mode is decided
+(by the definitive initialization pass), the instruction is lowered as follows:
 
-In case of a re-assignment, the function ``%3`` is called with ``%0`` as
-argument. As ``%3`` is a setter (e.g. for the property in the containing
-nominal type), the destination address ``%1`` is not used in this case.
+If the mode is ``initialization``, the function ``%2`` is called with ``%0`` as
+argument. The result is stored to ``%1``. In case of an address type, ``%1`` is
+simply passed as a first out-argument to ``%2``.
+
+The ``assign`` mode works similar to ``initialization``, except that the
+destination is "assigned" rather than "initialized". This means that the
+existing value in the destination is destroyed before the new value is
+stored.
+
+If the mode is ``assign_wrapped_value``, the function ``%3`` is called with
+``%0`` as argument. As ``%3`` is a setter (e.g. for the property in the
+containing nominal type), the destination address ``%1`` is not used in this
+case.
 
 This instruction is only valid in Raw SIL and is rewritten as appropriate
 by the definitive initialization pass.

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -877,10 +877,10 @@ public:
                                                SILValue Src, SILValue Dest,
                                                SILValue Initializer,
                                                SILValue Setter,
-                                          AssignOwnershipQualifier Qualifier) {
+                                               AssignByWrapperInst::Mode mode) {
     return insert(new (getModule())
                   AssignByWrapperInst(getSILDebugLocation(Loc), Src, Dest,
-                                       Initializer, Setter, Qualifier));
+                                       Initializer, Setter, mode));
   }
 
   StoreBorrowInst *createStoreBorrow(SILLocation Loc, SILValue Src,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1243,7 +1243,7 @@ void SILCloner<ImplClass>::visitAssignByWrapperInst(AssignByWrapperInst *Inst) {
                                       getOpValue(Inst->getDest()),
                                       getOpValue(Inst->getInitializer()),
                                       getOpValue(Inst->getSetter()),
-                                      Inst->getOwnershipQualifier()));
+                                      Inst->getMode()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4370,39 +4370,38 @@ class AssignByWrapperInst
   friend SILBuilder;
 
 public:
-  /// The assignment destination for the property wrapper
-  enum class Destination {
-    BackingWrapper,
-    WrappedValue,
+  enum Mode {
+    /// The mode is not decided yet (by DefiniteInitialization).
+    Unknown,
+    
+    /// The initializer is called with Src as argument. The result is stored to
+    /// Dest.
+    Initialization,
+    
+    // Like ``Initialization``, except that the destination is "assigned" rather
+    // than "initialized". This means that the existing value in the destination
+    // is destroyed before the new value is stored.
+    Assign,
+    
+    /// The setter is called with Src as argument. The Dest is not used in this
+    /// case.
+    AssignWrappedValue
   };
 
 private:
-  Destination AssignDest = Destination::WrappedValue;
-
   AssignByWrapperInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest,
-                       SILValue Initializer, SILValue Setter,
-                       AssignOwnershipQualifier Qualifier =
-                         AssignOwnershipQualifier::Unknown);
+                       SILValue Initializer, SILValue Setter, Mode mode);
 
 public:
-
   SILValue getInitializer() { return Operands[2].get(); }
   SILValue getSetter() { return  Operands[3].get(); }
 
-  AssignOwnershipQualifier getOwnershipQualifier() const {
-    return AssignOwnershipQualifier(
-      SILNode::Bits.AssignByWrapperInst.OwnershipQualifier);
+  Mode getMode() const {
+    return Mode(SILNode::Bits.AssignByWrapperInst.Mode);
   }
 
-  Destination getAssignDestination() const { return AssignDest; }
-
-  void setAssignInfo(AssignOwnershipQualifier qualifier, Destination dest) {
-    assert(qualifier == AssignOwnershipQualifier::Init && dest == Destination::BackingWrapper ||
-           qualifier == AssignOwnershipQualifier::Reassign && dest == Destination::BackingWrapper ||
-           qualifier == AssignOwnershipQualifier::Reassign && dest == Destination::WrappedValue);
-
-    SILNode::Bits.AssignByWrapperInst.OwnershipQualifier = unsigned(qualifier);
-    AssignDest = dest;
+  void setMode(Mode mode) {
+    SILNode::Bits.AssignByWrapperInst.Mode = unsigned(mode);
   }
 };
 

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -120,6 +120,7 @@ public:
   enum { NumStoreOwnershipQualifierBits = 2 };
   enum { NumLoadOwnershipQualifierBits = 2 };
   enum { NumAssignOwnershipQualifierBits = 2 };
+  enum { NumAssignByWrapperModeBits = 2 };
   enum { NumSILAccessKindBits = 2 };
   enum { NumSILAccessEnforcementBits = 2 };
 
@@ -311,8 +312,8 @@ protected:
     OwnershipQualifier : NumAssignOwnershipQualifierBits
   );
   SWIFT_INLINE_BITFIELD(AssignByWrapperInst, NonValueInstruction,
-                        NumAssignOwnershipQualifierBits,
-    OwnershipQualifier : NumAssignOwnershipQualifierBits
+                        NumAssignByWrapperModeBits,
+    Mode : NumAssignByWrapperModeBits
   );
 
   SWIFT_INLINE_BITFIELD(UncheckedOwnershipConversionInst,SingleValueInstruction,

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1080,11 +1080,10 @@ AssignByWrapperInst::AssignByWrapperInst(SILDebugLocation Loc,
                                            SILValue Src, SILValue Dest,
                                            SILValue Initializer,
                                            SILValue Setter,
-                                          AssignOwnershipQualifier Qualifier) :
+                                           AssignByWrapperInst::Mode mode) :
     AssignInstBase(Loc, Src, Dest, Initializer, Setter) {
   assert(Initializer->getType().is<SILFunctionType>());
-  SILNode::Bits.AssignByWrapperInst.OwnershipQualifier =
-      unsigned(Qualifier);
+  SILNode::Bits.AssignByWrapperInst.Mode = unsigned(mode);
 }
 
 MarkFunctionEscapeInst *

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1453,7 +1453,19 @@ public:
 
   void visitAssignByWrapperInst(AssignByWrapperInst *AI) {
     *this << getIDAndType(AI->getSrc()) << " to ";
-    printAssignOwnershipQualifier(AI->getOwnershipQualifier());
+    switch (AI->getMode()) {
+    case AssignByWrapperInst::Unknown:
+      break;
+    case AssignByWrapperInst::Initialization:
+      *this << "[initialization] ";
+      break;
+    case AssignByWrapperInst::Assign:
+      *this << "[assign] ";
+      break;
+    case AssignByWrapperInst::AssignWrappedValue:
+      *this << "[assign_wrapped_value] ";
+      break;
+    }
     *this << getIDAndType(AI->getDest())
           << ", init " << getIDAndType(AI->getInitializer())
           << ", set " << getIDAndType(AI->getSetter());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1981,6 +1981,32 @@ static bool parseAssignOwnershipQualifier(AssignOwnershipQualifier &Result,
   return false;
 }
 
+static bool parseAssignByWrapperMode(AssignByWrapperInst::Mode &Result,
+                                          SILParser &P) {
+  StringRef Str;
+  // If we do not parse '[' ... ']', we have unknown. Set value and return.
+  if (!parseSILOptional(Str, P)) {
+    Result = AssignByWrapperInst::Unknown;
+    return false;
+  }
+
+  // Then try to parse one of our other initialization kinds. We do not support
+  // parsing unknown here so we use that as our fail value.
+  auto Tmp = llvm::StringSwitch<AssignByWrapperInst::Mode>(Str)
+        .Case("initialization", AssignByWrapperInst::Initialization)
+        .Case("assign", AssignByWrapperInst::Assign)
+        .Case("assign_wrapped_value", AssignByWrapperInst::AssignWrappedValue)
+        .Default(AssignByWrapperInst::Unknown);
+
+  // Thus return true (following the conventions in this file) if we fail.
+  if (Tmp == AssignByWrapperInst::Unknown)
+    return true;
+
+  // Otherwise, assign Result and return false.
+  Result = Tmp;
+  return false;
+}
+
 // Parse a list of integer indices, prefaced with the given string label.
 // Returns true on error.
 static bool parseIndexList(Parser &P, StringRef label,
@@ -3659,9 +3685,9 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::AssignByWrapperInst: {
     SILValue Src, DestAddr, InitFn, SetFn;
     SourceLoc DestLoc;
-    AssignOwnershipQualifier AssignQualifier;
+    AssignByWrapperInst::Mode mode;
     if (parseTypedValueRef(Src, B) || parseVerbatim("to") ||
-        parseAssignOwnershipQualifier(AssignQualifier, *this) ||
+        parseAssignByWrapperMode(mode, *this) ||
         parseTypedValueRef(DestAddr, DestLoc, B) ||
         P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ",") ||
         parseVerbatim("init") || parseTypedValueRef(InitFn, B) ||
@@ -3677,7 +3703,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     }
 
     ResultVal = B.createAssignByWrapper(InstLoc, Src, DestAddr, InitFn, SetFn,
-                                        AssignQualifier);
+                                        mode);
     break;
   }
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1549,7 +1549,7 @@ namespace {
 
         SGF.B.createAssignByWrapper(loc, Mval.forward(SGF), proj.forward(SGF),
                                      initFn.getValue(), setterFn.getValue(),
-                                     AssignOwnershipQualifier::Unknown);
+                                     AssignByWrapperInst::Unknown);
 
         return;
       }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2012,16 +2012,13 @@ void LifetimeChecker::updateInstructionForInitState(unsigned UseID) {
 
     switch (Use.Kind) {
     case DIUseKind::Initialization:
-      AI->setAssignInfo(AssignOwnershipQualifier::Init,
-                        AssignByWrapperInst::Destination::BackingWrapper);
+      AI->setMode(AssignByWrapperInst::Initialization);
       break;
     case DIUseKind::Assign:
-      AI->setAssignInfo(AssignOwnershipQualifier::Reassign,
-                        AssignByWrapperInst::Destination::BackingWrapper);
+      AI->setMode(AssignByWrapperInst::Assign);
       break;
     case DIUseKind::AssignWrappedValue:
-      AI->setAssignInfo(AssignOwnershipQualifier::Reassign,
-                        AssignByWrapperInst::Destination::WrappedValue);
+      AI->setMode(AssignByWrapperInst::AssignWrappedValue);
       break;
     default:
       llvm_unreachable("Wrong use kind for assign_by_wrapper");

--- a/test/SILOptimizer/di_property_wrappers_leak.swift
+++ b/test/SILOptimizer/di_property_wrappers_leak.swift
@@ -31,10 +31,47 @@ struct TestWrappedValueLeak {
   }
 }
 
-TestSuite("Property Wrapper DI").test("test wrapped value leak") {
+var propertyWrapperTests = TestSuite("Property Wrapper DI")
+
+propertyWrapperTests.test("test wrapped value leak") {
   _ = TestWrappedValueLeak()
   _ = TestWrappedValueLeak(conditionalInit: true)
   _ = TestWrappedValueLeak(conditionalInit: false)
+}
+
+protocol IntInitializable {
+  init(_ i: Int)
+}
+
+extension LifetimeTracked : IntInitializable {
+  convenience init(_ i: Int) {
+    self.init(i, identity: 0)
+  }
+}
+
+struct TestWrappedValueLeakGeneric<T : IntInitializable> {
+  @Wrapper var wrapped: T = T(0)
+  var str: String
+
+  init() {
+    wrapped = T(42)
+    str = ""
+    wrapped = T(27)
+  }
+
+  init(conditionalInit: Bool) {
+    if (conditionalInit) {
+      wrapped = T(42)
+    }
+    str = ""
+    wrapped = T(27)
+  }
+}
+
+propertyWrapperTests.test("test wrapped value leak - generic") {
+  _ = TestWrappedValueLeakGeneric<LifetimeTracked>()
+  _ = TestWrappedValueLeakGeneric<LifetimeTracked>(conditionalInit: true)
+  _ = TestWrappedValueLeakGeneric<LifetimeTracked>(conditionalInit: false)
 }
 
 runAllTests()

--- a/test/SILOptimizer/raw_sil_inst_lowering.sil
+++ b/test/SILOptimizer/raw_sil_inst_lowering.sil
@@ -77,3 +77,141 @@ bb0(%0 : $*SomeClass, %1 : @owned $SomeClass):
   // CHECK: return
   return %9 : $()
 }
+
+@propertyWrapper struct Wrapper<T> {
+  @_hasStorage var wrappedValue: T
+  init(wrappedValue initialValue: T)
+}
+
+struct RefStruct {
+  @_hasStorage var _wrapped: Wrapper<SomeClass>
+}
+
+
+sil @init_closure : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
+sil @init_closure_indirect : $@convention(thin) (@owned SomeClass) -> @out Wrapper<SomeClass>
+sil @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+
+// CHECK-LABEL: sil [ossa] @assign_by_wrapper_initialization_direct
+// CHECK:   [[E:%[0-9]+]] = struct_element_addr
+// CHECK:   [[C:%[0-9]+]] = function_ref @init_closure
+// CHECK:   [[P:%[0-9]+]] = partial_apply [callee_guaranteed] [[C]]()
+// CHECK-NOT: partial_apply
+// CHECK:   [[R:%[0-9]+]] = apply [[P]](%0)
+// CHECK:   store [[R]] to [init] [[E]]
+// CHECK: } // end sil function 'assign_by_wrapper_initialization_direct'
+sil [ossa] @assign_by_wrapper_initialization_direct : $@convention(method) (@owned SomeClass) -> @owned RefStruct {
+bb0(%0 : @owned $SomeClass):
+  %1 = alloc_stack $RefStruct
+  %7 = struct_element_addr %1 : $*RefStruct, #RefStruct._wrapped
+  %8 = function_ref @init_closure : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %9 = partial_apply [callee_guaranteed] %8() : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %10 = function_ref @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  %11 = partial_apply [callee_guaranteed] %10(%1) : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  assign_by_wrapper %0 : $SomeClass to [initialization] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %16 = load [take] %1 : $*RefStruct
+  dealloc_stack %1 : $*RefStruct
+  return %16 : $RefStruct
+}
+
+// CHECK-LABEL: sil [ossa] @assign_by_wrapper_initialization_indirect
+// CHECK:   [[E:%[0-9]+]] = struct_element_addr
+// CHECK:   [[C:%[0-9]+]] = function_ref @init_closure_indirect
+// CHECK:   [[P:%[0-9]+]] = partial_apply [callee_guaranteed] [[C]]()
+// CHECK-NOT: partial_apply
+// CHECK-NOT: destroy_addr
+// CHECK:   [[R:%[0-9]+]] = apply [[P]]([[E]], %0)
+// CHECK: } // end sil function 'assign_by_wrapper_initialization_indirect'
+sil [ossa] @assign_by_wrapper_initialization_indirect : $@convention(method) (@owned SomeClass) -> @owned RefStruct {
+bb0(%0 : @owned $SomeClass):
+  %1 = alloc_stack $RefStruct
+  %7 = struct_element_addr %1 : $*RefStruct, #RefStruct._wrapped
+  %8 = function_ref @init_closure_indirect : $@convention(thin) (@owned SomeClass) -> @out Wrapper<SomeClass>
+  %9 = partial_apply [callee_guaranteed] %8() : $@convention(thin) (@owned SomeClass) -> @out Wrapper<SomeClass>
+  %10 = function_ref @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  %11 = partial_apply [callee_guaranteed] %10(%1) : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  assign_by_wrapper %0 : $SomeClass to [initialization] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @out Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %9 : $@callee_guaranteed (@owned SomeClass) -> @out Wrapper<SomeClass>
+  %16 = load [take] %1 : $*RefStruct
+  dealloc_stack %1 : $*RefStruct
+  return %16 : $RefStruct
+}
+
+// CHECK-LABEL: sil [ossa] @assign_by_wrapper_assign_direct
+// CHECK:   [[E:%[0-9]+]] = struct_element_addr
+// CHECK:   [[C:%[0-9]+]] = function_ref @init_closure
+// CHECK:   [[P:%[0-9]+]] = partial_apply [callee_guaranteed] [[C]]()
+// CHECK-NOT: partial_apply
+// CHECK:   [[R:%[0-9]+]] = apply [[P]](%0)
+// CHECK:   store [[R]] to [assign] [[E]]
+// CHECK: } // end sil function 'assign_by_wrapper_assign_direct'
+sil [ossa] @assign_by_wrapper_assign_direct : $@convention(method) (@owned SomeClass, @owned Wrapper<SomeClass>) -> @owned RefStruct {
+bb0(%0 : @owned $SomeClass, %1 : @owned $Wrapper<SomeClass>):
+  %2 = alloc_stack $RefStruct
+  %7 = struct_element_addr %2 : $*RefStruct, #RefStruct._wrapped
+  store %1 to [init] %7 : $*Wrapper<SomeClass>
+  %8 = function_ref @init_closure : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %9 = partial_apply [callee_guaranteed] %8() : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %10 = function_ref @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  %11 = partial_apply [callee_guaranteed] %10(%2) : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  assign_by_wrapper %0 : $SomeClass to [assign] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %16 = load [take] %2 : $*RefStruct
+  dealloc_stack %2 : $*RefStruct
+  return %16 : $RefStruct
+}
+
+// CHECK-LABEL: sil [ossa] @assign_by_wrapper_assign_indirect
+// CHECK:   [[E:%[0-9]+]] = struct_element_addr
+// CHECK:   [[C:%[0-9]+]] = function_ref @init_closure_indirect
+// CHECK:   [[P:%[0-9]+]] = partial_apply [callee_guaranteed] [[C]]()
+// CHECK-NOT: partial_apply
+// CHECK:   destroy_addr [[E]]
+// CHECK:   [[R:%[0-9]+]] = apply [[P]]([[E]], %0)
+// CHECK: } // end sil function 'assign_by_wrapper_assign_indirect'
+sil [ossa] @assign_by_wrapper_assign_indirect : $@convention(method) (@owned SomeClass, @owned Wrapper<SomeClass>) -> @owned RefStruct {
+bb0(%0 : @owned $SomeClass, %1 : @owned $Wrapper<SomeClass>):
+  %2 = alloc_stack $RefStruct
+  %7 = struct_element_addr %2 : $*RefStruct, #RefStruct._wrapped
+  store %1 to [init] %7 : $*Wrapper<SomeClass>
+  %8 = function_ref @init_closure_indirect : $@convention(thin) (@owned SomeClass) -> @out Wrapper<SomeClass>
+  %9 = partial_apply [callee_guaranteed] %8() : $@convention(thin) (@owned SomeClass) -> @out Wrapper<SomeClass>
+  %10 = function_ref @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  %11 = partial_apply [callee_guaranteed] %10(%2) : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  assign_by_wrapper %0 : $SomeClass to [assign] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @out Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %9 : $@callee_guaranteed (@owned SomeClass) -> @out Wrapper<SomeClass>
+  %16 = load [take] %2 : $*RefStruct
+  dealloc_stack %2 : $*RefStruct
+  return %16 : $RefStruct
+}
+
+// CHECK-LABEL: sil [ossa] @assign_by_wrapper_assign_wrapped_value
+// CHECK:   [[A:%[0-9]+]] = alloc_stack $RefStruct
+// CHECK:   [[E:%[0-9]+]] = struct_element_addr
+// CHECK-NOT: partial_apply
+// CHECK:   [[C:%[0-9]+]] = function_ref @set_closure
+// CHECK:   [[P:%[0-9]+]] = partial_apply [callee_guaranteed] [[C]]([[A]])
+// CHECK:   apply [[P]](%0)
+// CHECK: } // end sil function 'assign_by_wrapper_assign_wrapped_value'
+sil [ossa] @assign_by_wrapper_assign_wrapped_value : $@convention(method) (@owned SomeClass, @owned RefStruct) -> @owned RefStruct {
+bb0(%0 : @owned $SomeClass, %1 : @owned $RefStruct):
+  %2 = alloc_stack $RefStruct
+  store %1 to [init] %2 : $*RefStruct
+  %7 = struct_element_addr %2 : $*RefStruct, #RefStruct._wrapped
+  %8 = function_ref @init_closure : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %9 = partial_apply [callee_guaranteed] %8() : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %10 = function_ref @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  %11 = partial_apply [callee_guaranteed] %10(%2) : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
+  assign_by_wrapper %0 : $SomeClass to [assign_wrapped_value] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  destroy_value %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>
+  %16 = load [take] %2 : $*RefStruct
+  dealloc_stack %2 : $*RefStruct
+  return %16 : $RefStruct
+}
+


### PR DESCRIPTION
* Refactoring: replace "Destination" and the ownership qualifier by a single "Mode".  This represents much better the mode how the instruction is to be lowered. NFC
* Make assign_by_wrapper printable and parseable.
* Fix lowering of the assign modes for indirect results of the init-closure: The indirect result was initialized and not assigned to. The fix is to insert a destroy_addr before calling the init closure. This fixes a memory lifetime error and/or a memory leak. Found by inspection.
* Fix an iterator-invalidation crash in RawSILInstLowering
* Add tests for lowering assign_by_wrapper (a follow-up of https://github.com/apple/swift/pull/36211)
