### PR TITLE
Remove Unused Experimental Cross-Module Flag

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -574,12 +574,6 @@ def experimental_cxx_stdlib :
   Separate<["-"], "experimental-cxx-stdlib">,
   HelpText<"C++ standard library to use; forwarded to Clang's -stdlib flag">;
 
-def enable_experimental_cross_module_incremental_build :
-  Flag<["-"], "enable-experimental-cross-module-incremental-build">,
-  Flags<[FrontendOption]>,
-  HelpText<"(experimental) Enable cross-module incremental build metadata and "
-           "driver scheduling">;
-
 
 // Diagnostic control options
 def suppress_warnings : Flag<["-"], "suppress-warnings">,


### PR DESCRIPTION
Now that we're using -{enable,disable}-incremental-imports, drop the
experimental flag.