### PR TITLE
tests: cleanup for two ownership verifier tests.

### DIFF
--- a/test/SIL/ownership-verifier/interior_pointer.sil
+++ b/test/SIL/ownership-verifier/interior_pointer.sil
@@ -123,23 +123,6 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'recursive_interior_pointer_error'
-// CHECK-NEXT: Found outside of lifetime use?!
-// CHECK-NEXT: Value:   %2 = begin_borrow %0 : $KlassUser
-// CHECK-NEXT: Consuming User:   end_borrow %2 : $KlassUser
-// CHECK-NEXT: Non Consuming User:   %6 = load [copy] %3 : $*Klass
-// CHECK-NEXT: Block: bb0
-// CHECK: Error#: 0. End Error in Function: 'recursive_interior_pointer_error'
-sil [ossa] @recursive_interior_pointer_error : $@convention(thin) (@owned KlassUser, @guaranteed Klass) -> @owned Klass {
-bb0(%0 : @owned $KlassUser, %0a : @guaranteed $Klass):
-  %1 = begin_borrow %0 : $KlassUser
-  %2 = ref_tail_addr %1 : $KlassUser, $Klass
-  end_borrow %1 : $KlassUser
-  destroy_value %0 : $KlassUser
-  %3 = load [copy] %2 : $*Klass
-  return %3 : $Klass
-}
-
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'open_existential_box_interior_pointer_error'
 // CHECK-NEXT: Found outside of lifetime use?!
 // CHECK-NEXT: Value:   %1 = begin_borrow %0 : $Error                   // users: %3, %2

--- a/test/SIL/ownership-verifier/load_borrow_invalidation_partial_apply.sil
+++ b/test/SIL/ownership-verifier/load_borrow_invalidation_partial_apply.sil
@@ -51,6 +51,9 @@ bb0(%0 :  @owned $WrapperStruct):
   return %res : $()
 }
 
+// Note: The MemoryLifetimeVerifier will also report an error for this function. Therefore
+//       we run sil-opt with -dont-abort-on-memory-lifetime-error.
+
 // CHECK-LABEL: Begin Error in function caller2
 // CHECK: SIL verification failed: Found load borrow that is invalidated by a local write?!: loadBorrowImmutabilityAnalysis.isImmutable(LBI)
 // CHECK-LABEL: End Error in function caller2


### PR DESCRIPTION
This is a follow-up of https://github.com/apple/swift/pull/36211
