### PR TITLE
Enable lifetime extension for local variables and function arguments …

### DIFF
--- a/test/DebugInfo/async-direct-arg.swift
+++ b/test/DebugInfo/async-direct-arg.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - \
 // RUN:    -module-name a -enable-experimental-concurrency \
-// RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK \
-// RUN:    --check-prefix=CHECK-%target-cpu
+// RUN:    -parse-as-library | %FileCheck %s --check-prefix=CHECK
 // REQUIRES: concurrency
 
 // UNSUPPORTED: CPU=arm64e
@@ -10,6 +9,8 @@
 // argument.
 
 // CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.0"
+// CHECK: call void @llvm.dbg.declare
+// CHECK: call void @llvm.dbg.declare
 // CHECK: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[X0:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.1"
 // FIXME: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[X1:[0-9]+]], {{.*}}!DIExpression(DW_OP

--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - \
+// RUN:    -module-name a -enable-experimental-concurrency \
+// RUN:    | %FileCheck %s --check-prefix=CHECK
+// REQUIRES: concurrency
+
+// UNSUPPORTED: CPU=arm64e
+
+// Test that lifetime extension preserves a dbg.declare for "n" in the resume
+// funclet.
+
+// CHECK-LABEL: define {{.*}} void @"$s1a4fiboyS2iYF.resume.0"
+// CHECK-NEXT: entryresume.0:
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[LHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[RHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NOT: {{ ret }}
+// CHECK: call void asm sideeffect ""
+// CHECK: ![[R]] = !DILocalVariable(name: "retval"
+// CHECK: ![[LHS]] = !DILocalVariable(name: "lhs"
+// CHECK: ![[RHS]] = !DILocalVariable(name: "rhs"
+// CHECK: ![[N]] = !DILocalVariable(name: "n"
+public func fibo(_ n: Int) async -> Int {
+  var retval = n
+  if retval < 2 { return 1 }
+  retval = retval - 1
+  let lhs = await fibo(retval - 1)
+  let rhs = await fibo(retval - 2)
+  return lhs + rhs + retval
+}


### PR DESCRIPTION
…in async

functions at -Onone to force them to get promoted into the async context.

This patch includes a partial revert of a83bfabc8bdbd0dbf527649145c8cd0c954987c1.
