### PR TITLE
Enforce safe access to unsafe global actor declarations only from "new" code

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -56,6 +56,10 @@ public:
     /// The declaration is isolated to a global actor. It can refer to other
     /// entities with the same global actor.
     GlobalActor,
+    /// The declaration is isolated to a global actor but with the "unsafe"
+    /// annotation, which means that we only enforce the isolation if we're
+    /// coming from something with specific isolation.
+    GlobalActorUnsafe,
   };
 
 private:
@@ -93,8 +97,9 @@ public:
     return ActorIsolation(ActorInstance, actor);
   }
 
-  static ActorIsolation forGlobalActor(Type globalActor) {
-    return ActorIsolation(GlobalActor, globalActor);
+  static ActorIsolation forGlobalActor(Type globalActor, bool unsafe) {
+    return ActorIsolation(
+        unsafe ? GlobalActorUnsafe : GlobalActor, globalActor);
   }
 
   Kind getKind() const { return kind; }
@@ -108,8 +113,12 @@ public:
     return actor;
   }
 
+  bool isGlobalActor() const {
+    return getKind() == GlobalActor || getKind() == GlobalActorUnsafe;
+  }
+
   Type getGlobalActor() const {
-    assert(getKind() == GlobalActor);
+    assert(isGlobalActor());
     return globalActor;
   }
 
@@ -135,6 +144,7 @@ public:
       return lhs.actor == rhs.actor;
 
     case GlobalActor:
+    case GlobalActorUnsafe:
       return areTypesEqual(lhs.globalActor, rhs.globalActor);
     }
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8085,7 +8085,8 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
       return ActorIsolation::forIndependent(ActorIndependentKind::Safe);
 
     case ClosureActorIsolation::GlobalActor: {
-      return ActorIsolation::forGlobalActor(isolation.getGlobalActor());
+      return ActorIsolation::forGlobalActor(
+          isolation.getGlobalActor(), /*unsafe=*/false);
     }
 
     case ClosureActorIsolation::ActorInstance: {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -690,6 +690,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
       break;
 
     case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
       Out << "global actor " << FormatOpts.OpeningQuotationMark
         << isolation.getGlobalActor().getString()
         << FormatOpts.ClosingQuotationMark << "-isolated";

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1519,6 +1519,7 @@ bool ActorIsolation::requiresSubstitution() const {
     return false;
 
   case GlobalActor:
+  case GlobalActorUnsafe:
     return getGlobalActor()->hasTypeParameter();
   }
   llvm_unreachable("unhandled actor isolation kind!");
@@ -1533,7 +1534,9 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
     return *this;
 
   case GlobalActor:
-    return forGlobalActor(getGlobalActor().subst(subs));
+  case GlobalActorUnsafe:
+    return forGlobalActor(
+        getGlobalActor().subst(subs), kind == GlobalActorUnsafe);
   }
   llvm_unreachable("unhandled actor isolation kind!");
 }
@@ -1558,8 +1561,12 @@ void swift::simple_display(
       break;
 
     case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
       out << "actor-isolated to global actor "
           << state.getGlobalActor().getString();
+
+      if (state == ActorIsolation::GlobalActorUnsafe)
+        out << "(unsafe)";
       break;
   }
 }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4303,6 +4303,7 @@ Optional<SILValue> SILGenFunction::emitLoadActorExecutorForCallee(
       }
 
       case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
         return emitLoadGlobalActorExecutor(actorIso.getGlobalActor());
     }
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -472,6 +472,7 @@ void SILGenFunction::emitProlog(CaptureInfo captureInfo,
       case ActorIsolation::Unspecified:
       case ActorIsolation::Independent:
       case ActorIsolation::IndependentUnsafe:
+      case ActorIsolation::GlobalActorUnsafe:
         break;
 
       case ActorIsolation::ActorInstance: {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1297,7 +1297,6 @@ namespace {
         case ActorIsolationRestriction::Unrestricted:
         case ActorIsolationRestriction::Unsafe:
           break;
-        case ActorIsolationRestriction::CrossGlobalActor:
         case ActorIsolationRestriction::GlobalActor: {
           ctx.Diags.diagnose(argLoc, diag::actor_isolated_inout_state,
                              decl->getDescriptiveKind(), decl->getName(),
@@ -1683,11 +1682,9 @@ namespace {
       case ActorIsolationRestriction::ActorSelf:
         llvm_unreachable("non-member reference into an actor");
 
-      case ActorIsolationRestriction::CrossGlobalActor:
       case ActorIsolationRestriction::GlobalActor:
         return checkGlobalActorReference(
-            valueRef, loc, isolation.getGlobalActor(),
-            isolation == ActorIsolationRestriction::CrossGlobalActor);
+            valueRef, loc, isolation.getGlobalActor(), isolation.isCrossActor);
 
       case ActorIsolationRestriction::Unsafe:
         return diagnoseReferenceToUnsafeGlobal(value, loc);
@@ -1855,11 +1852,10 @@ namespace {
         llvm_unreachable("Unhandled actor isolation");
       }
 
-      case ActorIsolationRestriction::CrossGlobalActor:
       case ActorIsolationRestriction::GlobalActor:
         return checkGlobalActorReference(
             memberRef, memberLoc, isolation.getGlobalActor(),
-            isolation == ActorIsolationRestriction::CrossGlobalActor);
+            isolation.isCrossActor);
 
       case ActorIsolationRestriction::Unsafe:
         // This case is hit when passing actor state inout to functions in some

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -90,6 +90,12 @@ public:
     /// permitted from other declarations with that same global actor or
     /// are permitted from elsewhere as a cross-actor reference.
     GlobalActor,
+
+    /// References to a declaration that is part of a global actor are
+    /// permitted from other declarations with that same global actor or
+    /// are permitted from elsewhere as a cross-actor reference, but
+    /// contexts with unspecified isolation won't diagnose anything.
+    GlobalActorUnsafe,
   };
 
 private:
@@ -125,7 +131,7 @@ public:
 
   /// Retrieve the actor class that the declaration is within.
   Type getGlobalActor() const {
-    assert(kind == GlobalActor);
+    assert(kind == GlobalActor || kind == GlobalActorUnsafe);
     return Type(data.globalActor);
   }
 
@@ -152,8 +158,9 @@ public:
   /// Accesses to the given declaration can only be made via this particular
   /// global actor or is a cross-actor access.
   static ActorIsolationRestriction forGlobalActor(
-      Type globalActor, bool isCrossActor) {
-    ActorIsolationRestriction result(GlobalActor, isCrossActor);
+      Type globalActor, bool isCrossActor, bool isUnsafe) {
+    ActorIsolationRestriction result(
+        isUnsafe ? GlobalActorUnsafe : GlobalActor, isCrossActor);
     result.data.globalActor = globalActor.getPointer();
     return result;
   }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -74,22 +74,24 @@ public:
     /// There is no restriction on references to the given declaration.
     Unrestricted,
 
-    /// Access to the declaration is unsafe in a concurrent context.
+    /// Access to the declaration is unsafe in any concurrent context.
     Unsafe,
 
     /// References to this entity are allowed from anywhere, but doing so
-    /// may cross an actor boundary if it is not on \c self.
+    /// may cross an actor boundary if it is not from within the same actor's
+    /// isolation domain.
     CrossActorSelf,
 
-    /// References to this member of an actor are only permitted on 'self'.
+    /// References to this member of an actor are only permitted from within
+    /// the actor's isolation domain.
     ActorSelf,
 
     /// References to a declaration that is part of a global actor are only
     /// permitted from other declarations with that same global actor.
     GlobalActor,
 
-    /// Referneces to this entity are allowed from anywhere, but doing so may
-    /// cross an actor bounder if it is not from the same global actor.
+    /// References to this entity are allowed from anywhere, but doing so may
+    /// cross an actor boundary if it is not from the same global actor.
     CrossGlobalActor,
   };
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -408,7 +408,6 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
     }
     return true;
 
-  case ActorIsolationRestriction::CrossGlobalActor:
   case ActorIsolationRestriction::GlobalActor:
     // FIXME: Consider whether to limit @objc on global-actor-qualified
     // declarations.

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -408,6 +408,7 @@ static bool checkObjCActorIsolation(const ValueDecl *VD,
     }
     return true;
 
+  case ActorIsolationRestriction::GlobalActorUnsafe:
   case ActorIsolationRestriction::GlobalActor:
     // FIXME: Consider whether to limit @objc on global-actor-qualified
     // declarations.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2762,13 +2762,10 @@ bool ConformanceChecker::checkActorIsolation(
     return diagnoseNonConcurrentTypesInReference(
         witness, DC, witness->getLoc(), ConcurrentReferenceKind::CrossActor);
 
-  case ActorIsolationRestriction::CrossGlobalActor:
-    isCrossActor = true;
-    LLVM_FALLTHROUGH;
-
   case ActorIsolationRestriction::GlobalActor: {
     // Hang on to the global actor that's used for the witness. It will need
     // to match that of the requirement.
+    isCrossActor = witnessRestriction.isCrossActor;
     witnessGlobalActor = witness->getDeclContext()->mapTypeIntoContext(
         witnessRestriction.getGlobalActor());
     break;

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -239,7 +239,7 @@ func barSync() {
 // Unsafe global actors
 // ----------------------------------------------------------------------
 protocol UGA {
-  @SomeGlobalActor(unsafe) func req()
+  @SomeGlobalActor(unsafe) func req() // expected-note{{calls to instance method 'req()' from outside of its actor context are implicitly asynchronous}}
 }
 
 struct StructUGA1: UGA {
@@ -252,7 +252,7 @@ struct StructUGA2: UGA {
 
 @GenericGlobalActor<String>
 func testUGA<T: UGA>(_ value: T) {
-  value.req()
+  value.req() // expected-error{{instance method 'req()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'GenericGlobalActor<String>'}}
 }
 
 class UGAClass {


### PR DESCRIPTION
Allow references to unsafe global actor-isolated declarations only from
existing code that has not adopted concurrency features (such as
async, @Concurrent closures, etc.). This allows declarations that
should be isolated to a global actor to be annotated as such without
breaking existing code (as if isolation was unspecified), while code
that does adopt concurrency will treat the declaration as being part
of that global actor.

rdar://74241687