### PR TITLE
[Diagnostics] Prioritize type mismatches over labeling failures for c…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9221,13 +9221,6 @@ bool ConstraintSystem::simplifyAppliedOverloadsImpl(
       for (auto *choice : choices.slice(1))
         choice->setDisabled();
     }
-
-    // Don't attempt further optimization in "diagnostic mode" because
-    // in such mode we'd like to attempt all of the available overloads
-    // regardless of problems related to missing or extraneous labels
-    // and/or arguments.
-    if (solverState)
-      return false;
   }
 
   /// The common result type amongst all function overloads.

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -648,7 +648,7 @@ let arr = [BottleLayout]()
 let layout = BottleLayout(count:1)
 let ix = arr.firstIndex(of:layout) // expected-error {{referencing instance method 'firstIndex(of:)' on 'Collection' requires that 'BottleLayout' conform to 'Equatable'}}
 
-let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{missing argument label 'ascii:' in call}}
+let _: () -> UInt8 = { .init("a" as Unicode.Scalar) } // expected-error {{initializer 'init(_:)' requires that 'Unicode.Scalar' conform to 'BinaryInteger'}}
 
 // https://bugs.swift.org/browse/SR-9068
 func compare<C: Collection, Key: Hashable, Value: Equatable>(c: C)

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -249,7 +249,7 @@ func erroneousSR11350(x: Int) {
       if b {
         acceptInt(0) { }
       }
-    }).domap(0) // expected-error{{value of type '()?' has no member 'domap'}}
+    }).domap(0) // expected-error{{value of type 'Optional<()>' has no member 'domap'}}
   }
 }
 

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -113,7 +113,7 @@ func unsafeRawBufferPointerConversions(
   _ = UnsafeRawBufferPointer(start: rp, count: 1)
   _ = UnsafeMutableRawBufferPointer(mrbp)
   _ = UnsafeRawBufferPointer(mrbp)
-  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{missing argument label 'mutating:' in call}}
+  _ = UnsafeMutableRawBufferPointer(rbp) // expected-error {{cannot convert value of type 'UnsafeRawBufferPointer' to expected argument type 'UnsafeMutableRawBufferPointer'}}
   _ = UnsafeRawBufferPointer(rbp)
   _ = UnsafeMutableRawBufferPointer(mbpi)
   _ = UnsafeRawBufferPointer(mbpi)

--- a/validation-test/Sema/SwiftUI/rdar72771072.swift
+++ b/validation-test/Sema/SwiftUI/rdar72771072.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+enum E {
+  case a, b, c
+}
+
+struct S : View {
+  let values: [E] = [.a, .b, .c]
+
+  var body: some View {
+    ScrollView(.vertical) {
+      Group {
+        Group {
+          ForEach(values, id: \.self) { color in
+            Button(action: { labeled(true) }) { // expected-error {{missing argument label 'value:' in call}} {{38-38=value: }}
+              Text("").bold()
+            }.buttonStyle(BorderlessButtonStyle())
+          }
+
+          ForEach([1, 2, 3, 4, 5, 6, 7, 8, 9], id: \.self) { _ in
+            Button(action: { labeled(value: true) }) {
+              Text("").bold()
+            }.buttonStyle(BorderlessButtonStyle())
+          }
+        }
+        .frame(width: 100, height: 100)
+        .padding(.top, 1)
+      }
+    }
+    .frame(width: 100)
+  }
+
+  func labeled(value: Bool) {}
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar45470505.swift
@@ -4,7 +4,6 @@ extension BinaryInteger {
   init(bytes: [UInt8]) { fatalError() }
 
   init<S: Sequence>(bytes: S) where S.Iterator.Element == UInt8 {
-    // expected-note@-1 {{incorrect labels for candidate (have: '(_:)', expected: '(bytes:)')}}
     self.init(bytes // expected-error {{no exact matches in call to initializer}}
     // expected-note@-1 {{}}
 


### PR DESCRIPTION
…alls

Since labels are considered part of the name, mismatches in labeling
should be invalidate overload choices. Let's prefer an overload with
correct labels but incorrect types over the one with incorrect labels.

This also means that it's possible to restore performance optimizations
related to early filtering in diagnostic mode, which is important for
deeply nested code i.e. SwiftUI views.

Resolves: rdar://72771072

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
