### PR TITLE
XFAIL TSAN Tests on AS Hosts

### DIFF
--- a/test/Sanitizers/tsan-emptyarraystorage.swift
+++ b/test/Sanitizers/tsan-emptyarraystorage.swift
@@ -6,6 +6,9 @@
 // REQUIRES: foundation
 // UNSUPPORTED: OS=tvos
 
+// rdar://problem/75006869
+// XFAIL: OS=macosx && CPU=arm64
+
 import Foundation
 
 let sem = DispatchSemaphore(value: 0)

--- a/test/Sanitizers/tsan-libdispatch.swift
+++ b/test/Sanitizers/tsan-libdispatch.swift
@@ -9,6 +9,9 @@
 // don't support TSan.
 // UNSUPPORTED: remote_run
 
+// rdar://problem/75006869
+// XFAIL: OS=macosx && CPU=arm64
+
 // Test ThreadSanitizer execution end-to-end with libdispatch.
 
 import Dispatch

--- a/test/Sanitizers/tsan-norace-block-release.swift
+++ b/test/Sanitizers/tsan-norace-block-release.swift
@@ -8,6 +8,9 @@
 // don't support TSan.
 // UNSUPPORTED: remote_run
 
+// rdar://problem/75006869
+// UNSUPPORTED: OS=macosx && CPU=arm64
+
 // Test that we do not report a race on block release operation.
 import Dispatch
 #if canImport(Darwin)

--- a/test/Sanitizers/tsan-norace-deinit-run-time.swift
+++ b/test/Sanitizers/tsan-norace-deinit-run-time.swift
@@ -8,6 +8,9 @@
 // don't support TSan.
 // UNSUPPORTED: remote_run
 
+// rdar://problem/75006869
+// XFAIL: OS=macosx && CPU=arm64
+
 // Test that we do not report a race on deinit; the synchronization is guaranteed by runtime.
 import Dispatch
 #if canImport(Darwin)

--- a/test/Sanitizers/tsan-static-exclusivity.swift
+++ b/test/Sanitizers/tsan-static-exclusivity.swift
@@ -5,7 +5,6 @@
 // don't support TSan.
 // UNSUPPORTED: remote_run
 
-
 struct OtherStruct {
   mutating
   func mutableTakingClosure(_ c: () -> Void) { }

--- a/test/Sanitizers/tsan.swift
+++ b/test/Sanitizers/tsan.swift
@@ -6,6 +6,9 @@
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: CPU=powerpc64le
 
+// rdar://problem/75006869
+// XFAIL: OS=macosx && CPU=arm64
+
 // FIXME: This should be covered by "tsan_runtime"; older versions of Apple OSs
 // don't support TSan.
 // UNSUPPORTED: remote_run


### PR DESCRIPTION
TSAN currently assumes an iOS-style address space for arm64 hosts. Apple
Silicon Macs use a much larger x86-style address space despite being
arm64 devices, so TSAN panics.

XFAIL these tests until https://reviews.llvm.org/D86377 goes through

rdar://problem/75006869