### PR TITLE
[AST] Only use serialized locs for 'getRawComment()' in symbol graph

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -872,7 +872,7 @@ public:
   }
 
   /// \returns the unparsed comment attached to this declaration.
-  RawComment getRawComment(bool SerializedOK = true) const;
+  RawComment getRawComment(bool SerializedOK = false) const;
 
   Optional<StringRef> getGroupName() const;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -600,6 +600,9 @@ const Decl::CachedExternalSourceLocs *Decl::getSerializedLocs() const {
     return CachedSerializedLocs;
   }
   auto *File = cast<FileUnit>(getDeclContext()->getModuleScopeContext());
+  assert(File->getKind() == FileUnitKind::SerializedAST &&
+         "getSerializedLocs() should only be called on decls in "
+         "a 'SerializedASTFile'");
   auto Locs = File->getBasicLocsForDecl(this);
   if (!Locs.hasValue()) {
     static const Decl::CachedExternalSourceLocs NullLocs{};

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -440,7 +440,7 @@ const ValueDecl *findRequirementDeclWithDocComment(const ValueDecl *VD,
   std::queue<const ValueDecl *> requirements;
   while (true) {
     for (auto *req : VD->getSatisfiedProtocolRequirements()) {
-      if (!req->getRawComment().isEmpty())
+      if (!req->getRawComment(AllowSerialized).isEmpty())
         return req;
       else
         requirements.push(req);


### PR DESCRIPTION
* Don't use serialized source locations in `getRawComment()` by default
* Only call `getSerialiedLocs()` for decls in `SerializedASTFile` (Calling it for `SourceFile` decls is useless)
* Propagate `AllowSerialized` parameter in `findRequirementDeclWithDocComment()` (I just noticed this when investigating the issue)

rdar://problem/75010520