### PR TITLE
[Driver][Index] Add driver support to specify an overriding output path to record in the index data

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -79,6 +79,7 @@ TYPE("json-features",       JSONFeatures,              "features.json",   "")
 
 
 TYPE("index-data",          IndexData,                 "",                "")
+TYPE("index-unit-output-path", IndexUnitOutputPath,    "",                "")
 TYPE("yaml-opt-record",     YAMLOptRecord,             "opt.yaml",        "")
 TYPE("bitstream-opt-record",BitstreamOptRecord,        "opt.bitstream",   "")
 

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -157,7 +157,8 @@ public:
 
   /// Associate a new \p PrimaryOutputFile (of type \c getPrimaryOutputType())
   /// with the provided \p Input pair of Base and Primary inputs.
-  void addPrimaryOutput(CommandInputPair Input, StringRef PrimaryOutputFile);
+  void addPrimaryOutput(CommandInputPair Input, StringRef PrimaryOutputFile,
+                        StringRef IndexUnitOutputPath);
 
   /// Return true iff the set of additional output types in \c this is
   /// identical to the set of additional output types in \p other.
@@ -183,6 +184,13 @@ public:
   /// contexts with absent primary outputs another way -- but this is currently
   /// assumed at several call sites.
   SmallVector<StringRef, 16> getPrimaryOutputFilenames() const;
+
+
+  /// Returns the output file path to record in the index data for each input.
+  /// The return value will contain one \c StringRef per primary input if any
+  /// input had an output filename for the index data that was different to its
+  /// primary output filename, and be empty otherwise.
+  SmallVector<StringRef, 16> getIndexUnitOutputFilenames() const;
 
   /// Assuming (and asserting) that there are one or more input pairs, associate
   /// an additional output named \p OutputFilename of type \p type with the

--- a/include/swift/Driver/Util.h
+++ b/include/swift/Driver/Util.h
@@ -49,6 +49,7 @@ namespace driver {
       SourceInputActions,
       InputJobsAndSourceInputActions,
       Output,
+      IndexUnitOutputPaths,
       /// Batch mode frontend invocations may have so many supplementary
       /// outputs that they don't comfortably fit as command-line arguments.
       /// In that case, add a FilelistInfo to record the path to the file.

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -105,6 +105,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_Remapping:
   case file_types::TY_IndexData:
   case file_types::TY_BitstreamOptRecord:
+  case file_types::TY_IndexUnitOutputPath:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -155,6 +156,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_PrivateSwiftModuleInterfaceFile:
   case file_types::TY_JSONDependencies:
   case file_types::TY_JSONFeatures:
+  case file_types::TY_IndexUnitOutputPath:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -205,6 +207,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
   case file_types::TY_JSONFeatures:
+  case file_types::TY_IndexUnitOutputPath:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1699,6 +1699,12 @@ static void writeOutputToFilelist(llvm::raw_fd_ostream &out, const Job *job,
   for (auto &output : outputInfo.getPrimaryOutputFilenames())
     out << output << "\n";
 }
+static void writeIndexUnitOutputPathsToFilelist(llvm::raw_fd_ostream &out,
+                                                const Job *job) {
+  const CommandOutput &outputInfo = job->getOutput();
+  for (auto &output : outputInfo.getIndexUnitOutputFilenames())
+    out << output << "\n";
+}
 static void writeSupplementarOutputToFilelist(llvm::raw_fd_ostream &out,
                                               const Job *job) {
   job->getOutput().writeOutputFileMap(out);
@@ -1732,13 +1738,15 @@ static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,
       writeInputJobsToFilelist(out, job, filelistInfo.type);
       writeSourceInputActionsToFilelist(out, job, args);
       break;
-    case FilelistInfo::WhichFiles::Output: {
+    case FilelistInfo::WhichFiles::Output:
       writeOutputToFilelist(out, job, filelistInfo.type);
       break;
-      }
-      case FilelistInfo::WhichFiles::SupplementaryOutput:
-        writeSupplementarOutputToFilelist(out, job);
-        break;
+    case FilelistInfo::WhichFiles::IndexUnitOutputPaths:
+      writeIndexUnitOutputPathsToFilelist(out, job);
+      break;
+    case FilelistInfo::WhichFiles::SupplementaryOutput:
+      writeSupplementarOutputToFilelist(out, job);
+      break;
     }
   }
   return ok;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -498,15 +498,30 @@ ToolChain::constructInvocation(const CompileJobAction &job,
 
   // Add the output file argument if necessary.
   if (context.Output.getPrimaryOutputType() != file_types::TY_Nothing) {
+    auto IndexUnitOutputs = context.Output.getIndexUnitOutputFilenames();
+
     if (context.shouldUseMainOutputFileListInFrontendInvocation()) {
       Arguments.push_back("-output-filelist");
       Arguments.push_back(context.getTemporaryFilePath("outputs", ""));
       II.FilelistInfos.push_back({Arguments.back(),
                                   context.Output.getPrimaryOutputType(),
                                   FilelistInfo::WhichFiles::Output});
+      if (!IndexUnitOutputs.empty()) {
+        Arguments.push_back("-index-unit-output-path-filelist");
+        Arguments.push_back(context.getTemporaryFilePath("index-unit-outputs",
+                                                         ""));
+        II.FilelistInfos.push_back({
+          Arguments.back(), file_types::TY_IndexUnitOutputPath,
+          FilelistInfo::WhichFiles::IndexUnitOutputPaths});
+      }
     } else {
       for (auto FileName : context.Output.getPrimaryOutputFilenames()) {
         Arguments.push_back("-o");
+        Arguments.push_back(context.Args.MakeArgString(FileName));
+      }
+
+      for (auto FileName : IndexUnitOutputs) {
+        Arguments.push_back("-index-unit-output-path");
         Arguments.push_back(context.Args.MakeArgString(FileName));
       }
     }
@@ -639,6 +654,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_SwiftSourceInfoFile:
   case file_types::TY_SwiftCrossImportDir:
   case file_types::TY_SwiftOverlayFile:
+  case file_types::TY_IndexUnitOutputPath:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -896,6 +912,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_SwiftSourceInfoFile:
     case file_types::TY_SwiftCrossImportDir:
     case file_types::TY_SwiftOverlayFile:
+    case file_types::TY_IndexUnitOutputPath:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -5,6 +5,9 @@
     },
     {
       "name": "experimental-allow-module-with-compiler-errors"
+    },
+    {
+      "name": "index-unit-output-path"
     }
   ]
 }

--- a/test/Index/Store/unit-custom-output-path-driver.swift
+++ b/test/Index/Store/unit-custom-output-path-driver.swift
@@ -1,0 +1,218 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %/t/main.swift
+// RUN: touch %/t/second.swift
+
+// 1. Incremental mode (single primary file)
+//
+// A) Run without an "index-unit-output-path" entry:
+//    RUN: echo '{                                 ' > %/t/outputmap.json
+//    RUN: echo '   "%/t/main.swift":{             ' >> %/t/outputmap.json
+//    RUN: echo '      "object": "%/t/main_out.o"  ' >> %/t/outputmap.json
+//    RUN: echo '   },                             ' >> %/t/outputmap.json
+//    RUN: echo '   "%/t/second.swift":{           ' >> %/t/outputmap.json
+//    RUN: echo '      "object": "%/t/second_out.o"' >> %/t/outputmap.json
+//    RUN: echo '   }                              ' >> %/t/outputmap.json
+//    RUN: echo '}                                 ' >> %/t/outputmap.json
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -disable-batch-mode -output-file-map %/t/outputmap.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_without \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Check the unit output is based on the "object" field
+//    RUN: c-index-test core -print-unit %/t/idx_without | %FileCheck -check-prefixes=INDEX_WITHOUT %s
+//
+//    INDEX_WITHOUT:      main_out.o-{{.*}}
+//    INDEX_WITHOUT-NEXT: --------
+//    INDEX_WITHOUT:      out-file: {{.*}}main_out.o
+//
+//    INDEX_WITHOUT:      second_out.o-{{.*}}
+//    INDEX_WITHOUT-NEXT: --------
+//    INDEX_WITHOUT:      out-file: {{.*}}second_out.o
+//
+// B) Run with an "index-unit-output-path" entry different from the "output" entry:
+//    RUN: echo '{                                                     ' > %/t/outputmap-custom.json
+//    RUN: echo '   "%/t/main.swift":{                                 ' >> %/t/outputmap-custom.json
+//    RUN: echo '      "object": "%/t/main_out.o",                     ' >> %/t/outputmap-custom.json
+//    RUN: echo '      "index-unit-output-path": "%/t/main_custom.o"   ' >> %/t/outputmap-custom.json
+//    RUN: echo '   },                                                 ' >> %/t/outputmap-custom.json
+//    RUN: echo '   "%/t/second.swift":{                               ' >> %/t/outputmap-custom.json
+//    RUN: echo '      "object": "%/t/second_out.o",                   ' >> %/t/outputmap-custom.json
+//    RUN: echo '      "index-unit-output-path": "%/t/second_custom.o" ' >> %/t/outputmap-custom.json
+//    RUN: echo '   }                                                  ' >> %/t/outputmap-custom.json
+//    RUN: echo '}                                                     ' >> %/t/outputmap-custom.json
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -disable-batch-mode -output-file-map %/t/outputmap-custom.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_with \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Run the same command as above again but with different "output" entry
+//    RUN: echo '{                                                     ' > %/t/outputmap-different.json
+//    RUN: echo '   "%/t/main.swift":{                                 ' >> %/t/outputmap-different.json
+//    RUN: echo '      "object": "%/t/main_different.o",               ' >> %/t/outputmap-different.json
+//    RUN: echo '      "index-unit-output-path": "%/t/main_custom.o"   ' >> %/t/outputmap-different.json
+//    RUN: echo '   },                                                 ' >> %/t/outputmap-different.json
+//    RUN: echo '   "%/t/second.swift":{                               ' >> %/t/outputmap-different.json
+//    RUN: echo '      "object": "%/t/second_different.o",             ' >> %/t/outputmap-different.json
+//    RUN: echo '      "index-unit-output-path": "%/t/second_custom.o" ' >> %/t/outputmap-different.json
+//    RUN: echo '   }                                                  ' >> %/t/outputmap-different.json
+//    RUN: echo '}                                                     ' >> %/t/outputmap-different.json
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -disable-batch-mode -output-file-map %/t/outputmap-different.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_with \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Check the unit output is based on -index-unit-output-path:
+//    RUN: c-index-test core -print-unit %/t/idx_with | %FileCheck -check-prefixes=INDEX_WITH %s
+//
+//    Check no units were produced based on the -o values
+//    RUN: c-index-test core -print-unit %/t/idx_with | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
+//
+//    INDEX_WITH:      main_custom.o-{{.*}}
+//    INDEX_WITH-NEXT: --------
+//    INDEX_WITH:      out-file: {{.*}}main_custom.o
+//
+//    INDEX_WITH:      second_custom.o-{{.*}}
+//    INDEX_WITH-NEXT: --------
+//    INDEX_WITH:      out-file: {{.*}}second_custom.o
+//
+//    INDEX_WITH_NEGATIVE-NOT: main_out.o
+//    INDEX_WITH_NEGATIVE-NOT: main_different.o
+//    INDEX_WITH_NEGATIVE-NOT: second_out.o
+//    INDEX_WITH_NEGATIVE-NOT: second_different.o
+//
+//    Run with a diferent -index-unit-output-path
+//    RUN: echo '{                                                     ' > %/t/outputmap-different2.json
+//    RUN: echo '   "%/t/main.swift":{                                 ' >> %/t/outputmap-different2.json
+//    RUN: echo '      "object": "%/t/main_different.o",               ' >> %/t/outputmap-different2.json
+//    RUN: echo '      "index-unit-output-path": "%/t/xmain_custom.o"  ' >> %/t/outputmap-different2.json
+//    RUN: echo '   },                                                 ' >> %/t/outputmap-different2.json
+//    RUN: echo '   "%/t/second.swift":{                               ' >> %/t/outputmap-different2.json
+//    RUN: echo '      "object": "%/t/second_different.o",             ' >> %/t/outputmap-different2.json
+//    RUN: echo '      "index-unit-output-path": "%/t/xsecond_custom.o"' >> %/t/outputmap-different2.json
+//    RUN: echo '   }                                                  ' >> %/t/outputmap-different2.json
+//    RUN: echo '}                                                     ' >> %/t/outputmap-different2.json
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -disable-batch-mode -output-file-map %/t/outputmap-different2.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_with \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Check it resulted in a second unit being added to the store
+//    RUN: c-index-test core -print-unit %/t/idx_with | %FileCheck -check-prefixes=INDEX_WITH,INDEX_WITH_SECOND %s
+//
+//    INDEX_WITH_SECOND: xmain_custom.o-{{.*}}
+//    INDEX_WITH_SECOND: --------
+//    INDEX_WITH_SECOND: out-file: {{.*}}xmain_custom.o
+//
+//    INDEX_WITH_SECOND: xsecond_custom.o-{{.*}}
+//    INDEX_WITH_SECOND: --------
+//    INDEX_WITH_SECOND: out-file: {{.*}}xsecond_custom.o
+//
+// C) Do the above again but with a fresh index store and using file lists.
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -disable-batch-mode -driver-filelist-threshold=0 \
+//    RUN:     -output-file-map %/t/outputmap-custom.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_with_list \
+//    RUN:     %/t/main.swift %/t/second.swift
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -driver-filelist-threshold=0 -output-file-map %/t/outputmap-different.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_with_list \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    RUN: c-index-test core -print-unit %/t/idx_with_list | %FileCheck -check-prefixes=INDEX_WITH %s
+//    RUN: c-index-test core -print-unit %/t/idx_with_list | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
+
+
+// 2. Batch mode (multiple primary files)
+//
+// A) Run without an "index-unit-output-path" entry:
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -enable-batch-mode -driver-batch-count 1 -output-file-map %/t/outputmap.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_batch_without \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Check the unit output is based on the "output" values
+//    RUN: c-index-test core -print-unit %/t/idx_batch_without | %FileCheck -check-prefixes=INDEX_WITHOUT %s
+//
+// B) Run with "index-unit-output-path" values different from the "output" values:
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -enable-batch-mode -driver-batch-count 1 -output-file-map %/t/outputmap-custom.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_batch_with \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Run the same command as above again but with different "output" value
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -enable-batch-mode -driver-batch-count 1 -output-file-map %/t/outputmap-different.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_batch_with \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Check the unit output is based on "index-unit-output-path":
+//    RUN: c-index-test core -print-unit %/t/idx_batch_with | %FileCheck -check-prefixes=INDEX_WITH %s
+//
+//    Check the unit output is not baed on the "output" values:
+//    RUN: c-index-test core -print-unit %/t/idx_batch_with | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
+//
+// C) Do the above again but with a fresh index store and using file lists.
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -driver-filelist-threshold=0 -enable-batch-mode -driver-batch-count 1 \
+//    RUN:     -output-file-map %/t/outputmap-custom.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_batch_with_list \
+//    RUN:     %/t/main.swift %/t/second.swift
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -driver-filelist-threshold=0 -enable-batch-mode -driver-batch-count 1 \
+//    RUN:     -output-file-map %/t/outputmap-different.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_batch_with_list \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    RUN: c-index-test core -print-unit %/t/idx_batch_with_list | %FileCheck -check-prefixes=INDEX_WITH %s
+//    RUN: c-index-test core -print-unit %/t/idx_batch_with_list | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
+
+
+// 3. Multi-threaded WMO
+//
+// A) Run without an "index-unit-output-path" entry:
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -whole-module-optimization -num-threads 2 -output-file-map %/t/outputmap.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_wmo_without \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Check the unit output is based on the "output" entry
+//    RUN: c-index-test core -print-unit %/t/idx_wmo_without | %FileCheck -check-prefixes=INDEX_WITHOUT %s
+//
+// B) Run with an "index-unit-output-path" entry different from the "output" value
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -whole-module-optimization -num-threads 2 -output-file-map %/t/outputmap-custom.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_wmo_with \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Run the same command as above again but with different "output" values
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -whole-module-optimization -num-threads 2 -output-file-map %/t/outputmap-different.json \
+//    RUN:     -module-name mod_name -index-store-path %/t/idx_wmo_with \
+//    RUN:     %/t/main.swift %/t/second.swift
+//
+//    Check the unit output is based on "index-unit-output-path" entry
+//    RUN: c-index-test core -print-unit %/t/idx_wmo_with | %FileCheck -check-prefixes=INDEX_WITH %s
+//    Check no units were produced based on the "output" values:
+//    RUN: c-index-test core -print-unit %/t/idx_wmo_with | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s
+
+
+// 4. Index file
+//
+// A) Run without -index-unit-output-path
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -module-name mod_name -index-store-path %/t/idx_index_without \
+//    RUN:     %/t/main.swift %/t/second.swift -index-file -index-file-path %/t/main.swift \
+//    RUN:     -o %/t/main_out.o
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -module-name mod_name -index-store-path %/t/idx_index_without \
+//    RUN:     %/t/main.swift %/t/second.swift -index-file -index-file-path %/t/second.swift \
+//    RUN:     -o %/t/second_out.o
+//
+//    Check that the unit output is based on -o
+//    RUN: c-index-test core -print-unit %/t/idx_index_without | %FileCheck -check-prefixes=INDEX_WITHOUT %s
+//
+// B) Run with -index-unit-output-path
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -module-name mod_name -index-store-path %/t/idx_index_with \
+//    RUN:     %/t/main.swift %/t/second.swift -index-file -index-file-path %/t/main.swift \
+//    RUN:     -o %/t/main_out.o -index-unit-output-path %/t/main_custom.o
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -module-name mod_name -index-store-path %/t/idx_index_with \
+//    RUN:     %/t/main.swift %/t/second.swift -index-file -index-file-path %/t/second.swift \
+//    RUN:     -o %/t/second_out.o -index-unit-output-path %/t/second_custom.o
+//
+//    Run the same commands as above again but with different -o value
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -module-name mod_name -index-store-path %/t/idx_index_with \
+//    RUN:     %/t/main.swift %/t/second.swift -index-file -index-file-path %/t/main.swift \
+//    RUN:     -o %/t/main_different.o -index-unit-output-path %/t/main_custom.o
+//    RUN: %target-swiftc_driver -Xfrontend -index-ignore-stdlib -module-name mod_name -index-store-path %/t/idx_index_with \
+//    RUN:     %/t/main.swift %/t/second.swift -index-file -index-file-path %/t/second.swift \
+//    RUN:     -o %/t/second_different.o -index-unit-output-path %/t/second_custom.o
+//
+//    Check that the unit output is based on -index-unit-output-path
+//    RUN: c-index-test core -print-unit %/t/idx_index_with | %FileCheck -check-prefixes=INDEX_WITH %s
+//
+//    Check that the unit output is not based on -o
+//    RUN: c-index-test core -print-unit %/t/idx_index_with | %FileCheck -check-prefixes=INDEX_WITH_NEGATIVE %s

--- a/test/Index/Store/unit-custom-output-path.swift
+++ b/test/Index/Store/unit-custom-output-path.swift
@@ -102,7 +102,7 @@
 //
 // B) Run with -index-unit-output-path values different from the -o values:
 //    RUN: %target-swift-frontend -typecheck -parse-stdlib -enable-batch-mode \
-//    RUN:     -module-name mod_name -index-store-path %t/idx_with \
+//    RUN:     -module-name mod_name -index-store-path %t/idx_batch_with \
 //    RUN:     -primary-file %t/main.swift -primary-file %t/second.swift \
 //    RUN:     -o %t/main_out.o -o %t/second_out.o \
 //    RUN:     -index-unit-output-path %t/custom_main.o -index-unit-output-path %t/custom_second.o


### PR DESCRIPTION
The frontend supports this via new options -index-unit-output-path and -index-unit-output-path-filelist that mirror -o and -output-filelist. These are intended to allow sharing index data across builds in separate directories (so different -o values) that are otherwise equivalent as far as the index data is concerned (e.g. an ASAN build and a non-ASAN build) by supplying the same -index-unit-output-path for both.

This change updates the driver to add these new options to the frontend invocation 1) when a new "index-unit-output-path" entry is specified for one or more input files in the -output-file-map json or 2) when -index-file is specified (guaranteeing a single primary input) and a new -index-unit-output-path driver option is passed.

Equivalent change for the new driver here: https://github.com/apple/swift-driver/pull/516

Resolves rdar://problem/74816412