### PR TITLE
[libSyntax] Store Range of ParsedRawSyntaxNode in dedicated field

### DIFF
--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -85,11 +85,11 @@ ParsedRawSyntaxRecorder::recordRawSyntax(SyntaxKind kind,
       if (subnode.isNull()) {
         subnodes.push_back(nullptr);
       } else if (subnode.isRecorded()) {
-        localRange = subnode.getRecordedRange();
+        localRange = subnode.getRange();
         subnodes.push_back(subnode.takeOpaqueNode());
       } else {
         auto recorded = getRecordedNode(subnode.copyDeferred(), *this);
-        localRange = recorded.getRecordedRange();
+        localRange = recorded.getRange();
         subnodes.push_back(recorded.takeOpaqueNode());
       }
 
@@ -131,7 +131,7 @@ ParsedRawSyntaxNode ParsedRawSyntaxRecorder::makeDeferred(
   for (auto &node : deferredNodes) {
     // Cached range.
     if (!node.isNull() && !node.isMissing()) {
-      auto nodeRange = node.getDeferredRange();
+      auto nodeRange = node.getRange();
       if (nodeRange.isValid()) {
         if (range.isInvalid())
           range = nodeRange;
@@ -185,9 +185,7 @@ void ParsedRawSyntaxRecorder::verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> 
   for (const auto &elem: elements) {
     if (elem.isMissing() || elem.isNull())
       continue;
-    CharSourceRange range = elem.isRecorded()
-      ? elem.getRecordedRange()
-      : elem.getDeferredRange();
+    CharSourceRange range = elem.getRange();
     if (range.isValid()) {
       assert((prevEndLoc.isInvalid() || range.getStart() == prevEndLoc)
              && "Non-contiguous child ranges?");

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -88,7 +88,7 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  auto length = foundNode.getRecordedRange().getByteLength();
+  auto length = foundNode.getRange().getByteLength();
   getStorage().push_back(std::move(foundNode));
   return length;
 }


### PR DESCRIPTION
Essentially all ParsedRawSyntaxNode types have a range associated with them, so let's just store it in a dedicated field with a common getter.

Additionally, this cleans up the recorded storage to just contain an `OpaqueSyntaxNode`. When deferred nodes are being handled by SyntaxParseActions, we can use this OpaqueNode storage to store either recorded or deferred node data, which is left to be interpreted by the `SyntaxParseAction`.

We could also rewrite `TokLoc` and `TokLength` in `DeferredTokenNode` in terms of the new `Range` property for now. But since I’ll move `DeferredTokenNode` down to `SyntaxParseActions` in the next PR which also needs the range information, it’s easier to keep the information duplicated for now.