### PR TITLE
[libSyntax] Create deferred nodes in SyntaxParseActions

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -187,6 +187,9 @@ public:
   getDeferredChild(size_t ChildIndex,
                    const SyntaxParsingContext *SyntaxContext) const;
 
+  size_t
+  getDeferredNumChildren(const SyntaxParsingContext *SyntaxContext) const;
+
   ParsedRawSyntaxNode copyDeferred() const {
     assert(isDeferredLayout() || isDeferredToken() && "node not deferred");
     ParsedRawSyntaxNode copy;
@@ -203,8 +206,10 @@ public:
   /// Dump this piece of syntax recursively for debugging or testing.
   SWIFT_DEBUG_DUMP;
 
-  /// Dump this piece of syntax recursively.
-  void dump(raw_ostream &OS, unsigned Indent = 0) const;
+  /// Dump this piece of syntax recursively. If \p Context is passed, this
+  /// method is also able to traverse its children and dump them.
+  void dump(raw_ostream &OS, const SyntaxParsingContext *Context = nullptr,
+            unsigned Indent = 0) const;
 
   static ParsedRawSyntaxNode null() {
     return ParsedRawSyntaxNode{};

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -106,16 +106,25 @@ public:
   /// null).
   DataKind getDataKind() const { return Data.getKind(); }
 
-  /// Returns the opaque data of this node. This must be interpreted by the
-  /// \c SyntaxParseAction, which likely also needs the node type to know
-  /// what type of node the data represents.
-  OpaqueSyntaxNode getData() const { return Data.getOpaque(); }
+  /// Returns the opaque data of this node, assuming that it is deferred. This
+  /// must be interpreted by the \c SyntaxParseAction, which likely also needs
+  /// the node type (layout or token) to interpret the data.
+  /// The data opaque data returned by this function *must not* be used to
+  /// record the node, only to insepect it.
+  OpaqueSyntaxNode getUnsafeDeferredOpaqueData() const {
+    assert(isDeferredLayout() || isDeferredToken());
+    return Data.getOpaque();
+  }
 
-  RecordedOrDeferredNode getRecordedOrDeferredNode() const { return Data; }
+  RecordedOrDeferredNode takeRecordedOrDeferredNode() {
+    RecordedOrDeferredNode Data = this->Data;
+    reset();
+    return Data;
+  }
 
   /// Return the opaque data of this node and reset it.
   OpaqueSyntaxNode takeData() {
-    OpaqueSyntaxNode Data = this->getData();
+    OpaqueSyntaxNode Data = this->Data.getOpaque();
     reset();
     return Data;
   }

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -163,19 +163,6 @@ public:
   /// Returns the range of this node including leading and trailing trivia.
   CharSourceRange getRange() const { return Range; }
 
-  // Recorded Data ===========================================================//
-
-  OpaqueSyntaxNode getOpaqueNode() const {
-    assert(isRecorded());
-    return Data.getOpaque();
-  }
-  OpaqueSyntaxNode takeOpaqueNode() {
-    assert(isRecorded());
-    auto opaque = Data.getOpaque();
-    reset();
-    return opaque;
-  }
-
   // Deferred Layout Data ====================================================//
 
   /// If this node is a deferred layout node, return the child at index \p

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -43,7 +43,9 @@ class ParsedRawSyntaxRecorder final {
 
   /// Assuming that \p node is a deferred layout or token node, record it and
   /// return the recorded node.
-  ParsedRawSyntaxNode recordDeferredNode(const ParsedRawSyntaxNode &node);
+  /// This consumes the data from \c node, which is unusable after it has been
+  /// recorded. The returned node should be used afterwards instead.
+  ParsedRawSyntaxNode recordDeferredNode(ParsedRawSyntaxNode &node);
 
 public:
   explicit ParsedRawSyntaxRecorder(std::shared_ptr<SyntaxParseActions> spActions)

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -98,6 +98,9 @@ public:
   ParsedRawSyntaxNode getDeferredChild(const ParsedRawSyntaxNode &parent,
                                        size_t ChildIndex) const;
 
+  /// For a deferred layout node \p node, retrieve the number of children.
+  size_t getDeferredNumChildren(const ParsedRawSyntaxNode &node) const;
+
 #ifndef NDEBUG
   static void verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements);
 #endif

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -41,6 +41,10 @@ namespace syntax {
 class ParsedRawSyntaxRecorder final {
   std::shared_ptr<SyntaxParseActions> SPActions;
 
+  /// Assuming that \p node is a deferred layout or token node, record it and
+  /// return the recorded node.
+  ParsedRawSyntaxNode recordDeferredNode(const ParsedRawSyntaxNode &node);
+
 public:
   explicit ParsedRawSyntaxRecorder(std::shared_ptr<SyntaxParseActions> spActions)
     : SPActions(std::move(spActions)) {}
@@ -69,6 +73,10 @@ public:
                                                      SourceLoc loc);
 
   /// Form a deferred syntax layout node.
+  /// All nodes in \p deferred nodes must be deferred. Otherwise, we'd have a
+  /// deferred layout node with recorded child nodes. Should we decide to
+  /// discard the deferred layout node, we would also need to discard its
+  /// recorded children, which cannot be done.
   ParsedRawSyntaxNode
   makeDeferred(syntax::SyntaxKind k,
                MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
@@ -85,9 +93,14 @@ public:
   ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,
                                  syntax::SyntaxKind kind);
 
-  #ifndef NDEBUG
+  /// For a deferred layout node \p parent, retrieve the deferred child node
+  /// at \p ChildIndex.
+  ParsedRawSyntaxNode getDeferredChild(const ParsedRawSyntaxNode &parent,
+                                       size_t ChildIndex) const;
+
+#ifndef NDEBUG
   static void verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements);
-  #endif
+#endif
 };
 
 } // end namespace swift

--- a/include/swift/Parse/ParsedSyntaxNodes.h.gyb
+++ b/include/swift/Parse/ParsedSyntaxNodes.h.gyb
@@ -62,9 +62,13 @@ public:
   /// ${line}
 %       end
 %       if child.is_optional:
-  llvm::Optional<Parsed${child.type_name}> getDeferred${child.name}();
+  llvm::Optional<Parsed${child.type_name}> getDeferred${child.name}(
+      const SyntaxParsingContext *SyntaxContext
+  );
 %       else:
-  Parsed${child.type_name} getDeferred${child.name}();
+  Parsed${child.type_name} getDeferred${child.name}(
+      const SyntaxParsingContext *SyntaxContext
+  );
 %       end
 %     end
 

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -19,10 +19,11 @@
 #define SWIFT_PARSE_SYNTAXPARSEACTIONS_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
+#include "llvm/Support/Allocator.h"
 
 namespace swift {
 
-class CharSourceRange;
 class ParsedTriviaPiece;
 class SourceFile;
 class SourceLoc;
@@ -35,7 +36,54 @@ enum class SyntaxKind;
 
 typedef const void *OpaqueSyntaxNode;
 
+// MARK: - Helper types
+
+/// A syntax node that can either be deferred or recorded. The actual data is
+/// opaque and needs to be interpreted by the \c SyntaxParseAction which created
+/// it.
+class RecordedOrDeferredNode {
+public:
+  enum class Kind : uint8_t {
+    Null,
+    Recorded,
+    DeferredLayout,
+    DeferredToken,
+  };
+
+private:
+  OpaqueSyntaxNode Opaque;
+  Kind NodeKind;
+
+public:
+  RecordedOrDeferredNode(OpaqueSyntaxNode Node, Kind NodeKind)
+      : Opaque(Node), NodeKind(NodeKind) {}
+
+  OpaqueSyntaxNode getOpaque() const { return Opaque; }
+  Kind getKind() const { return NodeKind; }
+};
+
+/// Data returned from \c getDeferredChild. This is enough data to construct
+/// a \c ParsedRawSyntaxNode. We don't return \c ParsedRawSyntaxNodes from
+/// \c getDeferredChild to maintain a clean dependency relationship of
+/// \c ParsedRawSyntaxNode being on a higher level than \c SyntaxParseActions.
+struct DeferredNodeInfo {
+  OpaqueSyntaxNode Data;
+  syntax::SyntaxKind SyntaxKind;
+  tok TokenKind;
+  bool IsMissing;
+  CharSourceRange Range;
+
+  DeferredNodeInfo(OpaqueSyntaxNode Data, syntax::SyntaxKind SyntaxKind,
+                   tok TokenKind, bool IsMissing, CharSourceRange Range)
+      : Data(Data), SyntaxKind(SyntaxKind), TokenKind(TokenKind),
+        IsMissing(IsMissing), Range(Range) {}
+};
+
+// MARK: - SyntaxParseActions
+
 class SyntaxParseActions {
+  llvm::BumpPtrAllocator DeferredNodeAllocator;
+
   virtual void _anchor();
 
 public:
@@ -52,9 +100,47 @@ public:
   /// The provided \c elements are an exact layout appropriate for the syntax
   /// \c kind. Missing optional elements are represented with a null
   /// OpaqueSyntaxNode object.
-  virtual OpaqueSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                           ArrayRef<OpaqueSyntaxNode> elements,
-                                           CharSourceRange range) = 0;
+  virtual OpaqueSyntaxNode
+  recordRawSyntax(syntax::SyntaxKind kind,
+                  ArrayRef<OpaqueSyntaxNode> elements) = 0;
+
+  /// Create a deferred token node that may or may not be recorded later using
+  /// \c recordDeferredToken. The \c SyntaxParseAction is responsible for
+  /// keeping the deferred token alive until the action is destructed.
+  virtual OpaqueSyntaxNode makeDeferredToken(tok tokenKind,
+                                             StringRef leadingTrivia,
+                                             StringRef trailingTrivia,
+                                             CharSourceRange range,
+                                             bool isMissing);
+
+  /// Create a deferred layout node that may or may not be recorded later using
+  /// \c recordDeferredLayout. The \c SyntaxParseAction is responsible for
+  /// keeping the deferred token alive until it is destructed.
+  virtual OpaqueSyntaxNode
+  makeDeferredLayout(syntax::SyntaxKind k, bool isMissing,
+                     const ArrayRef<RecordedOrDeferredNode> &children);
+
+  /// Record a deferred token node that was previously created using \c
+  /// makeDeferredToken. The deferred data will never be used again, so it can
+  /// be destroyed by this method. Note that not all deferred nodes will be
+  /// recorded and that pending deferred nodes need to be freed when the \c
+  /// SyntaxParseActions is destructed.
+  virtual OpaqueSyntaxNode recordDeferredToken(OpaqueSyntaxNode deferred);
+
+  /// Record a deferred layout node. See recordDeferredToken.
+  virtual OpaqueSyntaxNode recordDeferredLayout(OpaqueSyntaxNode deferred);
+
+  /// Since most data of \c ParsedRawSyntax is described as opaque data, the
+  /// \c ParsedRawSyntax node needs to reach out to the \c SyntaxParseAction,
+  /// which created it, to retrieve children.
+  /// This method assumes that \p node represents a *deferred* layout node.
+  /// This methods returns all information needed to construct a \c
+  /// ParsedRawSyntaxNode of a child node. \p node is the parent node for which
+  /// the child at position \p ChildIndex should be retrieved. Furthmore, \p
+  /// node starts at \p StartLoc.
+  virtual DeferredNodeInfo getDeferredChild(OpaqueSyntaxNode node,
+                                            size_t childIndex,
+                                            SourceLoc startLoc);
 
   /// Attempt to realize an opaque raw syntax node for a source file into a
   /// SourceFileSyntax node. This will return \c None if the parsing action

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -67,13 +67,13 @@ public:
 /// \c getDeferredChild to maintain a clean dependency relationship of
 /// \c ParsedRawSyntaxNode being on a higher level than \c SyntaxParseActions.
 struct DeferredNodeInfo {
-  OpaqueSyntaxNode Data;
+  RecordedOrDeferredNode Data;
   syntax::SyntaxKind SyntaxKind;
   tok TokenKind;
   bool IsMissing;
   CharSourceRange Range;
 
-  DeferredNodeInfo(OpaqueSyntaxNode Data, syntax::SyntaxKind SyntaxKind,
+  DeferredNodeInfo(RecordedOrDeferredNode Data, syntax::SyntaxKind SyntaxKind,
                    tok TokenKind, bool IsMissing, CharSourceRange Range)
       : Data(Data), SyntaxKind(SyntaxKind), TokenKind(TokenKind),
         IsMissing(IsMissing), Range(Range) {}

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -142,6 +142,10 @@ public:
                                             size_t childIndex,
                                             SourceLoc startLoc);
 
+  /// Return the number of children, \p node has. These can be retrieved using
+  /// \c getDeferredChild.
+  virtual size_t getDeferredNumChildren(OpaqueSyntaxNode node);
+
   /// Attempt to realize an opaque raw syntax node for a source file into a
   /// SourceFileSyntax node. This will return \c None if the parsing action
   /// doesn't support the realization of syntax nodes.

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -255,6 +255,9 @@ public:
   const SyntaxParsingContext *getRoot() const;
 
   ParsedRawSyntaxRecorder &getRecorder() { return getRootData()->Recorder; }
+  const ParsedRawSyntaxRecorder &getRecorder() const {
+    return getRootData()->Recorder;
+  }
 
   llvm::BumpPtrAllocator &getScratchAlloc() {
     return getRootData()->ScratchAlloc;

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -64,9 +64,9 @@ private:
 
   OpaqueSyntaxNode recordMissingToken(tok tokenKind, SourceLoc loc) override;
 
-  OpaqueSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                   ArrayRef<OpaqueSyntaxNode> elements,
-                                   CharSourceRange range) override;
+  OpaqueSyntaxNode
+  recordRawSyntax(syntax::SyntaxKind kind,
+                  ArrayRef<OpaqueSyntaxNode> elements) override;
 
   std::pair<size_t, OpaqueSyntaxNode>
   lookupNode(size_t lexerOffset, syntax::SyntaxKind kind) override;

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -22,6 +22,7 @@ add_swift_host_library(swiftParse STATIC
   ParseStmt.cpp
   ParseType.cpp
   PersistentParserState.cpp
+  SyntaxParseActions.cpp
   SyntaxParsingCache.cpp
   SyntaxParsingContext.cpp)
 _swift_gyb_target_sources(swiftParse PRIVATE

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1263,7 +1263,7 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
 
   if (SyntaxContext->isEnabled()) {
     if (auto UPES = PatternCtx.popIf<ParsedUnresolvedPatternExprSyntax>()) {
-      PatternCtx.addSyntax(UPES->getDeferredPattern());
+      PatternCtx.addSyntax(UPES->getDeferredPattern(SyntaxContext));
     } else {
       PatternCtx.setCreateSyntax(SyntaxKind::ExpressionPattern);
     }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -406,9 +406,9 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       if (InputNode.is<ParsedTupleTypeSyntax>()) {
         auto TupleTypeNode = std::move(InputNode).castTo<ParsedTupleTypeSyntax>();
         // Decompose TupleTypeSyntax and repack into FunctionType.
-        auto LeftParen = TupleTypeNode.getDeferredLeftParen();
-        auto Arguments = TupleTypeNode.getDeferredElements();
-        auto RightParen = TupleTypeNode.getDeferredRightParen();
+        auto LeftParen = TupleTypeNode.getDeferredLeftParen(SyntaxContext);
+        auto Arguments = TupleTypeNode.getDeferredElements(SyntaxContext);
+        auto RightParen = TupleTypeNode.getDeferredRightParen(SyntaxContext);
         Builder
           .useLeftParen(std::move(LeftParen))
           .useArguments(std::move(Arguments))

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -17,6 +17,12 @@ using namespace swift;
 using namespace swift::syntax;
 using namespace llvm;
 
+ParsedRawSyntaxNode ParsedRawSyntaxNode::getDeferredChild(
+    size_t ChildIndex, const SyntaxParsingContext *SyntaxContext) const {
+  assert(isDeferredLayout());
+  return SyntaxContext->getRecorder().getDeferredChild(*this, ChildIndex);
+}
+
 void ParsedRawSyntaxNode::dump() const {
   dump(llvm::errs(), /*Indent*/ 0);
   llvm::errs() << '\n';
@@ -42,11 +48,7 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
       break;
     case DataKind::DeferredLayout:
       dumpSyntaxKind(OS, getKind());
-      OS << " [deferred]";
-      for (const auto &child : getDeferredChildren()) {
-        OS << "\n";
-        child.dump(OS, Indent + 2);
-      }
+      OS << " [deferred layout]";
       break;
     case DataKind::DeferredToken:
       dumpSyntaxKind(OS, getKind());

--- a/lib/Parse/ParsedRawSyntaxNode.cpp
+++ b/lib/Parse/ParsedRawSyntaxNode.cpp
@@ -33,7 +33,7 @@ void ParsedRawSyntaxNode::dump(llvm::raw_ostream &OS, unsigned Indent) const {
     OS << ' ';
   OS << '(';
 
-  switch (DK) {
+  switch (getDataKind()) {
     case DataKind::Null:
       OS << "<NULL>";
       break;

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -223,6 +223,12 @@ ParsedRawSyntaxRecorder::getDeferredChild(const ParsedRawSyntaxNode &parent,
                              childInfo.IsMissing);
 }
 
+size_t ParsedRawSyntaxRecorder::getDeferredNumChildren(
+    const ParsedRawSyntaxNode &node) const {
+  assert(node.isDeferredLayout());
+  return SPActions->getDeferredNumChildren(node.getData());
+}
+
 #ifndef NDEBUG
 void ParsedRawSyntaxRecorder::verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements) {
   SourceLoc prevEndLoc;

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -214,14 +214,11 @@ ParsedRawSyntaxRecorder::getDeferredChild(const ParsedRawSyntaxNode &parent,
                                           size_t childIndex) const {
   assert(parent.isDeferredLayout());
   auto childInfo = SPActions->getDeferredChild(
-      parent.getUnsafeDeferredOpaqueData(),
-      childIndex, parent.getRange().getStart());
-  return ParsedRawSyntaxNode(childInfo.Data, childInfo.Range,
+      parent.getUnsafeDeferredOpaqueData(), childIndex,
+      parent.getRange().getStart());
+  return ParsedRawSyntaxNode(childInfo.Data.getOpaque(), childInfo.Range,
                              childInfo.SyntaxKind, childInfo.TokenKind,
-                             childInfo.SyntaxKind == syntax::SyntaxKind::Token
-                                 ? RecordedOrDeferredNode::Kind::DeferredToken
-                                 : RecordedOrDeferredNode::Kind::DeferredLayout,
-                             childInfo.IsMissing);
+                             childInfo.Data.getKind(), childInfo.IsMissing);
 }
 
 size_t ParsedRawSyntaxRecorder::getDeferredNumChildren(

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -142,8 +142,9 @@ ParsedRawSyntaxNode ParsedRawSyntaxRecorder::makeDeferred(
   RecordedOrDeferredNode *newPtr =
       ctx.getScratchAlloc().Allocate<RecordedOrDeferredNode>(
           deferredNodes.size());
-  auto ptr = newPtr;
-  for (auto &node : deferredNodes) {
+  auto children = llvm::makeMutableArrayRef(newPtr, deferredNodes.size());
+  for (size_t i = 0; i < deferredNodes.size(); ++i) {
+    auto &node = deferredNodes[i];
     assert(!node.isRecorded() &&
            "Cannot create a deferred layout node that has recorded children");
     // Cached range.
@@ -157,11 +158,8 @@ ParsedRawSyntaxNode ParsedRawSyntaxRecorder::makeDeferred(
       }
     }
 
-    auto kind = node.getDataKind();
-    new (ptr) RecordedOrDeferredNode(node.takeData(), kind);
-    ptr++;
+    children[i] = node.getRecordedOrDeferredNode();
   }
-  auto children = llvm::makeMutableArrayRef(newPtr, deferredNodes.size());
   auto data = SPActions->makeDeferredLayout(k, /*IsMissing=*/false, children);
   return ParsedRawSyntaxNode(data, range, k, tok::NUM_TOKENS,
                              ParsedRawSyntaxNode::DataKind::DeferredLayout,

--- a/lib/Parse/ParsedSyntaxNodes.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxNodes.cpp.gyb
@@ -27,15 +27,15 @@ using namespace swift::syntax;
 %   for child in node.children:
 %     if child.is_optional:
 Optional<Parsed${child.type_name}>
-Parsed${node.name}::getDeferred${child.name}() {
-  auto &RawChild = getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}];
+Parsed${node.name}::getDeferred${child.name}(const SyntaxParsingContext *SyntaxContext) {
+  auto RawChild = getRaw().getDeferredChild(${node.name}::Cursor::${child.name}, SyntaxContext);
   if (RawChild.isNull())
     return None;
   return Parsed${child.type_name} {RawChild.copyDeferred()};
 }
 %     else:
-Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}() {
-  return Parsed${child.type_name} {getRaw().getDeferredChildren()[${node.name}::Cursor::${child.name}].copyDeferred()};
+Parsed${child.type_name} Parsed${node.name}::getDeferred${child.name}(const SyntaxParsingContext *SyntaxContext) {
+  return Parsed${child.type_name} {getRaw().getDeferredChild(${node.name}::Cursor::${child.name}, SyntaxContext).copyDeferred()};
 }
 %     end
 

--- a/lib/Parse/SyntaxParseActions.cpp
+++ b/lib/Parse/SyntaxParseActions.cpp
@@ -147,21 +147,28 @@ DeferredNodeInfo SyntaxParseActions::getDeferredChild(OpaqueSyntaxNode node,
   auto Child = Data->Children[ChildIndex];
   switch (Child.getKind()) {
   case RecordedOrDeferredNode::Kind::Null:
-    llvm_unreachable("A child node should not be Null");
+    return DeferredNodeInfo(
+        RecordedOrDeferredNode(nullptr, RecordedOrDeferredNode::Kind::Null),
+        syntax::SyntaxKind::Unknown, tok::NUM_TOKENS,
+        /*IsMissing=*/false, CharSourceRange());
   case RecordedOrDeferredNode::Kind::Recorded:
     llvm_unreachable("Children of deferred nodes must also be deferred");
     break;
   case RecordedOrDeferredNode::Kind::DeferredLayout: {
     auto ChildData = static_cast<const DeferredLayoutNode *>(Child.getOpaque());
-    return DeferredNodeInfo(ChildData, ChildData->Kind, tok::NUM_TOKENS,
-                            /*IsMissing=*/false,
-                            CharSourceRange(StartLoc, ChildData->Length));
+    return DeferredNodeInfo(
+        RecordedOrDeferredNode(ChildData,
+                               RecordedOrDeferredNode::Kind::DeferredLayout),
+        ChildData->Kind, tok::NUM_TOKENS,
+        /*IsMissing=*/false, CharSourceRange(StartLoc, ChildData->Length));
   }
   case RecordedOrDeferredNode::Kind::DeferredToken: {
     auto ChildData = static_cast<const DeferredTokenNode *>(Child.getOpaque());
-    return DeferredNodeInfo(ChildData, syntax::SyntaxKind::Token,
-                            ChildData->TokenKind, ChildData->IsMissing,
-                            ChildData->Range);
+    return DeferredNodeInfo(
+        RecordedOrDeferredNode(ChildData,
+                               RecordedOrDeferredNode::Kind::DeferredToken),
+        syntax::SyntaxKind::Token, ChildData->TokenKind, ChildData->IsMissing,
+        ChildData->Range);
   }
   }
 }

--- a/lib/Parse/SyntaxParseActions.cpp
+++ b/lib/Parse/SyntaxParseActions.cpp
@@ -165,3 +165,8 @@ DeferredNodeInfo SyntaxParseActions::getDeferredChild(OpaqueSyntaxNode node,
   }
   }
 }
+
+size_t SyntaxParseActions::getDeferredNumChildren(OpaqueSyntaxNode node) {
+  auto Data = static_cast<const DeferredLayoutNode *>(node);
+  return Data->Children.size();
+}

--- a/lib/Parse/SyntaxParseActions.cpp
+++ b/lib/Parse/SyntaxParseActions.cpp
@@ -1,0 +1,167 @@
+//===--- SyntaxParseActions.cpp -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Parse/SyntaxParseActions.h"
+#include "swift/Parse/Token.h"
+#include "swift/Syntax/SyntaxKind.h"
+
+using namespace swift;
+
+struct DeferredTokenNode {
+  bool IsMissing;
+  tok TokenKind;
+  StringRef LeadingTrivia;
+  StringRef TrailingTrivia;
+  /// The range of the token including trivia.
+  CharSourceRange Range;
+
+  DeferredTokenNode(bool IsMissing, tok TokenKind, StringRef LeadingTrivia,
+                    StringRef TrailingTrivia, CharSourceRange Range)
+      : IsMissing(IsMissing), TokenKind(TokenKind),
+        LeadingTrivia(LeadingTrivia), TrailingTrivia(TrailingTrivia),
+        Range(Range) {}
+};
+
+struct DeferredLayoutNode {
+  syntax::SyntaxKind Kind;
+  ArrayRef<RecordedOrDeferredNode> Children;
+  unsigned Length;
+
+  DeferredLayoutNode(syntax::SyntaxKind Kind,
+                     ArrayRef<RecordedOrDeferredNode> Children, unsigned Length)
+      : Kind(Kind), Children(Children), Length(Length) {}
+};
+
+OpaqueSyntaxNode SyntaxParseActions::makeDeferredToken(tok tokenKind,
+                                                       StringRef leadingTrivia,
+                                                       StringRef trailingTrivia,
+                                                       CharSourceRange range,
+                                                       bool isMissing) {
+  return new (DeferredNodeAllocator) DeferredTokenNode(
+      isMissing, tokenKind, leadingTrivia, trailingTrivia, range);
+}
+
+OpaqueSyntaxNode SyntaxParseActions::makeDeferredLayout(
+    syntax::SyntaxKind k, bool isMissing,
+    const ArrayRef<RecordedOrDeferredNode> &children) {
+  assert(!isMissing && "Missing layout nodes not implemented yet");
+
+  // Compute the length of this node.
+  unsigned length = 0;
+  for (auto &child : children) {
+    switch (child.getKind()) {
+    case RecordedOrDeferredNode::Kind::Null:
+      break;
+    case RecordedOrDeferredNode::Kind::Recorded:
+      llvm_unreachable("Children of deferred nodes must also be deferred");
+      break;
+    case RecordedOrDeferredNode::Kind::DeferredLayout:
+      length +=
+          static_cast<const DeferredLayoutNode *>(child.getOpaque())->Length;
+      break;
+    case RecordedOrDeferredNode::Kind::DeferredToken:
+      length += static_cast<const DeferredTokenNode *>(child.getOpaque())
+                    ->Range.getByteLength();
+      break;
+    }
+  }
+
+  return new (DeferredNodeAllocator) DeferredLayoutNode(k, children, length);
+}
+
+OpaqueSyntaxNode
+SyntaxParseActions::recordDeferredToken(OpaqueSyntaxNode deferred) {
+  auto Data = static_cast<const DeferredTokenNode *>(deferred);
+  if (Data->IsMissing) {
+    return recordMissingToken(Data->TokenKind, Data->Range.getStart());
+  } else {
+    return recordToken(Data->TokenKind, Data->LeadingTrivia,
+                       Data->TrailingTrivia, Data->Range);
+  }
+}
+
+OpaqueSyntaxNode
+SyntaxParseActions::recordDeferredLayout(OpaqueSyntaxNode deferred) {
+  auto Data = static_cast<const DeferredLayoutNode *>(deferred);
+
+  auto childrenStore =
+      DeferredNodeAllocator.Allocate<OpaqueSyntaxNode>(Data->Children.size());
+  MutableArrayRef<OpaqueSyntaxNode> children =
+      llvm::makeMutableArrayRef(childrenStore, Data->Children.size());
+
+  for (size_t i = 0; i < Data->Children.size(); ++i) {
+    auto Child = Data->Children[i];
+    switch (Child.getKind()) {
+    case RecordedOrDeferredNode::Kind::Null:
+      children[i] = Child.getOpaque();
+      break;
+    case RecordedOrDeferredNode::Kind::Recorded:
+      llvm_unreachable("Children of deferred nodes must also be deferred");
+      break;
+    case RecordedOrDeferredNode::Kind::DeferredLayout:
+      children[i] = recordDeferredLayout(Child.getOpaque());
+      break;
+    case RecordedOrDeferredNode::Kind::DeferredToken:
+      children[i] = recordDeferredToken(Child.getOpaque());
+      break;
+    }
+  }
+  return recordRawSyntax(Data->Kind, children);
+}
+
+DeferredNodeInfo SyntaxParseActions::getDeferredChild(OpaqueSyntaxNode node,
+                                                      size_t ChildIndex,
+                                                      SourceLoc StartLoc) {
+  auto Data = static_cast<const DeferredLayoutNode *>(node);
+
+  // Compute the start offset of the child node by advancing StartLoc by the
+  // length of all previous child nodes.
+  for (unsigned i = 0; i < ChildIndex; ++i) {
+    auto Child = Data->Children[i];
+    switch (Child.getKind()) {
+    case RecordedOrDeferredNode::Kind::Null:
+      break;
+    case RecordedOrDeferredNode::Kind::Recorded:
+      llvm_unreachable("Children of deferred nodes must also be deferred");
+    case RecordedOrDeferredNode::Kind::DeferredLayout:
+      StartLoc = StartLoc.getAdvancedLoc(
+          static_cast<const DeferredLayoutNode *>(Child.getOpaque())->Length);
+      break;
+    case RecordedOrDeferredNode::Kind::DeferredToken:
+      StartLoc = StartLoc.getAdvancedLoc(
+          static_cast<const DeferredTokenNode *>(Child.getOpaque())
+              ->Range.getByteLength());
+      break;
+    }
+  }
+
+  auto Child = Data->Children[ChildIndex];
+  switch (Child.getKind()) {
+  case RecordedOrDeferredNode::Kind::Null:
+    llvm_unreachable("A child node should not be Null");
+  case RecordedOrDeferredNode::Kind::Recorded:
+    llvm_unreachable("Children of deferred nodes must also be deferred");
+    break;
+  case RecordedOrDeferredNode::Kind::DeferredLayout: {
+    auto ChildData = static_cast<const DeferredLayoutNode *>(Child.getOpaque());
+    return DeferredNodeInfo(ChildData, ChildData->Kind, tok::NUM_TOKENS,
+                            /*IsMissing=*/false,
+                            CharSourceRange(StartLoc, ChildData->Length));
+  }
+  case RecordedOrDeferredNode::Kind::DeferredToken: {
+    auto ChildData = static_cast<const DeferredTokenNode *>(Child.getOpaque());
+    return DeferredNodeInfo(ChildData, syntax::SyntaxKind::Token,
+                            ChildData->TokenKind, ChildData->IsMissing,
+                            ChildData->Range);
+  }
+  }
+}

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -329,7 +329,8 @@ OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {
   // the root context.
   getStorage().clear();
 
-  return root.takeOpaqueNode();
+  assert(root.isRecorded() && "Root of syntax tree should be recorded");
+  return root.takeData();
 }
 
 void SyntaxParsingContext::synthesize(tok Kind, SourceLoc Loc) {

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -137,14 +137,17 @@ SyntaxTreeCreator::recordMissingToken(tok kind, SourceLoc loc) {
 
 OpaqueSyntaxNode
 SyntaxTreeCreator::recordRawSyntax(syntax::SyntaxKind kind,
-                                   ArrayRef<OpaqueSyntaxNode> elements,
-                                   CharSourceRange range) {
+                                   ArrayRef<OpaqueSyntaxNode> elements) {
   SmallVector<const RawSyntax *, 16> parts;
   parts.reserve(elements.size());
+  size_t TextLength = 0;
   for (OpaqueSyntaxNode opaqueN : elements) {
-    parts.push_back(static_cast<const RawSyntax *>(opaqueN));
+    auto Raw = static_cast<const RawSyntax *>(opaqueN);
+    parts.push_back(Raw);
+    if (Raw) {
+      TextLength += Raw->getTextLength();
+    }
   }
-  size_t TextLength = range.isValid() ? range.getByteLength() : 0;
   auto raw =
       RawSyntax::make(kind, parts, TextLength, SourcePresence::Present, Arena);
   return static_cast<OpaqueSyntaxNode>(raw);

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -176,9 +176,9 @@ private:
     return getNodeHandler()(&node);
   }
 
-  OpaqueSyntaxNode recordRawSyntax(SyntaxKind kind,
-                                   ArrayRef<OpaqueSyntaxNode> elements,
-                                   CharSourceRange range) override {
+  OpaqueSyntaxNode
+  recordRawSyntax(SyntaxKind kind,
+                  ArrayRef<OpaqueSyntaxNode> elements) override {
     CRawSyntaxNode node;
     auto numValue = serialization::getNumericValue(kind);
     node.kind = numValue;


### PR DESCRIPTION
Move the creation of deferred nodes from the `ParsedRawSyntaxRecorder` to `SyntaxParseActions`. By itself this does not offer any advantage, but from here we will be able to optimize the creation of deferred nodes inside the different `SyntaxParseActions` implementations.

All implementation that is currently in `SyntaxParseActions` is transitional. In the next PR these will be pushed to `CLibParseActions` (which will mostly match what’s currently in `SyntaxParseActions`) and `SyntaxTreeCreator` (which can avoid creating deferred nodes altogether by directly constructing `RawSyntax` nodes).