### PR TITLE
[libSyntax] Improve data structure in RawSyntax

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -37,7 +37,7 @@ namespace swift {
   class NominalTypeDecl;
   class ValueDecl;
   class SourceLoc;
-  enum class tok;
+  enum class tok : uint8_t;
   enum class AccessorKind;
 
 /// Describes the context in which a name is being printed, which

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -32,10 +32,10 @@ class SyntaxParseActions;
 class SyntaxParsingContext;
 class SourceLoc;
 class Token;
-enum class tok;
+enum class tok : uint8_t;
 
 namespace syntax {
-  enum class SyntaxKind;
+enum class SyntaxKind : uint16_t;
 }
 
 class ParsedRawSyntaxRecorder final {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -60,7 +60,7 @@ namespace swift {
   
   namespace syntax {
     class RawSyntax;
-    enum class SyntaxKind;
+    enum class SyntaxKind : uint16_t;
   }// end of syntax namespace
 
   /// Different contexts in which BraceItemList are parsed.

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -27,11 +27,11 @@ namespace swift {
 class ParsedTriviaPiece;
 class SourceFile;
 class SourceLoc;
-enum class tok;
+enum class tok : uint8_t;
 
 namespace syntax {
 class SourceFileSyntax;
-enum class SyntaxKind;
+enum class SyntaxKind : uint16_t;
 }
 
 typedef const void *OpaqueSyntaxNode;

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -27,12 +27,12 @@ class ParsedSyntax;
 class ParsedTokenSyntax;
 struct ParsedTrivia;
 class SourceFile;
-enum class tok;
+enum class tok : uint8_t;
 class Token;
 class DiagnosticEngine;
 
 namespace syntax {
-  enum class SyntaxKind;
+enum class SyntaxKind : uint16_t;
 }
 
 enum class SyntaxContextKind {

--- a/include/swift/Syntax/SyntaxKind.h.gyb
+++ b/include/swift/Syntax/SyntaxKind.h.gyb
@@ -31,7 +31,7 @@
 namespace swift {
 namespace syntax {
 
-enum class SyntaxKind {
+enum class SyntaxKind : uint16_t {
   Token,
 % for name, nodes in grouped_nodes.items():
 %   for node in nodes:
@@ -47,9 +47,6 @@ enum class SyntaxKind {
 
   // NOTE: Unknown must be the last kind.
   Unknown,
-};
-enum : unsigned {
-  NumSyntaxKindBits = countBitsUsed(static_cast<unsigned>(SyntaxKind::Unknown))
 };
 
 void dumpSyntaxKind(llvm::raw_ostream &os, const SyntaxKind kind);

--- a/include/swift/Syntax/TokenKinds.h
+++ b/include/swift/Syntax/TokenKinds.h
@@ -21,7 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace swift {
-enum class tok {
+enum class tok : uint8_t {
 #define TOKEN(X) X,
 #include "swift/Syntax/TokenKinds.def"
 


### PR DESCRIPTION
It turns out that the bitpacked `Common` struct is actually fairly expensive because the CPU needs to apply bitmasks to fetch the `IsToken` and `Presence` flag. We've got padding space available, so we might as well properly align these boolean flags.

Also on a source level, replace a couple of bit-restricted unsigned fields by their representing type (e.g.`SyntaxKind`).

It turns out that the bitpacked Commons struct is actually fairly expensive because the CPU needs to apply bitmasks to fetch the IsToken and Presence flag. We've got padding space available, so we might as well properly align these boolean flags.

Furthermore, we can pull out the common bits to `RawSyntax` and have the `Bits` union only contain the token- or layout-specific fields.
This also allows us to initialise these fields in the constructor's initialiser list (instead of in the initialiser body).

Lastly, change copyToArenaIfNecessary to work on a `char *&` and `length`, which allows us to initialise leading/trailing trivia/token text in the initialiser list and adjust if necessary later.