### PR TITLE
Docs: fix example in C++ interop manifesto

### DIFF
--- a/docs/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperabilityManifesto.md
@@ -2842,7 +2842,7 @@ public:
 // C++ header imported in Swift.
 
 struct MyCxxContainer {
-  public subscript(_ i: Int) { get set }
+  public subscript(_ i: Int) -> Double { get set }
 }
 ```
 


### PR DESCRIPTION
This adds the missing return type to subscript in one of the examples in C++ interop manifesto.