### PR TITLE
[libSyntax] Explicitly pass source file length to c parse actions

### DIFF
--- a/include/swift-c/SyntaxParser/SwiftSyntaxParser.h
+++ b/include/swift-c/SyntaxParser/SwiftSyntaxParser.h
@@ -218,8 +218,10 @@ swiftparse_parser_set_node_lookup(swiftparse_parser_t,
 /// via the return value of \c swiftparse_parse_string.
 ///
 /// \param source a null-terminated UTF8 string buffer.
+/// \param len The length of the source string. This allows \p source to contain
+///            intermediate null characters.
 SWIFTPARSE_PUBLIC swiftparse_client_node_t
-swiftparse_parse_string(swiftparse_parser_t, const char *source);
+swiftparse_parse_string(swiftparse_parser_t, const char *source, size_t len);
 
 /// Returns a constant string pointer for verification purposes.
 ///

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -95,7 +95,7 @@ public:
     setDiagnosticHandler(nullptr);
   }
 
-  swiftparse_client_node_t parse(const char *source);
+  swiftparse_client_node_t parse(const char *source, size_t len);
 };
 
 class CLibParseActions : public SyntaxParseActions {
@@ -274,10 +274,10 @@ struct SynParserDiagConsumer: public DiagnosticConsumer {
   }
 };
 
-swiftparse_client_node_t SynParser::parse(const char *source) {
+swiftparse_client_node_t SynParser::parse(const char *source, size_t len) {
   SourceManager SM;
-  unsigned bufID = SM.addNewSourceBuffer(
-    llvm::MemoryBuffer::getMemBuffer(source, "syntax_parse_source"));
+  unsigned bufID = SM.addNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(
+      StringRef(source, len), "syntax_parse_source"));
   TypeCheckerOptions tyckOpts;
   LangOptions langOpts;
   langOpts.BuildSyntaxTree = true;
@@ -329,10 +329,11 @@ swiftparse_parser_set_node_lookup(swiftparse_parser_t c_parser,
   parser->setNodeLookup(lookup);
 }
 
-swiftparse_client_node_t
-swiftparse_parse_string(swiftparse_parser_t c_parser, const char *source) {
+swiftparse_client_node_t swiftparse_parse_string(swiftparse_parser_t c_parser,
+                                                 const char *source,
+                                                 size_t len) {
   SynParser *parser = static_cast<SynParser*>(c_parser);
-  return parser->parse(source);
+  return parser->parse(source, len);
 }
 
 const char* swiftparse_syntax_structure_versioning_identifier(void) {

--- a/unittests/SyntaxParser/SyntaxParserTests.cpp
+++ b/unittests/SyntaxParser/SyntaxParserTests.cpp
@@ -19,21 +19,21 @@
 using namespace swift;
 
 static swiftparse_client_node_t
-parse(const char *source, swiftparse_node_handler_t node_handler,
+parse(StringRef source, swiftparse_node_handler_t node_handler,
       swiftparse_node_lookup_t node_lookup) {
   swiftparse_parser_t parser = swiftparse_parser_create();
   swiftparse_parser_set_node_handler(parser, node_handler);
   swiftparse_parser_set_node_lookup(parser, node_lookup);
-  swiftparse_client_node_t top = swiftparse_parse_string(parser, source);
+  swiftparse_client_node_t top = swiftparse_parse_string(parser, source.data(), source.size());
   swiftparse_parser_dispose(parser);
   return top;
 }
 
 TEST(SwiftSyntaxParserTests, IncrementalParsing) {
-  const char *source1 =
+  StringRef source1 =
   "func t1() { }\n"
   "func t2() { }\n";
-  const char *source2 =
+  StringRef source2 =
   "func t1renamed() { }\n"
   "func t2() { }\n";
 


### PR DESCRIPTION
Previously, the passed in source file was implicitly terminated by the first null character. The source file might, however, contain a null character in the middle and we shouldn't stop parsing at it.

Accompanies https://github.com/apple/swift-syntax/pull/261
