### PR TITLE
[IRGen] Fix ABI for thick async functions.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -212,7 +212,7 @@ types where the metadata itself has unknown layout.)
   global ::= global 'TD'                 // dynamic dispatch thunk
   global ::= global 'Td'                 // direct method reference thunk
   global ::= global 'TI'                 // implementation of a dynamic_replaceable function
-  global :== global 'Tu'                 // async function pointer of a function
+  global ::= global 'Tu'                 // async function pointer of a function
   global ::= global 'TX'                 // function pointer of a dynamic_replaceable function
   global ::= entity entity 'TV'          // vtable override thunk, derived followed by base
   global ::= type label-list? 'D'        // type mangling for the debugger with label list for function types.

--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -59,6 +59,8 @@ public:
   using BuiltType = swift::Type;
   using BuiltTypeDecl = swift::GenericTypeDecl *; // nominal or type alias
   using BuiltProtocolDecl = swift::ProtocolDecl *;
+  using BuiltSubstitution = std::pair<Type, Type>;
+  using BuiltRequirement = swift::Requirement;
   explicit ASTBuilder(ASTContext &ctx) : Ctx(ctx) {}
 
   ASTContext &getASTContext() { return Ctx; }
@@ -99,11 +101,14 @@ public:
                           Type output, FunctionTypeFlags flags);
 
   Type createImplFunctionType(
-    Demangle::ImplParameterConvention calleeConvention,
-    ArrayRef<Demangle::ImplFunctionParam<Type>> params,
-    ArrayRef<Demangle::ImplFunctionResult<Type>> results,
-    Optional<Demangle::ImplFunctionResult<Type>> errorResult,
-    ImplFunctionTypeFlags flags);
+      Demangle::ImplParameterConvention calleeConvention,
+      BuiltRequirement *witnessMethodConformanceRequirement,
+      ArrayRef<BuiltType> GenericParameters,
+      ArrayRef<BuiltRequirement> Requirements,
+      ArrayRef<Demangle::ImplFunctionParam<Type>> params,
+      ArrayRef<Demangle::ImplFunctionResult<Type>> results,
+      Optional<Demangle::ImplFunctionResult<Type>> errorResult,
+      ImplFunctionTypeFlags flags);
 
   Type createProtocolCompositionType(ArrayRef<ProtocolDecl *> protocols,
                                      Type superclass,
@@ -128,8 +133,6 @@ public:
 
   Type createSILBoxType(Type base);
   using BuiltSILBoxField = llvm::PointerIntPair<Type, 1>;
-  using BuiltSubstitution = std::pair<Type, Type>;
-  using BuiltRequirement = swift::Requirement;
   using BuiltLayoutConstraint = swift::LayoutConstraint;
   Type createSILBoxTypeWithLayout(ArrayRef<BuiltSILBoxField> Fields,
                                   ArrayRef<BuiltSubstitution> Substitutions,

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -799,9 +799,12 @@ public:
     }
     case NodeKind::ImplFunctionType: {
       auto calleeConvention = ImplParameterConvention::Direct_Unowned;
+      BuiltRequirement *witnessMethodConformanceRequirement = nullptr;
       llvm::SmallVector<ImplFunctionParam<BuiltType>, 8> parameters;
       llvm::SmallVector<ImplFunctionResult<BuiltType>, 8> results;
       llvm::SmallVector<ImplFunctionResult<BuiltType>, 8> errorResults;
+      llvm::SmallVector<BuiltType, 4> genericParameters;
+      llvm::SmallVector<BuiltRequirement, 4> requirements;
       ImplFunctionTypeFlags flags;
 
       for (unsigned i = 0; i < Node->getNumChildren(); i++) {
@@ -834,6 +837,9 @@ public:
           } else if (text == "block") {
             flags =
               flags.withRepresentation(ImplFunctionRepresentation::Block);
+          } else if (text == "witness_method") {
+            flags = flags.withRepresentation(
+                ImplFunctionRepresentation::WitnessMethod);
           }
         } else if (child->getKind() == NodeKind::ImplFunctionAttribute) {
           if (!child->hasText())
@@ -871,6 +877,27 @@ public:
           if (decodeImplFunctionPart(child, errorResults))
             return MAKE_NODE_TYPE_ERROR0(child,
                                          "failed to decode function part");
+        } else if (child->getKind() == NodeKind::DependentGenericSignature) {
+          llvm::SmallVector<unsigned, 4> genericParamsAtDepth;
+
+          if (auto error = decodeDependentGenericSignatureNode(
+                  child, requirements, genericParamsAtDepth))
+            return *error;
+          if (flags.getRepresentation() ==
+              ImplFunctionRepresentation::WitnessMethod) {
+            // By convention, the first requirement of a witness method is the
+            // conformance of Self to the protocol.
+            witnessMethodConformanceRequirement = &requirements[0];
+          }
+
+          for (unsigned long depth = 0, depths = genericParamsAtDepth.size();
+               depth < depths; ++depth) {
+            for (unsigned index = 0; index < genericParamsAtDepth[depth];
+                 ++index) {
+              genericParameters.emplace_back(
+                  Builder.createGenericTypeParameterType(depth, index));
+            }
+          }
         } else {
           return MAKE_NODE_TYPE_ERROR0(child, "unexpected kind");
         }
@@ -891,11 +918,11 @@ public:
       // TODO: Some cases not handled above, but *probably* they cannot
       // appear as the types of values in SIL (yet?):
       // - functions with yield returns
-      // - functions with generic signatures
       // - foreign error conventions
-      return Builder.createImplFunctionType(calleeConvention,
-                                            parameters, results,
-                                            errorResult, flags);
+      return Builder.createImplFunctionType(
+          calleeConvention, witnessMethodConformanceRequirement,
+          genericParameters, requirements, parameters, results, errorResult,
+          flags);
     }
 
     case NodeKind::ArgumentTuple:
@@ -1066,35 +1093,12 @@ public:
           return MAKE_NODE_TYPE_ERROR0(substNode, "expected type list");
 
         auto *dependentGenericSignatureNode = Node->getChild(1);
-        if (dependentGenericSignatureNode->getKind() !=
-            NodeKind::DependentGenericSignature)
-          return MAKE_NODE_TYPE_ERROR0(dependentGenericSignatureNode,
-                                       "expected dependent generic signature");
-        if (dependentGenericSignatureNode->getNumChildren() < 1)
-          return MAKE_NODE_TYPE_ERROR(
-              dependentGenericSignatureNode,
-              "fewer children (%zu) than required (1)",
-              dependentGenericSignatureNode->getNumChildren());
-        decodeRequirement<BuiltType, BuiltRequirement, BuiltLayoutConstraint,
-                          BuilderType>(
-            dependentGenericSignatureNode, requirements, Builder/*,
-            [&](NodePointer Node) -> BuiltType {
-              return decodeMangledType(Node).getType();
-            },
-            [&](LayoutConstraintKind Kind) -> BuiltLayoutConstraint {
-              return {}; // Not implemented!
-            },
-            [&](LayoutConstraintKind Kind, unsigned SizeInBits,
-                unsigned Alignment) -> BuiltLayoutConstraint {
-              return {}; // Not Implemented!
-              }*/);
-        // The number of generic parameters at each depth are in a mini
-        // state machine and come first.
         llvm::SmallVector<unsigned, 4> genericParamsAtDepth;
-        for (auto *reqNode : *dependentGenericSignatureNode)
-          if (reqNode->getKind() == NodeKind::DependentGenericParamCount)
-            if (reqNode->hasIndex())
-              genericParamsAtDepth.push_back(reqNode->getIndex());
+        if (auto error = decodeDependentGenericSignatureNode(
+                dependentGenericSignatureNode, requirements,
+                genericParamsAtDepth))
+          return *error;
+
         unsigned depth = 0;
         unsigned index = 0;
         for (auto *subst : *substNode) {
@@ -1443,6 +1447,43 @@ private:
 
     params.push_back(std::move(param));
     return true;
+  }
+
+  llvm::Optional<TypeLookupError> decodeDependentGenericSignatureNode(
+      NodePointer dependentGenericSignatureNode,
+      llvm::SmallVectorImpl<BuiltRequirement> &requirements,
+      llvm::SmallVectorImpl<unsigned> &genericParamsAtDepth) {
+    using NodeKind = Demangle::Node::Kind;
+    if (dependentGenericSignatureNode->getKind() !=
+        NodeKind::DependentGenericSignature)
+      return llvm::Optional<TypeLookupError>(
+          MAKE_NODE_TYPE_ERROR0(dependentGenericSignatureNode,
+                                "expected dependent generic signature"));
+    if (dependentGenericSignatureNode->getNumChildren() < 1)
+      return llvm::Optional<TypeLookupError>(MAKE_NODE_TYPE_ERROR(
+          dependentGenericSignatureNode,
+          "fewer children (%zu) than required (1)",
+          dependentGenericSignatureNode->getNumChildren()));
+    decodeRequirement<BuiltType, BuiltRequirement, BuiltLayoutConstraint,
+                      BuilderType>(dependentGenericSignatureNode, requirements,
+                                   Builder /*,
+[&](NodePointer Node) -> BuiltType {
+return decodeMangledType(Node).getType();
+},
+[&](LayoutConstraintKind Kind) -> BuiltLayoutConstraint {
+return {}; // Not implemented!
+},
+[&](LayoutConstraintKind Kind, unsigned SizeInBits,
+unsigned Alignment) -> BuiltLayoutConstraint {
+return {}; // Not Implemented!
+}*/);
+    // The number of generic parameters at each depth are in a mini
+    // state machine and come first.
+    for (auto *reqNode : *dependentGenericSignatureNode)
+      if (reqNode->getKind() == NodeKind::DependentGenericParamCount)
+        if (reqNode->hasIndex())
+          genericParamsAtDepth.push_back(reqNode->getIndex());
+    return llvm::None;
   }
 };
 

--- a/include/swift/IRGen/IRGenSILPasses.h
+++ b/include/swift/IRGen/IRGenSILPasses.h
@@ -19,6 +19,7 @@ namespace irgen {
 /// Create a pass to hoist alloc_stack instructions with non-fixed size.
 SILTransform *createAllocStackHoisting();
 SILTransform *createLoadableByAddress();
+SILTransform *createPartialApplyLowering();
 
 } // end namespace irgen
 } // end namespace swift

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -447,6 +447,11 @@ class LinkEntity {
     /// context.
     /// The pointer is a SILFunction*.
     AsyncFunctionPointer,
+
+    /// The thunk provided for partially applying a function at some values
+    /// which are captured.
+    /// The pointer is an llvm::Function*.
+    PartialApplyForwarder,
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;
 
@@ -1214,6 +1219,15 @@ public:
       llvm_unreachable("Link entity is not an async function pointer");
     }
 
+    return entity;
+  }
+
+  static LinkEntity forPartialApplyForwarder(llvm::Function *function) {
+    LinkEntity entity;
+    entity.Pointer = function;
+    entity.SecondaryPointer = nullptr;
+    entity.Data =
+        LINKENTITY_SET_FIELD(Kind, unsigned(Kind::PartialApplyForwarder));
     return entity;
   }
 

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -452,6 +452,10 @@ class LinkEntity {
     /// which are captured.
     /// The pointer is an llvm::Function*.
     PartialApplyForwarder,
+
+    /// An async function pointer to a partial apply forwarder.
+    /// The pointer is the llvm::Function* for a partial apply forwarder.
+    PartialApplyForwarderAsyncFunctionPointer,
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;
 
@@ -1175,6 +1179,10 @@ public:
       entity.Data = LINKENTITY_SET_FIELD(
           Kind, unsigned(LinkEntity::Kind::DispatchThunkAllocatorAsyncFunctionPointer));
       break;
+    case LinkEntity::Kind::PartialApplyForwarder:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::PartialApplyForwarderAsyncFunctionPointer));
+      break;
 
     default:
       llvm_unreachable("Link entity kind cannot have an async function pointer");
@@ -1213,6 +1221,11 @@ public:
     case LinkEntity::Kind::DispatchThunkAllocatorAsyncFunctionPointer:
       entity.Data = LINKENTITY_SET_FIELD(
           Kind, unsigned(LinkEntity::Kind::DispatchThunkAllocator));
+      break;
+
+    case LinkEntity::Kind::PartialApplyForwarderAsyncFunctionPointer:
+      entity.Data = LINKENTITY_SET_FIELD(
+          Kind, unsigned(LinkEntity::Kind::PartialApplyForwarder));
       break;
 
     default:

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -417,9 +417,14 @@ public:
       const TypeRef *result, FunctionTypeFlags flags) {
     return FunctionTypeRef::create(*this, params, result, flags);
   }
+  using BuiltSubstitution = std::pair<const TypeRef *, const TypeRef *>;
+  using BuiltRequirement = TypeRefRequirement;
 
   const FunctionTypeRef *createImplFunctionType(
       Demangle::ImplParameterConvention calleeConvention,
+      BuiltRequirement *witnessMethodConformanceRequirement,
+      const llvm::SmallVectorImpl<BuiltType> &genericParameters,
+      const llvm::SmallVectorImpl<BuiltRequirement> &requirements,
       llvm::ArrayRef<Demangle::ImplFunctionParam<const TypeRef *>> params,
       llvm::ArrayRef<Demangle::ImplFunctionResult<const TypeRef *>> results,
       llvm::Optional<Demangle::ImplFunctionResult<const TypeRef *>> errorResult,
@@ -519,8 +524,6 @@ public:
   }
 
   using BuiltSILBoxField = typename SILBoxTypeWithLayoutTypeRef::Field;
-  using BuiltSubstitution = std::pair<const TypeRef *, const TypeRef *>;
-  using BuiltRequirement = TypeRefRequirement;
   using BuiltLayoutConstraint = TypeRefLayoutConstraint;
   BuiltLayoutConstraint getLayoutConstraint(LayoutConstraintKind kind) {
     // FIXME: Implement this.

--- a/include/swift/SIL/SILInstructionWorklist.h
+++ b/include/swift/SIL/SILInstructionWorklist.h
@@ -215,7 +215,7 @@ public:
     return newInstruction;
   }
 
-  // This method is to be used when an instruction is found to be dead,
+  // This method is to be used when an instruction is found to be dead or
   // replaceable with another preexisting expression. Here we add all uses of
   // instruction to the worklist, and replace all uses of instruction with the
   // new value.

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -296,6 +296,8 @@ IRGEN_PASS(LoadableByAddress, "loadable-address",
      "SIL Large Loadable type by-address lowering.")
 PASS(MandatorySILLinker, "mandatory-linker",
      "Deserialize all referenced SIL functions that are shared or transparent")
+IRGEN_PASS(PartialApplyLowering, "partial-apply-lowering",
+           "Partial Apply Lowering")
 PASS(PerformanceSILLinker, "performance-linker",
      "Deserialize all referenced SIL functions")
 PASS(RawSILInstLowering, "raw-sil-inst-lowering",

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -478,11 +478,24 @@ getResultDifferentiability(ImplResultDifferentiability diffKind) {
 
 Type ASTBuilder::createImplFunctionType(
     Demangle::ImplParameterConvention calleeConvention,
+    BuiltRequirement *witnessMethodConformanceRequirement,
+    ArrayRef<BuiltType> GenericParameters,
+    ArrayRef<BuiltRequirement> Requirements,
     ArrayRef<Demangle::ImplFunctionParam<Type>> params,
     ArrayRef<Demangle::ImplFunctionResult<Type>> results,
     Optional<Demangle::ImplFunctionResult<Type>> errorResult,
     ImplFunctionTypeFlags flags) {
   GenericSignature genericSig;
+  if (GenericParameters.size() > 0) {
+    llvm::SmallVector<GenericTypeParamType *, 4> CastGenericParameters;
+    for (auto Parameter : GenericParameters) {
+      CastGenericParameters.push_back(
+          Parameter->castTo<GenericTypeParamType>());
+    }
+    genericSig = GenericSignature::get(CastGenericParameters, Requirements);
+  } else {
+    assert(Requirements.size() == 0);
+  }
 
   SILCoroutineKind funcCoroutineKind = SILCoroutineKind::None;
   ParameterConvention funcCalleeConvention =
@@ -567,11 +580,15 @@ Type ASTBuilder::createImplFunctionType(
                    representation, flags.isPseudogeneric(), !flags.isEscaping(),
                    flags.isConcurrent(), flags.isAsync(), diffKind, clangFnType)
                    .build();
-
-  return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,
-                              funcCalleeConvention, funcParams, funcYields,
-                              funcResults, funcErrorResult,
-                              SubstitutionMap(), SubstitutionMap(), Ctx);
+  auto witnessMethodConformance =
+      witnessMethodConformanceRequirement
+          ? ProtocolConformanceRef(
+                witnessMethodConformanceRequirement->getProtocolDecl())
+          : ProtocolConformanceRef();
+  return SILFunctionType::get(
+      genericSig, einfo, funcCoroutineKind, funcCalleeConvention, funcParams,
+      funcYields, funcResults, funcErrorResult,
+      SubstitutionMap(), SubstitutionMap(), Ctx, witnessMethodConformance);
 }
 
 Type ASTBuilder::createProtocolCompositionType(

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -52,6 +52,7 @@ add_swift_host_library(swiftIRGen STATIC
   MetadataLayout.cpp
   MetadataRequest.cpp
   Outlining.cpp
+  PartialApplyLowering.cpp
   StructLayout.cpp
   SwiftTargetInfo.cpp
   TypeLayout.cpp

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3334,19 +3334,6 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
   Explosion llArgs;
 
   auto &lv = getLoweredValue(i->getCallee());
-  if (i->getOrigCalleeType()->isAsync()) {
-    auto result = getPartialApplicationFunction(*this, i->getCallee(),
-                                                i->getSubstitutionMap(),
-                                                i->getSubstCalleeType());
-    llvm::Value *innerContext = std::get<1>(result);
-    llvm::Value *size;
-    llvm::Value *fnPtr;
-    std::tie(fnPtr, size) = getAsyncFunctionAndSize(
-        *this, i->getOrigCalleeType()->getRepresentation(), std::get<0>(result),
-        innerContext, {/*function*/ false, /*size*/ true});
-    assert(fnPtr == nullptr);
-    llArgs.add(size);
-  }
 
   // Lower the parameters in the callee's generic context.
   {

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -447,7 +447,8 @@ std::string LinkEntity::mangleAsString() const {
   case Kind::AsyncFunctionPointer:
   case Kind::DispatchThunkAsyncFunctionPointer:
   case Kind::DispatchThunkInitializerAsyncFunctionPointer:
-  case Kind::DispatchThunkAllocatorAsyncFunctionPointer: {
+  case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::PartialApplyForwarderAsyncFunctionPointer: {
     std::string Result(getUnderlyingEntityForAsyncFunctionPointer()
         .mangleAsString());
     Result.append("Tu");
@@ -742,6 +743,7 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::DispatchThunkAsyncFunctionPointer:
   case Kind::DispatchThunkInitializerAsyncFunctionPointer:
   case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::PartialApplyForwarderAsyncFunctionPointer:
     return getUnderlyingEntityForAsyncFunctionPointer()
         .getLinkage(ForDefinition);
   case Kind::PartialApplyForwarder:
@@ -769,6 +771,7 @@ bool LinkEntity::isContextDescriptor() const {
   case Kind::DispatchThunkAsyncFunctionPointer:
   case Kind::DispatchThunkInitializerAsyncFunctionPointer:
   case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::PartialApplyForwarderAsyncFunctionPointer:
   case Kind::MethodDescriptor:
   case Kind::MethodDescriptorDerivative:
   case Kind::MethodDescriptorInitializer:
@@ -942,6 +945,7 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
   case Kind::DispatchThunkAsyncFunctionPointer:
   case Kind::DispatchThunkInitializerAsyncFunctionPointer:
   case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::PartialApplyForwarderAsyncFunctionPointer:
   case Kind::AsyncFunctionPointerAST:
     return IGM.AsyncFunctionPointerTy;
   case Kind::PartialApplyForwarder:
@@ -977,6 +981,7 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   case Kind::DispatchThunkAsyncFunctionPointer:
   case Kind::DispatchThunkInitializerAsyncFunctionPointer:
   case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::PartialApplyForwarderAsyncFunctionPointer:
   case Kind::ObjCClassRef:
   case Kind::ObjCClass:
   case Kind::TypeMetadataLazyCacheVariable:
@@ -1124,6 +1129,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   case Kind::DispatchThunkAsyncFunctionPointer:
   case Kind::DispatchThunkInitializerAsyncFunctionPointer:
   case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::PartialApplyForwarderAsyncFunctionPointer:
     return getUnderlyingEntityForAsyncFunctionPointer()
         .isWeakImported(module);
   }
@@ -1239,6 +1245,7 @@ DeclContext *LinkEntity::getDeclContextForEmission() const {
   case Kind::DispatchThunkAsyncFunctionPointer:
   case Kind::DispatchThunkInitializerAsyncFunctionPointer:
   case Kind::DispatchThunkAllocatorAsyncFunctionPointer:
+  case Kind::PartialApplyForwarderAsyncFunctionPointer:
     return getUnderlyingEntityForAsyncFunctionPointer()
         .getDeclContextForEmission();
   }

--- a/lib/IRGen/PartialApplyLowering.cpp
+++ b/lib/IRGen/PartialApplyLowering.cpp
@@ -1,0 +1,475 @@
+//===---- PartialApplyLowering.cpp - Prepare partial_applies for IRGen ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "partial-apply-lowerer"
+
+#include "swift/AST/ExtInfo.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/IRGen/IRGenSILPasses.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILInstructionWorklist.h"
+#include "swift/SIL/SILVisitor.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "llvm/ADT/None.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#include "IRGenMangler.h"
+#include "IRGenModule.h"
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                        PartialApplyLowerer Interface
+//===----------------------------------------------------------------------===//
+
+class PartialApplyLowerer
+    : public SILInstructionVisitor<PartialApplyLowerer, SILInstruction *> {
+
+  SILFunction &function;
+  irgen::IRGenModule &IGM;
+  SILOptFunctionBuilder &thunkBuilder;
+
+  SmallSILInstructionWorklist<256> worklist;
+  bool madeChange;
+
+  InstModCallbacks instModCallbacks;
+  SmallVectorImpl<SILFunction *> &thunks;
+  SmallVector<SILInstruction *, 16> instructionsPendingDeletion;
+
+  SILFunction *createThunk(PartialApplyInst *instruction);
+  CanSILFunctionType createThunkType(PartialApplyInst *instruction);
+
+public:
+  PartialApplyLowerer(SILFunction &function, irgen::IRGenModule &IGM,
+                      SILOptFunctionBuilder &thunkBuilder,
+                      SmallVectorImpl<SILFunction *> &thunks)
+      : function(function), IGM(IGM), thunkBuilder(thunkBuilder),
+        worklist("APAF"), madeChange(false),
+        instModCallbacks(
+            [&](SILInstruction *instruction) {
+              worklist.erase(instruction);
+              instructionsPendingDeletion.push_back(instruction);
+            },
+            [&](SILInstruction *instruction) { worklist.add(instruction); },
+            [this](Operand *use, SILValue newValue) {
+              use->set(newValue);
+              worklist.add(use->getUser());
+            }),
+        thunks(thunks) {}
+
+  bool run();
+
+  SILInstruction *visitSILInstruction(SILInstruction *) { return nullptr; }
+  SILInstruction *visitPartialApplyInst(PartialApplyInst *instruction);
+};
+
+//===----------------------------------------------------------------------===//
+//                PartialApplyLowerer Utility Methods
+//===----------------------------------------------------------------------===//
+
+bool PartialApplyLowerer::run() {
+  madeChange = false;
+
+  for (auto &block : function) {
+    for (auto &instruction : block) {
+      worklist.add(&instruction);
+    }
+  }
+
+  while (!worklist.isEmpty()) {
+    auto *instruction = worklist.pop_back_val();
+    if (instruction == nullptr) {
+      continue;
+    }
+
+#ifndef NDEBUG
+    std::string instructionDescription;
+#endif
+    LLVM_DEBUG(llvm::raw_string_ostream SS(instructionDescription);
+               instruction->print(SS); instructionDescription = SS.str(););
+    LLVM_DEBUG(llvm::dbgs()
+               << "APAF: Visiting: " << instructionDescription << '\n');
+
+    if (auto replacement = visit(instruction)) {
+      worklist.replaceInstructionWithInstruction(instruction, replacement
+#ifndef NDEBUG
+                                                 ,
+                                                 instructionDescription
+#endif
+      );
+      madeChange = true;
+    }
+  }
+  for (SILInstruction *instruction : instructionsPendingDeletion) {
+    worklist.eraseInstFromFunction(*instruction);
+    madeChange = true;
+  }
+  instructionsPendingDeletion.clear();
+
+  return madeChange;
+}
+
+CanSILFunctionType
+PartialApplyLowerer::createThunkType(PartialApplyInst *instruction) {
+  // The type is defined in three stages:
+  // (1) creation of an AnyFunctionType as follows:
+  //     arguments:
+  //     - the arguments of the callee
+  //     - the callee itself
+  //     result:
+  //     - the results of the callee
+  //     generic signature:
+  //     - the signature of the original function, if any
+  // (2) lowering that AnyFunctionType to an initial SILFunctionType
+  // (3) create the final SILFunctionType whose by adjusting the parameter
+  //     convention of every parameter (except the final) to match the
+  //     callee's convention for that parameter
+  // TODO: Just define the type correctly to begin with.
+
+  auto calleeType = instruction->getSubstCalleeType();
+
+  // (1) Create an AnyFunctionType.
+  // Form the result type which is just the tuple consisting of the callee's
+  // results.
+  llvm::SmallVector<TupleTypeElt, 2> results;
+  for (auto result : calleeType->getResults()) {
+    results.push_back(
+        result
+            .getReturnValueType(function.getModule(), calleeType,
+                                function.getTypeExpansionContext())
+            ->mapTypeOutOfContext());
+  }
+  auto resultType =
+      TupleType::get(results, function.getModule().getASTContext());
+
+  // Form the list of parameters.  These are the original callee's parameters
+  // followed by the callee itself.
+  llvm::SmallVector<AnyFunctionType::Param, 8> parameters; {
+    for (auto parameter : calleeType->getParameters()) {
+      parameters.push_back(AnyFunctionType::Param(
+          parameter
+              .getArgumentType(function.getModule(), calleeType,
+                               function.getTypeExpansionContext())
+              ->mapTypeOutOfContext(),
+          Identifier()));
+    }
+    switch (calleeType->getRepresentation()) {
+    case swift::SILFunctionTypeRepresentation::Method:
+    case swift::SILFunctionTypeRepresentation::WitnessMethod:
+      // If the function is a method or a witness method, keep its generic
+      // arguments.
+      parameters.push_back(
+          AnyFunctionType::Param(instruction->getOrigCalleeType()));
+      break;
+    case swift::SILFunctionTypeRepresentation::Thin:
+    case swift::SILFunctionTypeRepresentation::Thick:
+    case swift::SILFunctionTypeRepresentation::Block:
+    case swift::SILFunctionTypeRepresentation::Closure:
+    case swift::SILFunctionTypeRepresentation::ObjCMethod:
+    case swift::SILFunctionTypeRepresentation::CFunctionPointer:
+      // Non-constant thick functions which are generic, i.e. those that are
+      // passed-in as arguments, will refer to the archetypes of the function
+      // to which they are passed  As such, in order to be passed to the thunk,
+      // their types must be mapped out of the function's context to replace
+      // those archetypes with generic parameters.
+      parameters.push_back(
+          AnyFunctionType::Param(calleeType->mapTypeOutOfContext()));
+      break;
+    }
+  }
+
+  // The generic signature is just the original function's generic signature.
+  CanGenericSignature signature;
+  if (auto *env = function.getGenericEnvironment()) {
+    signature = env->getGenericSignature()->getCanonicalSignature();
+  } else {
+    signature = CanGenericSignature();
+  }
+
+  AnyFunctionType *ty;
+  if (signature) {
+    GenericFunctionType::ExtInfo info;
+    ty = GenericFunctionType::get(signature, parameters, resultType, info);
+  } else {
+    FunctionType::ExtInfo info;
+    ty = FunctionType::get(parameters, resultType, info);
+  }
+
+  // (2) Lower the initial AnyFunctionType to a SILFunctionType.
+  auto unadjusted =
+      IGM.getLoweredType(ty).castTo<SILFunctionType>()->getWithExtInfo(
+          SILExtInfoBuilder()
+              .withAsync()
+              .withRepresentation(SILFunctionTypeRepresentation::Thin)
+              .build());
+
+  // (3) Create the final SILFunctionType by modifying the parameters of the
+  //     intermediate SILFunctionType.
+  // Adjust the parameter infos of each of the function's parameters to match
+  // those of the callee, since that information gets lost during lowering.
+  llvm::SmallVector<SILParameterInfo, 2> parameterInfos; {
+    auto originalThunkParameters = unadjusted->getParameters();
+    auto calleeParameters = calleeType->getParameters();
+    for (auto index : indices(originalThunkParameters)) {
+      auto originalThunkParameter = originalThunkParameters[index];
+      if (index < calleeParameters.size()) {
+        auto calleeParameter = calleeParameters[index];
+        SILParameterInfo info =
+            SILParameterInfo(originalThunkParameter.getInterfaceType(),
+                             calleeParameter.getConvention(),
+                             originalThunkParameter.getDifferentiability());
+        parameterInfos.push_back(info);
+      } else {
+        parameterInfos.push_back(originalThunkParameter);
+      }
+    }
+  }
+
+  auto result = SILFunctionType::get(
+      unadjusted->getInvocationGenericSignature().getPointer(),
+      unadjusted->getExtInfo(), unadjusted->getCoroutineKind(),
+      unadjusted->getCalleeConvention(), parameterInfos,
+      unadjusted->getYields(), unadjusted->getResults(),
+      unadjusted->hasErrorResult()
+          ? Optional<SILResultInfo>(unadjusted->getErrorResult())
+          : llvm::None,
+      unadjusted->getPatternSubstitutions(),
+      unadjusted->getInvocationSubstitutions(), function.getASTContext(),
+      unadjusted->getWitnessMethodConformanceOrInvalid());
+
+  return result;
+}
+
+SILFunction *PartialApplyLowerer::createThunk(PartialApplyInst *instruction) {
+  auto calleeType = instruction->getSubstCalleeType();
+  auto thunkType = createThunkType(instruction);
+
+  irgen::IRGenMangler Mangler;
+  auto name = Mangler.mangleAsyncNonconstantPartialApplyThunk(
+      function.getName(), thunks.size());
+
+  SILLocation location = RegularLocation::getAutoGeneratedLocation();
+  auto *thunk = thunkBuilder.createFunction(
+      /*linkage=*/SILLinkage::Private, /*name=*/name,
+      /*type=*/thunkType,
+      /*genericEnv=*/function.getGenericEnvironment(), /*loc*/ llvm::None,
+      /*isBareSILFunction=*/IsNotBare, /*isTransparent=*/IsNotTransparent,
+      /*isSerialized=*/IsNotSerialized, /*isDynamic=*/IsNotDynamic,
+      ProfileCounter(),
+      /*isThunk=*/IsThunk, /*subclassScope=*/SubclassScope::NotApplicable,
+      /*inlineStrategy=*/InlineDefault,
+      /*effectsKind=*/EffectsKind::Unspecified,
+      /*InsertBefore=*/nullptr, function.getDebugScope());
+
+  thunk->setDebugScope(new (function.getModule())
+                           SILDebugScope(function.getLocation(), thunk));
+
+  auto *body = thunk->createBasicBlock();
+  SILBuilder builder(body);
+  builder.setCurrentDebugScope(body->getParent()->getDebugScope());
+
+  SILFunctionConventions fnConv(thunkType, IGM.getSILModule());
+  for (auto indirectResult : thunkType->getIndirectFormalResults()) {
+    auto outTy =
+        fnConv.getSILType(indirectResult, function.getTypeExpansionContext());
+    outTy = thunk->mapTypeIntoContext(outTy);
+    body->createFunctionArgument(outTy, nullptr);
+  }
+
+  for (auto parameter : thunkType->getParameters()) {
+    if (auto *genericEnvironment = thunk->getGenericEnvironment()) {
+      auto argTy =
+          genericEnvironment->mapTypeIntoContext(parameter.getInterfaceType())
+              ->getCanonicalType();
+      parameter = SILParameterInfo(argTy, parameter.getConvention(),
+                                   parameter.getDifferentiability());
+    }
+    auto argTy =
+        fnConv.getSILType(parameter, function.getTypeExpansionContext());
+    body->createFunctionArgument(argTy, nullptr);
+  }
+
+  auto args = body->getSILFunctionArguments();
+  auto size = args.size();
+  SILValue callee = args[size - 1];
+
+  llvm::SmallVector<SILValue, 8> forwardedArguments;
+  for (unsigned index = 0, end = size - 1; index < end; ++index) {
+    forwardedArguments.push_back(body->getArgument(index));
+  }
+
+  if (isConsumedParameter(calleeType->getCalleeConvention())) {
+    callee = builder.createCopyValue(location, callee);
+  }
+
+  auto returnValue = builder.createApply(
+      location, callee, instruction->getSubstitutionMap(), forwardedArguments);
+  builder.createReturn(location, returnValue);
+
+  assert(function.getDebugScope()->Parent != thunk->getDebugScope()->Parent);
+
+  return thunk;
+}
+
+//===----------------------------------------------------------------------===//
+//                PartialApplyLowerer Visitor Methods
+//===----------------------------------------------------------------------===//
+
+SILInstruction *
+PartialApplyLowerer::visitPartialApplyInst(PartialApplyInst *instruction) {
+  if (!instruction->getFunctionType()->isAsync()) {
+    return nullptr;
+  }
+
+  // If we cannot get the referenced function, then we have a non-constant
+  // function.  IRGen cannot create an AsyncFunctionPointer for the partial
+  // apply forwarder it will generate for this partial_apply instruction because
+  // the AsyncFunctionPointers it forms for partial apply forwarders contain
+  // the same async context size as the function which is partially applied*.
+  // Without a fixed function which is partially applied, there is no fixed size
+  // to use for the AsyncFunctionPointer.
+  //
+  // * In fact, it emits the @llvm.coro.async.size.replace intrinsic into the
+  //   partial apply forwarder's body which is then processed by LLVM's
+  //   CoroCleanup to rewrite the AsyncFunctionPointer for the forwarder with
+  //   the async context size of the function which is partially applied.  In
+  //   any case, a fixed function whose async context size can be used is
+  //   required.
+  if (instruction->getReferencedFunctionOrNull() != nullptr) {
+    return nullptr;
+  }
+  // if (calleeType->getRepresentation() !=
+  // SILFunctionTypeRepresentation::Thick) {
+  //  return nullptr;
+  //}
+
+  // A partial apply of a thick, async function:
+  //
+  //     %closure1 = partial_apply %thick_input(%captures)
+  //                 : @async @convention(thick) (
+  //                     Rest...,
+  //                     Captures...
+  //                 )
+  //                     -> Return
+  //
+  // Make two changes:
+  // (1) Introduce a function
+  //
+  //     sil thunk(
+  //         %rest... : Rest...,
+  //         %captures... : Captures...,
+  //         %thick_input : @async @convention(thick) (
+  //             Rest...,
+  //             Captures...
+  //         )
+  //             -> Return,
+  //     )
+  //         -> Return
+  //     {
+  //       %return = apply %thick_input(%rest..., %captures...)
+  //                 : @async @convention(thick) (
+  //                     Rest...,
+  //                     Captures...
+  //                 )
+  //                     -> Return
+  //       return %return : $Return
+  //     }
+  //
+  // (2) Replace the original instruction
+  //
+  //     %callee = function_ref @thunk : $@async @convention(thin)
+  //     %closure2 = partial_apply %callee(%captures..., %thick_input)
+  //                : $@async @convention(thin) (
+  //                      Captures...,
+  //                      Rest...,
+  //                      @async @convention(thick) (Rest..., Captures...) -> Return
+  //                  )
+  //
+  // Note that the type of the original's return
+  //
+  //     %closure1 : $@async @convention(thick) (Rest...) -> Return
+  //
+  // matches that of the replacement instruction's return
+  //
+  //     %closure2 : $@async @convention(thick) (Rest...) -> Return
+
+  // (1) Introduce the thunk.
+  auto *thunk = createThunk(instruction);
+  thunks.push_back(thunk);
+
+  // (2) Replace the original partial_apply with a partial_apply of the
+  //     thunk, adding the original callee as the final argument.
+  llvm::SmallVector<SILValue, 8> arguments;
+  {
+    for (auto argument : instruction->getArguments()) {
+      arguments.push_back(argument);
+    }
+    arguments.push_back(instruction->getCallee());
+  }
+
+  SILBuilderWithScope originalBuilder(instruction);
+  // %callee = function_ref @thunk : $@async @convention(thin) (
+  //               Rest...,
+  //               Captures...,
+  //               @async @convention(thick) (
+  //                   Rest...,
+  //                   Captures...
+  //               ) -> Return
+  //           ) -> Return
+  SILValue thunkRef =
+      originalBuilder.createFunctionRef(instruction->getLoc(), thunk);
+  // %closure2 = partial_apply %callee(%captures..., %thick_input)
+  //            : $@async @convention(thin) (
+  //                  Captures...,
+  //                  Rest...,
+  //                  @async @convention(thick) (Rest..., Captures...) -> Return
+  //              )
+  auto *replacement = originalBuilder.createPartialApply(
+      instruction->getLoc(), thunkRef, thunk->getForwardingSubstitutionMap(),
+      arguments,
+      instruction->getType().getAs<SILFunctionType>()->getCalleeConvention(),
+      instruction->isOnStack(),
+      GenericSpecializationInformation::create(instruction, originalBuilder));
+
+  return replacement;
+}
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+class PartialApplyLowering : public SILFunctionTransform {
+  void run() override {
+    SmallVector<SILFunction *, 2> thunks;
+
+    auto *function = getFunction();
+    SILOptFunctionBuilder thunkBuilder(*this);
+    PartialApplyLowerer lowerer(*function, *getIRGenModule(), thunkBuilder,
+                                thunks);
+    if (lowerer.run()) {
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Everything);
+
+      for (auto thunk : thunks) {
+        addFunctionToPassManagerWorklist(thunk, function);
+      }
+    }
+  }
+};
+} // end anonymous namespace
+
+SILTransform *irgen::createPartialApplyLowering() {
+  return new PartialApplyLowering();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -752,6 +752,7 @@ SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
   // Insert SIL passes to run during IRGen.
   // Hoist generic alloc_stack instructions to the entry block to enable better
   // llvm-ir generation for dynamic alloca instructions.
+  P.addPartialApplyLowering();
   P.addAllocStackHoisting();
   P.addLoadableByAddress();
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1499,8 +1499,58 @@ public:
                                          result);
   }
 
+  struct BuiltLayoutConstraint {
+    bool operator==(BuiltLayoutConstraint rhs) const { return true; }
+    operator bool() const { return true; }
+  };
+  using BuiltLayoutConstraint = BuiltLayoutConstraint;
+  BuiltLayoutConstraint getLayoutConstraint(LayoutConstraintKind kind) {
+    return {};
+  }
+  BuiltLayoutConstraint
+  getLayoutConstraintWithSizeAlign(LayoutConstraintKind kind, unsigned size,
+                                   unsigned alignment) {
+    return {};
+  }
+
+#if LLVM_PTR_SIZE == 4
+  /// Unfortunately the alignment of TypeRef is too large to squeeze in 3 extra
+  /// bits on (some?) 32-bit systems.
+  class BigBuiltTypeIntPair {
+    BuiltType Ptr;
+    RequirementKind Int;
+
+  public:
+    BigBuiltTypeIntPair(BuiltType ptr, RequirementKind i) : Ptr(ptr), Int(i) {}
+    RequirementKind getInt() const { return Int; }
+    BuiltType getPointer() const { return Ptr; }
+    uint64_t getOpaqueValue() const {
+      return (uint64_t)Ptr | ((uint64_t)Int << 32);
+    }
+  };
+#endif
+
+  struct Requirement : public RequirementBase<BuiltType,
+#if LLVM_PTR_SIZE == 4
+         BigBuiltTypeIntPair,
+#else
+         llvm::PointerIntPair<BuiltType, 3, RequirementKind>,
+
+#endif
+         BuiltLayoutConstraint> {
+    Requirement(RequirementKind kind, BuiltType first, BuiltType second)
+        : RequirementBase(kind, first, second) {}
+    Requirement(RequirementKind kind, BuiltType first,
+                BuiltLayoutConstraint second)
+        : RequirementBase(kind, first, second) {}
+  };
+  using BuiltRequirement = Requirement;
+
   TypeLookupErrorOr<BuiltType> createImplFunctionType(
       Demangle::ImplParameterConvention calleeConvention,
+      BuiltRequirement *witnessMethodConformanceRequirement,
+      llvm::ArrayRef<BuiltType> genericParameters,
+      llvm::ArrayRef<BuiltRequirement> requirements,
       llvm::ArrayRef<Demangle::ImplFunctionParam<BuiltType>> params,
       llvm::ArrayRef<Demangle::ImplFunctionResult<BuiltType>> results,
       llvm::Optional<Demangle::ImplFunctionResult<BuiltType>> errorResult,
@@ -1568,51 +1618,6 @@ public:
 
   using BuiltSILBoxField = llvm::PointerIntPair<BuiltType, 1>;
   using BuiltSubstitution = std::pair<BuiltType, BuiltType>;
-  struct BuiltLayoutConstraint {
-    bool operator==(BuiltLayoutConstraint rhs) const { return true; }
-    operator bool() const { return true; }
-  };
-  using BuiltLayoutConstraint = BuiltLayoutConstraint;
-  BuiltLayoutConstraint getLayoutConstraint(LayoutConstraintKind kind) {
-    return {};
-  }
-  BuiltLayoutConstraint
-  getLayoutConstraintWithSizeAlign(LayoutConstraintKind kind, unsigned size,
-                                   unsigned alignment) {
-    return {};
-  }
-
-#if LLVM_PTR_SIZE == 4
-  /// Unfortunately the alignment of TypeRef is too large to squeeze in 3 extra
-  /// bits on (some?) 32-bit systems.
-  class BigBuiltTypeIntPair {
-    BuiltType Ptr;
-    RequirementKind Int;
-  public:
-    BigBuiltTypeIntPair(BuiltType ptr, RequirementKind i) : Ptr(ptr), Int(i) {}
-    RequirementKind getInt() const { return Int; }
-    BuiltType getPointer() const { return Ptr; }
-    uint64_t getOpaqueValue() const {
-      return (uint64_t)Ptr | ((uint64_t)Int << 32);
-    }
-  };
-#endif
-
-  struct Requirement : public RequirementBase<BuiltType,
-#if LLVM_PTR_SIZE == 4
-         BigBuiltTypeIntPair,
-#else
-         llvm::PointerIntPair<BuiltType, 3, RequirementKind>,
-
-#endif
-         BuiltLayoutConstraint> {
-    Requirement(RequirementKind kind, BuiltType first, BuiltType second)
-        : RequirementBase(kind, first, second) {}
-    Requirement(RequirementKind kind, BuiltType first,
-                BuiltLayoutConstraint second)
-        : RequirementBase(kind, first, second) {}
-  };
-  using BuiltRequirement = Requirement;
 
   TypeLookupErrorOr<BuiltType> createSILBoxTypeWithLayout(
       llvm::ArrayRef<BuiltSILBoxField> Fields,

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -94,6 +94,7 @@ _$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Sw
 _$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
 _$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _$sTA.123 ---> {T:} partial apply forwarder with unmangled suffix ".123"
+$s4main3fooyySiFyyXEfU_TA.1 ---> {T:} closure #1 () -> () in main.foo(Swift.Int) -> ()partial apply forwarder with unmangled suffix ".1"
 _TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> ()
 _TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
 _TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -592,6 +592,14 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   return %40 : $()
 }
 
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc { i8*, %swift.refcounted* } @create_pa_f2(i8* %0, %swift.refcounted* %1, i32 %2) {{#[0-9]+}}
+sil @create_pa_f2 : $@convention(thin) (@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int64, Int32) -> @owned @async @callee_guaranteed (Int64) -> Int64 {
+bb0(%thick : $@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int64 , %captured : $Int32):
+  %pa_f = partial_apply [callee_guaranteed] %thick(%captured) : $@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int64
+  %pa_f2 = partial_apply [callee_guaranteed] %thick(%captured) : $@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int64
+  return %pa_f : $@async @callee_guaranteed (Int64) -> Int64
+}
+
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24complex_generic_functionTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
@@ -600,4 +608,6 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s12create_pa_f2Tw_"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s12create_pa_f2Tw0_"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -12,8 +12,17 @@ class SwiftClass {}
 sil_vtable SwiftClass {}
 sil @$s13partial_apply10SwiftClassCfD : $@async @convention(method) (SwiftClass) -> ()
 
-sil @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
-sil @partially_applyable_to_two_classes : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> ()
+sil @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> () {
+entry(%c : $SwiftClass):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+sil @partially_applyable_to_two_classes : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> () {
+entry(%c : $SwiftClass, %d : $SwiftClass):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+
 
 sil @use_closure : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
 
@@ -53,7 +62,10 @@ entry(%a : $SwiftClass, %b: $SwiftClass):
   return %t : $()
 }
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s22generic_captured_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-sil public_external @generic_captured_param : $@async @convention(thin) <T> (Int, @inout T) -> Int
+sil @generic_captured_param : $@async @convention(thin) <T> (Int, @inout T) -> Int {
+entry(%i : $Int, %t : $*T):
+return %i : $Int
+}
 
 sil @partial_apply_generic_capture : $@async @convention(thin) (Int) -> @async @callee_owned (Int) -> Int {
 entry(%x : $Int):
@@ -65,7 +77,11 @@ entry(%x : $Int):
   return %p : $@async @callee_owned (Int) -> Int
 }
 
-sil public_external @generic_captured_and_open_param : $@async @convention(thin) <T> (@in T, @inout T) -> @out T
+sil public @generic_captured_and_open_param : $@async @convention(thin) <T> (@in T, @inout T) -> @out T {
+entry(%o : $*T, %i : $*T, %io : $*T):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_open_generic_capture(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 sil @partial_apply_open_generic_capture : $@async @convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T {
@@ -80,7 +96,11 @@ entry(%a : $*T):
 /* as the partial apply context.                                             */
 /*****************************************************************************/
 
-sil public_external @guaranteed_captured_class_param : $@async @convention(thin) (Int, @guaranteed SwiftClass) -> Int
+sil public @guaranteed_captured_class_param : $@async @convention(thin) (Int, @guaranteed SwiftClass) -> Int {
+entry(%i : $Int, %c : $SwiftClass):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
@@ -91,7 +111,11 @@ bb0(%x : $SwiftClass):
   return %p : $@async @callee_owned (Int) -> Int
 }
 
-sil public_external @indirect_guaranteed_captured_class_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClass) -> Int
+sil public @indirect_guaranteed_captured_class_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClass) -> Int {
+entry(%i : $Int, %c : $*SwiftClass):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s40indirect_guaranteed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}} {
@@ -103,7 +127,11 @@ bb0(%x : $*SwiftClass):
   return %p : $@async @callee_owned (Int) -> Int
 }
 
-sil public_external @indirect_consumed_captured_class_param : $@async @convention(thin) (Int, @in SwiftClass) -> Int
+sil public @indirect_consumed_captured_class_param : $@async @convention(thin) (Int, @in SwiftClass) -> Int {
+entry(%i : $Int, %c : $*SwiftClass):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}} {
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s38indirect_consumed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
@@ -122,7 +150,12 @@ bb0(%x : $*SwiftClass):
 
 struct SwiftClassPair { var x: SwiftClass, y: SwiftClass }
 
-sil public_external @guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @guaranteed SwiftClassPair) -> Int
+sil public @guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @guaranteed SwiftClassPair) -> Int {
+entry(%i : $Int, %c : $SwiftClassPair):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s36guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
@@ -134,7 +167,11 @@ bb0(%x : $SwiftClassPair):
   return %p : $@async @callee_owned (Int) -> Int
 }
 
-sil public_external @indirect_guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
+sil public @indirect_guaranteed_captured_class_pair_param : $@async @convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int {
+entry(%i : $Int, %c : $*SwiftClassPair):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
@@ -146,7 +183,12 @@ bb0(%x : $*SwiftClassPair):
   return %p : $@async @callee_owned (Int) -> Int
 }
 
-sil public_external @indirect_consumed_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+sil public @indirect_consumed_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int {
+entry(%i : $Int, %c : $*SwiftClassPair):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s43indirect_consumed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
@@ -158,7 +200,11 @@ bb0(%x : $*SwiftClassPair):
   return %p : $@async @callee_owned (Int) -> Int
 }
 
-sil public_external @captured_fixed_and_dependent_params : $@async @convention(thin) <A> (@owned SwiftClass, @in A, Int) -> ()
+sil public @captured_fixed_and_dependent_params : $@async @convention(thin) <A> (@owned SwiftClass, @in A, Int) -> () {
+entry(%c : $SwiftClass, %a : $*A, %i : $Int):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_non_fixed_layout(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s35captured_fixed_and_dependent_paramsTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
@@ -169,7 +215,11 @@ bb0(%a : $SwiftClass, %b : $*T, %c : $Int):
   return %p : $@async @callee_owned () -> ()
 }
 
-sil public_external @captured_dependent_out_param : $@async @convention(thin) <A> (@in A) -> @out A
+sil public @captured_dependent_out_param : $@async @convention(thin) <A> (@in A) -> @out A {
+entry(%o : $*A, %i : $*A):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 sil @partial_apply_with_out_param : $@async @convention(thin) <T> (@in T) -> @async @callee_owned () -> @out T {
 bb0(%x : $*T):
@@ -207,9 +257,6 @@ sil public_external @receive_closure : $@async @convention(thin) <C where C : Ba
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_partial_apply(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-
 sil @test_partial_apply : $@async @convention(thin) (@owned Base) -> () {
 bb0(%0 : $Base):
  %1 = function_ref @parametric_casting_closure : $@async @convention(thin) <C where C : Base> (@owned Base) -> @owned C
@@ -221,26 +268,15 @@ bb0(%0 : $Base):
  return %5 : $()
 }
 
-sil public_external @partial_empty_box : $@async @convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
-
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @empty_box(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-sil @empty_box : $@async @convention(thin) () -> () {
-entry:
-  // CHECK: [[BOX:%.*]] = call {{.*}}swift_allocEmptyBox
-  // CHECK: store %swift.refcounted* [[BOX]]
-  // CHECK: store %swift.opaque* undef
-  %b = alloc_box $<τ_0_0> { var τ_0_0 } <()>
-  %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <()>, 0
-  %f = function_ref @partial_empty_box : $@async @convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
-  %g = partial_apply %f(%b, %ba) : $@async @convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout_aliasable ()) -> ()
-  return undef : $()
-}
-
 protocol P0 {}
 protocol P1 { associatedtype X : P0 }
 protocol P2 { associatedtype Y : P1 }
 
-sil hidden_external @complex_generic_function : $@async @convention(thin) <T where T : P2, T.Y : P2> (Int) -> ()
+sil hidden @complex_generic_function : $@async @convention(thin) <T where T : P2, T.Y : P2> (Int) -> () {
+entry(%i : $Int):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 sil @partial_apply_complex_generic_function : $@async @convention(thin) <T where T : P2, T.Y : P2> (Int) -> () {
 bb0(%0 : $Int):
@@ -250,14 +286,15 @@ bb0(%0 : $Int):
   return %result : $()
 }
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_complex_generic_function(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24complex_generic_functionTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-
 struct ComplexBoundedType<T: P2> {}
 
 // SR-901: Ensure that a partial_apply which captures bound generic type
 // metadata doesn't crash when restoring the generic context.
 
-sil hidden_external @generic_function : $@async @convention(thin) <T> () -> ()
+sil hidden @generic_function : $@async @convention(thin) <T> () -> () {
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 sil @partial_apply_with_generic_type : $@async @convention(thin) <U: P2> () -> () {
 bb0:
   %fn = function_ref @generic_function : $@async @convention(thin) <T> () -> ()
@@ -286,16 +323,18 @@ enum GenericEnum<T> {
   case X(String)
   case Y(T, T, T, T, T)
 }
-sil public_external @generic_indirect_return : $@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
+sil public @generic_indirect_return : $@async @convention(thin) <T> (Int) -> @owned GenericEnum<T> {
+entry(%i : $Int):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23generic_indirect_returnTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 sil @partial_apply_generic_indirect_return : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum<Int> {
   bb0(%0 : $Int):
   %fn = function_ref @generic_indirect_return :$@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
   %pa = partial_apply %fn<Int> (%0) : $@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
   return %pa : $@async @callee_owned () -> @owned GenericEnum<Int>
-
 }
 
 // Crash on partial apply of a generic enum.
@@ -303,10 +342,13 @@ enum GenericEnum2<T> {
   case X(String)
   case Y(T)
 }
-sil public_external @generic_indirect_return2 : $@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T>
+sil public @generic_indirect_return2 : $@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T> {
+entry(%i : $Int):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return2(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24generic_indirect_return2TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 sil @partial_apply_generic_indirect_return2 : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum2<Int> {
   bb0(%0 : $Int):
   %fn = function_ref @generic_indirect_return2 :$@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T>
@@ -316,7 +358,11 @@ sil @partial_apply_generic_indirect_return2 : $@async @convention(thin) (Int) ->
 
 struct SwiftStruct {}
 
-sil @fun : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> ()
+sil @fun : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> () {
+entry(%t : $@thin SwiftStruct.Type, %c : $SwiftClass):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_thin_type(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
@@ -358,7 +404,11 @@ struct A2<T>  {
 
 class  A3 {}
 
-sil @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error)
+sil @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error) {
+entry(%a : $*A2<A3>):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 sil @repo : $@async @convention(thin) (@in_guaranteed A2<A3>) -> @owned @async @callee_guaranteed () -> (@owned A1, @error Error) {
 bb0(%0 : $*A2<A3>):
@@ -405,7 +455,6 @@ bb0(%x : $*SwiftClassPair):
 sil public_external @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
 sil @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in_guaranteed SwiftClassPair) -> () {
 bb0(%x : $*SwiftClassPair):
@@ -419,9 +468,12 @@ bb0(%x : $*SwiftClassPair):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
-sil public_external @indirect_in_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int
+sil public @indirect_in_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int {
+entry(%i : $Int, %p : $*SwiftClassPair):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 sil @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> () {
 bb0(%x : $*SwiftClassPair):
@@ -437,9 +489,12 @@ bb0(%x : $*SwiftClassPair):
 
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
-sil public_external @indirect_in_constant_captured_class_pair_param : $@async @convention(thin) (Int, @in_constant SwiftClassPair) -> Int
+sil public @indirect_in_constant_captured_class_pair_param : $@async @convention(thin) (Int, @in_constant SwiftClassPair) -> Int {
+entry(%i : $Int, %ic : $*SwiftClassPair):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 sil @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> () {
 bb0(%x : $*SwiftClassPair):
@@ -453,7 +508,11 @@ bb0(%x : $*SwiftClassPair):
   return %t : $()
 }
 
-sil public_external @closure : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> ()
+sil public @closure : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> () {
+entry(%i : $*ResilientInt, %c : $SwiftClass):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // Make sure that we use the heap header size (16) for the initial offset.
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_initial_offset(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
@@ -476,7 +535,11 @@ struct SomeType : Proto2 {
   var x : Int
 }
 
-sil @foo : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
+sil @foo : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> () {
+entry(%z : $*τ_0_0, %o : $*τ_0_1):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
@@ -503,7 +566,11 @@ struct FixedType {
 }
 // CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @fixed_followed_by_empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
-sil @foo2 : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
+sil @foo2 : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> () {
+entry(%z : $*τ_0_0, %o : $*τ_0_1, %t : $*τ_0_2):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 sil @fixed_followed_by_empty_followed_by_non_fixed : $@async @convention(thin)  (EmptyType, @in_guaranteed SomeType, FixedType) -> () {
 entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   %5 = alloc_stack $EmptyType
@@ -524,3 +591,12 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   %40 = tuple()
   return %40 : $()
 }
+
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24complex_generic_functionTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23generic_indirect_returnTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24generic_indirect_return2TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -I %t -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -g -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -g -I %t -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: concurrency
 
@@ -26,7 +26,7 @@ entry(%c : $SwiftClass, %d : $SwiftClass):
 
 sil @use_closure : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_class : $@async @convention(thin) (SwiftClass) -> @async @callee_owned () -> () {
 entry(%c : $SwiftClass):
   %f = function_ref @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
@@ -34,7 +34,7 @@ entry(%c : $SwiftClass):
   return %g : $@async @callee_owned () -> ()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class_on_stack(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class_on_stack(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_class_on_stack : $@async @convention(thin) (@owned SwiftClass) -> () {
 entry(%a : $SwiftClass):
   %f = function_ref @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
@@ -47,7 +47,7 @@ entry(%a : $SwiftClass):
   return %t : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_two_classes_on_stack(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_two_classes_on_stack(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_two_classes_on_stack : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> () {
 entry(%a : $SwiftClass, %b: $SwiftClass):
@@ -61,7 +61,7 @@ entry(%a : $SwiftClass, %b: $SwiftClass):
   %t = tuple()
   return %t : $()
 }
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s22generic_captured_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s22generic_captured_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @generic_captured_param : $@async @convention(thin) <T> (Int, @inout T) -> Int {
 entry(%i : $Int, %t : $*T):
 return %i : $Int
@@ -83,7 +83,7 @@ entry(%o : $*T, %i : $*T, %io : $*T):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_open_generic_capture(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_open_generic_capture(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_open_generic_capture : $@async @convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T {
 entry(%a : $*T):
   %f = function_ref @generic_captured_and_open_param : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
@@ -102,7 +102,7 @@ entry(%i : $Int, %c : $SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_guaranteed_class_param : $@async @convention(thin) (@owned SwiftClass) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $SwiftClass):
@@ -117,8 +117,8 @@ entry(%i : $Int, %c : $*SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s40indirect_guaranteed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s40indirect_guaranteed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_guaranteed_class_param : $@async @convention(thin) (@in SwiftClass) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClass):
@@ -133,8 +133,8 @@ entry(%i : $Int, %c : $*SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s38indirect_consumed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s38indirect_consumed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_consumed_class_param : $@async @convention(thin) (@in SwiftClass) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClass):
@@ -157,8 +157,8 @@ entry(%i : $Int, %c : $SwiftClassPair):
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s36guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s36guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_guaranteed_class_pair_param : $@async @convention(thin) (@owned SwiftClassPair) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $SwiftClassPair):
@@ -173,8 +173,8 @@ entry(%i : $Int, %c : $*SwiftClassPair):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClassPair):
@@ -190,8 +190,8 @@ entry(%i : $Int, %c : $*SwiftClassPair):
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s43indirect_consumed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s43indirect_consumed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_consumed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClassPair):
@@ -206,8 +206,8 @@ entry(%c : $SwiftClass, %a : $*A, %i : $Int):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_non_fixed_layout(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s35captured_fixed_and_dependent_paramsTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_non_fixed_layout(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s35captured_fixed_and_dependent_paramsTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_indirect_non_fixed_layout : $@async @convention(thin) <T> (@owned SwiftClass, @in T, Int) -> @async @callee_owned () -> () {
 bb0(%a : $SwiftClass, %b : $*T, %c : $Int):
   %f = function_ref @captured_fixed_and_dependent_params : $@async @convention(thin) <B> (@owned SwiftClass, @in B, Int) -> ()
@@ -228,7 +228,7 @@ bb0(%x : $*T):
   return %p : $@async @callee_owned () -> @out T
 }
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s28captured_dependent_out_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s28captured_dependent_out_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_dynamic_with_out_param : $@async @convention(thin) <T> (Int32, @owned @async @callee_owned (Int32) -> @out T) -> @async @callee_owned () -> @out T {
 bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
@@ -236,7 +236,7 @@ bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
   return %p : $@async @callee_owned () -> @out T
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_dynamic_with_out_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_dynamic_with_out_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 class Base {
 }
@@ -255,7 +255,7 @@ bb0(%0 : $Base):
 
 sil public_external @receive_closure : $@async @convention(thin) <C where C : Base> (@owned @async @callee_owned () -> (@owned C)) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_partial_apply(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_partial_apply(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @test_partial_apply : $@async @convention(thin) (@owned Base) -> () {
 bb0(%0 : $Base):
@@ -285,7 +285,7 @@ bb0(%0 : $Int):
   %result = tuple ()
   return %result : $()
 }
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_complex_generic_function(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_complex_generic_function(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 struct ComplexBoundedType<T: P2> {}
 
 // SR-901: Ensure that a partial_apply which captures bound generic type
@@ -329,7 +329,7 @@ entry(%i : $Int):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_generic_indirect_return : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum<Int> {
   bb0(%0 : $Int):
   %fn = function_ref @generic_indirect_return :$@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
@@ -348,7 +348,7 @@ entry(%i : $Int):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return2(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return2(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_generic_indirect_return2 : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum2<Int> {
   bb0(%0 : $Int):
   %fn = function_ref @generic_indirect_return2 :$@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T>
@@ -364,7 +364,7 @@ entry(%t : $@thin SwiftStruct.Type, %c : $SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_thin_type(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_thin_type(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_thin_type : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> @async @callee_owned () -> () {
 entry(%0: $@thin SwiftStruct.Type, %1: $SwiftClass):
@@ -376,7 +376,7 @@ entry(%0: $@thin SwiftStruct.Type, %1: $SwiftClass):
 sil @afun : $@async @convention(thin) (Int) -> @error Error
 
 // Check that we don't assert on a thin noescape function.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @convert_thin_test(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @convert_thin_test(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @convert_thin_test : $@async @convention(thin) (Int) -> () {
 bb(%0 : $Int):
   %f = function_ref @afun : $@async @convention(thin) (Int) -> @error Error
@@ -443,7 +443,7 @@ bb0(%0 : $*A2<A3>):
 sil_vtable A3 {}
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @owned @async @callee_guaranteed (Int) -> Int {
 bb0(%x : $*SwiftClassPair):
@@ -454,7 +454,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in_guaranteed SwiftClassPair) -> () {
 bb0(%x : $*SwiftClassPair):
@@ -467,7 +467,7 @@ bb0(%x : $*SwiftClassPair):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @indirect_in_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int {
 entry(%i : $Int, %p : $*SwiftClassPair):
@@ -488,7 +488,7 @@ bb0(%x : $*SwiftClassPair):
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @indirect_in_constant_captured_class_pair_param : $@async @convention(thin) (Int, @in_constant SwiftClassPair) -> Int {
 entry(%i : $Int, %ic : $*SwiftClassPair):
@@ -515,7 +515,7 @@ entry(%i : $*ResilientInt, %c : $SwiftClass):
 }
 
 // Make sure that we use the heap header size (16) for the initial offset.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_initial_offset(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_initial_offset(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @test_initial_offset : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> () {
 bb0(%x : $*ResilientInt, %y : $SwiftClass):
@@ -541,7 +541,7 @@ entry(%z : $*τ_0_0, %o : $*τ_0_1):
   unreachable
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @empty_followed_by_non_fixed : $@async @convention(thin)  (EmptyType, @in_guaranteed SomeType) -> () {
 entry(%0 : $EmptyType, %1: $*SomeType):
@@ -564,7 +564,7 @@ entry(%0 : $EmptyType, %1: $*SomeType):
 struct FixedType {
   var f: Int32
 }
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @fixed_followed_by_empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @fixed_followed_by_empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @foo2 : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> () {
 entry(%z : $*τ_0_0, %o : $*τ_0_1, %t : $*τ_0_2):
@@ -592,11 +592,12 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   return %40 : $()
 }
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24complex_generic_functionTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23generic_indirect_returnTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24generic_indirect_return2TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24complex_generic_functionTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23generic_indirect_returnTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24generic_indirect_return2TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -6,6 +6,7 @@
 sil_stage canonical
 
 import Builtin
+import Swift
 
 public protocol P {}
 public class C : P {}
@@ -28,8 +29,6 @@ bb0(%0 : $*S):
   return %2 : $@async @callee_owned (@in O) -> ()
 }
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23unspecialized_uncurriedTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-
 sil hidden @specialized_curried : $@async @convention(thin) (@owned E) -> @owned @async @callee_owned () -> @owned D<C> {
 bb0(%0 : $E):
   %1 = function_ref @unspecialized_uncurried : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@guaranteed E) -> @owned D<τ_0_0>
@@ -37,11 +36,18 @@ bb0(%0 : $E):
   return %2 : $@async @callee_owned () -> @owned D<C>
 }
 
-sil hidden_external @unspecialized_uncurried : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@guaranteed E) -> @owned D<τ_0_0>
+sil hidden @unspecialized_uncurried : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@guaranteed E) -> @owned D<τ_0_0> {
+entry(%e : $E):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingPTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-sil hidden_external @takingP : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+sil hidden_external @takingP : $@async @convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> () {
+entry(%p : $*τ_0_0):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 sil hidden @reabstract_context : $@async @convention(thin) (@owned C) -> () {
 bb0(%0 : $C):
@@ -67,12 +73,23 @@ public class WeakBox<T> {}
 
 public struct EmptyType {}
 
-sil hidden_external @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> ()
-sil hidden_external @takingQAndEmpty : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>, EmptyType) -> ()
-sil hidden_external @takingEmptyAndQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (EmptyType, @owned WeakBox<τ_0_0>) -> ()
+sil hidden @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> () {
+entry(%b : $WeakBox<τ_0_0>):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+sil hidden @takingQAndEmpty : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>, EmptyType) -> () {
+entry(%b : $WeakBox<τ_0_0>, %e : $EmptyType):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+sil hidden @takingEmptyAndQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (EmptyType, @owned WeakBox<τ_0_0>) -> () {
+entry(%e : $EmptyType, %b : $WeakBox<τ_0_0>):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @bind_polymorphic_param_from_context : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> () {
 bb0(%0 : $*τ_0_1):
@@ -101,7 +118,6 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_forwarder_parameter(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> () {
 bb0(%0 : $*τ_0_1):
@@ -116,10 +132,13 @@ struct S {
   var x : Builtin.Int64
 }
 
-sil hidden_external @takingQAndS : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (S, @owned WeakBox<τ_0_0>) -> ()
+sil hidden @takingQAndS : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (S, @owned WeakBox<τ_0_0>) -> () {
+entry(%s : $S, %b : $WeakBox<τ_0_0>):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context_with_layout(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s11takingQAndSTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil public @bind_polymorphic_param_from_context_with_layout : $@async @convention(thin) <τ_0_1>(@in τ_0_1, S) -> @owned @async @callee_owned () -> () {
 bb0(%0 : $*τ_0_1, %1: $S):
   %2 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
@@ -151,7 +170,6 @@ bb0:
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @specializes_closure_returning_closure(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s15returns_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 protocol MyEquatable {
   static func isEqual (lhs: Self, rhs: Self) -> Builtin.Int1
 }
@@ -179,8 +197,16 @@ extension Outer : MyEquatable where Value : MyEquatable {
 public struct Outermost<Value> {
 }
 
-sil @$closure : $@async @convention(method) <Value where Value : MyEquatable> (Outer<Value>, Outer<Value>, @thin Outer<Value>.Type) -> Builtin.Int1
-sil @$closure2 : $@async @convention(method) <Value where Value : MyEquatable> (Outermost<Value>, Outermost<Value>, @thin Outermost<Value>.Type) -> Builtin.Int1
+sil @$closure : $@async @convention(method) <Value where Value : MyEquatable> (Outer<Value>, Outer<Value>, @thin Outer<Value>.Type) -> Builtin.Int1 {
+entry(%o1 : $Outer<Value>, %o2 : $Outer<Value>, %ot : $@thin Outer<Value>.Type):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
+sil @$closure2 : $@async @convention(method) <Value where Value : MyEquatable> (Outermost<Value>, Outermost<Value>, @thin Outermost<Value>.Type) -> Builtin.Int1 {
+entry(%o1 : $Outermost<Value>, %o2 : $Outermost<Value>, %t : $@thin Outermost<Value>.Type):
+  %0 = builtin "int_trap"() : $Never
+  unreachable
+}
 
 sil @$dont_crash_test_capture_specialized_conditional_conformance : $@async @convention(thin) <Element where Element : MyExtended> (Outer<Inner<Element>>) -> () {
 bb0(%0 : $Outer<Inner<Element>>):
@@ -229,3 +255,11 @@ sil_vtable D {}
 sil_vtable E {}
 sil_vtable Empty {}
 sil_witness_table C: P module main {}
+
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23unspecialized_uncurriedTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingPTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s11takingQAndSTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s15returns_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+

--- a/test/IRGen/async/partial_apply_lowering.sil
+++ b/test/IRGen/async/partial_apply_lowering.sil
@@ -1,0 +1,34 @@
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all -inline -partial-apply-lowering %s | %FileCheck %s --check-prefix=CHECK-SIL
+
+import Builtin
+import Swift
+import SwiftShims
+
+
+public protocol Observable {
+  associatedtype Result
+  func subscribe<T: Observer>(o: T) async -> ()
+}
+public protocol Observer {
+  associatedtype Result
+}
+
+// CHECK-SIL-LABEL: sil hidden @witness_method : $@convention(thin) @async <S where S : Observable><O where O : Observer, S.Result == O.Result><T> (@in S, @in_guaranteed T) -> @owned @async @callee_guaranteed (@in O) -> () {
+//       CHECK-SIL: bb0([[OBSERVABLE:%[^,]+]] : $*S, [[GENERIC:%[^,]+]] : $*T):
+//       CHECK-SIL:   [[WITNESS_METHOD:%[^,]+]] = witness_method $S, #Observable.subscribe : <Self where Self : Observable><T where T : Observer> (Self) -> (T) async -> () : $@convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+//       CHECK-SIL:   [[THUNK:%[^,]+]] = function_ref @$s14witness_methodTw_ : $@convention(thin) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result><τ_2_0> (@in τ_1_0, @in_guaranteed τ_0_0, @convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()) -> ()
+//       CHECK-SIL:   [[THICK_FUNC:%[^,]+]] = partial_apply [callee_guaranteed] [[THUNK]]<S, O, T>([[OBSERVABLE]], [[WITNESS_METHOD]]) : $@convention(thin) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result><τ_2_0> (@in τ_1_0, @in_guaranteed τ_0_0, @convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()) -> ()
+//       CHECK-SIL:   return [[THICK_FUNC]] : $@async @callee_guaranteed (@in O) -> ()
+// CHECK-SIL-LABEL: } // end sil function 'witness_method'
+
+// CHECK-SIL-LABEL: sil private [thunk] [ossa] @$s14witness_methodTw_ : $@convention(thin) @async <S where S : Observable><O where O : Observer, S.Result == O.Result><T> (@in O, @in_guaranteed S, @convention(witness_method: Observable) @async <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in O, @in_guaranteed S) -> ()) -> () {
+//       CHECK-SIL: bb0([[OBSERVER:%[^,]+]] : $*O, [[OBSERVABLE:%[^,]+]] : $*S, [[WITNESS_METHOD:%[^,]+]] : $@convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()):
+//       CHECK-SIL:   [[RESULT:%[^,]+]] = apply [[WITNESS_METHOD]]<S, O>([[OBSERVER]], [[OBSERVABLE]]) : $@convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+//       CHECK-SIL:   return [[RESULT]] : $()
+// CHECK-SIL-LABEL: } // end sil function '$s14witness_methodTw_'
+sil hidden @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result><T> (@in S, @in_guaranteed T) -> @owned @async @callee_guaranteed (@in O) -> () {
+bb0(%0 : $*S, %t: $*T):
+  %1 = witness_method $S, #Observable.subscribe : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  %2 = partial_apply [callee_guaranteed] %1<S, O>(%0) : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  return %2 : $@async @callee_guaranteed (@in O) -> ()
+}

--- a/test/IRGen/async/run-partialapply-capture-classinstance_generic-and-int-to-string.sil
+++ b/test/IRGen/async/run-partialapply-capture-classinstance_generic-and-int-to-string.sil
@@ -18,7 +18,7 @@ import _Concurrency
 
 // CHECK-LL: @Super_runTu =
 // CHECK-LL: @Sub_runTu =
-// CHECK-LL: @"$s20partial_apply_methodTwTu" =
+// CHECK-LL: @"$s20partial_apply_methodTw_Tu" =
 
 protocol Q {
   func testU() -> String

--- a/test/IRGen/async/run-partialapply-capture-classinstance_generic-and-int-to-string.sil
+++ b/test/IRGen/async/run-partialapply-capture-classinstance_generic-and-int-to-string.sil
@@ -1,0 +1,295 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all -inline -partial-apply-lowering %s | %FileCheck %s --check-prefix=CHECK-SIL
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize_none
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+
+import Builtin
+import Swift
+import _Concurrency
+
+// CHECK-LL: @Super_runTu =
+// CHECK-LL: @Sub_runTu =
+// CHECK-LL: @"$s20partial_apply_methodTwTu" =
+
+protocol Q {
+  func testU() -> String
+}
+
+sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+class Super {
+  init(_ t: String)
+  @_hasStorage private final let t: String { get }
+  func run<U>(on u: U, at i: Int64) async -> String where U : Q
+  deinit
+}
+
+@_inheritsConvenienceInitializers class Sub : Super {
+  @_hasStorage @_hasInitialValue var t2: String? { get set }
+  override func run<U>(on u: U, at i: Int64) async -> String where U : Q
+  override init(_ t: String)
+  deinit
+}
+
+struct QImpl : Q {
+  func testU() -> String
+  init()
+}
+
+sil hidden [exact_self_class] @Super_allocating_init : $@convention(method) (@owned String, @thick Super.Type) -> @owned Super {
+bb0(%value : $String, %super_type : $@thick Super.Type):
+  %uninitialized = alloc_ref $Super
+  %Super_init = function_ref @Super_init : $@convention(method) (@owned String, @owned Super) -> @owned Super
+  %result = apply %Super_init(%value, %uninitialized) : $@convention(method) (@owned String, @owned Super) -> @owned Super
+  return %result : $Super
+}
+
+sil hidden @Super_init : $@convention(method) (@owned String, @owned Super) -> @owned Super {
+bb0(%value : $String, %instance : $Super):
+  retain_value %value : $String
+  %field_addr = ref_element_addr %instance : $Super, #Super.t
+  store %value to %field_addr : $*String
+  release_value %value : $String
+  return %instance : $Super
+}
+
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @Super_run(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2) #0 {
+sil hidden @Super_run : $@convention(method) @async <U where U : Q> (@in_guaranteed U, Int64, @guaranteed Super) -> @owned String {
+bb0(%generic_addr : $*U, %int_arg : $Int64, %int : $Super):
+  %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  // CHECK: QImpl()
+  %printGeneric_result = apply %printGeneric<U>(%generic_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %testU = witness_method $U, #Q.testU : <Self where Self : Q> (Self) -> () -> String : $@convention(witness_method: Q) <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0) -> @owned String
+  %testU_result = apply %testU<U>(%generic_addr) : $@convention(witness_method: Q) <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0) -> @owned String
+  %testU_result_addr = alloc_stack $String
+  store %testU_result to %testU_result_addr : $*String
+  // CHECK: QImpl.testU
+  %printGeneric_result2 = apply %printGeneric<String>(%testU_result_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %testU_result_addr : $*String
+  dealloc_stack %testU_result_addr : $*String
+  %int_arg_addr = alloc_stack $Int64
+  store %int_arg to %int_arg_addr : $*Int64
+  // CHECK: 42
+  %printGeneric_result3 = apply %printGeneric<Int64>(%int_arg_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  dealloc_stack %int_arg_addr : $*Int64
+  %field_addr = ref_element_addr %int : $Super, #Super.t
+  %field = load %field_addr : $*String
+  retain_value %field : $String
+  return %field : $String
+}
+
+sil hidden @Super_deinit : $@convention(method) (@guaranteed Super) -> @owned Builtin.NativeObject {
+bb0(%instance : $Super):
+  %field_addr = ref_element_addr %instance : $Super, #Super.t
+  %field = begin_access [deinit] [static] %field_addr : $*String
+  destroy_addr %field : $*String
+  end_access %field : $*String
+  %uninitialized = unchecked_ref_cast %instance : $Super to $Builtin.NativeObject
+  return %uninitialized : $Builtin.NativeObject
+}
+
+sil hidden @Super_deallocating_deinit : $@convention(method) (@owned Super) -> () {
+bb0(%instance : $Super):
+  %Super_deinit = function_ref @Super_deinit : $@convention(method) (@guaranteed Super) -> @owned Builtin.NativeObject
+  %uninitialized = apply %Super_deinit(%instance) : $@convention(method) (@guaranteed Super) -> @owned Builtin.NativeObject
+  %uninitailized_super = unchecked_ref_cast %uninitialized : $Builtin.NativeObject to $Super
+  dealloc_ref %uninitailized_super : $Super
+  %out = tuple ()
+  return %out : $()
+}
+
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @Sub_run(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2) #0 {
+sil hidden @Sub_run : $@convention(method) @async <U where U : Q> (@in_guaranteed U, Int64, @guaranteed Sub) -> @owned String {
+bb0(%U_addr : $*U, %int : $Int64, %sub : $Sub):
+  strong_retain %sub : $Sub
+  %super = upcast %sub : $Sub to $Super
+  %Super_run = function_ref @Super_run : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String
+  %result = apply %Super_run<U>(%U_addr, %int, %super) : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String
+  strong_release %super : $Super
+  return %result : $String
+}
+
+sil hidden [exact_self_class] @Sub_allocating_init : $@convention(method) (@owned String, @thick Sub.Type) -> @owned Sub {
+bb0(%value : $String, %type : $@thick Sub.Type):
+  %uninitialized = alloc_ref $Sub
+  %Sub_init = function_ref @Sub_init : $@convention(method) (@owned String, @owned Sub) -> @owned Sub
+  %result = apply %Sub_init(%value, %uninitialized) : $@convention(method) (@owned String, @owned Sub) -> @owned Sub
+  return %result : $Sub
+}
+
+sil hidden @Sub_init : $@convention(method) (@owned String, @owned Sub) -> @owned Sub {
+bb0(%value : $String, %uninitialized : $Sub):
+  %field_addr = ref_element_addr %uninitialized : $Sub, #Sub.t2
+  %none = enum $Optional<String>, #Optional.none!enumelt
+  store %none to %field_addr : $*Optional<String>
+  %uninitialized_super = upcast %uninitialized : $Sub to $Super
+  retain_value %value : $String
+  %Super_init = function_ref @Super_init : $@convention(method) (@owned String, @owned Super) -> @owned Super
+  %result_super = apply %Super_init(%value, %uninitialized_super) : $@convention(method) (@owned String, @owned Super) -> @owned Super
+  %result = unchecked_ref_cast %result_super : $Super to $Sub
+  strong_retain %result : $Sub
+  release_value %value : $String
+  return %result : $Sub
+}
+
+sil hidden @Sub_deinit : $@convention(method) (@guaranteed Sub) -> @owned Builtin.NativeObject {
+bb0(%initialized : $Sub):
+  %initialized_super = upcast %initialized : $Sub to $Super
+  %Super_deinit = function_ref @Super_deinit : $@convention(method) (@guaranteed Super) -> @owned Builtin.NativeObject
+  %uninitialized = apply %Super_deinit(%initialized_super) : $@convention(method) (@guaranteed Super) -> @owned Builtin.NativeObject
+  %uninitialized_super = unchecked_ref_cast %uninitialized : $Builtin.NativeObject to $Sub
+  %field_addr = ref_element_addr %uninitialized_super : $Sub, #Sub.t2
+  %field = begin_access [deinit] [static] %field_addr : $*Optional<String>
+  destroy_addr %field : $*Optional<String>
+  end_access %field : $*Optional<String>
+  return %uninitialized : $Builtin.NativeObject
+}
+
+sil hidden @Sub_deallocating_deinit : $@convention(method) (@owned Sub) -> () {
+bb0(%initialized : $Sub):
+  %Sub_deinit = function_ref @Sub_deinit : $@convention(method) (@guaranteed Sub) -> @owned Builtin.NativeObject
+  %uninitialized = apply %Sub_deinit(%initialized) : $@convention(method) (@guaranteed Sub) -> @owned Builtin.NativeObject
+  %uninitialized_sub = unchecked_ref_cast %uninitialized : $Builtin.NativeObject to $Sub
+  dealloc_ref %uninitialized_sub : $Sub
+  %out = tuple ()
+  return %out : $()
+}
+
+// CHECK-SIL-LABEL: sil hidden @partial_apply_method 
+//  CHECK-SIL-SAME: : $@convention(thin) <U where U : Q> (
+//  CHECK-SIL-SAME:     @guaranteed Super, 
+//  CHECK-SIL-SAME:     @convention(method) @async <U where U : Q> (@in_guaranteed U, Int64, @guaranteed Super) -> @owned String
+//  CHECK-SIL-SAME: ) -> 
+//  CHECK-SIL-SAME:     @async @callee_guaranteed (@in_guaranteed U, Int64) -> @owned String {
+//       CHECK-SIL: bb0(
+//  CHECK-SIL-SAME:     [[INSTANCE:%[^,]+]] : $Super, 
+//  CHECK-SIL-SAME:     [[DYNAMIC_METHOD:%[^,]+]] : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String
+//  CHECK-SIL-SAME: ):
+//       CHECK-SIL:   [[THUNK:%[^,]+]] = function_ref @$s20partial_apply_methodTw_ : $@convention(thin) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super, @convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String) -> @owned String
+//       CHECK-SIL:   [[RESULT:%[^,]+]] = partial_apply [callee_guaranteed] [[THUNK]]<U>([[INSTANCE]], [[DYNAMIC_METHOD]]) : $@convention(thin) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super, @convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String) -> @owned String
+//       CHECK-SIL:   return [[RESULT]] : $@async @callee_guaranteed (@in_guaranteed U, Int64) -> @owned String
+// CHECK-SIL-LABEL: } // end sil function 'partial_apply_method'
+
+// CHECK-SIL-LABEL: sil private [thunk] [ossa] @$s20partial_apply_methodTw_ : $@convention(thin) @async <U where U : Q> (
+//  CHECK-SIL-SAME:     @in_guaranteed U, 
+//  CHECK-SIL-SAME:     Int64, 
+//  CHECK-SIL-SAME:     @guaranteed Super, 
+//  CHECK-SIL-SAME:     @convention(method) @async <U where U : Q> (@in_guaranteed U, Int64, @guaranteed Super) -> @owned String) -> @owned String 
+//  CHECK-SIL-SAME: {
+//       CHECK-SIL: bb0(
+//  CHECK-SIL-SAME:     [[GENERIC_ADDR:%[^,]+]] : $*U, 
+//  CHECK-SIL-SAME:     [[INT:%[^,]+]] : $Int64, 
+//  CHECK-SIL-SAME:     [[INSTANCE:%[^,]+]] : @guaranteed $Super, 
+//  CHECK-SIL-SAME:     [[METHOD:%[^,]+]] : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String
+//  CHECK-SIL-SAME: ):
+//       CHECK-SIL:   [[RESULT:%[^,]+]] = apply [[METHOD]]<U>(
+//  CHECK-SIL-SAME:       [[GENERIC_ADDR]], 
+//  CHECK-SIL-SAME:       [[INT]], 
+//  CHECK-SIL-SAME:       [[INSTANCE]]
+//  CHECK-SIL-SAME:   ) : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String
+//       CHECK-SIL:   return [[RESULT]] : $String
+// CHECK-SIL-LABEL: } // end sil function '$s20partial_apply_methodTw_'
+
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s20partial_apply_methodTw_TA"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2) #0 {
+sil hidden @partial_apply_method : $@convention(thin) <U where U : Q> (@guaranteed Super, @convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String) -> @callee_guaranteed @async (@in_guaranteed U, Int64) -> @owned String {
+entry(%int : $Super, %fn : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String):
+    %pa = partial_apply [callee_guaranteed] %fn<U>(%int) : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String
+    return %pa : $@callee_guaranteed @async (@in_guaranteed U, Int64) -> @owned String
+}
+
+sil hidden @doit : $@convention(thin) @async <U where U : Q> (Int64, @in_guaranteed U, @guaranteed Super) -> @owned String {
+bb0(%int : $Int64, %generic_addr : $*U, %instance : $Super):
+  %run_method = class_method %instance : $Super, #Super.run : <U where U : Q> (Super) -> (U, Int64) async -> String, $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String
+  %partial_apply_method = function_ref @partial_apply_method : $@convention(thin) <U where U : Q> (@guaranteed Super, @convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String) -> @callee_guaranteed @async (@in_guaranteed U, Int64) -> @owned String
+  %partially_applied_method = apply %partial_apply_method<U>(%instance, %run_method) : $@convention(thin) <U where U : Q> (@guaranteed Super, @convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String) -> @callee_guaranteed @async (@in_guaranteed U, Int64) -> @owned String
+  %result = apply %partially_applied_method(%generic_addr, %int) : $@callee_guaranteed @async (@in_guaranteed U, Int64) -> @owned String
+  return %result : $String
+}
+
+sil hidden @QImpl_testU : $@convention(method) (QImpl) -> @owned String {
+bb0(%instance : $QImpl):
+  %string_literal = string_literal utf8 "QImpl.testU"
+  %utf8CodeUnitCount = integer_literal $Builtin.Word, 11
+  %isASCII = integer_literal $Builtin.Int1, -1
+  %string_type = metatype $@thin String.Type
+  %String_init = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %result = apply %String_init(%string_literal, %utf8CodeUnitCount, %isASCII, %string_type) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  return %result : $String
+}
+
+sil [serialized] [always_inline] [readonly] [_semantics "string.makeUTF8"] @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+
+sil private [transparent] [thunk] @QImpl_testU_conformance_thunk : $@convention(witness_method: Q) (@in_guaranteed QImpl) -> @owned String {
+bb0(%qimpl_addr : $*QImpl):
+  %qimpl = load %qimpl_addr : $*QImpl
+  %QImpl_testU = function_ref @QImpl_testU : $@convention(method) (QImpl) -> @owned String
+  %result = apply %QImpl_testU(%qimpl) : $@convention(method) (QImpl) -> @owned String
+  return %result : $String
+}
+
+sil @test_case : $@convention(thin) @async () -> () {
+  %sub_type = metatype $@thick Sub.Type
+  %string_literal = string_literal utf8 "42"
+  %utf8CodeUnitCount = integer_literal $Builtin.Word, 2
+  %isASCII = integer_literal $Builtin.Int1, -1
+  %string_type = metatype $@thin String.Type
+  %string_init = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %string = apply %string_init(%string_literal, %utf8CodeUnitCount, %isASCII, %string_type) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %Sub_allocating_init = function_ref @Sub_allocating_init : $@convention(method) (@owned String, @thick Sub.Type) -> @owned Sub
+  %instance_sub = apply %Sub_allocating_init(%string, %sub_type) : $@convention(method) (@owned String, @thick Sub.Type) -> @owned Sub
+  %int_literal = integer_literal $Builtin.Int64, 42
+  %int = struct $Int64 (%int_literal : $Builtin.Int64)
+  %qimpl = struct $QImpl ()
+  %qimpl_addr = alloc_stack $QImpl
+  store %qimpl to %qimpl_addr : $*QImpl
+  %instance_super = upcast %instance_sub : $Sub to $Super
+  %doit = function_ref @doit : $@convention(thin) @async <τ_0_0 where τ_0_0 : Q> (Int64, @in_guaranteed τ_0_0, @guaranteed Super) -> @owned String
+  %doit_result = apply %doit<QImpl>(%int, %qimpl_addr, %instance_super) : $@convention(thin) @async <τ_0_0 where τ_0_0 : Q> (Int64, @in_guaranteed τ_0_0, @guaranteed Super) -> @owned String
+  dealloc_stack %qimpl_addr : $*QImpl
+  strong_release %instance_sub : $Sub
+
+  %void = tuple()
+  return %void : $()
+}
+
+// Defined in _Concurrency
+sil @$ss13_runAsyncMainyyyyYKcF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> @error Error) -> ()
+
+// main
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %test_case_nothrow = function_ref @test_case : $@convention(thin) @async () -> ()
+  %test_case = convert_function %test_case_nothrow : $@convention(thin) @async () -> () to $@convention(thin) @async () -> @error Error
+  %thick_test_case = thin_to_thick_function %test_case : $@convention(thin) @async () -> @error Error to $@callee_guaranteed @async () -> @error Error
+  %runAsyncMain = function_ref @$ss13_runAsyncMainyyyyYKcF : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> @error Error) -> ()
+  %result = apply %runAsyncMain(%thick_test_case) : $@convention(thin) (@guaranteed @async @callee_guaranteed () -> @error Error) -> ()
+
+  %out_literal = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%out_literal : $Builtin.Int32)
+  return %out : $Int32
+}
+
+sil_vtable Super {
+  #Super.init!allocator: (Super.Type) -> (String) -> Super : @Super_allocating_init
+  #Super.run: <U where U : Q> (Super) -> (U, Int64) async -> String : @Super_run
+  #Super.deinit!deallocator: @Super_deallocating_deinit
+}
+
+sil_vtable Sub {
+  #Super.init!allocator: (Super.Type) -> (String) -> Super : @Sub_allocating_init [override]
+  #Super.run: <U where U : Q> (Super) -> (U, Int64) async -> String : @Sub_run [override]
+  #Sub.deinit!deallocator: @Sub_deallocating_deinit
+}
+
+sil_witness_table hidden QImpl: Q module main {
+  method #Q.testU: <Self where Self : Q> (Self) -> () -> String : @QImpl_testU_conformance_thunk
+}

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -2,6 +2,7 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
 // RUN: %target-codesign %t/%target-library-name(PrintShims)
 // RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-sil-opt -sil-inline-generics -enable-sil-verify-all -inline -partial-apply-lowering %s | %FileCheck %s --check-prefix=CHECK-SIL
 // RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency -g -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t) 
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
@@ -13,7 +14,6 @@
 
 import Builtin
 import Swift
-import PrintShims
 import _Concurrency
 
 sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
@@ -55,12 +55,78 @@ sil_witness_table ObserverImpl : Observer module main {
     associated_type Result : ()
 }
 
+// CHECK-SIL-LABEL: sil hidden @witness_method
+//  CHECK-SIL-SAME: : $@convention(thin) @async
+//  CHECK-SIL-SAME:     <S where S : Observable>
+//  CHECK-SIL-SAME:     <O where O : Observer, S.Result == O.Result>
+//  CHECK-SIL-SAME:     (@in S) -> @owned @async @callee_guaranteed (@in O) -> () {
+//       CHECK-SIL: bb0([[S_INSTANCE:%[^,]+]] : $*S):
+//       CHECK-SIL:   [[WITNESS_METHOD:%[^,]+]] = witness_method $S, #Observable.subscribe
+//  CHECK-SIL-SAME:       : <Self where Self : Observable><T where T : Observer> (Self) -> (T) async -> ()
+//  CHECK-SIL-SAME:       : $@convention(witness_method: Observable) @async
+//  CHECK-SIL-SAME:           <τ_0_0 where τ_0_0 : Observable>
+//  CHECK-SIL-SAME:           <τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result>
+//  CHECK-SIL-SAME:           (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+//       CHECK-SIL:   [[THUNK:%[^,]+]] = function_ref @$s14witness_methodTw_
+//  CHECK-SIL-SAME:       : $@convention(thin) @async
+//  CHECK-SIL-SAME:           <τ_0_0 where τ_0_0 : Observable>
+//  CHECK-SIL-SAME:           <τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result>
+//  CHECK-SIL-SAME:           (
+//  CHECK-SIL-SAME:               @in τ_1_0,
+//  CHECK-SIL-SAME:               @in_guaranteed τ_0_0,
+//  CHECK-SIL-SAME:               @convention(witness_method: Observable) @async
+//  CHECK-SIL-SAME:                   <τ_0_0 where τ_0_0 : Observable>
+//  CHECK-SIL-SAME:                   <τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result>
+//  CHECK-SIL-SAME:                   (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+//  CHECK-SIL-SAME:           ) -> ()
+//       CHECK-SIL:   [[RESULT:%[^,]+]] = partial_apply [callee_guaranteed] [[THUNK]]<S, O>([[S_INSTANCE]], [[WITNESS_METHOD]])
+//  CHECK-SIL-SAME:       : $@convention(thin) @async
+//  CHECK-SIL-SAME:           <τ_0_0 where τ_0_0 : Observable>
+//  CHECK-SIL-SAME:           <τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result>
+//  CHECK-SIL-SAME:           (
+//  CHECK-SIL-SAME:               @in τ_1_0,
+//  CHECK-SIL-SAME:               @in_guaranteed τ_0_0,
+//  CHECK-SIL-SAME:               @convention(witness_method: Observable) @async
+//  CHECK-SIL-SAME:                   <τ_0_0 where τ_0_0 : Observable>
+//  CHECK-SIL-SAME:                   <τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result>
+//  CHECK-SIL-SAME:                   (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+//  CHECK-SIL-SAME:           ) -> ()
+//       CHECK-SIL:   return [[RESULT]] : $@async @callee_guaranteed (@in O) -> ()
+// CHECK-SIL-LABEL: } // end sil function 'witness_method'
+
+// CHECK-SIL-LABEL: sil private [thunk] [ossa] @$s14witness_methodTw_ 
+//  CHECK-SIL-SAME: : $@convention(thin) @async 
+//  CHECK-SIL-SAME:     <S where S : Observable>
+//  CHECK-SIL-SAME:     <O where O : Observer, S.Result == O.Result> 
+//  CHECK-SIL-SAME:     (
+//  CHECK-SIL-SAME:         @in O, 
+//  CHECK-SIL-SAME:         @in_guaranteed S, 
+//  CHECK-SIL-SAME:         @convention(witness_method: Observable) @async 
+//  CHECK-SIL-SAME:             <S where S : Observable>
+//  CHECK-SIL-SAME:             <O where O : Observer, S.Result == O.Result> 
+//  CHECK-SIL-SAME:             (@in O, @in_guaranteed S) -> ()
+//  CHECK-SIL-SAME:     ) -> () {
+//       CHECK-SIL: bb0(
+//  CHECK-SIL-SAME:     [[O_INSTANCE:%[^,]+]] : $*O, 
+//  CHECK-SIL-SAME:     [[S_INSTANCE:%[^,]+]] : $*S, 
+//  CHECK-SIL-SAME:     [[WITNESS_METHOD:%[^,]+]] : $
+//  CHECK-SIL-SAME:         @convention(witness_method: Observable) @async 
+//  CHECK-SIL-SAME:         <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> 
+//  CHECK-SIL-SAME:         (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+//  CHECK-SIL-SAME: ):
+//       CHECK-SIL:   [[RESULT:%[^,]+]] = apply [[WITNESS_METHOD]]<S, O>(
+//  CHECK-SIL-SAME:       [[O_INSTANCE]], 
+//  CHECK-SIL-SAME:       [[S_INSTANCE]]
+//  CHECK-SIL-SAME:   ) : $@convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> () 
+//       CHECK-SIL:   return [[RESULT]] : $()                                 
+// CHECK-SIL-LABEL: } // end sil function '$s14witness_methodTw_'
+
 // CHECK-LL: define internal swift{{(tail)?}}cc void @"$s14witness_methodTw_TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-sil hidden @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> () {
+sil hidden @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_guaranteed (@in O) -> () {
 bb0(%0 : $*S):
   %1 = witness_method $S, #Observable.subscribe : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
-  %2 = partial_apply %1<S, O>(%0) : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
-  return %2 : $@async @callee_owned (@in O) -> ()
+  %2 = partial_apply [callee_guaranteed] %1<S, O>(%0) : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()
+  return %2 : $@async @callee_guaranteed (@in O) -> ()
 }
 
 

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -69,13 +69,13 @@ sil @test_case : $@convention(thin) @async () -> () {
   strong_retain %observableImpl : $ObservableImpl
   %observableImpl_addr = alloc_stack $ObservableImpl
   store %observableImpl to %observableImpl_addr : $*ObservableImpl
-  %witness_method = function_ref @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> ()
-  %partiallyApplied = apply %witness_method<ObservableImpl, ObserverImpl>(%observableImpl_addr) : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> ()
+  %witness_method = function_ref @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_guaranteed (@in O) -> ()
+  %partiallyApplied = apply %witness_method<ObservableImpl, ObserverImpl>(%observableImpl_addr) : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_guaranteed (@in O) -> ()
   %observerImpl = alloc_ref $ObserverImpl
   %observerImpl_addr = alloc_stack $ObserverImpl
   store %observerImpl to %observerImpl_addr : $*ObserverImpl
 
-  %result = apply %partiallyApplied(%observerImpl_addr) : $@async @callee_owned (@in ObserverImpl) -> ()
+  %result = apply %partiallyApplied(%observerImpl_addr) : $@async @callee_guaranteed (@in ObserverImpl) -> ()
 
   dealloc_stack %observerImpl_addr : $*ObserverImpl
   dealloc_stack %observableImpl_addr : $*ObservableImpl

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -55,7 +55,7 @@ sil_witness_table ObserverImpl : Observer module main {
     associated_type Result : ()
 }
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$sTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s14witness_methodTw_TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_owned (@in O) -> () {
 bb0(%0 : $*S):
   %1 = witness_method $S, #Observable.subscribe : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -25,7 +25,7 @@ bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
   return %p : $@async @callee_owned () -> @out T
 }
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$sTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s36partial_apply_dynamic_with_out_paramTw_TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 // CHECK-LL: define internal swift{{(tail)?}}cc void @"$s6calleeTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @callee : $@async @convention(thin) <T> (Int32, @in_guaranteed T) -> @out T {
 entry(%out_t : $*T, %x : $Int32, %in_t : $*T):


### PR DESCRIPTION
Previously, thick async functions were represented sometimes as a pair of (AsyncFunctionPointer, nullptr)--when the thick function was produced via a thin_to_thick_function, e.g.--and sometimes as a pair of (FunctionPointer, ThickContext)--when the thick function was produced by a partial_apply--with the size stored in the slot of the ThickContext.

That optimized for the wrong case: partial applies of dynamic async functions; in that case, there is no appropriate AsyncFunctionPointer to form when lowering the partial_apply instruction.  The far more common case is to know exactly which function is being partially applied.  In that case, we can form the appropriate AsyncFunctionPointer.

Furthermore, the previous representation made calling a thick function more complex: it was always necessary to check whether the context was in fact null and then proceed along two different paths depending.

Here, that behavior is corrected by creating a thunk in a mandatory IRGen SIL pass in the case that the function that is being partially applied is dynamic.  That new thunk is then partially applied in place of the original partial_apply of the dynamic function.