### PR TITLE
[Frontend/Test] Fix flaky lock_interface test

### DIFF
--- a/test/Driver/lock_interface.swift
+++ b/test/Driver/lock_interface.swift
@@ -13,8 +13,10 @@
 // RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -module-cache-path %t/module-cache &> %t/result.txt
 // RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD < %t/result.txt
 
+/// Checking that the compiler rebuilds the same module more than once can
+/// fail depending on how fast the jobs are executed. Just make sure the
+/// compiler accepts the -disable-interface-lock flag.
 // RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-interface-lock -module-cache-path %t/module-cache-no-lock &> %t/result.txt
-
 // RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD-NO-LOCK < %t/result.txt
 
 // Reset the permissions
@@ -25,6 +27,4 @@
 // CHECK-REBUILD-NOT: rebuilding module 'Foo' from interface
 // CHECK-REBUILD-NOT: building module interface without lock file
 
-// CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface
-// CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface
 // CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface

--- a/test/Driver/lock_interface.swift
+++ b/test/Driver/lock_interface.swift
@@ -10,21 +10,21 @@
 // RUN: echo 'import Foo' > %t/file-01.swift
 // RUN: echo 'import Foo' > %t/file-02.swift
 // RUN: echo 'import Foo' > %t/file-03.swift
-// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -module-cache-path %t/module-cache &> %t/result.txt
-// RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD < %t/result.txt
+// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -module-cache-path %t/module-cache &> %t/result-with-lock.txt
 
 /// Checking that the compiler rebuilds the same module more than once can
 /// fail depending on how fast the jobs are executed. Just make sure the
 /// compiler accepts the -disable-interface-lock flag.
-// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-interface-lock -module-cache-path %t/module-cache-no-lock &> %t/result.txt
-// RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD-NO-LOCK < %t/result.txt
+// RUN: %target-swiftc_driver -j20 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -I %t/sdk -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-interface-lock -module-cache-path %t/module-cache-no-lock &> %t/result-no-lock.txt
 
-// Reset the permissions
+/// Reset the permissions before running the tests likely to fail.
 // RUN: chmod a+w %t/sdk
 
 // Ensure we only build Foo module once from the interface
+// RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD < %t/result-with-lock.txt
 // CHECK-REBUILD: rebuilding module 'Foo' from interface
 // CHECK-REBUILD-NOT: rebuilding module 'Foo' from interface
 // CHECK-REBUILD-NOT: building module interface without lock file
 
+// RUN: %FileCheck %s  -check-prefix=CHECK-REBUILD-NO-LOCK < %t/result-no-lock.txt
 // CHECK-REBUILD-NO-LOCK: rebuilding module 'Foo' from interface


### PR DESCRIPTION
Testing that the compiler rebuilds the same module more than once with `-disable-interface-lock` was not reliable as some jobs could be executed after the module was rebuilt. Just make sure the compiler accepts the flag.

Also reorder permission change and FileCheck calls to make failures less likely to leave the tmp folder in an unwritable state.

This test was reenabled in #36185.