### PR TITLE
Work Around +asserts Canonicalization Differences in Substitution

### DIFF
--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -1136,7 +1136,7 @@ class MemberInitsHelper<T> { }
 
 extension MemberInits {
   // CHECK-LABEL: sil [ossa] @$s21failable_initializers11MemberInitsVyACySayqd__GGSayACyqd__GGcADRszSQRd__lufC : $@convention(method) <Value><T where Value == Array<T>, T : Equatable> (@owned Array<MemberInits<T>>, @thin MemberInits<Array<T>>.Type) -> @owned MemberInits<Array<T>> {
-  public init<T>(_ array: [MemberInits<T>]) where Value == [T] {
+  public init<T>(_ array: Array<MemberInits<T>>) where Value == [T] {
     box = nil
 
     // CHECK: [[INIT_FN:%.*]] = function_ref @$s21failable_initializers11MemberInitsV5value33_4497B2E9306011E5BAC13C07BEAC2557LLSSvpfi : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> () -> @owned String


### PR DESCRIPTION
On +asserts builds, this code

```
public struct MemberInits<Value : Equatable> {
  fileprivate var value: String = "default"
}

extension MemberInits {
  public init<T>(_ array: [MemberInits<T>]) where Value == [T] {}
}
```

Produces an apply of the memberwise initializer substituting BoundGenericType,
on -asserts builds it produces a substitution of an ArraySliceType. This
suggests we have an assertion that is mutating the substitution map
somewhere. For now, switch to an explicit BoundGenericType to homogenize
this test while I'm looking into why this happens.