### PR TITLE
Support actor isolation for property wrappers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4406,6 +4406,11 @@ ERROR(actorindependent_local_var,none,
       "'@actorIndependent' can not be applied to local variables",
       ())
 
+ERROR(actor_instance_property_wrapper,none,
+      "%0 property in property wrapper type %1 cannot be isolated to "
+      "the actor instance; consider @actorIndependent",
+      (Identifier, Identifier))
+
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "
       "module was not imported", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4446,8 +4446,6 @@ ERROR(global_actor_on_actor_class,none,
       "actor class %0 cannot have a global actor", (Identifier))
 ERROR(global_actor_on_local_variable,none,
       "local variable %0 cannot have a global actor", (DeclName))
-ERROR(global_actor_on_struct_property,none,
-      "stored property %0 of a struct cannot have a global actor", (DeclName))
 ERROR(global_actor_non_unsafe_init,none,
       "global actor attribute %0 argument can only be '(unsafe)'", (Type))
       

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -458,15 +458,6 @@ GlobalActorAttributeRequest::evaluate(
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
       }
-
-      // Global actors don't make sense on a stored property of a struct.
-      if (var->hasStorage() && var->getDeclContext()->getSelfStructDecl() &&
-          var->isInstanceMember()) {
-        var->diagnose(diag::global_actor_on_struct_property, var->getName())
-          .highlight(globalActorAttr->getRangeWithAt());
-        return None;
-      }
-
     }
   } else if (isa<ExtensionDecl>(decl)) {
     // Extensions are okay.

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -82,6 +82,22 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
     return nullptr;
   }
 
+  // The property must not be isolated to an actor instance.
+  switch (auto isolation = getActorIsolation(var)) {
+  case ActorIsolation::ActorInstance:
+    var->diagnose(
+        diag::actor_instance_property_wrapper, var->getName(),
+        nominal->getName());
+    return nullptr;
+
+  case ActorIsolation::GlobalActor:
+  case ActorIsolation::GlobalActorUnsafe:
+  case ActorIsolation::Independent:
+  case ActorIsolation::IndependentUnsafe:
+  case ActorIsolation::Unspecified:
+    break;
+  }
+
   return var;
 }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2528,8 +2528,6 @@ static void typeCheckSynthesizedWrapperInitializer(
           dyn_cast_or_null<Initializer>(pbd->getInitContext(i))) {
     TypeChecker::contextualizeInitializer(initializerContext, initializer);
   }
-  checkPropertyWrapperActorIsolation(pbd, initializer);
-  TypeChecker::checkPropertyWrapperEffects(pbd, initializer);
 }
 
 static PropertyWrapperMutability::Value
@@ -2875,6 +2873,8 @@ PropertyWrapperBackingPropertyInfoRequest::evaluate(Evaluator &evaluator,
       // Check initializer effects.
       auto *initContext = new (ctx) PropertyWrapperInitializer(
           dc, param, PropertyWrapperInitializer::Kind::WrappedValue);
+      TypeChecker::contextualizeInitializer(initContext, wrappedValueInit);
+      checkInitializerActorIsolation(initContext, wrappedValueInit);
       TypeChecker::checkInitializerEffects(initContext, wrappedValueInit);
     } else {
       typeCheckSynthesizedWrapperInitializer(

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -99,3 +99,30 @@ func acceptCV<T: ConcurrentValue>(_: T) { }
 func testCV(r: NSRange) {
   acceptCV(r)
 }
+
+// Global actor (unsafe) isolation.
+
+actor SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+class MyButton : NXButton {
+  @MainActor func testMain() {
+    onButtonPress() // okay
+  }
+
+  @SomeGlobalActor func testOther() {
+    onButtonPress() // expected-error{{instance method 'onButtonPress()' isolated to global actor 'MainActor' can not be referenced from different global actor 'SomeGlobalActor'}}
+  }
+
+  func test() {
+    onButtonPress() // okay
+  }
+}
+
+func testButtons(mb: MyButton) {
+  mb.onButtonPress()
+}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -234,6 +234,107 @@ func barSync() {
   foo() // expected-error {{global function 'foo()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
 }
 
+// ----------------------------------------------------------------------
+// Property wrappers
+// ----------------------------------------------------------------------
+
+@propertyWrapper
+@OtherGlobalActor
+struct WrapperOnActor<Wrapped> {
+  @actorIndependent(unsafe) private var stored: Wrapped
+
+  init(wrappedValue: Wrapped) {
+    stored = wrappedValue
+  }
+
+  @MainActor var wrappedValue: Wrapped {
+    get { stored }
+    set { stored = newValue }
+  }
+
+  @SomeGlobalActor var projectedValue: Wrapped {
+    get { stored }
+    set { stored = newValue }
+  }
+}
+
+@propertyWrapper
+actor WrapperActor<Wrapped> {
+  @actorIndependent(unsafe) var storage: Wrapped
+
+  init(wrappedValue: Wrapped) {
+    storage = wrappedValue
+  }
+
+  @actorIndependent var wrappedValue: Wrapped {
+    get { storage }
+    set { storage = newValue }
+  }
+
+  @actorIndependent var projectedValue: Wrapped {
+    get { storage }
+    set { storage = newValue }
+  }
+}
+
+struct HasWrapperOnActor {
+  @WrapperOnActor var synced: Int = 0
+  // expected-note@-1 3{{mutable state is only available within the actor instance}}
+
+  // expected-note@+1 3{{to make instance method 'testErrors()'}}
+  func testErrors() {
+    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this context}}
+    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from this context}}
+  }
+
+  @MainActor mutating func testOnMain() {
+    _ = synced
+    synced = 17
+  }
+
+  @WrapperActor var actorSynced: Int = 0
+
+  func testActorSynced() {
+    _ = actorSynced
+    _ = $actorSynced
+    _ = _actorSynced
+  }
+}
+
+
+@propertyWrapper
+actor WrapperActorBad1<Wrapped> {
+  var storage: Wrapped
+
+  init(wrappedValue: Wrapped) {
+    storage = wrappedValue
+  }
+
+  var wrappedValue: Wrapped { // expected-error{{'wrappedValue' property in property wrapper type 'WrapperActorBad1' cannot be isolated to the actor instance; consider @actorIndependent}}}}
+    get { storage }
+    set { storage = newValue }
+  }
+}
+
+@propertyWrapper
+actor WrapperActorBad2<Wrapped> {
+  @actorIndependent(unsafe) var storage: Wrapped
+
+  init(wrappedValue: Wrapped) {
+    storage = wrappedValue
+  }
+
+  @actorIndependent var wrappedValue: Wrapped {
+    get { storage }
+    set { storage = newValue }
+  }
+
+  var projectedValue: Wrapped { // expected-error{{'projectedValue' property in property wrapper type 'WrapperActorBad2' cannot be isolated to the actor instance; consider @actorIndependent}}
+    get { storage }
+    set { storage = newValue }
+  }
+}
 
 // ----------------------------------------------------------------------
 // Unsafe global actors
@@ -265,4 +366,46 @@ class UGASubclass1: UGAClass {
 
 class UGASubclass2: UGAClass {
   override func method() { }
+}
+
+@propertyWrapper
+@OtherGlobalActor(unsafe)
+struct WrapperOnUnsafeActor<Wrapped> {
+  @actorIndependent(unsafe) private var stored: Wrapped
+
+  init(wrappedValue: Wrapped) {
+    stored = wrappedValue
+  }
+
+  @MainActor(unsafe) var wrappedValue: Wrapped {
+    get { stored }
+    set { stored = newValue }
+  }
+
+  @SomeGlobalActor(unsafe) var projectedValue: Wrapped {
+    get { stored }
+    set { stored = newValue }
+  }
+}
+
+struct HasWrapperOnUnsafeActor {
+  @WrapperOnUnsafeActor var synced: Int = 0
+  // expected-note@-1 3{{mutable state is only available within the actor instance}}
+
+  func testUnsafeOkay() {
+    _ = synced
+    _ = $synced
+    _ = _synced
+  }
+
+  @actorIndependent func testErrors() {
+    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from}}
+    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from}}
+    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from}}
+  }
+
+  @MainActor mutating func testOnMain() {
+    _ = synced
+    synced = 17
+  }
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -279,7 +279,7 @@ actor WrapperActor<Wrapped> {
 
 struct HasWrapperOnActor {
   @WrapperOnActor var synced: Int = 0
-  // expected-note@-1 3{{mutable state is only available within the actor instance}}
+  // expected-note@-1 3{{property declared here}}
 
   // expected-note@+1 3{{to make instance method 'testErrors()'}}
   func testErrors() {
@@ -338,7 +338,7 @@ actor WrapperActorBad2<Wrapped> {
 
 actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
-  // expected-note@-1 3{{mutable state is only available within the actor instance}}
+  // expected-note@-1 3{{property declared here}}
   func f() {
     _ = synced // expected-error{{'synced' isolated to global actor}}
     _ = $synced // expected-error{{'$synced' isolated to global actor}}
@@ -400,7 +400,7 @@ struct WrapperOnUnsafeActor<Wrapped> {
 
 struct HasWrapperOnUnsafeActor {
   @WrapperOnUnsafeActor var synced: Int = 0
-  // expected-note@-1 3{{mutable state is only available within the actor instance}}
+  // expected-note@-1 3{{property declared here}}
 
   func testUnsafeOkay() {
     _ = synced

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -243,7 +243,7 @@ func barSync() {
 struct WrapperOnActor<Wrapped> {
   @actorIndependent(unsafe) private var stored: Wrapped
 
-  init(wrappedValue: Wrapped) {
+  @actorIndependent init(wrappedValue: Wrapped) {
     stored = wrappedValue
   }
 
@@ -333,6 +333,16 @@ actor WrapperActorBad2<Wrapped> {
   var projectedValue: Wrapped { // expected-error{{'projectedValue' property in property wrapper type 'WrapperActorBad2' cannot be isolated to the actor instance; consider @actorIndependent}}
     get { storage }
     set { storage = newValue }
+  }
+}
+
+actor ActorWithWrapper {
+  @WrapperOnActor var synced: Int = 0
+  // expected-note@-1 3{{mutable state is only available within the actor instance}}
+  func f() {
+    _ = synced // expected-error{{'synced' isolated to global actor}}
+    _ = $synced // expected-error{{'$synced' isolated to global actor}}
+    _ = _synced // expected-error{{'_synced' isolated to global actor}}
   }
 }
 

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -129,4 +129,14 @@ typedef void ( ^ObjCErrorHandler )( NSError * _Nullable inError );
 
 #define MAGIC_NUMBER 42
 
+
+__attribute__((__swift_attr__("@MainActor(unsafe)")))
+@interface NXView : NSObject
+-(void)onDisplay;
+@end
+
+@interface NXButton: NXView
+-(void)onButtonPress;
+@end
+
 #pragma clang assume_nonnull end

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -65,7 +65,7 @@ struct OtherGlobalActor {
 }
 
 @GA1 struct X {
-  @GA1 var member: Int // expected-error{{stored property 'member' of a struct cannot have a global actor}}
+  @GA1 var member: Int
 }
 
 struct Y {


### PR DESCRIPTION
Property wrappers can provide global actor isolation based on the
property wrapper type itself (which affects the backing property),
`wrappedValue` (which affects the wrapped property), and
`projectedValue` (which affects the $ property). This allows us to
express, e.g., property wrappers that require accesses to occur on a
particular global actor.

Thanks to @hborla for walking through this with me.

More in support of rdar://74241687