### PR TITLE
[Dependency Scanning] When re-using a CompilerInvocation in batch scanning, update it with the entry-specific arguments.

### DIFF
--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -5,16 +5,16 @@
 
 // RUN: echo "[{" > %/t/inputs/input.json
 // RUN: echo "\"clangModuleName\": \"G\"," >> %/t/inputs/input.json
-// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx10.9\"," >> %/t/inputs/input.json
-// RUN: echo "\"output\": \"%/t/outputs/G_109.pcm.json\"" >> %/t/inputs/input.json
+// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx11.0\"," >> %/t/inputs/input.json
+// RUN: echo "\"output\": \"%/t/outputs/G_110.pcm.json\"" >> %/t/inputs/input.json
 // RUN: echo "}," >> %/t/inputs/input.json
 // RUN: echo "{" >> %/t/inputs/input.json
 // RUN: echo "\"clangModuleName\": \"G\"," >> %/t/inputs/input.json
-// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx11.0\"," >> %/t/inputs/input.json
-// RUN: echo "\"output\": \"%/t/outputs/G_110.pcm.json\"" >> %/t/inputs/input.json
+// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx10.9\"," >> %/t/inputs/input.json
+// RUN: echo "\"output\": \"%/t/outputs/G_109.pcm.json\"" >> %/t/inputs/input.json
 // RUN: echo "}]" >> %/t/inputs/input.json
 
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
+// RUN: %target-swift-frontend -scan-dependencies -target x86_64-apple-macosx11.0 -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s -check-prefix=CHECK-PCM109 < %t/outputs/G_109.pcm.json


### PR DESCRIPTION
Otherwise, the arguments from the parent invocation of the batch scanner may overrule the arguments the batch entry expects.

Resolves rdar://74812312
