### PR TITLE
[Concurrency] remove Task.hasTaskLocalValues, they all do

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -336,21 +336,6 @@ extension Task {
       }
     }
 
-    /// Whether this (or its parents) have task local values.
-    var hasLocalValues: Bool {
-      get {
-        (bits & (1 << 27)) != 0
-      }
-
-      set {
-        if newValue {
-          bits = bits | 1 << 27
-        } else {
-          bits = (bits & ~(1 << 27))
-        }
-      }
-    }
-
   }
 }
 


### PR DESCRIPTION
This isn't used nor correct anymore -- the flag was removed and all tasks have the task local pointer.