### PR TITLE
[NFC] Add a poison flag to SIL destroy_value.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5178,7 +5178,7 @@ destroy_value
 
 ::
 
-  sil-instruction ::= 'destroy_value' sil-operand
+  sil-instruction ::= 'destroy_value' '[poison]'? sil-operand
 
   destroy_value %0 : $A
 

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1245,13 +1245,14 @@ public:
                       CopyValueInst(getSILDebugLocation(Loc), operand));
   }
 
-  DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand) {
+  DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand,
+                                       bool poisonRefs = false) {
     assert(isLoadableOrOpaque(operand->getType()));
     assert(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitDestroyValueOperation");
-    return insert(new (getModule())
-                      DestroyValueInst(getSILDebugLocation(Loc), operand));
+    return insert(new (getModule()) DestroyValueInst(getSILDebugLocation(Loc),
+                                                     operand, poisonRefs));
   }
 
   UnconditionalCheckedCastInst *

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1807,7 +1807,8 @@ void SILCloner<ImplClass>::visitDestroyValueInst(DestroyValueInst *Inst) {
 
   recordClonedInstruction(
       Inst, getBuilder().createDestroyValue(getOpLocation(Inst->getLoc()),
-                                            getOpValue(Inst->getOperand())));
+                                            getOpValue(Inst->getOperand()),
+                                            Inst->poisonRefs()));
 }
 
 template <typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7141,8 +7141,17 @@ class DestroyValueInst
                                   NonValueInstruction> {
   friend class SILBuilder;
 
-  DestroyValueInst(SILDebugLocation DebugLoc, SILValue operand)
-      : UnaryInstructionBase(DebugLoc, operand) {}
+  DestroyValueInst(SILDebugLocation DebugLoc, SILValue operand, bool poisonRefs)
+      : UnaryInstructionBase(DebugLoc, operand) {
+    setPoisonRefs(poisonRefs);
+  }
+
+public:
+  bool poisonRefs() const { return SILNode::Bits.DestroyValueInst.PoisonRefs; }
+
+  void setPoisonRefs(bool poisonRefs = true) {
+    SILNode::Bits.DestroyValueInst.PoisonRefs = poisonRefs;
+  }
 };
 
 /// Given an object reference, return true iff it is non-nil and refers

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -337,6 +337,9 @@ protected:
     Immutable : 1
   );
 
+  SWIFT_INLINE_BITFIELD(DestroyValueInst, NonValueInstruction, 1,
+                        PoisonRefs : 1);
+
   SWIFT_INLINE_BITFIELD(EndCOWMutationInst, NonValueInstruction, 1,
     KeepUnique : 1
   );

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -384,6 +384,11 @@ namespace {
       return true;
     }
     
+    bool visitDestroyValueInst(const DestroyValueInst *RHS) {
+      auto *left = cast<DestroyValueInst>(LHS);
+      return left->poisonRefs() == RHS->poisonRefs();
+    }
+
     bool visitBeginCOWMutationInst(const BeginCOWMutationInst *RHS) {
       auto *left = cast<BeginCOWMutationInst>(LHS);
       return left->isNative() == RHS->isNative();

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1703,6 +1703,8 @@ public:
 #include "swift/AST/ReferenceStorage.def"
 
   void visitDestroyValueInst(DestroyValueInst *I) {
+    if (I->poisonRefs())
+      *this << "[poison] ";
     *this << getIDAndType(I->getOperand());
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2974,7 +2974,6 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     UNARY_INSTRUCTION(IsUnique)
     UNARY_INSTRUCTION(DestroyAddr)
     UNARY_INSTRUCTION(CopyValue)
-    UNARY_INSTRUCTION(DestroyValue)
     UNARY_INSTRUCTION(EndBorrow)
     UNARY_INSTRUCTION(DestructureStruct)
     UNARY_INSTRUCTION(DestructureTuple)
@@ -3001,6 +3000,14 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
 #undef UNARY_INSTRUCTION
 #undef REFCOUNTING_INSTRUCTION
 
+  case SILInstructionKind::DestroyValueInst: {
+    bool poisonRefs = false;
+    if (parseSILOptional(poisonRefs, *this, "poison")
+        || parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
+      return true;
+    ResultVal = B.createDestroyValue(InstLoc, Val, poisonRefs);
+    break;
+  }
   case SILInstructionKind::BeginCOWMutationInst: {
     bool native = false;
     if (parseSILOptional(native, *this, "native") ||

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2482,7 +2482,8 @@ public:
             "Source value should be an object value");
     require(!I->getOperand()->getType().isTrivial(*I->getFunction()),
             "Source value should be non-trivial");
-    require(!fnConv.useLoweredAddresses() || F.hasOwnership(),
+    require(I->poisonRefs() || !fnConv.useLoweredAddresses()
+            || F.hasOwnership(),
             "destroy_value is only valid in functions with qualified "
             "ownership");
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1858,7 +1858,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   REFCOUNTING_INSTRUCTION(RetainValueAddr)
   REFCOUNTING_INSTRUCTION(UnmanagedRetainValue)
   UNARY_INSTRUCTION(CopyValue)
-  UNARY_INSTRUCTION(DestroyValue)
   REFCOUNTING_INSTRUCTION(ReleaseValue)
   REFCOUNTING_INSTRUCTION(ReleaseValueAddr)
   REFCOUNTING_INSTRUCTION(UnmanagedReleaseValue)
@@ -1895,6 +1894,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getLocalValue(ValID, getSILType(MF->getType(TyID),
                                         (SILValueCategory)TyCategory, Fn)),
         verificationType);
+    break;
+  }
+
+  case SILInstructionKind::DestroyValueInst: {
+    assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
+    unsigned poisonRefs = Attr;
+    ResultInst = Builder.createDestroyValue(
+        Loc,
+        getLocalValue(ValID, getSILType(MF->getType(TyID),
+                                        (SILValueCategory)TyCategory, Fn)),
+        poisonRefs != 0);
     break;
   }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1399,6 +1399,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       Attr = unsigned(SILValue(UOCI).getOwnershipKind());
     } else if (auto *IEC = dyn_cast<IsEscapingClosureInst>(&SI)) {
       Attr = IEC->getVerificationType();
+    } else if (auto *DVI = dyn_cast<DestroyValueInst>(&SI)) {
+      Attr = DVI->poisonRefs();
     } else if (auto *BCMI = dyn_cast<BeginCOWMutationInst>(&SI)) {
       Attr = BCMI->isNative();
     } else if (auto *ECMI = dyn_cast<EndCOWMutationInst>(&SI)) {

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -31,3 +31,15 @@ bb0(%0 : $@sil_unmanaged Builtin.NativeObject):
   %1 = strong_copy_unmanaged_value %0 : $@sil_unmanaged Builtin.NativeObject
   return %1 : $Builtin.NativeObject
 }
+
+// CHECK-LABEL: sil [ossa] @test_poison
+// CHECK: bb0([[T0:%[0-9]+]] : @owned $Builtin.NativeObject):
+// CHECK-NEXT: destroy_value [poison] [[T0]] : $Builtin.NativeObject
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+sil [ossa] @test_poison : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value [poison] %0 : $Builtin.NativeObject
+  %2 = tuple ()
+  return %2 : $()
+}

--- a/test/SIL/Serialization/copy_value_destroy_value.sil
+++ b/test/SIL/Serialization/copy_value_destroy_value.sil
@@ -20,6 +20,17 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %1 : $Builtin.NativeObject
 }
 
+// CHECK-LABEL: sil [serialized] [ossa] @test_poison
+// CHECK: bb0(%0 : @owned $Builtin.NativeObject):
+// CHECK-NEXT: destroy_value [poison] %0 : $Builtin.NativeObject
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+sil [serialized] [ossa] @test_poison : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  destroy_value [poison] %0 : $Builtin.NativeObject
+  %2 = tuple ()
+  return %2 : $()
+}
 
 // CHECK-LABEL: sil [serialized] [ossa] @test_strong_copy_unowned_value : $@convention(thin) (@owned @sil_unowned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK: bb0([[T0:%[0-9]+]] : @owned $@sil_unowned Builtin.NativeObject):
@@ -32,3 +43,4 @@ bb0(%0 : @owned $@sil_unowned Builtin.NativeObject):
   destroy_value %0 : $@sil_unowned Builtin.NativeObject
   return %1 : $Builtin.NativeObject
 }
+


### PR DESCRIPTION
When the IRGen side is implemented, this will overwrite shadow debug
variables with a poison sentinel for all references within the value.
