### PR TITLE
[ConstraintSystem] Use correct locator when filtering disjunction cho…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9380,7 +9380,7 @@ bool ConstraintSystem::simplifyAppliedOverloads(
   AppliedDisjunctions[disjunction->getLocator()] = argFnType;
   return simplifyAppliedOverloadsImpl(disjunction, fnTypeVar, argFnType,
                                       /*numOptionalUnwraps*/ result->second,
-                                      locator);
+                                      applicableFn->getLocator());
 }
 
 bool ConstraintSystem::simplifyAppliedOverloads(

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -38,3 +38,25 @@ func testUnresolvedMember(i: Int) -> X {
   // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
   return .init(i, i)
 }
+
+func test_member_filtering() {
+  struct S {
+    // Result types here are different intentionally,
+    // if there were the same simplication logic would
+    // trigger and disable overloads during constraint
+    // generation.
+    func foo(_: Int) -> S { S() }
+    func foo(_: String) -> Int { 42 }
+
+    func bar(v: String) {}
+    func bar(_: Int) {}
+    func bar(a: Double, b: Int) {}
+  }
+
+  func test(s: S) {
+    // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(v:)
+    // CHECK-NEXT: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(a:b:)
+    // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar
+    s.foo(42).bar(42)
+  }
+}


### PR DESCRIPTION
…ices

`simplifyAppliedOverloads(Constraint *, ...)` wouldn't filter choices
based on labels unless it finds recorded labels in the constraint system
based on the provided locator. `addOverloadSet` used incorrect locator
when calling `simplifyAppliedOverloads` which means that this call was
effectively a no-op.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
