### PR TITLE
[SymbolGraph] don't scan every available module for cross-import overlays

### DIFF
--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -260,7 +260,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
   // don't need to print these errors.
   CI.removeDiagnosticConsumer(&DiagPrinter);
   
-  SmallVector<ModuleDecl *, 2> Overlays;
+  SmallVector<ModuleDecl *> Overlays;
   M->findDeclaredCrossImportOverlaysTransitive(Overlays);
   for (const auto *OM : Overlays) {
     auto CIM = CI.getASTContext().getModuleByName(OM->getNameStr());

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -260,16 +260,16 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
   // don't need to print these errors.
   CI.removeDiagnosticConsumer(&DiagPrinter);
   
-  for (const auto &ModuleName : VisibleModuleNames) {
-    if (ModuleName.str().startswith("_")) {
-      auto CIM = CI.getASTContext().getModuleByName(ModuleName.str());
-      if (CIM && CIM->isCrossImportOverlayOf(M)) {
-        const auto &CIMainFile = CIM->getMainFile(FileUnitKind::SerializedAST);
-        llvm::errs() << "Emitting symbol graph for cross-import overlay module file: "
-          << CIMainFile.getModuleDefiningPath() << '\n';
-        
-        Success |= symbolgraphgen::emitSymbolGraphForModule(CIM, Options);
-      }
+  SmallVector<ModuleDecl *, 2> Overlays;
+  M->findDeclaredCrossImportOverlaysTransitive(Overlays);
+  for (const auto *OM : Overlays) {
+    auto CIM = CI.getASTContext().getModuleByName(OM->getNameStr());
+    if (CIM) {
+      const auto &CIMainFile = CIM->getMainFile(FileUnitKind::SerializedAST);
+      llvm::errs() << "Emitting symbol graph for cross-import overlay module file: "
+        << CIMainFile.getModuleDefiningPath() << '\n';
+      
+      Success |= symbolgraphgen::emitSymbolGraphForModule(CIM, Options);
     }
   }
 

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -217,12 +217,13 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args, const char *Argv
   }
 
   auto M = CI.getASTContext().getModuleByName(options::ModuleName);
-  SmallVector<Identifier, 32> VisibleModuleNames;
-  CI.getASTContext().getVisibleTopLevelModuleNames(VisibleModuleNames);
   if (!M) {
     llvm::errs()
       << "Couldn't load module '" << options::ModuleName << '\''
       << " in the current SDK and search paths.\n";
+    
+    SmallVector<Identifier, 32> VisibleModuleNames;
+    CI.getASTContext().getVisibleTopLevelModuleNames(VisibleModuleNames);
 
     if (VisibleModuleNames.empty()) {
       llvm::errs() << "Could not find any modules.\n";


### PR DESCRIPTION
Resolves rdar://74928853

When the symbol graph tool checks for cross-import overlays declared by the current module, it currently looks through all the available modules, and *loads every module whose name begins with an underscore* to check it. This can lead to a wildly inefficient situation if there are many large overlay modules in the SDK. In one situation the symbol graph tool tool two minutes on my machine for a module with only a handful of items in it, just because of the overlay module scan.

This PR changes this behavior to instead query the module itself for any overlay modules, the same way that SourceKit would. This speeds up that module's call to a fraction of a second, providing a three order-of-magnitude speedup to the call overall.