### PR TITLE
[AST Printing] Consider the storage decl as the "enclosing" decl of an accessor

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2629,14 +2629,14 @@ static std::vector<Feature> getUniqueFeaturesUsed(Decl *decl) {
   if (features.empty())
     return features;
 
-  auto enclosingDecl = decl->getDeclContext()->getAsDecl();
+  Decl *enclosingDecl;
+  if (auto accessor = dyn_cast<AccessorDecl>(decl))
+    enclosingDecl = accessor->getStorage();
+  else
+    enclosingDecl = decl->getDeclContext()->getAsDecl();
   if (!enclosingDecl)
     return features;
 
-  if (!isa<NominalTypeDecl>(enclosingDecl) &&
-      !isa<ExtensionDecl>(enclosingDecl))
-    return features;
-  
   auto enclosingFeatures = getFeaturesUsed(enclosingDecl);
   if (enclosingFeatures.empty())
     return features;

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -73,6 +73,17 @@ public class OldSchool: MP {
   func f() throws
 }
 
+// CHECK: public struct UsesRP {
+public struct UsesRP {
+  // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
+  // CHECK-NEXT:  public var value: FeatureTest.RP? {
+  // CHECK-NOT: #if compiler(>=5.3) && $RethrowsProtocol
+  // CHECK: get
+  public var value: RP? {
+    nil
+  }
+}
+
 // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
 // CHECK-NEXT: public func acceptsRP
 public func acceptsRP<T: RP>(_: T) { }


### PR DESCRIPTION
Fixes spurious #if's when printing for backward compatibility, rdar://75074036
