### PR TITLE
[Concurrency] Simple Task.yield implementation

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -522,15 +522,13 @@ extension Task {
     // Create the asynchronous task future, it will do nothing, but simply serves
     // as a way for us to yield our execution until the executor gets to it and
     // resumes us.
-    // FIXME: This should be an empty closure instead. Returning `0` here is
-    //        a workaround for rdar://74957357
     // TODO: consider if it would be useful for this task to be a child task
-    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, nil, { return 0 })
+    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, {})
 
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(task))
 
-    let _ = await Handle<Int, Never>(task).get()
+    let _ = await Handle<Void, Never>(task).get()
   }
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -504,6 +504,8 @@ extension Task {
 }
 
 // ==== Voluntary Suspension -----------------------------------------------------
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
 
   /// Explicitly suspend the current task, potentially giving up execution actor

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -708,7 +708,7 @@ extension TaskGroup: AsyncSequence {
     /// - SeeAlso: `TaskGroup.next()` for a detailed discussion its semantics.
     public mutating func next() async -> Element? {
       guard !finished else { return nil }
-      guard let element = try await group.next() else {
+      guard let element = await group.next() else {
         finished = true
         return nil
       }

--- a/test/Concurrency/Runtime/async_task_yield.swift
+++ b/test/Concurrency/Runtime/async_task_yield.swift
@@ -1,0 +1,42 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+protocol Go: Actor {
+  func go(times: Int) async -> Int
+}
+extension Go {
+  func go(times: Int) async -> Int {
+    for i in 0...times {
+      print("\(Self.self) @ \(i)")
+      await Task.yield()
+    }
+    return times
+  }
+}
+
+actor One: Go {}
+actor Two: Go {}
+
+func yielding() async {
+  let one = One()
+  let two = Two()
+  try! await Task.withGroup(resultType: Int.self) { group in
+    await group.add {
+      await one.go(times: 100)
+    }
+    await group.add {
+      await two.go(times: 100)
+    }
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    await yielding()
+    // TODO: No idea for a good test for this... Open to ideas?
+    // CHECK:      One
+    // CHECK-NEXT: Two
+  }
+}

--- a/test/Concurrency/Runtime/async_task_yield.swift
+++ b/test/Concurrency/Runtime/async_task_yield.swift
@@ -3,9 +3,12 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 protocol Go: Actor {
   func go(times: Int) async -> Int
 }
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Go {
   func go(times: Int) async -> Int {
     for i in 0...times {
@@ -16,22 +19,26 @@ extension Go {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor One: Go {}
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Two: Go {}
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func yielding() async {
   let one = One()
   let two = Two()
-  try! await Task.withGroup(resultType: Int.self) { group in
-    await group.add {
+  await withTaskGroup(of: Int.self) { group in
+    await group.spawn {
       await one.go(times: 100)
     }
-    await group.add {
+    await group.spawn {
       await two.go(times: 100)
     }
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await yielding()


### PR DESCRIPTION
Pretty simple/naive implementation of Task.yield...

I'm guessing this isn't quite the final form of this.

It is the same impl style as today's Task.sleep: https://github.com/apple/swift/pull/35983

Though I think we should somehow implement be able to implement this without creating a new Task.

### ABI

- This likely should change to have a single runtime call to a new `swift_task_yield`?