### PR TITLE
[stdlib] Make some methods on Optional transparent

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -157,7 +157,7 @@ public enum Optional<Wrapped>: ExpressibleByNilLiteral {
   ///   of the instance.
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @inlinable
+  @_transparent
   public func map<U>(
     _ transform: (Wrapped) throws -> U
   ) rethrows -> U? {
@@ -188,7 +188,7 @@ public enum Optional<Wrapped>: ExpressibleByNilLiteral {
   ///   of the instance.  
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
-  @inlinable
+  @_transparent
   public func flatMap<U>(
     _ transform: (Wrapped) throws -> U?
   ) rethrows -> U? {
@@ -364,7 +364,7 @@ extension Optional: Equatable where Wrapped: Equatable {
   /// - Parameters:
   ///   - lhs: An optional value to compare.
   ///   - rhs: Another optional value to compare.
-  @inlinable
+  @_transparent
   public static func ==(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
     switch (lhs, rhs) {
     case let (l?, r?):


### PR DESCRIPTION
In unspecialised generic code (i.e. anything that isn't entirely `@inlinable`), this can make an enormous difference.

I’d appreciate somebody triggering benchmarks for this.