### PR TITLE
IRGen: Enable update of extended frame pointer entry on x86_64

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -94,6 +94,8 @@ static void configureX86_64(IRGenModule &IGM, const llvm::Triple &triple,
   // x86-64 only has 48 effective bits of address space and reserves the high
   // half for the kernel.
   target.SwiftRetainIgnoresNegativeValues = true;
+
+  target.UsableSwiftAsyncContextAddrIntrinsic = true;
 }
 
 /// Configures target-specific information for 32-bit x86 platforms.


### PR DESCRIPTION
So far this was only enabled on arm64. Let's see whether the x86_64 backend can handle it.