### PR TITLE
[libSyntax] Hide null AbsoluteRawSyntax behind a custom OptionalStorage implementation

### DIFF
--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -450,6 +450,7 @@ public:
   /// Get a child based on a particular node's "Cursor", indicating
   /// the position of the terms in the production of the Swift grammar.
   const RawSyntax *getChild(CursorIndex Index) const {
+    assert(Index < getNumChildren() && "Index out of bounds");
     return getLayout()[Index];
   }
 

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -53,42 +53,253 @@ namespace syntax {
 
 /// The class for holding parented syntax.
 ///
-/// This structure should not contain significant public
-/// API or internal modification API.
+/// \c SyntaxDataRef is designed for efficiency, not memory safety.
+/// It *does not* retain the \c RawSyntax that backs the syntax node, the \c
+/// SyntaxArena in which the \c RawSyntax node lives nor the parent \c
+/// SyntaxDataRef node. It is the user's responsibility to ensure these values
+/// outlive the \c SyntaxDataRef.
 ///
-/// It is essentially a wrapper around \c AbsoluteRawSyntax that also keeps
-/// track of the parent.
-class SyntaxData : public llvm::ThreadSafeRefCountedBase<SyntaxData> {
-  const AbsoluteRawSyntax AbsoluteRaw;
-  RC<const SyntaxData> Parent;
+/// Always use \c SyntaxData if performance is not a concern and memory safety
+/// should be guaranteed.
+class SyntaxDataRef {
+  friend class SyntaxData;
 
+protected:
+  /// The \c AbsoluteRawSyntaxNode that provides the majority of this node's
+  /// data. The underlying \c RawSyntax node is *not* retained by the \c
+  /// SyntaxDataRef. It is the user's responsibility to ensure that the \c
+  /// RawSyntax's \c SyntaxArena outlives this \c SyntaxDataRef.
+  ///
+  /// In \c SyntaxData, the backing \c SyntaxArena is retained via the \c Arena
+  /// property, lifiting the responsibility to guarantee the \c RawSyntax node
+  /// stays alive from the user.
+  const AbsoluteRawSyntax AbsoluteRaw;
+
+  /// The parent of this node. The parent is *not* retained by the \c
+  /// SyntaxDataRef. It is the user's responsibility to ensure that the parent
+  /// always outlives the child.
+  ///
+  /// If this is a \c SyntaxData object, \c Parent is guaranteed to also be a
+  /// \c SyntaxData object, which is manually retained when \c this is created
+  /// and released when \c this is destroyed.
+  const SyntaxDataRef *Parent;
+
+#ifndef NDEBUG
+  /// In debug builds, a flag that specifies if this instance is a \c
+  /// SyntaxDataRef or a \c SyntaxData object.
+  bool IsRef = true;
+#endif
+
+  /// Creates an empty \c SyntaxDataRef variable to which values can later be
+  /// stored.
+  SyntaxDataRef() : AbsoluteRaw() {}
+
+  /// Creates a \c SyntaxDataRef. \p AbsoluteRaw must not be null. If \p Parent
+  /// is a \c nullptr, this node represents the root of a tree.
+  SyntaxDataRef(const AbsoluteRawSyntax &AbsoluteRaw,
+                const SyntaxDataRef *Parent)
+      : AbsoluteRaw(AbsoluteRaw), Parent(Parent) {
+    assert(!AbsoluteRaw.isNull() &&
+           "SyntaxDataRef must always have a value. Use default constructor to "
+           "create a SyntaxDataRef to be populated later.");
+  }
+
+public:
+  SyntaxDataRef(const SyntaxDataRef &DataRef) = default;
+  SyntaxDataRef(SyntaxDataRef &&DataRef) = default;
+
+  // MARK: - Retrieving underlying data
+
+  /// Whether this is a null node created by the default constructor, and will
+  /// be populated later.
+  bool isNull() const { return AbsoluteRaw.isNull(); }
+
+  const AbsoluteRawSyntax &getAbsoluteRaw() const {
+    assert(!isNull() && "Cannot get AbsoluteRaw of a null SyntaxDataRef");
+    return AbsoluteRaw;
+  }
+
+  /// Returns the raw syntax node for this syntax node.
+  const RawSyntax *getRaw() const { return getAbsoluteRaw().getRaw(); }
+
+  // MARK: - Retrieving related nodes
+
+  const SyntaxDataRef *getParentRef() const {
+    assert(!isNull() && "Cannot get Parent of a null SyntaxDataRef");
+    return Parent;
+  }
+
+  /// Returns true if this syntax node has a parent.
+  bool hasParent() const { return getParentRef() != nullptr; }
+
+  /// Returns the number of children this SyntaxData has.
+  size_t getNumChildren() const { return getRaw()->getLayout().size(); }
+
+  /// Returns the child index of this node in its parent, if it has a parent,
+  /// otherwise 0.
+  AbsoluteSyntaxPosition::IndexInParentType getIndexInParent() const {
+    return getAbsoluteRaw().getPosition().getIndexInParent();
+  }
+
+  // MARK: - Retrieving source locations
+
+  /// Get the offset at which the leading trivia of this node starts.
+  AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const {
+    return getAbsoluteRaw().getPosition();
+  }
+
+  /// Get the offset at which the content of this node (excluding leading
+  /// trivia) starts.
+  AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
+    if (auto FirstToken = getAbsoluteRaw().getFirstToken()) {
+      return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
+          FirstToken->getRaw()->getLeadingTriviaLength());
+    } else {
+      return getAbsolutePositionBeforeLeadingTrivia();
+    }
+  }
+
+  /// Get the offset at which the content (excluding trailing trivia) of this
+  /// node ends.
+  AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const {
+    if (auto LastToken = getAbsoluteRaw().getLastToken()) {
+      return getAbsoluteEndPositionAfterTrailingTrivia().advancedBy(
+          -LastToken->getRaw()->getTrailingTriviaLength());
+    } else {
+      return getAbsoluteEndPositionAfterTrailingTrivia();
+    }
+  }
+
+  /// Get the offset at chiwh the trailing trivia of this node ends.
+  AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const {
+    return getAbsolutePositionBeforeLeadingTrivia().advancedBy(
+        getRaw()->getTextLength());
+  }
+
+  // MARK: - Getting the node's kind
+
+  /// Returns which kind of syntax node this is.
+  SyntaxKind getKind() const { return getRaw()->getKind(); }
+
+  /// Returns true if the data node represents type syntax.
+  bool isType() const { return getRaw()->isType(); }
+
+  /// Returns true if the data node represents statement syntax.
+  bool isStmt() const { return getRaw()->isStmt(); }
+
+  /// Returns true if the data node represents declaration syntax.
+  bool isDecl() const { return getRaw()->isDecl(); }
+
+  /// Returns true if the data node represents expression syntax.
+  bool isExpr() const { return getRaw()->isExpr(); }
+
+  /// Returns true if the data node represents pattern syntax.
+  bool isPattern() const { return getRaw()->isPattern(); }
+
+  /// Returns true if this syntax is of some "unknown" kind.
+  bool isUnknown() const { return getRaw()->isUnknown(); }
+
+  // MARK: - Miscellaneous
+
+  /// Dump a debug description of the syntax data for debugging to
+  /// standard error.
+  void dump(llvm::raw_ostream &OS) const;
+
+  SWIFT_DEBUG_DUMP;
+};
+
+class SyntaxData final : public SyntaxDataRef {
   /// If this node is the root of a Syntax tree (i.e. \c Parent is \c nullptr ),
   /// the arena in which this node's \c RawSyntax node has been allocated.
   /// This keeps this \c RawSyntax nodes referenced by this tree alive.
+  /// If \c Parent has a value, this is always \c nullptr.
   RC<SyntaxArena> Arena;
 
-  /// Create a intermediate node with a parent.
-  SyntaxData(AbsoluteRawSyntax AbsoluteRaw, const RC<const SyntaxData> &Parent)
-      : AbsoluteRaw(AbsoluteRaw), Parent(Parent), Arena(nullptr) {}
+  mutable std::atomic<int> RefCount{0};
 
-  /// Create a new root node
-  SyntaxData(AbsoluteRawSyntax AbsoluteRaw)
-      : AbsoluteRaw(AbsoluteRaw), Parent(nullptr),
-        Arena(AbsoluteRaw.getRaw()->getArena()) {}
+  /// Create a non-root node with a \p Parent.
+  SyntaxData(const AbsoluteRawSyntax &AbsoluteRaw,
+             const RC<const SyntaxData> &Parent)
+      : SyntaxDataRef(AbsoluteRaw, Parent.get()), Arena(nullptr) {
+    assert(
+        Parent != nullptr &&
+        "Use SyntaxData(AbsoluteRawSyntax) or makeRoot to create a root node.");
+    assert(!Parent->IsRef &&
+           "Cannot create a SyntaxData as a child of a SyntaxDataRef");
+    Parent->Retain();
+#ifndef NDEBUG
+    IsRef = false;
+#endif
+  }
+
+  /// Create a new root node.
+  SyntaxData(const AbsoluteRawSyntax &AbsoluteRaw)
+      : SyntaxDataRef(AbsoluteRaw, nullptr),
+        Arena(AbsoluteRaw.getRaw()->getArena()) {
+#ifndef NDEBUG
+    IsRef = false;
+#endif
+  }
 
 public:
-  /// With a new \c RawSyntax node, create a new node from this one and
-  /// recursively rebuild the parental chain up to the root.
-  RC<const SyntaxData> replacingSelf(const RawSyntax *NewRaw) const;
-
-  /// Replace a child in the raw syntax and recursively rebuild the
-  /// parental chain up to the root.
-  template <typename CursorType>
-  RC<const SyntaxData> replacingChild(const RawSyntax *RawChild,
-                                      CursorType ChildCursor) const {
-    auto NewRaw = AbsoluteRaw.getRaw()->replacingChild(ChildCursor, RawChild);
-    return replacingSelf(NewRaw);
+  SyntaxData(const SyntaxData &DataRef)
+      : SyntaxDataRef(DataRef.AbsoluteRaw, DataRef.Parent),
+        Arena(DataRef.Arena) {
+    if (auto Parent = getParent()) {
+      assert(!Parent->IsRef &&
+             "Parent of a SyntaxData node should always be a SyntaxData node");
+      Parent->Retain();
+    }
   }
+
+  ~SyntaxData() {
+    assert(RefCount == 0 &&
+           "Destruction occured when there are still references to this.");
+    if (auto Parent = getParent()) {
+      Parent->Release();
+    }
+  }
+
+  /// Make a new \c SyntaxData node for the tree's root.
+  static RC<const SyntaxData> makeRoot(const AbsoluteRawSyntax &AbsoluteRaw) {
+    return RC<const SyntaxData>(new SyntaxData(AbsoluteRaw));
+  }
+
+  void Retain() const { RefCount.fetch_add(1, std::memory_order_relaxed); }
+
+  void Release() const {
+    int NewRefCount = RefCount.fetch_sub(1, std::memory_order_acq_rel) - 1;
+    assert(NewRefCount >= 0 && "Reference count was already zero.");
+    if (NewRefCount == 0) {
+      delete this;
+    }
+  }
+
+  // MARK: - Retrieving related nodes
+
+  /// Return the parent syntax if there is one, otherwise return \c nullptr.
+  RC<const SyntaxData> getParent() const {
+    if (auto ParentRef = getParentRef()) {
+      assert(!ParentRef->IsRef &&
+             "Parent of a SyntaxData node should always be a SyntaxData node");
+      return RC<const SyntaxData>(static_cast<const SyntaxData *>(ParentRef));
+    } else {
+      return nullptr;
+    }
+  }
+
+  /// Gets the child at the index specified by the provided cursor if there is
+  /// one, otherwise returns \c nullptr.
+  template <typename CursorType>
+  RC<const SyntaxData> getChild(CursorType Cursor) const {
+    return getChild(
+        (AbsoluteSyntaxPosition::IndexInParentType)cursorIndex(Cursor));
+  }
+
+  /// Gets the child at the specified \p Index  if there is one, otherwise
+  /// returns \c nullptr.
+  RC<const SyntaxData>
+  getChild(AbsoluteSyntaxPosition::IndexInParentType Index) const;
 
   /// Get the node immediately before this current node that does contain a
   /// non-missing token. Return \c nullptr if we cannot find such node.
@@ -106,86 +317,20 @@ public:
   /// this node does not contain non-missing tokens.
   RC<const SyntaxData> getLastToken() const;
 
-  /// Make a new \c SyntaxData node for the tree's root.
-  static RC<const SyntaxData> makeRoot(AbsoluteRawSyntax AbsoluteRaw) {
-    return RC<const SyntaxData>(new SyntaxData(AbsoluteRaw));
-  }
+  // MARK: - Modifying node
 
-  const AbsoluteRawSyntax &getAbsoluteRaw() const { return AbsoluteRaw; }
+  /// With a new \c RawSyntax node, create a new node from this one and
+  /// recursively rebuild the parental chain up to the root.
+  RC<const SyntaxData> replacingSelf(const RawSyntax *NewRaw) const;
 
-  /// Returns the raw syntax node for this syntax node.
-  const RawSyntax *getRaw() const { return AbsoluteRaw.getRaw(); }
-
-  /// Returns the kind of syntax node this is.
-  SyntaxKind getKind() const { return AbsoluteRaw.getRaw()->getKind(); }
-
-  /// Return the parent syntax if there is one.
-  RC<const SyntaxData> getParent() const { return Parent; }
-
-  /// Returns true if this syntax node has a parent.
-  bool hasParent() const {
-    return Parent != nullptr;
-  }
-
-  /// Returns the child index of this node in its parent, if it has a parent,
-  /// otherwise 0.
-  AbsoluteSyntaxPosition::IndexInParentType getIndexInParent() const {
-    return AbsoluteRaw.getPosition().getIndexInParent();
-  }
-
-  /// Returns the number of children this SyntaxData represents.
-  size_t getNumChildren() const {
-    return AbsoluteRaw.getRaw()->getLayout().size();
-  }
-
-  /// Gets the child at the index specified by the provided cursor.
+  /// Replace a child in the raw syntax and recursively rebuild the
+  /// parental chain up to the root.
   template <typename CursorType>
-  RC<const SyntaxData> getChild(CursorType Cursor) const {
-    return getChild(
-        (AbsoluteSyntaxPosition::IndexInParentType)cursorIndex(Cursor));
+  RC<const SyntaxData> replacingChild(const RawSyntax *RawChild,
+                                      CursorType ChildCursor) const {
+    auto NewRaw = AbsoluteRaw.getRaw()->replacingChild(ChildCursor, RawChild);
+    return replacingSelf(NewRaw);
   }
-
-  /// Gets the child at the specified \p Index.
-  RC<const SyntaxData>
-  getChild(AbsoluteSyntaxPosition::IndexInParentType Index) const;
-
-  /// Get the offset at which the leading trivia of this node starts.
-  AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const;
-
-  /// Get the offset at which the content (excluding trailing trivia) of this
-  /// node ends.
-  AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const;
-
-  /// Get the offset at which the content of this node (excluding leading
-  /// trivia) starts.
-  AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const;
-
-  /// Get the offset at chiwh the trailing trivia of this node ends.
-  AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const;
-
-  /// Returns true if the data node represents type syntax.
-  bool isType() const;
-
-  /// Returns true if the data node represents statement syntax.
-  bool isStmt() const;
-
-  /// Returns true if the data node represents declaration syntax.
-  bool isDecl() const;
-
-  /// Returns true if the data node represents expression syntax.
-  bool isExpr() const;
-
-  /// Returns true if the data node represents pattern syntax.
-  bool isPattern() const;
-
-  /// Returns true if this syntax is of some "unknown" kind.
-  bool isUnknown() const;
-
-  /// Dump a debug description of the syntax data for debugging to
-  /// standard error.
-  void dump(llvm::raw_ostream &OS) const;
-
-  SWIFT_DEBUG_DUMP;
 };
 
 } // end namespace syntax


### PR DESCRIPTION
This includes all changes from #36250 and addresses this discussion with a follow-up commit described below: https://github.com/apple/swift/pull/36250#discussion_r587863352

This splits the previous null `AbsoluteRawSyntax` type into two categories and removes the public null initializer and `isNull` method.

1. The default initializer of `AbsoluteRawSyntax` now create uninitialized memory. This is exactly what we need since we just need to allocate the memory to initialise it using the `SyntaxDataRef::getChild` method wherever we use it (the actual usage will come in a future PR).
2. Make `Optional<AbsoluteRawSyntax>` and `Optional<SyntaxDataRef>` zero-cost wrappers around their underlying type. These use the old null type to indicate a missing optional value.

Overall, I believe this makes the code both safer (we now enforce null types properly in the type system) and potentially faster (although I haven't been able to measure an improvement).