### PR TITLE
[sourcekit] Response 'edit' immediately if client needs nothing

### DIFF
--- a/test/SourceKit/Sema/edit_nowait.swift
+++ b/test/SourceKit/Sema/edit_nowait.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "" > %t/t.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=open %t/t.swift -- %t/t.swift == \
+// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=0 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -print-raw-response == \
+// RUN:   -req=edit -offset=13 -replace="print" -length=5 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift -print-raw-response \
+// RUN: | %FileCheck --check-prefix=EDIT_NOWAIT %s
+
+// EDIT_NOWAIT:      {
+// EDIT_NOWAIT-NEXT: }
+// EDIT_NOWAIT-NEXT: {
+// EDIT_NOWAIT-NEXT: }
+
+// RUN: %sourcekitd-test \
+// RUN: %sourcekitd-test \
+// RUN:   -req=open %t/t.swift -- %t/t.swift == \
+// RUN:   -req=edit -offset=0 -replace="func foo() { warn("") }" -length=0 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift == \
+// RUN:   -req=edit -offset=13 -replace="print" -length=4 -req-opts=enablesyntaxmap=0,enablesubstructure=0,enablediagnostics=0 %t/t.swift == \
+// RUN:   -req=print-annotations %s \
+// RUN: | %FileCheck --check-prefix=ANNOTATION %s
+
+// ANNOTATION:      [
+// ANNOTATION-NEXT:   {
+// ANNOTATION-NEXT:     key.kind: source.lang.swift.ref.function.free,
+// ANNOTATION-NEXT:     key.offset: 13,
+// ANNOTATION-NEXT:     key.length: 5,
+// ANNOTATION-NEXT:     key.is_system: 1
+// ANNOTATION-NEXT:   }
+// ANNOTATION-NEXT: ]

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -276,6 +276,8 @@ public:
 
   virtual void recordFormattedText(StringRef Text) = 0;
 
+  virtual bool diagnosticsEnabled() = 0;
+
   virtual void setDiagnosticStage(UIdent DiagStage) = 0;
   virtual void handleDiagnostic(const DiagnosticEntryInfo &Info,
                                 UIdent DiagStage) = 0;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -2016,7 +2016,8 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer, bool ReportDi
           "same time is not supported. Use the syntax tree to compute the "
           "document structure.");
     }
-  } else {
+  } else if (Consumer.documentStructureEnabled() ||
+             Consumer.syntaxMapEnabled()) {
     ide::SyntaxModelContext ModelContext(Impl.SyntaxInfo->getSourceFile());
 
     SwiftEditorSyntaxWalker SyntaxWalker(
@@ -2498,6 +2499,14 @@ void SwiftLangSupport::editorReplaceText(StringRef Name,
     if (EditorDoc->getSyntaxTree().hasValue()) {
       SyntaxCache.emplace(EditorDoc->getSyntaxTree().getValue());
       SyntaxCache->addEdit(Offset, Offset + Length, Buf->getBufferSize());
+    }
+
+    // If client doesn't need any information, we doen't need to parse it.
+    if (!Consumer.documentStructureEnabled() &&
+        !Consumer.syntaxMapEnabled() &&
+        !Consumer.diagnosticsEnabled() &&
+        !Consumer.syntaxTreeEnabled()) {
+      return;
     }
 
     SyntaxParsingCache *SyntaxCachePtr = nullptr;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -897,6 +897,7 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   case SourceKitRequest::Open:
     sourcekitd_request_dictionary_set_uid(Req, KeyRequest, RequestEditorOpen);
     sourcekitd_request_dictionary_set_string(Req, KeyName, SemaName.c_str());
+    addRequestOptionsDirect(Req, Opts);
     break;
 
   case SourceKitRequest::Close:
@@ -912,6 +913,7 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_int64(Req, KeyLength, Opts.Length);
     sourcekitd_request_dictionary_set_string(Req, KeySourceText,
                                        Opts.ReplaceText.getValue().c_str());
+    addRequestOptionsDirect(Req, Opts);
     break;
 
   case SourceKitRequest::PrintAnnotations:

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2496,6 +2496,8 @@ public:
 
   void recordFormattedText(StringRef Text) override;
 
+  bool diagnosticsEnabled() override { return Opts.EnableDiagnostics; }
+
   void setDiagnosticStage(UIdent DiagStage) override;
   void handleDiagnostic(const DiagnosticEntryInfo &Info,
                         UIdent DiagStage) override;

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -72,6 +72,8 @@ class NullEditorConsumer : public EditorConsumer {
 
   void recordAffectedLineRange(unsigned Line, unsigned Length) override {}
 
+  bool diagnosticsEnabled() override { return false; }
+
   void setDiagnosticStage(UIdent DiagStage) override {}
   void handleDiagnostic(const DiagnosticEntryInfo &Info,
                         UIdent DiagStage) override {}

--- a/unittests/SourceKit/SwiftLang/EditingTest.cpp
+++ b/unittests/SourceKit/SwiftLang/EditingTest.cpp
@@ -92,6 +92,8 @@ private:
 
   void recordFormattedText(StringRef Text) override {}
 
+  bool diagnosticsEnabled() override { return true; }
+
   void setDiagnosticStage(UIdent diagStage) override { DiagStage = diagStage; }
   void handleDiagnostic(const DiagnosticEntryInfo &Info,
                         UIdent DiagStage) override {


### PR DESCRIPTION
If the client doesn't want anything as the response of `editor.replacetext` requests, immediately response an empty dictionary. There's no need to wait for parse and update the snapshot.

rdar://problem/74984613