### PR TITLE
Introduce `-warn-concurrency` flag to warn about concurrency issues.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -238,6 +238,12 @@ namespace swift {
     /// optimized custom allocator, so that memory debugging tools can be used.
     bool UseMalloc = false;
 
+    /// Provide additional warnings about code that is unsafe in the
+    /// eventual Swift concurrency model, and will eventually become errors
+    /// in a future Swift language version, but are too noisy for existing
+    /// language modes.
+    bool WarnConcurrency = false;
+
     /// Enable experimental #assert feature.
     bool EnableExperimentalStaticAssert = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -616,6 +616,11 @@ def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
   Alias<warn_swift3_objc_inference_complete>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>;
 
+def warn_concurrency : Flag<["-"], "warn-concurrency">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Warn about code that is unsafe according to the Swift Concurrency "
+           "model and will become ill-formed in a future language version">;
+
 def Rpass_EQ : Joined<["-"], "Rpass=">,
   Flags<[FrontendOption]>,
   HelpText<"Report performed transformations by optimization passes whose "

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -217,6 +217,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments,
                        options::OPT_warn_swift3_objc_inference_minimal,
                        options::OPT_warn_swift3_objc_inference_complete);
+  inputArgs.AddLastArg(arguments, options::OPT_warn_concurrency);
   inputArgs.AddLastArg(arguments, options::OPT_warn_implicit_overrides);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -549,6 +549,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.WarnConcurrency |= Args.hasArg(OPT_warn_concurrency);
+
   Opts.WarnImplicitOverrides =
     Args.hasArg(OPT_warn_implicit_overrides);
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -837,11 +837,19 @@ static bool diagnoseNonConcurrentProperty(
   return false;
 }
 
+/// Whether we should diagnose cases where ConcurrentValue conformances are
+/// missing.
+static bool shouldDiagnoseNonConcurrentValueViolations(
+    const LangOptions &langOpts) {
+  return langOpts.EnableExperimentalConcurrency ||
+      langOpts.WarnConcurrency;
+}
+
 bool swift::diagnoseNonConcurrentTypesInReference(
     ConcreteDeclRef declRef, const DeclContext *dc, SourceLoc loc,
     ConcurrentReferenceKind refKind) {
   // Bail out immediately if we aren't supposed to do this checking.
-  if (!dc->getASTContext().LangOpts.EnableExperimentalConcurrency)
+  if (!shouldDiagnoseNonConcurrentValueViolations(dc->getASTContext().LangOpts))
     return false;
 
   // For functions, check the parameter and result types.
@@ -1214,7 +1222,7 @@ namespace {
           if (!indexExpr || !indexExpr->getType())
             continue;
 
-          if (ctx.LangOpts.EnableExperimentalConcurrency &&
+          if (shouldDiagnoseNonConcurrentValueViolations(ctx.LangOpts) &&
               !isConcurrentValueType(getDeclContext(), indexExpr->getType())) {
             ctx.Diags.diagnose(
                 component.getLoc(), diag::non_concurrent_keypath_capture,
@@ -2554,6 +2562,9 @@ void swift::checkOverrideActorIsolation(ValueDecl *value) {
 }
 
 static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
+  if (dc->getASTContext().LangOpts.WarnConcurrency)
+    return true;
+
   while (!dc->isModuleScopeContext()) {
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
       // Async and concurrent closures use concurrency features.
@@ -2593,16 +2604,21 @@ static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
   return false;
 }
 
-static DiagnosticBehavior toDiagnosticBehavior(ConcurrentValueCheck check,
+static DiagnosticBehavior toDiagnosticBehavior(const LangOptions &langOpts,
+                                               ConcurrentValueCheck check,
                                                bool diagnoseImplicit = false) {
   switch (check) {
   case ConcurrentValueCheck::ImpliedByStandardProtocol:
-    return DiagnosticBehavior::Warning;
+    return shouldDiagnoseNonConcurrentValueViolations(langOpts)
+        ? DiagnosticBehavior::Warning
+        : DiagnosticBehavior::Ignore;
   case ConcurrentValueCheck::Explicit:
     return DiagnosticBehavior::Unspecified;
   case ConcurrentValueCheck::Implicit:
-    return diagnoseImplicit ? DiagnosticBehavior::Unspecified
-                            : DiagnosticBehavior::Ignore;
+    return (diagnoseImplicit &&
+            shouldDiagnoseNonConcurrentValueViolations(langOpts))
+      ? DiagnosticBehavior::Unspecified
+      : DiagnosticBehavior::Ignore;
   }
 }
 
@@ -2612,7 +2628,8 @@ static bool checkConcurrentValueInstanceStorage(
     NominalTypeDecl *nominal, DeclContext *dc, ConcurrentValueCheck check) {
   // Stored properties of structs and classes must have
   // ConcurrentValue-conforming types.
-  auto behavior = toDiagnosticBehavior(check);
+  const auto &langOpts = dc->getASTContext().LangOpts;
+  auto behavior = toDiagnosticBehavior(langOpts, check);
   bool invalid = false;
   if (isa<StructDecl>(nominal) || isa<ClassDecl>(nominal)) {
     auto classDecl = dyn_cast<ClassDecl>(nominal);
@@ -2689,7 +2706,8 @@ bool swift::checkConcurrentValueConformance(
 
   // ConcurrentValue can only be used in the same source file.
   auto conformanceDecl = conformanceDC->getAsDecl();
-  auto behavior = toDiagnosticBehavior(check, /*diagnoseImplicit=*/true);
+  auto behavior = toDiagnosticBehavior(
+      nominal->getASTContext().LangOpts, check, /*diagnoseImplicit=*/true);
   if (!conformanceDC->getParentSourceFile() ||
       conformanceDC->getParentSourceFile() != nominal->getParentSourceFile()) {
     conformanceDecl->diagnose(diag::concurrent_value_outside_source_file,

--- a/test/Constraints/ErrorBridging.swift
+++ b/test/Constraints/ErrorBridging.swift
@@ -75,7 +75,7 @@ func throwErrorCode() throws {
   throw FictionalServerError.meltedDown // expected-error{{thrown error code type 'FictionalServerError.Code' does not conform to 'Error'; construct an 'FictionalServerError' instance}}{{29-29=(}}{{40-40=)}}
 }
 
-class MyErrorClass { } // expected-warning{{non-final class 'MyErrorClass' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class MyErrorClass { }
 extension MyErrorClass: Error { }
 
 class MyClass { }

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -346,7 +346,7 @@ extension Int: JSONLeaf { }
 extension Array: JSON where Element: JSON { }
 
 protocol SR13035Error: Error {}
-class ChildError: SR13035Error {} // expected-warning{{non-final class 'ChildError' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class ChildError: SR13035Error {}
 
 protocol AnyC {
   func foo()

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -7,8 +7,8 @@ class Cat {}
 enum HomeworkError : Error {
   case TooHard
   case TooMuch
-  case CatAteIt(Cat) // expected-warning{{associated value 'CatAteIt' of 'ConcurrentValue'-conforming enum 'HomeworkError' has non-concurrent-value type 'Cat'}}
-  case CatHidIt(Cat) // expected-warning{{associated value 'CatHidIt' of 'ConcurrentValue'-conforming enum 'HomeworkError' has non-concurrent-value type 'Cat'}}
+  case CatAteIt(Cat)
+  case CatHidIt(Cat)
 }
 
 func someValidPointer<T>() -> UnsafePointer<T> { fatalError() }
@@ -1013,14 +1013,14 @@ func testOptionalTryNeverFailsAddressOnlyVar<T>(_ obj: T) {
   var copy = try? obj // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{initialization of variable 'copy' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
-class SomeErrorClass : Error { } // expected-warning{{non-final class 'SomeErrorClass' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class SomeErrorClass : Error { }
 
 // CHECK-LABEL: sil_vtable SomeErrorClass
 // CHECK-NEXT:   #SomeErrorClass.init!allocator: {{.*}} : @$s6errors14SomeErrorClassCACycfC
 // CHECK-NEXT:   #SomeErrorClass.deinit!deallocator: @$s6errors14SomeErrorClassCfD
 // CHECK-NEXT: }
 
-class OtherErrorSub : OtherError { } // expected-warning{{non-final class 'OtherErrorSub' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class OtherErrorSub : OtherError { }
 
 // CHECK-LABEL: sil_vtable OtherErrorSub {
 // CHECK-NEXT:  #OtherError.init!allocator: {{.*}} : @$s6errors13OtherErrorSubCACycfC [override]

--- a/test/Sema/existential_nested_type.swift
+++ b/test/Sema/existential_nested_type.swift
@@ -10,7 +10,7 @@ protocol HasAssoc {
 }
 
 enum MyError : Error {
-  case bad(Any) // expected-warning{{associated value 'bad' of 'ConcurrentValue'-conforming enum 'MyError' has non-concurrent-value type 'Any'}}
+  case bad(Any)
 }
 
 func checkIt(_ js: Any) throws {

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -145,7 +145,7 @@ B(foo: 0) // expected-warning{{unused}}
 
 // rdar://problem/33040113 - Provide fix-it for missing "try" when calling throwing Swift function
 
-class E_33040113 : Error {} // expected-warning{{non-final class 'E_33040113' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class E_33040113 : Error {}
 func rdar33040113() throws -> Int {
     throw E_33040113()
 }

--- a/test/decl/protocol/special/Error.swift
+++ b/test/decl/protocol/special/Error.swift
@@ -34,13 +34,13 @@ enum EmptyErrorDomain: Error {}
 struct ErrorStruct : Error {
 }
 
-class ErrorClass : Error { // expected-warning{{non-final class 'ErrorClass' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class ErrorClass : Error {
 }
 
 struct ErrorStruct2 { }
 
 extension ErrorStruct2 : Error { }
 
-class ErrorClass2 { } // expected-warning{{non-final class 'ErrorClass2' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class ErrorClass2 { }
 
 extension ErrorClass2 : Error { }

--- a/test/decl/protocol/special/coding/enum_coding_key.swift
+++ b/test/decl/protocol/special/coding/enum_coding_key.swift
@@ -45,7 +45,6 @@ struct StructKey : CodingKey { // expected-error {{type 'StructKey' does not con
 
 // Classes conforming to CodingKey should not get implict derived conformance.
 class ClassKey : CodingKey { //expected-error {{type 'ClassKey' does not conform to protocol 'CodingKey'}}
-  // expected-warning@-1{{non-final class 'ClassKey' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
 }
 
 // Types which are valid for CodingKey derived conformance should not get that

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -212,7 +212,7 @@ func sr_6400_3(error: Error) {
 }
 
 class SR_6400_A {}
-class SR_6400_B: SR_6400_FakeApplicationDelegate & Error {} // expected-warning{{non-final class 'SR_6400_B' cannot conform to `ConcurrentValue`; use `UnsafeConcurrentValue`}}
+class SR_6400_B: SR_6400_FakeApplicationDelegate & Error {}
 
 func sr_6400_4() {
   do {


### PR DESCRIPTION
To help support incremental adoption of the concurrency model, a number
of concurrency-related diagnostics are enabled only in "new" code that
takes advantage of concurrency features---async, @Concurrent functions,
actors, etc. This warning flag opts into additional warnings that better
approximate the eventual concurrency model, and which will become
errors a future Swift version, allowing one to both experiment with
the full concurrency model and also properly prepare for it.