### PR TITLE
Add UnsafeThrowingContinuation back as a deprecated typealias.

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -211,3 +211,6 @@ public func withUnsafeThrowingContinuation<T>(
     fn(UnsafeContinuation<T, Error>($0))
   }
 }
+
+@available(*, deprecated, message: "please use UnsafeContination<..., Error>")
+public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>


### PR DESCRIPTION
This helps migrate clients that reference this type.
Fixes rdar://75104903.
