### PR TITLE
Add build_script_log file to help us understand the build times for e…

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1351,10 +1351,11 @@ def main_normal():
     # Create build directory.
     shell.makedirs(invocation.workspace.build_root)
 
-    # Create .build_script_log.
-    build_script_log = os.path.join(invocation.workspace.build_root,
-                                    ".build_script_log")
-    open(build_script_log, 'w').close()
+    # Create .build_script_log
+    if not args.dry_run:
+        build_script_log = os.path.join(invocation.workspace.build_root,
+                                        ".build_script_log")
+        open(build_script_log, 'w').close()
 
     # Build ninja if required, which will update the toolchain.
     if args.build_ninja:

--- a/utils/build-script
+++ b/utils/build-script
@@ -1351,6 +1351,11 @@ def main_normal():
     # Create build directory.
     shell.makedirs(invocation.workspace.build_root)
 
+    # Create .build_script_log.
+    build_script_log = os.path.join(invocation.workspace.build_root,
+                                    ".build_script_log")
+    open(build_script_log, 'w').close()
+
     # Build ninja if required, which will update the toolchain.
     if args.build_ninja:
         invocation.build_ninja()

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -257,6 +257,16 @@ for component in ${components[@]} ; do
   )
 done
 
+function log_event() {
+    build_script_log_path=${BUILD_DIR}/.build_script_log
+    event_type=$1
+    event_command=$2
+    evnet_duration=$3
+
+    build_event="{\"event\":\"${event_type}\", \"command\":\"${event_command}\", \"duration\":\"${evnet_duration}\"}"
+    echo "${build_event}" >> ${build_script_log_path}
+}
+
 # Centralized access point for traced command invocation.
 # Every operation that might mutates file system should be called via
 # these functions.
@@ -265,10 +275,14 @@ function call() {
     if [[ ${DRY_RUN} ]] || [[ "${VERBOSE_BUILD}" ]]; then
         echo "${PS4}"$(quoted_print "$@")
     fi
+
+    SECONDS=0
     if [[ ! ${DRY_RUN} ]]; then
+        log_event "start" "$(quoted_print "$@")" "${SECONDS}"
         { set -x; } 2>/dev/null
         "$@"
         { set +x; } 2>/dev/null
+        log_event "finish" "$(quoted_print "$@")" "${SECONDS}"
     fi
 }
 


### PR DESCRIPTION
…ach command

Event will contain:
event: `start|finish`
command: `full command`
duration: `in seconds`

```
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64", "duration":"0"}
```

Example:

```
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64", "duration":"0"}
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"start", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"finish", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"start", "command":"/usr/local/bin/cmake --build /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64 -- -j24 -v all", "duration":"0"}
{"event":"finish", "command":"/usr/local/bin/cmake --build /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/cmark-macosx-x86_64 -- -j24 -v all", "duration":"2"}
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64", "duration":"0"}
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"start", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"finish", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"start", "command":"ln -s -f /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../../usr/include/c++ /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/include", "duration":"0"}
{"event":"finish", "command":"ln -s -f /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../../usr/include/c++ /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/include", "duration":"0"}
{"event":"start", "command":"/usr/local/bin/cmake --build /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64 -- -j24 -v all", "duration":"0"}
{"event":"finish", "command":"/usr/local/bin/cmake --build /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64 -- -j24 -v all", "duration":"212"}
{"event":"start", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.ios.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.ios.a", "duration":"0"}
{"event":"finish", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.ios.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.ios.a", "duration":"0"}
{"event":"start", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.iossim.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.iossim.a", "duration":"0"}
{"event":"finish", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.iossim.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.iossim.a", "duration":"0"}
{"event":"start", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.watchos.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.watchos.a", "duration":"0"}
{"event":"finish", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.watchos.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.watchos.a", "duration":"0"}
{"event":"start", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.watchossim.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.watchossim.a", "duration":"0"}
{"event":"finish", "command":"cp /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.watchossim.a /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.watchossim.a", "duration":"0"}
{"event":"start", "command":"lipo -remove i386 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.tvos.a -output /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.tvos.a", "duration":"0"}
{"event":"finish", "command":"lipo -remove i386 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.tvos.a -output /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.tvos.a", "duration":"0"}
{"event":"start", "command":"lipo -remove i386 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.tvossim.a -output /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.tvossim.a", "duration":"0"}
{"event":"finish", "command":"lipo -remove i386 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/clang/12.0.0/lib/darwin/libclang_rt.tvossim.a -output /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/llvm-macosx-x86_64/bin/../lib/clang/10.0.0/lib/darwin/libclang_rt.tvossim.a", "duration":"0"}
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64", "duration":"1"}
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"start", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"finish", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/libcxx-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64", "duration":"0"}
{"event":"start", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"finish", "command":"mkdir -p /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64/.cmake/api/v1/query", "duration":"0"}
{"event":"start", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"finish", "command":"touch /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64/.cmake/api/v1/query/codemodel-v2 /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64/.cmake/api/v1/query/cache-v2", "duration":"0"}
{"event":"start", "command":"/usr/local/bin/cmake --build /Users/buildnode/jenkins/workspace/swift-PR-macos/branch-main/buildbot_incremental/swift-macosx-x86_64 -- -j24 -v all swift-stdlib-macosx-x86_64 swift-stdlib-iphonesimulator-i386 swift-stdlib-iphonesimulator-x86_64 swift-stdlib-iphonesimulator-arm64 swift-stdlib-iphoneos-armv7 swift-stdlib-iphoneos-armv7s swift-stdlib-iphoneos-arm64 swift-stdlib-iphoneos-arm64e swift-stdlib-watchsimulator-i386 swift-stdlib-watchsimulator-arm64 swift-stdlib-watchos-armv7k swift-benchmark-macosx-x86_64 swift-benchmark-iphoneos-armv7 swift-benchmark-iphoneos-arm64 swift-benchmark-iphoneos-arm64e swift-benchmark-watchos-armv7k", "duration":"0"}
```