### PR TITLE
Sema: Fix crash with local 'lazy' variables that contain a closure

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -58,26 +58,6 @@ using namespace swift;
 
 #define DEBUG_TYPE "TypeCheckStmt"
 
-#ifndef NDEBUG
-/// Determine whether the given context is for the backing property of a
-/// property wrapper.
-static bool isPropertyWrapperBackingInitContext(DeclContext *dc) {
-  auto initContext = dyn_cast<Initializer>(dc);
-  if (!initContext) return false;
-
-  auto patternInitContext = dyn_cast<PatternBindingInitializer>(initContext);
-  if (!patternInitContext) return false;
-
-  auto binding = patternInitContext->getBinding();
-  if (!binding) return false;
-
-  auto singleVar = binding->getSingleVar();
-  if (!singleVar) return false;
-
-  return singleVar->getOriginalWrappedProperty() != nullptr;
-}
-#endif
-
 namespace {
   class ContextualizeClosures : public ASTWalker {
     DeclContext *ParentDC;
@@ -129,20 +109,7 @@ namespace {
 
       // Explicit closures start their own sequence.
       if (auto CE = dyn_cast<ClosureExpr>(E)) {
-        // In the repl, the parent top-level context may have been re-written.
-        if (CE->getParent() != ParentDC) {
-          if ((CE->getParent()->getContextKind() !=
-                    ParentDC->getContextKind()) ||
-              ParentDC->getContextKind() != DeclContextKind::TopLevelCodeDecl) {
-            // If a closure is nested within an auto closure, we'll need to update
-            // its parent to the auto closure parent.
-            assert((ParentDC->getContextKind() ==
-                      DeclContextKind::AbstractClosureExpr ||
-                    isPropertyWrapperBackingInitContext(ParentDC)) &&
-                   "Incorrect parent decl context for closure");
-            CE->setParent(ParentDC);
-          }
-        }
+        CE->setParent(ParentDC);
 
         // If the closure was type checked within its enclosing context,
         // we need to walk into it with a new sequence.

--- a/test/SILGen/lazy_locals.swift
+++ b/test/SILGen/lazy_locals.swift
@@ -37,3 +37,9 @@ func generic<T>(x: T) -> T {
 }
 
 // CHECK-LABEL: sil private [lazy_getter] [noinline] [ossa] @$s11lazy_locals7generic1xxx_tlF1zL_xvg : $@convention(thin) <T> (@guaranteed <τ_0_0> { var Optional<τ_0_0> } <T>, @in_guaranteed T) -> @out T {
+
+func lazyLocalWithNestedClosure() {
+  lazy var x = {
+    return 3
+  }()
+}


### PR DESCRIPTION
There was some bogus logic here that's no longer necessary.

Fixes https://bugs.swift.org/browse/SR-14271 / rdar://problem/74747109.