### PR TITLE
Sema: Relax witness availability check

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1670,8 +1670,8 @@ bool TypeChecker::isAvailabilitySafeForConformance(
     return true;
 
   auto &Context = proto->getASTContext();
-  NominalTypeDecl *conformingDecl = dc->getSelfNominalTypeDecl();
-  assert(conformingDecl && "Must have conforming declaration");
+  assert(dc->getSelfNominalTypeDecl() &&
+         "Must have a nominal or extension context");
 
   // Make sure that any access of the witness through the protocol
   // can only occur when the witness is available. That is, make sure that
@@ -1688,8 +1688,7 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   requirementInfo = AvailabilityInference::availableRange(requirement, Context);
 
   AvailabilityContext infoForConformingDecl =
-      overApproximateAvailabilityAtLocation(conformingDecl->getLoc(),
-                                            conformingDecl);
+      overApproximateAvailabilityAtLocation(dc->getAsDecl()->getLoc(), dc);
 
   // Constrain over-approximates intersection of version ranges.
   witnessInfo.constrainWith(infoForConformingDecl);

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1388,7 +1388,7 @@ protocol ProtocolWithRequirementMentioningUnavailable {
 
 protocol HasMethodF {
   associatedtype T
-  func f(_ p: T) // expected-note 5{{protocol requirement here}}
+  func f(_ p: T) // expected-note 4{{protocol requirement here}}
 }
 
 class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF {
@@ -1439,7 +1439,8 @@ extension HasNoMethodF1 : HasMethodF {
 class HasNoMethodF2 { }
 @available(OSX, introduced: 10.51)
 extension HasNoMethodF2 : HasMethodF {
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
+  // This is OK, because the conformance was introduced by an extension.
+  func f(_ p: Int) { }
 }
 
 @available(OSX, introduced: 10.51)
@@ -1453,7 +1454,7 @@ extension HasNoMethodF3 : HasMethodF {
 
 @available(OSX, introduced: 10.51)
 protocol HasMethodFOn10_51 {
-  func f(_ p: Int) // expected-note {{protocol requirement here}}
+  func f(_ p: Int)
 }
 
 class ConformsToUnavailableProtocolWithUnavailableWitness : HasMethodFOn10_51 {
@@ -1465,7 +1466,8 @@ class ConformsToUnavailableProtocolWithUnavailableWitness : HasMethodFOn10_51 {
 class HasNoMethodF4 { }
 @available(OSX, introduced: 10.52)
 extension HasNoMethodF4 : HasMethodFOn10_51 {
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodFOn10_51' requires 'f' to be available in macOS 10.51 and newer}}
+  // This is OK, because the conformance was introduced by an extension.
+  func f(_ p: Int) { }
 }
 
 @available(OSX, introduced: 10.51)

--- a/test/Sema/conformance_availability.swift
+++ b/test/Sema/conformance_availability.swift
@@ -322,3 +322,32 @@ func usesUnavailableHashable(_ c: UnavailableHashable) {
   // expected-error@-1 2 {{conformance of 'UnavailableHashable' to 'Hashable' is only available in macOS 100 or newer}}
   // expected-note@-2 2 {{add 'if #available' version check}}
 }
+
+// Actually make sure we check witness availability correctly.
+protocol Vehicle {
+  func move() // expected-note {{protocol requirement here}}
+}
+
+@available(macOS 100, *)
+struct Pony : Vehicle {
+  func move() {}
+}
+
+struct Bike {}
+
+@available(macOS 100, *)
+extension Bike : Vehicle {
+  func move() {}
+}
+
+class Car {}
+class ClownCar : Car {}
+
+@available(macOS 200, *)
+extension Car {
+  func move() {} // expected-note {{'move()' declared here}}
+}
+
+@available(macOS 100, *)
+extension ClownCar : Vehicle {}
+// expected-error@-1 {{protocol 'Vehicle' requires 'move()' to be available in macOS 100 and newer}}


### PR DESCRIPTION
We were checking that the witness is at least as available as
the intersection of the protocol and the conforming type.

In the case where the conformance is defined in an extension,
this should actually be the intersection of the protocol and
the _availability of the extension_.

Fixes <rdar://problem/74114880>.