### PR TITLE
Some clean-ups and improvements for cross-actor properties.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4298,20 +4298,21 @@ ERROR(actor_isolated_mutating_func,none,
       "cannot call mutating async function %0 on actor-isolated %1 %2",
       (DeclName, DescriptiveDeclKind, DeclName))
 ERROR(actor_isolated_global_actor_context,none,
-      "actor-isolated %0 %1 can not be referenced from context of global "
-      "actor %2",
-      (DescriptiveDeclKind, DeclName, Type))
+      "actor-isolated %0 %1 can not be %select{referenced|mutated|used 'inout'}3 "
+      "from%select{| synchronous}4 context of global actor %2",
+      (DescriptiveDeclKind, DeclName, Type, unsigned, bool))
 ERROR(global_actor_from_instance_actor_context,none,
-      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4 from actor %3",
-      (DescriptiveDeclKind, DeclName, Type, DeclName, unsigned))
+      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
+      " from actor %3 %select{|in a synchronous context}5",
+      (DescriptiveDeclKind, DeclName, Type, DeclName, unsigned, bool))
 ERROR(global_actor_from_other_global_actor_context,none,
       "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
-      " from different global actor %3",
-      (DescriptiveDeclKind, DeclName, Type, Type, unsigned))
+      " from different global actor %3 %select{|in a synchronous context}5",
+      (DescriptiveDeclKind, DeclName, Type, Type, unsigned, bool))
 ERROR(global_actor_from_nonactor_context,none,
       "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
-      " from %select{this|an '@actorIndependent'}3 context",
-      (DescriptiveDeclKind, DeclName, Type, bool, unsigned))
+      " from %select{this|an '@actorIndependent'}3%select{| synchronous}5 context",
+      (DescriptiveDeclKind, DeclName, Type, bool, unsigned, bool))
 ERROR(actor_isolated_partial_apply,none,
         "actor-isolated %0 %1 can not be partially applied",
         (DescriptiveDeclKind, DeclName))

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2198,7 +2198,7 @@ RValue RValueEmitter::visitMemberRefExpr(MemberRefExpr *e,
 
 RValue RValueEmitter::visitDynamicMemberRefExpr(DynamicMemberRefExpr *E,
                                                 SGFContext C) {
-  assert(!E->isImplicitlyAsync() && "actors do not have @objc members");
+  assert(!E->isImplicitlyAsync() && "an actor-isolated @objc member?");
   return SGF.emitDynamicMemberRefExpr(E, C);
 }
 
@@ -2220,7 +2220,7 @@ RValue RValueEmitter::visitSubscriptExpr(SubscriptExpr *E, SGFContext C) {
 
 RValue RValueEmitter::visitDynamicSubscriptExpr(
                                       DynamicSubscriptExpr *E, SGFContext C) {
-  assert(!E->isImplicitlyAsync() && "actors do not have @objc members");
+  assert(!E->isImplicitlyAsync() && "an actor-isolated @objc member?");
   return SGF.emitDynamicSubscriptExpr(E, C);
 }
 

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -203,6 +203,16 @@ func blender(_ peeler : () -> Void) {
   await (true ? wisk : {n in return})(1)
 }
 
+actor Chain {
+  var next : Chain?
+}
+
+func walkChain(chain : Chain) async {
+  _ = chain.next?.next?.next?.next // expected-error 4 {{property access is 'async' but is not marked with 'await'}}
+  _ = (await chain.next)?.next?.next?.next // expected-error 3 {{property access is 'async' but is not marked with 'await'}}
+  _ = (await chain.next?.next)?.next?.next // expected-error 2 {{property access is 'async' but is not marked with 'await'}}
+}
+
 
 // want to make sure there is no note about implicitly async on this func.
 @BananaActor func rice() async {}

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -16,17 +16,31 @@ actor A {
   func keypaths() {
     _ = #keyPath(A.x) // expected-error{{argument of '#keyPath' refers to non-'@objc' property 'x'}}
     _ = #keyPath(A.y) // expected-error{{argument of '#keyPath' refers to non-'@objc' property 'y'}}
+    _ = #keyPath(A.computed) // expected-error{{argument of '#keyPath' refers to non-'@objc' property 'computed'}}
     _ = #keyPath(A.z)
   }
 
   var x: Int = 0 // expected-note{{add '@objc' to expose this property to Objective-C}}
+
   @objc var y: Int = 0 // expected-note{{add '@objc' to expose this property to Objective-C}}
   // expected-error@-1{{actor-isolated property 'y' cannot be @objc}}
+
   @objc @actorIndependent(unsafe) var z: Int = 0
+
+  // expected-note@+1 {{add '@objc' to expose this property to Objective-C}}
+  @objc var computed : Int { // expected-error{{actor-isolated property 'computed' cannot be @objc}}
+    get { 120 }
+  }
 
   func f() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}
   func g() { } // expected-note{{add '@objc' to expose this instance method to Objective-C}}
   @objc func h() async { }
+
+  @objc @asyncHandler func i() {}
+}
+
+func outside(a : A) async {
+  await a.i() // expected-warning {{no 'async' operations occur within 'await' expression}}
 }
 
 

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -57,7 +57,7 @@ func referenceAsyncGlobalActor() {
 
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'callGlobalActor()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func callGlobalActor() {
-  syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
 }
 
 func fromClosure() {
@@ -67,20 +67,20 @@ func fromClosure() {
     x()
   }()
 
-  // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
   let _ = { syncGlobActorFn() }()
 }
 
 class Taylor {
   init() {
-    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn
   }
 
   deinit {
-    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn
@@ -88,7 +88,7 @@ class Taylor {
 
   // expected-note@+1 2 {{add '@SomeGlobalActor' to make instance method 'method1()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
   func method1() {
-    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn
@@ -96,7 +96,7 @@ class Taylor {
 
   // expected-note@+1 2 {{add '@SomeGlobalActor' to make instance method 'cannotBeHandler()' part of global actor 'SomeGlobalActor'}} {{3-3=@SomeGlobalActor }}
   func cannotBeHandler() -> Int {
-    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    syncGlobActorFn() // expected-error {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
 
     // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
     _ = syncGlobActorFn

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -231,7 +231,7 @@ func bar() async {
 
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
 func barSync() {
-  foo() // expected-error {{global function 'foo()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+  foo() // expected-error {{global function 'foo()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
 }
 
 // ----------------------------------------------------------------------
@@ -283,9 +283,9 @@ struct HasWrapperOnActor {
 
   // expected-note@+1 3{{to make instance method 'testErrors()'}}
   func testErrors() {
-    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this context}}
-    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
-    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from this context}}
+    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from this synchronous context}}
   }
 
   @MainActor mutating func testOnMain() {


### PR DESCRIPTION
A follow-on to #35965 that improves its implementation.

- [x] NFC refactoring of some bits of type-checking to share code and make the implementation more clear.
- [x] Improve diagnostic messages for implicitly-async calls and prop accesses in sync contexts. The messages as-is made it sound like it's not possible _at all_ to do those things.
- [x] Make sure chained actor accesses emit an error for each uncovered lookup.
- [x] Address `@objc` properties on actors.