### PR TITLE
IRGen: Set the mangler's generic signature correctly

### DIFF
--- a/include/swift/AST/PrettyStackTrace.h
+++ b/include/swift/AST/PrettyStackTrace.h
@@ -167,13 +167,12 @@ public:
 /// PrettyStackTraceConformance - Observe that we are processing a
 /// specific protocol conformance.
 class PrettyStackTraceConformance : public llvm::PrettyStackTraceEntry {
-  const ASTContext &Context;
   const ProtocolConformance *Conformance;
   const char *Action;
 public:
-  PrettyStackTraceConformance(const ASTContext &C, const char *action,
+  PrettyStackTraceConformance(const char *action,
                               const ProtocolConformance *conformance)
-    : Context(C), Conformance(conformance), Action(action) {}
+    : Conformance(conformance), Action(action) {}
   virtual void print(llvm::raw_ostream &OS) const override;
 };
 

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -232,6 +232,7 @@ void PrettyStackTraceTypeRepr::print(llvm::raw_ostream &out) const {
 
 void PrettyStackTraceConformance::print(llvm::raw_ostream &out) const {
   out << "While " << Action << ' ';
+  auto &Context = Conformance->getDeclContext()->getASTContext();
   printConformanceDescription(out, Conformance, Context);
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8539,8 +8539,7 @@ void ClangImporter::Implementation::finishNormalConformance(
   (void)unused;
 
   auto *proto = conformance->getProtocol();
-  PrettyStackTraceConformance trace(SwiftContext, "completing import of",
-                                    conformance);
+  PrettyStackTraceConformance trace("completing import of", conformance);
 
   finishTypeWitnesses(conformance);
   conformance->finishSignatureConformances();

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2147,7 +2147,7 @@ void IRGenModule::emitSILWitnessTable(SILWitnessTable *wt) {
   IRGen.ensureRelativeSymbolCollocation(*wt);
 
   auto conf = wt->getConformance();
-  PrettyStackTraceConformance _st(Context, "emitting witness table for", conf);
+  PrettyStackTraceConformance _st("emitting witness table for", conf);
 
   unsigned tableSize = 0;
   llvm::GlobalVariable *global = nullptr;

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -308,7 +308,7 @@ getTypeRefImpl(IRGenModule &IGM,
   }
 
   IRGenMangler Mangler;
-  auto SymbolicName = Mangler.mangleTypeForReflection(IGM, type);
+  auto SymbolicName = Mangler.mangleTypeForReflection(IGM, sig, type);
   return {IGM.getAddrOfStringForTypeRef(SymbolicName, role),
           SymbolicName.runtimeSizeInBytes()};
 }
@@ -628,25 +628,21 @@ class AssociatedTypeMetadataBuilder : public ReflectionMetadataBuilder {
   ArrayRef<std::pair<StringRef, CanType>> AssociatedTypes;
 
   void layout() override {
-    // If the conforming type is generic, we just want to emit the
-    // unbound generic type here.
-    auto *Nominal = Conformance->getType()->getAnyNominal();
-    assert(Nominal && "Structural conformance?");
+    PrettyStackTraceConformance DebugStack("emitting associated type metadata",
+                                           Conformance);
 
-    PrettyStackTraceDecl DebugStack("emitting associated type metadata",
-                                    Nominal);
-
-    addNominalRef(Nominal);
+    auto *DC = Conformance->getDeclContext();
+    addNominalRef(DC->getSelfNominalTypeDecl());
     addNominalRef(Conformance->getProtocol());
 
     B.addInt32(AssociatedTypes.size());
     B.addInt32(AssociatedTypeRecordSize);
 
+    auto genericSig = DC->getGenericSignatureOfContext().getCanonicalSignature();
     for (auto AssocTy : AssociatedTypes) {
       auto NameGlobal = IGM.getAddrOfFieldName(AssocTy.first);
       B.addRelativeAddress(NameGlobal);
-      addTypeRef(AssocTy.second,
-                 Nominal->getGenericSignature().getCanonicalSignature());
+      addTypeRef(AssocTy.second, genericSig);
     }
   }
 

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -144,8 +144,10 @@ IRGenMangler::withSymbolicReferences(IRGenModule &IGM,
 
 SymbolicMangling
 IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
-                                      Type Ty) {
+                                      CanGenericSignature Sig,
+                                      CanType Ty) {
   return withSymbolicReferences(IGM, [&]{
+    bindGenericParameters(Sig);
     appendType(Ty);
   });
 }
@@ -179,20 +181,6 @@ std::string IRGenMangler::mangleProtocolConformanceInstantiationCache(
   }
   appendOperator("MK");
   return finalize();
-}
-
-SymbolicMangling
-IRGenMangler::mangleProtocolConformanceForReflection(IRGenModule &IGM,
-                                  Type ty, ProtocolConformanceRef conformance) {
-  return withSymbolicReferences(IGM, [&]{
-    if (conformance.isConcrete()) {
-      appendProtocolConformance(conformance.getConcrete());
-    } else {
-      // Use a special mangling for abstract conformances.
-      appendType(ty);
-      appendProtocolName(conformance.getAbstract());
-    }
-  });
 }
 
 std::string IRGenMangler::mangleTypeForLLVMTypeName(CanType Ty) {

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -483,6 +483,7 @@ public:
   std::string mangleOutlinedCopyFunction(CanType ty,
                                          CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(ty);
     if (sig)
       appendGenericSignature(sig);
@@ -492,6 +493,7 @@ public:
   std::string mangleOutlinedConsumeFunction(CanType ty,
                                             CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(ty);
     if (sig)
       appendGenericSignature(sig);
@@ -502,6 +504,7 @@ public:
   std::string mangleOutlinedRetainFunction(CanType t,
                                            CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(t);
     if (sig)
       appendGenericSignature(sig);
@@ -511,6 +514,7 @@ public:
   std::string mangleOutlinedReleaseFunction(CanType t,
                                             CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(t);
     if (sig)
       appendGenericSignature(sig);
@@ -521,6 +525,7 @@ public:
   std::string mangleOutlinedInitializeWithTakeFunction(CanType t,
                                                        CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(t);
     if (sig)
       appendGenericSignature(sig);
@@ -530,6 +535,7 @@ public:
   std::string mangleOutlinedInitializeWithCopyFunction(CanType t,
                                                        CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(t);
     if (sig)
       appendGenericSignature(sig);
@@ -539,6 +545,7 @@ public:
   std::string mangleOutlinedAssignWithTakeFunction(CanType t,
                                                    CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(t);
     if (sig)
       appendGenericSignature(sig);
@@ -548,6 +555,7 @@ public:
   std::string mangleOutlinedAssignWithCopyFunction(CanType t,
                                                    CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(t);
     if (sig)
       appendGenericSignature(sig);
@@ -557,6 +565,7 @@ public:
   std::string mangleOutlinedDestroyFunction(CanType t,
                                             CanGenericSignature sig) {
     beginMangling();
+    bindGenericParameters(sig);
     appendType(t);
     if (sig)
       appendGenericSignature(sig);
@@ -571,11 +580,8 @@ public:
   }
 
   SymbolicMangling mangleTypeForReflection(IRGenModule &IGM,
-                                           Type Ty);
-  
-  SymbolicMangling mangleProtocolConformanceForReflection(IRGenModule &IGM,
-                                            Type Ty,
-                                            ProtocolConformanceRef conformance);
+                                           CanGenericSignature genericSig,
+                                           CanType Ty);
 
   std::string mangleTypeForLLVMTypeName(CanType Ty);
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -498,8 +498,7 @@ public:
     if (!Conformance)
       return nullptr;
 
-    PrettyStackTraceConformance trace(SGM.getASTContext(),
-                                      "generating SIL witness table",
+    PrettyStackTraceConformance trace("generating SIL witness table",
                                       Conformance);
 
     auto *proto = Conformance->getProtocol();
@@ -886,8 +885,7 @@ public:
   }
 
   void emit() {
-    PrettyStackTraceConformance trace(SGM.getASTContext(),
-                                      "generating SIL witness table",
+    PrettyStackTraceConformance trace("generating SIL witness table",
                                       conformance);
 
     // Add entries for all the requirements.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1813,8 +1813,7 @@ static void diagnoseConformanceImpliedByConditionalConformance(
 ProtocolConformance *MultiConformanceChecker::
 checkIndividualConformance(NormalProtocolConformance *conformance,
                            bool issueFixit) {
-  PrettyStackTraceConformance trace(getASTContext(), "type-checking",
-                                    conformance);
+  PrettyStackTraceConformance trace("type-checking", conformance);
 
   std::vector<MissingWitness> revivedMissingWitnesses;
   switch (conformance->getState()) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6209,8 +6209,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
   using namespace decls_block;
 
   PrettyStackTraceModuleFile traceModule("While reading from", *this);
-  PrettyStackTraceConformance trace(getAssociatedModule()->getASTContext(),
-                                    "finishing conformance for",
+  PrettyStackTraceConformance trace("finishing conformance for",
                                     conformance);
   ++NumNormalProtocolConformancesCompleted;
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -3437,8 +3437,7 @@ llvm::Expected<SILWitnessTable *>
   auto theConformance = cast<RootProtocolConformance>(
                           maybeConformance.get().getConcrete());
 
-  PrettyStackTraceConformance trace(SILMod.getASTContext(),
-                                    "deserializing SIL witness table for",
+  PrettyStackTraceConformance trace("deserializing SIL witness table for",
                                     theConformance);
 
   if (!existingWt)

--- a/test/IRGen/Inputs/retroactive_conformance_other.swift
+++ b/test/IRGen/Inputs/retroactive_conformance_other.swift
@@ -1,0 +1,6 @@
+public protocol P {}
+
+public enum E<First, Second> {
+  case left(First)
+  case right(Second)
+}

--- a/test/IRGen/retroactive_conformance.swift
+++ b/test/IRGen/retroactive_conformance.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/retroactive_conformance_other.swiftmodule %S/Inputs/retroactive_conformance_other.swift
+// RUN: %target-swift-frontend -emit-ir %s -I %t
+
+import retroactive_conformance_other
+
+public struct Foo<T: P> {}
+
+public enum MyError : Error {
+  case a
+}
+
+extension E: P where First: P {
+}
+
+public enum Bar<T: P> {
+  case x(Foo<E<T, MyError>>)
+  case y
+}
+
+


### PR DESCRIPTION
Otherwise, we'll fall over if we try to mangle a retroactive conformance.

Fixes <rdar://problem/70483417>.