### PR TITLE
AST: Skip stub initializers when printing module interfaces

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -238,6 +238,12 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
         }
       }
 
+      // Skip stub constructors.
+      if (auto *ctor = dyn_cast<ConstructorDecl>(D)) {
+        if (ctor->hasStubImplementation())
+          return false;
+      }
+
       return ShouldPrintChecker::shouldPrint(D, options);
     }
   };

--- a/test/ModuleInterface/stub-init.swift
+++ b/test/ModuleInterface/stub-init.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -module-name test %s | %FileCheck %s
+
+public class Base {
+  public init(x: Int) {}
+}
+
+public class Derived: Base {
+  public init(z: Int) {
+    super.init(x: z)
+  }
+}
+
+// CHECK-LABEL: public class Base {
+// CHECK-NEXT:    public init(x: Swift.Int)
+// CHECK-NEXT:    {{(@objc )?}}deinit
+// CHECK-NEXT: }
+
+// CHECK-LABEL: public class Derived : test.Base {
+// CHECK-NEXT:    public init(z: Swift.Int)
+// CHECK-NEXT:    {{(@objc )?}}deinit
+// CHECK-NEXT: }
+


### PR DESCRIPTION
When a derived class does not inherit a designated initializer from
its base class, we override the designated initializer's vtable
entry with a stub which traps with a fatal error.

The stub cannot be called and clients do not need to be aware of
its existence, so don't print it at all in the module interface.

Fixes rdar://problem/71122015 / https://bugs.swift.org/browse/SR-13832.