### PR TITLE
Revert "[ConstraintSystem] Use correct locator when filtering disjunc…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9373,7 +9373,7 @@ bool ConstraintSystem::simplifyAppliedOverloads(
   AppliedDisjunctions[disjunction->getLocator()] = argFnType;
   return simplifyAppliedOverloadsImpl(disjunction, fnTypeVar, argFnType,
                                       /*numOptionalUnwraps*/ result->second,
-                                      applicableFn->getLocator());
+                                      locator);
 }
 
 bool ConstraintSystem::simplifyAppliedOverloads(

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -38,25 +38,3 @@ func testUnresolvedMember(i: Int) -> X {
   // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
   return .init(i, i)
 }
-
-func test_member_filtering() {
-  struct S {
-    // Result types here are different intentionally,
-    // if there were the same simplication logic would
-    // trigger and disable overloads during constraint
-    // generation.
-    func foo(_: Int) -> S { S() }
-    func foo(_: String) -> Int { 42 }
-
-    func bar(v: String) {}
-    func bar(_: Int) {}
-    func bar(a: Double, b: Int) {}
-  }
-
-  func test(s: S) {
-    // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(v:)
-    // CHECK-NEXT: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(a:b:)
-    // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar
-    s.foo(42).bar(42)
-  }
-}


### PR DESCRIPTION
…tion choices"

This reverts commit 2df4ba7ae62ca4bb4726e6812641473e35034598 from #36300 which conflicts with #36267 and was missed because of classic "time of test was too old before merging".