### PR TITLE
[cxx-interop] Bail earlier when importing invalid records.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3334,6 +3334,22 @@ namespace {
       return result;
     }
 
+    bool isCxxRecordImportable(const clang::CXXRecordDecl *decl) {
+      if (auto dtor = decl->getDestructor()) {
+        if (dtor->isDeleted() || dtor->getAccess() != clang::AS_public) {
+          return false;
+        }
+      }
+
+      // If we have no way of copying the type we can't import the class
+      // at all because we cannot express the correct semantics as a swift
+      // struct.
+      return llvm::none_of(decl->ctors(), [](clang::CXXConstructorDecl *ctor) {
+        return ctor->isCopyConstructor() &&
+               (ctor->isDeleted() || ctor->getAccess() != clang::AS_public);
+      });
+    }
+
     Decl *VisitRecordDecl(const clang::RecordDecl *decl) {
       // Track whether this record contains fields we can't reference in Swift
       // as stored properties.
@@ -3626,29 +3642,8 @@ namespace {
 
       result->setHasUnreferenceableStorage(hasUnreferenceableStorage);
 
-      if (cxxRecordDecl) {
+      if (cxxRecordDecl)
         result->setIsCxxNonTrivial(!cxxRecordDecl->isTriviallyCopyable());
-
-        for (auto ctor : cxxRecordDecl->ctors()) {
-          if (ctor->isCopyConstructor()) {
-            // If we have no way of copying the type we can't import the class
-            // at all because we cannot express the correct semantics as a swift
-            // struct.
-            if (ctor->isDeleted() || ctor->getAccess() != clang::AS_public)
-              return nullptr;
-          }
-          if (ctor->getAccess() != clang::AS_public) {
-            result->setIsCxxNonTrivial(true);
-            break;
-          }
-        }
-
-        if (auto dtor = cxxRecordDecl->getDestructor()) {
-          if (dtor->isDeleted() || dtor->getAccess() != clang::AS_public) {
-            return nullptr;
-          }
-        }
-      }
 
       return result;
     }
@@ -3703,6 +3698,11 @@ namespace {
                                                   copyCtor);
         }
       }
+
+      // It is import that we bail on an unimportable record *before* we import
+      // any of its members or cache the decl.
+      if (!isCxxRecordImportable(decl))
+        return nullptr;
 
       return VisitRecordDecl(decl);
     }

--- a/test/Interop/Cxx/class/Inputs/invalid-nested-struct.h
+++ b/test/Interop/Cxx/class/Inputs/invalid-nested-struct.h
@@ -1,0 +1,63 @@
+// When we import this class, make sure that we bail before trying to import
+// its sub-decls (i.e., "ForwardDeclaredSibling").
+struct CannotImport {
+  void test(struct ForwardDeclaredSibling *) {}
+
+  ~CannotImport() = delete;
+  CannotImport(CannotImport const &) = delete;
+};
+
+// We shouldn't be able to import this class either because it also doesn't have
+// a copy ctor or destructor.
+struct ForwardDeclaredSibling : CannotImport {};
+
+// This is a longer regression test to make sure we don't improperly cache a
+// typedef that's invalid.
+namespace RegressionTest {
+
+template <class From>
+struct pointer_traits {
+  template <class To>
+  struct rebind {
+    typedef To other;
+  };
+};
+
+template <class T, class U>
+struct Convert {
+  typedef typename pointer_traits<T>::template rebind<U>::other type;
+};
+
+template <class>
+struct Forward;
+
+template <class V>
+struct SomeTypeTrait {
+  typedef Forward<V> *F;
+  typedef typename Convert<V, F>::type A;
+};
+
+template <class V>
+struct Forward {
+  typedef typename SomeTypeTrait<V>::A A;
+
+private:
+  ~Forward() = delete;
+  Forward(Forward const &) = delete;
+};
+
+template <class V>
+struct SomeOtherTypeTrait : SomeTypeTrait<V> {
+  typedef typename SomeTypeTrait<V>::A A;
+};
+
+// Just to instantiate all the templates.
+struct FinalUser {
+  typedef Forward<void *> F;
+  typedef SomeOtherTypeTrait<void *> O;
+  typedef SomeTypeTrait<void *> Z;
+};
+
+void test(typename FinalUser::Z) {}
+
+} // namespace RegressionTest

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -67,3 +67,8 @@ module LinkedRecords {
   header "linked-records.h"
   requires cplusplus
 }
+
+module InvalidNestedStruct {
+  header "invalid-nested-struct.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/invalid-nested-struct-module-interface.swift
+++ b/test/Interop/Cxx/class/invalid-nested-struct-module-interface.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=InvalidNestedStruct -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK-NOT: CannotImport
+// CHECK-NOT: ForwardDeclaredSibling

--- a/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
@@ -52,21 +52,6 @@ func pass(s: StructWithSubobjectDefaultedCopyConstructor) {
   // CHECK: bb0(%0 : $StructWithSubobjectDefaultedCopyConstructor):
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithMoveConstructor)
-func pass(s: StructWithMoveConstructor) {
-  // CHECK: bb0(%0 : $*StructWithMoveConstructor):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithInheritedMoveConstructor)
-func pass(s: StructWithInheritedMoveConstructor) {
-  // CHECK: bb0(%0 : $*StructWithInheritedMoveConstructor):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithSubobjectMoveConstructor)
-func pass(s: StructWithSubobjectMoveConstructor) {
-  // CHECK: bb0(%0 : $*StructWithSubobjectMoveConstructor):
-}
-
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithCopyAssignment)
 func pass(s: StructWithCopyAssignment) {
   // CHECK: bb0(%0 : $*StructWithCopyAssignment):
@@ -80,21 +65,6 @@ func pass(s: StructWithInheritedCopyAssignment) {
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithSubobjectCopyAssignment)
 func pass(s: StructWithSubobjectCopyAssignment) {
   // CHECK: bb0(%0 : $*StructWithSubobjectCopyAssignment):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithMoveAssignment)
-func pass(s: StructWithMoveAssignment) {
-  // CHECK: bb0(%0 : $*StructWithMoveAssignment):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithInheritedMoveAssignment)
-func pass(s: StructWithInheritedMoveAssignment) {
-  // CHECK: bb0(%0 : $*StructWithInheritedMoveAssignment):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithSubobjectMoveAssignment)
-func pass(s: StructWithSubobjectMoveAssignment) {
-  // CHECK: bb0(%0 : $*StructWithSubobjectMoveAssignment):
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithDestructor)
@@ -132,9 +102,4 @@ func pass(s: StructWithSubobjectDefaultedDestructor) {
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructTriviallyCopyableMovable)
 func pass(s: StructTriviallyCopyableMovable) {
   // CHECK: bb0(%0 : $StructTriviallyCopyableMovable):
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructNonCopyableNonMovable)
-func pass(s: StructNonCopyableNonMovable) {
-  // CHECK: bb0(%0 : $StructNonCopyableNonMovable):
 }

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -5,6 +5,13 @@
 // CHECK-NOT: StructWithInheritedPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructWithSubobjectPrivateDefaultedCopyConstructor
 // CHECK-NOT: StructNonCopyableTriviallyMovable
+// CHECK-NOT: StructNonCopyableNonMovable
+// CHECK-NOT: StructWithMoveConstructor
+// CHECK-NOT: StructWithInheritedMoveConstructor
+// CHECK-NOT: StructWithSubobjectMoveConstructor
+// CHECK-NOT: StructWithMoveAssignment
+// CHECK-NOT: StructWithInheritedMoveAssignment
+// CHECK-NOT: StructWithSubobjectMoveAssignment
 // CHECK-NOT: StructWithPrivateDefaultedDestructor
 // CHECK-NOT: StructWithInheritedPrivateDefaultedDestructor
 // CHECK-NOT: StructWithSubobjectPrivateDefaultedDestructor


### PR DESCRIPTION
If we have a C++ record decl that's invalid (because of a deleted destructor or copy constructor), bail before we import any of its members or cache the decl. This way, we don't accidentally import any "nested" decls.