### PR TITLE
[SE-0293] Implement revision #3 of property wrapper parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,36 @@ CHANGELOG
 Swift 5.5
 ---------
 
+* [SE-0293][]:
+
+  Property wrappers can now be applied to function and closure parameters:
+
+  ```swift
+  @propertyWrapper
+  struct Wrapper<Value> {
+    var wrappedValue: Value
+
+    var projectedValue: Self { return self }
+
+    init(wrappedValue: Value) { ... }
+
+    init(projectedValue: Self) { ... }
+  }
+
+  func test(@Wrapper value: Int) {
+    print(value)
+    print($value)
+    print(_value)
+  }
+
+  test(value: 10)
+
+  let projection = Wrapper(wrappedValue: 10)
+  test($value: projection)
+  ```
+
+  The call-site can pass a wrapped value or a projected value, and the property wrapper will be initialized using `init(wrappedValue:)` or `init(projectedValue:)`, respectively.
+
 * [SE-0299][]:
 
   It is now possible to use leading-dot syntax in generic contexts to access static members of protocol extensions where `Self` is constrained to a fully concrete type:

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -110,9 +110,9 @@ public:
     return TheFunction.get<AbstractClosureExpr *>()->getParameters();
   }
 
-  bool hasPropertyWrapperParameters() const {
+  bool hasExternalPropertyWrapperParameters() const {
     return llvm::any_of(*getParameters(), [](const ParamDecl *param) {
-      return param->hasAttachedPropertyWrapper();
+      return param->hasExternalPropertyWrapper();
     });
   }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5013,6 +5013,10 @@ public:
   /// Whether this var has an implicit property wrapper attribute.
   bool hasImplicitPropertyWrapper() const;
 
+  /// Whether this var is a parameter with an attached property wrapper
+  /// that has an external effect on the function.
+  bool hasExternalPropertyWrapper() const;
+
   /// Whether all of the attached property wrappers have an init(wrappedValue:)
   /// initializer.
   bool allAttachedPropertyWrappersHaveWrappedValueInit() const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1788,8 +1788,9 @@ ERROR(function_type_access,none,
       "|cannot be declared "
       "%select{in this context|fileprivate|internal|public|open}1}0 "
       "because its %select{parameter|result}5 uses "
-      "%select{a private|a fileprivate|an internal|an '@_spi'|an '@_spi'}3 type",
-      (bool, AccessLevel, bool, AccessLevel, unsigned, bool))
+      "%select{a private|a fileprivate|an internal|an '@_spi'|an '@_spi'}3"
+      "%select{| API wrapper}6 type",
+      (bool, AccessLevel, bool, AccessLevel, unsigned, bool, bool))
 ERROR(function_type_spi,none,
       "%select{function|method|initializer}0 "
       "cannot be declared '@_spi' "
@@ -1802,18 +1803,19 @@ WARNING(function_type_access_warn,none,
         "%select{should be declared %select{private|fileprivate|internal|%error|%error}1"
         "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its %select{parameter|result}5 uses "
-        "%select{a private|a fileprivate|an internal|%error|%error}3 type",
-        (bool, AccessLevel, bool, AccessLevel, unsigned, bool))
+        "%select{a private|a fileprivate|an internal|%error|%error}3 "
+        "%select{|API wrapper}6 type",
+        (bool, AccessLevel, bool, AccessLevel, unsigned, bool, bool))
 ERROR(function_type_usable_from_inline,none,
-      "the %select{parameter|result}1 of a "
+      "the %select{parameter|result}1%select{| API wrapper}2 of a "
       "'@usableFromInline' %select{function|method|initializer}0 "
       "must be '@usableFromInline' or public",
-      (unsigned, bool))
+      (unsigned, bool, bool))
 WARNING(function_type_usable_from_inline_warn,none,
-        "the %select{parameter|result}1 of a "
+        "the %select{parameter|result}1%select{| API wrapper}2 of a "
         "'@usableFromInline' %select{function|method|initializer}0 "
         "should be '@usableFromInline' or public",
-        (unsigned, bool))
+        (unsigned, bool, bool))
 
 ERROR(spi_attribute_on_non_public,none,
       "%select{private|fileprivate|internal|%error|%error}0 %1 "

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5904,7 +5904,7 @@ bool VarDecl::hasImplicitPropertyWrapper() const {
 }
 
 bool VarDecl::hasExternalPropertyWrapper() const {
-  if (!hasAttachedPropertyWrapper())
+  if (!hasAttachedPropertyWrapper() || !isa<ParamDecl>(this))
     return false;
 
   // This decision needs to be made before closures are type checked (and

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -967,7 +967,7 @@ ParameterListInfo::ParameterListInfo(
       acceptsUnlabeledTrailingClosures.set(i);
     }
 
-    if (param->hasAttachedPropertyWrapper()) {
+    if (param->hasExternalPropertyWrapper()) {
       propertyWrappers.set(i);
     }
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -244,13 +244,13 @@ struct ArgumentInitHelper {
   }
 
   void emitParam(ParamDecl *PD) {
-    if (auto *backingVar = PD->getPropertyWrapperBackingProperty()) {
+    if (PD->hasExternalPropertyWrapper()) {
       auto initInfo = PD->getPropertyWrapperInitializerInfo();
       if (initInfo.hasSynthesizedInitializers()) {
         SGF.SGM.emitPropertyWrapperBackingInitializer(PD);
       }
 
-      PD = cast<ParamDecl>(backingVar);
+      PD = cast<ParamDecl>(PD->getPropertyWrapperBackingProperty());
     }
 
     auto type = PD->getType();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1033,8 +1033,7 @@ namespace {
           ValueKind valueKind = (initKind == PropertyWrapperInitKind::ProjectedValue ?
                                  ValueKind::ProjectedValue : ValueKind::WrappedValue);
 
-          paramRef = AppliedPropertyWrapperExpr::create(context, ref, innerParam,
-                                                        innerParam->getStartLoc(),
+          paramRef = AppliedPropertyWrapperExpr::create(context, ref, innerParam, SourceLoc(),
                                                         wrapperType, paramRef, valueKind);
           cs.cacheExprTypes(paramRef);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -689,7 +689,7 @@ namespace {
       Expr *result = forceUnwrapIfExpected(declRefExpr, choice, locator);
 
       if (auto *fnDecl = dyn_cast<AbstractFunctionDecl>(decl)) {
-        if (AnyFunctionRef(fnDecl).hasPropertyWrapperParameters() &&
+        if (AnyFunctionRef(fnDecl).hasExternalPropertyWrapperParameters() &&
             (declRefExpr->getFunctionRefKind() == FunctionRefKind::Compound ||
              declRefExpr->getFunctionRefKind() == FunctionRefKind::Unapplied)) {
           auto &appliedWrappers = solution.appliedPropertyWrappers[locator.getAnchor()];
@@ -7932,7 +7932,7 @@ namespace {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         rewriteFunction(closure);
 
-        if (AnyFunctionRef(closure).hasPropertyWrapperParameters()) {
+        if (AnyFunctionRef(closure).hasExternalPropertyWrapperParameters()) {
           return { false, rewriteClosure(closure) };
         }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4058,21 +4058,7 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     anchor = apply->getFn();
   }
 
-  auto supportsProjectedValueInit = [&](ParamDecl *param) -> bool {
-    if (!param->hasAttachedPropertyWrapper())
-      return false;
-
-    if (param->hasImplicitPropertyWrapper())
-      return true;
-
-    if (param->getAttachedPropertyWrappers().front()->getArg())
-      return false;
-
-    auto wrapperInfo = param->getAttachedPropertyWrapperTypeInfo(0);
-    return wrapperInfo.projectedValueVar && wrapperInfo.hasProjectedValueInit;
-  };
-
-  if (argLabel.hasDollarPrefix() && (!param || !supportsProjectedValueInit(param))) {
+  if (argLabel.hasDollarPrefix() && (!param || !param->hasExternalPropertyWrapper())) {
     if (!shouldAttemptFixes())
       return getTypeMatchFailure(locator);
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -920,7 +920,29 @@ public:
     const TypeRepr *complainRepr = nullptr;
     auto downgradeToWarning = DowngradeToWarning::No;
 
+    bool hasInaccessibleParameterWrapper = false;
     for (auto *P : *fn->getParameters()) {
+      // Check for inaccessible API property wrappers attached to the parameter.
+      if (P->hasExternalPropertyWrapper()) {
+        auto wrapperAttrs = P->getAttachedPropertyWrappers();
+        for (auto index : indices(wrapperAttrs)) {
+          auto wrapperType = P->getAttachedPropertyWrapperType(index);
+          auto wrapperTypeRepr = wrapperAttrs[index]->getTypeRepr();
+          checkTypeAccess(wrapperType, wrapperTypeRepr, fn, /*mayBeInferred*/ false,
+              [&](AccessScope typeAccessScope, const TypeRepr *thisComplainRepr,
+                  DowngradeToWarning downgradeDiag) {
+                if (typeAccessScope.isChildOf(minAccessScope) ||
+                    (!complainRepr &&
+                     typeAccessScope.hasEqualDeclContextWith(minAccessScope))) {
+                  minAccessScope = typeAccessScope;
+                  complainRepr = thisComplainRepr;
+                  downgradeToWarning = downgradeDiag;
+                  hasInaccessibleParameterWrapper = true;
+                }
+              });
+        }
+      }
+
       checkTypeAccess(
           P->getInterfaceType(), P->getTypeRepr(), fn, /*mayBeInferred*/ false,
           [&](AccessScope typeAccessScope, const TypeRepr *thisComplainRepr,
@@ -970,7 +992,8 @@ public:
         diagID = diag::function_type_access_warn;
       auto diag = fn->diagnose(diagID, isExplicit, fnAccess,
                                isa<FileUnit>(fn->getDeclContext()), minAccess,
-                               functionKind, problemIsResult);
+                               functionKind, problemIsResult,
+                               hasInaccessibleParameterWrapper);
       highlightOffendingType(diag, complainRepr);
     }
   }
@@ -1394,6 +1417,26 @@ public:
       : isTypeContext ? FK_Method : FK_Function;
 
     for (auto *P : *fn->getParameters()) {
+      // Check for inaccessible API property wrappers attached to the parameter.
+      if (P->hasExternalPropertyWrapper()) {
+        auto wrapperAttrs = P->getAttachedPropertyWrappers();
+        for (auto index : indices(wrapperAttrs)) {
+          auto wrapperType = P->getAttachedPropertyWrapperType(index);
+          auto wrapperTypeRepr = wrapperAttrs[index]->getTypeRepr();
+          checkTypeAccess(wrapperType, wrapperTypeRepr, fn, /*mayBeInferred*/ false,
+              [&](AccessScope typeAccessScope, const TypeRepr *complainRepr,
+                  DowngradeToWarning downgradeDiag) {
+                auto diagID = diag::function_type_usable_from_inline;
+                if (!fn->getASTContext().isSwiftVersionAtLeast(5))
+                  diagID = diag::function_type_usable_from_inline_warn;
+                auto diag = fn->diagnose(diagID, functionKind,
+                                         /*problemIsResult=*/false,
+                                         /*inaccessibleWrapper=*/true);
+                highlightOffendingType(diag, complainRepr);
+              });
+        }
+      }
+
       checkTypeAccess(
           P->getInterfaceType(), P->getTypeRepr(), fn, /*mayBeInferred*/ false,
           [&](AccessScope typeAccessScope, const TypeRepr *complainRepr,
@@ -1402,7 +1445,8 @@ public:
             if (!fn->getASTContext().isSwiftVersionAtLeast(5))
               diagID = diag::function_type_usable_from_inline_warn;
             auto diag = fn->diagnose(diagID, functionKind,
-                                     /*problemIsResult=*/false);
+                                     /*problemIsResult=*/false,
+                                     /*inaccessibleWrapper=*/false);
             highlightOffendingType(diag, complainRepr);
           });
     }
@@ -1417,7 +1461,8 @@ public:
         if (!fn->getASTContext().isSwiftVersionAtLeast(5))
           diagID = diag::function_type_usable_from_inline_warn;
         auto diag = fn->diagnose(diagID, functionKind,
-                                 /*problemIsResult=*/true);
+                                 /*problemIsResult=*/true,
+                                 /*inaccessibleWrapper=*/false);
         highlightOffendingType(diag, complainRepr);
       });
     }
@@ -1718,8 +1763,15 @@ public:
   void visitAbstractFunctionDecl(AbstractFunctionDecl *fn) {
     checkGenericParams(fn, fn);
 
-    for (auto *P : *fn->getParameters())
+    for (auto *P : *fn->getParameters()) {
+      auto wrapperAttrs = P->getAttachedPropertyWrappers();
+      for (auto index : indices(wrapperAttrs)) {
+        auto wrapperType = P->getAttachedPropertyWrapperType(index);
+        checkType(wrapperType, wrapperAttrs[index]->getTypeRepr(), fn);
+      }
+
       checkType(P->getInterfaceType(), P->getTypeRepr(), fn);
+    }
   }
 
   void visitFuncDecl(FuncDecl *FD) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3022,6 +3022,9 @@ void TypeChecker::checkParameterList(ParameterList *params,
       }
     }
 
+    if (param->hasAttachedPropertyWrapper())
+      (void) param->getPropertyWrapperInitializerInfo();
+
     auto *SF = param->getDeclContext()->getParentSourceFile();
     param->visitAuxiliaryDecls([&](VarDecl *auxiliaryDecl) {
       if (!isa<ParamDecl>(auxiliaryDecl))

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -230,3 +230,20 @@ public func publicFunc(@PublicWrapper value: String) {
   // property wrapper init from projected value of value #1 in publicFunc(value:)
   // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfW : $@convention(thin) (@owned PublicWrapper<String>) -> @owned PublicWrapper<String>
 }
+
+// CHECK-LABEL: sil [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tF : $@convention(thin) (@guaranteed PublicWrapper<String>) -> ()
+@inlinable func inlinableFunc(@PublicWrapper value: String) {
+  // property wrapper backing initializer of value #1 in inlinableFunc(value:)
+  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned PublicWrapper<String>
+
+  // property wrapper init from projected value of value #1 in inlinableFunc(value:)
+  // CHECK: sil non_abi [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfW : $@convention(thin) (@owned PublicWrapper<String>) -> @owned PublicWrapper<String>
+
+
+  _ = publicFunc(value:)
+
+  // implicit closure #1 in inlinableFunc(value:)
+  // CHECK: sil shared [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFySScfu_ : $@convention(thin) (@guaranteed String) -> ()
+  // CHECK: function_ref @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned PublicWrapper<String>
+  // CHECK: function_ref @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tF : $@convention(thin) (@guaranteed PublicWrapper<String>) -> ()
+}

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -105,6 +105,7 @@ struct NonMutatingSetterWrapper<Value> {
     nonmutating set { }
   }
 
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter24NonMutatingSetterWrapperV12wrappedValueACyxGx_tcfC : $@convention(method) <Value> (@in Value, @thin NonMutatingSetterWrapper<Value>.Type) -> @out NonMutatingSetterWrapper<Value>
   init(wrappedValue: Value) {
     self.value = wrappedValue
   }
@@ -114,36 +115,36 @@ struct NonMutatingSetterWrapper<Value> {
 class ClassWrapper<Value> {
   var wrappedValue: Value
 
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter12ClassWrapperC12wrappedValueACyxGx_tcfc : $@convention(method) <Value> (@in Value, @owned ClassWrapper<Value>) -> @owned ClassWrapper<Value>
   init(wrappedValue: Value) {
     self.wrappedValue = wrappedValue
   }
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2yAA0efG7WrapperVySSG_AA05ClassJ0CySiGtF : $@convention(thin) (@guaranteed NonMutatingSetterWrapper<String>, @guaranteed ClassWrapper<Int>) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitF : $@convention(thin) (@guaranteed String, Int) -> ()
 func testNonMutatingSetter(@NonMutatingSetterWrapper value1: String, @ClassWrapper value2: Int) {
+  // CHECK: alloc_box ${ var NonMutatingSetterWrapper<String> }, var, name "_value1"
+  // CHECK: function_ref @$s26property_wrapper_parameter24NonMutatingSetterWrapperV12wrappedValueACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin NonMutatingSetterWrapper<τ_0_0>.Type) -> @out NonMutatingSetterWrapper<τ_0_0>
+  // CHECK: alloc_box ${ var ClassWrapper<Int> }, var, name "_value2"
+  // CHECK: function_ref @$s26property_wrapper_parameter12ClassWrapperC12wrappedValueACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thick ClassWrapper<τ_0_0>.Type) -> @owned ClassWrapper<τ_0_0>
+
   _ = value1
   value1 = "hello!"
 
-  // property wrapper backing initializer of value1 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2yAA0efG7WrapperVySSG_AA05ClassJ0CySiGtFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned NonMutatingSetterWrapper<String>
-
-  // property wrapper backing initializer of value2 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2yAA0efG7WrapperVySSG_AA05ClassJ0CySiGtFADL_SivpfP : $@convention(thin) (Int) -> @owned ClassWrapper<Int>
-
   // getter of value1 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2yAA0efG7WrapperVySSG_AA05ClassJ0CySiGtFACL_SSvg : $@convention(thin) (@guaranteed NonMutatingSetterWrapper<String>) -> @owned String
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFACL_SSvg : $@convention(thin) (@guaranteed { var NonMutatingSetterWrapper<String> }) -> @owned String
 
   // setter of value1 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2yAA0efG7WrapperVySSG_AA05ClassJ0CySiGtFACL_SSvs : $@convention(thin) (@owned String, @guaranteed NonMutatingSetterWrapper<String>) -> ()
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFACL_SSvs : $@convention(thin) (@owned String, @guaranteed { var NonMutatingSetterWrapper<String> }) -> ()
 
   _ = value2
   value2 = 10
 
   // getter of value2 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2yAA0efG7WrapperVySSG_AA05ClassJ0CySiGtFADL_Sivg : $@convention(thin) (@guaranteed ClassWrapper<Int>) -> Int
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFADL_Sivg : $@convention(thin) (@guaranteed { var ClassWrapper<Int> }) -> Int
 
   // setter of value2 #1 in testNonMutatingSetter(value1:value2:)
-  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2yAA0efG7WrapperVySSG_AA05ClassJ0CySiGtFADL_Sivs : $@convention(thin) (Int, @guaranteed ClassWrapper<Int>) -> ()
+  // CHECK: sil private [ossa] @$s26property_wrapper_parameter21testNonMutatingSetter6value16value2ySS_SitFADL_Sivs : $@convention(thin) (Int, @guaranteed { var ClassWrapper<Int> }) -> ()
 }
 
 @propertyWrapper


### PR DESCRIPTION
* The distinction between API wrappers and implementation-detail wrappers is formalized, and determined by the compiler based on whether the property wrapper type defines `init(projectedValue:)` (and also defines `var projectedValue`).
* Only API property wrappers on parameters use caller-side application of the property wrapper, and are part of the function signature. Implementation-detail property wrappers on parameters use callee-side application of the property wrapper, and have no external effect on the function. 
