### PR TITLE
[Concurrency] Task.withGroup can be rethrows

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -64,7 +64,7 @@ extension Task {
     resultType: TaskResult.Type,
     returning returnType: BodyResult.Type = BodyResult.self,
     body: (inout Task.Group<TaskResult>) async throws -> BodyResult
-  ) async throws -> BodyResult {
+  ) async rethrows -> BodyResult {
     let task = Builtin.getCurrentAsyncTask()
     let _group = _taskGroupCreate(task: task)
     var group: Task.Group<TaskResult>! = Task.Group(task: task, group: _group)

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -14,7 +14,7 @@ func boom() async throws -> Int {
 }
 
 func test_taskGroup_throws() async {
-  let got: Int = try! await Task.withGroup(resultType: Int.self) { group in
+  let got: Int = await Task.withGroup(resultType: Int.self) { group in
     await group.add { try await boom()  }
 
     do {


### PR DESCRIPTION
Uncovered during evolution review, doesn't really change much in practice because we often call next() which always is throwing