### PR TITLE
[libSyntax] Create SyntaxRef, which uses SyntaxDataRef internally

### DIFF
--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -11,13 +11,29 @@
 //===----------------------------------------------------------------------===//
 //
 // This file defines the Syntax type, the main public-facing classes and
-// subclasses for dealing with Swift Syntax.
+// subclasses for dealing with Swift Syntax. It essentially wraps
+// SyntaxData(Ref) and provides convenience APIs (like retrieving children)
+// based on the syntax kind.
 //
-// Syntax types contain a strong reference to the root of the tree to keep
-// the subtree above alive, and a weak reference to the data representing
-// the syntax node (weak to prevent retain cycles). All significant public API
-// are contained in Syntax and its subclasses.
+// There are two versions of the Syntax type.
+// SyntaxRef:
+// SyntaxRef is designed around efficiency. It *does not* retain the
+// SyntaxDataRef that stores its data - the user must gurantee that the
+// SyntaxDataRef outlives the SyntaxRef that references it. Instead,
+// SyntaxDataRef provides a *view* into the SyntaxDataRef and the view provides
+// all convinience APIs. The advantage of this is that the underlying SyntaxData
+// can be stack-allocated and does not need to be copied when the the SyntaxRef
+// is being passsed around or when the SyntaxRef is being casted.
 //
+// Syntax:
+// The syntax nodes are designed for memory safety. Syntax nodes always retain
+// (and ref-count) heap-allocated SyntaxData nodes. While this provides maximum
+// memory safety, the heap allocations and the ref-counting has a significant
+// performance overhead.
+//
+// Note that the two access modes can also be mixed. When a syntax tree is
+// accessed by Syntax (memory-safe) nodes, they can be demoted to SyntaxRef
+// nodes to perform perfomance-critical tasks.
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_SYNTAX_SYNTAX_H
@@ -47,19 +63,137 @@ SyntaxNode makeRoot(const RawSyntax *Raw) {
 
 const auto NoParent = llvm::None;
 
-/// The main handle for syntax nodes - subclasses contain all public
-/// structured editing APIs.
+/// Marker type to construct \c SyntaxRef nodes without validation. This is used
+/// to create \c SyntaxRef inside \c OwnedSyntaxRef and \c
+/// OptionalOwnedSyntaxRef that point to a \c SyntaxDataRef which is yet to be
+/// initialised.
+/// Validation will occur in these types once the \c SyntaxRef is accessed.
+struct no_validation_t {};
+
+// MARK: - OwnedSyntaxRef
+
+/// Holds a \c SyntaxDataRef and provides a \c SyntaxRef (or one of its
+/// subclasses) as an accessor to the \c SyntaxDataRef.
+/// The user of this type needs to make sure that the \c OwnedSyntaxRef always
+/// outlives the \c SyntaxRef provided by it, because otherwise the \c SyntaxRef
+/// points to invalid memory.
+/// It allows transparent access to the \c SyntaxRef through the \c -> operator.
 ///
-/// Essentially, this is a wrapper around \c SyntaxData that provides
-/// convenience methods based on the node's kind.
-class Syntax {
-protected:
-  RC<const SyntaxData> Data;
+/// All methods that return a \c OwnedSyntaxRef should be inlined to avoid
+/// copying the \c SyntaxDataRef, which is rather expensive because the struct
+/// is rather large.
+///
+/// A typical initialisation of a OwnedSyntaxRef looks as follows:
+/// \code
+/// OwnedSyntaxRef<MySyntaxRef> Result;
+/// someSyntaxDataRef.getChildRef(Index, Result.getDataPtr());
+/// \endcode
+/// The first line creates an empty \c OwnedSyntaxRef with uninitialised memory.
+/// The second line invokes a method that fills \c Data of \c OwnedSyntaxRef.
+/// This way, we directly write the \c SyntaxDataRef to the correct memory
+/// location and avoid copying it around.
+template <typename SyntaxRefType>
+class OwnedSyntaxRef {
+  SyntaxDataRef Data;
+  SyntaxRefType Ref;
 
 public:
-  explicit Syntax(const RC<const SyntaxData> &Data) : Data(Data) {}
+  /// Create an *uninintialized* \c OwnedSyntaxRef. Its storage needs to be
+  /// initialised by writing a \c SyntaxDataRef to the pointer returned by
+  /// \c getDataPtr()
+  /// Implementation Note: We need to initialise \c Ref without validation,
+  /// because \c Data is still uninitialised. \c Ref will be validated when
+  /// accessed using \c getRef or \c -> .
+  OwnedSyntaxRef() : Data(), Ref(getDataPtr(), no_validation_t()) {}
 
-  virtual ~Syntax() {}
+  OwnedSyntaxRef(const OwnedSyntaxRef &Other)
+      : Data(Other.Data), Ref(getDataPtr(), no_validation_t()) {}
+  OwnedSyntaxRef(OwnedSyntaxRef &&Other)
+      : Data(std::move(Other.Data)), Ref(getDataPtr(), no_validation_t()) {}
+
+  /// The pointer to the location at which \c this stores the \c Data.
+  /// Can be used to retroactively populate the \c Data after \c OwnedSyntaxRef
+  /// has been constructed with uninitialised memory.
+  SyntaxDataRef *getDataPtr() { return &Data; }
+
+  const SyntaxRefType &getRef() {
+    assert(Ref.getDataRef() == getDataPtr() &&
+           "Ref no longer pointing to Data?");
+#ifndef NDEBUG
+    // This might be the first access to Ref after Data has been modified.
+    // Validate the node.
+    Ref.validate();
+#endif
+    return Ref;
+  }
+
+  const SyntaxRefType *operator->() {
+    assert(Ref.getDataRef() == getDataPtr() &&
+           "Ref no longer pointing to Data?");
+#ifndef NDEBUG
+    // This might be the first access to Ref after Data has been modified.
+    // Validate the node.
+    Ref.validate();
+#endif
+    return &Ref;
+  }
+};
+
+/// Same as \c OwnedSyntaxRef but can be null. We don't use \c
+/// Optional<OwnedSyntaxRef<SyntaxRefType>>>, because then we couldn't access
+/// the underlying \c SytnaxRefType via the \c -> operator (the use of \c ->
+/// would access the \c OwnedSyntaxRef<SyntaxRefType> wrapped by \c Optional and
+/// not the \c SyntaxRefType wrapped by \c OwnedSyntaxRef.
+template <typename SyntaxRefType>
+class OptionalOwnedSyntaxRef {
+  Optional<SyntaxDataRef> Data;
+  SyntaxRefType Ref;
+
+public:
+  OptionalOwnedSyntaxRef() : Data(), Ref(getDataPtr(), no_validation_t()) {}
+
+  OptionalOwnedSyntaxRef(const OptionalOwnedSyntaxRef &Other)
+      : Data(Other.Data), Ref(getDataPtr(), no_validation_t()) {}
+  OptionalOwnedSyntaxRef(OptionalOwnedSyntaxRef &&Other)
+      : Data(std::move(Other.Data)), Ref(getDataPtr(), no_validation_t()) {}
+
+  SyntaxDataRef *getDataPtr() { return Data.getPointer(); }
+
+  bool hasValue() const { return Data.hasValue(); }
+
+  explicit operator bool() const { return hasValue(); }
+
+  const SyntaxRefType &getRef() {
+    assert(Ref.getDataRef() == getDataPtr() &&
+           "Ref no longer pointing to Data?");
+    assert(hasValue() && "Accessing a OptionalOwnedSyntaxRef without a value");
+#ifndef NDEBUG
+    // This might be the first access to Ref after Data has been populated.
+    // Validate the node.
+    Ref.validate();
+#endif
+    return Ref;
+  }
+
+  SyntaxRefType *operator->() {
+    assert(Ref.getDataRef() == getDataPtr() &&
+           "Ref no longer pointing to Data?");
+    assert(hasValue() && "OptionalOwnedSyntaxRef doesn't have a value");
+    return &Ref;
+  }
+};
+
+// MARK: - Syntax
+
+/// See comment on top of file.
+class Syntax {
+protected:
+  const RC<const SyntaxData> Data;
+
+public:
+  explicit Syntax(const RC<const SyntaxData> &Data) : Data(Data) {
+    assert(Data != nullptr && "Syntax must be backed by non-null Data");
+  }
 
   /// Get the kind of syntax.
   SyntaxKind getKind() const;
@@ -194,8 +328,196 @@ public:
   AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const {
     return Data->getAbsoluteEndPositionAfterTrailingTrivia();
   }
+};
 
-  // TODO: hasSameStructureAs ?
+// MARK: - SyntaxRef
+
+/// See comment on top of file.
+class SyntaxRef {
+  const SyntaxDataRef * const Data;
+
+public:
+  /// Create a \c SyntaxRef and validate that the \p Data can actually represent
+  /// a \c SyntaxRef. Validation in particular performs checks for derived
+  /// types.
+  explicit SyntaxRef(const SyntaxDataRef *Data) : Data(Data) {
+    assert(Data != nullptr && "SyntaxRef must reference Data");
+    this->validate();
+  }
+  SyntaxRef(const SyntaxDataRef *Data, no_validation_t) : Data(Data) {
+    assert(Data != nullptr && "SyntaxRef must reference Data");
+  }
+
+  /// Demote a \c Syntax to a \c SyntaxRef
+  SyntaxRef(const Syntax &Node) : SyntaxRef(Node.getData().get()) {}
+
+  void validate() {}
+
+  // MARK: - Get underlying data
+
+  /// Get the \c SyntaxDataRef that stores the data of this \c SyntaxRef node.
+  const SyntaxDataRef *getDataRef() const {
+    return Data;
+  }
+
+  const AbsoluteRawSyntax &getAbsoluteRaw() const {
+    return getDataRef()->getAbsoluteRaw();
+  }
+
+  /// Get the shared raw syntax.
+  const RawSyntax *getRaw() const { return getDataRef()->getRaw(); }
+
+  /// Get the kind of syntax.
+  SyntaxKind getKind() const { return getRaw()->getKind(); }
+
+  /// Get an ID for the \c RawSyntax node backing this \c Syntax which is
+  /// stable across incremental parses.
+  /// Note that this is different from the \c AbsoluteRawSyntax's \c NodeId,
+  /// which uniquely identifies this node in the tree, but is not stable across
+  /// incremental parses.
+  SyntaxNodeId getId() const { return getRaw()->getId(); }
+
+  /// Return the number of bytes this node takes when spelled out in the source,
+  /// including trivia.
+  size_t getTextLength() const { return getRaw()->getTextLength(); }
+
+  // MARK: Parents/children
+
+  /// Return the parent of this node, if it has one, otherwise return \c None.
+  llvm::Optional<SyntaxRef> getParentRef() const {
+    if (auto ParentDataRef = getDataRef()->getParentRef()) {
+      return SyntaxRef(ParentDataRef);
+    } else {
+      return None;
+    }
+  }
+
+  /// Get the number of child nodes in this piece of syntax.
+  size_t getNumChildren() const { return getDataRef()->getNumChildren(); }
+
+  /// Returns the child index of this node in its parent, if it has one,
+  /// otherwise 0.
+  CursorIndex getIndexInParent() const {
+    return getDataRef()->getIndexInParent();
+  }
+
+  /// Get the \p N -th child of this piece of syntax.
+  OptionalOwnedSyntaxRef<SyntaxRef> getChildRef(const size_t N) const {
+    OptionalOwnedSyntaxRef<SyntaxRef> Result;
+    getDataRef()->getChildRef(N, Result.getDataPtr());
+    return Result;
+  }
+
+  // MARK: Position
+
+  /// Get the offset at which the leading trivia of this node starts.
+  AbsoluteOffsetPosition getAbsolutePositionBeforeLeadingTrivia() const {
+    return getDataRef()->getAbsolutePositionBeforeLeadingTrivia();
+  }
+
+  /// Get the offset at which the actual content (i.e. non-triva) of this node
+  /// starts.
+  AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
+    return getDataRef()->getAbsolutePositionAfterLeadingTrivia();
+  }
+
+  /// Get the offset at which the trailing trivia of this node starts.
+  AbsoluteOffsetPosition getAbsoluteEndPositionBeforeTrailingTrivia() const {
+    return getDataRef()->getAbsoluteEndPositionBeforeTrailingTrivia();
+  }
+
+  /// Get the offset at which the trailing trivia of this node ends.
+  AbsoluteOffsetPosition getAbsoluteEndPositionAfterTrailingTrivia() const {
+    return getDataRef()->getAbsoluteEndPositionAfterTrailingTrivia();
+  }
+
+  // MARK: - Get node kind
+
+  /// Returns true if this syntax node represents a token.
+  bool isToken() const { return getRaw()->isToken(); }
+
+  /// Returns true if this syntax node represents a statement.
+  bool isStmt() const { return getRaw()->isStmt(); }
+
+  /// Returns true if this syntax node represents a declaration.
+  bool isDecl() const { return getRaw()->isDecl(); }
+
+  /// Returns true if this syntax node represents an expression.
+  bool isExpr() const { return getRaw()->isExpr(); }
+
+  /// Returns true if this syntax node represents a pattern.
+  bool isPattern() const { return getRaw()->isPattern(); }
+
+  /// Returns true if this syntax node represents a type.
+  bool isType() const { return getRaw()->isType(); }
+
+  /// Returns true if this syntax is of some "unknown" kind.
+  bool isUnknown() const { return getRaw()->isUnknown(); }
+
+  /// Returns true if the node is "missing" in the source (i.e. it was
+  /// expected (or optional) but not written.
+  bool isMissing() const { return getRaw()->isMissing(); }
+
+  /// Returns true if the node is "present" in the source.
+  bool isPresent() const { return getRaw()->isPresent(); }
+
+  // MARK: Casting
+
+  /// Returns true if the syntax node is of the given type \p T.
+  template <typename T>
+  bool is() const {
+    return T::classof(this);
+  }
+
+  /// Cast this Syntax node to a more specific type, asserting it's of the
+  /// right kind \p T.
+  template <typename T>
+  T castTo() const {
+    assert(is<T>() && "castTo<T>() node of incompatible type!");
+    return T(getDataRef());
+  }
+
+  /// If this Syntax node is of the right kind \p T, cast and return it,
+  /// otherwise return None.
+  template <typename T>
+  llvm::Optional<T> getAs() const {
+    if (is<T>()) {
+      return castTo<T>();
+    } else {
+      return None;
+    }
+  }
+
+  static bool kindof(SyntaxKind Kind) { return true; }
+
+  static bool classof(const SyntaxRef *S) {
+    // Trivially true.
+    return true;
+  }
+
+  // MARK: - Miscellaneous
+
+  /// Print the syntax node with full fidelity to the given output stream.
+  void print(llvm::raw_ostream &OS,
+             SyntaxPrintOptions Opts = SyntaxPrintOptions()) const {
+    if (auto Raw = getRaw()) {
+      Raw->print(OS, Opts);
+    }
+  }
+
+  /// Print a debug representation of the syntax node to the given output stream
+  /// and indentation level.
+  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const {
+    getRaw()->dump(OS, Indent);
+  }
+
+  /// Print a debug representation of the syntax node to standard error.
+  SWIFT_DEBUG_DUMP { getRaw()->dump(); }
+
+  bool hasSameIdentityAs(const SyntaxRef &Other) const {
+    return getDataRef()->getAbsoluteRaw().getNodeId() ==
+           Other.getDataRef()->getAbsoluteRaw().getNodeId();
+  }
 };
 
 } // end namespace syntax

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -68,10 +68,14 @@ private:
   }
 
 public:
-  SyntaxCollection(const RC<const SyntaxData> &Data) : Syntax(Data) {}
+  SyntaxCollection(const RC<const SyntaxData> &Data) : Syntax(Data) {
+    validate();
+  }
 
   SyntaxCollection(std::initializer_list<Element> list):
     SyntaxCollection(SyntaxCollection::makeData(list)) {}
+
+  void validate() {}
 
   /// Returns true if the collection is empty.
   bool empty() const {

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -20,6 +20,8 @@
 namespace swift {
 namespace syntax {
 
+// MARK: - SyntaxCollection
+
 template <SyntaxKind CollectionKind, typename Element>
 class SyntaxCollection;
 
@@ -211,6 +213,85 @@ public:
     return kindof(S->getKind());
   }
 };
+
+// MARK: - SyntaxCollectionRef
+
+template <SyntaxKind CollectionKind, typename Element>
+class SyntaxCollectionRef;
+
+template <SyntaxKind CollectionKind, typename Element>
+struct SyntaxCollectionRefIterator {
+  const SyntaxCollectionRef<CollectionKind, Element> &Collection;
+  size_t Index;
+
+  OwnedSyntaxRef<Element> operator*() { return Collection.getChild(Index); }
+
+  SyntaxCollectionRefIterator<CollectionKind, Element> &operator++() {
+    ++Index;
+    return *this;
+  }
+
+  bool operator==(
+      const SyntaxCollectionRefIterator<CollectionKind, Element> &Other) {
+    return Collection.hasSameIdentityAs(Other.Collection) &&
+           Index == Other.Index;
+  }
+
+  bool operator!=(
+      const SyntaxCollectionRefIterator<CollectionKind, Element> &Other) {
+    return !operator==(Other);
+  }
+};
+
+/// A generic unbounded collection of \c SyntaxRef nodes.
+template <SyntaxKind CollectionKind, typename Element>
+class SyntaxCollectionRef : public SyntaxRef {
+  friend class Syntax;
+
+public:
+  SyntaxCollectionRef(const SyntaxDataRef *Data) : SyntaxRef(Data) {
+    validate();
+  }
+  SyntaxCollectionRef(const SyntaxDataRef *Data, no_validation_t)
+      : SyntaxRef(Data) {}
+
+  void validate() {}
+
+  /// Returns true if the collection is empty.
+  bool empty() const { return size() == 0; }
+
+  /// Returns the number of elements in the collection.
+  size_t size() const { return getRaw()->getLayout().size(); }
+
+  SyntaxCollectionRefIterator<CollectionKind, Element> begin() const {
+    return SyntaxCollectionRefIterator<CollectionKind, Element>{
+        /*Collection=*/*this,
+        /*Index=*/0,
+    };
+  }
+
+  SyntaxCollectionRefIterator<CollectionKind, Element> end() const {
+    return SyntaxCollectionRefIterator<CollectionKind, Element>{
+        /*Collection=*/*this,
+        /*Index=*/getRaw()->getLayout().size(),
+    };
+  }
+
+  /// Return the element at the given Index.
+  ///
+  /// Precondition: Index < size()
+  OwnedSyntaxRef<Element> getChild(const size_t Index) const {
+    assert(Index < size() && "Index out of bounds");
+    OwnedSyntaxRef<Element> Result;
+    getDataRef()->getChildRef(Index, Result.getDataPtr());
+    return Result;
+  }
+
+  static bool kindof(SyntaxKind Kind) { return Kind == CollectionKind; }
+
+  static bool classof(const SyntaxRef *S) { return kindof(S->getKind()); }
+};
+
 
 } // end namespace syntax
 } // end namespace swift

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -89,9 +89,6 @@ protected:
   /// and released when \c this is destroyed.
   const SyntaxDataRef *Parent;
 
-  /// Creates an *uninitialized* \c SyntaxDataRef.
-  SyntaxDataRef() {}
-
   /// Creates a \c SyntaxDataRef. \p AbsoluteRaw must not be null. If \p Parent
   /// is a \c nullptr, this node represents the root of a tree.
   SyntaxDataRef(const AbsoluteRawSyntax &AbsoluteRaw,
@@ -101,15 +98,21 @@ protected:
 
 #ifndef NDEBUG
   virtual bool isRef() const { return true; }
-  virtual ~SyntaxDataRef() {}
 #endif
 
 public:
+  /// Creates an *uninitialized* \c SyntaxDataRef.
+  SyntaxDataRef() {}
+
   SyntaxDataRef(const SyntaxDataRef &DataRef) = default;
   SyntaxDataRef(SyntaxDataRef &&DataRef) = default;
 
   SyntaxDataRef &operator=(SyntaxDataRef const &other) = default;
   SyntaxDataRef &operator=(SyntaxDataRef &&other) = default;
+
+#ifndef NDEBUG
+  virtual ~SyntaxDataRef() {}
+#endif
 
   // MARK: - Retrieving underlying data
 
@@ -136,6 +139,50 @@ public:
   /// otherwise 0.
   AbsoluteSyntaxPosition::IndexInParentType getIndexInParent() const {
     return getAbsoluteRaw().getPosition().getIndexInParent();
+  }
+
+  /// If \c this node has a child at \p Cursor, write the child's \c
+  /// SyntaxDataRef to \p DataMem and return \c true.
+  /// If no child exists at \p Cursor, leave \p DataMem untouched and return \c
+  /// false.
+  template <typename CursorType>
+  bool getChildRef(CursorType Cursor, SyntaxDataRef *DataMem) const {
+    return getChildRef(
+        (AbsoluteSyntaxPosition::IndexInParentType)cursorIndex(Cursor),
+        DataMem);
+  }
+
+  /// If \c this node has a child at \p Index, write the child's \c
+  /// SyntaxDataRef to \p DataMem and return \c true. If no child exists at \p
+  /// Index, leave \p DataMem untouched and return \c false.
+  bool getChildRef(AbsoluteSyntaxPosition::IndexInParentType Index,
+                   SyntaxDataRef *DataMem) const {
+    auto AbsoluteRaw = getAbsoluteRaw().getChild(Index);
+    if (AbsoluteRaw) {
+      new (DataMem) SyntaxDataRef(*AbsoluteRaw,
+                                  /*Parent=*/const_cast<SyntaxDataRef *>(this));
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /// Assuming that the child at \p Cursor exists, write its \c SyntaxData to \p
+  /// DataMem.
+  template <typename CursorType>
+  void getPresentChildRef(CursorType Cursor, SyntaxDataRef *DataMem) const {
+    return getPresentChildRef(
+        (AbsoluteSyntaxPosition::IndexInParentType)cursorIndex(Cursor),
+        DataMem);
+  }
+
+  /// Assuming that the child at \p Index exists, write its \c SyntaxData to \p
+  /// DataMem.
+  void getPresentChildRef(AbsoluteSyntaxPosition::IndexInParentType Index,
+                          SyntaxDataRef *DataMem) const {
+    auto AbsoluteRaw = getAbsoluteRaw().getPresentChild(Index);
+    new (DataMem) SyntaxDataRef(AbsoluteRaw,
+                                /*Parent=*/const_cast<SyntaxDataRef *>(this));
   }
 
   // MARK: - Retrieving source locations

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -125,6 +125,7 @@ public:
 
   // MARK: - Retrieving related nodes
 
+  /// Return the parent \c SyntaxDataRef if it exists, otherwise \c nullptr.
   const SyntaxDataRef *getParentRef() const {
     return Parent;
   }

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -56,9 +56,7 @@ class ${node.name} ${qualifier} : public ${node.base_type} {
 %     if node.is_buildable():
       friend class ${node.name}Builder;
 %     end
-%     if node.requires_validation():
   void validate() const;
-%     end
 
 public:
 %     if node.children:
@@ -70,10 +68,8 @@ public:
 %     end
 
   ${node.name}(const RC<const SyntaxData> &Data) : ${node.base_type}(Data) {
-%     if node.requires_validation():
-      this->validate();
-%     end
-    }
+    this->validate();
+  }
 
 %     for child in node.children:
 %       for line in dedented_lines(child.description):

--- a/include/swift/Syntax/SyntaxNodes.h.gyb
+++ b/include/swift/Syntax/SyntaxNodes.h.gyb
@@ -35,6 +35,7 @@ namespace syntax {
 % for node in SYNTAX_NODES:
 %   if not node.is_syntax_collection():
 class ${node.name};
+class ${node.name}Ref;
 %   end
 % end
 
@@ -43,6 +44,9 @@ class ${node.name};
 using ${node.name} =
   SyntaxCollection<SyntaxKind::${node.syntax_kind},
                    ${node.collection_element_type}>;
+using ${node.name}Ref =
+  SyntaxCollectionRef<SyntaxKind::${node.syntax_kind},
+                      ${node.collection_element_type}Ref>;
 %   end
 % end
 
@@ -120,12 +124,81 @@ public:
   }
 };
 
+/// See doc comment on \c SyntaxDataRef for more details.
+class ${node.name}Ref ${qualifier} : public ${node.base_type}Ref {
+  friend class ${node.name}; // Non-Ref node is a friend so it can call validate
+
+public:
+%     if node.children:
+  using Cursor = ${node.name}::Cursor; // Use same cursor as non-Ref node.
+%     end
+
+  explicit ${node.name}Ref(const SyntaxDataRef *Data) : ${node.base_type}Ref(Data) {
+    this->validate();
+  }
+
+  /// Create a \c ${node.name}Ref node, but don't validate it. Useful if the
+  /// underlying \c SyntaxDataRef is populated later.
+  /// \c validate should be called after \p Data has been populated.
+  ${node.name}Ref(const SyntaxDataRef *Data, no_validation_t) : ${node.base_type}Ref(Data) {}
+
+  /// Demote a \c ${node.name} node to a \c ${node.name}Ref node.
+  /// The \c ${node.name} node continues to hold the \c SyntaxData and must thus
+  /// outlive the \c ${node.name}Ref node.
+  ${node.name}Ref(const ${node.name} &Node) : ${node.base_type}Ref(Node.getData().get()) {}
+
+  /// Validate the syntax node. This is automatically done when creating a node
+  /// unless the \c no_validation_t marker is passed.
+  void validate() const;
+
+%     for child in node.children:
+%       for line in dedented_lines(child.description):
+  /// ${line}
+%       end
+%       if child.is_optional:
+  inline OptionalOwnedSyntaxRef<${child.type_name}Ref> get${child.name}() const;
+%       else:
+  inline OwnedSyntaxRef<${child.type_name}Ref> get${child.name}() const;
+%       end
+
+%     end
+  static bool kindof(SyntaxKind Kind) {
+%     if node.is_base():
+    return is${node.syntax_kind}Kind(Kind);
+%     else:
+    return Kind == SyntaxKind::${node.syntax_kind};
+%     end
+  }
+
+  static bool classof(const SyntaxRef *S) {
+    return kindof(S->getKind());
+  }
+};
 %   end
 % end
 
 /// Calculating an identifier for all syntax nodes' structures for verification
 /// purposes.
 const char* getSyntaxStructureVersioningIdentifier();
+
+% for node in SYNTAX_NODES:
+%   for child in node.children:
+%     if child.is_optional:
+OptionalOwnedSyntaxRef<${child.type_name}Ref> ${node.name}Ref::get${child.name}() const {
+  OptionalOwnedSyntaxRef<${child.type_name}Ref> Result;
+  getDataRef()->getChildRef(Cursor::${child.name}, Result.getDataPtr());
+  return Result;
+}
+%     else:
+OwnedSyntaxRef<${child.type_name}Ref> ${node.name}Ref::get${child.name}() const {
+  OwnedSyntaxRef<${child.type_name}Ref> Result;
+  getDataRef()->getPresentChildRef(Cursor::${child.name}, Result.getDataPtr());
+  return Result;
+}
+%     end
+%   end
+% end
+
 }
 }
 

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -33,7 +33,9 @@ protected:
     assert(getRaw()->isToken());
   }
 public:
-  TokenSyntax(const RC<const SyntaxData> &Data) : Syntax(Data) {}
+  TokenSyntax(const RC<const SyntaxData> &Data) : Syntax(Data) {
+    validate();
+  }
 
   static TokenSyntax missingToken(const tok Kind, StringRef Text,
                                   const RC<SyntaxArena> &Arena) {

--- a/include/swift/Syntax/TokenSyntax.h
+++ b/include/swift/Syntax/TokenSyntax.h
@@ -60,16 +60,6 @@ public:
     return TokenSyntax(getData()->replacingSelf(NewRaw));
   }
 
-  /* TODO: If we really need them.
-  bool isKeyword() const;
-
-  bool isPunctuation() const;
-
-  bool isOperator() const;
-
-  bool isLiteral() const;
-  */
-
   bool isMissing() const {
     return getRaw()->isMissing();
   }
@@ -98,6 +88,55 @@ public:
   static bool classof(const Syntax *S) {
     return kindof(S->getKind());
   }
+};
+
+/// See comment in \c SyntaxRef.
+/// 
+/// This duplicates some code from \c TokenSyntax, but since \c TokenSyntaxRef
+/// needs to inherit from \c SyntaxRef and \c TokenSyntax needs to inherit from
+/// \c Syntax, there's no easy way to share the code. And the duplicate is
+/// fairly small.
+class TokenSyntaxRef final : public SyntaxRef {
+public:
+  TokenSyntaxRef(const SyntaxDataRef *Data) : SyntaxRef(Data) {
+    validate();
+  }
+  TokenSyntaxRef(const SyntaxDataRef *Data, no_validation_t)
+      : SyntaxRef(Data) {}
+
+  void validate() const { assert(getRaw()->isToken()); }
+
+  /// Demote a \c TokenSyntax to a \c TokenSyntaxRef
+  TokenSyntaxRef(const TokenSyntax &Token) : SyntaxRef(Token.getData().get()) {}
+
+  StringRef getLeadingTrivia() const { return getRaw()->getLeadingTrivia(); }
+  Trivia getLeadingTriviaPieces() const {
+    return getRaw()->getLeadingTriviaPieces();
+  }
+
+  StringRef getTrailingTrivia() const { return getRaw()->getTrailingTrivia(); }
+  Trivia getTrailingTriviaPieces() const {
+    return getRaw()->getTrailingTriviaPieces();
+  }
+
+  bool isMissing() const { return getRaw()->isMissing(); }
+
+  tok getTokenKind() const { return getRaw()->getTokenKind(); }
+
+  StringRef getText() const { return getRaw()->getTokenText(); }
+
+  StringRef getIdentifierText() const {
+    StringRef text = getText();
+    if (text.front() == '`') {
+      assert(text.back() == '`');
+      return text.slice(1, text.size() - 1);
+    }
+    return text;
+  }
+
+  static bool kindof(SyntaxKind Kind) { return isTokenKind(Kind); }
+
+  static bool classof(const SyntaxRef *S) { return kindof(S->getKind()); }
 };
 
 } // end namespace syntax

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -25,32 +25,39 @@ using namespace swift;
 using namespace swift::syntax;
 
 % for node in SYNTAX_NODES:
-%   if node.requires_validation():
-void ${node.name}::validate() const {
+%   if not node.is_syntax_collection():
+void ${node.name}Ref::validate() const {
+%     if node.requires_validation():
 #ifndef NDEBUG
-  auto raw = getData()->getRaw();
+  auto raw = getDataRef()->getRaw();
   if (isMissing()) return;
   assert(raw->getLayout().size() == ${len(node.children)});
-%     for child in node.children:
-%       if child.token_choices:
-%         choices = ", ".join("tok::" + choice.kind
-%                             for choice in child.token_choices)
+%       for child in node.children:
+%         if child.token_choices:
+%           choices = ", ".join("tok::" + choice.kind
+%                               for choice in child.token_choices)
   syntax_assert_child_token(raw, ${child.name}, ${choices});
-%       end
-%       if child.main_token() and child.text_choices:
-%         token_kind = child.main_token().kind
-%         choices = ", ".join("\"%s\"" % choice
-%                             for choice in child.text_choices)
+%         end
+%         if child.main_token() and child.text_choices:
+%           token_kind = child.main_token().kind
+%           choices = ", ".join("\"%s\"" % choice
+%                               for choice in child.text_choices)
   syntax_assert_child_token_text(raw, ${child.name},
                                  tok::${token_kind}, ${choices});
-%       end
-%       if child.node_choices:
+%         end
+%         if child.node_choices:
   if (auto __Child = raw->getChild(Cursor::${child.name}))
     assert(${check_child_condition_raw(child)}(__Child));
+%         end
 %       end
-%     end
 #endif
+%     end
 }
+
+void ${node.name}::validate() const {
+  ${node.name}Ref(*this).validate();
+}
+
 %   end
 
 %   for child in node.children:


### PR DESCRIPTION
Now that we have a fast `SyntaxDataRef`, create a corresponding `SyntaxRef` hierarchy. In contrast to the `Syntax` hierarchy, `SyntaxRef` does **not** own the backing `SyntaxDataRef`, but merely has a pointer to the `SyntaxDataRef`. In addition to the requirements imposed by `SyntaxDataRef`, the user of the `SyntaxRef` hierarchy needs to make sure that the backing `SyntaxDataRef` of a `SyntaxRef` node stays alive. While this sounds like a lot of requirements, it has performance advantages:
 - Passing a `SyntaxRef` node around is just passing a pointer around.
 - When casting a `SyntaxRef` node, we only need to create a new `SyntaxRef` (aka. pointer) that points to the same underlying `SyntaxDataRef` – there's no need to duplicate the `SyntaxDataRef`.
 - As `SyntaxDataRef` is not ref-counted, there's no ref-counting overhead involved.

Furthermore, the requirements are typically fulfilled. The `getChild` methods on SyntaxRef return an `OwnedSyntaxRef`, which stores the `SyntaxDataRef`. As long as this variable is stored somewhere on the stack, the corresponding `SyntaxRef` can safely be used for the duration of the stack frame. Even calls like the following are possible, because `OwnedSyntaxRef` returned by `getChild` stays alive for the duration of the entire statement.

```cpp
useSyntaxRef(mySyntaxRef.getChild(0).getRef())
```