### PR TITLE
[Frontend] don't pop the last path component from -emit-symbol-graph-dir

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -164,7 +164,6 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     }
     SmallString<256> OutputDir(serializationOpts.SymbolGraphOutputDir);
     llvm::sys::fs::make_absolute(OutputDir);
-    llvm::sys::path::remove_filename(OutputDir);
     serializationOpts.SymbolGraphOutputDir = OutputDir.str().str();
   }
   

--- a/test/SymbolGraph/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/EmitWhileBuilding.swift
@@ -2,6 +2,12 @@
 // RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/ -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
 
+// also try without the trailing slash on `-emit-symbol-graph-dir` and make sure it works
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/ -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+
 /// Does a foo.
 public func foo() {}
 


### PR DESCRIPTION
Resolves rdar://74318113

When the frontend receives `-emit-symbol-graph-dir`, it pops the last component from the path before saving it. This worked in the initial PR, because the test only supplied the path with a trailing slash. However, if you supply a path *without* a trailing slash, this would cause the frontend to emit the symbol graphs into the parent directory of the path you actually gave. This PR stops the behavior.