### PR TITLE
stdlib: fix ARC for getting an ArraySlice of an CocoaArray with non-contiguous storage.

### DIFF
--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -83,12 +83,13 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     let result = _ContiguousArrayBuffer<AnyObject>(
       _uninitializedCount: boundsCount,
       minimumCapacity: 0)
-
-    // Tell Cocoa to copy the objects into our storage
-    core.getObjects(
-      UnsafeMutableRawPointer(result.firstElementAddress)
-      .assumingMemoryBound(to: AnyObject.self),
-      range: _SwiftNSRange(location: bounds.lowerBound, length: boundsCount))
+    
+    let base = UnsafeMutableRawPointer(result.firstElementAddress)
+      .assumingMemoryBound(to: AnyObject.self)
+      
+    for idx in 0..<boundsCount {
+      (base + idx).initialize(to: core.objectAt(idx + bounds.lowerBound))
+    }
 
     return _SliceBuffer(_buffer: result, shiftedToStartIndex: bounds.lowerBound)
   }


### PR DESCRIPTION
For this special case we copied the objects out of the cocoa array without retaining them.
This lead to a double-free crash.

Unfortunately I could not come up with an isolated test case.

rdar://74807247