### PR TITLE
[Driver] Use library search group when linking statically

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -263,12 +263,25 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     Arguments.push_back(context.Args.MakeArgString(context.OI.SDKPath));
   }
 
+  // If we are linking statically, we need to add all
+  // dependencies to a library search group to resolve
+  // potential circular dependencies
+  if (staticExecutable || staticStdlib) {
+    Arguments.push_back("-Xlinker");
+    Arguments.push_back("--start-group");
+  }
+
   // Add any autolinking scripts to the arguments
   for (const Job *Cmd : context.Inputs) {
     auto &OutputInfo = Cmd->getOutput();
     if (OutputInfo.getPrimaryOutputType() == file_types::TY_AutolinkFile)
       Arguments.push_back(context.Args.MakeArgString(
           Twine("@") + OutputInfo.getPrimaryOutputFilename()));
+  }
+
+  if (staticExecutable || staticStdlib) {
+    Arguments.push_back("-Xlinker");
+    Arguments.push_back("--end-group");
   }
 
   // Add the runtime library link paths.

--- a/test/Driver/linker-args-order-linux.swift
+++ b/test/Driver/linker-args-order-linux.swift
@@ -6,4 +6,4 @@ print("hello world!")
 // RUN: %target-swiftc_driver -driver-print-jobs -static-stdlib -o %t/static-stdlib %s -Xlinker --no-allow-multiple-definition 2>&1| %FileCheck %s
 // CHECK: {{.*}}/swift-frontend -frontend -c -primary-file {{.*}}/linker-args-order-linux.swift
 // CHECK: {{.*}}/swift-autolink-extract{{.*}}
-// CHECK: {{.*}}swiftrt.o /{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.o @/{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.autolink {{.*}} @{{.*}}/static-stdlib-args.lnk {{.*}} -Xlinker --no-allow-multiple-definition
+// CHECK: {{.*}}swiftrt.o /{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.o -Xlinker --start-group @/{{.*}}/linker-args-order-linux-{{[a-z0-9]+}}.autolink -Xlinker --end-group {{.*}} @{{.*}}/static-stdlib-args.lnk {{.*}} -Xlinker --no-allow-multiple-definition


### PR DESCRIPTION
Fixes rdar://75099393

When statically linking, we sometimes run into circular dependencies (e.g. Foundation and CoreFoundation). Using library search groups resolves linker issues in these cases.