### PR TITLE
[Diagnostics] Verify that optional evaluation got type from context b…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3793,7 +3793,9 @@ bool ConstraintSystem::repairFailures(
       // Because result type of the optional evaluation is supposed to
       // represent the type of its sub-expression with added level of
       // optionality if needed.
-      if (!lhs->getOptionalObjectType() && !lhs->hasTypeVariable()) {
+      auto contextualTy = simplifyType(rhs)->getOptionalObjectType();
+      if (!lhs->getOptionalObjectType() && !lhs->hasTypeVariable() &&
+          !contextualTy->isTypeVariableOrMember()) {
         conversionsOrFixes.push_back(IgnoreContextualType::create(
             *this, lhs, rhs, getConstraintLocator(OEE->getSubExpr())));
         return true;

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1360,3 +1360,17 @@ SR5688_1!.count // expected-error {{function 'SR5688_1' was used as a property; 
 
 func SR5688_2() -> Int? { 0 }
 let _: Int = SR5688_2! // expected-error {{function 'SR5688_2' was used as a property; add () to call it}} {{22-22=()}}
+
+
+// rdar://74696023 - Fallback error when passing incorrect optional type to `==` operator
+func rdar74696023() {
+  struct MyError {
+    var code: Int = 0
+  }
+
+  func test(error: MyError?, code: Int32) {
+    guard error?.code == code else { fatalError() } // expected-error {{value of optional type 'Int?' must be unwrapped to a value of type 'Int'}}
+    // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  }
+}


### PR DESCRIPTION
…efore recording a fix

Instead of assuming that there is a mismatch between context and
result of the optional chain, let's actually verify that optional
evaluation expression does have a type before recording a fix.

Resolves: rdar://74696023

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
