### PR TITLE
DiagnoseLifetimeIssues: handle ObjectiveC weak properties

### DIFF
--- a/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
+++ b/test/SILOptimizer/diagnose_lifetime_issues_objc.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-sil %s -o /dev/null -verify
+// REQUIRES: objc_interop
+
+import Foundation
+
+class MyServiceDelegate : NSObject, NSXPCListenerDelegate { }
+
+public func warningForDeadDelegate() {
+  let delegate = MyServiceDelegate()
+  let listener = NSXPCListener.service()
+  listener.delegate = delegate  // expected-warning {{weak reference will always be nil because the referenced object is deallocated here}}
+  listener.resume()
+}


### PR DESCRIPTION
Issue warnings if an object is stored to an ObjectiveC weak property (via a setter) and destroyed before the property is ever used again.

rdar://74620325
