### PR TITLE
C++ Interop: import subscript operators

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1797,6 +1797,23 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       isFunction = true;
       addEmptyArgNamesForClangFunction(functionDecl, argumentNames);
       break;
+    case clang::OverloadedOperatorKind::OO_Subscript: {
+      auto returnType = functionDecl->getReturnType();
+      if (!returnType->isReferenceType()) {
+        // TODO: support non-reference return types (SR-14351)
+        return ImportedName();
+      }
+      if (returnType->getPointeeType().isConstQualified()) {
+        baseName = "__operatorSubscriptConst";
+        result.info.accessorKind = ImportedAccessorKind::SubscriptGetter;
+      } else {
+        baseName = "__operatorSubscript";
+        result.info.accessorKind = ImportedAccessorKind::SubscriptSetter;
+      }
+      isFunction = true;
+      addEmptyArgNamesForClangFunction(functionDecl, argumentNames);
+      break;
+    }
     default:
       // We don't import these yet.
       return ImportedName();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -490,6 +490,15 @@ public:
   /// pairs.
   llvm::DenseMap<std::pair<FuncDecl *, FuncDecl *>, SubscriptDecl *> Subscripts;
 
+  /// Keep track of getter/setter pairs for functions imported from C++
+  /// subscript operators based on the type in which they are declared and
+  /// the type of their parameter.
+  ///
+  /// `.first` corresponds to a getter
+  /// `.second` corresponds to a setter
+  llvm::MapVector<std::pair<NominalTypeDecl *, Type>,
+                  std::pair<FuncDecl *, FuncDecl *>> cxxSubscripts;
+
   /// Keeps track of the Clang functions that have been turned into
   /// properties.
   llvm::DenseMap<const clang::FunctionDecl *, VarDecl *> FunctionsAsProperties;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2311,6 +2311,9 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
           break;
         }
       }
+      if (auto subscript = dyn_cast<SubscriptDecl>(storage)) {
+        break;
+      }
 
       // Anything else should not have a synthesized setter.
       LLVM_FALLTHROUGH;

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -39,4 +39,112 @@ struct HasDeletedOperator {
   void operator!=(HasDeletedOperator) const = delete;
 };
 
+struct ReadWriteIntArray {
+private:
+  int values[5] = { 1, 2, 3, 4, 5 };
+
+public:
+  const int &operator[](int x) const {
+    return values[x];
+  }
+  int &operator[](int x) {
+    return values[x];
+  }
+
+  struct NestedIntArray {
+  private:
+    int values[5] = { 1, 2, 3, 4, 5 };
+
+  public:
+    const int &operator[](int x) const {
+      return values[x];
+    }
+  };
+};
+
+struct ReadOnlyIntArray {
+private:
+  int values[5] = { 1, 2, 3, 4, 5 };
+
+public:
+  ReadOnlyIntArray(int first) {
+    values[0] = first;
+  }
+  ReadOnlyIntArray(const ReadOnlyIntArray &other) {}
+
+  const int &operator[](int x) const {
+    return values[x];
+  }
+};
+
+struct WriteOnlyIntArray {
+private:
+  int values[5] = { 1, 2, 3, 4, 5 };
+
+public:
+  int &operator[](int x) {
+    return values[x];
+  }
+};
+
+struct DifferentTypesArray {
+private:
+  int values[3] = { 1, 2, 3 };
+  double doubleValues[2] = { 1.5, 2.5 };
+  bool boolValues[2] = { true, false };
+
+public:
+  const int &operator[](int x) const {
+    return values[x];
+  }
+  int &operator[](int x) {
+    return values[x];
+  }
+  bool &operator[](bool x) {
+    return boolValues[x];
+  }
+  const bool &operator[](bool x) const {
+    return boolValues[x];
+  }
+  const double &operator[](double x) const {
+    return doubleValues[x == 0.0];
+  }
+};
+
+template<class T>
+struct TemplatedArray {
+  T ts[];
+
+  T &operator[](int i) {
+    return ts[i];
+  }
+  const T &operator[](int i) const {
+    return ts[i];
+  }
+};
+typedef TemplatedArray<double> TemplatedDoubleArray;
+
+struct TemplatedSubscriptArray {
+  int *ptr;
+
+  template<class T>
+  T &operator[](T i) {
+    return ptr[i];
+  }
+  template<class T>
+  const T &operator[](T i) const {
+    return ptr[i];
+  }
+};
+
+struct NonReferenceReadIntArray {
+private:
+  int values[3] = { 1, 2, 3 };
+
+public:
+  int operator[](int x) const {
+    return values[x];
+  }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
@@ -27,3 +27,11 @@ int AddressOnlyIntWrapper::operator()(int x) const {
 int AddressOnlyIntWrapper::operator()(int x, int y) const {
   return value + x * y;
 }
+
+const int& ReadWriteIntArray::operator[](int x) const {
+  return values[x];
+}
+
+int& ReadWriteIntArray::operator[](int x) {
+  return values[x];
+}

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -20,4 +20,13 @@ struct AddressOnlyIntWrapper {
   int operator()(int x, int y) const;
 };
 
+struct ReadWriteIntArray {
+private:
+  int values[5] = { 1, 2, 3, 4, 5 };
+
+public:
+  const int &operator[](int x) const;
+  int &operator[](int x);
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -19,3 +19,21 @@ public func call(_ wrapper: inout AddressOnlyIntWrapper) -> Int32 { wrapper() }
 
 // CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN21AddressOnlyIntWrapperclEv|"\?\?GAddressOnlyIntWrapper@@QEAAHXZ")]](%struct.AddressOnlyIntWrapper* {{%[0-9]+}})
 // CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.AddressOnlyIntWrapper* nonnull dereferenceable(4) {{.*}})
+
+public func index(_ arr: inout ReadOnlyIntArray, _ arg: Int32) -> Int32 { arr[arg] }
+
+// CHECK: call [[RES:i32|i64]]* [[NAME:@(_ZNK16ReadOnlyIntArrayixEi|"\?\?AReadOnlyIntArray@@QEBAAEBHH@Z")]](%struct.ReadOnlyIntArray* {{%[0-9]+}}, {{i32|i64}} {{%[0-9]+}})
+// CHECK: define linkonce_odr nonnull align 4 dereferenceable(4) [[RES]]* [[NAME]](%struct.ReadOnlyIntArray* nonnull dereferenceable(20) {{.*}}, {{i32 %x|\[1 x i32\] %x|i64 %x|%struct.ReadOnlyIntArray\* byval\(%struct.ReadOnlyIntArray\) align 2 %rhs}})
+// CHECK:   [[THIS:%.*]] = load %struct.ReadOnlyIntArray*, %struct.ReadOnlyIntArray**
+// CHECK:   [[VALUES:%.*]] = getelementptr inbounds %struct.ReadOnlyIntArray, %struct.ReadOnlyIntArray* [[THIS]]
+// CHECK:   [[VALUE:%.*]] = getelementptr inbounds [5 x {{i32|i64}}], [5 x {{i32|i64}}]* [[VALUES]]
+// CHECK:   ret {{i32|i64}}* [[VALUE]]
+
+public func index(_ arr: inout ReadWriteIntArray, _ arg: Int32, _ val: Int32) { arr[arg] = val }
+
+// CHECK: call [[RES:i32|i64]]* [[NAME:@(_ZN17ReadWriteIntArrayixEi|"\?\?AReadWriteIntArray@@QEAAAEAHH@Z")]](%struct.ReadWriteIntArray* {{%[0-9]+}}, {{i32|i64}} {{%[0-9]+}})
+// CHECK: define linkonce_odr nonnull align 4 dereferenceable(4) [[RES]]* [[NAME]](%struct.ReadWriteIntArray* nonnull dereferenceable(20) {{.*}}, {{i32 %x|\[1 x i32\] %x|i64 %x|%struct.ReadWriteIntArray\* byval\(%struct.ReadWriteIntArray\) align 2 %rhs}})
+// CHECK:   [[THIS:%.*]] = load %struct.ReadWriteIntArray*, %struct.ReadWriteIntArray**
+// CHECK:   [[VALUES:%.*]] = getelementptr inbounds %struct.ReadWriteIntArray, %struct.ReadWriteIntArray* [[THIS]]
+// CHECK:   [[VALUE:%.*]] = getelementptr inbounds [5 x {{i32|i64}}], [5 x {{i32|i64}}]* [[VALUES]]
+// CHECK:   ret {{i32|i64}}* [[VALUE]]

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -15,3 +15,83 @@
 
 // CHECK: struct HasDeletedOperator {
 // CHECK: }
+
+
+// CHECK: struct ReadWriteIntArray {
+// CHECK:   struct NestedIntArray {
+// CHECK:     @available(*, unavailable, message: "use subscript")
+// CHECK:     mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+
+// CHECK:     subscript(x: Int32) -> Int32 { mutating get }
+// CHECK:   }
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
+
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get set }
+// CHECK: }
+
+
+// CHECK: struct ReadOnlyIntArray {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK: }
+
+
+// CHECK: struct WriteOnlyIntArray {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
+
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get set }
+// CHECK: }
+
+
+// CHECK: struct DifferentTypesArray {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Bool) -> UnsafeMutablePointer<Bool>
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Bool) -> UnsafePointer<Bool>
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Double) -> UnsafePointer<Double>
+
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get set }
+// CHECK:   subscript(x: Bool) -> Bool { mutating get set }
+// CHECK:   subscript(x: Double) -> Double { mutating get }
+// CHECK: }
+
+
+// CHECK: struct TemplatedArray<T> {
+// CHECK: }
+// CHECK: struct __CxxTemplateInst14TemplatedArrayIdE {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ i: Int32) -> UnsafeMutablePointer<Double>
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ i: Int32) -> UnsafePointer<Double>
+
+// CHECK:   subscript(i: Int32) -> Double { mutating get set }
+// CHECK: }
+// CHECK: typealias TemplatedDoubleArray = __CxxTemplateInst14TemplatedArrayIdE
+
+
+// CHECK: struct TemplatedSubscriptArray {
+// CHECK: }
+
+
+// Non-reference subscript operators are not currently imported (SR-14351)
+// so just make sure we don't crash.
+// CHECK: struct NonReferenceReadIntArray {
+// CHECK: }

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -32,3 +32,46 @@ public func call(_ wrapper: inout AddressOnlyIntWrapper) -> Int32 { wrapper() }
 // CHECK: end_access [[SELFACCESS]] : $*AddressOnlyIntWrapper
 
 // CHECK: sil [clang AddressOnlyIntWrapper.callAsFunction] [[NAME]] : $@convention(c) (@inout AddressOnlyIntWrapper) -> Int32
+
+public func index(_ arr: inout ReadOnlyIntArray, _ arg: Int32) -> Int32 { arr[arg] }
+
+// CHECK: sil @$s4main5indexys5Int32VSo16ReadOnlyIntArrayVz_ADtF : $@convention(thin) (@inout ReadOnlyIntArray, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $*ReadOnlyIntArray, [[INDEX:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*ReadOnlyIntArray
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*ReadOnlyIntArray
+// CHECK:   [[OP:%.*]] = function_ref [[READCLASSNAME:@(_ZNK16ReadOnlyIntArrayixEi|\?\?AReadOnlyIntArray@@QEBAAEBHH@Z)]] : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo16ReadOnlyIntArrayVz_ADtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo16ReadOnlyIntArrayVys5Int32VADcig : $@convention(method) (Int32, @inout ReadOnlyIntArray) -> Int32 {
+// CHECK: bb0([[INDEX:%.*]] : $Int32, [[SELF:%.*]] : $*ReadOnlyIntArray):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*ReadOnlyIntArray
+// CHECK:   [[OP:%.*]] = function_ref [[READCLASSNAME]] : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[INDEX]]) : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK:   end_access [[SELFACCESS]] : $*ReadOnlyIntArray
+// CHECK:   [[PTR2:%.*]] = struct_extract [[PTR]] : $UnsafePointer<Int32>, #UnsafePointer._rawValue
+// CHECK:   pointer_to_address [[PTR2]] : $Builtin.RawPointer to [strict] $*Int32
+// CHECK: } // end sil function '$sSo16ReadOnlyIntArrayVys5Int32VADcig'
+
+public func index(_ arr: inout ReadWriteIntArray, _ arg: Int32, _ val: Int32) { arr[arg] = val }
+
+// CHECK: sil @$s4main5indexyySo17ReadWriteIntArrayVz_s5Int32VAFtF : $@convention(thin) (@inout ReadWriteIntArray, Int32, Int32) -> () {
+// CHECK: bb0([[ARR:%.*]] : $*ReadWriteIntArray, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*ReadWriteIntArray
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*ReadWriteIntArray
+// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAME:@(_ZN17ReadWriteIntArrayixEi|\?\?AReadWriteIntArray@@QEAAAEAHH@Z)]] : $@convention(c) (@inout ReadWriteIntArray, Int32) -> UnsafeMutablePointer<Int32>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout ReadWriteIntArray, Int32) -> UnsafeMutablePointer<Int32>
+// CHECK: } // end sil function '$s4main5indexyySo17ReadWriteIntArrayVz_s5Int32VAFtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo17ReadWriteIntArrayVys5Int32VADcis : $@convention(method) (Int32, Int32, @inout ReadWriteIntArray) -> () {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $Int32, [[SELF:%.*]] : $*ReadWriteIntArray):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*ReadWriteIntArray
+// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAME]] : $@convention(c) (@inout ReadWriteIntArray, Int32) -> UnsafeMutablePointer<Int32>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[INDEX]]) : $@convention(c) (@inout ReadWriteIntArray, Int32) -> UnsafeMutablePointer<Int32>
+// CHECK:   end_access [[SELFACCESS]] : $*ReadWriteIntArray
+// CHECK:   [[PTR2:%.*]] = struct_extract [[PTR]] : $UnsafeMutablePointer<Int32>, #UnsafeMutablePointer._rawValue
+// CHECK:   pointer_to_address [[PTR2]] : $Builtin.RawPointer to [strict] $*Int32
+// CHECK: } // end sil function '$sSo17ReadWriteIntArrayVys5Int32VADcis'
+
+// CHECK: sil [clang ReadOnlyIntArray.__operatorSubscriptConst] [[READCLASSNAME]] : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
+// CHECK: sil [clang ReadWriteIntArray.__operatorSubscript] [[READWRITECLASSNAME]] : $@convention(c) (@inout ReadWriteIntArray, Int32) -> UnsafeMutablePointer<Int32>

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -15,3 +15,18 @@ var addressOnly = AddressOnlyIntWrapper(42)
 let addressOnlyResultCall0 = addressOnly()
 let addressOnlyResultCall1 = addressOnly(1)
 let addressOnlyResultCall2 = addressOnly(1, 2)
+
+var readWriteIntArray = ReadWriteIntArray()
+readWriteIntArray[2] = 321
+let readWriteValue = readWriteIntArray[2]
+
+var readOnlyIntArray = ReadOnlyIntArray(3)
+let readOnlyValue = readOnlyIntArray[1]
+
+var writeOnlyIntArray = WriteOnlyIntArray()
+writeOnlyIntArray[2] = 654
+let writeOnlyValue = writeOnlyIntArray[2]
+
+var diffTypesArray = DifferentTypesArray()
+let diffTypesResultInt: Int32 = diffTypesArray[0]
+let diffTypesResultDouble: Double = diffTypesArray[0.5]

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -43,4 +43,51 @@ OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
   expectEqual(57, resultTwoArgs)
 }
 
+OperatorsTestSuite.test("ReadWriteIntArray.subscript (inline)") {
+  var arr = ReadWriteIntArray()
+
+  let resultBefore = arr[1]
+  expectEqual(2, resultBefore)
+
+  arr[1] = 234
+
+  let resultAfter = arr[1]
+  expectEqual(234, resultAfter)
+}
+
+OperatorsTestSuite.test("ReadOnlyIntArray.subscript (inline)") {
+  var arr = ReadOnlyIntArray(1)
+
+  let result0 = arr[0]
+  let result2 = arr[2]
+  let result4 = arr[4]
+
+  expectEqual(1, result0)
+  expectEqual(3, result2)
+  expectEqual(5, result4)
+}
+
+OperatorsTestSuite.test("WriteOnlyIntArray.subscript (inline)") {
+  var arr = WriteOnlyIntArray()
+
+  let resultBefore = arr[0]
+  expectEqual(1, resultBefore)
+
+  arr[0] = 654
+
+  let resultAfter = arr[0]
+  expectEqual(654, resultAfter)
+}
+
+OperatorsTestSuite.test("DifferentTypesArray.subscript (inline)") {
+  var arr = DifferentTypesArray()
+
+  let resultInt: Int32 = arr[2]
+  let resultDouble: Double = arr[0.1]
+
+  expectEqual(3, resultInt)
+  expectEqual(1.5.rounded(.down), resultDouble.rounded(.down))
+  expectEqual(1.5.rounded(.up), resultDouble.rounded(.up))
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -47,4 +47,16 @@ OperatorsTestSuite.test("AddressOnlyIntWrapper.call (out-of-line)") {
   expectEqual(57, resultTwoArgs)
 }
 
+OperatorsTestSuite.test("ReadWriteIntArray.subscript (out-of-line)") {
+  var arr = ReadWriteIntArray()
+
+  let resultBefore = arr[1]
+  expectEqual(2, resultBefore)
+
+  arr[1] = 234
+
+  let resultAfter = arr[1]
+  expectEqual(234, resultAfter)
+}
+
 runAllTests()


### PR DESCRIPTION
This change adds support for calling `operator[]` from Swift code via a synthesized Swift subscript.

For example:
```cpp
struct MyStruct {
  const int &operator[](int x) const { ... }
  int &operator[](int x) { ... }
};
```
is translated into
```swift
struct MyStruct {
  @available(*, unavailable, message: "use subscript")
  mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>

  @available(*, unavailable, message: "use subscript")
  mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>

  subscript(x: Int32) -> Int32 {
    mutating get {
      return self.__operatorSubscriptConst(x).pointee
    }
    set {
      self.__operatorSubscript(x).pointee = newValue
    }
  }
}
```

Fixes SR-12598.