### PR TITLE
[SymbolGraph] don't filter out symbols if their availability was for a platform-agnostic target

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -64,12 +64,14 @@ namespace {
 bool isUnavailableOrObsoleted(const Decl *D) {
   if (const auto *Avail =
         D->getAttrs().getUnavailable(D->getASTContext())) {
-    switch (Avail->getVersionAvailability(D->getASTContext())) {
-      case AvailableVersionComparison::Unavailable:
-      case AvailableVersionComparison::Obsoleted:
-        return true;
-      default:
-        break;
+    if (Avail->Platform != PlatformKind::none) {
+      switch (Avail->getVersionAvailability(D->getASTContext())) {
+        case AvailableVersionComparison::Unavailable:
+        case AvailableVersionComparison::Obsoleted:
+          return true;
+        default:
+          break;
+      }
     }
   }
   return false;

--- a/test/SymbolGraph/Symbols/Mixins/Availability/PlatformAgnostic.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Availability/PlatformAgnostic.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name PlatformAgnostic -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name PlatformAgnostic -I %t -pretty-print -output-dir %t
+
+// RUN: %FileCheck %s --input-file %t/PlatformAgnostic.symbols.json --check-prefix CHECK-FS
+// RUN: %FileCheck %s --input-file %t/PlatformAgnostic.symbols.json --check-prefix CHECK-FP
+// RUN: %FileCheck %s --input-file %t/PlatformAgnostic.symbols.json --check-prefix CHECK-SO
+
+// CHECK-FS: FutureSwift
+@available(swift 99)
+public struct FutureSwift {}
+
+// CHECK-FP: FuturePackage
+@available(_PackageDescription 99)
+public struct FuturePackage {}
+
+// CHECK-SO: SwiftObsolete
+@available(swift, obsoleted: 1.0)
+public struct SwiftObsolete {}

--- a/test/SymbolGraph/Symbols/Unavailable.swift
+++ b/test/SymbolGraph/Symbols/Unavailable.swift
@@ -25,13 +25,4 @@ extension ShouldAppear {
   public func shouldntAppear2() {}
 }
 
-// CHECK-NOT: SwiftObsoleted
-@available(swift, obsoleted: 1.0)
-public struct SwiftObsoleted {}
-
-@available(swift, obsoleted: 1.0)
-extension ShouldAppear {
-  public func shouldntAppear3() {}
-}
-
 // CHECK-NOT: shouldntAppear


### PR DESCRIPTION
Resolves rdar://74670284

When filtering symbols from the symbol graph for being unavailable, the Symbol Graph AST Walker always filtered out a symbol if the availability checking mechanism returned something that matched an outdated version. However, this would always return information for platform-agnostic targets, like Swift-language or SwiftPM-specific availability info. In the case of SwiftPM, this was because `swift-symbolgraph-extract` never set up the SwiftPM version, so it defaulted to 0.0.0, and caused every version comparison to fail.

This PR updates the AST Walker to only consider an availability attribute if it was for a platform-specific target, thus sparing Swift-language and SwiftPM availability from being filtered out.