### PR TITLE
[SILGen] Don't emit property wrapper generator functions for local property wrappers with initializers.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1796,14 +1796,20 @@ public:
   }
 
   /// Whether or not an opaque value placeholder should be injected into the
-  /// first \c wrappedValue argument of an apply expression.
+  /// first \c wrappedValue argument of an apply expression so the initializer
+  /// expression can be turned into a property wrapper generator function.
   bool shouldInjectWrappedValuePlaceholder(ApplyExpr *apply) const {
     if (kind != Kind::expression ||
         expression.contextualPurpose != CTP_Initialization)
       return false;
 
     auto *wrappedVar = expression.propertyWrapper.wrappedVar;
-    if (!apply || !wrappedVar || wrappedVar->isStatic())
+    if (!apply || !wrappedVar)
+      return false;
+
+    // Don't create property wrapper generator functions for static variables and
+    // local variables with initializers.
+    if (wrappedVar->isStatic() || wrappedVar->getDeclContext()->isLocalContext())
       return false;
 
     return expression.propertyWrapper.innermostWrappedValueInit == apply;

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1190,14 +1190,16 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
     if (var && var->getDeclContext()->isLocalContext()) {
       if (auto *orig = var->getOriginalWrappedProperty()) {
         auto wrapperInfo = orig->getPropertyWrapperBackingPropertyInfo();
-        Init = wrapperInfo.getWrappedValuePlaceholder()->getOriginalWrappedValue();
+        if (auto *placeholder = wrapperInfo.getWrappedValuePlaceholder()) {
+          Init = placeholder->getOriginalWrappedValue();
 
-        auto value = emitRValue(Init);
-        emitApplyOfPropertyWrapperBackingInitializer(SILLocation(PBD), orig,
-                                                     getForwardingSubstitutionMap(),
-                                                     std::move(value))
-          .forwardInto(*this, SILLocation(PBD), initialization.get());
-        return;
+          auto value = emitRValue(Init);
+          emitApplyOfPropertyWrapperBackingInitializer(SILLocation(PBD), orig,
+                                                       getForwardingSubstitutionMap(),
+                                                       std::move(value))
+            .forwardInto(*this, SILLocation(PBD), initialization.get());
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
Instead of emitting a property wrapper generator function and applying it, call the property wrapper initializer directly. The generator function isn't necessary if the local variable is initialized inline, and the generator function doesn't (yet) support capturing local variables that are referenced from the wrapper attribute. 

Resolves: rdar://75162444