### PR TITLE
Add test for relaxed circularity check from parse-time lookup removal

### DIFF
--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -653,3 +653,12 @@ func sr9015() {
   let closure1 = { closure2() } // expected-error {{circular reference}} expected-note {{through reference here}} expected-note {{through reference here}}
   let closure2 = { closure1() } // expected-note {{through reference here}} expected-note {{through reference here}} expected-note {{through reference here}}
 }
+
+func color(with value: Int) -> Int {
+  return value
+}
+
+func useColor() {
+  let color = color(with: 123)
+  _ = color
+}


### PR DESCRIPTION
This didn't work in 5.3:

    error: variable used within its own initial value
    let color = color(with: 123)
                ^

The old parse-time circularity check would kick in if nothing else in an outer local scope had the same name as the binding currently being initialized. However, type and global members were not in scope to parse-time name lookup, so the error would kick in even if the code would otherwise have a valid interpretation. Of course with https://github.com/apple/swift/pull/34137, this is all gone and we diagnose all cycles later, where we have more semantic information.