### PR TITLE
Improve request evaluator cycle diagnostics

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -212,7 +212,7 @@ public:
   
   SourceLoc getLoc() const {
     if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
-      return afd->getLoc();
+      return afd->getLocByPrintingIfNeeded();
     }
     if (auto ce = TheFunction.dyn_cast<AbstractClosureExpr *>()) {
       return ce->getLoc();

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -804,6 +804,11 @@ public:
   /// in diagnostics.
   SourceLoc getLoc(bool SerializedOK = true) const;
 
+  /// Returns a source location for use in diagnostics. If necessary, this
+  /// method will ask the \c DiagnosticEngine to print the declaration into a
+  /// source buffer and use that rather than returning an invalid \c SourceLoc.
+  SourceLoc getLocByPrintingIfNeeded() const;
+
   /// Returns the source range of the entire declaration.
   SourceRange getSourceRange() const;
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1017,6 +1017,10 @@ namespace swift {
     //// \c finishProcessing.
     bool finishProcessing();
 
+    /// Gets a source location for the indicated declaration, if necessary by
+    /// pretty-printing it using ASTPrinter.
+    SourceLoc getDiagnosticLocForDecl(const Decl *decl);
+
     /// Format the given diagnostic text and place the result in the given
     /// buffer.
     static void formatDiagnosticText(

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2956,6 +2956,31 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Perform a series of recursive calls with the \c first and \c rest decls that
+/// will eventually cause a cycle in the request stack.
+///
+/// This request is used to test diag::circular_reference and
+/// diag::circular_reference_through.
+class DebugIntentionallyCauseCycleRequest
+    : public SimpleRequest<
+          DebugIntentionallyCauseCycleRequest,
+          evaluator::SideEffect(Decl *, ArrayRef<Decl *>),
+          RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  evaluator::SideEffect
+  evaluate(Evaluator &evaluator, Decl *first, ArrayRef<Decl *> rest) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -326,3 +326,6 @@ SWIFT_REQUEST(TypeChecker, GetImplicitSendableRequest,
 SWIFT_REQUEST(TypeChecker, TypeCheckCompletionHandlerAsyncAttrRequest,
               bool (AbstractFunctionDecl *, CompletionHandlerAsyncAttr *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, DebugIntentionallyCauseCycleRequest,
+              evaluator::SideEffect(Decl *, ArrayRef<Decl *>), Cached,
+              NoLocationInfo)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -572,6 +572,10 @@ namespace swift {
 
     /// See \ref FrontendOptions.PrintFullConvention
     bool PrintFullConvention = false;
+
+    /// Deliberately create a request cycle involving the declarations for the
+    /// types named here. Used to test the request evaluator's diagnostics.
+    std::vector<std::string> DebugCauseCycleViaDeclNames;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -271,6 +271,8 @@ def debug_emit_invalid_swiftinterface_syntax : Flag<["-"], "debug-emit-invalid-s
 
 def debug_cycles : Flag<["-"], "debug-cycles">,
   HelpText<"Print out debug dumps when cycles are detected in evaluation">;
+def debug_cause_cycle_via_decl : Separate<["-"], "debug-cause-cycle-via-decl">,
+  HelpText<"Intentially creates a request cycle involving each of the declarations passed with this flag">;
 
 def debug_time_function_bodies : Flag<["-"], "debug-time-function-bodies">,
   HelpText<"Dumps the time it takes to type-check each function body">;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -630,6 +630,10 @@ Result->X = SM.getLocFromExternalSource(Locs->SourceFilePath, Locs->X.Line,   \
   return Result;
 }
 
+SourceLoc Decl::getLocByPrintingIfNeeded() const {
+  return getASTContext().Diags.getDiagnosticLocForDecl(this);
+}
+
 StringRef Decl::getAlternateModuleName() const {
   for (auto *Att: Attrs) {
     if (auto *OD = dyn_cast<OriginallyDefinedInAttr>(Att)) {
@@ -8185,7 +8189,7 @@ void swift::simple_display(llvm::raw_ostream &out, AccessorKind kind) {
 }
 
 SourceLoc swift::extractNearestSourceLoc(const Decl *decl) {
-  auto loc = decl->getLoc();
+  auto loc = decl->getLocByPrintingIfNeeded();
   if (loc.isValid())
     return loc;
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -920,6 +920,143 @@ static AccessLevel getBufferAccessLevel(const Decl *decl) {
   return level;
 }
 
+SourceLoc DiagnosticEngine::getDiagnosticLocForDecl(const Decl *decl) {
+  if (!decl)
+    return SourceLoc();
+
+  if (decl->getLoc().isValid())
+    return decl->getLoc();
+
+  // There is no location we can point to. Pretty-print the declaration
+  // so we can point to it.
+  SourceLoc ppLoc = PrettyPrintedDeclarations[decl];
+  if (ppLoc.isInvalid()) {
+    class TrackingPrinter : public StreamPrinter {
+      SmallVectorImpl<std::pair<const Decl *, uint64_t>> &Entries;
+      AccessLevel bufferAccessLevel;
+
+    public:
+      TrackingPrinter(
+          SmallVectorImpl<std::pair<const Decl *, uint64_t>> &Entries,
+          raw_ostream &OS, AccessLevel bufferAccessLevel) :
+        StreamPrinter(OS), Entries(Entries),
+        bufferAccessLevel(bufferAccessLevel) {}
+
+      void printDeclLoc(const Decl *D) override {
+        if (getBufferAccessLevel(D) == bufferAccessLevel)
+          Entries.push_back({ D, OS.tell() });
+      }
+    };
+    SmallVector<std::pair<const Decl *, uint64_t>, 8> entries;
+    llvm::SmallString<128> buffer;
+    llvm::SmallString<128> bufferName;
+    {
+      // The access level of the buffer we want to print. Declarations below
+      // this access level will be omitted from the buffer; declarations
+      // above it will be printed, but (except for Open declarations in the
+      // Public buffer) will not be recorded in PrettyPrintedDeclarations as
+      // the "true" SourceLoc for the declaration.
+      AccessLevel bufferAccessLevel = getBufferAccessLevel(decl);
+
+      // Figure out which declaration to print. It's the top-most
+      // declaration (not a module).
+      const Decl *ppDecl = decl;
+      auto dc = decl->getDeclContext();
+
+      // FIXME: Horrible, horrible hackaround. We're not getting a
+      // DeclContext everywhere we should.
+      if (!dc) {
+        return SourceLoc();
+      }
+
+      while (!dc->isModuleContext()) {
+        switch (dc->getContextKind()) {
+        case DeclContextKind::Module:
+          llvm_unreachable("Not in a module context!");
+          break;
+
+        case DeclContextKind::FileUnit:
+        case DeclContextKind::TopLevelCodeDecl:
+          break;
+
+        case DeclContextKind::ExtensionDecl:
+          ppDecl = cast<ExtensionDecl>(dc);
+          break;
+
+        case DeclContextKind::GenericTypeDecl:
+          ppDecl = cast<GenericTypeDecl>(dc);
+          break;
+
+        case DeclContextKind::SerializedLocal:
+        case DeclContextKind::Initializer:
+        case DeclContextKind::AbstractClosureExpr:
+        case DeclContextKind::AbstractFunctionDecl:
+        case DeclContextKind::SubscriptDecl:
+        case DeclContextKind::EnumElementDecl:
+          break;
+        }
+
+        dc = dc->getParent();
+      }
+
+      // Build the module name path (in reverse), which we use to
+      // build the name of the buffer.
+      SmallVector<StringRef, 4> nameComponents;
+      while (dc) {
+        nameComponents.push_back(cast<ModuleDecl>(dc)->getName().str());
+        dc = dc->getParent();
+      }
+
+      for (unsigned i = nameComponents.size(); i; --i) {
+        bufferName += nameComponents[i-1];
+        bufferName += '.';
+      }
+
+      if (auto value = dyn_cast<ValueDecl>(ppDecl)) {
+        bufferName += value->getBaseName().userFacingName();
+      } else if (auto ext = dyn_cast<ExtensionDecl>(ppDecl)) {
+        bufferName += ext->getExtendedType().getString();
+      }
+
+      // If we're using a lowered access level, give the buffer a distinct
+      // name.
+      if (bufferAccessLevel != AccessLevel::Public) {
+        assert(bufferAccessLevel < AccessLevel::Public
+               && "Above-public access levels should use public buffer");
+        bufferName += " (";
+        bufferName += getAccessLevelSpelling(bufferAccessLevel);
+        bufferName += ")";
+      }
+
+      // Pretty-print the declaration we've picked.
+      llvm::raw_svector_ostream out(buffer);
+      TrackingPrinter printer(entries, out, bufferAccessLevel);
+      llvm::SaveAndRestore<bool> isPrettyPrinting(IsPrettyPrintingDecl, true);
+      ppDecl->print(
+          printer,
+          PrintOptions::printForDiagnostics(
+              bufferAccessLevel,
+              decl->getASTContext().TypeCheckerOpts.PrintFullConvention));
+    }
+
+    // Build a buffer with the pretty-printed declaration.
+    auto bufferID = SourceMgr.addMemBufferCopy(buffer, bufferName);
+    auto memBufferStartLoc = SourceMgr.getLocForBufferStart(bufferID);
+
+    // Go through all of the pretty-printed entries and record their
+    // locations.
+    for (auto entry : entries) {
+      PrettyPrintedDeclarations[entry.first] =
+          memBufferStartLoc.getAdvancedLoc(entry.second);
+    }
+
+    // Grab the pretty-printed location.
+    ppLoc = PrettyPrintedDeclarations[decl];
+  }
+
+  return ppLoc;
+}
+
 Optional<DiagnosticInfo>
 DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
   auto behavior = state.determineBehavior(diagnostic);
@@ -931,140 +1068,9 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
   if (loc.isInvalid() && diagnostic.getDecl()) {
     const Decl *decl = diagnostic.getDecl();
     // If a declaration was provided instead of a location, and that declaration
-    // has a location we can point to, use that location.
-    loc = decl->getLoc();
-
-    if (loc.isInvalid()) {
-      // There is no location we can point to. Pretty-print the declaration
-      // so we can point to it.
-      SourceLoc ppLoc = PrettyPrintedDeclarations[decl];
-      if (ppLoc.isInvalid()) {
-        class TrackingPrinter : public StreamPrinter {
-          SmallVectorImpl<std::pair<const Decl *, uint64_t>> &Entries;
-          AccessLevel bufferAccessLevel;
-
-        public:
-          TrackingPrinter(
-              SmallVectorImpl<std::pair<const Decl *, uint64_t>> &Entries,
-              raw_ostream &OS, AccessLevel bufferAccessLevel) :
-            StreamPrinter(OS), Entries(Entries),
-            bufferAccessLevel(bufferAccessLevel) {}
-
-          void printDeclLoc(const Decl *D) override {
-            if (getBufferAccessLevel(D) == bufferAccessLevel)
-              Entries.push_back({ D, OS.tell() });
-          }
-        };
-        SmallVector<std::pair<const Decl *, uint64_t>, 8> entries;
-        llvm::SmallString<128> buffer;
-        llvm::SmallString<128> bufferName;
-        {
-          // The access level of the buffer we want to print. Declarations below
-          // this access level will be omitted from the buffer; declarations
-          // above it will be printed, but (except for Open declarations in the
-          // Public buffer) will not be recorded in PrettyPrintedDeclarations as
-          // the "true" SourceLoc for the declaration.
-          AccessLevel bufferAccessLevel = getBufferAccessLevel(decl);
-
-          // Figure out which declaration to print. It's the top-most
-          // declaration (not a module).
-          const Decl *ppDecl = decl;
-          auto dc = decl->getDeclContext();
-
-          // FIXME: Horrible, horrible hackaround. We're not getting a
-          // DeclContext everywhere we should.
-          if (!dc) {
-            return None;
-          }
-
-          while (!dc->isModuleContext()) {
-            switch (dc->getContextKind()) {
-            case DeclContextKind::Module:
-              llvm_unreachable("Not in a module context!");
-              break;
-
-            case DeclContextKind::FileUnit:
-            case DeclContextKind::TopLevelCodeDecl:
-              break;
-
-            case DeclContextKind::ExtensionDecl:
-              ppDecl = cast<ExtensionDecl>(dc);
-              break;
-
-            case DeclContextKind::GenericTypeDecl:
-              ppDecl = cast<GenericTypeDecl>(dc);
-              break;
-
-            case DeclContextKind::SerializedLocal:
-            case DeclContextKind::Initializer:
-            case DeclContextKind::AbstractClosureExpr:
-            case DeclContextKind::AbstractFunctionDecl:
-            case DeclContextKind::SubscriptDecl:
-            case DeclContextKind::EnumElementDecl:
-              break;
-            }
-
-            dc = dc->getParent();
-          }
-
-          // Build the module name path (in reverse), which we use to
-          // build the name of the buffer.
-          SmallVector<StringRef, 4> nameComponents;
-          while (dc) {
-            nameComponents.push_back(cast<ModuleDecl>(dc)->getName().str());
-            dc = dc->getParent();
-          }
-
-          for (unsigned i = nameComponents.size(); i; --i) {
-            bufferName += nameComponents[i-1];
-            bufferName += '.';
-          }
-
-          if (auto value = dyn_cast<ValueDecl>(ppDecl)) {
-            bufferName += value->getBaseName().userFacingName();
-          } else if (auto ext = dyn_cast<ExtensionDecl>(ppDecl)) {
-            bufferName += ext->getExtendedType().getString();
-          }
-
-          // If we're using a lowered access level, give the buffer a distinct
-          // name.
-          if (bufferAccessLevel != AccessLevel::Public) {
-            assert(bufferAccessLevel < AccessLevel::Public
-                   && "Above-public access levels should use public buffer");
-            bufferName += " (";
-            bufferName += getAccessLevelSpelling(bufferAccessLevel);
-            bufferName += ")";
-          }
-
-          // Pretty-print the declaration we've picked.
-          llvm::raw_svector_ostream out(buffer);
-          TrackingPrinter printer(entries, out, bufferAccessLevel);
-          llvm::SaveAndRestore<bool> isPrettyPrinting(
-              IsPrettyPrintingDecl, true);
-          ppDecl->print(
-              printer,
-              PrintOptions::printForDiagnostics(
-                  bufferAccessLevel,
-                  decl->getASTContext().TypeCheckerOpts.PrintFullConvention));
-        }
-
-        // Build a buffer with the pretty-printed declaration.
-        auto bufferID = SourceMgr.addMemBufferCopy(buffer, bufferName);
-        auto memBufferStartLoc = SourceMgr.getLocForBufferStart(bufferID);
-
-        // Go through all of the pretty-printed entries and record their
-        // locations.
-        for (auto entry : entries) {
-          PrettyPrintedDeclarations[entry.first] =
-              memBufferStartLoc.getAdvancedLoc(entry.second);
-        }
-
-        // Grab the pretty-printed location.
-        ppLoc = PrettyPrintedDeclarations[decl];
-      }
-
-      loc = ppLoc;
-    }
+    // has a location we can point to (or we can generate one), use that
+    // location.
+    loc = getDiagnosticLocForDecl(decl);
   }
 
   return DiagnosticInfo(

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -71,8 +71,12 @@ bool Evaluator::checkDependency(const ActiveRequest &request) {
 
 void Evaluator::diagnoseCycle(const ActiveRequest &request) {
   if (debugDumpCycles) {
-    llvm::errs() << "===CYCLE DETECTED===\n";
+    llvm::errs() << "=== CYCLE DETECTED ===\n";
     for (auto &req : activeRequests) {
+      if (req == request)
+        llvm::errs() << "==> ";
+      else
+        llvm::errs() << "    ";
       simple_display(llvm::errs(), req);
       llvm::errs() << "\n";
     }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -823,6 +823,10 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
     Opts.DebugForbidTypecheckPrefix = A->getValue();
   }
 
+  for (const Arg *A : Args.filtered(OPT_debug_cause_cycle_via_decl)) {
+    Opts.DebugCauseCycleViaDeclNames.push_back(A->getValue());
+  }
+
   if (Args.getLastArg(OPT_solver_disable_shrink))
     Opts.SolverDisableShrink = true;
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -350,13 +350,63 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
     diagnoseObjCMethodConflicts(SF);
     diagnoseObjCUnsatisfiedOptReqConflicts(SF);
     diagnoseUnintendedObjCMethodOverrides(SF);
-    return;
+    break;
   case SourceFileKind::SIL:
   case SourceFileKind::Interface:
     // SIL modules and .swiftinterface files don't benefit from whole-module
     // ObjC checking - skip it.
-    return;
+    break;
   }
+
+  // If requested, create an artificial cycle to diagnose an error at.
+  const auto &cycleViaDeclNames =
+      Ctx.TypeCheckerOpts.DebugCauseCycleViaDeclNames;
+  if (cycleViaDeclNames.empty())
+    return;
+
+  SmallVector<Decl *, 4> cycleViaDecls;
+  for (const auto &fullName : cycleViaDeclNames) {
+    SmallVector<ComponentIdentTypeRepr *, 4> components;
+    StringRef rest{fullName};
+    do {
+      StringRef first;
+      std::tie(first, rest) = rest.split('.');
+
+      auto firstIdent = Ctx.getIdentifier(first);
+      components.push_back(
+         new (Ctx) SimpleIdentTypeRepr(DeclNameLoc(), DeclNameRef(firstIdent)));
+    } while (!rest.empty());
+
+    TypeRepr *repr = components.size() == 1
+                   ? static_cast<TypeRepr*>(components.front())
+                   : CompoundIdentTypeRepr::create(Ctx, components);
+    Type ty = swift::performTypeResolution(repr, Ctx, /*isSILMode=*/false,
+                                           /*isSILType=*/false,
+                                           /*GenericEnv=*/nullptr,
+                                           /*GenericParams=*/nullptr,
+                                           &SF);
+    cycleViaDecls.push_back(ty->getNominalOrBoundGenericNominal());
+  }
+
+  (void)evaluateOrDefault(Ctx.evaluator, DebugIntentionallyCauseCycleRequest{
+                            cycleViaDecls.front(),
+                            makeArrayRef(cycleViaDecls).drop_front() },
+                          {});
+}
+
+evaluator::SideEffect
+DebugIntentionallyCauseCycleRequest::evaluate(Evaluator &evaluator, Decl *first,
+                                              ArrayRef<Decl *> rest) const {
+  if (rest.empty())
+    return evaluateOrDefault(evaluator, *this, {});
+
+  SmallVector<Decl *, 4> newRest;
+  llvm::append_range(newRest, rest.drop_front());
+  newRest.push_back(first);
+
+  return evaluateOrDefault(evaluator, DebugIntentionallyCauseCycleRequest{
+                               rest.front(), newRest },
+                           {});
 }
 
 bool swift::isAdditiveArithmeticConformanceDerivationEnabled(SourceFile &SF) {

--- a/test/CircularReferences/Inputs/custom-modules/CircularLibrary.h
+++ b/test/CircularReferences/Inputs/custom-modules/CircularLibrary.h
@@ -1,0 +1,20 @@
+#define MY_ENUM(_name) \
+  enum _name _name; \
+  enum __attribute__((enum_extensibility(open))) _name
+
+typedef MY_ENUM(MyWholeNumber) {
+  MyWholeNumberZero = 0,
+  MyWholeNumberOne,
+  MyWholeNumberTwo,
+  MyWholeNumberThree,
+  MyWholeNumberFour,
+  MyWholeNumberFive,
+  MyWholeNumberSix,
+  MyWholeNumberSeven,
+  MyWholeNumberEight
+};
+
+@interface MyNumberwang
+- (_Nonnull instancetype)init;
+@property (readonly) MyWholeNumber number;
+@end

--- a/test/CircularReferences/Inputs/custom-modules/CircularLibrary.swift
+++ b/test/CircularReferences/Inputs/custom-modules/CircularLibrary.swift
@@ -1,0 +1,13 @@
+@_exported import CircularLibrary
+
+extension MyWholeNumber: Strideable {
+	public typealias Stride = RawValue.Stride
+
+	public func advanced(by n: Stride) -> MyWholeNumber {
+		return MyWholeNumber(rawValue: rawValue.advanced(by: n))!
+	}
+
+	public func distance(to other: MyWholeNumber) -> Stride {
+		return rawValue.distance(to: other.rawValue)
+	}
+}

--- a/test/CircularReferences/Inputs/custom-modules/module.modulemap
+++ b/test/CircularReferences/Inputs/custom-modules/module.modulemap
@@ -1,0 +1,4 @@
+module CircularLibrary {
+  umbrella header "CircularLibrary.h"
+  export *
+}

--- a/test/CircularReferences/overlay_extensions.swift
+++ b/test/CircularReferences/overlay_extensions.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -emit-module %S/Inputs/custom-modules/CircularLibrary.swift -I %S/Inputs/custom-modules -o %t/CircularLibrary.swiftmodule
+// RUN: not --crash %target-swift-frontend -emit-sil -O %s -I %S/Inputs/custom-modules -I %t -o %t/pretty_printed_decls.sil 2>%t.txt
+// RUN: %FileCheck %s <%t.txt
+
+// FIXME: This test case should probably succeed, not fail; a lookup of
+// MyWholeNumber.RawValue during the GenericSpecializer pass causes a recursive
+// lookup of MyWholeNumber.RawValue while trying to resolve the
+// MyWholeNumber.Stride typealias, creating a request cycle. (SR-14324)
+//
+// For now, we'll use this test to make sure that we get a useful diagnostic
+// when this happens, but in the long run we should actually fix this bug.
+
+// REQUIRES: objc_interop
+
+// The "not --crash" is only true for an asserts compiler.
+// REQUIRES: asserts
+
+import CircularLibrary
+
+func fn() {
+  var array: [MyNumberwang] = []
+  array.sort { $0.number < $1.number }
+}
+fn()
+
+//      CHECK: {{^}}CircularLibrary.MyWholeNumber:1:{{[0-9]+}}: error: circular reference
+// CHECK-NEXT: {{^}}public enum MyWholeNumber : UInt32 {
+// CHECK-NEXT: {{^}}            ^

--- a/test/CircularReferences/pretty_printed_decls.swift
+++ b/test/CircularReferences/pretty_printed_decls.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -emit-module %S/Inputs/custom-modules/CircularLibrary.swift -I %S/Inputs/custom-modules -o %t/CircularLibrary.swiftmodule
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -I %t -debug-cause-cycle-via-decl MyWholeNumber.RawValue -debug-cause-cycle-via-decl MyWholeNumber -debug-cause-cycle-via-decl MyNumberwang -debug-cycles 2>%t.txt
+// RUN: %FileCheck %s <%t.txt
+
+// REQUIRES: objc_interop
+
+import CircularLibrary
+
+// FIXME: This first failure is actually a bug! It's a purer form of the test
+//        case in test/CircularReferences/overlay_extensions.swift. (SR-14324)
+// CHECK-LABEL: {{^}}=== CYCLE DETECTED ===
+//   CHECK-NOT: error: circular reference
+//       CHECK: {{^}}==> DirectLookupRequest(directly looking up 'RawValue' on CircularLibrary.(file).MyWholeNumber with options
+//  CHECK-NEXT: {{^}}CircularLibrary.MyWholeNumber:{{[0-9]+:[0-9]+}}: error: circular reference
+//  CHECK-NEXT: {{^}}public enum MyWholeNumber : UInt32 {
+//  CHECK-NEXT: {{^}}            ^
+
+// This failure is the one the test case is actually intended to cause.
+// CHECK-LABEL: {{^}}=== CYCLE DETECTED ===
+//  CHECK-NEXT: {{^}}==> DebugIntentionallyCauseCycleRequest(Swift.(file).UInt32, {CircularLibrary.(file).MyWholeNumber, CircularLibrary.(file).MyNumberwang})
+//  CHECK-NEXT: {{^}}    DebugIntentionallyCauseCycleRequest(CircularLibrary.(file).MyWholeNumber, {CircularLibrary.(file).MyNumberwang, Swift.(file).UInt32})
+//  CHECK-NEXT: {{^}}    DebugIntentionallyCauseCycleRequest(CircularLibrary.(file).MyNumberwang, {Swift.(file).UInt32, CircularLibrary.(file).MyWholeNumber})
+//  CHECK-NEXT: {{^}}Swift.UInt32:{{[0-9]+:[0-9]+}}: error: circular reference
+//  CHECK-NEXT: {{^}}@frozen public struct UInt32 : FixedWidthInteger, UnsignedInteger, _ExpressibleByBuiltinIntegerLiteral {
+//  CHECK-NEXT: {{^}}                      ^
+//  CHECK-NEXT: {{^}}CircularLibrary.MyNumberwang:{{[0-9]+:[0-9]+}}: note: through reference here
+//  CHECK-NEXT: {{^}}open class MyNumberwang {
+//  CHECK-NEXT: {{^}}           ^
+//  CHECK-NEXT: {{^}}CircularLibrary.MyWholeNumber:{{[0-9]+:[0-9]+}}: note: through reference here
+//  CHECK-NEXT: {{^}}public enum MyWholeNumber : UInt32 {
+//  CHECK-NEXT: {{^}}            ^


### PR DESCRIPTION
This PR:

* Refactors `DiagnosticEngine`'s declaration-pretty-printing facility to allow it to be used from `extractNearestSourceLoc()`, improving cycle diagnostics that were previously emitted at `<invalid>:0`.
* Modifies the `-debug-cycles` output to indicate which request in the dumped stack was repeated.

~~I haven't figured out how to test these changes yet, which is why this is still currently a WIP.~~