### PR TITLE
[IRGen] Use coro.end.async to return from an async function

### DIFF
--- a/lib/IRGen/GenThunk.cpp
+++ b/lib/IRGen/GenThunk.cpp
@@ -354,7 +354,6 @@ void IRGenThunk::emit() {
 
   if (isAsync) {
     emitAsyncReturn(IGF, *asyncLayout, origTy, result);
-    IGF.emitCoroutineOrAsyncExit();
     return;
   }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -44,6 +44,7 @@
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Constant.h"
+#include "llvm/IR/Instructions.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Target/TargetMachine.h"
 
@@ -755,6 +756,9 @@ public:
   llvm::CallingConv::ID DefaultCC;     /// default calling convention
   llvm::CallingConv::ID SwiftCC;       /// swift calling convention
   llvm::CallingConv::ID SwiftAsyncCC;  /// swift calling convention for async
+
+  /// What kind of tail call should be used for async->async calls.
+  llvm::CallInst::TailCallKind AsyncTailCallKind;
 
   Signature getAssociatedTypeWitnessTableAccessFunctionSignature();
 

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -18,7 +18,7 @@ public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
 
 // CHECK: define{{.*}} swift{{(tail)?}}cc void @"$s5async8testThisyyAA9SomeClassCnYF"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
 // CHECK-64: call swiftcc i8* @swift_task_alloc(%swift.task* %{{[0-9]+}}, i64 64)
-// CHECK: tail call swift{{(tail)?}}cc void @swift_task_future_wait(
+// CHECK: {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_future_wait(
 public func testThis(_ task: __owned SomeClass) async {
   do {
     let _ = try await task_future_wait(task)

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -84,7 +84,7 @@ bb0:
 // CHECK:  br label %coro.end
 
 // CHECK: coro.end:
-// CHECK:   call i1 @llvm.coro.end(
+// CHECK:   call i1 (i8*, i1, ...) @llvm.coro.end.async(
 // CHECK:   unreachable
 
 // CHECK: await.async.maybe.resume:

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -28,6 +28,10 @@ final actor MyActor {
 // CHECK: [[CAST_ACTOR:%[0-9]+]] = bitcast %T4test7MyActorC* [[ACTOR]] to %swift.executor*
 // CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 2, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
 // CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 2, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[SIGNED_RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
+// CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.task*, %swift.executor*, %swift.context*)* {{.*}} to i8*
+// CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.task*, %swift.executor*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
+// CHECK: unreachable
+
 sil @test_simple : $@convention(method) @async (@guaranteed MyActor) -> () {
 bb0(%0 : $MyActor):
   hop_to_executor %0 : $MyActor
@@ -35,7 +39,7 @@ bb0(%0 : $MyActor):
   return %3 : $()
 }
 
-// CHECK-LABEL: define internal void @__swift_suspend_point
+// CHECK-LABEL: define internal swifttailcc void @__swift_suspend_point
 // CHECK-SAME:  (i8* %0, %swift.executor* %1, %swift.task* %2, %swift.executor* %3, %swift.context* [[CTXT:%[^,]+]])
 // CHECK:    [[RESUME_ADDR:%[0-9]+]] = getelementptr inbounds %swift.task, %swift.task* %2, i32 0, i32 4
 // CHECK:    store i8* %0, i8** [[RESUME_ADDR]]
@@ -46,8 +50,15 @@ bb0(%0 : $MyActor):
 // CHECK-arm64e: [[PTRAUTH_SIGN:%[^,]+]] = call i64 @llvm.ptrauth.sign.i64(i64 [[CTXT_INT]], i32 2, i64 [[PTRAUTH_BLEND]])
 // CHECK-arm64e: [[CTXT:%[^,]+]] = inttoptr i64 [[PTRAUTH_SIGN]] to %swift.context*
 // CHECK:    store %swift.context* [[CTXT]], %swift.context** [[CTXT_ADDR]]
-// CHECK:    tail call swift{{(tail)?}}cc void @swift_task_switch(%swift.task* %2, %swift.executor* %3, %swift.executor* %1)
+// CHECK:    {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_switch(%swift.task* %2, %swift.executor* %3, %swift.executor* %1)
 // CHECK:    ret void
+
+// CHECK: define{{.*}} void @[[TAIL_CALL_FUNC]](i8* %0, %swift.task* %1, %swift.executor* %2, %swift.context* %3)
+// CHECK:   %4 = bitcast i8* %0 to void (%swift.task*, %swift.executor*, %swift.context*)*
+// CHECK:   {{(must)?}}tail call swift{{(tail)?}}cc void %4(%swift.task* %1, %swift.executor* %2, %swift.context* swiftasync %3)
+// CHECK:   ret void
+// CHECK: }
+
 
 sil_vtable MyActor {
 }

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -405,7 +405,7 @@ bb0(%x : $*SwiftClassPair):
 sil public_external @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.70"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}} {
 
 sil @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in_guaranteed SwiftClassPair) -> () {
 bb0(%x : $*SwiftClassPair):

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -101,7 +101,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_forwarder_parameter(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA.19"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> () {
 bb0(%0 : $*τ_0_1):

--- a/test/IRGen/async/unreachable.swift
+++ b/test/IRGen/async/unreachable.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-frontend -primary-file %s -g -emit-ir -enable-experimental-concurrency -disable-llvm-optzns -disable-swift-specific-llvm-optzns | %FileCheck %s
 // REQUIRES: concurrency
 
-// CHECK: call i1 @llvm.coro.end
+// CHECK: call i1 (i8*, i1, ...) @llvm.coro.end.async
 func foo() async -> Never {
   await bar()
   fatalError()
 }
 
-// CHECK: call i1 @llvm.coro.end
+// CHECK: call i1 (i8*, i1, ...) @llvm.coro.end.async
 func bar() async -> Never {
   await foo()
   fatalError()


### PR DESCRIPTION
The `coro.end.async` intrinsic allow specifying a function that is to be
tail-called as the last thing before returning.

LLVM lowering will inline the `must-tail-call` function argument to
`coro.end.async`. This `must-tail-call` function can contain a
`musttail` call.

```
define @my_must_tail_call_func(void (*)(i64) %fnptr, i64 %args) {
  musttail call void %fnptr(i64 %args)
  ret void
}

define @async_func() {
  ...
  coro.end.async(..., @my_must_tail_call_func, %return_continuation, i64 %args)
  unreachable
}
```

Changes from: #35792
- Add conditional MustTail when it is supported.
- Rebased and resolved conflicts.