### PR TITLE
Declarations within Actor-conforming protocols are actor-isolated.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -65,12 +65,14 @@ public:
 private:
   Kind kind;
   union {
-    ClassDecl *actor;
+    NominalTypeDecl *actor;
     Type globalActor;
     void *pointer;
   };
 
-  ActorIsolation(Kind kind, ClassDecl *actor) : kind(kind), actor(actor) { }
+  ActorIsolation(Kind kind, NominalTypeDecl *actor)
+      : kind(kind), actor(actor) { }
+
   ActorIsolation(Kind kind, Type globalActor)
       : kind(kind), globalActor(globalActor) { }
 
@@ -93,7 +95,7 @@ public:
     return ActorIsolation(isoKind, nullptr);
   }
 
-  static ActorIsolation forActorInstance(ClassDecl *actor) {
+  static ActorIsolation forActorInstance(NominalTypeDecl *actor) {
     return ActorIsolation(ActorInstance, actor);
   }
 
@@ -108,7 +110,7 @@ public:
 
   bool isUnspecified() const { return kind == Unspecified; }
 
-  ClassDecl *getActor() const {
+  NominalTypeDecl *getActor() const {
     assert(getKind() == ActorInstance);
     return actor;
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3159,6 +3159,11 @@ public:
   /// with placeholders for unimportable stored properties.
   ArrayRef<Decl *> getStoredPropertiesAndMissingMemberPlaceholders() const;
 
+  /// Whether this nominal type qualifies as an actor, meaning that it is
+  /// either an actor type or a protocol whose `Self` type conforms to the
+  /// `Actor` protocol.
+  bool isActor() const;
+
   /// Return the range of semantics attributes attached to this NominalTypeDecl.
   auto getSemanticsAttrs() const
       -> decltype(getAttrs().getSemanticsAttrs()) {
@@ -3698,9 +3703,6 @@ public:
   bool isForeign() const {
     return getForeignClassKind() != ForeignKind::Normal;
   }
-
-  /// Whether the class is an actor.
-  bool isActor() const;
 
   /// Whether the class is (known to be) a default actor.
   bool isDefaultActor() const;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -917,10 +917,10 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Determine whether the given class is an actor.
+/// Determine whether the given nominal type is an actor.
 class IsActorRequest :
     public SimpleRequest<IsActorRequest,
-                         bool(ClassDecl *),
+                         bool(NominalTypeDecl *),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -928,7 +928,7 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
+  bool evaluate(Evaluator &evaluator, NominalTypeDecl *nominal) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -94,7 +94,7 @@ SWIFT_REQUEST(TypeChecker, IsAsyncHandlerRequest, bool(FuncDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CanBeAsyncHandlerRequest, bool(FuncDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(ClassDecl *),
+SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest, bool(ClassDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -731,6 +731,9 @@ public:
   /// Break an existential down into a set of constraints.
   ExistentialLayout getExistentialLayout();
 
+  /// Determines whether this type is an actor type.
+  bool isActorType();
+
   /// Determines the element type of a known
   /// [Autoreleasing]Unsafe[Mutable][Raw]Pointer variant, or returns null if the
   /// type is not a pointer.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3763,6 +3763,14 @@ PropertyWrapperTypeInfo NominalTypeDecl::getPropertyWrapperTypeInfo() const {
                            PropertyWrapperTypeInfo());
 }
 
+bool NominalTypeDecl::isActor() const {
+  auto mutableThis = const_cast<NominalTypeDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           IsActorRequest{mutableThis},
+                           false);
+}
+
+
 GenericTypeDecl::GenericTypeDecl(DeclKind K, DeclContext *DC,
                                  Identifier name, SourceLoc nameLoc,
                                  ArrayRef<TypeLoc> inherited,
@@ -4201,13 +4209,6 @@ GetDestructorRequest::evaluate(Evaluator &evaluator, ClassDecl *CD) const {
   DD->setSynthesized(true);
 
   return DD;
-}
-
-bool ClassDecl::isActor() const {
-  auto mutableThis = const_cast<ClassDecl *>(this);
-  return evaluateOrDefault(getASTContext().evaluator,
-                           IsActorRequest{mutableThis},
-                           false);
 }
 
 bool ClassDecl::isDefaultActor() const {

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -103,8 +103,8 @@ private:
     /// The local context that an entity is tied to.
     DeclContext *localContext;
 
-    /// The actor class that the entity is declared in.
-    ClassDecl *actorClass;
+    /// The actor that the entity is declared in.
+    NominalTypeDecl *actorType;
 
     /// The global actor type.
     TypeBase *globalActor;
@@ -123,10 +123,10 @@ public:
 
   Kind getKind() const { return kind; }
 
-  /// Retrieve the actor class that the declaration is within.
-  ClassDecl *getActorClass() const {
+  /// Retrieve the actor type that the declaration is within.
+  NominalTypeDecl *getActorType() const {
     assert(kind == ActorSelf || kind == CrossActorSelf);
-    return data.actorClass;
+    return data.actorType;
   }
 
   /// Retrieve the actor class that the declaration is within.
@@ -148,10 +148,10 @@ public:
   /// Accesses to the given declaration can only be made via the 'self' of
   /// the current actor or is a cross-actor access.
   static ActorIsolationRestriction forActorSelf(
-      ClassDecl *actorClass, bool isCrossActor) {
+      NominalTypeDecl *actor, bool isCrossActor) {
     ActorIsolationRestriction result(isCrossActor? CrossActorSelf : ActorSelf,
                                      isCrossActor);
-    result.data.actorClass = actorClass;
+    result.data.actorType = actor;
     return result;
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2729,7 +2729,11 @@ bool ConformanceChecker::checkActorIsolation(
   switch (auto witnessRestriction =
               ActorIsolationRestriction::forDeclaration(witness)) {
   case ActorIsolationRestriction::ActorSelf: {
-    // Actor-isolated witnesses cannot conform to protocol requirements.
+    // An actor-isolated witness can only conform to an actor-isolated
+    // requirement.
+    if (getActorIsolation(requirement) == ActorIsolation::ActorInstance)
+      return false;
+
     witness->diagnose(diag::actor_isolated_witness,
                       witness->getDescriptiveKind(),
                       witness->getName());

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -667,3 +667,27 @@ class SomeClassWithInits {
     }
   }
 }
+
+// ----------------------------------------------------------------------
+// Actor protocols.
+// ----------------------------------------------------------------------
+protocol P: Actor {
+  func f()
+}
+
+extension P {
+  func g() { f() }
+}
+
+actor MyActorP: P {
+  func f() { }
+
+  func h() { g() }
+}
+
+func testCrossActorProtocol<T: P>(t: T) async {
+  await t.f()
+  await t.g()
+  t.f() // expected-error{{call is 'async' but is not marked with 'await'}}
+  t.g() // expected-error{{call is 'async' but is not marked with 'await'}}
+}


### PR DESCRIPTION
The Actor protocol is used only to describe actors. When a protocol's
Self type conforms to the actor protocol, any instance declarations on
the protocol or extensions thereof are considered to be actor-isolated
to 'self'.

Because the instance requirements of such a protocol are
actor-isolated to 'self', they can be witnessed by actor-isolated
instance declarations on an actor type. For example:

```swift
protocol P: Actor {
  func f() // okay, actor-isolated to self
}

extension P {
  func g() { f() } // okay, actor-islated to self
}

actor MyActor: P {
  func f() { } // okay, witnesses actor-isolated requirement
}
```
