### PR TITLE
[Frontend] Don't load modules from the prebuilt cache for private interfaces

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -521,11 +521,11 @@ class ModuleInterfaceLoaderImpl {
     namespace path = llvm::sys::path;
     StringRef sdkPath = ctx.SearchPathOpts.SDKPath;
 
-    // Check if the interface file comes from the SDK
-    if (sdkPath.empty() || !hasPrefix(path::begin(interfacePath),
-                                      path::end(interfacePath),
-                                      path::begin(sdkPath),
-                                      path::end(sdkPath)))
+    // Check if this is a public interface file from the SDK.
+    if (sdkPath.empty() ||
+        !hasPrefix(path::begin(interfacePath), path::end(interfacePath),
+                   path::begin(sdkPath), path::end(sdkPath)) ||
+        StringRef(interfacePath).endswith(".private.swiftinterface"))
       return None;
 
     // Assemble the expected path: $PREBUILT_CACHE/Foo.swiftmodule or
@@ -558,11 +558,11 @@ class ModuleInterfaceLoaderImpl {
     namespace path = llvm::sys::path;
     StringRef sdkPath = ctx.SearchPathOpts.SDKPath;
 
-    // Check if the interface file comes from the SDK
-    if (sdkPath.empty() || !hasPrefix(path::begin(interfacePath),
-                                      path::end(interfacePath),
-                                      path::begin(sdkPath),
-                                      path::end(sdkPath)))
+    // Check if this is a public interface file from the SDK.
+    if (sdkPath.empty() ||
+        !hasPrefix(path::begin(interfacePath), path::end(interfacePath),
+                   path::begin(sdkPath), path::end(sdkPath)) ||
+        StringRef(interfacePath).endswith(".private.swiftinterface"))
       return None;
 
     // If the module isn't target-specific, there's no fallback path.

--- a/test/ModuleInterface/loading-order.swift
+++ b/test/ModuleInterface/loading-order.swift
@@ -1,9 +1,11 @@
 /// Test the loading order of module interfaces between the SDK and the
 /// prebuilt cache. The order should be:
 ///
-/// 1. Local cache (not tested here)
-/// 2. Next to the swiftinterface file
-/// 3. Prebuilt-module cache
+/// 1. swiftmodule in the local cache (not tested here)
+/// 2. swiftmodule next to the swiftinterface file
+/// 3. If it's a private swiftinterface, rebuild the swiftmodule from the private swiftinterface
+/// 4. swiftmodule in the prebuilt-module cache
+/// 5. Rebuild the swiftmodule from the swiftinterface file and keep in the local cache
 
 /// Create folders for a) our Swift module, b) the module cache, and c) a
 /// fake resource dir with a default prebuilt module cache inside.
@@ -16,16 +18,20 @@
 // RUN: echo 'public func prebuiltModule() {}' > %t/PrebuiltModule.swift
 
 /// Compile this into a module in the SDK.
-// RUN: %target-swift-frontend -emit-module %t/NextToSwiftinterface.swift -o %t/MyModule.swiftmodule/%target-swiftmodule-name -module-name MyModule -parse-stdlib -emit-module-interface-path %t/MyModule.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-frontend -emit-module %t/NextToSwiftinterface.swift -o %t/MyModule.swiftmodule/%target-swiftmodule-name -module-name MyModule -parse-stdlib -emit-module-interface-path %t/MyModule.swiftmodule/%target-swiftinterface-name -emit-private-module-interface-path %t/MyModule.swiftmodule/%target-private-swiftinterface-name
 
-/// Also put a module with a different API into the default prebuilt cache under the same name.
+/// Also put a module with a different API into the default prebuilt cache under the same name to detect when its picked.
 // RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/MyModule.swiftmodule/%target-swiftmodule-name -module-name MyModule -parse-stdlib
 
 /// Import this module and expect to use the swiftmodule next to the swiftinterface.
 // RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -D FIRST_NEXT_TO_SWIFTINTERFACE
 
-/// Remove the first swiftmodule and import again to use the prebuilt swiftmodule.
+/// Remove the swiftmodule next to the swiftinterface, the compiler should rebuild from the private swiftinterface.
 // RUN: rm %t/MyModule.swiftmodule/%target-swiftmodule-name
+// RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -D FIRST_NEXT_TO_SWIFTINTERFACE
+
+/// Remove the private swiftinterface and import again to use the prebuilt swiftmodule.
+// RUN: rm %t/MyModule.swiftmodule/%target-private-swiftinterface-name
 // RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -D THEN_PREBUILT_MODULE
 
 import MyModule

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2023,6 +2023,7 @@ config.substitutions.append(('%target-swiftmodule-name', target_specific_module_
 config.substitutions.append(('%target-swiftdoc-name', target_specific_module_triple + '.swiftdoc'))
 config.substitutions.append(('%target-swiftsourceinfo-name', target_specific_module_triple + '.swiftsourceinfo'))
 config.substitutions.append(('%target-swiftinterface-name', target_specific_module_triple + '.swiftinterface'))
+config.substitutions.append(('%target-private-swiftinterface-name', target_specific_module_triple + '.private.swiftinterface'))
 
 config.substitutions.append(('%target-object-format', config.target_object_format))
 config.substitutions.append(('%{target-shared-library-prefix}', config.target_shared_library_prefix))


### PR DESCRIPTION
The compiler shouldn't use a swiftmodule file from the prebuilt cache when a private swiftinterface is present. The prebuilt cache only has the public interfaces of modules. Instead, when loading modules with a private interface the compiler should use swiftmodules from the local cache, the one next to the swiftinterface or rebuild it, in that order.

rdar://73007024