### PR TITLE
[libSyntax] Only keep track of range in ParsedRawSyntaxNode if verifying element ranges

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -20,12 +20,12 @@
 #define SWIFT_PARSE_PARSEDRAWSYNTAXRECORDER_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Parse/ParsedRawSyntaxNode.h"
 #include <memory>
 
 namespace swift {
 
 class CharSourceRange;
-class ParsedRawSyntaxNode;
 struct ParsedTrivia;
 class ParsedTriviaPiece;
 class SyntaxParseActions;
@@ -37,6 +37,18 @@ enum class tok;
 namespace syntax {
   enum class SyntaxKind;
 }
+
+/// The information returned from the \c lookupNode method in \c
+/// SyntaxParseActions.
+struct ParseLookupResult {
+  ParsedRawSyntaxNode Node;
+
+  /// The length of \c Node spelled out in source, including trivia.
+  size_t Length;
+
+  ParseLookupResult(ParsedRawSyntaxNode &&Node, size_t Length)
+      : Node(std::move(Node)), Length(Length) {}
+};
 
 class ParsedRawSyntaxRecorder final {
   std::shared_ptr<SyntaxParseActions> SPActions;
@@ -92,8 +104,8 @@ public:
   ParsedRawSyntaxNode makeDeferredMissing(tok tokKind, SourceLoc loc);
 
   /// Used for incremental re-parsing.
-  ParsedRawSyntaxNode lookupNode(size_t lexerOffset, SourceLoc loc,
-                                 syntax::SyntaxKind kind);
+  ParseLookupResult lookupNode(size_t lexerOffset, SourceLoc loc,
+                               syntax::SyntaxKind kind);
 
   /// For a deferred layout node \p parent, retrieve the deferred child node
   /// at \p ChildIndex.
@@ -103,8 +115,11 @@ public:
   /// For a deferred layout node \p node, retrieve the number of children.
   size_t getDeferredNumChildren(const ParsedRawSyntaxNode &node) const;
 
-#ifndef NDEBUG
-  static void verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements);
+#ifdef PARSEDRAWSYNTAXNODE_VERIFY_RANGES
+  /// Verify that the ranges of \p elements are all consecutive and return the
+  /// range spanned by all \p elements.
+  static CharSourceRange
+  verifyElementRanges(ArrayRef<ParsedRawSyntaxNode> elements);
 #endif
 };
 

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -71,12 +71,11 @@ struct DeferredNodeInfo {
   syntax::SyntaxKind SyntaxKind;
   tok TokenKind;
   bool IsMissing;
-  CharSourceRange Range;
 
   DeferredNodeInfo(RecordedOrDeferredNode Data, syntax::SyntaxKind SyntaxKind,
-                   tok TokenKind, bool IsMissing, CharSourceRange Range)
+                   tok TokenKind, bool IsMissing)
       : Data(Data), SyntaxKind(SyntaxKind), TokenKind(TokenKind),
-        IsMissing(IsMissing), Range(Range) {}
+        IsMissing(IsMissing) {}
 };
 
 // MARK: - SyntaxParseActions
@@ -133,12 +132,24 @@ public:
   /// which created it, to retrieve children.
   /// This method assumes that \p node represents a *deferred* layout node.
   /// This methods returns all information needed to construct a \c
-  /// ParsedRawSyntaxNode of a child node. \p node is the parent node for which
-  /// the child at position \p ChildIndex should be retrieved. Furthmore, \p
-  /// node starts at \p StartLoc.
+  /// ParsedRawSyntaxNode of a child node, except for the range which can be
+  /// retrieved using \c getDeferredChildRange if element ranges should be
+  /// verified
+  /// \p node is the parent node for which the child at position \p ChildIndex
+  /// should be retrieved. Furthmore, \p node starts at \p StartLoc.
   virtual DeferredNodeInfo getDeferredChild(OpaqueSyntaxNode node,
-                                            size_t childIndex,
-                                            SourceLoc startLoc) = 0;
+                                            size_t childIndex) const = 0;
+
+  /// To verify \c ParsedRawSyntaxNode element ranges, the range of child nodes
+  /// returend by \c getDeferredChild needs to be determined. That's what this
+  /// method does.
+  /// It assumes that \p node is a deferred layout node starting at \p startLoc
+  /// and returns the range of the child node at \p childIndex.
+  /// This method is not designed with performance in mind. Do not use in
+  /// performance-critical code.
+  virtual CharSourceRange getDeferredChildRange(OpaqueSyntaxNode node,
+                                                size_t childIndex,
+                                                SourceLoc startLoc) const = 0;
 
   /// Return the number of children, \p node has. These can be retrieved using
   /// \c getDeferredChild.

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -85,8 +85,12 @@ private:
   OpaqueSyntaxNode recordDeferredToken(OpaqueSyntaxNode deferred) override;
   OpaqueSyntaxNode recordDeferredLayout(OpaqueSyntaxNode deferred) override;
 
-  DeferredNodeInfo getDeferredChild(OpaqueSyntaxNode node, size_t ChildIndex,
-                                    SourceLoc StartLoc) override;
+  DeferredNodeInfo getDeferredChild(OpaqueSyntaxNode node,
+                                    size_t ChildIndex) const override;
+
+  CharSourceRange getDeferredChildRange(OpaqueSyntaxNode node,
+                                        size_t ChildIndex,
+                                        SourceLoc StartLoc) const override;
 
   size_t getDeferredNumChildren(OpaqueSyntaxNode node) override;
 };

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -84,13 +84,12 @@ size_t SyntaxParsingContext::lookupNode(size_t LexerOffset, SourceLoc Loc) {
   assert(Mode == AccumulationMode::CreateSyntax &&
          "Loading from cache is only supported for mode CreateSyntax");
   auto foundNode = getRecorder().lookupNode(LexerOffset, Loc, SynKind);
-  if (foundNode.isNull()) {
+  if (foundNode.Node.isNull()) {
     return 0;
   }
   Mode = AccumulationMode::SkippedForIncrementalUpdate;
-  auto length = foundNode.getRange().getByteLength();
-  getStorage().push_back(std::move(foundNode));
-  return length;
+  getStorage().push_back(std::move(foundNode.Node));
+  return foundNode.Length;
 }
 
 ParsedRawSyntaxNode


### PR DESCRIPTION
This removed the `Range` property from `ParsedRawSyntaxNode` in non-assert builds. The eventual goal is/was to make it a a zero-cost wrapper around `RecordedOrDeferredNode` by also removing the `SyntaxKind`, `TokenKind` and `IsMissing` properties. However, their removal had negative impact on SwiftSyntax parsing and I’m thus holding it back for now.

Since `ParsedRawSyntaxNode`s are being passed around a lot during parsing (they are effectively the return type of the parsing functions once migrated to libSyntax parsing), every byte we save in these has a positive impact on performance.

I measured and this change has **no impact** on SwiftSyntax parsing performance.