### PR TITLE
[DependencyScanning] Reset LLVM option occurences for each batch scan entry

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -982,6 +982,11 @@ forEachBatchEntry(CompilerInstance &invocationInstance,
       // those of the current scanner invocation.
       updateCachedInstanceOpts(*pInstance, invocationInstance, entry.arguments);
     } else {
+      // We must reset option occurences because we are handling an unrelated command-line
+      // to those parsed before. We must do so because LLVM options parsing is done
+      // using a managed static `GlobalParser`.
+      llvm::cl::ResetAllOptionOccurrences();
+
       // Create a new instance by the arguments and save it in the map.
       subInstanceMap->insert(
           {entry.arguments,


### PR DESCRIPTION
We must reset option occurences on each entry because we are handling an unrelated command-lines to those parsed before. We must do so because LLVM options parsing is done using a managed static `GlobalParser`.

Resolves rdar://75247030