### PR TITLE
[ClangImporter] Fix -Wcovered-switch-default warning (NFC)

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -629,12 +629,10 @@ OptionalTypeKind importer::translateNullability(
 
   case clang::NullabilityKind::Unspecified:
     return OptionalTypeKind::OTK_ImplicitlyUnwrappedOptional;
-
-  default:
-    return OptionalTypeKind::OTK_Optional;
   }
 
   llvm_unreachable("Invalid NullabilityKind.");
+  return OptionalTypeKind::OTK_Optional;
 }
 
 bool importer::isRequiredInitializer(const clang::ObjCMethodDecl *method) {


### PR DESCRIPTION
This switch handles all `NullabilityKind` cases. This change silences the warning by moving the `default` clause out of the switch. NFC.