### PR TITLE
[test] Remove tee debugging dumps

### DIFF
--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -15,7 +15,7 @@
 // MUST-EXEC-DAG: Disabling incremental build: could not read build record
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0], "./yet-another.swift": [443865900, 0]}, build_time: [443865901, 0]}' > %t/main~buildrecord.swiftdeps
-// RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 -driver-show-incremental -driver-show-job-lifecycle |tee /tmp/x| %FileCheck %s -check-prefix=NO-EXEC
+// RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 -driver-show-incremental -driver-show-job-lifecycle | %FileCheck %s -check-prefix=NO-EXEC
 
 // NO-EXEC: inputs: ["{{(\.\/)?}}main.swift"], output: {{[{].*[}]}}{{(, condition: check-dependencies)?}}
 // NO-EXEC: inputs: ["{{(\.\/)?}}other.swift"], output: {{[{].*[}]}}{{(, condition: check-dependencies)?}}

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -4,7 +4,7 @@
 // RUN: cp -r %S/Inputs/only-skip-once/* %t
 // RUN: touch -t 201401240005 %t/*
 
-// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | tee /tmp/x | %FileCheck -check-prefix=CHECK-INITIAL %s
+// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
 
 // CHECK-INITIAL: {{(Job finished: {compile: main.o <= main.swift}|Finished Compiling main.swift)}}
 // CHECK-INITIAL: {{(Job finished: {compile: file1.o <= file1.swift}|Finished Compiling file1.swift)}}
@@ -12,7 +12,7 @@
 // CHECK-INITIAL: {{(Job finished: {link: main <= main.o file1.o file2.o}|Finished Linking main)}}
 
 // RUN: touch -t 201401240006 %t/file2.swift
-// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 |tee /tmp/y |  %FileCheck -check-prefix=CHECK-REBUILD %s
+// RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 |  %FileCheck -check-prefix=CHECK-REBUILD %s
 
 // We should skip the main and file1 rebuilds here, but we should only note skipping them _once_
 // CHECK-REBUILD-DAG: {{(Job finished: {compile: file2.o <= file2.swift}|Finished Compiling file2.swift)}}


### PR DESCRIPTION
This causes tests to fail natively on Android, which doesn't have `/tmp`, and likely Windows too.

@davidungar, you added these, likely for debugging. @compnerd and @drodriguez, you have reviewed pulls like this before.