### PR TITLE
[NFC] Add SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE

### DIFF
--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -158,6 +158,13 @@ SwiftTargetInfo::SwiftTargetInfo(
             SWIFT_ABI_DEFAULT_OBJC_RESERVED_BITS_MASK);
   setToMask(FunctionPointerSpareBits, numPointerBits,
             SWIFT_ABI_DEFAULT_FUNCTION_SPARE_BITS_MASK);
+  if (numPointerBits == 64) {
+    ReferencePoisonDebugValue =
+      SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_64;
+  } else {
+    ReferencePoisonDebugValue =
+      SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_32;
+  }
 }
 
 SwiftTargetInfo SwiftTargetInfo::get(IRGenModule &IGM) {

--- a/lib/IRGen/SwiftTargetInfo.h
+++ b/lib/IRGen/SwiftTargetInfo.h
@@ -88,6 +88,11 @@ public:
   /// Changes to this must be kept in sync with swift/Runtime/Metadata.h.
   uint64_t LeastValidPointerValue;
 
+  /// Poison sentinel value recognized by LLDB as a former reference to a
+  /// potentially deinitialized object. It uses no spare bits and cannot point
+  /// to readable memory.
+  uint64_t ReferencePoisonDebugValue;
+
   /// The maximum number of scalars that we allow to be returned directly.
   unsigned MaxScalarsForDirectResult = 3;
 

--- a/stdlib/public/SwiftShims/System.h
+++ b/stdlib/public/SwiftShims/System.h
@@ -69,6 +69,16 @@
 // Only the bottom 56 bits are used, and heap objects are eight-byte-aligned.
 #define SWIFT_ABI_DEFAULT_64BIT_SPARE_BITS_MASK 0xFF00000000000007ULL
 
+// Poison sentinel value recognized by LLDB as a former reference to a
+// potentially deinitialized object. It uses no spare bits and cannot point to
+// readable memory.
+//
+// This is not ABI per-se but does stay in-sync with LLDB. If it becomes
+// out-of-sync, then users won't see a friendly diagnostic when inspecting
+// references past their lifetime.
+#define SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_32 0x00000880ULL
+#define SWIFT_ABI_DEFAULT_REFERENCE_POISON_DEBUG_VALUE_64 0x0000000000000880ULL
+
 /*********************************** i386 *************************************/
 
 // Heap objects are pointer-aligned, so the low two bits are unused.


### PR DESCRIPTION
Poison sentinel value recognized by LLDB as a former reference to a
potentially deinitialized object. It uses no spare bits and cannot point to
readable memory.

This is not ABI per-se but does stay in-sync with LLDB. If it becomes
out-of-sync, then users won't see a friendly diagnostic when
inspecting references past their lifetime.

I'm pushing this in before its use in the compiler so functionality can be
added to LLDB in parallel.
