### PR TITLE
SILOptimizer: move DestroyHoisting out of the mandatory pipeline

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -122,9 +122,6 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
     P.addSILSkippingChecker();
 #endif
 
-  if (Options.shouldOptimize()) {
-    P.addDestroyHoisting();
-  }
   P.addMandatoryInlining();
   P.addMandatorySILLinker();
 
@@ -480,6 +477,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   if (!P.getOptions().DisableCopyPropagation) {
     P.addCopyPropagation();
   }
+  P.addDestroyHoisting();
   P.addSemanticARCOpts();
 
   // Devirtualizes differentiability witnesses into functions that reference them.

--- a/test/SILOptimizer/bridged_casts_folding.sil
+++ b/test/SILOptimizer/bridged_casts_folding.sil
@@ -49,9 +49,9 @@ bb3(%8 : @owned $NSObjectSubclass):
 
 // CHECK-LABEL: sil @anyhashable_cast_take_on_success
 // CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
-// CHECK:       [[YES]]{{.*}}:
 // CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK: } // end sil function 'anyhashable_cast_take_on_success'
 sil [ossa] @anyhashable_cast_take_on_success : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
 entry(%0 : $*AnyHashable, %1 : @owned $NSObjectSubclass):
   %2 = alloc_stack $NSObjectSubclass

--- a/test/SILOptimizer/bridged_casts_folding_ownership.sil
+++ b/test/SILOptimizer/bridged_casts_folding_ownership.sil
@@ -51,9 +51,9 @@ bb3(%8 : @owned $NSObjectSubclass):
 
 // CHECK-LABEL: sil @anyhashable_cast_take_on_success
 // CHECK:         [[BRIDGED:%.*]] = apply {{.*}}(%0)
-// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
-// CHECK:       [[YES]]{{.*}}:
 // CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    checked_cast_br [[BRIDGED]] : $NSObject to NSObjectSubclass, [[YES:bb[0-9]+]], [[NO:bb[0-9]+]]
+// CHECK: } // end sil function 'anyhashable_cast_take_on_success'
 sil [ossa] @anyhashable_cast_take_on_success : $@convention(thin) (@in AnyHashable, @owned NSObjectSubclass) -> @owned NSObjectSubclass {
 entry(%0 : $*AnyHashable, %1 : @owned $NSObjectSubclass):
   %2 = alloc_stack $NSObjectSubclass


### PR DESCRIPTION
Now that we have OSSA also in the early stage of the -O pipeline, we can do DestroyHoisting there.
