### PR TITLE
GSB: getConformanceAccessPath() doesn't need to use getMinimalConformanceSource()

### DIFF
--- a/test/Generics/sr11153.swift
+++ b/test/Generics/sr11153.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | not %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s
+
+// CHECK: Requirement signature: <Self where Self.Field : FieldAlgebra>
+public protocol VectorSpace {
+    associatedtype Field: FieldAlgebra
+}
+
+// CHECK: Requirement signature: <Self where Self : VectorSpace, Self == Self.Field, Self.ComparableSubalgebra : ComparableFieldAlgebra>
+public protocol FieldAlgebra: VectorSpace where Self.Field == Self {
+    associatedtype ComparableSubalgebra: ComparableFieldAlgebra
+    static var zero: Self { get }
+}
+
+// CHECK: Requirement signature: <Self where Self : FieldAlgebra, Self == Self.ComparableSubalgebra>
+public protocol ComparableFieldAlgebra: FieldAlgebra where Self.ComparableSubalgebra == Self {
+}
+
+// CHECK: Generic signature: <F where F : FieldAlgebra>
+public func test<F: FieldAlgebra>(_ f: F) {
+    _ = F.ComparableSubalgebra.zero
+}

--- a/validation-test/compiler_crashers_2_fixed/Inputs/sr11153_2_other.swift
+++ b/validation-test/compiler_crashers_2_fixed/Inputs/sr11153_2_other.swift
@@ -1,0 +1,17 @@
+protocol Snapshotting {
+    associatedtype NativeType: NativeInserting where NativeType.SnapshotType == Self
+    associatedtype ChangeType: SnapshotChange where ChangeType.SnapshotType == Self
+}
+
+protocol NativeInserting {
+    associatedtype SnapshotType : Snapshotting where SnapshotType.NativeType == Self
+}
+
+protocol SnapshotProperties : OptionSet where RawValue == Int {
+    static var all: Self { get }
+}
+
+protocol SnapshotChange {
+    associatedtype SnapshotType : Snapshotting where SnapshotType.ChangeType == Self
+    associatedtype PropertiesType : SnapshotProperties
+}

--- a/validation-test/compiler_crashers_2_fixed/sr11153_2.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11153_2.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %S/Inputs/sr11153_2_other.swift -primary-file %s
+// RUN: %target-swift-frontend -emit-ir %S/Inputs/sr11153_2_other.swift %s
+
+class WatchRegistry {
+    func single<S: Snapshotting>(objectType: S.Type) throws -> Watch<S>
+    {
+        return try Watch<S>.singleObject(objectType: S.self, properties: S.ChangeType.PropertiesType.all)
+    }
+}
+
+class Watch<SnapshotType : Snapshotting> {
+    static func singleObject(objectType: SnapshotType.Type, properties: SnapshotType.ChangeType.PropertiesType) throws -> Watch<SnapshotType> {
+        fatalError()
+    }
+}


### PR DESCRIPTION
Previously we would look for a derived source before an explicit one,
on account of the explicit one possibly being redundant. However, the
presence of 'self-derived' sources meant that we had to call
getMinimalConformanceSource() to ensure the derived sources
were actually usable and would not produce an infinite conformance
access path.

I'd like to remove getMinimalConformanceSource() now that we have
an alternate algorithm to identify redundant explicit requirements.

Instead, we can handle the explicit case first, by checking for a
conformance requirement in the generic signature -- its presence
means it was not redundant, by construction.

Then once we handle that case, we know we're going to use a derived
source, and finding the shortest one seems to be good enough.

This fixes the IRGen crash in https://bugs.swift.org/browse/SR-11153;
the requirement signatures in that test still have unnecessary
same-type requirements printed, so I added a separate RUN: line
for those, and it's marked as known-failing with 'not %FileCheck'.