### PR TITLE
Check The DeclContext When Retrieving Conforming Decls

### DIFF
--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -90,6 +90,11 @@ void ConformingMethodListCallbacks::doneParsing() {
   if (T->hasArchetype())
     T = T->mapTypeOutOfContext();
 
+  // If there are no (instance) members for this type, bail.
+  if (!T->mayHaveMembers() || T->is<ModuleType>()) {
+    return;
+  }
+
   llvm::SmallPtrSet<ProtocolDecl*, 8> expectedProtocols;
   for (auto Name: ExpectedTypeNames) {
     if (auto *PD = resolveProtocolName(CurDeclContext, Name)) {
@@ -107,8 +112,7 @@ void ConformingMethodListCallbacks::doneParsing() {
 void ConformingMethodListCallbacks::getMatchingMethods(
     Type T, llvm::SmallPtrSetImpl<ProtocolDecl*> &expectedTypes,
     SmallVectorImpl<ValueDecl *> &result) {
-  if (!T->mayHaveMembers())
-    return;
+  assert(T->mayHaveMembers() && !T->is<ModuleType>());
 
   class LocalConsumer : public VisibleDeclConsumer {
     ModuleDecl *CurModule;

--- a/validation-test/IDE/crashers_2_fixed/rdar75299825.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar75299825.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test --conforming-methods --conforming-methods-expected-types=s:SQ -source-filename %s -code-completion-token=COMPLETE
+
+Swift#^COMPLETE^#


### PR DESCRIPTION
Checking for staticness is not enough because top-level decls count as
non-static yet do not have a sufficient curry level to satisfy this
check. Make sure we're looking for decls that reside inside of types.

rdar://75299825, SR-14327