### PR TITLE
Soften errors for invalid @objc attributes added by access notes

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -118,7 +118,7 @@ protected:
       Invalid : 1
     );
 
-    SWIFT_INLINE_BITFIELD(ObjCAttr, DeclAttribute, 1+1+1,
+    SWIFT_INLINE_BITFIELD(ObjCAttr, DeclAttribute, 1+1+1+1,
       /// Whether this attribute has location information that trails the main
       /// record, which contains the locations of the parentheses and any names.
       HasTrailingLocationInfo : 1,
@@ -128,7 +128,10 @@ protected:
 
       /// Whether the @objc was inferred using Swift 3's deprecated inference
       /// rules.
-      Swift3Inferred : 1
+      Swift3Inferred : 1,
+
+      /// Whether the @objc was created by an access note.
+      AddedByAccessNote : 1
     );
 
     SWIFT_INLINE_BITFIELD(DynamicReplacementAttr, DeclAttribute, 1,
@@ -749,6 +752,7 @@ class ObjCAttr final : public DeclAttribute,
     Bits.ObjCAttr.HasTrailingLocationInfo = false;
     Bits.ObjCAttr.ImplicitName = implicitName;
     Bits.ObjCAttr.Swift3Inferred = false;
+    Bits.ObjCAttr.AddedByAccessNote = false;
 
     if (name) {
       NameData = name->getOpaqueValue();
@@ -866,6 +870,17 @@ public:
   /// @objc inference rules.
   void setSwift3Inferred(bool inferred = true) {
     Bits.ObjCAttr.Swift3Inferred = inferred;
+  }
+
+  /// Determine whether this attribute was added by an access note. If it is,
+  /// the compiler will not treat it as a hard error if the attribute is
+  /// invalid.
+  bool getAddedByAccessNote() const {
+    return Bits.ObjCAttr.AddedByAccessNote;
+  }
+
+  void setAddedByAccessNote(bool accessNote = true) {
+    Bits.ObjCAttr.AddedByAccessNote = accessNote;
   }
 
   /// Clear the name of this entity.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4820,7 +4820,7 @@ ERROR(objc_extension_not_class,none,
       "'@objc' can only be applied to an extension of a class", ())
 
 // If you change this, also change enum ObjCReason
-#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @IBAction|marked @IBSegueAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)}"
+#define OBJC_ATTR_SELECT "select{marked @_cdecl|marked dynamic|marked @objc|marked @IBOutlet|marked @IBAction|marked @IBSegueAction|marked @NSManaged|a member of an @objc protocol|implicitly @objc|an @objc override|an implementation of an @objc requirement|marked @IBInspectable|marked @GKInspectable|in an @objc extension of a class (without @nonobjc)|marked @objc by an access note}"
 
 WARNING(attribute_meaningless_when_nonobjc,none,
         "'@%0' attribute is meaningless on a property that cannot be "

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1822,10 +1822,10 @@ struct ParsedDeclName {
   }
 
   /// Form a declaration name from this parsed declaration name.
-  DeclName formDeclName(ASTContext &ctx) const;
+  DeclName formDeclName(ASTContext &ctx, bool isSubscript = false) const;
 
   /// Form a declaration name from this parsed declaration name.
-  DeclNameRef formDeclNameRef(ASTContext &ctx) const;
+  DeclNameRef formDeclNameRef(ASTContext &ctx, bool isSubscript = false) const;
 };
 
 /// To assist debugging parser crashes, tell us the location of the
@@ -1846,14 +1846,16 @@ DeclName formDeclName(ASTContext &ctx,
                       StringRef baseName,
                       ArrayRef<StringRef> argumentLabels,
                       bool isFunctionName,
-                      bool isInitializer);
+                      bool isInitializer,
+                      bool isSubscript = false);
 
 /// Form a Swift declaration name referemce from its constituent parts.
 DeclNameRef formDeclNameRef(ASTContext &ctx,
                             StringRef baseName,
                             ArrayRef<StringRef> argumentLabels,
                             bool isFunctionName,
-                            bool isInitializer);
+                            bool isInitializer,
+                            bool isSubscript = false);
 
 /// Parse a stringified Swift declaration name, e.g. "init(frame:)".
 DeclName parseDeclName(ASTContext &ctx, StringRef name);

--- a/lib/AST/AccessNotes.cpp
+++ b/lib/AST/AccessNotes.cpp
@@ -46,14 +46,7 @@ AccessNoteDeclName::AccessNoteDeclName(ASTContext &ctx, StringRef str) {
   else
     accessorKind = None;
 
-  name = parsedName.formDeclName(ctx);
-
-  // FIXME: parseDeclName() doesn't handle the special `subscript` name.
-  // Fixing this without affecting existing uses in import-as-member will need
-  // a bit of work. Hack around the problem for this specific caller instead.
-  if (name.getBaseName() == ctx.getIdentifier("subscript"))
-    name = DeclName(ctx, DeclBaseName::createSubscript(),
-                    name.getArgumentNames());
+  name = parsedName.formDeclName(ctx, /*isSubscript=*/true);
 }
 
 bool AccessNoteDeclName::matches(ValueDecl *VD) const {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1332,6 +1332,7 @@ SourceLoc ObjCAttr::getRParenLoc() const {
 ObjCAttr *ObjCAttr::clone(ASTContext &context) const {
   auto attr = new (context) ObjCAttr(getName(), isNameImplicit());
   attr->setSwift3Inferred(isSwift3Inferred());
+  attr->setAddedByAccessNote(getAddedByAccessNote());
   return attr;
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1130,6 +1130,9 @@ void AttributeChecker::visitOptionalAttr(OptionalAttr *attr) {
 }
 
 void TypeChecker::checkDeclAttributes(Decl *D) {
+  if (auto VD = dyn_cast<ValueDecl>(D))
+    TypeChecker::applyAccessNote(VD);
+  
   AttributeChecker Checker(D);
   // We need to check all OriginallyDefinedInAttr relative to each other, so
   // collect them and check in batch later.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -47,13 +47,16 @@ using namespace swift;
 namespace {
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
-  void diagnoseAndRemoveAttr(DiagnosticEngine &Diags, Decl *D,
-                             DeclAttribute *attr, ArgTypes &&...Args) {
+  InFlightDiagnostic
+  diagnoseAndRemoveAttr(DiagnosticEngine &Diags, Decl *D, DeclAttribute *attr,
+                        ArgTypes &&...Args) {
+    attr->setInvalid();
+
     assert(!D->hasClangNode() && "Clang importer propagated a bogus attribute");
     if (!D->hasClangNode()) {
       SourceLoc loc = attr->getLocation();
 #ifndef NDEBUG
-      if (!loc.isValid()) {
+      if (!loc.isValid() && !attr->getAddedByAccessNote()) {
         llvm::errs() << "Attribute '";
         attr->print(llvm::errs());
         llvm::errs() << "' has invalid location, failed to diagnose!\n";
@@ -64,12 +67,11 @@ namespace {
         loc = D->getLoc();
       }
       if (loc.isValid()) {
-        Diags.diagnose(loc, std::forward<ArgTypes>(Args)...)
-          .fixItRemove(attr->getRangeWithAt());
+        return std::move(Diags.diagnose(loc, std::forward<ArgTypes>(Args)...)
+                            .fixItRemove(attr->getRangeWithAt()));
       }
     }
-
-    attr->setInvalid();
+    return InFlightDiagnostic();
   }
 
 /// This visits each attribute on a decl.  The visitor should return true if
@@ -83,9 +85,10 @@ public:
 
   /// This emits a diagnostic with a fixit to remove the attribute.
   template<typename ...ArgTypes>
-  void diagnoseAndRemoveAttr(DeclAttribute *attr, ArgTypes &&...Args) {
-    ::diagnoseAndRemoveAttr(Ctx.Diags, D, attr,
-                            std::forward<ArgTypes>(Args)...);
+  InFlightDiagnostic diagnoseAndRemoveAttr(DeclAttribute *attr,
+                                           ArgTypes &&...Args) {
+    return ::diagnoseAndRemoveAttr(Ctx.Diags, D, attr,
+                                   std::forward<ArgTypes>(Args)...);
   }
 
   template <typename... ArgTypes>
@@ -936,7 +939,8 @@ static bool checkObjCDeclContext(Decl *D) {
   return false;
 }
 
-static void diagnoseObjCAttrWithoutFoundation(ObjCAttr *attr, Decl *decl) {
+static void diagnoseObjCAttrWithoutFoundation(ObjCAttr *attr, Decl *decl,
+                                              DiagnosticBehavior behavior) {
   auto *SF = decl->getDeclContext()->getParentSourceFile();
   assert(SF);
 
@@ -948,7 +952,8 @@ static void diagnoseObjCAttrWithoutFoundation(ObjCAttr *attr, Decl *decl) {
 
   if (!ctx.LangOpts.EnableObjCInterop) {
     ctx.Diags.diagnose(attr->getLocation(), diag::objc_interop_disabled)
-      .fixItRemove(attr->getRangeWithAt());
+      .fixItRemove(attr->getRangeWithAt())
+      .limitBehavior(behavior);
     return;
   }
 
@@ -968,10 +973,14 @@ static void diagnoseObjCAttrWithoutFoundation(ObjCAttr *attr, Decl *decl) {
   ctx.Diags.diagnose(attr->getLocation(),
                      diag::attr_used_without_required_module, attr,
                      ctx.Id_Foundation)
-    .highlight(attr->getRangeWithAt());
+    .highlight(attr->getRangeWithAt())
+    .limitBehavior(behavior);
 }
 
 void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
+  auto reason = objCReasonForObjCAttr(attr);
+  auto behavior = behaviorLimitForObjCReason(reason, Ctx);
+
   // Only certain decls can be ObjC.
   Optional<Diag<>> error;
   if (isa<ClassDecl>(D) ||
@@ -1007,7 +1016,7 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
   }
 
   if (error) {
-    diagnoseAndRemoveAttr(attr, *error);
+    diagnoseAndRemoveAttr(attr, *error).limitBehavior(behavior);
     return;
   }
 
@@ -1026,7 +1035,8 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
           Lexer::getLocForEndOfToken(Ctx.SourceMgr, firstNameLoc);
         diagnose(firstNameLoc, diag::objc_name_req_nullary,
                  D->getDescriptiveKind())
-          .fixItRemoveChars(afterFirstNameLoc, attr->getRParenLoc());
+          .fixItRemoveChars(afterFirstNameLoc, attr->getRParenLoc())
+          .limitBehavior(behavior);
         const_cast<ObjCAttr *>(attr)->setName(
           ObjCSelector(Ctx, 0, objcName->getSelectorPieces()[0]),
           /*implicit=*/false);
@@ -1035,7 +1045,8 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
       diagnose(attr->getLParenLoc(),
                isa<SubscriptDecl>(D)
                  ? diag::objc_name_subscript
-                 : diag::objc_name_deinit);
+                 : diag::objc_name_deinit)
+          .limitBehavior(behavior);
       const_cast<ObjCAttr *>(attr)->clearName();
     } else {
       auto func = cast<AbstractFunctionDecl>(D);
@@ -1070,7 +1081,8 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
                  numArgumentNames != 1,
                  numParameters,
                  numParameters != 1,
-                 func->hasThrows());
+                 func->hasThrows())
+            .limitBehavior(behavior);
         D->getAttrs().add(
           ObjCAttr::createUnnamed(Ctx, attr->AtLoc,  attr->Range.Start));
         D->getAttrs().removeAttribute(attr);
@@ -1078,11 +1090,12 @@ void AttributeChecker::visitObjCAttr(ObjCAttr *attr) {
     }
   } else if (isa<EnumElementDecl>(D)) {
     // Enum elements require names.
-    diagnoseAndRemoveAttr(attr, diag::objc_enum_case_req_name);
+    diagnoseAndRemoveAttr(attr, diag::objc_enum_case_req_name)
+        .limitBehavior(behavior);
   }
 
   // Diagnose an @objc attribute used without importing Foundation.
-  diagnoseObjCAttrWithoutFoundation(attr, D);
+  diagnoseObjCAttrWithoutFoundation(attr, D, behavior);
 }
 
 void AttributeChecker::visitNonObjCAttr(NonObjCAttr *attr) {
@@ -1132,7 +1145,7 @@ void AttributeChecker::visitOptionalAttr(OptionalAttr *attr) {
 void TypeChecker::checkDeclAttributes(Decl *D) {
   if (auto VD = dyn_cast<ValueDecl>(D))
     TypeChecker::applyAccessNote(VD);
-  
+
   AttributeChecker Checker(D);
   // We need to check all OriginallyDefinedInAttr relative to each other, so
   // collect them and check in batch later.
@@ -1177,13 +1190,20 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
     default: break;
     }
 
+    DiagnosticBehavior behavior = attr->getAddedByAccessNote()
+                                ? DiagnosticBehavior::Remark
+                                : DiagnosticBehavior::Unspecified;
+
     if (!OnlyKind.empty())
       Checker.diagnoseAndRemoveAttr(attr, diag::attr_only_one_decl_kind,
-                                    attr, OnlyKind);
+                                    attr, OnlyKind)
+          .limitBehavior(behavior);
     else if (attr->isDeclModifier())
-      Checker.diagnoseAndRemoveAttr(attr, diag::invalid_decl_modifier, attr);
+      Checker.diagnoseAndRemoveAttr(attr, diag::invalid_decl_modifier, attr)
+          .limitBehavior(behavior);
     else
-      Checker.diagnoseAndRemoveAttr(attr, diag::invalid_decl_attribute, attr);
+      Checker.diagnoseAndRemoveAttr(attr, diag::invalid_decl_attribute, attr)
+          .limitBehavior(behavior);
   }
   Checker.checkOriginalDefinedInAttrs(D, ODIAttrs);
 }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1483,7 +1483,7 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
   DiagnosticStateRAII diagState(VD->getASTContext().Diags);
 
   // Access notes may add attributes that affect this calculus.
-  (void)evaluateOrDefault(evaluator, ApplyAccessNoteRequest{VD}, {});
+  TypeChecker::applyAccessNote(VD);
 
   auto dc = VD->getDeclContext();
   Optional<ObjCReason> isObjC;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1663,11 +1663,16 @@ static ObjCSelector inferObjCName(ValueDecl *decl) {
             *attr->getName() != overriddenNameAsSel) {
           // If the user explicitly wrote the wrong name, complain.
           if (!attr->isNameImplicit()) {
-            ctx.Diags.diagnose(attr->AtLoc,
+            SourceLoc diagLoc = attr->AtLoc, firstNameLoc;
+            if (diagLoc.isInvalid())
+              diagLoc = decl->getLoc();
+            if (!attr->getNameLocs().empty())
+              firstNameLoc = attr->getNameLocs().front();
+            ctx.Diags.diagnose(diagLoc,
                         diag::objc_override_property_name_mismatch,
                         attr->getName()->getSelectorPieces()[0],
                         overriddenName)
-              .fixItReplaceChars(attr->getNameLocs().front(),
+              .fixItReplaceChars(firstNameLoc,
                                  attr->getRParenLoc(),
                                  overriddenName.str());
             overridden->diagnose(diag::overridden_here);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1649,6 +1649,7 @@ public:
     // when the VarDecl is merely used from another file.
 
     // Compute these requests in case they emit diagnostics.
+    TypeChecker::applyAccessNote(VD);
     (void) VD->getInterfaceType();
     (void) VD->isGetterMutating();
     (void) VD->isSetterMutating();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1447,6 +1447,7 @@ static void addOrRemoveAttr(ValueDecl *VD, const AccessNotesFile &notes,
 
   if (*expected) {
     attr = willCreate();
+    attr->setAddedByAccessNote();
     VD->getAttrs().add(attr);
 
     SmallString<64> attrString;
@@ -1470,9 +1471,7 @@ static void applyAccessNote(ValueDecl *VD, const AccessNote &note,
   ASTContext &ctx = VD->getASTContext();
 
   addOrRemoveAttr<ObjCAttr>(VD, notes, note.ObjC, [&]{
-    auto attr = ObjCAttr::create(ctx, note.ObjCName, false);
-    attr->setAddedByAccessNote();
-    return attr;
+    return ObjCAttr::create(ctx, note.ObjCName, false);
   });
 
   addOrRemoveAttr<DynamicAttr>(VD, notes, note.Dynamic, [&]{

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1514,6 +1514,11 @@ static void applyAccessNote(ValueDecl *VD, const AccessNote &note,
   }
 }
 
+void TypeChecker::applyAccessNote(ValueDecl *VD) {
+  (void)evaluateOrDefault(VD->getASTContext().evaluator,
+                          ApplyAccessNoteRequest{VD}, {});
+}
+
 evaluator::SideEffect
 ApplyAccessNoteRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
   AccessNotesFile &notes = VD->getModuleContext()->getAccessNotes();
@@ -1545,8 +1550,7 @@ public:
     PrettyStackTraceDecl StackTrace("type-checking", decl);
 
     if (auto VD = dyn_cast<ValueDecl>(decl))
-      (void)evaluateOrDefault(VD->getASTContext().evaluator,
-                              ApplyAccessNoteRequest{VD}, {});
+      TypeChecker::applyAccessNote(VD);
 
     DeclVisitor<DeclChecker>::visit(decl);
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1470,7 +1470,9 @@ static void applyAccessNote(ValueDecl *VD, const AccessNote &note,
   ASTContext &ctx = VD->getASTContext();
 
   addOrRemoveAttr<ObjCAttr>(VD, notes, note.ObjC, [&]{
-    return ObjCAttr::create(ctx, note.ObjCName, false);
+    auto attr = ObjCAttr::create(ctx, note.ObjCName, false);
+    attr->setAddedByAccessNote();
+    return attr;
   });
 
   addOrRemoveAttr<DynamicAttr>(VD, notes, note.Dynamic, [&]{

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -69,6 +69,9 @@ public:
     ExplicitlyGKInspectable,
     /// Is it a member of an @objc extension of a class.
     MemberOfObjCExtension,
+    /// Has an explicit '@objc' attribute added by an access note, rather than
+    /// written in source code.
+    ExplicitlyObjCByAccessNote,
 
     // These kinds do not appear in diagnostics.
 

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -26,6 +26,7 @@ namespace swift {
 
 class AbstractFunctionDecl;
 class ASTContext;
+class ObjCAttr;
 class SubscriptDecl;
 class ValueDecl;
 class VarDecl;
@@ -120,6 +121,9 @@ public:
 /// particular reason.
 DiagnosticBehavior
 behaviorLimitForObjCReason(ObjCReason reason, ASTContext &ctx);
+
+/// Returns the ObjCReason for this ObjCAttr to be attached to the declaration.
+ObjCReason objCReasonForObjCAttr(const ObjCAttr *attr);
 
 /// Return the %select discriminator for the OBJC_ATTR_SELECT macro used to
 /// complain about the correct attribute during @objc inference.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5271,7 +5271,7 @@ canSuppressPotentialWitnessWarningWithNonObjC(ValueDecl *requirement,
 
   // ... but not explicitly.
   if (auto attr = witness->getAttrs().getAttribute<ObjCAttr>()) {
-    if (!attr->isImplicit()) return false;
+    if (!attr->isImplicit() || attr->getAddedByAccessNote()) return false;
   }
 
   // And not because it has to be for overriding.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1184,6 +1184,12 @@ UnresolvedMemberExpr *getUnresolvedMemberChainBase(Expr *expr);
 bool typeSupportsBuilderOp(Type builderType, DeclContext *dc, Identifier fnName,
                            ArrayRef<Identifier> argLabels = {},
                            SmallVectorImpl<ValueDecl *> *allResults = nullptr);
+
+/// Forces all changes specified by the module's access notes file to be
+/// applied to this declaration. It is safe to call this function more than
+/// once.
+void applyAccessNote(ValueDecl *VD);
+
 }; // namespace TypeChecker
 
 /// Temporary on-stack storage and unescaping for encoded diagnostic

--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# coding=utf8
+
+"""
+Convert selected @objc attributes in a source file into access notes, removing
+the originals in the process.
+"""
+
+from __future__ import print_function
+
+import io
+import re
+import sys
+
+#
+# Entry point
+#
+
+
+def main():
+    if len(sys.argv) != 4:
+        print('Too few args to ' + sys.argv[0])
+        print('Usage: access-note-gen.py <input-file> <output-source-file> ' +
+              '<output-access-notes-file>')
+        sys.exit(1)
+
+    with io.open(sys.argv[1], mode='r', encoding='utf8') as input_file, \
+         io.open(sys.argv[2], mode='w', encoding='utf8') as output_file, \
+         io.open(sys.argv[3], mode='w', encoding='utf8') as access_notes_file:
+
+        # Add header to access notes file
+        access_notes_file.write(u"""\
+Reason: 'fancy tests'
+Notes:""")
+
+        # Loop over input lines, transforming them into output lines, writing access
+        # notes as a side effect.
+        for input_line in input_file:
+            # Look for access-note-move comments.
+            input_line = access_note_move_re.sub(replacer(move_at_objc_to_access_note,
+                                                          access_notes_file),
+                                                 input_line, count=1)
+
+            # Look for access-note-adjust comments.
+            input_line = adjust_comment_re.sub(replacer(adjust_comments),
+                                               input_line, count=1)
+
+            output_file.write(input_line)
+
+
+#
+# Offsets
+#
+
+"""Matches an @±N offset."""
+offset_re_fragment = r'[ \t]*(?:@([+-]\d+))?[ \t]*'
+
+
+def offsetify(*offsets):
+    """Sum line offsets matched by offset_re_fragment and convert them to strings
+       like @+3 or @-2."""
+
+    offset = sum([int(o) for o in offsets if o is not None])
+    if offset < 0:
+        return u"@-" + str(-offset)
+    elif offset > 0:
+        return u"@+" + str(offset)
+    else:
+        return u""
+
+
+#
+# Adjusting comments
+#
+
+"""Matches expected-warning/note/remark and its offset."""
+expected_other_diag_re = re.compile(r'expected-(warning|note|remark)' +
+                                    offset_re_fragment)
+
+"""Matches expected-error and its offset."""
+expected_error_re = re.compile(r'expected-error' + offset_re_fragment)
+
+"""Matches the string 'marked @objc'."""
+marked_objc_re = re.compile(r'marked @objc')
+
+"""Matches any non-none fix-it expectation."""
+fixit_re = re.compile(r'{{\d+-\d+=[^}]*}}')
+
+
+def adjust_comments(offset, comment_str):
+    """Replace expected-errors with expected-remarks, and make other adjustments
+       to diagnostics so that they reflect access notes."""
+
+    adjusted = expected_other_diag_re.sub(lambda m: u"expected-" + m.group(1) +
+                                                    offsetify(offset, m.group(2)),
+                                          comment_str)
+    adjusted = expected_error_re.sub(lambda m: u"expected-remark" +
+                                               offsetify(offset, m.group(1)),
+                                     adjusted)
+    adjusted = marked_objc_re.sub(u"marked @objc by an access note", adjusted)
+    adjusted = fixit_re.sub(u"{{none}}", adjusted)
+
+    return u"// [expectations adjusted] " + adjusted
+
+
+#
+# Writing attrs to access notes
+#
+
+def move_at_objc_to_access_note(access_notes_file, arg, offset, access_note_name):
+    """Write an @objc attribute into an access notes file, then return the
+       string that will replace the attribute and trailing comment."""
+
+    access_notes_file.write(u"""
+- Name: '{}'
+  ObjC: true""".format(access_note_name))
+    if arg:
+        access_notes_file.write(u"""
+  ObjCName: '{}'""".format(arg))
+
+    # Default to shifting expected diagnostics down 1 line.
+    if offset is None:
+        offset = 1
+
+    return u"// access-note-adjust" + offsetify(offset) + u" [attr moved] " + \
+           u"expected-remark{{access note for fancy tests adds attribute 'objc' to " + \
+           u"this }} expected-note{{add attribute explicitly to silence this warning}}"
+
+
+#
+# Matching lines
+#
+
+"""Matches '@objc(foo) // access-note-move{{access-note-name}}'
+   or '@objc // access-note-move{{access-note-name}}'"""
+access_note_move_re = re.compile(r'@objc(?:\(([\w:]+)\))?[ \t]*' +
+                                 r'//[ \t]*access-note-move' +
+                                 offset_re_fragment +
+                                 r'\{\{([^}]*)\}\}')
+
+"""Matches // access-note-adjust <comment>"""
+adjust_comment_re = re.compile(r'//[ \t]*access-note-adjust' + offset_re_fragment +
+                               r'(.*)')
+
+
+def replacer(fn, *args):
+    """Returns a lambda which calls fn with args, followed by the groups from
+       the match passed to the lambda."""
+
+    return lambda m: fn(*(args + m.groups()))
+
+
+main()

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1,8 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %S/Inputs/access-note-gen.py %s %t/attr_objc_access_note.swift %t/attr_objc_access_note.accessnotes
+
+// Test with @objc attrs, without access notes
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference
 // RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference > %t.ast
-// RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t.ast
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference > %t/attr_objc.ast
+// RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t/attr_objc.ast
+
+// Test without @objc attrs, with access notes
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %t/attr_objc_access_note.swift -access-notes-path %t/attr_objc_access_note.accessnotes -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %t/attr_objc_access_note.swift -access-notes-path %t/attr_objc_access_note.accessnotes -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %t/attr_objc_access_note.swift
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %t/attr_objc_access_note.swift -access-notes-path %t/attr_objc_access_note.accessnotes -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference > %t/attr_objc_access_note.ast
+// RUN: %FileCheck -check-prefix CHECK-DUMP %t/attr_objc_access_note.swift < %t/attr_objc_access_note.ast
+
+// Test with both @objc attrs and access notes
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -typecheck -verify -verify-ignore-unknown %s -access-notes-path %t/attr_objc_access_note.accessnotes -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference
+// RUN: %target-swift-ide-test -skip-deinit=false -print-ast-typechecked -source-filename %s -access-notes-path %t/attr_objc_access_note.accessnotes -function-definitions=true -prefer-type-repr=false -print-implicit-attrs=true -explode-pattern-binding-decls=true -disable-objc-attr-requires-foundation-module -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck -dump-ast -disable-objc-attr-requires-foundation-module %s -access-notes-path %t/attr_objc_access_note.accessnotes -swift-version 4 -enable-source-import -I %S/Inputs -enable-swift3-objc-inference > %t/attr_objc_2.ast
+// RUN: %FileCheck -check-prefix CHECK-DUMP %s < %t/attr_objc_2.ast
+
 // REQUIRES: objc_interop
+
+// HOW TO WORK ON THIS TEST
+//
+// This file is primarily used to test '@objc' in source files, but it is also
+// processed to produce test files for access notes, which can annotate
+// declarations with '@objc' based on a sidecar file. This processing produces
+// a source file with most of the '@objc' annotations removed, plus an access
+// note file which adds back the removed '@objc' annotations. The three files
+// are then tested in various combinations.
+//
+// The processing step uses the following special commands, which must appear
+// at the beginning of a line comment to be recognized:
+//
+// * `access-note-adjust @±offset` (where the offset is optional) modifies the
+//   rest of the line comment to:
+//
+//   1. Change expected errors to expected remarks
+//   2. Adjust the line offsets of all expected diagnostics by the offset
+//   3. Change the phrase "marked @objc" to "marked @objc by an access note"
+//   4. Change all expected fix-its to "{{none}}"
+//
+// * `access-note-move @±offset {{name}}` (where the offset is optional) can
+//   only appear immediately after an `@objc` or `@objc(someName)` attribute.
+//   It removes the attribute from the source code, adds a corresponding
+//   access note for `name` to the access note file, and does the same
+//   processing to the rest of the line as access-note-adjust. Note that in this
+//   case, the offset is @+1, not @+0, unless something else is specified.
+//
+// Note that, in some cases, we need additional access notes to be added that
+// don't directly correspond to any attribute in the source code (usually
+// because one @objc attribute covers several declarations). When this happens,
+// we write a commented-out @objc attribute and use the `access-note-move`
+// command.
+
 
 import Foundation
 
@@ -15,17 +66,17 @@ enum ErrorEnum : Error {
   case failed
 }
 
-@objc
+@objc // access-note-move{{Class_ObjC1}}
 class Class_ObjC1 {}
 
 protocol Protocol_Class1 : class {} // expected-note {{protocol 'Protocol_Class1' declared here}}
 
 protocol Protocol_Class2 : class {}
 
-@objc
+@objc // access-note-move{{Protocol_ObjC1}}
 protocol Protocol_ObjC1 {}
 
-@objc
+@objc // access-note-move{{Protocol_ObjC2}}
 protocol Protocol_ObjC2 {}
 
 
@@ -41,15 +92,15 @@ class FáncyName {}
 @objc(FancyName)
 extension FáncyName {}
 
-@objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+@objc // access-note-move{{subject_globalVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
 var subject_globalVar: Int
 
 var subject_getterSetter: Int {
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{getter:subject_getterSetter()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   get {
     return 0
   }
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{setter:subject_getterSetter()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   set {
   }
 }
@@ -65,8 +116,8 @@ var subject_global_observingAccessorsVar1: Int = 0 {
 
 class subject_getterSetter1 {
   var instanceVar1: Int {
-    @objc
-    get { // expected-error {{'@objc' getter for non-'@objc' property}}
+    @objc // access-note-move{{getter:subject_getterSetter1.instanceVar1()}}
+    get { // access-note-adjust expected-error {{'@objc' getter for non-'@objc' property}}
       return 0
     }
   }
@@ -75,18 +126,18 @@ class subject_getterSetter1 {
     get {
       return 0
     }
-    @objc
-    set { // expected-error {{'@objc' setter for non-'@objc' property}}
+    @objc // access-note-move{{setter:subject_getterSetter1.instanceVar2()}}
+    set { // access-note-adjust expected-error {{'@objc' setter for non-'@objc' property}}
     }
   }
 
   var instanceVar3: Int {
-    @objc
-    get { // expected-error {{'@objc' getter for non-'@objc' property}}
+    @objc // access-note-move{{getter:subject_getterSetter1.instanceVar3()}}
+    get { // access-note-adjust expected-error {{'@objc' getter for non-'@objc' property}}
       return 0
     }
-    @objc
-    set { // expected-error {{'@objc' setter for non-'@objc' property}}
+    @objc // access-note-move{{setter:subject_getterSetter1.instanceVar3()}}
+    set { // access-note-adjust expected-error {{'@objc' setter for non-'@objc' property}}
     }
   }
 
@@ -101,14 +152,14 @@ class subject_getterSetter1 {
 }
 
 class subject_staticVar1 {
-  @objc
+  @objc // access-note-move{{subject_staticVar1.staticVar1}}
   class var staticVar1: Int = 42 // expected-error {{class stored properties not supported}}
 
-  @objc
+  @objc // access-note-move{{subject_staticVar1.staticVar2}}
   class var staticVar2: Int { return 42 }
 }
 
-@objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
+@objc // access-note-move{{subject_freeFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
 func subject_freeFunc() {
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
@@ -119,7 +170,7 @@ func subject_freeFunc() {
   }
 }
 
-@objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
+@objc // access-note-move{{subject_genericFunc(t:)}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
 func subject_genericFunc<T>(t: T) {
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
@@ -132,152 +183,158 @@ func subject_genericFunc<T>(t: T) {
 func subject_funcParam(a: @objc Int) { // expected-error {{attribute can only be applied to declarations, not types}} {{1-1=@objc }} {{27-33=}}
 }
 
-@objc // expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
+@objc // access-note-move{{subject_struct}} expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
 struct subject_struct {
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_struct.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_instanceVar: Int
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_struct.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   init() {}
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_struct.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_instanceFunc() {}
 }
 
-@objc // expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
+@objc // access-note-move{{subject_genericStruct}} expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
 struct subject_genericStruct<T> {
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_genericStruct.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_instanceVar: Int
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_genericStruct.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   init() {}
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_genericStruct.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_instanceFunc() {}
 }
 
-@objc
+@objc // access-note-move{{subject_class1}}
 class subject_class1 { // no-error
-  @objc
+  @objc // access-note-move{{subject_class1.subject_instanceVar}}
   var subject_instanceVar: Int // no-error
 
-  @objc
+  @objc // access-note-move{{subject_class1.init()}}
   init() {} // no-error
 
-  @objc
+  @objc // access-note-move{{subject_class1.subject_instanceFunc()}}
   func subject_instanceFunc() {} // no-error
   
   
 }
 
-@objc
+@objc // access-note-move{{subject_class2}}
 class subject_class2 : Protocol_Class1, PlainProtocol { // no-error
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
+@objc // access-note-move{{subject_genericClass}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class subject_genericClass<T> {
-  @objc
+  @objc // access-note-move{{subject_genericClass.subject_instanceVar}}
   var subject_instanceVar: Int // no-error
 
-  @objc
+  @objc // access-note-move{{subject_genericClass.init()}}
   init() {} // no-error
 
-  @objc
+  @objc // access-note-move{{subject_genericClass.subject_instanceFunc()}}
   func subject_instanceFunc() {} // no_error
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
+@objc // access-note-move{{subject_genericClass2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
 class subject_genericClass2<T> : Class_ObjC1 {
-  @objc
+  @objc // access-note-move{{subject_genericClass2.subject_instanceVar}}
   var subject_instanceVar: Int // no-error
 
-  @objc
+  @objc // access-note-move{{subject_genericClass2.init(foo:)}}
   init(foo: Int) {} // no-error
 
-  @objc
+  @objc // access-note-move{{subject_genericClass2.subject_instanceFunc()}}
   func subject_instanceFunc() {} // no_error
 }
 
 extension subject_genericClass where T : Hashable {
-  @objc
-  var prop: Int { return 0 } // expected-error{{members of constrained extensions cannot be declared @objc}}
+  @objc // access-note-move{{subject_genericClass.prop}}
+  var prop: Int { return 0 } // access-note-adjust expected-error{{members of constrained extensions cannot be declared @objc}}
 }
 
 extension subject_genericClass {
-  @objc
-  var extProp: Int { return 0 } // expected-error{{extensions of generic classes cannot contain '@objc' members}}
+  @objc // access-note-move{{subject_genericClass.extProp}}
+  var extProp: Int { return 0 } // access-note-adjust expected-error{{extensions of generic classes cannot contain '@objc' members}}
   
-  @objc
-  func extFoo() {} // expected-error{{extensions of generic classes cannot contain '@objc' members}}
+  @objc // access-note-move{{subject_genericClass.extFoo()}}
+  func extFoo() {} // access-note-adjust expected-error{{extensions of generic classes cannot contain '@objc' members}}
 }
 
-@objc
+@objc // access-note-move{{subject_enum}}
 enum subject_enum: Int {
-  @objc // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
+  @objc // access-note-move{{subject_enum.subject_enumElement1}} expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement1
 
-  @objc(subject_enumElement2)
+  @objc(subject_enumElement2) // access-note-move{{subject_enum.subject_enumElement2}}
   case subject_enumElement2
 
-  @objc(subject_enumElement3) // expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-31=}}
+  // Fake for access notes: @objc(subject_enumElement3) // access-note-move@+2{{subject_enum.subject_enumElement4}}
+  @objc(subject_enumElement3) // access-note-move{{subject_enum.subject_enumElement3}} expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-31=}}
   case subject_enumElement3, subject_enumElement4
+  // Becuase of the fake access-note-move above, we expect to see extra diagnostics when we run this test with both explicit @objc attributes *and* access notes:
+  // expected-remark@-2 * {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}} expected-remark@-2 * {{access note for fancy tests adds attribute 'objc' to this enum case}} expected-note@-2 * {{add attribute explicitly to silence this warning}}
 
-  @objc // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
+  // Fake for access notes: @objc // access-note-move@+2{{subject_enum.subject_enumElement6}}
+  @objc // access-note-move{{subject_enum.subject_enumElement5}} expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement5, subject_enumElement6
+  // Becuase of the fake access-note-move above, we expect to see extra diagnostics when we run this test with both explicit @objc attributes *and* access notes:
+  // expected-remark@-2 * {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} expected-remark@-2 * {{access note for fancy tests adds attribute 'objc' to this enum case}} expected-note@-2 * {{add attribute explicitly to silence this warning}}
 
   @nonobjc // expected-error {{'@nonobjc' attribute cannot be applied to this declaration}}
   case subject_enumElement7
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_enum.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   init() {}
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // access-note-move{{subject_enum.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_instanceFunc() {}
 }
 
 enum subject_enum2 {
-  @objc(subject_enum2Element1) // expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-32=}}
+  @objc(subject_enum2Element1) // access-note-move{{subject_enum2.subject_enumElement1}} expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-32=}}
   case subject_enumElement1
 }
 
-@objc
+@objc // access-note-move{{subject_protocol1}}
 protocol subject_protocol1 {
-  @objc
+  @objc // access-note-move{{subject_protocol1.subject_instanceVar}}
   var subject_instanceVar: Int { get }
 
-  @objc
+  @objc // access-note-move{{subject_protocol1.subject_instanceFunc()}}
   func subject_instanceFunc()
 }
 
-@objc // no-error
+@objc // access-note-move{{subject_protocol2}} // no-error
 protocol subject_protocol2 {}
 // CHECK-LABEL: @objc protocol subject_protocol2 {
 
-@objc // no-error
+@objc // access-note-move{{subject_protocol3}} // no-error
 protocol subject_protocol3 {}
 // CHECK-LABEL: @objc protocol subject_protocol3 {
 
-@objc
+@objc // access-note-move{{subject_protocol4}}
 protocol subject_protocol4 : PlainProtocol {} // expected-error {{@objc protocol 'subject_protocol4' cannot refine non-@objc protocol 'PlainProtocol'}}
 
-@objc
+@objc // access-note-move{{subject_protocol5}}
 protocol subject_protocol5 : Protocol_Class1 {} // expected-error {{@objc protocol 'subject_protocol5' cannot refine non-@objc protocol 'Protocol_Class1'}}
 
-@objc
+@objc // access-note-move{{subject_protocol6}}
 protocol subject_protocol6 : Protocol_ObjC1 {}
 
 protocol subject_containerProtocol1 {
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{subject_containerProtocol1.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   var subject_instanceVar: Int { get }
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{subject_containerProtocol1.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func subject_instanceFunc()
 
-  @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{subject_containerProtocol1.subject_staticFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   static func subject_staticFunc()
 }
 
-@objc
+@objc // access-note-move{{subject_containerObjCProtocol1}}
 protocol subject_containerObjCProtocol1 {
   func func_FunctionReturn1() -> PlainStruct
   // expected-error@-1 {{method cannot be a member of an @objc protocol because its result type cannot be represented in Objective-C}}
@@ -304,27 +361,29 @@ protocol subject_containerObjCProtocol1 {
   // expected-note@-3 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
 }
 
-@objc
+@objc // access-note-move{{subject_containerObjCProtocol2}}
 protocol subject_containerObjCProtocol2 {
   init(a: Int)
-  @objc
+
+  @objc // FIXME: Access notes can't distinguish between init(a:) overloads
   init(a: Double)
 
   func func1() -> Int
-  @objc
+  @objc // access-note-move{{subject_containerObjCProtocol2.func1_()}}
   func func1_() -> Int
 
   var instanceVar1: Int { get set }
-  @objc
+  @objc // access-note-move{{subject_containerObjCProtocol2.instanceVar1_}}
   var instanceVar1_: Int { get set }
 
   subscript(i: Int) -> Int { get set }
-  @objc
+
+  @objc // FIXME: Access notes can't distinguish between subscript(_:) overloads
   subscript(i: String) -> Int { get set}
 }
 
 protocol nonObjCProtocol {
-  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{nonObjCProtocol.objcRequirement()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func objcRequirement()
 }
 
@@ -334,7 +393,7 @@ func concreteContext1() {
 }
 
 class ConcreteContext2 {
-  @objc
+  @objc // access-note-move{{ConcreteContext2.subject_inConcreteContext}}
   class subject_inConcreteContext {}
 }
 
@@ -342,484 +401,484 @@ class ConcreteContext3 {
 
   func dynamicSelf1() -> Self { return self }
 
-  @objc
+  @objc // access-note-move{{ConcreteContext3.dynamicSelf1_()}}
   func dynamicSelf1_() -> Self { return self }
 
-  @objc
-  func genericParams<T: NSObject>() -> [T] { return [] } // expected-error{{method cannot be marked @objc because it has generic parameters}}
+  @objc // access-note-move{{ConcreteContext3.genericParams()}}
+  func genericParams<T: NSObject>() -> [T] { return [] } // access-note-adjust expected-error{{method cannot be marked @objc because it has generic parameters}}
 
-  @objc
-  func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.returnObjCProtocolMetatype()}}
+  func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias AnotherNSCoding = NSCoding
   typealias MetaNSCoding1 = NSCoding.Protocol
   typealias MetaNSCoding2 = AnotherNSCoding.Protocol
 
-  @objc
-  func returnObjCAliasProtocolMetatype1() -> AnotherNSCoding.Protocol { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype1()}}
+  func returnObjCAliasProtocolMetatype1() -> AnotherNSCoding.Protocol { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc
-  func returnObjCAliasProtocolMetatype2() -> MetaNSCoding1 { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype2()}}
+  func returnObjCAliasProtocolMetatype2() -> MetaNSCoding1 { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc
-  func returnObjCAliasProtocolMetatype3() -> MetaNSCoding2 { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype3()}}
+  func returnObjCAliasProtocolMetatype3() -> MetaNSCoding2 { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias Composition = NSCopying & NSCoding
 
-  @objc
-  func returnCompositionMetatype1() -> Composition.Protocol { return Composition.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.returnCompositionMetatype1()}}
+  func returnCompositionMetatype1() -> Composition.Protocol { return Composition.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc
-  func returnCompositionMetatype2() -> (NSCopying & NSCoding).Protocol { return (NSCopying & NSCoding).self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.returnCompositionMetatype2()}}
+  func returnCompositionMetatype2() -> (NSCopying & NSCoding).Protocol { return (NSCopying & NSCoding).self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias NSCodingExistential = NSCoding.Type
 
-  @objc
-  func inoutFunc(a: inout Int) {} // expected-error{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.inoutFunc(a:)}}
+  func inoutFunc(a: inout Int) {} // access-note-adjust expected-error{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
 
-  @objc
-  func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram1(a:)}}
+  func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 
-  @objc
-  func metatypeOfExistentialMetatypePram2(a: NSCoding.Type.Protocol) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  @objc // access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram2(a:)}}
+  func metatypeOfExistentialMetatypePram2(a: NSCoding.Type.Protocol) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
 func genericContext1<T>(_: T) {
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
-  class subject_inGenericContext {} // expected-error{{type 'subject_inGenericContext' cannot be nested in generic function 'genericContext1'}}
+  @objc // expected-error {{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
+  class subject_inGenericContext {} // expected-error {{type 'subject_inGenericContext' cannot be nested in generic function 'genericContext1'}}
 
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
-  class subject_inGenericContext2 : Class_ObjC1 {} // expected-error{{type 'subject_inGenericContext2' cannot be nested in generic function 'genericContext1'}}
+  @objc // expected-error {{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
+  class subject_inGenericContext2 : Class_ObjC1 {} // expected-error {{type 'subject_inGenericContext2' cannot be nested in generic function 'genericContext1'}}
 
-  class subject_constructor_inGenericContext { // expected-error{{type 'subject_constructor_inGenericContext' cannot be nested in generic function 'genericContext1'}}
+  class subject_constructor_inGenericContext { // expected-error {{type 'subject_constructor_inGenericContext' cannot be nested in generic function 'genericContext1'}}
     @objc
     init() {} // no-error
   }
 
-  class subject_var_inGenericContext { // expected-error{{type 'subject_var_inGenericContext' cannot be nested in generic function 'genericContext1'}}
+  class subject_var_inGenericContext { // expected-error {{type 'subject_var_inGenericContext' cannot be nested in generic function 'genericContext1'}}
     @objc
     var subject_instanceVar: Int = 0 // no-error
   }
 
-  class subject_func_inGenericContext { // expected-error{{type 'subject_func_inGenericContext' cannot be nested in generic function 'genericContext1'}}
+  class subject_func_inGenericContext { // expected-error {{type 'subject_func_inGenericContext' cannot be nested in generic function 'genericContext1'}}
     @objc
     func f() {} // no-error
   }
 }
 
 class GenericContext2<T> {
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
+  @objc // access-note-move{{GenericContext2.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
   class subject_inGenericContext {}
 
-  @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
+  @objc // access-note-move{{GenericContext2.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
   class subject_inGenericContext2 : Class_ObjC1 {}
 
-  @objc
+  @objc // access-note-move{{GenericContext2.f()}}
   func f() {} // no-error
 }
 
 class GenericContext3<T> {
   class MoreNested {
-    @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{5-11=}}
+    @objc // access-note-move{{GenericContext3.MoreNested.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{5-11=}}
     class subject_inGenericContext {}
 
-    @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{5-11=}}
+    @objc // access-note-move{{GenericContext3.MoreNested.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{5-11=}}
     class subject_inGenericContext2 : Class_ObjC1 {}
 
-    @objc
+    @objc // access-note-move{{GenericContext3.MoreNested.f()}}
     func f() {} // no-error
   }
 }
 
 class GenericContext4<T> {
-  @objc
-  func foo() where T: Hashable { } // expected-error {{instance method cannot be marked @objc because it has a 'where' clause}}
+  @objc // access-note-move{{GenericContext4.foo()}}
+  func foo() where T: Hashable { } // access-note-adjust expected-error {{instance method cannot be marked @objc because it has a 'where' clause}}
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
+@objc // access-note-move{{ConcreteSubclassOfGeneric}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class ConcreteSubclassOfGeneric : GenericContext3<Int> {}
 
 extension ConcreteSubclassOfGeneric {
-  @objc
+  @objc // access-note-move{{ConcreteSubclassOfGeneric.foo()}}
   func foo() {} // okay
 }
 
-@objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
+@objc // access-note-move{{ConcreteSubclassOfGeneric2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
 class ConcreteSubclassOfGeneric2 : subject_genericClass2<Int> {}
 
 extension ConcreteSubclassOfGeneric2 {
-  @objc
+  @objc // access-note-move{{ConcreteSubclassOfGeneric2.foo()}}
   func foo() {} // okay
 }
 
-@objc(CustomNameForSubclassOfGeneric) // okay
+@objc(CustomNameForSubclassOfGeneric) // access-note-move{{ConcreteSubclassOfGeneric3}} no-error
 class ConcreteSubclassOfGeneric3 : GenericContext3<Int> {}
 
 extension ConcreteSubclassOfGeneric3 {
-  @objc
+  @objc // access-note-move{{ConcreteSubclassOfGeneric3.foo()}}
   func foo() {} // okay
 }
 
 class subject_subscriptIndexed1 {
-  @objc
+  @objc // access-note-move{{subject_subscriptIndexed1.subscript(_:)}}
   subscript(a: Int) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptIndexed2 {
-  @objc
+  @objc // access-note-move{{subject_subscriptIndexed2.subscript(_:)}}
   subscript(a: Int8) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptIndexed3 {
-  @objc
+  @objc // access-note-move{{subject_subscriptIndexed3.subscript(_:)}}
   subscript(a: UInt8) -> Int { // no-error
     get { return 0 }
   }
 }
 
 class subject_subscriptKeyed1 {
-  @objc
+  @objc // access-note-move{{subject_subscriptKeyed1.subscript(_:)}}
   subscript(a: String) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptKeyed2 {
-  @objc
+  @objc // access-note-move{{subject_subscriptKeyed2.subscript(_:)}}
   subscript(a: Class_ObjC1) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptKeyed3 {
-  @objc
+  @objc // access-note-move{{subject_subscriptKeyed3.subscript(_:)}}
   subscript(a: Class_ObjC1.Type) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptKeyed4 {
-  @objc
+  @objc // access-note-move{{subject_subscriptKeyed4.subscript(_:)}}
   subscript(a: Protocol_ObjC1) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptKeyed5 {
-  @objc
+  @objc // access-note-move{{subject_subscriptKeyed5.subscript(_:)}}
   subscript(a: Protocol_ObjC1.Type) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptKeyed6 {
-  @objc
+  @objc // access-note-move{{subject_subscriptKeyed6.subscript(_:)}}
   subscript(a: Protocol_ObjC1 & Protocol_ObjC2) -> Int { // no-error
     get { return 0 }
   }
 }
 class subject_subscriptKeyed7 {
-  @objc
+  @objc // access-note-move{{subject_subscriptKeyed7.subscript(_:)}}
   subscript(a: (Protocol_ObjC1 & Protocol_ObjC2).Type) -> Int { // no-error
     get { return 0 }
   }
 }
 
 class subject_subscriptBridgedFloat {
-  @objc
+  @objc // access-note-move{{subject_subscriptBridgedFloat.subscript(_:)}}
   subscript(a: Float32) -> Int {
     get { return 0 }
   }
 }
 
 class subject_subscriptGeneric<T> {
-  @objc
+  @objc // access-note-move{{subject_subscriptGeneric.subscript(_:)}}
   subscript(a: Int) -> Int { // no-error
     get { return 0 }
   }
 }
 
 class subject_subscriptInvalid1 {
-  @objc
-  class subscript(_ i: Int) -> AnyObject? { // expected-error {{class subscript cannot be marked @objc}}
+  @objc // access-note-move{{subject_subscriptInvalid1.subscript(_:)}}
+  class subscript(_ i: Int) -> AnyObject? { // access-note-adjust expected-error {{class subscript cannot be marked @objc}}
     return nil
   }
 }
 
 class subject_subscriptInvalid2 {
-  @objc
+  @objc // access-note-move{{subject_subscriptInvalid2.subscript(_:)}}
   subscript(a: PlainClass) -> Int {
-  // expected-error@-1 {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid3 {
-  @objc
-  subscript(a: PlainClass.Type) -> Int { // expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  @objc // access-note-move{{subject_subscriptInvalid3.subscript(_:)}}
+  subscript(a: PlainClass.Type) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid4 {
-  @objc
-  subscript(a: PlainStruct) -> Int { // expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  @objc // access-note-move{{subject_subscriptInvalid4.subscript(_:)}}
+  subscript(a: PlainStruct) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{Swift structs cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid5 {
-  @objc
-  subscript(a: PlainEnum) -> Int { // expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  @objc // access-note-move{{subject_subscriptInvalid5.subscript(_:)}}
+  subscript(a: PlainEnum) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{enums cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid6 {
-  @objc
-  subscript(a: PlainProtocol) -> Int { // expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  @objc // access-note-move{{subject_subscriptInvalid6.subscript(_:)}}
+  subscript(a: PlainProtocol) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid7 {
-  @objc
-  subscript(a: Protocol_Class1) -> Int { // expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  @objc // access-note-move{{subject_subscriptInvalid7.subscript(_:)}}
+  subscript(a: Protocol_Class1) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid8 {
-  @objc
-  subscript(a: Protocol_Class1 & Protocol_Class2) -> Int { // expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  @objc // access-note-move{{subject_subscriptInvalid8.subscript(_:)}}
+  subscript(a: Protocol_Class1 & Protocol_Class2) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 
 class subject_propertyInvalid1 {
-  @objc
-  let plainStruct = PlainStruct() // expected-error {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  @objc // access-note-move{{subject_propertyInvalid1.plainStruct}}
+  let plainStruct = PlainStruct() // access-note-adjust expected-error {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-1{{Swift structs cannot be represented in Objective-C}}
 }
 
 //===--- Tests for @objc inference.
 
-@objc
+@objc // access-note-move{{infer_instanceFunc1}}
 class infer_instanceFunc1 {
 // CHECK-LABEL: @objc class infer_instanceFunc1 {
 
   func func1() {}
 // CHECK-LABEL: @objc func func1() {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func1_()}}
   func func1_() {} // no-error
 
   func func2(a: Int) {}
 // CHECK-LABEL: @objc func func2(a: Int) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func2_(a:)}}
   func func2_(a: Int) {} // no-error
 
   func func3(a: Int) -> Int {}
 // CHECK-LABEL: @objc func func3(a: Int) -> Int {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func3_(a:)}}
   func func3_(a: Int) -> Int {} // no-error
 
   func func4(a: Int, b: Double) {}
 // CHECK-LABEL: @objc func func4(a: Int, b: Double) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func4_(a:b:)}}
   func func4_(a: Int, b: Double) {} // no-error
 
   func func5(a: String) {}
 // CHECK-LABEL: @objc func func5(a: String) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func5_(a:)}}
   func func5_(a: String) {} // no-error
 
   func func6() -> String {}
 // CHECK-LABEL: @objc func func6() -> String {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func6_()}}
   func func6_() -> String {} // no-error
 
   func func7(a: PlainClass) {}
 // CHECK-LABEL: {{^}} func func7(a: PlainClass) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func7_(a:)}}
   func func7_(a: PlainClass) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   func func7m(a: PlainClass.Type) {}
 // CHECK-LABEL: {{^}} func func7m(a: PlainClass.Type) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func7m_(a:)}}
   func func7m_(a: PlainClass.Type) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 
   func func8() -> PlainClass {}
 // CHECK-LABEL: {{^}} func func8() -> PlainClass {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func8_()}}
   func func8_() -> PlainClass {}
-  // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   func func8m() -> PlainClass.Type {}
 // CHECK-LABEL: {{^}} func func8m() -> PlainClass.Type {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func8m_()}}
   func func8m_() -> PlainClass.Type {}
-  // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   func func9(a: PlainStruct) {}
 // CHECK-LABEL: {{^}} func func9(a: PlainStruct) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func9_(a:)}}
   func func9_(a: PlainStruct) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   func func10() -> PlainStruct {}
 // CHECK-LABEL: {{^}} func func10() -> PlainStruct {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func10_()}}
   func func10_() -> PlainStruct {}
-  // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   func func11(a: PlainEnum) {}
 // CHECK-LABEL: {{^}} func func11(a: PlainEnum) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func11_(a:)}}
   func func11_(a: PlainEnum) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
 
   func func12(a: PlainProtocol) {}
 // CHECK-LABEL: {{^}} func func12(a: PlainProtocol) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func12_(a:)}}
   func func12_(a: PlainProtocol) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   func func13(a: Class_ObjC1) {}
 // CHECK-LABEL: @objc func func13(a: Class_ObjC1) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func13_(a:)}}
   func func13_(a: Class_ObjC1) {} // no-error
 
   func func14(a: Protocol_Class1) {}
 // CHECK-LABEL: {{^}} func func14(a: Protocol_Class1) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func14_(a:)}}
   func func14_(a: Protocol_Class1) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   func func15(a: Protocol_ObjC1) {}
 // CHECK-LABEL: @objc func func15(a: Protocol_ObjC1) {
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func15_(a:)}}
   func func15_(a: Protocol_ObjC1) {} // no-error
 
   func func16(a: AnyObject) {}
 // CHECK-LABEL: @objc func func16(a: AnyObject) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func16_(a:)}}
   func func16_(a: AnyObject) {} // no-error
 
   func func17(a: @escaping () -> ()) {}
 // CHECK-LABEL: {{^}}  @objc func func17(a: @escaping () -> ()) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func17_(a:)}}
   func func17_(a: @escaping () -> ()) {}
 
   func func18(a: @escaping (Int) -> (), b: Int) {}
 // CHECK-LABEL: {{^}}  @objc func func18(a: @escaping (Int) -> (), b: Int)
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func18_(a:b:)}}
   func func18_(a: @escaping (Int) -> (), b: Int) {}
 
   func func19(a: @escaping (String) -> (), b: Int) {}
 // CHECK-LABEL: {{^}}  @objc func func19(a: @escaping (String) -> (), b: Int) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func19_(a:b:)}}
   func func19_(a: @escaping (String) -> (), b: Int) {}
 
   func func_FunctionReturn1() -> () -> () {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn1() -> () -> () {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_FunctionReturn1_()}}
   func func_FunctionReturn1_() -> () -> () {}
 
   func func_FunctionReturn2() -> (Int) -> () {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn2() -> (Int) -> () {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_FunctionReturn2_()}}
   func func_FunctionReturn2_() -> (Int) -> () {}
 
   func func_FunctionReturn3() -> () -> Int {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn3() -> () -> Int {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_FunctionReturn3_()}}
   func func_FunctionReturn3_() -> () -> Int {}
 
   func func_FunctionReturn4() -> (String) -> () {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn4() -> (String) -> () {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_FunctionReturn4_()}}
   func func_FunctionReturn4_() -> (String) -> () {}
 
   func func_FunctionReturn5() -> () -> String {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn5() -> () -> String {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_FunctionReturn5_()}}
   func func_FunctionReturn5_() -> () -> String {}
 
 
   func func_ZeroParams1() {}
 // CHECK-LABEL: @objc func func_ZeroParams1() {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_ZeroParams1a()}}
   func func_ZeroParams1a() {} // no-error
 
 
   func func_OneParam1(a: Int) {}
 // CHECK-LABEL: @objc func func_OneParam1(a: Int) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_OneParam1a(a:)}}
   func func_OneParam1a(a: Int) {} // no-error
 
 
   func func_TupleStyle1(a: Int, b: Int) {}
   // CHECK-LABEL: {{^}} @objc func func_TupleStyle1(a: Int, b: Int) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_TupleStyle1a(a:b:)}}
   func func_TupleStyle1a(a: Int, b: Int) {}
 
   func func_TupleStyle2(a: Int, b: Int, c: Int) {}
 // CHECK-LABEL: {{^}} @objc func func_TupleStyle2(a: Int, b: Int, c: Int) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_TupleStyle2a(a:b:c:)}}
   func func_TupleStyle2a(a: Int, b: Int, c: Int) {}
 
   // Check that we produce diagnostics for every parameter and return type.
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_MultipleDiags(a:b:)}}
   func func_MultipleDiags(a: PlainStruct, b: PlainEnum) -> Any {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter 1 cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter 1 cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
-  // expected-error@-3 {{method cannot be marked @objc because the type of the parameter 2 cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-3 {{method cannot be marked @objc because the type of the parameter 2 cannot be represented in Objective-C}}
   // expected-note@-4 {{non-'@objc' enums cannot be represented in Objective-C}}
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_UnnamedParam1(_:)}}
   func func_UnnamedParam1(_: Int) {} // no-error
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_UnnamedParam2(_:)}}
   func func_UnnamedParam2(_: PlainStruct) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
-  @objc
+  @objc // access-note-move{{infer_instanceFunc1.func_varParam1(a:)}}
   func func_varParam1(a: AnyObject) {
     var a = a
     let b = a; a = b
@@ -832,7 +891,7 @@ class infer_instanceFunc1 {
 // CHECK-LABEL: @objc func func_varParam2(a: AnyObject) {
 }
 
-@objc
+@objc // access-note-move{{infer_constructor1}}
 class infer_constructor1 {
 // CHECK-LABEL: @objc class infer_constructor1
 
@@ -852,7 +911,7 @@ class infer_constructor1 {
   // CHECK: @objc init(forMurder _: ())
 }
 
-@objc
+@objc // access-note-move{{infer_destructor1}}
 class infer_destructor1 {
 // CHECK-LABEL: @objc class infer_destructor1
 
@@ -868,7 +927,7 @@ class infer_destructor2 {
   // CHECK: @objc deinit
 }
 
-@objc
+@objc // access-note-move{{infer_instanceVar1}}
 class infer_instanceVar1 {
 // CHECK-LABEL: @objc class infer_instanceVar1 {
   init() {}
@@ -880,10 +939,11 @@ class infer_instanceVar1 {
   // CHECK: @objc var instanceVar2: Int
   // CHECK: {{^}}  var instanceVar3: PlainProtocol
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.instanceVar1_}}
   var (instanceVar1_, instanceVar2_): (Int, PlainProtocol)
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
+  // Fake for access notes: @objc // access-note-move@-3{{infer_instanceVar1.instanceVar2_}}
 
   var intstanceVar4: Int {
   // CHECK: @objc var intstanceVar4: Int {
@@ -899,7 +959,7 @@ class infer_instanceVar1 {
     // CHECK-NEXT: @objc set {}
   }
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.instanceVar5_}}
   var instanceVar5_: Int {
   // CHECK: @objc var instanceVar5_: Int {
     get {}
@@ -918,7 +978,7 @@ class infer_instanceVar1 {
     // CHECK-NEXT: {{^}} @objc set {
   }
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.observingAccessorsVar1_}}
   var observingAccessorsVar1_: Int {
   // CHECK: {{^}} @objc @_hasStorage var observingAccessorsVar1_: Int {
     willSet {}
@@ -955,31 +1015,31 @@ class infer_instanceVar1 {
   var var_tuple1: ()
 // CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple1: ()
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_tuple1_}}
   var var_tuple1_: ()
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
 
   var var_tuple2: Void
 // CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple2: Void
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_tuple2_}}
   var var_tuple2_: Void
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
 
   var var_tuple3: (Int)
 // CHECK-LABEL: @objc var var_tuple3: (Int)
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_tuple3_}}
   var var_tuple3_: (Int) // no-error
 
   var var_tuple4: (Int, Int)
 // CHECK-LABEL: {{^}} var var_tuple4: (Int, Int)
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_tuple4_}}
   var var_tuple4_: (Int, Int)
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{tuples cannot be represented in Objective-C}}
 
   //===--- Stdlib integer types.
@@ -1008,107 +1068,107 @@ class infer_instanceVar1 {
   var var_PlainClass: PlainClass
 // CHECK-LABEL: {{^}}  var var_PlainClass: PlainClass
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainClass_}}
   var var_PlainClass_: PlainClass
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   var var_PlainStruct: PlainStruct
 // CHECK-LABEL: {{^}}  var var_PlainStruct: PlainStruct
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainStruct_}}
   var var_PlainStruct_: PlainStruct
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_PlainEnum: PlainEnum
 // CHECK-LABEL: {{^}} var var_PlainEnum: PlainEnum
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainEnum_}}
   var var_PlainEnum_: PlainEnum
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
 
   var var_PlainProtocol: PlainProtocol
 // CHECK-LABEL: {{^}}  var var_PlainProtocol: PlainProtocol
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainProtocol_}}
   var var_PlainProtocol_: PlainProtocol
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_ClassObjC: Class_ObjC1
 // CHECK-LABEL: @objc var var_ClassObjC: Class_ObjC1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ClassObjC_}}
   var var_ClassObjC_: Class_ObjC1 // no-error
 
   var var_ProtocolClass: Protocol_Class1
 // CHECK-LABEL: {{^}}  var var_ProtocolClass: Protocol_Class1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ProtocolClass_}}
   var var_ProtocolClass_: Protocol_Class1
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_ProtocolObjC: Protocol_ObjC1
 // CHECK-LABEL: @objc var var_ProtocolObjC: Protocol_ObjC1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ProtocolObjC_}}
   var var_ProtocolObjC_: Protocol_ObjC1 // no-error
 
 
   var var_PlainClassMetatype: PlainClass.Type
 // CHECK-LABEL: {{^}}  var var_PlainClassMetatype: PlainClass.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainClassMetatype_}}
   var var_PlainClassMetatype_: PlainClass.Type
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainStructMetatype: PlainStruct.Type
 // CHECK-LABEL: {{^}}  var var_PlainStructMetatype: PlainStruct.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainStructMetatype_}}
   var var_PlainStructMetatype_: PlainStruct.Type
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainEnumMetatype: PlainEnum.Type
 // CHECK-LABEL: {{^}}  var var_PlainEnumMetatype: PlainEnum.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainEnumMetatype_}}
   var var_PlainEnumMetatype_: PlainEnum.Type
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainExistentialMetatype: PlainProtocol.Type
 // CHECK-LABEL: {{^}}  var var_PlainExistentialMetatype: PlainProtocol.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_PlainExistentialMetatype_}}
   var var_PlainExistentialMetatype_: PlainProtocol.Type
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ClassObjCMetatype: Class_ObjC1.Type
 // CHECK-LABEL: @objc var var_ClassObjCMetatype: Class_ObjC1.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ClassObjCMetatype_}}
   var var_ClassObjCMetatype_: Class_ObjC1.Type // no-error
 
   var var_ProtocolClassMetatype: Protocol_Class1.Type
 // CHECK-LABEL: {{^}}  var var_ProtocolClassMetatype: Protocol_Class1.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ProtocolClassMetatype_}}
   var var_ProtocolClassMetatype_: Protocol_Class1.Type
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ProtocolObjCMetatype1: Protocol_ObjC1.Type
 // CHECK-LABEL: @objc var var_ProtocolObjCMetatype1: Protocol_ObjC1.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ProtocolObjCMetatype1_}}
   var var_ProtocolObjCMetatype1_: Protocol_ObjC1.Type // no-error
 
   var var_ProtocolObjCMetatype2: Protocol_ObjC2.Type
 // CHECK-LABEL: @objc var var_ProtocolObjCMetatype2: Protocol_ObjC2.Type
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ProtocolObjCMetatype2_}}
   var var_ProtocolObjCMetatype2_: Protocol_ObjC2.Type // no-error
 
   var var_AnyObject1: AnyObject
@@ -1119,75 +1179,75 @@ class infer_instanceVar1 {
   var var_Existential0: Any
 // CHECK-LABEL: @objc var var_Existential0: Any
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential0_}}
   var var_Existential0_: Any
 
   var var_Existential1: PlainProtocol
   // CHECK-LABEL: {{^}}  var var_Existential1: PlainProtocol
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential1_}}
   var var_Existential1_: PlainProtocol
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential2: PlainProtocol & PlainProtocol
 // CHECK-LABEL: {{^}}  var var_Existential2: PlainProtocol
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential2_}}
   var var_Existential2_: PlainProtocol & PlainProtocol
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential3: PlainProtocol & Protocol_Class1
 // CHECK-LABEL: {{^}}  var var_Existential3: PlainProtocol & Protocol_Class1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential3_}}
   var var_Existential3_: PlainProtocol & Protocol_Class1
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential4: PlainProtocol & Protocol_ObjC1
 // CHECK-LABEL: {{^}}  var var_Existential4: PlainProtocol & Protocol_ObjC1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential4_}}
   var var_Existential4_: PlainProtocol & Protocol_ObjC1
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential5: Protocol_Class1
   // CHECK-LABEL: {{^}}  var var_Existential5: Protocol_Class1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential5_}}
   var var_Existential5_: Protocol_Class1
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential6: Protocol_Class1 & Protocol_Class2
 // CHECK-LABEL: {{^}}  var var_Existential6: Protocol_Class1 & Protocol_Class2
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential6_}}
   var var_Existential6_: Protocol_Class1 & Protocol_Class2
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential7: Protocol_Class1 & Protocol_ObjC1
 // CHECK-LABEL: {{^}}  var var_Existential7: Protocol_Class1 & Protocol_ObjC1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential7_}}
   var var_Existential7_: Protocol_Class1 & Protocol_ObjC1
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential8: Protocol_ObjC1
 // CHECK-LABEL: @objc var var_Existential8: Protocol_ObjC1
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential8_}}
   var var_Existential8_: Protocol_ObjC1 // no-error
 
   var var_Existential9: Protocol_ObjC1 & Protocol_ObjC2
 // CHECK-LABEL: @objc var var_Existential9: Protocol_ObjC1 & Protocol_ObjC2
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_Existential9_}}
   var var_Existential9_: Protocol_ObjC1 & Protocol_ObjC2 // no-error
 
 
@@ -1441,141 +1501,141 @@ class infer_instanceVar1 {
   var var_FunctionTypeReturn1: () -> () -> ()
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn1: () -> () -> ()
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_FunctionTypeReturn1_}}
   var var_FunctionTypeReturn1_: () -> () -> () // no-error
 
   var var_FunctionTypeReturn2: () -> (Int) -> ()
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn2: () -> (Int) -> ()
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_FunctionTypeReturn2_}}
   var var_FunctionTypeReturn2_: () -> (Int) -> () // no-error
 
   var var_FunctionTypeReturn3: () -> () -> Int
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn3: () -> () -> Int
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_FunctionTypeReturn3_}}
   var var_FunctionTypeReturn3_: () -> () -> Int // no-error
 
   var var_FunctionTypeReturn4: () -> (String) -> ()
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn4: () -> (String) -> ()
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_FunctionTypeReturn4_}}
   var var_FunctionTypeReturn4_: () -> (String) -> () // no-error
 
   var var_FunctionTypeReturn5: () -> () -> String
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn5: () -> () -> String
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_FunctionTypeReturn5_}}
   var var_FunctionTypeReturn5_: () -> () -> String // no-error
 
 
   var var_BlockFunctionType1: @convention(block) () -> ()
 // CHECK-LABEL: @objc var var_BlockFunctionType1: @convention(block) () -> ()
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_BlockFunctionType1_}}
   var var_BlockFunctionType1_: @convention(block) () -> () // no-error
 
   var var_ArrayType1: [AnyObject]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType1: [AnyObject]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType1_}}
   var var_ArrayType1_: [AnyObject] // no-error
 
   var var_ArrayType2: [@convention(block) (AnyObject) -> AnyObject] // no-error
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType2: [@convention(block) (AnyObject) -> AnyObject]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType2_}}
   var var_ArrayType2_: [@convention(block) (AnyObject) -> AnyObject] // no-error
 
   var var_ArrayType3: [PlainStruct]
   // CHECK-LABEL: {{^}}  var var_ArrayType3: [PlainStruct]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType3_}}
   var var_ArrayType3_: [PlainStruct]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType4: [(AnyObject) -> AnyObject] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType4: [(AnyObject) -> AnyObject]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType4_}}
   var var_ArrayType4_: [(AnyObject) -> AnyObject]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType5: [Protocol_ObjC1]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType5: [Protocol_ObjC1]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType5_}}
   var var_ArrayType5_: [Protocol_ObjC1] // no-error
 
   var var_ArrayType6: [Class_ObjC1]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType6: [Class_ObjC1]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType6_}}
   var var_ArrayType6_: [Class_ObjC1] // no-error
 
   var var_ArrayType7: [PlainClass]
   // CHECK-LABEL: {{^}}  var var_ArrayType7: [PlainClass]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType7_}}
   var var_ArrayType7_: [PlainClass]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType8: [PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType8: [PlainProtocol]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType8_}}
   var var_ArrayType8_: [PlainProtocol]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType9: [Protocol_ObjC1 & PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType9: [PlainProtocol & Protocol_ObjC1]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType9_}}
   var var_ArrayType9_: [Protocol_ObjC1 & PlainProtocol]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType10_}}
   var var_ArrayType10_: [Protocol_ObjC1 & Protocol_ObjC2]
   // no-error
 
   var var_ArrayType11: [Any]
   // CHECK-LABEL: @objc var var_ArrayType11: [Any]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType11_}}
   var var_ArrayType11_: [Any]
 
   var var_ArrayType13: [Any?]
   // CHECK-LABEL: {{^}}  var var_ArrayType13: [Any?]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType13_}}
   var var_ArrayType13_: [Any?]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType15: [AnyObject?]
   // CHECK-LABEL: {{^}}  var var_ArrayType15: [AnyObject?]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType15_}}
   var var_ArrayType15_: [AnyObject?]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType16: [[@convention(block) (AnyObject) -> AnyObject]] // no-error
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType16: {{\[}}[@convention(block) (AnyObject) -> AnyObject]]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType16_}}
   var var_ArrayType16_: [[@convention(block) (AnyObject) -> AnyObject]] // no-error
 
   var var_ArrayType17: [[(AnyObject) -> AnyObject]] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType17: {{\[}}[(AnyObject) -> AnyObject]]
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar1.var_ArrayType17_}}
   var var_ArrayType17_: [[(AnyObject) -> AnyObject]]
-  // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 }
 
-@objc
+@objc // access-note-move{{ObjCBase}}
 class ObjCBase {}
 
 class infer_instanceVar2<
@@ -1591,67 +1651,67 @@ class infer_instanceVar2<
   var var_GP_Unconstrained: GP_Unconstrained
 // CHECK-LABEL: {{^}}  var var_GP_Unconstrained: GP_Unconstrained
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.var_GP_Unconstrained_}}
   var var_GP_Unconstrained_: GP_Unconstrained
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_PlainClass: GP_PlainClass
 // CHECK-LABEL: {{^}}  var var_GP_PlainClass: GP_PlainClass
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.var_GP_PlainClass_}}
   var var_GP_PlainClass_: GP_PlainClass
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_PlainProtocol: GP_PlainProtocol
 // CHECK-LABEL: {{^}}  var var_GP_PlainProtocol: GP_PlainProtocol
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.var_GP_PlainProtocol_}}
   var var_GP_PlainProtocol_: GP_PlainProtocol
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Class_ObjC: GP_Class_ObjC
 // CHECK-LABEL: {{^}}  var var_GP_Class_ObjC: GP_Class_ObjC
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.var_GP_Class_ObjC_}}
   var var_GP_Class_ObjC_: GP_Class_ObjC
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Protocol_Class: GP_Protocol_Class
 // CHECK-LABEL: {{^}}  var var_GP_Protocol_Class: GP_Protocol_Class
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.var_GP_Protocol_Class_}}
   var var_GP_Protocol_Class_: GP_Protocol_Class
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Protocol_ObjC: GP_Protocol_ObjC
 // CHECK-LABEL: {{^}}  var var_GP_Protocol_ObjC: GP_Protocol_ObjC
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.var_GP_Protocol_ObjCa}}
   var var_GP_Protocol_ObjCa: GP_Protocol_ObjC
-  // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   func func_GP_Unconstrained(a: GP_Unconstrained) {}
 // CHECK-LABEL: {{^}} func func_GP_Unconstrained(a: GP_Unconstrained) {
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.func_GP_Unconstrained_(a:)}}
   func func_GP_Unconstrained_(a: GP_Unconstrained) {}
-  // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.func_GP_Unconstrained_()}}
   func func_GP_Unconstrained_() -> GP_Unconstrained {}
-  // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar2.func_GP_Class_ObjC__()}}
   func func_GP_Class_ObjC__() -> GP_Class_ObjC {}
-  // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 }
 
@@ -1663,7 +1723,7 @@ class infer_instanceVar3 : Class_ObjC1 {
 }
 
 
-@objc
+@objc // access-note-move{{infer_instanceVar4}}
 protocol infer_instanceVar4 {
 // CHECK-LABEL: @objc protocol infer_instanceVar4 {
 
@@ -1675,7 +1735,7 @@ protocol infer_instanceVar4 {
 class infer_instanceVar5 {
 // CHECK-LABEL: {{^}}class infer_instanceVar5 {
 
-  @objc
+  @objc // access-note-move{{infer_instanceVar5.intstanceVar1}}
   var intstanceVar1: Int {
   // CHECK: @objc var intstanceVar1: Int
     get {}
@@ -1685,7 +1745,7 @@ class infer_instanceVar5 {
   }
 }
 
-@objc
+@objc // access-note-move{{infer_staticVar1}}
 class infer_staticVar1 {
 // CHECK-LABEL: @objc class infer_staticVar1 {
 
@@ -1697,7 +1757,7 @@ class infer_staticVar1 {
 class infer_subscript1 {
 // CHECK-LABEL: class infer_subscript1
 
-  @objc
+  @objc // access-note-move{{infer_subscript1.subscript(_:)}}
   subscript(i: Int) -> Int {
   // CHECK: @objc subscript(i: Int) -> Int
     get {}
@@ -1708,7 +1768,7 @@ class infer_subscript1 {
 }
 
 
-@objc
+@objc // access-note-move{{infer_throughConformanceProto1}}
 protocol infer_throughConformanceProto1 {
 // CHECK-LABEL: @objc protocol infer_throughConformanceProto1 {
 
@@ -1775,7 +1835,7 @@ protocol infer_protocol5 : Protocol_ObjC1, Protocol_Class1 {
 
 class C {
   // Don't crash.
-  @objc
+  @objc // access-note-move{{C.foo(x:)}}
   func foo(x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBAction func myAction(sender: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBSegueAction func myAction(coder: Undeclared, sender: Undeclared) -> Undeclared {fatalError()} // expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}}
@@ -1877,7 +1937,7 @@ class HasNSManaged {
 //===--- Pointer argument types
 //===---
 
-@objc
+@objc // access-note-move{{TakesCPointers}}
 class TakesCPointers {
 // CHECK-LABEL: {{^}}@objc class TakesCPointers {
   func constUnsafeMutablePointer(p: UnsafePointer<Int>) {}
@@ -1900,36 +1960,36 @@ class TakesCPointers {
   }
 
 // @objc with nullary names
-@objc(NSObjC2)
+@objc(NSObjC2) // access-note-move{{Class_ObjC2}}
 class Class_ObjC2 {
 // CHECK-LABEL: @objc(NSObjC2) class Class_ObjC2
 
-  @objc(initWithMalice)
+  @objc(initWithMalice) // access-note-move{{Class_ObjC2.init(foo:)}}
   init(foo: ()) { }
 
-  @objc(initWithIntent)
+  @objc(initWithIntent) // access-note-move{{Class_ObjC2.init(bar:)}}
   init(bar _: ()) { }
 
-  @objc(initForMurder)
+  @objc(initForMurder) // access-note-move{{Class_ObjC2.init()}}
   init() { }
 
-  @objc(isFoo)
+  @objc(isFoo) // access-note-move{{Class_ObjC2.foo()}}
   func foo() -> Bool {}
   // CHECK-LABEL: @objc(isFoo) func foo() -> Bool {
 }
 
-@objc() // expected-error{{expected name within parentheses of @objc attribute}}
+@objc() // expected-error {{expected name within parentheses of @objc attribute}}
 class Class_ObjC3 { 
 }
 
 // @objc with selector names
 extension PlainClass {
   // CHECK-LABEL: @objc(setFoo:) dynamic func
-  @objc(setFoo:)
+  @objc(setFoo:) // access-note-move{{PlainClass.foo(b:)}}
   func foo(b: Bool) { }
 
   // CHECK-LABEL: @objc(setWithRed:green:blue:alpha:) dynamic func set
-  @objc(setWithRed:green:blue:alpha:)
+  @objc(setWithRed:green:blue:alpha:) // access-note-move{{PlainClass.set(_:green:blue:alpha:)}}
   func set(_: Float, green: Float, blue: Float, alpha: Float) { }
 
   // CHECK-LABEL: @objc(createWithRed:green:blue:alpha:) dynamic class func createWith
@@ -1939,22 +1999,22 @@ extension PlainClass {
   // expected-error@-3{{missing ':' after selector piece in @objc attribute}}{{39-39=:}}
 
   // CHECK-LABEL: @objc(::) dynamic func badlyNamed
-  @objc(::)
+  @objc(::) // access-note-move{{PlainClass.badlyNamed(_:y:)}}
   func badlyNamed(_: Int, y: Int) {}
 }
 
-@objc(Class:) // expected-error{{'@objc' class must have a simple name}}{{12-13=}}
+@objc(Class:) // access-note-move{{BadClass1}} expected-error{{'@objc' class must have a simple name}}{{12-13=}}
 class BadClass1 { }
 
-@objc(Protocol:) // expected-error{{'@objc' protocol must have a simple name}}{{15-16=}}
+@objc(Protocol:) // access-note-move{{BadProto1}} expected-error{{'@objc' protocol must have a simple name}}{{15-16=}}
 protocol BadProto1 { }
 
-@objc(Enum:) // expected-error{{'@objc' enum must have a simple name}}{{11-12=}}
+@objc(Enum:) // access-note-move{{BadEnum1}} expected-error{{'@objc' enum must have a simple name}}{{11-12=}}
 enum BadEnum1: Int { case X }
 
-@objc
+@objc // access-note-move{{BadEnum2}}
 enum BadEnum2: Int {
-  @objc(X:) // expected-error{{'@objc' enum case must have a simple name}}{{10-11=}}
+  @objc(X:) // access-note-move{{BadEnum2.X}} expected-error{{'@objc' enum case must have a simple name}}{{10-11=}}
   case X
 }
 
@@ -1962,63 +2022,67 @@ class BadClass2 {
   @objc(realDealloc) // expected-error{{'@objc' deinitializer cannot have a name}}
   deinit { }
 
-  @objc(badprop:foo:wibble:) // expected-error{{'@objc' property must have a simple name}}{{16-28=}}
+  @objc(badprop:foo:wibble:) // access-note-move{{BadClass2.badprop}} expected-error{{'@objc' property must have a simple name}}{{16-28=}}
   var badprop: Int = 5
 
-  @objc(foo) // expected-error{{'@objc' subscript cannot have a name; did you mean to put the name on the getter or setter?}}
+  @objc(foo) // access-note-move{{BadClass2.subscript(_:)}} expected-error{{'@objc' subscript cannot have a name; did you mean to put the name on the getter or setter?}}
   subscript (i: Int) -> Int {
     get {
       return i
     }
   }
 
-  @objc(foo) // expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
+  @objc(foo) // access-note-move{{BadClass2.noArgNamesOneParam(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
   func noArgNamesOneParam(x: Int) { }
   
-  @objc(foo) // expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
+  @objc(foo) // access-note-move{{BadClass2.noArgNamesOneParam2(_:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
   func noArgNamesOneParam2(_: Int) { }
 
-  @objc(foo) // expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters}}
+  @objc(foo) // access-note-move{{BadClass2.noArgNamesTwoParams(_:y:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters}}
   func noArgNamesTwoParams(_: Int, y: Int) { }
 
-  @objc(foo:) // expected-error{{'@objc' method name provides one argument name, but method has 2 parameters}}
+  @objc(foo:) // access-note-move{{BadClass2.oneArgNameTwoParams(_:y:)}} expected-error{{'@objc' method name provides one argument name, but method has 2 parameters}}
   func oneArgNameTwoParams(_: Int, y: Int) { }
 
-  @objc(foo:) // expected-error{{'@objc' method name provides one argument name, but method has 0 parameters}}
+  @objc(foo:) // access-note-move{{BadClass2.oneArgNameNoParams()}} expected-error{{'@objc' method name provides one argument name, but method has 0 parameters}}
   func oneArgNameNoParams() { }
 
-  @objc(foo:) // expected-error{{'@objc' initializer name provides one argument name, but initializer has 0 parameters}}
+  @objc(foo:) // access-note-move{{BadClass2.init()}} expected-error{{'@objc' initializer name provides one argument name, but initializer has 0 parameters}}
   init() { }
 
   var _prop = 5
-  @objc
+  @objc // access-note-move{{BadClass2.prop}}
   var prop: Int {
-    @objc(property)
+    @objc(property) // access-note-move{{getter:BadClass2.prop()}}
     get { return _prop }
-    @objc(setProperty:)
+    @objc(setProperty:) // access-note-move{{setter:BadClass2.prop()}}
     set { _prop = newValue }
   }
 
   var prop2: Int {
-    @objc(property)
-    get { return _prop } // expected-error{{'@objc' getter for non-'@objc' property}}
-    @objc(setProperty:)
-    set { _prop = newValue } // expected-error{{'@objc' setter for non-'@objc' property}}
+    @objc(property) // access-note-move{{getter:BadClass2.prop2()}}
+    get { return _prop } // access-note-adjust expected-error{{'@objc' getter for non-'@objc' property}}
+    @objc(setProperty:) // access-note-move{{setter:BadClass2.prop2()}}
+    set { _prop = newValue } // access-note-adjust expected-error{{'@objc' setter for non-'@objc' property}}
   }
 
   var prop3: Int {
     @objc(setProperty:) // expected-error{{observing accessors are not allowed to be marked @objc}} {{5-25=}}
     didSet { }
   }
+}
 
-  @objc
+// FIXME: This could be part of BadClass except that access notes can't
+// distinguish between overloads of `subscript(_:)`.
+class GoodClass {
+  @objc // access-note-move{{GoodClass.subscript(_:)}}
   subscript (c: Class_ObjC1) -> Class_ObjC1 {
-    @objc(getAtClass:)
+    @objc(getAtClass:) // access-note-move{{getter:GoodClass.subscript(_:)}}
     get {
       return c
     }
 
-    @objc(setAtClass:class:)
+    @objc(setAtClass:class:) // access-note-move{{setter:GoodClass.subscript(_:)}}
     set {
     }
   }
@@ -2026,22 +2090,22 @@ class BadClass2 {
 
 // Swift overrides that aren't also @objc overrides.
 class Super {
-  @objc(renamedFoo)
+  @objc(renamedFoo) // access-note-move{{Super.foo}}
   var foo: Int { get { return 3 } } // expected-note 2{{overridden declaration is here}}
 
-  @objc
+  @objc // access-note-move{{Super.process(i:)}}
   func process(i: Int) -> Int { } // expected-note {{overriding '@objc' method 'process(i:)' here}}
 }
 
 class Sub1 : Super {
-  @objc(foo) // expected-error{{Objective-C property has a different name from the property it overrides ('foo' vs. 'renamedFoo')}}{{9-12=renamedFoo}}
+  @objc(foo) // access-note-move{{Sub1.foo}} expected-error{{Objective-C property has a different name from the property it overrides ('foo' vs. 'renamedFoo')}}{{9-12=renamedFoo}}
   override var foo: Int { get { return 5 } }
 
   override func process(i: Int?) -> Int { } // expected-error{{method cannot be an @objc override because the type of the parameter cannot be represented in Objective-C}}
 }
 
 class Sub2 : Super {
-  @objc
+  @objc // access-note-move{{Sub2.foo}}
   override var foo: Int { get { return 5 } }
 }
 
@@ -2050,12 +2114,12 @@ class Sub3 : Super {
 }
 
 class Sub4 : Super {
-  @objc(renamedFoo)
+  @objc(renamedFoo) // access-note-move{{Sub4.foo}}
   override var foo: Int { get { return 5 } }
 }
 
 class Sub5 : Super {
-  @objc(wrongFoo) // expected-error{{Objective-C property has a different name from the property it overrides ('wrongFoo' vs. 'renamedFoo')}} {{9-17=renamedFoo}}
+  @objc(wrongFoo) // access-note-move{{Sub5.foo}} expected-error{{Objective-C property has a different name from the property it overrides ('wrongFoo' vs. 'renamedFoo')}} {{9-17=renamedFoo}}
   override var foo: Int { get { return 5 } }
 }
 
@@ -2064,25 +2128,25 @@ struct NotObjCStruct {}
 
 // Closure arguments can only be @objc if their parameters and returns are.
 // CHECK-LABEL: @objc class ClosureArguments
-@objc
+@objc // access-note-move{{ClosureArguments}}
 class ClosureArguments {
   // CHECK: @objc func foo
-  @objc
+  @objc // access-note-move{{ClosureArguments.foo(f:)}}
   func foo(f: (Int) -> ()) {}
   // CHECK: @objc func bar
-  @objc
-  func bar(f: (NotObjCEnum) -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc // access-note-move{{ClosureArguments.bar(f:)}}
+  func bar(f: (NotObjCEnum) -> NotObjCStruct) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func bas
-  @objc
-  func bas(f: (NotObjCEnum) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc // access-note-move{{ClosureArguments.bas(f:)}}
+  func bas(f: (NotObjCEnum) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zim
-  @objc
-  func zim(f: () -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc // access-note-move{{ClosureArguments.zim(f:)}}
+  func zim(f: () -> NotObjCStruct) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zang
-  @objc
-  func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
-  @objc
-  func zangZang(f: (Int...) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc // access-note-move{{ClosureArguments.zang(f:)}}
+  func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc // access-note-move{{ClosureArguments.zangZang(f:)}}
+  func zangZang(f: (Int...) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func fooImplicit
   func fooImplicit(f: (Int) -> ()) {}
   // CHECK: {{^}}  func barImplicit
@@ -2101,14 +2165,14 @@ typealias GoodBlock = @convention(block) (Int) -> ()
 typealias BadBlock = @convention(block) (NotObjCEnum) -> () // expected-error{{'(NotObjCEnum) -> ()' is not representable in Objective-C, so it cannot be used with '@convention(block)'}}
 
 
-@objc
+@objc // access-note-move{{AccessControl}}
 class AccessControl {
   // CHECK: @objc func foo
   func foo() {}
   // CHECK: {{^}} private func bar
   private func bar() {}
   // CHECK: @objc private func baz
-  @objc
+  @objc // access-note-move{{AccessControl.baz()}}
   private func baz() {}
 }
 
@@ -2121,50 +2185,50 @@ class Load1 {
   class func initialize() {}
 }
 
-@objc
+@objc // access-note-move{{Load2}}
 class Load2 {
-  class func load() { } // expected-error{{method 'load()' defines Objective-C class method 'load', which is not permitted by Swift}}
-  class func alloc() {} // expected-error{{method 'alloc()' defines Objective-C class method 'alloc', which is not permitted by Swift}}
-  class func allocWithZone(_: Int) {} // expected-error{{method 'allocWithZone' defines Objective-C class method 'allocWithZone:', which is not permitted by Swift}}
-  class func initialize() {} // expected-error{{method 'initialize()' defines Objective-C class method 'initialize', which is not permitted by Swift}}
+  class func load() { } // expected-error {{method 'load()' defines Objective-C class method 'load', which is not permitted by Swift}}
+  class func alloc() {} // expected-error {{method 'alloc()' defines Objective-C class method 'alloc', which is not permitted by Swift}}
+  class func allocWithZone(_: Int) {} // expected-error {{method 'allocWithZone' defines Objective-C class method 'allocWithZone:', which is not permitted by Swift}}
+  class func initialize() {} // expected-error {{method 'initialize()' defines Objective-C class method 'initialize', which is not permitted by Swift}}
 }
 
-@objc
+@objc // access-note-move{{Load3}}
 class Load3 {
   class var load: Load3 {
-    get { return Load3() } // expected-error{{getter for 'load' defines Objective-C class method 'load', which is not permitted by Swift}}
+    get { return Load3() } // expected-error {{getter for 'load' defines Objective-C class method 'load', which is not permitted by Swift}}
     set { }
   }
 
-  @objc(alloc)
-  class var prop: Int { return 0 } // expected-error{{getter for 'prop' defines Objective-C class method 'alloc', which is not permitted by Swift}}
-  @objc(allocWithZone:)
-  class func fooWithZone(_: Int) {} // expected-error{{method 'fooWithZone' defines Objective-C class method 'allocWithZone:', which is not permitted by Swift}}
-  @objc(initialize)
-  class func barnitialize() {} // expected-error{{method 'barnitialize()' defines Objective-C class method 'initialize', which is not permitted by Swift}}
+  @objc(alloc) // access-note-move{{Load3.prop}}
+  class var prop: Int { return 0 } // expected-error {{getter for 'prop' defines Objective-C class method 'alloc', which is not permitted by Swift}}
+  @objc(allocWithZone:) // access-note-move{{Load3.fooWithZone(_:)}}
+  class func fooWithZone(_: Int) {} // expected-error {{method 'fooWithZone' defines Objective-C class method 'allocWithZone:', which is not permitted by Swift}}
+  @objc(initialize) // access-note-move{{Load3.barnitialize()}}
+  class func barnitialize() {} // expected-error {{method 'barnitialize()' defines Objective-C class method 'initialize', which is not permitted by Swift}}
 }
 
 // Members of protocol extensions cannot be @objc
 
 extension PlainProtocol {
-  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{PlainProtocol.property}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   var property: Int { return 5 }
 
-  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{PlainProtocol.subscript(_:)}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() }
 
-  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{PlainProtocol.fun()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func fun() { }
 }
 
 extension Protocol_ObjC1 {
-  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{Protocol_ObjC1.property}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   var property: Int { return 5 }
 
-  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{Protocol_ObjC1.subscript(_:)}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() }
 
-  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // access-note-move{{Protocol_ObjC1.fun()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func fun() { }
 }
 
@@ -2180,60 +2244,60 @@ extension Protocol_ObjC1 {
 //===---
 class ClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
-  @objc
+  @objc // access-note-move{{ClassThrows1.methodReturnsVoid()}}
   func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
-  @objc
+  @objc // access-note-move{{ClassThrows1.methodReturnsObjCClass()}}
   func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
 
   // CHECK: @objc func methodReturnsBridged() throws -> String
-  @objc
+  @objc // access-note-move{{ClassThrows1.methodReturnsBridged()}}
   func methodReturnsBridged() throws -> String { return String() }
 
   // CHECK: @objc func methodReturnsArray() throws -> [String]
-  @objc
+  @objc // access-note-move{{ClassThrows1.methodReturnsArray()}}
   func methodReturnsArray() throws -> [String] { return [String]() }
 
   // CHECK: @objc init(degrees: Double) throws
-  @objc
+  @objc // access-note-move{{ClassThrows1.init(degrees:)}}
   init(degrees: Double) throws { }
 
   // Errors
 
-  @objc
-  func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil } // expected-error{{throwing method cannot be marked @objc because it returns a value of optional type 'Class_ObjC1?'; 'nil' indicates failure to Objective-C}}
+  @objc // access-note-move{{ClassThrows1.methodReturnsOptionalObjCClass()}}
+  func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of optional type 'Class_ObjC1?'; 'nil' indicates failure to Objective-C}}
 
-  @objc
-  func methodReturnsOptionalArray() throws -> [String]? { return nil } // expected-error{{throwing method cannot be marked @objc because it returns a value of optional type '[String]?'; 'nil' indicates failure to Objective-C}}
+  @objc // access-note-move{{ClassThrows1.methodReturnsOptionalArray()}}
+  func methodReturnsOptionalArray() throws -> [String]? { return nil } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of optional type '[String]?'; 'nil' indicates failure to Objective-C}}
 
-  @objc
-  func methodReturnsInt() throws -> Int { return 0 } // expected-error{{throwing method cannot be marked @objc because it returns a value of type 'Int'; return 'Void' or a type that bridges to an Objective-C class}}
+  @objc // access-note-move{{ClassThrows1.methodReturnsInt()}}
+  func methodReturnsInt() throws -> Int { return 0 } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of type 'Int'; return 'Void' or a type that bridges to an Objective-C class}}
 
-  @objc
+  @objc // access-note-move{{ClassThrows1.methodAcceptsThrowingFunc(fn:)}}
   func methodAcceptsThrowingFunc(fn: (String) throws -> Int) { }
-  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{throwing function types cannot be represented in Objective-C}}
 
-  @objc
-  init?(radians: Double) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
+  @objc // access-note-move{{ClassThrows1.init(radians:)}}
+  init?(radians: Double) throws { } // access-note-adjust expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
-  @objc
-  init!(string: String) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
+  @objc // access-note-move{{ClassThrows1.init(string:)}}
+  init!(string: String) throws { } // access-note-adjust expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
-  @objc
+  @objc // access-note-move{{ClassThrows1.fooWithErrorEnum1(x:)}}
   func fooWithErrorEnum1(x: ErrorEnum) {}
-  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{non-'@objc' enums cannot be represented in Objective-C}}
 
   // CHECK: {{^}} func fooWithErrorEnum2(x: ErrorEnum)
   func fooWithErrorEnum2(x: ErrorEnum) {}
 
-  @objc
+  @objc // access-note-move{{ClassThrows1.fooWithErrorProtocolComposition1(x:)}}
   func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
-  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{protocol-constrained type containing 'Error' cannot be represented in Objective-C}}
 
   // CHECK: {{^}} func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1)
@@ -2242,7 +2306,7 @@ class ClassThrows1 {
 
 
 // CHECK-DUMP-LABEL: class_decl{{.*}}"ImplicitClassThrows1"
-@objc
+@objc // access-note-move{{ImplicitClassThrows1}}
 class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
   // CHECK-DUMP: func_decl{{.*}}"methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
@@ -2274,11 +2338,11 @@ class ImplicitClassThrows1 {
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
   func methodReturnsBridgedValueType() throws -> NSRange { return NSRange() }
 
-  @objc
+  @objc // access-note-move{{ImplicitClassThrows1.methodReturnsBridgedValueType2()}}
   func methodReturnsBridgedValueType2() throws -> NSRange {
     return NSRange()
   }
-  // expected-error@-3{{throwing method cannot be marked @objc because it returns a value of type 'NSRange' (aka '_NSRange'); return 'Void' or a type that bridges to an Objective-C class}}
+  // access-note-adjust expected-error@-3{{throwing method cannot be marked @objc because it returns a value of type 'NSRange' (aka '_NSRange'); return 'Void' or a type that bridges to an Objective-C class}}
 
   // CHECK: {{^}} @objc func methodReturnsError() throws -> Error
   func methodReturnsError() throws -> Error { return ErrorEnum.failed }
@@ -2292,7 +2356,7 @@ class ImplicitClassThrows1 {
 }
 
 // CHECK-DUMP-LABEL: class_decl{{.*}}"SubclassImplicitClassThrows1"
-@objc
+@objc // access-note-move{{SubclassImplicitClassThrows1}}
 class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping ((Int) -> Int), fn3: @escaping ((Int) -> Int))
   // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
@@ -2300,56 +2364,56 @@ class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
 }
 
 class ThrowsRedecl1 {
-  @objc
+  @objc // access-note-move{{ThrowsRedecl1.method1(_:error:)}}
   func method1(_ x: Int, error: Class_ObjC1) { } // expected-note{{declared here}}
-  @objc
-  func method1(_ x: Int) throws { } // expected-error{{with Objective-C selector 'method1:error:'}}
+  @objc // access-note-move{{ThrowsRedecl1.method1(_:)}}
+  func method1(_ x: Int) throws { } // expected-error {{with Objective-C selector 'method1:error:'}}
 
-  @objc
+  @objc // access-note-move{{ThrowsRedecl1.method2AndReturnError(_:)}}
   func method2AndReturnError(_ x: Int) { } // expected-note{{declared here}}
-  @objc
-  func method2() throws { } // expected-error{{with Objective-C selector 'method2AndReturnError:'}}
+  @objc // access-note-move{{ThrowsRedecl1.method2()}}
+  func method2() throws { } // expected-error {{with Objective-C selector 'method2AndReturnError:'}}
 
-  @objc
+  @objc // access-note-move{{ThrowsRedecl1.method3(_:error:closure:)}}
   func method3(_ x: Int, error: Int, closure: @escaping (Int) -> Int) { }  // expected-note{{declared here}}
-  @objc
-  func method3(_ x: Int, closure: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'method3:error:closure:'}}
+  @objc // access-note-move{{ThrowsRedecl1.method3(_:closure:)}}
+  func method3(_ x: Int, closure: (Int) -> Int) throws { } // expected-error {{with Objective-C selector 'method3:error:closure:'}}
 
-  @objc(initAndReturnError:)
+  @objc(initAndReturnError:) // access-note-move{{ThrowsRedecl1.initMethod1(error:)}}
   func initMethod1(error: Int) { } // expected-note{{declared here}}
-  @objc
-  init() throws { } // expected-error{{with Objective-C selector 'initAndReturnError:'}}
+  @objc // access-note-move{{ThrowsRedecl1.init()}}
+  init() throws { } // expected-error {{with Objective-C selector 'initAndReturnError:'}}
 
-  @objc(initWithString:error:)
+  @objc(initWithString:error:) // access-note-move{{ThrowsRedecl1.initMethod2(string:error:)}}
   func initMethod2(string: String, error: Int) { } // expected-note{{declared here}}
-  @objc
-  init(string: String) throws { } // expected-error{{with Objective-C selector 'initWithString:error:'}}
+  @objc // access-note-move{{ThrowsRedecl1.init(string:)}}
+  init(string: String) throws { } // expected-error {{with Objective-C selector 'initWithString:error:'}}
 
-  @objc(initAndReturnError:fn:)
+  @objc(initAndReturnError:fn:) // access-note-move{{ThrowsRedecl1.initMethod3(error:fn:)}}
   func initMethod3(error: Int, fn: @escaping (Int) -> Int) { } // expected-note{{declared here}}
-  @objc
-  init(fn: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'initAndReturnError:fn:'}}
+  @objc // access-note-move{{ThrowsRedecl1.init(fn:)}}
+  init(fn: (Int) -> Int) throws { } // expected-error {{with Objective-C selector 'initAndReturnError:fn:'}}
 }
 
 class ThrowsObjCName {
-  @objc(method4:closure:error:)
+  @objc(method4:closure:error:) // access-note-move{{ThrowsObjCName.method4(x:closure:)}}
   func method4(x: Int, closure: @escaping (Int) -> Int) throws { }
 
-  @objc(method5AndReturnError:x:closure:)
+  @objc(method5AndReturnError:x:closure:) // access-note-move{{ThrowsObjCName.method5(x:closure:)}}
   func method5(x: Int, closure: @escaping (Int) -> Int) throws { }
 
-  @objc(method6) // expected-error{{@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
+  @objc(method6) // access-note-move{{ThrowsObjCName.method6()}} expected-error{{@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
   func method6() throws { }
 
-  @objc(method7) // expected-error{{@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
+  @objc(method7) // access-note-move{{ThrowsObjCName.method7(x:)}} expected-error{{@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
   func method7(x: Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
-  @objc(method8:fn1:error:fn2:)
+  @objc(method8:fn1:error:fn2:) // access-note-move{{ThrowsObjCName.method8(_:fn1:fn2:)}}
   func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
-  @objc(method9AndReturnError:s:fn1:fn2:)
+  @objc(method9AndReturnError:s:fn1:fn2:) // access-note-move{{ThrowsObjCName.method9(_:fn1:fn2:)}}
   func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
@@ -2361,19 +2425,19 @@ class SubclassThrowsObjCName : ThrowsObjCName {
   override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
-@objc
+@objc // access-note-move{{ProtocolThrowsObjCName}}
 protocol ProtocolThrowsObjCName {
-  @objc
+  @objc // Access notes don't allow the `optional` keyword, that's fine, honestly.
   optional func doThing(_ x: String) throws -> String // expected-note{{requirement 'doThing' declared here}}
 }
 
 class ConformsToProtocolThrowsObjCName1 : ProtocolThrowsObjCName {
-  @objc
+  @objc // access-note-move{{ConformsToProtocolThrowsObjCName1.doThing(_:)}}
   func doThing(_ x: String) throws -> String { return x } // okay
 }
 
 class ConformsToProtocolThrowsObjCName2 : ProtocolThrowsObjCName {
-  @objc
+  @objc // access-note-move{{ConformsToProtocolThrowsObjCName2.doThing(_:)}}
   func doThing(_ x: Int) throws -> String { return "" }
   // expected-warning@-1{{instance method 'doThing' nearly matches optional requirement 'doThing' of protocol 'ProtocolThrowsObjCName'}}
   // expected-note@-2{{move 'doThing' to an extension to silence this warning}}
@@ -2381,17 +2445,17 @@ class ConformsToProtocolThrowsObjCName2 : ProtocolThrowsObjCName {
   // expected-note@-4{{candidate has non-matching type '(Int) throws -> String'}}
 }
 
-@objc
+@objc // access-note-move{{DictionaryTest}}
 class DictionaryTest {
   // CHECK-LABEL: @objc func func_dictionary1a(x: Dictionary<ObjC_Class1, ObjC_Class1>)
   func func_dictionary1a(x: Dictionary<ObjC_Class1, ObjC_Class1>) { }
 
   // CHECK-LABEL: @objc func func_dictionary1b(x: Dictionary<ObjC_Class1, ObjC_Class1>)
-  @objc
+  @objc // access-note-move{{DictionaryTest.func_dictionary1b(x:)}}
   func func_dictionary1b(x: Dictionary<ObjC_Class1, ObjC_Class1>) { }
 
   func func_dictionary2a(x: Dictionary<String, Int>) { }
-  @objc
+  @objc // access-note-move{{DictionaryTest.func_dictionary2b(x:)}}
   func func_dictionary2b(x: Dictionary<String, Int>) { }
 }
 
@@ -2408,7 +2472,7 @@ extension PlainClass {
   @nonobjc final func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
 }
 
-@objc
+@objc // access-note-move{{ObjC_Class1}}
 class ObjC_Class1 : Hashable {
   func hash(into hasher: inout Hasher) {}
 }
@@ -2418,7 +2482,7 @@ func ==(lhs: ObjC_Class1, rhs: ObjC_Class1) -> Bool {
 }
 
 // CHECK-LABEL: @objc class OperatorInClass
-@objc
+@objc // access-note-move{{OperatorInClass}}
 class OperatorInClass {
   // CHECK: {{^}} static func == (lhs: OperatorInClass, rhs: OperatorInClass) -> Bool
   static func ==(lhs: OperatorInClass, rhs: OperatorInClass) -> Bool {
@@ -2431,7 +2495,7 @@ class OperatorInClass {
   }
 } // CHECK: {{^}$}}
 
-@objc
+@objc // access-note-move{{OperatorInProtocol}}
 protocol OperatorInProtocol {
   static func +(lhs: Self, rhs: Self) -> Self // expected-error {{@objc protocols must not have operator requirements}}
 }
@@ -2443,7 +2507,7 @@ class AdoptsOperatorInProtocol : OperatorInProtocol {
 
 //===--- @objc inference for witnesses
 
-@objc
+@objc // access-note-move{{InferFromProtocol}}
 protocol InferFromProtocol {
   @objc(inferFromProtoMethod1:)
   optional func method1(value: Int)
@@ -2500,9 +2564,9 @@ extension SubclassInfersFromProtocol2 {
   func method1(value: Int) { }
 }
 
-@objc
+@objc // access-note-move{{NeverReturningMethod}}
 class NeverReturningMethod {
-  @objc
+  @objc // access-note-move{{NeverReturningMethod.doesNotReturn()}}
   func doesNotReturn() -> Never {}
 }
 
@@ -2522,35 +2586,36 @@ extension User {
 	}
 
 	var other: String {
-    unsafeAddress { // expected-error{{addressors are not allowed to be marked @objc}}
+    unsafeAddress { // expected-error {{addressors are not allowed to be marked @objc}}
     }
   }
 }
 
 // 'dynamic' methods cannot be @inlinable.
 class BadClass {
-  @inlinable @objc dynamic func badMethod1() {}
+  @objc // access-note-move{{BadClass.badMethod1()}}
+  @inlinable dynamic func badMethod1() {}
   // expected-error@-1 {{'@inlinable' attribute cannot be applied to 'dynamic' declarations}}
 }
 
-@objc
+@objc // access-note-move{{ObjCProtocolWithWeakProperty}}
 protocol ObjCProtocolWithWeakProperty {
    weak var weakProp: AnyObject? { get set } // okay
 }
 
-@objc
+@objc // access-note-move{{ObjCProtocolWithUnownedProperty}}
 protocol ObjCProtocolWithUnownedProperty {
    unowned var unownedProp: AnyObject { get set } // okay
 }
 
 // rdar://problem/46699152: errors about read/modify accessors being implicitly
 // marked @objc.
-@objc
+@objc // access-note-move{{MyObjCClass}}
 class MyObjCClass: NSObject {}
 
 @objc
 extension MyObjCClass {
-    @objc
+    @objc // access-note-move{{MyObjCClass.objCVarInObjCExtension}}
     static var objCVarInObjCExtension: Bool {
         get {
             return true
@@ -2577,7 +2642,7 @@ private extension MyObjCClass {
 
 class SR_9035_C {}
 
-@objc
+@objc // access-note-move{{SR_9035_P}}
 protocol SR_9035_P {
   func throwingMethod1() throws -> Unmanaged<CFArray> // Ok
   func throwingMethod2() throws -> Unmanaged<SR_9035_C> // expected-error {{method cannot be a member of an @objc protocol because its result type cannot be represented in Objective-C}}
@@ -2586,7 +2651,7 @@ protocol SR_9035_P {
 
 // SR-12801: Make sure we reject an @objc generic subscript.
 class SR12801 {
-  @objc
+  @objc // access-note-move{{SR12801.subscript(_:)}}
   subscript<T>(foo : [T]) -> Int { return 0 }
-  // expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
+  // access-note-adjust expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
 }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -15,25 +15,31 @@ enum ErrorEnum : Error {
   case failed
 }
 
-@objc class Class_ObjC1 {}
+@objc
+class Class_ObjC1 {}
 
 protocol Protocol_Class1 : class {} // expected-note {{protocol 'Protocol_Class1' declared here}}
 
 protocol Protocol_Class2 : class {}
 
-@objc protocol Protocol_ObjC1 {}
+@objc
+protocol Protocol_ObjC1 {}
 
-@objc protocol Protocol_ObjC2 {}
+@objc
+protocol Protocol_ObjC2 {}
 
 
 
 
 //===--- Subjects of @objc attribute.
 
-@objc extension PlainStruct { } // expected-error{{'@objc' can only be applied to an extension of a class}}{{1-7=}}
+@objc // expected-error{{'@objc' can only be applied to an extension of a class}}{{1-7=}}
+extension PlainStruct { }
 
 class FáncyName {}
-@objc (FancyName) extension FáncyName {}
+
+@objc(FancyName)
+extension FáncyName {}
 
 @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
 var subject_globalVar: Int
@@ -138,7 +144,7 @@ struct subject_struct {
   func subject_instanceFunc() {}
 }
 
-@objc   // expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
+@objc // expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
 struct subject_genericStruct<T> {
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_instanceVar: Int
@@ -193,18 +199,21 @@ class subject_genericClass2<T> : Class_ObjC1 {
 }
 
 extension subject_genericClass where T : Hashable {
-  @objc var prop: Int { return 0 } // expected-error{{members of constrained extensions cannot be declared @objc}}
+  @objc
+  var prop: Int { return 0 } // expected-error{{members of constrained extensions cannot be declared @objc}}
 }
 
 extension subject_genericClass {
-  @objc var extProp: Int { return 0 } // expected-error{{extensions of generic classes cannot contain '@objc' members}}
+  @objc
+  var extProp: Int { return 0 } // expected-error{{extensions of generic classes cannot contain '@objc' members}}
   
-  @objc func extFoo() {} // expected-error{{extensions of generic classes cannot contain '@objc' members}}
+  @objc
+  func extFoo() {} // expected-error{{extensions of generic classes cannot contain '@objc' members}}
 }
 
 @objc
 enum subject_enum: Int {
-  @objc   // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
+  @objc // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement1
 
   @objc(subject_enumElement2)
@@ -213,7 +222,7 @@ enum subject_enum: Int {
   @objc(subject_enumElement3) // expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-31=}}
   case subject_enumElement3, subject_enumElement4
 
-  @objc   // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
+  @objc // expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement5, subject_enumElement6
 
   @nonobjc // expected-error {{'@nonobjc' attribute cannot be applied to this declaration}}
@@ -240,10 +249,12 @@ protocol subject_protocol1 {
   func subject_instanceFunc()
 }
 
-@objc protocol subject_protocol2 {} // no-error
+@objc // no-error
+protocol subject_protocol2 {}
 // CHECK-LABEL: @objc protocol subject_protocol2 {
 
-@objc protocol subject_protocol3 {} // no-error
+@objc // no-error
+protocol subject_protocol3 {}
 // CHECK-LABEL: @objc protocol subject_protocol3 {
 
 @objc
@@ -296,20 +307,25 @@ protocol subject_containerObjCProtocol1 {
 @objc
 protocol subject_containerObjCProtocol2 {
   init(a: Int)
-  @objc init(a: Double)
+  @objc
+  init(a: Double)
 
   func func1() -> Int
-  @objc func func1_() -> Int
+  @objc
+  func func1_() -> Int
 
   var instanceVar1: Int { get set }
-  @objc var instanceVar1_: Int { get set }
+  @objc
+  var instanceVar1_: Int { get set }
 
   subscript(i: Int) -> Int { get set }
-  @objc subscript(i: String) -> Int { get set}
+  @objc
+  subscript(i: String) -> Int { get set}
 }
 
 protocol nonObjCProtocol {
-  @objc func objcRequirement() // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  func objcRequirement()
 }
 
 func concreteContext1() {
@@ -326,44 +342,46 @@ class ConcreteContext3 {
 
   func dynamicSelf1() -> Self { return self }
 
-  @objc func dynamicSelf1_() -> Self { return self }
+  @objc
+  func dynamicSelf1_() -> Self { return self }
 
-  @objc func genericParams<T: NSObject>() -> [T] { return [] }
-  // expected-error@-1{{method cannot be marked @objc because it has generic parameters}}
+  @objc
+  func genericParams<T: NSObject>() -> [T] { return [] } // expected-error{{method cannot be marked @objc because it has generic parameters}}
 
-  @objc func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self }
-  // expected-error@-1{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc
+  func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias AnotherNSCoding = NSCoding
   typealias MetaNSCoding1 = NSCoding.Protocol
   typealias MetaNSCoding2 = AnotherNSCoding.Protocol
 
-  @objc func returnObjCAliasProtocolMetatype1() -> AnotherNSCoding.Protocol { return NSCoding.self }
-  // expected-error@-1{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc
+  func returnObjCAliasProtocolMetatype1() -> AnotherNSCoding.Protocol { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc func returnObjCAliasProtocolMetatype2() -> MetaNSCoding1 { return NSCoding.self }
-  // expected-error@-1{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc
+  func returnObjCAliasProtocolMetatype2() -> MetaNSCoding1 { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc func returnObjCAliasProtocolMetatype3() -> MetaNSCoding2 { return NSCoding.self }
-  // expected-error@-1{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc
+  func returnObjCAliasProtocolMetatype3() -> MetaNSCoding2 { return NSCoding.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias Composition = NSCopying & NSCoding
 
-  @objc func returnCompositionMetatype1() -> Composition.Protocol { return Composition.self }
-  // expected-error@-1{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc
+  func returnCompositionMetatype1() -> Composition.Protocol { return Composition.self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc func returnCompositionMetatype2() -> (NSCopying & NSCoding).Protocol { return (NSCopying & NSCoding).self }
-  // expected-error@-1{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  @objc
+  func returnCompositionMetatype2() -> (NSCopying & NSCoding).Protocol { return (NSCopying & NSCoding).self } // expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias NSCodingExistential = NSCoding.Type
 
-  @objc func inoutFunc(a: inout Int) {}
-  // expected-error@-1{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
-  @objc func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {}
-  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  @objc
+  func inoutFunc(a: inout Int) {} // expected-error{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
 
-  @objc func metatypeOfExistentialMetatypePram2(a: NSCoding.Type.Protocol) {}
-  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  @objc
+  func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+
+  @objc
+  func metatypeOfExistentialMetatypePram2(a: NSCoding.Type.Protocol) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
 func genericContext1<T>(_: T) {
@@ -422,21 +440,24 @@ class GenericContext4<T> {
 class ConcreteSubclassOfGeneric : GenericContext3<Int> {}
 
 extension ConcreteSubclassOfGeneric {
-  @objc func foo() {} // okay
+  @objc
+  func foo() {} // okay
 }
 
 @objc // expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
 class ConcreteSubclassOfGeneric2 : subject_genericClass2<Int> {}
 
 extension ConcreteSubclassOfGeneric2 {
-  @objc func foo() {} // okay
+  @objc
+  func foo() {} // okay
 }
 
 @objc(CustomNameForSubclassOfGeneric) // okay
 class ConcreteSubclassOfGeneric3 : GenericContext3<Int> {}
 
 extension ConcreteSubclassOfGeneric3 {
-  @objc func foo() {} // okay
+  @objc
+  func foo() {} // okay
 }
 
 class subject_subscriptIndexed1 {
@@ -516,8 +537,8 @@ class subject_subscriptGeneric<T> {
 }
 
 class subject_subscriptInvalid1 {
-  @objc class subscript(_ i: Int) -> AnyObject? {
-  // expected-error@-1 {{class subscript cannot be marked @objc}}
+  @objc
+  class subscript(_ i: Int) -> AnyObject? { // expected-error {{class subscript cannot be marked @objc}}
     return nil
   }
 }
@@ -587,185 +608,219 @@ class infer_instanceFunc1 {
   func func1() {}
 // CHECK-LABEL: @objc func func1() {
 
-  @objc func func1_() {} // no-error
+  @objc
+  func func1_() {} // no-error
 
   func func2(a: Int) {}
 // CHECK-LABEL: @objc func func2(a: Int) {
 
-  @objc func func2_(a: Int) {} // no-error
+  @objc
+  func func2_(a: Int) {} // no-error
 
   func func3(a: Int) -> Int {}
 // CHECK-LABEL: @objc func func3(a: Int) -> Int {
 
-  @objc func func3_(a: Int) -> Int {} // no-error
+  @objc
+  func func3_(a: Int) -> Int {} // no-error
 
   func func4(a: Int, b: Double) {}
 // CHECK-LABEL: @objc func func4(a: Int, b: Double) {
 
-  @objc func func4_(a: Int, b: Double) {} // no-error
+  @objc
+  func func4_(a: Int, b: Double) {} // no-error
 
   func func5(a: String) {}
 // CHECK-LABEL: @objc func func5(a: String) {
 
-  @objc func func5_(a: String) {} // no-error
+  @objc
+  func func5_(a: String) {} // no-error
 
   func func6() -> String {}
 // CHECK-LABEL: @objc func func6() -> String {
 
-  @objc func func6_() -> String {} // no-error
+  @objc
+  func func6_() -> String {} // no-error
 
   func func7(a: PlainClass) {}
 // CHECK-LABEL: {{^}} func func7(a: PlainClass) {
 
-  @objc func func7_(a: PlainClass) {}
+  @objc
+  func func7_(a: PlainClass) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   func func7m(a: PlainClass.Type) {}
 // CHECK-LABEL: {{^}} func func7m(a: PlainClass.Type) {
 
-  @objc func func7m_(a: PlainClass.Type) {}
+  @objc
+  func func7m_(a: PlainClass.Type) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 
   func func8() -> PlainClass {}
 // CHECK-LABEL: {{^}} func func8() -> PlainClass {
 
-  @objc func func8_() -> PlainClass {}
+  @objc
+  func func8_() -> PlainClass {}
   // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   func func8m() -> PlainClass.Type {}
 // CHECK-LABEL: {{^}} func func8m() -> PlainClass.Type {
 
-  @objc func func8m_() -> PlainClass.Type {}
+  @objc
+  func func8m_() -> PlainClass.Type {}
   // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   func func9(a: PlainStruct) {}
 // CHECK-LABEL: {{^}} func func9(a: PlainStruct) {
 
-  @objc func func9_(a: PlainStruct) {}
+  @objc
+  func func9_(a: PlainStruct) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   func func10() -> PlainStruct {}
 // CHECK-LABEL: {{^}} func func10() -> PlainStruct {
 
-  @objc func func10_() -> PlainStruct {}
+  @objc
+  func func10_() -> PlainStruct {}
   // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   func func11(a: PlainEnum) {}
 // CHECK-LABEL: {{^}} func func11(a: PlainEnum) {
 
-  @objc func func11_(a: PlainEnum) {}
+  @objc
+  func func11_(a: PlainEnum) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
 
   func func12(a: PlainProtocol) {}
 // CHECK-LABEL: {{^}} func func12(a: PlainProtocol) {
 
-  @objc func func12_(a: PlainProtocol) {}
+  @objc
+  func func12_(a: PlainProtocol) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   func func13(a: Class_ObjC1) {}
 // CHECK-LABEL: @objc func func13(a: Class_ObjC1) {
 
-  @objc func func13_(a: Class_ObjC1) {} // no-error
+  @objc
+  func func13_(a: Class_ObjC1) {} // no-error
 
   func func14(a: Protocol_Class1) {}
 // CHECK-LABEL: {{^}} func func14(a: Protocol_Class1) {
 
-  @objc func func14_(a: Protocol_Class1) {}
+  @objc
+  func func14_(a: Protocol_Class1) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   func func15(a: Protocol_ObjC1) {}
 // CHECK-LABEL: @objc func func15(a: Protocol_ObjC1) {
-  @objc func func15_(a: Protocol_ObjC1) {} // no-error
+  @objc
+  func func15_(a: Protocol_ObjC1) {} // no-error
 
   func func16(a: AnyObject) {}
 // CHECK-LABEL: @objc func func16(a: AnyObject) {
 
-  @objc func func16_(a: AnyObject) {} // no-error
+  @objc
+  func func16_(a: AnyObject) {} // no-error
 
   func func17(a: @escaping () -> ()) {}
 // CHECK-LABEL: {{^}}  @objc func func17(a: @escaping () -> ()) {
 
-  @objc func func17_(a: @escaping () -> ()) {}
+  @objc
+  func func17_(a: @escaping () -> ()) {}
 
   func func18(a: @escaping (Int) -> (), b: Int) {}
 // CHECK-LABEL: {{^}}  @objc func func18(a: @escaping (Int) -> (), b: Int)
 
-  @objc func func18_(a: @escaping (Int) -> (), b: Int) {}
+  @objc
+  func func18_(a: @escaping (Int) -> (), b: Int) {}
 
   func func19(a: @escaping (String) -> (), b: Int) {}
 // CHECK-LABEL: {{^}}  @objc func func19(a: @escaping (String) -> (), b: Int) {
 
-  @objc func func19_(a: @escaping (String) -> (), b: Int) {}
+  @objc
+  func func19_(a: @escaping (String) -> (), b: Int) {}
 
   func func_FunctionReturn1() -> () -> () {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn1() -> () -> () {
 
-  @objc func func_FunctionReturn1_() -> () -> () {}
+  @objc
+  func func_FunctionReturn1_() -> () -> () {}
 
   func func_FunctionReturn2() -> (Int) -> () {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn2() -> (Int) -> () {
 
-  @objc func func_FunctionReturn2_() -> (Int) -> () {}
+  @objc
+  func func_FunctionReturn2_() -> (Int) -> () {}
 
   func func_FunctionReturn3() -> () -> Int {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn3() -> () -> Int {
 
-  @objc func func_FunctionReturn3_() -> () -> Int {}
+  @objc
+  func func_FunctionReturn3_() -> () -> Int {}
 
   func func_FunctionReturn4() -> (String) -> () {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn4() -> (String) -> () {
 
-  @objc func func_FunctionReturn4_() -> (String) -> () {}
+  @objc
+  func func_FunctionReturn4_() -> (String) -> () {}
 
   func func_FunctionReturn5() -> () -> String {}
 // CHECK-LABEL: {{^}}  @objc func func_FunctionReturn5() -> () -> String {
 
-  @objc func func_FunctionReturn5_() -> () -> String {}
+  @objc
+  func func_FunctionReturn5_() -> () -> String {}
 
 
   func func_ZeroParams1() {}
 // CHECK-LABEL: @objc func func_ZeroParams1() {
 
-  @objc func func_ZeroParams1a() {} // no-error
+  @objc
+  func func_ZeroParams1a() {} // no-error
 
 
   func func_OneParam1(a: Int) {}
 // CHECK-LABEL: @objc func func_OneParam1(a: Int) {
 
-  @objc func func_OneParam1a(a: Int) {} // no-error
+  @objc
+  func func_OneParam1a(a: Int) {} // no-error
 
 
   func func_TupleStyle1(a: Int, b: Int) {}
   // CHECK-LABEL: {{^}} @objc func func_TupleStyle1(a: Int, b: Int) {
 
-  @objc func func_TupleStyle1a(a: Int, b: Int) {}
+  @objc
+  func func_TupleStyle1a(a: Int, b: Int) {}
 
   func func_TupleStyle2(a: Int, b: Int, c: Int) {}
 // CHECK-LABEL: {{^}} @objc func func_TupleStyle2(a: Int, b: Int, c: Int) {
 
-  @objc func func_TupleStyle2a(a: Int, b: Int, c: Int) {}
+  @objc
+  func func_TupleStyle2a(a: Int, b: Int, c: Int) {}
 
   // Check that we produce diagnostics for every parameter and return type.
-  @objc func func_MultipleDiags(a: PlainStruct, b: PlainEnum) -> Any {}
+  @objc
+  func func_MultipleDiags(a: PlainStruct, b: PlainEnum) -> Any {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter 1 cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
   // expected-error@-3 {{method cannot be marked @objc because the type of the parameter 2 cannot be represented in Objective-C}}
   // expected-note@-4 {{non-'@objc' enums cannot be represented in Objective-C}}
 
-  @objc func func_UnnamedParam1(_: Int) {} // no-error
+  @objc
+  func func_UnnamedParam1(_: Int) {} // no-error
 
-  @objc func func_UnnamedParam2(_: PlainStruct) {}
+  @objc
+  func func_UnnamedParam2(_: PlainStruct) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
-  @objc func func_varParam1(a: AnyObject) {
+  @objc
+  func func_varParam1(a: AnyObject) {
     var a = a
     let b = a; a = b
   }
@@ -825,7 +880,8 @@ class infer_instanceVar1 {
   // CHECK: @objc var instanceVar2: Int
   // CHECK: {{^}}  var instanceVar3: PlainProtocol
 
-  @objc var (instanceVar1_, instanceVar2_): (Int, PlainProtocol)
+  @objc
+  var (instanceVar1_, instanceVar2_): (Int, PlainProtocol)
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
@@ -843,7 +899,8 @@ class infer_instanceVar1 {
     // CHECK-NEXT: @objc set {}
   }
 
-  @objc var instanceVar5_: Int {
+  @objc
+  var instanceVar5_: Int {
   // CHECK: @objc var instanceVar5_: Int {
     get {}
     // CHECK-NEXT: @objc get {}
@@ -861,7 +918,8 @@ class infer_instanceVar1 {
     // CHECK-NEXT: {{^}} @objc set {
   }
 
-  @objc var observingAccessorsVar1_: Int {
+  @objc
+  var observingAccessorsVar1_: Int {
   // CHECK: {{^}} @objc @_hasStorage var observingAccessorsVar1_: Int {
     willSet {}
     // CHECK-NEXT: {{^}} @objc get {
@@ -897,26 +955,30 @@ class infer_instanceVar1 {
   var var_tuple1: ()
 // CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple1: ()
 
-  @objc var var_tuple1_: ()
+  @objc
+  var var_tuple1_: ()
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
 
   var var_tuple2: Void
 // CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple2: Void
 
-  @objc var var_tuple2_: Void
+  @objc
+  var var_tuple2_: Void
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
 
   var var_tuple3: (Int)
 // CHECK-LABEL: @objc var var_tuple3: (Int)
 
-  @objc var var_tuple3_: (Int) // no-error
+  @objc
+  var var_tuple3_: (Int) // no-error
 
   var var_tuple4: (Int, Int)
 // CHECK-LABEL: {{^}} var var_tuple4: (Int, Int)
 
-  @objc var var_tuple4_: (Int, Int)
+  @objc
+  var var_tuple4_: (Int, Int)
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{tuples cannot be represented in Objective-C}}
 
@@ -946,93 +1008,108 @@ class infer_instanceVar1 {
   var var_PlainClass: PlainClass
 // CHECK-LABEL: {{^}}  var var_PlainClass: PlainClass
 
-  @objc var var_PlainClass_: PlainClass
+  @objc
+  var var_PlainClass_: PlainClass
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   var var_PlainStruct: PlainStruct
 // CHECK-LABEL: {{^}}  var var_PlainStruct: PlainStruct
 
-  @objc var var_PlainStruct_: PlainStruct
+  @objc
+  var var_PlainStruct_: PlainStruct
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_PlainEnum: PlainEnum
 // CHECK-LABEL: {{^}} var var_PlainEnum: PlainEnum
 
-  @objc var var_PlainEnum_: PlainEnum
+  @objc
+  var var_PlainEnum_: PlainEnum
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
 
   var var_PlainProtocol: PlainProtocol
 // CHECK-LABEL: {{^}}  var var_PlainProtocol: PlainProtocol
 
-  @objc var var_PlainProtocol_: PlainProtocol
+  @objc
+  var var_PlainProtocol_: PlainProtocol
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_ClassObjC: Class_ObjC1
 // CHECK-LABEL: @objc var var_ClassObjC: Class_ObjC1
 
-  @objc var var_ClassObjC_: Class_ObjC1 // no-error
+  @objc
+  var var_ClassObjC_: Class_ObjC1 // no-error
 
   var var_ProtocolClass: Protocol_Class1
 // CHECK-LABEL: {{^}}  var var_ProtocolClass: Protocol_Class1
 
-  @objc var var_ProtocolClass_: Protocol_Class1
+  @objc
+  var var_ProtocolClass_: Protocol_Class1
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_ProtocolObjC: Protocol_ObjC1
 // CHECK-LABEL: @objc var var_ProtocolObjC: Protocol_ObjC1
 
-  @objc var var_ProtocolObjC_: Protocol_ObjC1 // no-error
+  @objc
+  var var_ProtocolObjC_: Protocol_ObjC1 // no-error
 
 
   var var_PlainClassMetatype: PlainClass.Type
 // CHECK-LABEL: {{^}}  var var_PlainClassMetatype: PlainClass.Type
 
-  @objc var var_PlainClassMetatype_: PlainClass.Type
+  @objc
+  var var_PlainClassMetatype_: PlainClass.Type
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainStructMetatype: PlainStruct.Type
 // CHECK-LABEL: {{^}}  var var_PlainStructMetatype: PlainStruct.Type
 
-  @objc var var_PlainStructMetatype_: PlainStruct.Type
+  @objc
+  var var_PlainStructMetatype_: PlainStruct.Type
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainEnumMetatype: PlainEnum.Type
 // CHECK-LABEL: {{^}}  var var_PlainEnumMetatype: PlainEnum.Type
 
-  @objc var var_PlainEnumMetatype_: PlainEnum.Type
+  @objc
+  var var_PlainEnumMetatype_: PlainEnum.Type
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainExistentialMetatype: PlainProtocol.Type
 // CHECK-LABEL: {{^}}  var var_PlainExistentialMetatype: PlainProtocol.Type
 
-  @objc var var_PlainExistentialMetatype_: PlainProtocol.Type
+  @objc
+  var var_PlainExistentialMetatype_: PlainProtocol.Type
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ClassObjCMetatype: Class_ObjC1.Type
 // CHECK-LABEL: @objc var var_ClassObjCMetatype: Class_ObjC1.Type
 
-  @objc var var_ClassObjCMetatype_: Class_ObjC1.Type // no-error
+  @objc
+  var var_ClassObjCMetatype_: Class_ObjC1.Type // no-error
 
   var var_ProtocolClassMetatype: Protocol_Class1.Type
 // CHECK-LABEL: {{^}}  var var_ProtocolClassMetatype: Protocol_Class1.Type
 
-  @objc var var_ProtocolClassMetatype_: Protocol_Class1.Type
+  @objc
+  var var_ProtocolClassMetatype_: Protocol_Class1.Type
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ProtocolObjCMetatype1: Protocol_ObjC1.Type
 // CHECK-LABEL: @objc var var_ProtocolObjCMetatype1: Protocol_ObjC1.Type
 
-  @objc var var_ProtocolObjCMetatype1_: Protocol_ObjC1.Type // no-error
+  @objc
+  var var_ProtocolObjCMetatype1_: Protocol_ObjC1.Type // no-error
 
   var var_ProtocolObjCMetatype2: Protocol_ObjC2.Type
 // CHECK-LABEL: @objc var var_ProtocolObjCMetatype2: Protocol_ObjC2.Type
 
-  @objc var var_ProtocolObjCMetatype2_: Protocol_ObjC2.Type // no-error
+  @objc
+  var var_ProtocolObjCMetatype2_: Protocol_ObjC2.Type // no-error
 
   var var_AnyObject1: AnyObject
   var var_AnyObject2: AnyObject.Type
@@ -1042,66 +1119,76 @@ class infer_instanceVar1 {
   var var_Existential0: Any
 // CHECK-LABEL: @objc var var_Existential0: Any
 
-  @objc var var_Existential0_: Any
+  @objc
+  var var_Existential0_: Any
 
   var var_Existential1: PlainProtocol
   // CHECK-LABEL: {{^}}  var var_Existential1: PlainProtocol
 
-  @objc var var_Existential1_: PlainProtocol
+  @objc
+  var var_Existential1_: PlainProtocol
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential2: PlainProtocol & PlainProtocol
 // CHECK-LABEL: {{^}}  var var_Existential2: PlainProtocol
 
-  @objc var var_Existential2_: PlainProtocol & PlainProtocol
+  @objc
+  var var_Existential2_: PlainProtocol & PlainProtocol
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential3: PlainProtocol & Protocol_Class1
 // CHECK-LABEL: {{^}}  var var_Existential3: PlainProtocol & Protocol_Class1
 
-  @objc var var_Existential3_: PlainProtocol & Protocol_Class1
+  @objc
+  var var_Existential3_: PlainProtocol & Protocol_Class1
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential4: PlainProtocol & Protocol_ObjC1
 // CHECK-LABEL: {{^}}  var var_Existential4: PlainProtocol & Protocol_ObjC1
 
-  @objc var var_Existential4_: PlainProtocol & Protocol_ObjC1
+  @objc
+  var var_Existential4_: PlainProtocol & Protocol_ObjC1
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential5: Protocol_Class1
   // CHECK-LABEL: {{^}}  var var_Existential5: Protocol_Class1
 
-  @objc var var_Existential5_: Protocol_Class1
+  @objc
+  var var_Existential5_: Protocol_Class1
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential6: Protocol_Class1 & Protocol_Class2
 // CHECK-LABEL: {{^}}  var var_Existential6: Protocol_Class1 & Protocol_Class2
 
-  @objc var var_Existential6_: Protocol_Class1 & Protocol_Class2
+  @objc
+  var var_Existential6_: Protocol_Class1 & Protocol_Class2
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential7: Protocol_Class1 & Protocol_ObjC1
 // CHECK-LABEL: {{^}}  var var_Existential7: Protocol_Class1 & Protocol_ObjC1
 
-  @objc var var_Existential7_: Protocol_Class1 & Protocol_ObjC1
+  @objc
+  var var_Existential7_: Protocol_Class1 & Protocol_ObjC1
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential8: Protocol_ObjC1
 // CHECK-LABEL: @objc var var_Existential8: Protocol_ObjC1
 
-  @objc var var_Existential8_: Protocol_ObjC1 // no-error
+  @objc
+  var var_Existential8_: Protocol_ObjC1 // no-error
 
   var var_Existential9: Protocol_ObjC1 & Protocol_ObjC2
 // CHECK-LABEL: @objc var var_Existential9: Protocol_ObjC1 & Protocol_ObjC2
 
-  @objc var var_Existential9_: Protocol_ObjC1 & Protocol_ObjC2 // no-error
+  @objc
+  var var_Existential9_: Protocol_ObjC1 & Protocol_ObjC2 // no-error
 
 
   var var_ExistentialMetatype0: Any.Type
@@ -1354,116 +1441,137 @@ class infer_instanceVar1 {
   var var_FunctionTypeReturn1: () -> () -> ()
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn1: () -> () -> ()
 
-  @objc var var_FunctionTypeReturn1_: () -> () -> () // no-error
+  @objc
+  var var_FunctionTypeReturn1_: () -> () -> () // no-error
 
   var var_FunctionTypeReturn2: () -> (Int) -> ()
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn2: () -> (Int) -> ()
 
-  @objc var var_FunctionTypeReturn2_: () -> (Int) -> () // no-error
+  @objc
+  var var_FunctionTypeReturn2_: () -> (Int) -> () // no-error
 
   var var_FunctionTypeReturn3: () -> () -> Int
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn3: () -> () -> Int
 
-  @objc var var_FunctionTypeReturn3_: () -> () -> Int // no-error
+  @objc
+  var var_FunctionTypeReturn3_: () -> () -> Int // no-error
 
   var var_FunctionTypeReturn4: () -> (String) -> ()
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn4: () -> (String) -> ()
 
-  @objc var var_FunctionTypeReturn4_: () -> (String) -> () // no-error
+  @objc
+  var var_FunctionTypeReturn4_: () -> (String) -> () // no-error
 
   var var_FunctionTypeReturn5: () -> () -> String
 // CHECK-LABEL: {{^}}  @objc var var_FunctionTypeReturn5: () -> () -> String
 
-  @objc var var_FunctionTypeReturn5_: () -> () -> String // no-error
+  @objc
+  var var_FunctionTypeReturn5_: () -> () -> String // no-error
 
 
   var var_BlockFunctionType1: @convention(block) () -> ()
 // CHECK-LABEL: @objc var var_BlockFunctionType1: @convention(block) () -> ()
 
-  @objc var var_BlockFunctionType1_: @convention(block) () -> () // no-error
+  @objc
+  var var_BlockFunctionType1_: @convention(block) () -> () // no-error
 
   var var_ArrayType1: [AnyObject]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType1: [AnyObject]
 
-  @objc var var_ArrayType1_: [AnyObject] // no-error
+  @objc
+  var var_ArrayType1_: [AnyObject] // no-error
 
   var var_ArrayType2: [@convention(block) (AnyObject) -> AnyObject] // no-error
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType2: [@convention(block) (AnyObject) -> AnyObject]
 
-  @objc var var_ArrayType2_: [@convention(block) (AnyObject) -> AnyObject] // no-error
+  @objc
+  var var_ArrayType2_: [@convention(block) (AnyObject) -> AnyObject] // no-error
 
   var var_ArrayType3: [PlainStruct]
   // CHECK-LABEL: {{^}}  var var_ArrayType3: [PlainStruct]
 
-  @objc var var_ArrayType3_: [PlainStruct]
+  @objc
+  var var_ArrayType3_: [PlainStruct]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType4: [(AnyObject) -> AnyObject] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType4: [(AnyObject) -> AnyObject]
 
-  @objc var var_ArrayType4_: [(AnyObject) -> AnyObject]
+  @objc
+  var var_ArrayType4_: [(AnyObject) -> AnyObject]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType5: [Protocol_ObjC1]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType5: [Protocol_ObjC1]
 
-  @objc var var_ArrayType5_: [Protocol_ObjC1] // no-error
+  @objc
+  var var_ArrayType5_: [Protocol_ObjC1] // no-error
 
   var var_ArrayType6: [Class_ObjC1]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType6: [Class_ObjC1]
 
-  @objc var var_ArrayType6_: [Class_ObjC1] // no-error
+  @objc
+  var var_ArrayType6_: [Class_ObjC1] // no-error
 
   var var_ArrayType7: [PlainClass]
   // CHECK-LABEL: {{^}}  var var_ArrayType7: [PlainClass]
 
-  @objc var var_ArrayType7_: [PlainClass]
+  @objc
+  var var_ArrayType7_: [PlainClass]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType8: [PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType8: [PlainProtocol]
 
-  @objc var var_ArrayType8_: [PlainProtocol]
+  @objc
+  var var_ArrayType8_: [PlainProtocol]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType9: [Protocol_ObjC1 & PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType9: [PlainProtocol & Protocol_ObjC1]
 
-  @objc var var_ArrayType9_: [Protocol_ObjC1 & PlainProtocol]
+  @objc
+  var var_ArrayType9_: [Protocol_ObjC1 & PlainProtocol]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
 
-  @objc var var_ArrayType10_: [Protocol_ObjC1 & Protocol_ObjC2]
+  @objc
+  var var_ArrayType10_: [Protocol_ObjC1 & Protocol_ObjC2]
   // no-error
 
   var var_ArrayType11: [Any]
   // CHECK-LABEL: @objc var var_ArrayType11: [Any]
 
-  @objc var var_ArrayType11_: [Any]
+  @objc
+  var var_ArrayType11_: [Any]
 
   var var_ArrayType13: [Any?]
   // CHECK-LABEL: {{^}}  var var_ArrayType13: [Any?]
 
-  @objc var var_ArrayType13_: [Any?]
+  @objc
+  var var_ArrayType13_: [Any?]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType15: [AnyObject?]
   // CHECK-LABEL: {{^}}  var var_ArrayType15: [AnyObject?]
 
-  @objc var var_ArrayType15_: [AnyObject?]
+  @objc
+  var var_ArrayType15_: [AnyObject?]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType16: [[@convention(block) (AnyObject) -> AnyObject]] // no-error
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType16: {{\[}}[@convention(block) (AnyObject) -> AnyObject]]
 
-  @objc var var_ArrayType16_: [[@convention(block) (AnyObject) -> AnyObject]] // no-error
+  @objc
+  var var_ArrayType16_: [[@convention(block) (AnyObject) -> AnyObject]] // no-error
 
   var var_ArrayType17: [[(AnyObject) -> AnyObject]] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType17: {{\[}}[(AnyObject) -> AnyObject]]
 
-  @objc var var_ArrayType17_: [[(AnyObject) -> AnyObject]]
+  @objc
+  var var_ArrayType17_: [[(AnyObject) -> AnyObject]]
   // expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 }
 
@@ -1483,57 +1591,66 @@ class infer_instanceVar2<
   var var_GP_Unconstrained: GP_Unconstrained
 // CHECK-LABEL: {{^}}  var var_GP_Unconstrained: GP_Unconstrained
 
-  @objc var var_GP_Unconstrained_: GP_Unconstrained
+  @objc
+  var var_GP_Unconstrained_: GP_Unconstrained
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_PlainClass: GP_PlainClass
 // CHECK-LABEL: {{^}}  var var_GP_PlainClass: GP_PlainClass
 
-  @objc var var_GP_PlainClass_: GP_PlainClass
+  @objc
+  var var_GP_PlainClass_: GP_PlainClass
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_PlainProtocol: GP_PlainProtocol
 // CHECK-LABEL: {{^}}  var var_GP_PlainProtocol: GP_PlainProtocol
 
-  @objc var var_GP_PlainProtocol_: GP_PlainProtocol
+  @objc
+  var var_GP_PlainProtocol_: GP_PlainProtocol
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Class_ObjC: GP_Class_ObjC
 // CHECK-LABEL: {{^}}  var var_GP_Class_ObjC: GP_Class_ObjC
 
-  @objc var var_GP_Class_ObjC_: GP_Class_ObjC
+  @objc
+  var var_GP_Class_ObjC_: GP_Class_ObjC
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Protocol_Class: GP_Protocol_Class
 // CHECK-LABEL: {{^}}  var var_GP_Protocol_Class: GP_Protocol_Class
 
-  @objc var var_GP_Protocol_Class_: GP_Protocol_Class
+  @objc
+  var var_GP_Protocol_Class_: GP_Protocol_Class
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Protocol_ObjC: GP_Protocol_ObjC
 // CHECK-LABEL: {{^}}  var var_GP_Protocol_ObjC: GP_Protocol_ObjC
 
-  @objc var var_GP_Protocol_ObjCa: GP_Protocol_ObjC
+  @objc
+  var var_GP_Protocol_ObjCa: GP_Protocol_ObjC
   // expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   func func_GP_Unconstrained(a: GP_Unconstrained) {}
 // CHECK-LABEL: {{^}} func func_GP_Unconstrained(a: GP_Unconstrained) {
 
-  @objc func func_GP_Unconstrained_(a: GP_Unconstrained) {}
+  @objc
+  func func_GP_Unconstrained_(a: GP_Unconstrained) {}
   // expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
-  @objc func func_GP_Unconstrained_() -> GP_Unconstrained {}
+  @objc
+  func func_GP_Unconstrained_() -> GP_Unconstrained {}
   // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
-  @objc func func_GP_Class_ObjC__() -> GP_Class_ObjC {}
+  @objc
+  func func_GP_Class_ObjC__() -> GP_Class_ObjC {}
   // expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 }
@@ -1658,7 +1775,8 @@ protocol infer_protocol5 : Protocol_ObjC1, Protocol_Class1 {
 
 class C {
   // Don't crash.
-  @objc func foo(x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
+  @objc
+  func foo(x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBAction func myAction(sender: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBSegueAction func myAction(coder: Undeclared, sender: Undeclared) -> Undeclared {fatalError()} // expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}}
 }
@@ -1759,7 +1877,8 @@ class HasNSManaged {
 //===--- Pointer argument types
 //===---
 
-@objc class TakesCPointers {
+@objc
+class TakesCPointers {
 // CHECK-LABEL: {{^}}@objc class TakesCPointers {
   func constUnsafeMutablePointer(p: UnsafePointer<Int>) {}
   // CHECK-LABEL: @objc func constUnsafeMutablePointer(p: UnsafePointer<Int>) {
@@ -1835,7 +1954,7 @@ enum BadEnum1: Int { case X }
 
 @objc
 enum BadEnum2: Int {
-  @objc(X:)   // expected-error{{'@objc' enum case must have a simple name}}{{10-11=}}
+  @objc(X:) // expected-error{{'@objc' enum case must have a simple name}}{{10-11=}}
   case X
 }
 
@@ -1872,27 +1991,35 @@ class BadClass2 {
   init() { }
 
   var _prop = 5
-  @objc var prop: Int {
-    @objc(property) get { return _prop }
-    @objc(setProperty:) set { _prop = newValue }
+  @objc
+  var prop: Int {
+    @objc(property)
+    get { return _prop }
+    @objc(setProperty:)
+    set { _prop = newValue }
   }
 
   var prop2: Int {
-    @objc(property) get { return _prop } // expected-error{{'@objc' getter for non-'@objc' property}}
-    @objc(setProperty:) set { _prop = newValue } // expected-error{{'@objc' setter for non-'@objc' property}}
+    @objc(property)
+    get { return _prop } // expected-error{{'@objc' getter for non-'@objc' property}}
+    @objc(setProperty:)
+    set { _prop = newValue } // expected-error{{'@objc' setter for non-'@objc' property}}
   }
 
   var prop3: Int {
-    @objc(setProperty:) didSet { } // expected-error{{observing accessors are not allowed to be marked @objc}} {{5-25=}}
+    @objc(setProperty:) // expected-error{{observing accessors are not allowed to be marked @objc}} {{5-25=}}
+    didSet { }
   }
 
   @objc
   subscript (c: Class_ObjC1) -> Class_ObjC1 {
-    @objc(getAtClass:) get {
+    @objc(getAtClass:)
+    get {
       return c
     }
 
-    @objc(setAtClass:class:) set {
+    @objc(setAtClass:class:)
+    set {
     }
   }
 }
@@ -1902,7 +2029,8 @@ class Super {
   @objc(renamedFoo)
   var foo: Int { get { return 3 } } // expected-note 2{{overridden declaration is here}}
 
-  @objc func process(i: Int) -> Int { } // expected-note {{overriding '@objc' method 'process(i:)' here}}
+  @objc
+  func process(i: Int) -> Int { } // expected-note {{overriding '@objc' method 'process(i:)' here}}
 }
 
 class Sub1 : Super {
@@ -1936,18 +2064,25 @@ struct NotObjCStruct {}
 
 // Closure arguments can only be @objc if their parameters and returns are.
 // CHECK-LABEL: @objc class ClosureArguments
-@objc class ClosureArguments {
+@objc
+class ClosureArguments {
   // CHECK: @objc func foo
-  @objc func foo(f: (Int) -> ()) {}
+  @objc
+  func foo(f: (Int) -> ()) {}
   // CHECK: @objc func bar
-  @objc func bar(f: (NotObjCEnum) -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc
+  func bar(f: (NotObjCEnum) -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func bas
-  @objc func bas(f: (NotObjCEnum) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc
+  func bas(f: (NotObjCEnum) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zim
-  @objc func zim(f: () -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc
+  func zim(f: () -> NotObjCStruct) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zang
-  @objc func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
-  @objc func zangZang(f: (Int...) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc
+  func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  @objc
+  func zangZang(f: (Int...) -> ()) {} // expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func fooImplicit
   func fooImplicit(f: (Int) -> ()) {}
   // CHECK: {{^}}  func barImplicit
@@ -1966,13 +2101,15 @@ typealias GoodBlock = @convention(block) (Int) -> ()
 typealias BadBlock = @convention(block) (NotObjCEnum) -> () // expected-error{{'(NotObjCEnum) -> ()' is not representable in Objective-C, so it cannot be used with '@convention(block)'}}
 
 
-@objc class AccessControl {
+@objc
+class AccessControl {
   // CHECK: @objc func foo
   func foo() {}
   // CHECK: {{^}} private func bar
   private func bar() {}
   // CHECK: @objc private func baz
-  @objc private func baz() {}
+  @objc
+  private func baz() {}
 }
 
 //===--- Ban @objc +load methods
@@ -1984,36 +2121,51 @@ class Load1 {
   class func initialize() {}
 }
 
-@objc class Load2 {
+@objc
+class Load2 {
   class func load() { } // expected-error{{method 'load()' defines Objective-C class method 'load', which is not permitted by Swift}}
   class func alloc() {} // expected-error{{method 'alloc()' defines Objective-C class method 'alloc', which is not permitted by Swift}}
   class func allocWithZone(_: Int) {} // expected-error{{method 'allocWithZone' defines Objective-C class method 'allocWithZone:', which is not permitted by Swift}}
   class func initialize() {} // expected-error{{method 'initialize()' defines Objective-C class method 'initialize', which is not permitted by Swift}}
 }
 
-@objc class Load3 {
+@objc
+class Load3 {
   class var load: Load3 {
     get { return Load3() } // expected-error{{getter for 'load' defines Objective-C class method 'load', which is not permitted by Swift}}
     set { }
   }
 
-  @objc(alloc) class var prop: Int { return 0 } // expected-error{{getter for 'prop' defines Objective-C class method 'alloc', which is not permitted by Swift}}
-  @objc(allocWithZone:) class func fooWithZone(_: Int) {} // expected-error{{method 'fooWithZone' defines Objective-C class method 'allocWithZone:', which is not permitted by Swift}}
-  @objc(initialize) class func barnitialize() {} // expected-error{{method 'barnitialize()' defines Objective-C class method 'initialize', which is not permitted by Swift}}
+  @objc(alloc)
+  class var prop: Int { return 0 } // expected-error{{getter for 'prop' defines Objective-C class method 'alloc', which is not permitted by Swift}}
+  @objc(allocWithZone:)
+  class func fooWithZone(_: Int) {} // expected-error{{method 'fooWithZone' defines Objective-C class method 'allocWithZone:', which is not permitted by Swift}}
+  @objc(initialize)
+  class func barnitialize() {} // expected-error{{method 'barnitialize()' defines Objective-C class method 'initialize', which is not permitted by Swift}}
 }
 
 // Members of protocol extensions cannot be @objc
 
 extension PlainProtocol {
-  @objc var property: Int { return 5 } // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
-  @objc subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() } // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
-  @objc func fun() { } // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  var property: Int { return 5 }
+
+  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() }
+
+  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  func fun() { }
 }
 
 extension Protocol_ObjC1 {
-  @objc var property: Int { return 5 } // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
-  @objc subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() } // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
-  @objc func fun() { } // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  var property: Int { return 5 }
+
+  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() }
+
+  @objc // expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  func fun() { }
 }
 
 extension Protocol_ObjC1 {
@@ -2028,46 +2180,59 @@ extension Protocol_ObjC1 {
 //===---
 class ClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
-  @objc func methodReturnsVoid() throws { }
+  @objc
+  func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
-  @objc func methodReturnsObjCClass() throws -> Class_ObjC1 {
+  @objc
+  func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
 
   // CHECK: @objc func methodReturnsBridged() throws -> String
-  @objc func methodReturnsBridged() throws -> String { return String() }
+  @objc
+  func methodReturnsBridged() throws -> String { return String() }
 
   // CHECK: @objc func methodReturnsArray() throws -> [String]
-  @objc func methodReturnsArray() throws -> [String] { return [String]() }
+  @objc
+  func methodReturnsArray() throws -> [String] { return [String]() }
 
   // CHECK: @objc init(degrees: Double) throws
-  @objc init(degrees: Double) throws { }
+  @objc
+  init(degrees: Double) throws { }
 
   // Errors
 
-  @objc func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil } // expected-error{{throwing method cannot be marked @objc because it returns a value of optional type 'Class_ObjC1?'; 'nil' indicates failure to Objective-C}}
+  @objc
+  func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil } // expected-error{{throwing method cannot be marked @objc because it returns a value of optional type 'Class_ObjC1?'; 'nil' indicates failure to Objective-C}}
 
-  @objc func methodReturnsOptionalArray() throws -> [String]? { return nil } // expected-error{{throwing method cannot be marked @objc because it returns a value of optional type '[String]?'; 'nil' indicates failure to Objective-C}}
+  @objc
+  func methodReturnsOptionalArray() throws -> [String]? { return nil } // expected-error{{throwing method cannot be marked @objc because it returns a value of optional type '[String]?'; 'nil' indicates failure to Objective-C}}
 
-  @objc func methodReturnsInt() throws -> Int { return 0 } // expected-error{{throwing method cannot be marked @objc because it returns a value of type 'Int'; return 'Void' or a type that bridges to an Objective-C class}}
+  @objc
+  func methodReturnsInt() throws -> Int { return 0 } // expected-error{{throwing method cannot be marked @objc because it returns a value of type 'Int'; return 'Void' or a type that bridges to an Objective-C class}}
 
-  @objc func methodAcceptsThrowingFunc(fn: (String) throws -> Int) { }
+  @objc
+  func methodAcceptsThrowingFunc(fn: (String) throws -> Int) { }
   // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{throwing function types cannot be represented in Objective-C}}
 
-  @objc init?(radians: Double) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
+  @objc
+  init?(radians: Double) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
-  @objc init!(string: String) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
+  @objc
+  init!(string: String) throws { } // expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
-  @objc func fooWithErrorEnum1(x: ErrorEnum) {}
+  @objc
+  func fooWithErrorEnum1(x: ErrorEnum) {}
   // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{non-'@objc' enums cannot be represented in Objective-C}}
 
   // CHECK: {{^}} func fooWithErrorEnum2(x: ErrorEnum)
   func fooWithErrorEnum2(x: ErrorEnum) {}
 
-  @objc func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
+  @objc
+  func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
   // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{protocol-constrained type containing 'Error' cannot be represented in Objective-C}}
 
@@ -2077,7 +2242,8 @@ class ClassThrows1 {
 
 
 // CHECK-DUMP-LABEL: class_decl{{.*}}"ImplicitClassThrows1"
-@objc class ImplicitClassThrows1 {
+@objc
+class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
   // CHECK-DUMP: func_decl{{.*}}"methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   func methodReturnsVoid() throws { }
@@ -2108,7 +2274,8 @@ class ClassThrows1 {
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
   func methodReturnsBridgedValueType() throws -> NSRange { return NSRange() }
 
-  @objc func methodReturnsBridgedValueType2() throws -> NSRange {
+  @objc
+  func methodReturnsBridgedValueType2() throws -> NSRange {
     return NSRange()
   }
   // expected-error@-3{{throwing method cannot be marked @objc because it returns a value of type 'NSRange' (aka '_NSRange'); return 'Void' or a type that bridges to an Objective-C class}}
@@ -2125,40 +2292,57 @@ class ClassThrows1 {
 }
 
 // CHECK-DUMP-LABEL: class_decl{{.*}}"SubclassImplicitClassThrows1"
-@objc class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
+@objc
+class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping ((Int) -> Int), fn3: @escaping ((Int) -> Int))
   // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int)) throws { }
 }
 
 class ThrowsRedecl1 {
-  @objc func method1(_ x: Int, error: Class_ObjC1) { } // expected-note{{declared here}}
-  @objc func method1(_ x: Int) throws { } // expected-error{{with Objective-C selector 'method1:error:'}}
+  @objc
+  func method1(_ x: Int, error: Class_ObjC1) { } // expected-note{{declared here}}
+  @objc
+  func method1(_ x: Int) throws { } // expected-error{{with Objective-C selector 'method1:error:'}}
 
-  @objc func method2AndReturnError(_ x: Int) { } // expected-note{{declared here}}
-  @objc func method2() throws { } // expected-error{{with Objective-C selector 'method2AndReturnError:'}}
+  @objc
+  func method2AndReturnError(_ x: Int) { } // expected-note{{declared here}}
+  @objc
+  func method2() throws { } // expected-error{{with Objective-C selector 'method2AndReturnError:'}}
 
-  @objc func method3(_ x: Int, error: Int, closure: @escaping (Int) -> Int) { }  // expected-note{{declared here}}
-  @objc func method3(_ x: Int, closure: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'method3:error:closure:'}}
+  @objc
+  func method3(_ x: Int, error: Int, closure: @escaping (Int) -> Int) { }  // expected-note{{declared here}}
+  @objc
+  func method3(_ x: Int, closure: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'method3:error:closure:'}}
 
-  @objc(initAndReturnError:) func initMethod1(error: Int) { } // expected-note{{declared here}}
-  @objc init() throws { } // expected-error{{with Objective-C selector 'initAndReturnError:'}}
+  @objc(initAndReturnError:)
+  func initMethod1(error: Int) { } // expected-note{{declared here}}
+  @objc
+  init() throws { } // expected-error{{with Objective-C selector 'initAndReturnError:'}}
 
-  @objc(initWithString:error:) func initMethod2(string: String, error: Int) { } // expected-note{{declared here}}
-  @objc init(string: String) throws { } // expected-error{{with Objective-C selector 'initWithString:error:'}}
+  @objc(initWithString:error:)
+  func initMethod2(string: String, error: Int) { } // expected-note{{declared here}}
+  @objc
+  init(string: String) throws { } // expected-error{{with Objective-C selector 'initWithString:error:'}}
 
-  @objc(initAndReturnError:fn:) func initMethod3(error: Int, fn: @escaping (Int) -> Int) { } // expected-note{{declared here}}
-  @objc init(fn: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'initAndReturnError:fn:'}}
+  @objc(initAndReturnError:fn:)
+  func initMethod3(error: Int, fn: @escaping (Int) -> Int) { } // expected-note{{declared here}}
+  @objc
+  init(fn: (Int) -> Int) throws { } // expected-error{{with Objective-C selector 'initAndReturnError:fn:'}}
 }
 
 class ThrowsObjCName {
-  @objc(method4:closure:error:) func method4(x: Int, closure: @escaping (Int) -> Int) throws { }
+  @objc(method4:closure:error:)
+  func method4(x: Int, closure: @escaping (Int) -> Int) throws { }
 
-  @objc(method5AndReturnError:x:closure:) func method5(x: Int, closure: @escaping (Int) -> Int) throws { }
+  @objc(method5AndReturnError:x:closure:)
+  func method5(x: Int, closure: @escaping (Int) -> Int) throws { }
 
-  @objc(method6) func method6() throws { } // expected-error{{@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
+  @objc(method6) // expected-error{{@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
+  func method6() throws { }
 
-  @objc(method7) func method7(x: Int) throws { } // expected-error{{@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
+  @objc(method7) // expected-error{{@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
+  func method7(x: Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   @objc(method8:fn1:error:fn2:)
@@ -2177,34 +2361,42 @@ class SubclassThrowsObjCName : ThrowsObjCName {
   override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
-@objc protocol ProtocolThrowsObjCName {
-  @objc optional func doThing(_ x: String) throws -> String // expected-note{{requirement 'doThing' declared here}}
+@objc
+protocol ProtocolThrowsObjCName {
+  @objc
+  optional func doThing(_ x: String) throws -> String // expected-note{{requirement 'doThing' declared here}}
 }
 
 class ConformsToProtocolThrowsObjCName1 : ProtocolThrowsObjCName {
-  @objc func doThing(_ x: String) throws -> String { return x } // okay
+  @objc
+  func doThing(_ x: String) throws -> String { return x } // okay
 }
 
 class ConformsToProtocolThrowsObjCName2 : ProtocolThrowsObjCName {
-  @objc func doThing(_ x: Int) throws -> String { return "" }
+  @objc
+  func doThing(_ x: Int) throws -> String { return "" }
   // expected-warning@-1{{instance method 'doThing' nearly matches optional requirement 'doThing' of protocol 'ProtocolThrowsObjCName'}}
   // expected-note@-2{{move 'doThing' to an extension to silence this warning}}
-  // expected-note@-3{{make 'doThing' private to silence this warning}}{{9-9=private }}
+  // expected-note@-3{{make 'doThing' private to silence this warning}}{{3-3=private }}
   // expected-note@-4{{candidate has non-matching type '(Int) throws -> String'}}
 }
 
-@objc class DictionaryTest {
+@objc
+class DictionaryTest {
   // CHECK-LABEL: @objc func func_dictionary1a(x: Dictionary<ObjC_Class1, ObjC_Class1>)
   func func_dictionary1a(x: Dictionary<ObjC_Class1, ObjC_Class1>) { }
 
   // CHECK-LABEL: @objc func func_dictionary1b(x: Dictionary<ObjC_Class1, ObjC_Class1>)
-  @objc func func_dictionary1b(x: Dictionary<ObjC_Class1, ObjC_Class1>) { }
+  @objc
+  func func_dictionary1b(x: Dictionary<ObjC_Class1, ObjC_Class1>) { }
 
   func func_dictionary2a(x: Dictionary<String, Int>) { }
-  @objc func func_dictionary2b(x: Dictionary<String, Int>) { }
+  @objc
+  func func_dictionary2b(x: Dictionary<String, Int>) { }
 }
 
-@objc extension PlainClass {
+@objc
+extension PlainClass {
   // CHECK-LABEL: @objc final func objc_ext_objc_okay(_: Int) {
   final func objc_ext_objc_okay(_: Int) { }
 
@@ -2216,7 +2408,8 @@ class ConformsToProtocolThrowsObjCName2 : ProtocolThrowsObjCName {
   @nonobjc final func objc_ext_objc_explicit_nonobjc(_: PlainStruct) { }
 }
 
-@objc class ObjC_Class1 : Hashable {
+@objc
+class ObjC_Class1 : Hashable {
   func hash(into hasher: inout Hasher) {}
 }
 
@@ -2225,18 +2418,21 @@ func ==(lhs: ObjC_Class1, rhs: ObjC_Class1) -> Bool {
 }
 
 // CHECK-LABEL: @objc class OperatorInClass
-@objc class OperatorInClass {
+@objc
+class OperatorInClass {
   // CHECK: {{^}} static func == (lhs: OperatorInClass, rhs: OperatorInClass) -> Bool
   static func ==(lhs: OperatorInClass, rhs: OperatorInClass) -> Bool {
     return true
   }
   // CHECK: {{^}} @objc static func + (lhs: OperatorInClass, rhs: OperatorInClass) -> OperatorInClass
-  @objc static func +(lhs: OperatorInClass, rhs: OperatorInClass) -> OperatorInClass { // expected-error {{operator methods cannot be declared @objc}}
+  @objc
+  static func +(lhs: OperatorInClass, rhs: OperatorInClass) -> OperatorInClass { // expected-error {{operator methods cannot be declared @objc}}
     return lhs
   }
 } // CHECK: {{^}$}}
 
-@objc protocol OperatorInProtocol {
+@objc
+protocol OperatorInProtocol {
   static func +(lhs: Self, rhs: Self) -> Self // expected-error {{@objc protocols must not have operator requirements}}
 }
 
@@ -2247,7 +2443,8 @@ class AdoptsOperatorInProtocol : OperatorInProtocol {
 
 //===--- @objc inference for witnesses
 
-@objc protocol InferFromProtocol {
+@objc
+protocol InferFromProtocol {
   @objc(inferFromProtoMethod1:)
   optional func method1(value: Int)
 }
@@ -2303,15 +2500,18 @@ extension SubclassInfersFromProtocol2 {
   func method1(value: Int) { }
 }
 
-@objc class NeverReturningMethod {
-  @objc func doesNotReturn() -> Never {}
+@objc
+class NeverReturningMethod {
+  @objc
+  func doesNotReturn() -> Never {}
 }
 
 // SR-5025
 class User: NSObject {
 }
 
-@objc extension User {
+@objc
+extension User {
 	var name: String {
 		get {
 			return "No name"
@@ -2345,7 +2545,8 @@ protocol ObjCProtocolWithUnownedProperty {
 
 // rdar://problem/46699152: errors about read/modify accessors being implicitly
 // marked @objc.
-@objc class MyObjCClass: NSObject {}
+@objc
+class MyObjCClass: NSObject {}
 
 @objc
 extension MyObjCClass {
@@ -2361,7 +2562,8 @@ extension MyObjCClass {
     private func stillExposedToObjCDespiteBeingPrivate() {}
 }
 
-@objc private extension MyObjCClass {
+@objc
+private extension MyObjCClass {
   // CHECK: {{^}} @objc dynamic func alsoExposedToObjCDespiteBeingPrivate()
   func alsoExposedToObjCDespiteBeingPrivate() {}
 }
@@ -2375,7 +2577,8 @@ extension MyObjCClass {
 
 class SR_9035_C {}
 
-@objc protocol SR_9035_P {
+@objc
+protocol SR_9035_P {
   func throwingMethod1() throws -> Unmanaged<CFArray> // Ok
   func throwingMethod2() throws -> Unmanaged<SR_9035_C> // expected-error {{method cannot be a member of an @objc protocol because its result type cannot be represented in Objective-C}}
   // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
@@ -2383,6 +2586,7 @@ class SR_9035_C {}
 
 // SR-12801: Make sure we reject an @objc generic subscript.
 class SR12801 {
-  @objc subscript<T>(foo : [T]) -> Int { return 0 }
+  @objc
+  subscript<T>(foo : [T]) -> Int { return 0 }
   // expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
 }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -757,6 +757,10 @@ EnableExperimentalConcurrency("enable-experimental-concurrency",
                               llvm::cl::desc("Enable experimental concurrency model"),
                               llvm::cl::init(false));
 
+static llvm::cl::list<std::string>
+AccessNotesPath("access-notes-path", llvm::cl::desc("Path to access notes file"),
+                llvm::cl::cat(Category));
+
 } // namespace options
 
 static std::unique_ptr<llvm::MemoryBuffer>
@@ -3877,6 +3881,10 @@ int main(int argc, char *argv[]) {
     // Honor the *last* -module-cache-path specified.
     InitInvok.getClangImporterOptions().ModuleCachePath =
         options::ModuleCachePath[options::ModuleCachePath.size()-1];
+  }
+  if (!options::AccessNotesPath.empty()) {
+    InitInvok.getFrontendOptions().AccessNotesPath =
+        options::AccessNotesPath[options::AccessNotesPath.size()-1];
   }
   InitInvok.getClangImporterOptions().PrecompiledHeaderOutputDir =
     options::PCHOutputDir;


### PR DESCRIPTION
This PR modifies the existing `@objc` validation code to reduce its errors to remarks when the `@objc` attribute was added by an access note. It builds on previous work to add an `InFlightDiagnostic::limitBehavior()` method and use it during `@objc` checking so that it doesn't add a lot of new conditional paths or duplicate errors.

I have also adapted nearly all of the test cases in test/attr/attr_objc.swift for access notes without actually duplicating the code by annotating the tests with comments and generating test files from it using a small tool. These test changes account for most of the lines touched by this PR. This testing approach also shook out half a dozen bugs in access notes, which have all been fixed by the end of this PR.

Fixes rdar://71875410.

-----

Review instructions:

* ~~"Add DiagnosticStateRAII" and "Use behavior limits to control @objc errors" are being reviewed separately in #36474; you can ignore them until they're rebased away.~~
* "Add -access-notes-path to swift-ide-test" just adds a command-line flag to a test tool that we'll use later.
* "Regularize @objc use in attr/attr_objc.swift" is literally just adding newlines after `@objc` attributes which don't already have them. Skim it to make sure there are absolutely no functional changes to the test.
* "Diagnose access note @objc failures using remarks" is the biggie. Read the compiler changes, the new Python test-helper tool, and the changes at the top of attr/attr_objc.swift. Skim over the changes in the rest of attr/attr_objc.swift to make sure you don't see anything that looks like it would affect the meaning of an existing test.
* The remaining commits all fix tests that were broken in the new access-note-based RUN lines of attr/attr_objc.swift. Make sure these changes all look reasonable.