### PR TITLE
BatchModeBalancer: Jobs assigned to BatchPartitions using weight-hints

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -49,6 +49,9 @@ ERROR(error_static_emit_executable_disallowed,none,
 ERROR(error_unable_to_load_output_file_map, none,
       "unable to load output file map '%1': %0", (StringRef, StringRef))
 
+ERROR(error_unable_to_load_batch_weight_hint_file, none,
+      "unable to load batch weight file map '%1': %0", (StringRef, StringRef))
+
 ERROR(error_no_output_file_map_specified,none,
       "no output file map specified", ())
 

--- a/include/swift/Basic/BatchWeightHintFileMap.h
+++ b/include/swift/Basic/BatchWeightHintFileMap.h
@@ -1,0 +1,73 @@
+//===--- BatchWeightHintFileMap.h - Map of input-file to batch-weight-hints
+//----*- C++
+//-*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_BATCHWEIGHTHINTFILEMAP_H
+#define SWIFT_BASIC_BATCHWEIGHTHINTFILEMAP_H
+
+#include "swift/Basic/FileTypes.h"
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/YAMLParser.h"
+
+#include <memory>
+#include <string>
+
+namespace swift {
+
+/// This structure embeds a map that stores input-path to batch-weight-hints.
+class BatchWeightHintFileMap {
+private:
+  llvm::StringMap<double> InputToBatchWeightHintMap;
+
+public:
+  BatchWeightHintFileMap() {}
+
+  ~BatchWeightHintFileMap() = default;
+
+  /// Load a BatchWeightHintFileMap from the given \p Path.
+  static llvm::Expected<BatchWeightHintFileMap>
+  loadFromPath(StringRef Path, StringRef workingDirectory);
+
+  /// Load a BatchWeightHintFileMap from the given \p Buffer.
+  static llvm::Expected<BatchWeightHintFileMap>
+  loadFromBuffer(StringRef Data, StringRef workingDirectory);
+
+  /// Loads a BatchWeightHintFileMap from the given Buffer, takes ownership
+  /// of the buffer as well.
+  static llvm::Expected<BatchWeightHintFileMap>
+  loadFromBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                 StringRef workingDirectory);
+
+  /// Get the batch-weight-hint for the given \p Input, if present in the
+  /// BatchWeightHintFileMap. (If not present, returns 0.)
+  double getBatchWeightHintsForInput(StringRef Input);
+
+  /// Get the batch-weight-hint for a single compilion product.
+  double getBatchWeightHintsForSingleOutput();
+
+private:
+  /// Parses the given \p Buffer and returns either a BatchWeightHintFileMap or
+  /// error, take ownership of the buffer as well.
+  static llvm::Expected<BatchWeightHintFileMap>
+  parse(std::unique_ptr<llvm::MemoryBuffer> Buffer, StringRef workingDirectory);
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -18,6 +18,7 @@
 #define SWIFT_DRIVER_COMPILATION_H
 
 #include "swift/Basic/ArrayRefView.h"
+#include "swift/Basic/BatchWeightHintFileMap.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/NullablePtr.h"
@@ -208,6 +209,10 @@ private:
   /// Overrides maximum batch size, if in batch-mode and not overridden
   /// by \c BatchCount.
   const Optional<unsigned> BatchSizeLimit;
+
+  /// BatchWeightHint map when batch-mode is selected, if any,
+  /// a map containing: InputFileName -> weight_in_double.
+  Optional<BatchWeightHintFileMap> BatchWeightHintsMap = None;
 
   /// True if temporary files should not be deleted.
   const bool SaveTemps;
@@ -436,6 +441,16 @@ public:
 
   Optional<unsigned> getBatchSizeLimit() const {
     return BatchSizeLimit;
+  }
+
+  /// Getter for BatchWeightHints.
+  Optional<BatchWeightHintFileMap> getBatchWeightHints() const {
+    return BatchWeightHintsMap;
+  }
+
+  /// Setter for BatchWeightHints.
+  void setBatchWeightHints(Optional<BatchWeightHintFileMap> BWM) {
+    BatchWeightHintsMap = BWM;
   }
 
   /// Requests the path to a file containing all input source files. This can

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -18,6 +18,7 @@
 #define SWIFT_DRIVER_DRIVER_H
 
 #include "swift/AST/IRGenOptions.h"
+#include "swift/Basic/BatchWeightHintFileMap.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/OptionSet.h"
@@ -307,6 +308,12 @@ public:
   Optional<OutputFileMap>
   buildOutputFileMap(const llvm::opt::DerivedArgList &Args,
                      StringRef workingDirectory) const;
+
+  /// Construct the BatchWeightHintFileMap for the driver from the given \p
+  /// Args arguments. BatchWeightHints are provided in a json/yaml file.
+  Optional<BatchWeightHintFileMap>
+  buildBatchWeightHintFileMap(const llvm::opt::DerivedArgList &Args,
+                              StringRef workingDirectory) const;
 
   /// Add top-level Jobs to Compilation \p C for the given \p Actions and
   /// OutputInfo.

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_DRIVER_JOB_H
 #define SWIFT_DRIVER_JOB_H
 
+#include "swift/Basic/BatchWeightHintFileMap.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/LLVM.h"
@@ -308,6 +309,9 @@ private:
   /// The modification time of the main input file, if any.
   llvm::sys::TimePoint<> InputModTime = llvm::sys::TimePoint<>::max();
 
+  /// BatchWeightHint per Job, for BatchMode balancing.
+  double BatchWeightHint;
+
 #ifndef NDEBUG
   /// The "wave" of incremental jobs that this \c Job was scheduled into.
   ///
@@ -336,7 +340,8 @@ public:
         Inputs(std::move(Inputs)), Output(std::move(Output)),
         Executable(Executable), Arguments(std::move(Arguments)),
         ExtraEnvironment(std::move(ExtraEnvironment)),
-        FilelistFileInfos(std::move(Infos)), ResponseFile(ResponseFile) {}
+        FilelistFileInfos(std::move(Infos)), ResponseFile(ResponseFile),
+        BatchWeightHint(0) {}
 
   /// For testing dependency graphs that use Jobs
   Job(OutputFileMap &OFM, StringRef dummyBaseName)
@@ -356,6 +361,11 @@ public:
     assert(hasResponseFile());
     return ResponseFile->argString;
   }
+
+  // Getter and Setter for BatchWeightHint.
+  double getBatchWeightHint() const { return BatchWeightHint; }
+  void setBatchWeightHint(double bw) { BatchWeightHint = bw; }
+
   ArrayRef<FilelistInfo> getFilelistInfos() const { return FilelistFileInfos; }
   ArrayRef<const char *> getArgumentsForTaskExecution() const;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -127,6 +127,10 @@ def driver_batch_count : Separate<["-"], "driver-batch-count">,
 def driver_batch_size_limit : Separate<["-"], "driver-batch-size-limit">,
   InternalDebugOpt,
   HelpText<"Use the given number as the upper limit on dynamic batch-mode partition size">;
+def driver_batch_weight_hint_file : Separate<["-"], "driver-batch-weight-hint-file">,
+  Flags<[NoInteractiveOption, ArgumentIsPath]>,
+  HelpText<"A file which specifies the weight of each source file (either LOC, profiled execution time) for building a load-balanced batch in BatchMode">,
+  MetaVarName<"<path>">;
 
 def driver_force_response_files : Flag<["-"], "driver-force-response-files">,
   InternalDebugOpt,

--- a/lib/Basic/BatchWeightHintFileMap.cpp
+++ b/lib/Basic/BatchWeightHintFileMap.cpp
@@ -1,0 +1,146 @@
+//===--- BatchWeightHintFileMap.cpp - Map of inputs to multiple outputs ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/BatchWeightHintFileMap.h"
+#include "swift/Basic/FileTypes.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+#include <system_error>
+#include <sstream>
+#include <string>
+
+using namespace swift;
+
+llvm::Expected<BatchWeightHintFileMap>
+BatchWeightHintFileMap::loadFromPath(StringRef Path, StringRef workingDir) {
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
+      llvm::MemoryBuffer::getFile(Path);
+  if (!FileBufOrErr) {
+    return llvm::errorCodeToError(FileBufOrErr.getError());
+  }
+  return loadFromBuffer(std::move(FileBufOrErr.get()), workingDir);
+}
+
+llvm::Expected<BatchWeightHintFileMap>
+BatchWeightHintFileMap::loadFromBuffer(StringRef Data, StringRef workingDir) {
+  std::unique_ptr<llvm::MemoryBuffer> Buffer{
+      llvm::MemoryBuffer::getMemBuffer(Data)};
+  return loadFromBuffer(std::move(Buffer), workingDir);
+}
+
+llvm::Expected<BatchWeightHintFileMap>
+BatchWeightHintFileMap::loadFromBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                              StringRef workingDir) {
+  return parse(std::move(Buffer), workingDir);
+}
+
+double BatchWeightHintFileMap::getBatchWeightHintsForInput(StringRef Input) {
+  auto iter = InputToBatchWeightHintMap.find(Input);
+  if (iter == InputToBatchWeightHintMap.end())
+    return 0;
+  else
+    return iter->second;
+}
+
+double BatchWeightHintFileMap::getBatchWeightHintsForSingleOutput() {
+  return getBatchWeightHintsForInput(StringRef());
+}
+
+llvm::Expected<BatchWeightHintFileMap>
+BatchWeightHintFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                     StringRef workingDir) {
+  // Resolve the fully qualified path name.
+  auto tryToResolvePath =
+      [workingDir](
+          StringRef PathStr,
+          llvm::SmallVectorImpl<char> &PathStorage) -> StringRef {
+    if (workingDir.empty() || PathStr.empty() || PathStr == "-" ||
+        llvm::sys::path::is_absolute(PathStr)) {
+      return PathStr;
+    }
+    // Make a copy of the path.
+    SmallString<128> PathStrCopy(PathStr);
+    PathStorage.clear();
+    PathStorage.reserve(PathStrCopy.size() + workingDir.size() + 1);
+    PathStorage.insert(PathStorage.begin(), workingDir.begin(),
+                       workingDir.end());
+
+    // Append PathStr to PathStorage.
+    llvm::sys::path::append(PathStorage, PathStrCopy);
+    return StringRef(PathStorage.data(), PathStorage.size());
+  };
+
+  BatchWeightHintFileMap BWFM;
+  llvm::SourceMgr SM;
+
+  // Emit Error.
+  auto emitError =
+      [](const char *errorStr) -> llvm::Expected<BatchWeightHintFileMap> {
+    return llvm::make_error<llvm::StringError>(errorStr,
+                                               llvm::inconvertibleErrorCode());
+  };
+  /*
+  Format of the YAML file:
+  [
+  { "full_path/swift_file_1.swift" :  weight },
+  { "full_path/swift_file_2.swift" :  weight },
+  ]
+
+  */
+  llvm::yaml::Stream Stream(Buffer->getMemBufferRef(), SM);
+  for (auto DI = Stream.begin(); DI != Stream.end(); ++ DI) {
+    auto Root = DI->getRoot();
+    if (!Root) {
+      return emitError("No Root");
+    }
+    auto Array = dyn_cast<llvm::yaml::SequenceNode>(DI->getRoot());
+    if (!Array) {
+      return emitError("Root not a SequenceNode");
+    }
+    for (auto It = Array->begin(); It != Array->end(); ++ It) {
+      auto *Map = dyn_cast<llvm::yaml::MappingNode>(&*It);
+      if (!Map) {
+        return emitError("Not a Mapping Node in SequenceNode");
+      }
+      for (auto &Pair : *Map) {
+
+        llvm::yaml::Node *Key = Pair.getKey();
+        llvm::yaml::Node *Value = Pair.getValue();
+
+        auto *fileNameNode = dyn_cast<llvm::yaml::ScalarNode>(Pair.getKey());
+        if (!fileNameNode) {
+          return emitError("Bad Key as FileName");
+        }
+        // Drop all double quotes
+        auto fileNameSR = fileNameNode->getRawValue().str();
+        fileNameSR.erase(remove(fileNameSR.begin(), fileNameSR.end(), '\"'), fileNameSR.end());
+        auto fileName = StringRef(fileNameSR);
+
+        auto *weightNode = dyn_cast<llvm::yaml::ScalarNode>(Pair.getValue());
+        if (!weightNode) {
+          return emitError("Bad Value as Weight");
+        }
+        auto weightStr = weightNode->getRawValue();
+        double weight=0;
+        weightStr.getAsDouble(weight);
+
+        llvm::SmallString<128> InputStorage;
+			  auto resolvedPath = tryToResolvePath(fileName, InputStorage);
+        // Save in the map --> input path : weight.
+        BWFM.InputToBatchWeightHintMap[resolvedPath] = weight;
+      }
+    }
+  }
+  return BWFM;
+}

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -42,6 +42,7 @@ generate_revision_inc(llvm_revision_inc LLVM "${LLVM_MAIN_SRC_DIR}")
 generate_revision_inc(swift_revision_inc Swift "${SWIFT_SOURCE_DIR}")
 
 add_swift_host_library(swiftBasic STATIC
+  BatchWeightHintFileMap.cpp
   Cache.cpp
   ClusteredBitVector.cpp
   DiverseStack.cpp

--- a/test/Driver/batch_mode_with_hints.swift
+++ b/test/Driver/batch_mode_with_hints.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/file-04.swift %t/file-05.swift
+// RUN: touch %t/file-06.swift %t/file-07.swift %t/file-08.swift %t/file-09.swift %t/file-10.swift
+// RUN: touch %t/file-11.swift %t/file-12.swift %t/file-13.swift %t/file-14.swift %t/file-15.swift
+// RUN: touch %t/file-16.swift
+//
+// RUN: echo "[ {\"%/t/file-01.swift\" : 10}, {\"%/t/file-02.swift\" : 20}, {\"%/t/file-03.swift\" : 30}, {\"%/t/file-04.swift\" : 40}, {\"%/t/file-05.swift\" : 11}, {\"%/t/file-06.swift\" : 21}, {\"%/t/file-07.swift\" : 31}, {\"%/t/file-08.swift\" : 41}, {\"%/t/file-09.swift\" : 12}, {\"%/t/file-10.swift\" : 22}, {\"%/t/file-11.swift\" : 32}, {\"%/t/file-12.swift\" : 42}, {\"%/t/file-13.swift\" : 13}, {\"%/t/file-14.swift\" : 23}, {\"%/t/file-15.swift\" : 33}, {\"%/t/file-16.swift\" : 43} ]" > %t/hint.json
+//
+// RUN: %swiftc_driver -enable-batch-mode -driver-show-job-lifecycle -driver-skip-execution -driver-batch-weight-hint-file %t/hint.json -j 4 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/file-04.swift %t/file-05.swift %t/file-06.swift %t/file-07.swift %t/file-08.swift %t/file-09.swift %t/file-10.swift %t/file-11.swift %t/file-12.swift %t/file-13.swift %t/file-14.swift %t/file-15.swift %t/file-16.swift | %FileCheck %s -check-prefix=BATCHHINT
+//
+// BATCHHINT: Found 16 batchable jobs
+// BATCHHINT: Forming into 4 batches
+// BATCHHINT: BatchWeightHint:: Job=0  with Weight=4.300000e+01 is assigned to Partition=0
+// BATCHHINT: BatchWeightHint:: Job=1  with Weight=4.200000e+01 is assigned to Partition=1
+// BATCHHINT: BatchWeightHint:: Job=2  with Weight=4.100000e+01 is assigned to Partition=3
+// BATCHHINT: BatchWeightHint:: Job=3  with Weight=4.000000e+01 is assigned to Partition=2
+// BATCHHINT: BatchWeightHint:: Job=4  with Weight=3.300000e+01 is assigned to Partition=2
+// BATCHHINT: BatchWeightHint:: Job=5  with Weight=3.200000e+01 is assigned to Partition=3
+// BATCHHINT: BatchWeightHint:: Job=6  with Weight=3.100000e+01 is assigned to Partition=1
+// BATCHHINT: BatchWeightHint:: Job=7  with Weight=3.000000e+01 is assigned to Partition=0
+// BATCHHINT: BatchWeightHint:: Job=8  with Weight=2.300000e+01 is assigned to Partition=2
+// BATCHHINT: BatchWeightHint:: Job=9  with Weight=2.200000e+01 is assigned to Partition=1
+// BATCHHINT: BatchWeightHint:: Job=10  with Weight=2.100000e+01 is assigned to Partition=0
+// BATCHHINT: BatchWeightHint:: Job=11  with Weight=2.000000e+01 is assigned to Partition=3
+// BATCHHINT: BatchWeightHint:: Job=12  with Weight=1.300000e+01 is assigned to Partition=3
+// BATCHHINT: BatchWeightHint:: Job=13  with Weight=1.200000e+01 is assigned to Partition=0
+// BATCHHINT: BatchWeightHint:: Job=14  with Weight=1.100000e+01 is assigned to Partition=1
+// BATCHHINT: BatchWeightHint:: Job=15  with Weight=1.000000e+01 is assigned to Partition=2
+// BATCHHINT: BatchWeightHint:: Summary of partition weights after assignment:
+// BATCHHINT: BatchWeightHint:: PartitionWeight[0]=1.060000e+02
+// BATCHHINT: BatchWeightHint:: PartitionWeight[1]=1.060000e+02
+// BATCHHINT: BatchWeightHint:: PartitionWeight[2]=1.060000e+02
+// BATCHHINT: BatchWeightHint:: PartitionWeight[3]=1.060000e+02
+// BATCHHINT: Adding {compile: {{file-16-.*}} <= file-16.swift} to batch 0
+// BATCHHINT: Adding {compile: {{file-12-.*}} <= file-12.swift} to batch 1
+// BATCHHINT: Adding {compile: {{file-08-.*}} <= file-08.swift} to batch 3
+// BATCHHINT: Adding {compile: {{file-04-.*}} <= file-04.swift} to batch 2
+// BATCHHINT: Adding {compile: {{file-15-.*}} <= file-15.swift} to batch 2
+// BATCHHINT: Adding {compile: {{file-11-.*}} <= file-11.swift} to batch 3
+// BATCHHINT: Adding {compile: {{file-07-.*}} <= file-07.swift} to batch 1
+// BATCHHINT: Adding {compile: {{file-03-.*}} <= file-03.swift} to batch 0
+// BATCHHINT: Adding {compile: {{file-14-.*}} <= file-14.swift} to batch 2
+// BATCHHINT: Adding {compile: {{file-10-.*}} <= file-10.swift} to batch 1
+// BATCHHINT: Adding {compile: {{file-06-.*}} <= file-06.swift} to batch 0
+// BATCHHINT: Adding {compile: {{file-02-.*}} <= file-02.swift} to batch 3
+// BATCHHINT: Adding {compile: {{file-13-.*}} <= file-13.swift} to batch 3
+// BATCHHINT: Adding {compile: {{file-09-.*}} <= file-09.swift} to batch 0
+// BATCHHINT: Adding {compile: {{file-05-.*}} <= file-05.swift} to batch 1
+// BATCHHINT: Adding {compile: {{file-01-.*}} <= file-01.swift} to batch 2
+// BATCHHINT: Forming batch job from 4 constituents
+// BATCHHINT: Forming batch job from 4 constituents
+// BATCHHINT: Forming batch job from 4 constituents
+// BATCHHINT: Forming batch job from 4 constituents
+// BATCHHINT: Adding batch job to task queue: {compile: file-03{{.*}} file-06{{.*}} file-09{{.*}} ... 1 more <= file-03.swift file-06.swift file-09.swift ... 1 more}
+// BATCHHINT: Adding batch job to task queue: {compile: file-05{{.*}} file-07{{.*}} file-10{{.*}} ... 1 more <= file-05.swift file-07.swift file-10.swift ... 1 more}
+// BATCHHINT: Adding batch job to task queue: {compile: file-01{{.*}} file-04{{.*}} file-14{{.*}} ... 1 more <= file-01.swift file-04.swift file-14.swift ... 1 more}
+// BATCHHINT: Adding batch job to task queue: {compile: file-02{{.*}} file-08{{.*}} file-11{{.*}} ... 1 more <= file-02.swift file-08.swift file-11.swift ... 1 more}


### PR DESCRIPTION
<!-- What's in this pull request? -->

BatchMode today assigns a Job to a BatchPartition without paying attention to the complexity of the Job, i.e, some Jobs take longer time to compile than others. This often leads to imbalance among Batch executions as some batches may complete execution earlier than others. Furthermore, it leads to increased build times for BatchMode. BatchSeed may alleviate this problem but is random in nature. This PR proposes BatchModeBalancer where the developer supplies weights for jobs and then the driver assigns jobs to batches using these weight hints. The core idea during assignment is that the next job is assigned to a BatchPartition with the lowest total current weight. This should ensure that Batches have roughly equal weights after assignment. In terms of determining the weights, developers are free to use simple "LOCs" or use more complex approaches such as profile time of "Primary-File" execution.

We have compared BatchModeBalancer vs. BatchMode on a 2019 MacBook Pro. 

Compilation_mode | num_threads | time_in_sec
WMO | 8 | 5.889000
BatchMode |  8 | 2.989000
BatchMode_Balancer |  8 | 2.719000

WMO | 10 | 5.871000
BatchMode | 10  | 2.652000
BatchMode_Balancer | 10 | 2.360000




