### PR TITLE
Create integerparsing init for substring

### DIFF
--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -197,4 +197,31 @@ extension FixedWidthInteger {
   public init?(_ description: String) {
     self.init(description, radix: 10)
   }
+  
+  /// Creates a new integer value from the given Substring.
+  ///
+  /// Substring can be parsed at a high speed just by substituting strings.
+  ///
+  /// The Substring passed as `description` may begin with a plus or minus sign
+  /// character (`+` or `-`), followed by one or more numeric digits (`0-9`).
+  ///
+  ///     let x = Int("123")
+  ///     // x == 123
+  ///
+  /// If `description` is in an invalid format, or if the value it denotes in
+  /// base 10 is not representable, the result is `nil`. For example, the
+  /// following conversions result in `nil`:
+  ///
+  ///     Int(" 100")                       // Includes whitespace
+  ///     Int("21-50")                      // Invalid format
+  ///     Int("ff6600")                     // Characters out of bounds
+  ///     Int("10000000000000000000000000") // Out of range
+  ///
+  /// - Parameter description: The ASCII representation of a number.
+  @inlinable
+  @_semantics("optimize.sil.specialize.generic.partial.never")
+  @inline(__always)
+  public init?(_ description: Substring) {
+    self.init(String(description), radix: 10)
+  }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
When parsing a substring, _parseASCIISlowPath is being executed. Higher performance can be expected just by wrapping it with a String once.

Note
Current speed difference

Int(substring):: Time: 0.024948954582214355
Int(String(substring)):: Time: 7.700920104980469e-05

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
