### PR TITLE
[Refactoring] SyntacticRename should walk into ObjC Keypath components when matching name locations.

### DIFF
--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -424,6 +424,36 @@ std::pair<bool, Expr*> NameMatcher::walkToExprPre(Expr *E) {
           return {false, nullptr};
         return {false, E};
       }
+      case ExprKind::KeyPath: {
+        KeyPathExpr *KP = cast<KeyPathExpr>(E);
+
+        // Swift keypath components are visited already, so there's no need to
+        // handle them specially.
+        if (!KP->isObjC())
+          break;
+
+        for (auto Component: KP->getComponents()) {
+          switch (Component.getKind()) {
+          case KeyPathExpr::Component::Kind::UnresolvedProperty:
+          case KeyPathExpr::Component::Kind::Property:
+            tryResolve(ASTWalker::ParentTy(E), Component.getLoc());
+            break;
+          case KeyPathExpr::Component::Kind::DictionaryKey:
+          case KeyPathExpr::Component::Kind::Invalid:
+            break;
+          case KeyPathExpr::Component::Kind::OptionalForce:
+          case KeyPathExpr::Component::Kind::OptionalChain:
+          case KeyPathExpr::Component::Kind::OptionalWrap:
+          case KeyPathExpr::Component::Kind::UnresolvedSubscript:
+          case KeyPathExpr::Component::Kind::Subscript:
+          case KeyPathExpr::Component::Kind::Identity:
+          case KeyPathExpr::Component::Kind::TupleElement:
+            llvm_unreachable("Unexpected component in ObjC KeyPath expression");
+            break;
+          }
+        }
+        break;
+      }
       default: // ignored
         break;
     }

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/array.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/array.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/<base>array</base> = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*prop*/prop)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/<base>array</base>)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/<base>array</base>[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/dict.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/dict.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/<base>dict</base> = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*prop*/prop)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/<base>dict</base> . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/<base>dict</base> . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/inner.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/inner.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/<base>Inner</base> {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/<base>Inner</base> . /*prop*/prop)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/<base>Inner</base> . /*array*/array)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/<base>Inner</base> . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/<base>Inner</base> . /*dict*/dict . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/<base>Inner</base> . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/<base>Inner</base> . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/<base>Inner</base> . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/namedtuple.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/namedtuple.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/<base>namedTuple</base> = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*prop*/prop)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*namedTuple*/<base>namedTuple</base>)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/outer.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/outer.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/<base>Outer</base> {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/<base>Outer</base> . /*Inner*/Inner . /*prop*/prop)
+_ = #keyPath(/*Outer*/<base>Outer</base> . /*Inner*/Inner . /*array*/array)
+_ = #keyPath(/*Outer*/<base>Outer</base> . /*Inner*/Inner . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/<base>Outer</base> . /*Inner*/Inner . /*dict*/dict . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/<base>Outer</base> . /*Inner*/Inner . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/<base>Outer</base> . /*Inner*/Inner . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/<base>Outer</base> . /*Inner*/Inner . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/outerprop.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/outerprop.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/<base>outerProp</base> = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*prop*/prop)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey . /*outerProp*/<base>outerProp</base>)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/prop.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/prop.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/<base>prop</base> = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*prop*/<base>prop</base>)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/tuple.swift.expected
+++ b/test/refactoring/SyntacticRename/FindRangeOutputs/objc-keypath/tuple.swift.expected
@@ -1,0 +1,26 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/<base>tuple</base> = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*prop*/prop)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*tuple*/<base>tuple</base>)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+

--- a/test/refactoring/SyntacticRename/objc-keypath.swift
+++ b/test/refactoring/SyntacticRename/objc-keypath.swift
@@ -1,0 +1,43 @@
+@objcMembers class /*Outer:def*/Outer {
+  let /*outerProp:def*/outerProp = 10
+
+  @objcMembers class /*Inner:def*/Inner {
+    let /*prop:def*/prop = 20
+    let /*tuple:def*/tuple = (1, 4)
+    let /*namedTuple:def*/namedTuple = (x: 1, y: 3)
+    let /*array:def*/array = [1, 2, 3]
+    let /*dict:def*/dict = ["foo": Outer()]
+  }
+}
+
+// Valid
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*prop*/prop)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*dict*/dict . someKey . /*outerProp*/outerProp)
+
+// Invalid but resolved
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*tuple*/tuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*namedTuple*/namedTuple)
+_ = #keyPath(/*Outer*/Outer . /*Inner*/Inner . /*array*/array[0] . hashValue)
+
+// FIXME: Invalid and not resolved
+_ = #keyPath(/*Outer:unknown*/Outer . /*Inner:unknown*/Inner . /*dict:unknown*/dict . someKey . undefined)
+
+// RUN: %empty-directory(%t)
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="Outer" -old-name "Outer" >> %t/outer.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/outer.swift.expected %t/outer.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="Inner" -old-name "Inner" >> %t/inner.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/inner.swift.expected %t/inner.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="outerProp" -old-name "outerProp" >> %t/outerprop.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/outerprop.swift.expected %t/outerprop.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="prop" -old-name "prop" >> %t/prop.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/prop.swift.expected %t/prop.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="tuple" -old-name "tuple" >> %t/tuple.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/tuple.swift.expected %t/tuple.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="namedTuple" -old-name "namedTuple" >> %t/namedtuple.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/namedtuple.swift.expected %t/namedtuple.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="array" -old-name "array" >> %t/array.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/array.swift.expected %t/array.swift
+// RUN: %refactor -find-rename-ranges -source-filename %s -pos="dict" -old-name "dict" >> %t/dict.swift
+// RUN: diff -u %S/FindRangeOutputs/objc-keypath/dict.swift.expected %t/dict.swift


### PR DESCRIPTION
It wasn't previously so missed them.

Resolves rdar://61573935