### PR TITLE
[Module interfaces] More aggressively #if-out declarations.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2446,16 +2446,53 @@ static bool usesFeatureAsyncAwait(Decl *decl) {
 }
 
 static bool usesFeatureMarkerProtocol(Decl *decl) {
+  // Check an inheritance clause for a marker protocol.
+  auto checkInherited = [&](ArrayRef<TypeLoc> inherited) -> bool {
+    for (const auto &inheritedEntry : inherited) {
+      if (auto inheritedType = inheritedEntry.getType()) {
+        if (inheritedType->isExistentialType()) {
+          auto layout = inheritedType->getExistentialLayout();
+          for (ProtocolType *protoTy : layout.getProtocols()) {
+            if (protoTy->getDecl()->isMarkerProtocol())
+              return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  };
+
+  // Check generic requirements for a marker protocol.
+  auto checkRequirements = [&](ArrayRef<Requirement> requirements) -> bool {
+    for (const auto &req: requirements) {
+      if (req.getKind() == RequirementKind::Conformance &&
+          req.getSecondType()->castTo<ProtocolType>()->getDecl()
+              ->isMarkerProtocol())
+        return true;
+    }
+
+    return false;
+  };
+
   if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
     if (proto->isMarkerProtocol())
+      return true;
+
+    if (checkInherited(proto->getInherited()))
+      return true;
+
+    if (checkRequirements(proto->getRequirementSignature()))
       return true;
   }
 
   if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    if (auto proto = ext->getSelfProtocolDecl())
-      if (proto->isMarkerProtocol())
-        return true;
-  }       
+    if (checkRequirements(ext->getGenericRequirements()))
+      return true;
+
+    if (checkInherited(ext->getInherited()))
+      return true;
+  }
 
   return false;
 }
@@ -2524,15 +2561,40 @@ static bool usesFeatureRethrowsProtocol(
   if (!checked.insert(decl).second)
     return false;
 
+  // Check an inheritance clause for a marker protocol.
+  auto checkInherited = [&](ArrayRef<TypeLoc> inherited) -> bool {
+    for (const auto &inheritedEntry : inherited) {
+      if (auto inheritedType = inheritedEntry.getType()) {
+        if (inheritedType->isExistentialType()) {
+          auto layout = inheritedType->getExistentialLayout();
+          for (ProtocolType *protoTy : layout.getProtocols()) {
+            if (usesFeatureRethrowsProtocol(protoTy->getDecl(), checked))
+              return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  };
+
+  if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
+    if (checkInherited(nominal->getInherited()))
+      return true;
+  }
+
   if (auto proto = dyn_cast<ProtocolDecl>(decl)) {
     if (proto->getAttrs().hasAttribute<AtRethrowsAttr>())
       return true;
   }
 
   if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    if (auto proto = ext->getSelfProtocolDecl())
-      if (usesFeatureRethrowsProtocol(proto, checked))
+    if (auto nominal = ext->getSelfNominalTypeDecl())
+      if (usesFeatureRethrowsProtocol(nominal, checked))
         return true;
+
+    if (checkInherited(ext->getInherited()))
+      return true;
   }
 
   if (auto genericSig = decl->getInnermostDeclContext()

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -550,11 +550,11 @@ public:
         if (!handledProtocols.insert(inherited).second)
           return TypeWalker::Action::SkipChildren;
 
-        // If 'nominal' is an 'actor class', we do not synthesize its 
-        // conformance to the Actor protocol through a dummy extension.
+        // If 'nominal' is an actor, we do not synthesize its conformance
+        // to the Actor protocol through a dummy extension.
         // There is a special restriction on the Actor protocol in that
-        // it is only valid to conform to Actor on an 'actor class' decl,
-        // not extensions of that 'actor class'.
+        // it is only valid to conform to Actor on an 'actor' decl,
+        // not extensions of that 'actor'.
         if (actorClass &&
             inherited->isSpecificProtocol(KnownProtocolKind::Actor))
           return TypeWalker::Action::SkipChildren;

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -10,10 +10,10 @@
 // compilers to skip over the uses of newer features.
 
 // CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: actor {{.*}} MyActor
+// CHECK-NEXT: public actor MyActor
 // CHECK: }
 // CHECK-NEXT: #endif
-public actor class MyActor {
+public actor MyActor {
 }
 
 // CHECK: #if compiler(>=5.3) && $Actors
@@ -47,10 +47,10 @@ public func globalAsync() async { }
 // CHECK-NEXT: #endif
 @_marker public protocol MP2: MP { }
 
-// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK: public protocol MP3 : FeatureTest.MP {
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: public protocol MP3 : AnyObject, FeatureTest.MP {
 // CHECK-NEXT: }
-public protocol MP3: MP { }
+public protocol MP3: AnyObject, MP { }
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol
 // CHECK-NEXT: extension MP2 {
@@ -61,6 +61,14 @@ extension MP2 {
 
 // CHECK: class OldSchool {
 public class OldSchool: MP {
+  // CHECK: #if compiler(>=5.3) && $AsyncAwait
+  // CHECK-NEXT: takeClass()
+  // CHECK-NEXT: #endif
+  public func takeClass() async { }
+}
+
+// CHECK: class OldSchool2 {
+public class OldSchool2: MP {
   // CHECK: #if compiler(>=5.3) && $AsyncAwait
   // CHECK-NEXT: takeClass()
   // CHECK-NEXT: #endif
@@ -85,16 +93,22 @@ public struct UsesRP {
 }
 
 // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
+// CHECK-NEXT: public struct IsRP
+public struct IsRP: RP {
+  public func f() { }
+}
+
+// CHECK: #if compiler(>=5.3) && $RethrowsProtocol
 // CHECK-NEXT: public func acceptsRP
 public func acceptsRP<T: RP>(_: T) { }
 
-// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK: extension Array : FeatureTest.MP where Element : FeatureTest.MP {
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: extension Array : FeatureTest.MP where Element : FeatureTest.MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
-// CHECK-NEXT: }
+// CHECK: }
 
-// CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK: extension OldSchool : Swift.UnsafeConcurrentValue {
+// CHECK: #if compiler(>=5.3) && $MarkerProtocol
+// CHECK-NEXT: extension OldSchool : Swift.UnsafeConcurrentValue {
 extension OldSchool: UnsafeConcurrentValue { }
 // CHECK-NEXT: }
 

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -78,7 +78,7 @@ public class OldSchool2: MP {
 // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
 // CHECK-NEXT: @rethrows public protocol RP
 @rethrows public protocol RP {
-  func f() throws
+  func f() throws -> Bool
 }
 
 // CHECK: public struct UsesRP {
@@ -95,7 +95,15 @@ public struct UsesRP {
 // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
 // CHECK-NEXT: public struct IsRP
 public struct IsRP: RP {
-  public func f() { }
+  // CHECK-NEXT: public func f()
+  public func f() -> Bool { }
+
+  // CHECK-NOT: $RethrowsProtocol
+  // CHECK-NEXT: public var isF: 
+  // CHECK-NEXT: get
+  public var isF: Bool {
+    f()
+  }
 }
 
 // CHECK: #if compiler(>=5.3) && $RethrowsProtocol


### PR DESCRIPTION
Extend the checks for marker protocols and rethrows protocols to ensure
that we #if out more code that relies on them in module interface
generation. This makes the _Concurrency module parseable by much older
compilers.

Fixes rdar://75291705.
