### PR TITLE
GSB: Fix runaway recursion through EquivalenceClass::lookupNestedType()

### DIFF
--- a/test/Generics/sr14289.swift
+++ b/test/Generics/sr14289.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol One {
+    associatedtype MyType
+}
+
+public protocol Two {
+    associatedtype MyType
+}
+
+public protocol Three: One, Two where MyType: Three {}
+
+extension Three {
+  public func doStuff(_: MyType.MyType.MyType) {}
+}


### PR DESCRIPTION
We shouldn't generate NestedTypeNameMatch same-type constraints
between associated types we haven't realized yet.

Otherwise, since maybeResolveEquivalenceClass() can call
lookupNestedType() before looking up a PotentialArchetype, it
is possible that maybeResolveEquivalenceClass() will return
the newly-realized type even when resolutionKind is AlreadyKnown.

This can cause an infinite recursion in expandConformanceRequirement().

However, we don't really have to do this here at all, because if
a PotentialArchetype is registered with the same name later, we
will introduce the same-type constraint in addedNestedType().

It suffices for lookupNestedType() to return the best associated
type anchor and ignore the rest.

Fixes https://bugs.swift.org/browse/SR-14289 / rdar://problem/74876047.