### PR TITLE
[libSyntax] Several small improvements to libSyntax parsing

### DIFF
--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -21,7 +21,23 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Parse/ParsedRawSyntaxNode.h"
+#include "swift/Parse/SyntaxParseActions.h"
+#include "swift/SyntaxParse/SyntaxTreeCreator.h"
 #include <memory>
+
+/// Define a macro that creates a \c ParsedRawSyntaxNode. If \c
+/// PARSEDRAWSYNTAXNODE_VERIFY_RANGES is defined, it passes the \c Range
+/// parameter, otherwise it ignores it at the pre-processor level, which means
+/// that \c Range can be an invalid expression.
+#ifdef PARSEDRAWSYNTAXNODE_VERIFY_RANGES
+#define makeParsedRawSyntaxNode(Opaque, SynKind, TokKind, DataKind, IsMissing, \
+                                Range)                                         \
+  ParsedRawSyntaxNode(Opaque, SynKind, TokKind, DataKind, IsMissing, Range)
+#else
+#define makeParsedRawSyntaxNode(Opaque, SynKind, TokKind, DataKind, IsMissing, \
+                                Range)                                         \
+  ParsedRawSyntaxNode(Opaque, SynKind, TokKind, DataKind, IsMissing)
+#endif
 
 namespace swift {
 
@@ -57,18 +73,50 @@ class ParsedRawSyntaxRecorder final {
   /// return the recorded node.
   /// This consumes the data from \c node, which is unusable after it has been
   /// recorded. The returned node should be used afterwards instead.
-  ParsedRawSyntaxNode recordDeferredNode(ParsedRawSyntaxNode &node);
+  ParsedRawSyntaxNode recordDeferredNode(ParsedRawSyntaxNode &node) {
+    switch (node.getDataKind()) {
+    case RecordedOrDeferredNode::Kind::Null:
+    case RecordedOrDeferredNode::Kind::Recorded:
+      llvm_unreachable("Not deferred");
+    case RecordedOrDeferredNode::Kind::DeferredLayout: {
+      OpaqueSyntaxNode Data = SPActions->recordDeferredLayout(node.takeData());
+      return makeParsedRawSyntaxNode(Data, node.getKind(), node.getTokenKind(),
+                                     ParsedRawSyntaxNode::DataKind::Recorded,
+                                     node.isMissing(), node.getRange());
+    }
+    case RecordedOrDeferredNode::Kind::DeferredToken: {
+      OpaqueSyntaxNode Data = SPActions->recordDeferredToken(node.takeData());
+      return makeParsedRawSyntaxNode(Data, node.getKind(), node.getTokenKind(),
+                                     ParsedRawSyntaxNode::DataKind::Recorded,
+                                     node.isMissing(), node.getRange());
+    }
+    }
+  }
 
 public:
   explicit ParsedRawSyntaxRecorder(std::shared_ptr<SyntaxParseActions> spActions)
     : SPActions(std::move(spActions)) {}
 
   ParsedRawSyntaxNode recordToken(const Token &tok, StringRef leadingTrivia,
-                                  StringRef trailingTrivia);
+                                  StringRef trailingTrivia) {
+    return recordToken(tok.getKind(), tok.getRange(), leadingTrivia,
+                       trailingTrivia);
+  }
 
   ParsedRawSyntaxNode recordToken(tok tokenKind, CharSourceRange tokenRange,
                                   StringRef leadingTrivia,
-                                  StringRef trailingTrivia);
+                                  StringRef trailingTrivia) {
+    SourceLoc offset =
+        tokenRange.getStart().getAdvancedLoc(-leadingTrivia.size());
+    unsigned length = leadingTrivia.size() + tokenRange.getByteLength() +
+                      trailingTrivia.size();
+    CharSourceRange range(offset, length);
+    OpaqueSyntaxNode n =
+        SPActions->recordToken(tokenKind, leadingTrivia, trailingTrivia, range);
+    return makeParsedRawSyntaxNode(n, syntax::SyntaxKind::Token, tokenKind,
+                                   ParsedRawSyntaxNode::DataKind::Recorded,
+                                   /*IsMissing=*/false, range);
+  }
 
   /// Record a missing token. \p loc can be invalid or an approximate location
   /// of where the token would be if not missing.
@@ -77,8 +125,39 @@ public:
   /// The provided \p elements are an exact layout appropriate for the syntax
   /// \p kind. Missing optional elements are represented with a null
   /// ParsedRawSyntaxNode object.
-  ParsedRawSyntaxNode recordRawSyntax(syntax::SyntaxKind kind,
-                                      MutableArrayRef<ParsedRawSyntaxNode> elements);
+  ParsedRawSyntaxNode
+  recordRawSyntax(syntax::SyntaxKind kind,
+                  MutableArrayRef<ParsedRawSyntaxNode> elements) {
+    assert(kind != syntax::SyntaxKind::Token &&
+           "Use recordToken to record a token");
+#ifdef PARSEDRAWSYNTAXNODE_VERIFY_RANGES
+    auto range = ParsedRawSyntaxRecorder::verifyElementRanges(elements);
+#endif
+
+    SmallVector<OpaqueSyntaxNode, 16> subnodes;
+    if (!elements.empty()) {
+      for (auto &subnode : elements) {
+        switch (subnode.getDataKind()) {
+        case RecordedOrDeferredNode::Kind::Null:
+          subnodes.push_back(nullptr);
+          break;
+        case RecordedOrDeferredNode::Kind::Recorded:
+          subnodes.push_back(subnode.takeData());
+          break;
+        case RecordedOrDeferredNode::Kind::DeferredLayout:
+        case RecordedOrDeferredNode::Kind::DeferredToken: {
+          auto recorded = recordDeferredNode(subnode);
+          subnodes.push_back(recorded.takeData());
+          break;
+        }
+        }
+      }
+    }
+    OpaqueSyntaxNode n = SPActions->recordRawSyntax(kind, subnodes);
+    return makeParsedRawSyntaxNode(n, kind, tok::NUM_TOKENS,
+                                   ParsedRawSyntaxNode::DataKind::Recorded,
+                                   /*IsMissing=*/false, range);
+  }
 
   /// Record a raw syntax collecton without eny elements. \p loc can be invalid
   /// or an approximate location of where an element of the collection would be
@@ -98,7 +177,20 @@ public:
 
   /// Form a deferred token node.
   ParsedRawSyntaxNode makeDeferred(Token tok, StringRef leadingTrivia,
-                                   StringRef trailingTrivia);
+                                   StringRef trailingTrivia) {
+    CharSourceRange tokRange = tok.getRange();
+    CharSourceRange RangeWithTrivia = CharSourceRange(
+        tokRange.getStart().getAdvancedLoc(-leadingTrivia.size()),
+        (unsigned)leadingTrivia.size() + tokRange.getByteLength() +
+            (unsigned)trailingTrivia.size());
+    auto Data = SPActions->makeDeferredToken(tok.getKind(), leadingTrivia,
+                                             trailingTrivia, RangeWithTrivia,
+                                             /*IsMissing=*/false);
+    return makeParsedRawSyntaxNode(Data, syntax::SyntaxKind::Token,
+                                   tok.getKind(),
+                                   ParsedRawSyntaxNode::DataKind::DeferredToken,
+                                   /*IsMissing=*/false, RangeWithTrivia);
+  }
 
   /// Form a deferred missing token node.
   ParsedRawSyntaxNode makeDeferredMissing(tok tokKind, SourceLoc loc);

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -173,7 +173,21 @@ public:
   ParsedRawSyntaxNode
   makeDeferred(syntax::SyntaxKind k,
                MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
-               SyntaxParsingContext &ctx);
+               SyntaxParsingContext &ctx) {
+#ifdef PARSEDRAWSYNTAXNODE_VERIFY_RANGES
+    auto range = ParsedRawSyntaxRecorder::verifyElementRanges(deferredNodes);
+#endif
+
+    assert(llvm::none_of(deferredNodes, [](const ParsedRawSyntaxNode &node) {
+      return node.isRecorded();
+    }) && "Cannot create a deferred layout node that has recorded children");
+
+    auto data =
+        SPActions->makeDeferredLayout(k, /*IsMissing=*/false, deferredNodes);
+    return makeParsedRawSyntaxNode(
+        data, k, tok::NUM_TOKENS, ParsedRawSyntaxNode::DataKind::DeferredLayout,
+        /*IsMissing=*/false, range);
+  }
 
   /// Form a deferred token node.
   ParsedRawSyntaxNode makeDeferred(Token tok, StringRef leadingTrivia,

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -28,6 +28,7 @@ class ParsedTriviaPiece;
 class SourceFile;
 class SourceLoc;
 enum class tok : uint8_t;
+class ParsedRawSyntaxNode;
 
 namespace syntax {
 class SourceFileSyntax;
@@ -113,9 +114,11 @@ public:
   /// Create a deferred layout node that may or may not be recorded later using
   /// \c recordDeferredLayout. The \c SyntaxParseAction is responsible for
   /// keeping the deferred token alive until it is destructed.
+  /// From all nodes in \p children, the underlying opaque data will be *taken*
+  /// which resets the nodes.
   virtual OpaqueSyntaxNode
   makeDeferredLayout(syntax::SyntaxKind k, bool isMissing,
-                     const ArrayRef<RecordedOrDeferredNode> &children) = 0;
+                     const MutableArrayRef<ParsedRawSyntaxNode> &children) = 0;
 
   /// Record a deferred token node that was previously created using \c
   /// makeDeferredToken. The deferred data will never be used again, so it can

--- a/include/swift/SyntaxParse/SyntaxTreeCreator.h
+++ b/include/swift/SyntaxParse/SyntaxTreeCreator.h
@@ -76,9 +76,9 @@ private:
                                      CharSourceRange range,
                                      bool isMissing) override;
 
-  OpaqueSyntaxNode
-  makeDeferredLayout(syntax::SyntaxKind k, bool IsMissing,
-                     const ArrayRef<RecordedOrDeferredNode> &children) override;
+  OpaqueSyntaxNode makeDeferredLayout(
+      syntax::SyntaxKind k, bool IsMissing,
+      const MutableArrayRef<ParsedRawSyntaxNode> &children) override;
 
   OpaqueSyntaxNode recordDeferredToken(OpaqueSyntaxNode deferred) override;
   OpaqueSyntaxNode recordDeferredLayout(OpaqueSyntaxNode deferred) override;

--- a/lib/Parse/ParsedRawSyntaxRecorder.cpp
+++ b/lib/Parse/ParsedRawSyntaxRecorder.cpp
@@ -44,31 +44,6 @@ ParsedRawSyntaxRecorder::recordEmptyRawSyntaxCollection(SyntaxKind kind,
                                  /*IsMissing=*/false, CharSourceRange(loc, 0));
 }
 
-/// Create a deferred layout node.
-ParsedRawSyntaxNode ParsedRawSyntaxRecorder::makeDeferred(
-    syntax::SyntaxKind k, MutableArrayRef<ParsedRawSyntaxNode> deferredNodes,
-    SyntaxParsingContext &ctx) {
-#ifdef PARSEDRAWSYNTAXNODE_VERIFY_RANGES
-  auto range = ParsedRawSyntaxRecorder::verifyElementRanges(deferredNodes);
-#endif
-
-  RecordedOrDeferredNode *newPtr =
-      ctx.getScratchAlloc().Allocate<RecordedOrDeferredNode>(
-          deferredNodes.size());
-  auto children = llvm::makeMutableArrayRef(newPtr, deferredNodes.size());
-  for (size_t i = 0; i < deferredNodes.size(); ++i) {
-    auto &node = deferredNodes[i];
-    assert(!node.isRecorded() &&
-           "Cannot create a deferred layout node that has recorded children");
-
-    children[i] = node.takeRecordedOrDeferredNode();
-  }
-  auto data = SPActions->makeDeferredLayout(k, /*IsMissing=*/false, children);
-  return makeParsedRawSyntaxNode(data, k, tok::NUM_TOKENS,
-                                 ParsedRawSyntaxNode::DataKind::DeferredLayout,
-                                 /*IsMissing=*/false, range);
-}
-
 ParsedRawSyntaxNode
 ParsedRawSyntaxRecorder::makeDeferredMissing(tok tokKind, SourceLoc loc) {
   auto Data = SPActions->makeDeferredToken(

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -188,17 +188,25 @@ OpaqueSyntaxNode SyntaxTreeCreator::makeDeferredToken(tok tokenKind,
 }
 
 OpaqueSyntaxNode SyntaxTreeCreator::makeDeferredLayout(
-    syntax::SyntaxKind k, bool IsMissing,
-    const MutableArrayRef<ParsedRawSyntaxNode> &children) {
-  SmallVector<OpaqueSyntaxNode, 16> opaqueChildren;
-  opaqueChildren.reserve(children.size());
+    syntax::SyntaxKind kind, bool IsMissing,
+    const MutableArrayRef<ParsedRawSyntaxNode> &parsedChildren) {
+  assert(!IsMissing && "Missing layout nodes not implemented yet");
 
-  for (size_t i = 0; i < children.size(); ++i) {
-    opaqueChildren.push_back(children[i].takeData());
+  SmallVector<const RawSyntax *, 16> children;
+  children.reserve(parsedChildren.size());
+
+  size_t TextLength = 0;
+  for (size_t i = 0; i < parsedChildren.size(); ++i) {
+    auto Raw = static_cast<const RawSyntax *>(parsedChildren[i].takeData());
+    if (Raw) {
+      TextLength += Raw->getTextLength();
+    }
+    children.push_back(Raw);
   }
 
-  // Also see comment in makeDeferredToken
-  return recordRawSyntax(k, opaqueChildren);
+  auto raw = RawSyntax::make(kind, children, TextLength,
+                             SourcePresence::Present, Arena);
+  return static_cast<OpaqueSyntaxNode>(raw);
 }
 
 OpaqueSyntaxNode

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -11,17 +11,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SyntaxParse/SyntaxTreeCreator.h"
-#include "swift/Syntax/RawSyntax.h"
-#include "swift/Syntax/SyntaxVisitor.h"
-#include "swift/Syntax/Trivia.h"
-#include "swift/Parse/ParsedTrivia.h"
-#include "swift/Parse/SyntaxParsingCache.h"
-#include "swift/Parse/Token.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/OwnedString.h"
+#include "swift/Parse/ParsedRawSyntaxNode.h"
+#include "swift/Parse/ParsedTrivia.h"
+#include "swift/Parse/SyntaxParsingCache.h"
+#include "swift/Parse/Token.h"
+#include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/SyntaxVisitor.h"
+#include "swift/Syntax/Trivia.h"
 
 using namespace swift;
 using namespace swift::syntax;
@@ -188,12 +189,12 @@ OpaqueSyntaxNode SyntaxTreeCreator::makeDeferredToken(tok tokenKind,
 
 OpaqueSyntaxNode SyntaxTreeCreator::makeDeferredLayout(
     syntax::SyntaxKind k, bool IsMissing,
-    const ArrayRef<RecordedOrDeferredNode> &children) {
+    const MutableArrayRef<ParsedRawSyntaxNode> &children) {
   SmallVector<OpaqueSyntaxNode, 16> opaqueChildren;
   opaqueChildren.reserve(children.size());
 
   for (size_t i = 0; i < children.size(); ++i) {
-    opaqueChildren.push_back(children[i].getOpaque());
+    opaqueChildren.push_back(children[i].takeData());
   }
 
   // Also see comment in makeDeferredToken

--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -36,8 +36,10 @@ SyntaxTreeCreator::SyntaxTreeCreator(SourceManager &SM, unsigned bufferID,
   const char *Data = BufferContent.data();
   Arena->copyStringToArenaIfNecessary(Data, BufferContent.size());
   ArenaSourceBuffer = StringRef(Data, BufferContent.size());
-  Arena->setHotUseMemoryRegion(ArenaSourceBuffer.begin(),
-                               ArenaSourceBuffer.end());
+  if (!ArenaSourceBuffer.empty()) {
+    Arena->setHotUseMemoryRegion(ArenaSourceBuffer.begin(),
+                                 ArenaSourceBuffer.end());
+  }
 }
 
 SyntaxTreeCreator::~SyntaxTreeCreator() = default;

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -245,12 +245,21 @@ private:
 
   OpaqueSyntaxNode makeDeferredLayout(
       syntax::SyntaxKind k, bool isMissing,
-      const ArrayRef<RecordedOrDeferredNode> &children) override {
+      const MutableArrayRef<ParsedRawSyntaxNode> &parsedChildren) override {
     assert(!isMissing && "Missing layout nodes not implemented yet");
+
+    auto childrenMem = DeferredNodeAllocator.Allocate<RecordedOrDeferredNode>(
+        parsedChildren.size());
+    auto children =
+        llvm::makeMutableArrayRef(childrenMem, parsedChildren.size());
 
     // Compute the length of this node.
     unsigned length = 0;
-    for (auto &child : children) {
+    size_t index = 0;
+    for (auto &parsedChild : parsedChildren) {
+      auto child = parsedChild.takeRecordedOrDeferredNode();
+      children[index++] = child;
+
       switch (child.getKind()) {
       case RecordedOrDeferredNode::Kind::Null:
         break;


### PR DESCRIPTION
This is a colleciton of a couple small performance improvements, each in their seaprate commit:
- Moves a couple methods from the `ParsedRawSyntaxRecorder.cpp` file to the `ParsedRawSyntaxRecorder.h` to give the compiler an opportunity to inline them when it sees fit.
- Eliminate a loop and memory allocation to transform `ParsedRawSyntaxNode`s to `RecordedOrDeferredNode`s. Instead pass `ParsedRawSyntaxNode`s to `SyntaxParseActions` and let the actions extract the `RecordedOrDeferredNode`s themself.
- Inline `SyntaxTreeCreator::recordRawSyntax` into `SyntaxTreeCreator::makeDeferredLayout` and merge two consecutive loops into one.
- And a small bug fix that I didn’t want to open a separate PR for: Don't set hot use memory region if source is empty. If the source is empty, the start of the copied buffer is a nullptr which doesn't live inside the SyntaxArena's bump allocator. Thus the assert inside `setHotUseMemoryArea` fails.