### PR TITLE
[libSyntax] Pass trivia to SwiftSyntax as a plain string

### DIFF
--- a/include/swift-c/SyntaxParser/SwiftSyntaxParser.h
+++ b/include/swift-c/SyntaxParser/SwiftSyntaxParser.h
@@ -98,12 +98,19 @@ typedef struct {
 } swiftparse_trivia_piece_t;
 
 typedef struct {
-  const swiftparse_trivia_piece_t *leading_trivia;
-  const swiftparse_trivia_piece_t *trailing_trivia;
-  uint16_t leading_trivia_count;
-  uint16_t trailing_trivia_count;
+  // The length of the leading trivia in bytes.
+  uint32_t leading_trivia_length;
+  
+  // The length of the trailing trivia in bytes.
+  uint32_t trailing_trivia_length;
+
   swiftparse_token_kind_t kind;
+  
   /// Represents the range for the node, including trivia.
+  /// The length of the actual token is
+  /// \code
+  /// range.length - leading_trivia_length - trailing_trivia_length
+  /// \endcode
   swiftparse_range_t range;
 } swiftparse_token_data_t;
 
@@ -137,6 +144,18 @@ swiftparse_parser_create(void);
 
 SWIFTPARSE_PUBLIC void
 swiftparse_parser_dispose(swiftparse_parser_t);
+
+/// Callback with which \c swiftparse_parse_trivia returns the trivia pieces
+/// to the caller. \p pieces only points to valid memory while this block is 
+/// being executed and should not escape.
+typedef void
+    (^swiftparse_trivia_handler_t)(const swiftparse_trivia_piece_t *pieces, size_t len);
+
+/// Parse the given \p trivia into trivia pieces. \p callback will be invoked
+/// with a pointer to a list of \c swiftparse_trivia_piece_t structs that are
+/// only valid for the duration of the callback.
+SWIFTPARSE_PUBLIC void
+swiftparse_parse_trivia(const char *trivia, size_t len, swiftparse_trivia_handler_t callback);
 
 /// Invoked by the parser when a syntax node is parsed. The client should
 /// return a pointer to associate with that particular node.

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.exports
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.exports
@@ -1,6 +1,7 @@
 swiftparse_parse_string
 swiftparse_parser_create
 swiftparse_parser_dispose
+swiftparse_parse_trivia
 swiftparse_parser_set_node_handler
 swiftparse_parser_set_node_lookup
 swiftparse_syntax_structure_versioning_identifier

--- a/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
+++ b/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
@@ -98,14 +98,6 @@ convertClientNode(swiftparse_client_node_t client_node) {
   return std::unique_ptr<SPNode>((SPNode*)client_node);
 }
 
-static size_t trivialLen(ArrayRef<swiftparse_trivia_piece_t> trivia) {
-  size_t len = 0;
-  for (const auto &piece : trivia) {
-    len += piece.length;
-  }
-  return len;
-}
-
 static swiftparse_client_node_t
 makeNode(const swiftparse_syntax_node_t *raw_node, StringRef source) {
   SPNode *node = new SPNode();
@@ -114,12 +106,8 @@ makeNode(const swiftparse_syntax_node_t *raw_node, StringRef source) {
     auto range = raw_node->token_data.range;
     auto nodeText = source.substr(range.offset, range.length);
     node->tokKind = raw_node->token_data.kind;
-    size_t leadingTriviaLen =
-      trivialLen(makeArrayRef(raw_node->token_data.leading_trivia,
-                              raw_node->token_data.leading_trivia_count));
-    size_t trailingTriviaLen =
-      trivialLen(makeArrayRef(raw_node->token_data.trailing_trivia,
-                              raw_node->token_data.trailing_trivia_count));
+    auto leadingTriviaLen = raw_node->token_data.leading_trivia_length;
+    auto trailingTriviaLen = raw_node->token_data.trailing_trivia_length;
     node->leadingTriviaText = nodeText.take_front(leadingTriviaLen);
     node->tokenText = nodeText.substr(
         leadingTriviaLen, range.length - leadingTriviaLen - trailingTriviaLen);


### PR DESCRIPTION
This changes the model of how trivia is being transferred to SwiftSyntax. 

Previously, we would always parse trivia into its pieces and transfer the pieces from the C++ side to the Swift side. With performance improvements on the C++ side, we now no longer decompose trivia into their pieces during lexing – instead we create a raw trivia string which can lazily be lexed into pieces when needed.

When transmitting trivia to SwiftSyntax, so far we always eagerly lexed the raw trivia string into pieces, transmitting the pieces – this, however, adds an additional overhead of generating the pieces, which is not necessary in case the SwiftSyntax client does not care about trivia.

In the new model, we always only transmit the raw trivia string. When the SwiftSyntax client accesses the trivia pieces, SwiftSyntax reaches out to the C++ side again, asking it to decompose the raw trivia string into trivia pieces, which it can return. These decompositions are **not** cached, thus any access to trivia pieces causes the pieces to re-generated. In general the new best practice should be to only request the trivia pieces of a Syntax node once and hold on to it locally whenever possible.

This reduces the time spent in the [parsing performance test](https://github.com/apple/swift-syntax/blob/main/Tests/PerformanceTest/ParsingPerformanceTests.swift) by 10%. The test case parses a pretty long Swift file `MinimalCollections.swift` and generates a SwiftSyntax tree for it, so it should roughly capture the performance of a SwiftSyntax user that does not care about trivia.

I haven’t gathered any numbers on it, but I ass that performance will degrade if trivia of most tokens is requested, since we now have an additional step to perform here (transfer as raw string & later lex into pieces opposed to directly lexing into pieces).

CC: @allevato 