### PR TITLE
XFAIL a test that fails due to a new GSB assert

### DIFF
--- a/test/Generics/sr11153.swift
+++ b/test/Generics/sr11153.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | not %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s
 
+// XFAIL: asserts
+
 // CHECK: Requirement signature: <Self where Self.Field : FieldAlgebra>
 public protocol VectorSpace {
     associatedtype Field: FieldAlgebra


### PR DESCRIPTION
I added this test case in https://github.com/apple/swift/pull/36402;
the change in https://github.com/apple/swift/pull/36411 correctly
flags some bogus same-type requirements in a minimized signature
and asserts.
