### PR TITLE
[SymbolGraph] use fully qualified titles for enum elements

### DIFF
--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -120,7 +120,7 @@ void Symbol::serializeNames(llvm::json::OStream &OS) const {
     SmallVector<PathComponent, 8> PathComponents;
     getPathComponents(PathComponents);
 
-    if (isa<GenericTypeDecl>(VD)) {    
+    if (isa<GenericTypeDecl>(VD) || isa<EnumElementDecl>(VD)) {
       SmallString<64> FullyQualifiedTitle;
 
       for (const auto *It = PathComponents.begin(); It != PathComponents.end(); ++It) {

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph.swift
@@ -745,7 +745,7 @@ enum MyEnum {
 // CHECKCASE:             "spelling": "someCase"
 // CHECKCASE:           }
 // CHECKCASE:         ],
-// CHECKCASE:         "title": "someCase"
+// CHECKCASE:         "title": "MyEnum.someCase"
 // CHECKCASE:       },
 // CHECKCASE:       "pathComponents": [
 // CHECKCASE:         "MyEnum",

--- a/test/SymbolGraph/Symbols/Names.swift
+++ b/test/SymbolGraph/Symbols/Names.swift
@@ -5,6 +5,8 @@
 // RUN: %FileCheck %s --input-file %t/Names.symbols.json --check-prefix=FUNC
 // RUN: %FileCheck %s --input-file %t/Names.symbols.json --check-prefix=INNERTYPE
 // RUN: %FileCheck %s --input-file %t/Names.symbols.json --check-prefix=INNERTYPEALIAS
+// RUN: %FileCheck %s --input-file %t/Names.symbols.json --check-prefix=INNERENUM
+// RUN: %FileCheck %s --input-file %t/Names.symbols.json --check-prefix=INNERCASE
 
 public struct MyStruct {
   public struct InnerStruct {}
@@ -12,6 +14,10 @@ public struct MyStruct {
   public typealias InnerTypeAlias = InnerStruct
 
   public func foo() {}
+
+  public enum InnerEnum {
+      case InnerCase
+  }
 }
 
 // CHECK-LABEL: "precise": "s:5Names8MyStructV"
@@ -29,3 +35,11 @@ public struct MyStruct {
 // INNERTYPEALIAS-LABEL: "precise": "s:5Names8MyStructV14InnerTypeAliasa"
 // INNERTYPEALIAS: names
 // INNERTYPEALIAS-NEXT: "title": "MyStruct.InnerTypeAlias"
+
+// INNERENUM-LABEL: "precise": "s:5Names8MyStructV9InnerEnumO",
+// INNERENUM: names
+// INNERENUM-NEXT: "title": "MyStruct.InnerEnum"
+
+// INNERCASE-LABEL: "precise": "s:5Names8MyStructV9InnerEnumO0D4CaseyA2EmF",
+// INNERCASE: names
+// INNERCASE-NEXT: "title": "MyStruct.InnerEnum.InnerCase",


### PR DESCRIPTION
Resolves rdar://74051287

This PR updates the symbol graph's `symbol.names.title` field to use fully-qualified names for enumeration cases, as well as structs/enums/classes.