### PR TITLE
Add semantics attribute: must_specialize.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6162,6 +6162,16 @@ WARNING(debug_long_expression, none,
         "expression took %0ms to type-check (limit: %1ms)",
         (unsigned, unsigned))
 
+ERROR(must_specialize_function_not_public, none,
+      "function %0 marked as 'must_specialize' must not be publicly available.",
+      (StringRef))
+ERROR(must_specialize_function_never_specialized, none,
+      "function %0 was never called with concrete generic substitutions.",
+      (StringRef))
+NOTE(note_must_specialize_function_called_here, none,
+     "function marked 'must_specialize' called here %0",
+     (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Pattern match diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -120,5 +120,7 @@ SEMANTICS_ATTR(LIFETIMEMANAGEMENT_COPY, "lifetimemanagement.copy")
 
 SEMANTICS_ATTR(NO_PERFORMANCE_ANALYSIS, "no_performance_analysis")
 
+SEMANTICS_ATTR(MUST_SPECIALIZE, "must_specialize")
+
 #undef SEMANTICS_ATTR
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -299,6 +299,9 @@ PASS(LowerAggregateInstrs, "lower-aggregate-instrs",
      "Lower Aggregate SIL Instructions to Multiple Scalar Operations")
 PASS(MandatoryInlining, "mandatory-inlining",
      "Mandatory Inlining of Transparent Functions")
+PASS(MandatorySpecialization, "mandatory-specialization",
+     "Forces specialization of functions marked with the 'must_specialize' "
+     "semantics attribute.")
 PASS(Mem2Reg, "mem2reg",
      "Memory to SSA Value Conversion to Remove Stack Allocation")
 PASS(MemBehaviorDumper, "mem-behavior-dump",

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(swiftSILOptimizer PRIVATE
   MoveOnlyObjectChecker.cpp
   MoveOnlyAddressChecker.cpp
   MoveOnlyDeinitInsertion.cpp
+  MandatorySpecialization.cpp
   NestedSemanticFunctionCheck.cpp
   OptimizeHopToExecutor.cpp
   PerformanceDiagnostics.cpp

--- a/lib/SILOptimizer/Mandatory/MandatorySpecialization.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatorySpecialization.cpp
@@ -1,0 +1,280 @@
+//===--- MandatorySpecialization.cpp -
+//  Specialize functions marked with "must_specialize" attribute ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-mandatory-specializer"
+
+#include "swift/AST/DiagnosticsSema.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/OptimizationRemark.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILLinkage.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Generics.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+
+using namespace swift;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+//                            MandatorySpecializationPass
+//===----------------------------------------------------------------------===//
+
+class MandatorySpecializationPass : public SILModuleTransform {
+  SILOptFunctionBuilder *functionBuilder;
+  llvm::SmallPtrSet<SILFunction *, 32> visitedFunctions;
+  llvm::SmallPtrSet<SILInstruction *, 32> mustSpecializeApplySites;
+
+  // For any given function, find all of its callers.
+  llvm::DenseMap<SILFunction *, SmallVector<SILFunction *, 4>> functionCallers;
+  llvm::DenseMap<SILFunction *, SmallVector<FullApplySite, 4>> applySites;
+
+  // "recursivelySpecializeCalls" is called after "correctCallerFnAttributes"
+  // so we know any function without a concrete set of generic substitutions is
+  // marked "must_specialize". "recursivelySpecializeCalls" should be passed a
+  // function WITH OUT the must_specialize attribute. This means that all of its
+  // apply sites of "must_specialize" functions are concrete, so specilization
+  // should never fail. As stated above, we start at the top level with
+  // functions that aren't marked as "must_specialize". Once a specialized
+  // function is created, it is passed to "recursivelySpecializeCalls" (hence
+  // the "recursively" part of the name). The newly created (and specialized)
+  // function is known to only have concrete apply sites, so everything should
+  // just work, and again, specialization of functions called in the newly
+  // specialized function will never fail.
+  void recursivelySpecializeCalls(SILFunction &fn) {
+    // Don't create an infinite loop.
+    if (!visitedFunctions.insert(&fn).second)
+      return;
+
+    SmallVector<SILInstruction *, 64> worklist;
+    for (auto &bb : fn) {
+      for (auto &inst : bb) {
+        worklist.push_back(&inst);
+      }
+    }
+
+    for (auto *inst : worklist) {
+      if (!FullApplySite::isa(inst))
+        continue;
+
+      FullApplySite apply(inst);
+      SILFunction *callee = apply.getCalleeFunction();
+      if (!callee || !callee->hasSemanticsAttr(semantics::MUST_SPECIALIZE))
+        continue;
+
+      // If the caller and callee are both fragile, preserve the fragility when
+      // cloning the callee. Otherwise, strip it off so that we can optimize
+      // the body more.
+      //
+      // If it is OnoneSupport consider all specializations as non-serialized
+      // as we do not SIL serialize their bodies.
+      // It is important to set this flag here, because it affects the
+      // mangling of the specialization's name.
+      IsSerialized_t serialized = IsNotSerialized;
+      if (fn.isSerialized() && callee->isSerialized())
+        serialized = getModule()->isOptimizedOnoneSupportModule()
+                         ? IsNotSerialized
+                         : IsSerialized;
+
+      OptRemark::Emitter optRemarkEmitter(DEBUG_TYPE, fn);
+
+      ReabstractionInfo reInfo(
+          getModule()->getSwiftModule(), getModule()->isWholeModule(), apply,
+          callee, apply.getSubstitutionMap(), serialized,
+          /*ConvertIndirectToDirect=*/true, &optRemarkEmitter);
+      assert(reInfo.canBeSpecialized());
+
+      GenericFuncSpecializer functionSpecializer(
+          *functionBuilder, callee, apply.getSubstitutionMap(), reInfo);
+      SILFunction *specializedFn = functionSpecializer.lookupSpecialization();
+      if (!specializedFn) {
+        specializedFn = functionSpecializer.tryCreateSpecialization(true);
+        specializedFn->removeSemanticsAttr(semantics::MUST_SPECIALIZE);
+      }
+      assert(specializedFn);
+
+      mustSpecializeApplySites.erase(apply.getInstruction());
+
+      replaceWithSpecializedFunction(apply, specializedFn, reInfo);
+      recursivelyDeleteTriviallyDeadInstructions(apply.getInstruction(), true);
+
+      // It's important to do this top-down so we do it recursively.
+      recursivelySpecializeCalls(*specializedFn);
+    }
+  }
+
+  void buildCallGraph(SILFunction &fn) {
+    for (auto &bb : fn) {
+      for (auto &inst : bb) {
+        if (!FullApplySite::isa(&inst))
+          continue;
+
+        FullApplySite apply(&inst);
+        applySites[&fn].push_back(apply);
+        SILFunction *callee = apply.getCalleeFunction();
+        functionCallers[callee].push_back(&fn);
+      }
+    }
+  }
+
+  // Make sure that any functions that call functions that are marked as
+  // 'must_specialize' are themselves marked as 'must_specialize'.
+  void correctCallerFnAttributes(
+      SILFunction &fn, SmallPtrSet<SILFunction *, 32> &correctedFunctions) {
+    if (!fn.hasSemanticsAttr(semantics::MUST_SPECIALIZE) ||
+        !correctedFunctions.insert(&fn).second)
+      return;
+
+    for (SILFunction *caller : functionCallers[&fn]) {
+      // If this *is* a generic function and it doesn't have this attribute,
+      // make sure we correct that. If this is not a generic function, then it
+      // means we've reached the "top".
+      if (!caller->getLoweredFunctionType()->getInvocationGenericSignature())
+        continue;
+
+      // If all apply sites of "must_specialize" functions have full concrete
+      // substitutions, then it also means we've reached the "top".
+      if (llvm::all_of(applySites[caller], [](FullApplySite apply) {
+            return !apply.getCalleeFunction()->hasSemanticsAttr(
+                       semantics::MUST_SPECIALIZE) ||
+                   llvm::all_of(
+                       apply.getSubstitutionMap().getReplacementTypes(),
+                       [](Type type) { return type->getAnyGeneric(); });
+          }))
+        continue;
+
+      // Otherwise, propagate the attribute up to the caller.
+      if (!caller->hasSemanticsAttr(semantics::MUST_SPECIALIZE))
+        caller->addSemanticsAttr(semantics::MUST_SPECIALIZE);
+      correctCallerFnAttributes(*caller, correctedFunctions);
+    }
+  }
+
+  /// \returns true if verification failed and the compiler will exit.
+  bool verifySpecialized() {
+    bool failed = false;
+    // Error if there are any left over calls to 'must_specialize' functions.
+    for (auto *applyInst : mustSpecializeApplySites) {
+      FullApplySite apply(applyInst);
+      // If someone calls this function, we'll diagnose the error in the caller
+      // function.
+      if (functionCallers[apply.getFunction()].size())
+        continue;
+
+      auto fnName = Demangle::demangleSymbolAsString(
+          apply.getFunction()->getName(),
+          Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+      auto calleeName = Demangle::demangleSymbolAsString(
+          apply.getCalleeFunction()->getName(),
+          Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+      getModule()->getASTContext().Diags.diagnose(
+          apply.getFunction()->getLocation().getSourceLoc(),
+          diag::must_specialize_function_never_specialized, {fnName});
+      getModule()->getASTContext().Diags.diagnose(
+          applyInst->getLoc().getSourceLoc(),
+          diag::note_must_specialize_function_called_here, {calleeName});
+      failed = true;
+    }
+
+    // Check that all functions marked 'must_specialize' are not publically
+    // available.
+    for (auto &fn : getModule()->getFunctions()) {
+      if (fn.hasSemanticsAttr(semantics::MUST_SPECIALIZE) &&
+          hasPublicVisibility(fn.getLinkage())) {
+        auto fnName = Demangle::demangleSymbolAsString(
+            fn.getName(),
+            Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+        getModule()->getASTContext().Diags.diagnose(
+            fn.getLocation().getSourceLoc(),
+            diag::must_specialize_function_not_public, {fnName});
+        failed = true;
+      }
+    }
+
+    return failed;
+  }
+
+  // Delete all "must_specialize" functions. They can no longer be used.
+  bool deleteDeadFunctions() {
+    bool deletedFunctions = false;
+    SmallVector<SILFunction *, 64> functions;
+    for (auto &fn : getModule()->getFunctions())
+      functions.push_back(&fn);
+    for (SILFunction *fn : functions) {
+      if (fn->hasSemanticsAttr(semantics::MUST_SPECIALIZE)) {
+        deletedFunctions = true;
+        notifyWillDeleteFunction(fn);
+        getModule()->eraseFunction(fn);
+      }
+    }
+    return deletedFunctions;
+  }
+
+public:
+  MandatorySpecializationPass() = default;
+
+  /// The entry point to the transformation.
+  void run() override {
+    SILOptFunctionBuilder localFunctionBuilder(*this);
+    functionBuilder = &localFunctionBuilder;
+
+    for (SILFunction &fn : getModule()->getFunctions()) {
+      buildCallGraph(fn);
+    }
+
+    SmallPtrSet<SILFunction *, 32> correctedFunctions;
+    for (SILFunction &fn : getModule()->getFunctions()) {
+      correctCallerFnAttributes(fn, correctedFunctions);
+    }
+
+    for (SILFunction &fn : getModule()->getFunctions()) {
+      for (auto &bb : fn) {
+        for (auto &inst : bb) {
+          if (!FullApplySite::isa(&inst))
+            continue;
+
+          FullApplySite apply(&inst);
+          SILFunction *callee = apply.getCalleeFunction();
+          if (callee && callee->hasSemanticsAttr(semantics::MUST_SPECIALIZE))
+            mustSpecializeApplySites.insert(apply.getInstruction());
+        }
+      }
+    }
+
+    for (SILFunction &fn : getModule()->getFunctions()) {
+      // Only try to specialize the calls in top-level functions.
+      if (!fn.hasSemanticsAttr(semantics::MUST_SPECIALIZE))
+        recursivelySpecializeCalls(fn);
+    }
+
+    // If this returns true, it means we're going to fail to compile. So just
+    // exit.
+    if (verifySpecialized())
+      return;
+
+    // If we don't delete any functions it means that there are no function
+    // marked as "must_specialize".
+    if (deleteDeadFunctions()) {
+      invalidateAll();
+      invalidateFunctionTables();
+      getModule()->invalidateSILLoaderCaches();
+    }
+  }
+};
+
+} // end anonymous namespace
+
+SILTransform *swift::createMandatorySpecialization() {
+  return new MandatorySpecializationPass();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -90,6 +90,7 @@ static void addMandatoryDebugSerialization(SILPassPipelinePlan &P) {
   P.startPipeline("Mandatory Debug Serialization");
   P.addAddressLowering();
   P.addOwnershipModelEliminator();
+  P.addMandatorySpecialization();
   P.addMandatoryInlining();
 }
 
@@ -181,6 +182,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   if (Options.shouldOptimize() && EnableDestroyHoisting) {
     P.addDestroyHoisting();
   }
+  P.addMandatorySpecialization();
   P.addMandatoryInlining();
   P.addMandatorySILLinker();
 

--- a/test/SILOptimizer/mandatory_specialization.swift
+++ b/test/SILOptimizer/mandatory_specialization.swift
@@ -1,0 +1,179 @@
+// RUN: %target-swift-frontend -sil-verify-all -primary-file %s -emit-sil | %FileCheck %s
+// RUN: not %target-swift-frontend -sil-verify-all -primary-file %s -emit-sil -D ERRORS 2>&1 | %FileCheck %s --check-prefix=CHECK-ERROR
+
+// We shouldn't have any "must_specialize" functions left over.
+// CHECK-NOT: [_semantics "must_specialize"]
+
+// CHECK-LABEL: s24mandatory_specialization11twoGenerics1x1yxx_q_tr0_lFSi_SiTg5
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization11twoGenerics1x1yxx_q_tr0_lFSi_SiTg5'
+
+// CHECK-NOT: sil hidden [noinline] [_semantics "must_specialize"] @$s24mandatory_specialization11twoGenerics1x1yxx_q_tr0_lF
+@_semantics("must_specialize")
+@inline(never)
+func twoGenerics<T, U>(x: T, y: U) -> T { x }
+
+// CHECK-LABEL: sil shared [noinline] @$s24mandatory_specialization20callsWithHalfGeneric1xxx_tlFSi_Tg5
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization11twoGenerics1x1yxx_q_tr0_lFSi_SiTg5 : $@convention(thin) (Int, Int) -> Int
+// CHECK: apply [[FN]]({{.*}}, {{.*}}) : $@convention(thin) (Int, Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization20callsWithHalfGeneric1xxx_tlFSi_Tg5'
+
+// CHECK-NOT: sil hidden [noinline] [_semantics "must_specialize"] @$s24mandatory_specialization20callsWithHalfGeneric1xxx_tlF
+@inline(never)
+func callsWithHalfGeneric<T>(x: T) -> T { twoGenerics(x: x, y: 0) }
+
+// CHECK-LABEL: sil shared [noinline] @$s24mandatory_specialization16callsWithGeneric1xxx_tlFSi_Tg5
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization20callsWithHalfGeneric1xxx_tlFSi_Tg5 : $@convention(thin) (Int) -> Int
+// CHECK: apply [[FN]]({{.*}}) : $@convention(thin) (Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization16callsWithGeneric1xxx_tlFSi_Tg5'
+
+// CHECK-NOT: sil hidden [noinline] [_semantics "must_specialize"] @$s24mandatory_specialization16callsWithGeneric1xxx_tlF
+@inline(never)
+func callsWithGeneric<T>(x: T) -> T { callsWithHalfGeneric(x: x) }
+
+// CHECK-LABEL: sil shared [noinline] @$s24mandatory_specialization31twoUnrelatedGenericsSpecialized1x1ySix_q_tr0_lFAA6StructV_AFTg5
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization11twoGenerics1x1yxx_q_tr0_lFSi_SiTg5 : $@convention(thin) (Int, Int) -> Int
+// CHECK: apply [[FN]]({{.*}}, {{.*}}) : $@convention(thin) (Int, Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization31twoUnrelatedGenericsSpecialized1x1ySix_q_tr0_lFAA6StructV_AFTg5'
+
+// CHECK-NOT: sil hidden [noinline] [_semantics "must_specialize"] @$s24mandatory_specialization20twoUnrelatedGenerics1x1ySix_q_tr0_lF
+@_semantics("must_specialize")
+@inline(never)
+func twoUnrelatedGenericsSpecialized<T, U>(x: T, y: U) -> Int { twoGenerics(x: 0, y: 0) }
+
+// This one should NOT be specialized.
+// CHECK-LABEL: sil hidden [noinline] @$s24mandatory_specialization20twoUnrelatedGenerics1x1ySix_q_tr0_lF
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization11twoGenerics1x1yxx_q_tr0_lFSi_SiTg5 : $@convention(thin) (Int, Int) -> Int
+// CHECK: apply [[FN]]({{.*}}, {{.*}}) : $@convention(thin) (Int, Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization20twoUnrelatedGenerics1x1ySix_q_tr0_lF'
+@inline(never)
+func twoUnrelatedGenerics<T, U>(x: T, y: U) -> Int { twoGenerics(x: 0, y: 0) }
+
+// CHECK-NOT: sil hidden [transparent] [_semantics "must_specialize"] @$s24mandatory_specialization18transparentGeneric1xxx_tlF
+@_semantics("must_specialize")
+@_transparent
+func transparentGeneric<T>(x: T) -> T { x }
+
+// CHECK-LABEL: sil shared @$s24mandatory_specialization24transparentGenericCaller1xxx_tlFSi_Tg5
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization24transparentGenericCaller1xxx_tlFSi_Tg5'
+
+// CHECK-NOT: sil hidden @$s24mandatory_specialization24transparentGenericCaller1xxx_tlF
+func transparentGenericCaller<T>(x: T) -> T { transparentGeneric(x: x) }
+
+// CHECK-LABEL: sil shared @$s24mandatory_specialization23mustSpecializeCallsSelf1xxx_tlFSi_Tg5
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization23mustSpecializeCallsSelf1xxx_tlFSi_Tg5 : $@convention(thin) (Int) -> Int
+// CHECK: apply [[FN]]({{.*}}) : $@convention(thin) (Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization23mustSpecializeCallsSelf1xxx_tlFSi_Tg5'
+@_semantics("must_specialize")
+func mustSpecializeCallsSelf<T>(x: T) -> T { mustSpecializeCallsSelf(x: x) }
+
+// CHECK-LABEL: sil shared @$s24mandatory_specialization25mustSpecializeCallsCaller1xyx_tlFSi_Tg5
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization15recursiveCalleryyF : $@convention(thin) () -> ()
+// CHECK: apply [[FN]]() : $@convention(thin) () -> ()
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization25mustSpecializeCallsCaller1xyx_tlFSi_Tg5'
+@_semantics("must_specialize")
+func mustSpecializeCallsCaller<T>(x: T) { recursiveCaller() }
+
+// CHECK-LABEL: sil @$s24mandatory_specialization15recursiveCalleryyF
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization25mustSpecializeCallsCaller1xyx_tlFSi_Tg5 : $@convention(thin) (Int) -> ()
+// CHECK: apply [[FN]]({{.*}}) : $@convention(thin) (Int) -> ()
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization15recursiveCalleryyF'
+public func recursiveCaller() { mustSpecializeCallsCaller(x: 0) }
+
+struct Struct { }
+
+// CHECK-LABEL: @$s24mandatory_specialization5test1yyF
+// CHECK-NOT: apply
+// CHECK: [[FN1:%.*]] = function_ref @$s24mandatory_specialization16callsWithGeneric1xxx_tlFSi_Tg5 : $@convention(thin) (Int) -> Int
+// CHECK: apply [[FN1]]({{.*}}) : $@convention(thin) (Int) -> Int
+// CHECK-NOT: apply
+// CHECK: [[FN2:%.*]] = function_ref @$s24mandatory_specialization11twoGenerics1x1yxx_q_tr0_lFSi_SiTg5 : $@convention(thin) (Int, Int) -> Int
+// CHECK: apply [[FN2]]({{.*}}, {{.*}}) : $@convention(thin) (Int, Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization5test1yyF'
+@inline(never)
+public func test1() {
+  _ = callsWithGeneric(x: 1)
+  _ = twoGenerics(x: 41, y: 0)
+}
+
+// CHECK-LABEL: sil [noinline] @$s24mandatory_specialization5test2yyF
+// There are two calls to constructors for "Struct". Other than that we shouldn't have any other applies.
+// Note: when mand combine is updated to remove dead instructions, you can remove the following two applies.
+// CHECK: apply
+// CHECK: apply
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization31twoUnrelatedGenericsSpecialized1x1ySix_q_tr0_lFAA6StructV_AFTg5 : $@convention(thin) (Struct, Struct) -> Int
+// CHECK: apply [[FN]]({{.*}}, {{.*}}) : $@convention(thin) (Struct, Struct) -> Int
+// Two more constructors...
+// CHECK: apply
+// CHECK: apply
+// CHECK-NOT: apply
+// CHECK: [[FN2:%.*]] = function_ref @$s24mandatory_specialization20twoUnrelatedGenerics1x1ySix_q_tr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> Int
+// CHECK: apply [[FN2:%.*]]<Struct, Struct>({{.*}}, {{.*}}) : $@convention(thin) <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization5test2yyF'
+@inline(never)
+public func test2() {
+  _ = twoUnrelatedGenericsSpecialized(x: Struct(), y: Struct())
+  _ = twoUnrelatedGenerics(x: Struct(), y: Struct())
+}
+
+// CHECK-LABEL: sil [noinline] @$s24mandatory_specialization5test3yyF
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization5test2yyF : $@convention(thin) () -> ()
+// CHECK: apply [[FN]]() : $@convention(thin) () -> ()
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization5test3yyF'
+@inline(never)
+public func test3() {
+  test2()
+}
+
+// CHECK-LABEL: sil @$s24mandatory_specialization5test4yyF
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization24transparentGenericCaller1xxx_tlFSi_Tg5 : $@convention(thin) (Int) -> Int
+// CHECK: apply [[FN]]({{.*}}) : $@convention(thin) (Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL:end sil function '$s24mandatory_specialization5test4yyF'
+public func test4() { _ = transparentGenericCaller(x: 0) }
+
+// CHECK-LABEL: sil @$s24mandatory_specialization5test5yyF
+// CHECK-NOT: apply
+// CHECK: [[FN:%.*]] = function_ref @$s24mandatory_specialization23mustSpecializeCallsSelf1xxx_tlFSi_Tg5 : $@convention(thin) (Int) -> Int
+// CHECK: apply [[FN]]({{.*}}) : $@convention(thin) (Int) -> Int
+// CHECK-NOT: apply
+// CHECK-LABEL: end sil function '$s24mandatory_specialization5test5yyF'
+public func test5() { _ = mustSpecializeCallsSelf(x: 0) }
+
+#if ERRORS
+
+// CHECK-ERROR: error: function topLevelGeneric<A>(x:) was never called with concrete generic substitutions.
+// CHECK-ERROR: note: function marked 'must_specialize' called here callsWithGeneric<A>(x:)
+@inline(never)
+func topLevelGeneric<T>(x: T) -> T { callsWithGeneric(x: x) }
+
+// CHECK-ERROR: error: function publicMustSpecialize<A, B>(x:y:) marked as 'must_specialize' must not be publicly available.
+@_semantics("must_specialize")
+public func publicMustSpecialize<T, U>(x: T, y: U) -> T { x }
+
+// CHECK-ERROR: error: function publicGeneric<A>(x:) marked as 'must_specialize' must not be publicly available.
+@inline(never)
+public func publicGeneric<T>(x: T) -> T { callsWithHalfGeneric(x: x) }
+
+#endif


### PR DESCRIPTION
Adds a semantics attribute "must_specialize" which forces a generic function to be specialized. If the function cannot be specialized or is public, a compile-time error is emitted.

See [the forum post](https://forums.swift.org/t/adding-a-new-semantics-attribute-must-specialize) for further discussion and rational. 