### PR TITLE
[stdlib] Speed up the FixedPointConversion tests

### DIFF
--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt.swift
@@ -14,1498 +14,612 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToInt = TestSuite("FixedPointConversion_Debug32_ToInt")
+let FixedPointConversion_Debug32_ToInt = TestSuite(
+   "FixedPointConversion_Debug32_ToInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(2147483647)_NeverTraps") {
-  let input = getUInt32(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(2147483647)_NeverFails") {
-  let input = getUInt32(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(2147483648)_AlwaysTraps") {
-  let input = getUInt32(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(2147483648)_AlwaysFails") {
-  let input = getUInt32(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(2147483647)_NeverTraps") {
-  let input = getUInt64(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(2147483647)_NeverFails") {
-  let input = getUInt64(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(2147483648)_AlwaysTraps") {
-  let input = getUInt64(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(2147483648)_AlwaysFails") {
-  let input = getUInt64(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt64(-2147483648)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt64(-2147483648)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromInt64(-2147483649)_AlwaysTraps") {
-  let input = getInt64(-2147483649)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromInt64(-2147483649)_AlwaysFails") {
-  let input = getInt64(-2147483649)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(-2147483648)_NeverTraps") {
-  let input = getInt64(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(-2147483648)_NeverFails") {
-  let input = getInt64(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(2147483647)_NeverTraps") {
-  let input = getInt64(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(2147483647)_NeverFails") {
-  let input = getInt64(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(2147483648)_AlwaysTraps") {
-  let input = getInt64(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(2147483648)_AlwaysFails") {
-  let input = getInt64(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt(2147483647)_NeverTraps") {
-  let input = getUInt(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromUInt(2147483647)_NeverFails") {
-  let input = getUInt(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt(2147483648)_AlwaysTraps") {
-  let input = getUInt(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt(2147483648)_AlwaysFails") {
-  let input = getUInt(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt(-2147483648)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt(-2147483648)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(-128), getFloat16(-128.5)),
+  (getInt(+0), getFloat16(-0.5)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+0), getFloat16(+0.5)),
+  (getInt(+127), getFloat16(+127.5)),
+  (getInt(+255), getFloat16(+255.5)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(-32768), getFloat32(-32768.5)),
+  (getInt(-128), getFloat32(-128.5)),
+  (getInt(+0), getFloat32(-0.5)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+0), getFloat32(+0.5)),
+  (getInt(+127), getFloat32(+127.5)),
+  (getInt(+255), getFloat32(+255.5)),
+  (getInt(+32767), getFloat32(+32767.5)),
+  (getInt(+65535), getFloat32(+65535.5)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getFloat64(-2147483648)),
+  (getInt(-32768), getFloat64(-32768.5)),
+  (getInt(-128), getFloat64(-128.5)),
+  (getInt(+0), getFloat64(-0.5)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+0), getFloat64(+0.5)),
+  (getInt(+127), getFloat64(+127.5)),
+  (getInt(+255), getFloat64(+255.5)),
+  (getInt(+32767), getFloat64(+32767.5)),
+  (getInt(+65535), getFloat64(+65535.5)),
+  (getInt(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getFloat64(-2147483648)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-2147483649)_AlwaysTraps") {
-  let input = getFloat64(-2147483649)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-2147483649)_AlwaysFails") {
-  let input = getFloat64(-2147483649)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-2147483648)_NeverTraps") {
-  let input = getFloat64(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-2147483648)_NeverFails") {
-  let input = getFloat64(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(2147483647)_NeverTraps") {
-  let input = getFloat64(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(2147483647)_NeverFails") {
-  let input = getFloat64(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(2147483648)_AlwaysTraps") {
-  let input = getFloat64(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(2147483648)_AlwaysFails") {
-  let input = getFloat64(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getFloat80(-2147483648)),
+  (getInt(-32768), getFloat80(-32768.5)),
+  (getInt(-128), getFloat80(-128.5)),
+  (getInt(+0), getFloat80(-0.5)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+0), getFloat80(+0.5)),
+  (getInt(+127), getFloat80(+127.5)),
+  (getInt(+255), getFloat80(+255.5)),
+  (getInt(+32767), getFloat80(+32767.5)),
+  (getInt(+65535), getFloat80(+65535.5)),
+  (getInt(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getFloat80(-2147483648)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-2147483649)_AlwaysTraps") {
-  let input = getFloat80(-2147483649)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-2147483649)_AlwaysFails") {
-  let input = getFloat80(-2147483649)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-2147483648)_NeverTraps") {
-  let input = getFloat80(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-2147483648)_NeverFails") {
-  let input = getFloat80(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(2147483647)_NeverTraps") {
-  let input = getFloat80(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(2147483647)_NeverFails") {
-  let input = getFloat80(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(2147483648)_AlwaysTraps") {
-  let input = getFloat80(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(2147483648)_AlwaysFails") {
-  let input = getFloat80(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt16.swift
@@ -14,1700 +14,685 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToInt16 = TestSuite("FixedPointConversion_Debug32_ToInt16")
+let FixedPointConversion_Debug32_ToInt16 = TestSuite(
+   "FixedPointConversion_Debug32_ToInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int16(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(32767)_NeverTraps") {
-  let input = getUInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(32767)_NeverFails") {
-  let input = getUInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(32768)_AlwaysTraps") {
-  let input = getUInt16(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(32768)_AlwaysFails") {
-  let input = getUInt16(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(32767)_NeverTraps") {
-  let input = getUInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(32767)_NeverFails") {
-  let input = getUInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(32768)_AlwaysTraps") {
-  let input = getUInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(32768)_AlwaysFails") {
-  let input = getUInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(-32769)_AlwaysTraps") {
-  let input = getInt32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(-32769)_AlwaysFails") {
-  let input = getInt32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(-32768)_NeverTraps") {
-  let input = getInt32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(-32768)_NeverFails") {
-  let input = getInt32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(32767)_NeverTraps") {
-  let input = getInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(32767)_NeverFails") {
-  let input = getInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(32768)_AlwaysTraps") {
-  let input = getInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(32768)_AlwaysFails") {
-  let input = getInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(32767)_NeverTraps") {
-  let input = getUInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(32767)_NeverFails") {
-  let input = getUInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(32768)_AlwaysTraps") {
-  let input = getUInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(32768)_AlwaysFails") {
-  let input = getUInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(-32769)_AlwaysTraps") {
-  let input = getInt64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(-32769)_AlwaysFails") {
-  let input = getInt64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(-32768)_NeverTraps") {
-  let input = getInt64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(-32768)_NeverFails") {
-  let input = getInt64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(32767)_NeverTraps") {
-  let input = getInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(32767)_NeverFails") {
-  let input = getInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(32768)_AlwaysTraps") {
-  let input = getInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(32768)_AlwaysFails") {
-  let input = getInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(32767)_NeverTraps") {
-  let input = getUInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(32767)_NeverFails") {
-  let input = getUInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(32768)_AlwaysTraps") {
-  let input = getUInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(32768)_AlwaysFails") {
-  let input = getUInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt(-32769)_AlwaysTraps") {
-  let input = getInt(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromInt(-32769)_AlwaysFails") {
-  let input = getInt(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(-32768)_NeverTraps") {
-  let input = getInt(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(-32768)_NeverFails") {
-  let input = getInt(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(32767)_NeverTraps") {
-  let input = getInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(32767)_NeverFails") {
-  let input = getInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(32768)_AlwaysTraps") {
-  let input = getInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(32768)_AlwaysFails") {
-  let input = getInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+2147483647),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int16(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(-128), getFloat16(-128.5)),
+  (getInt16(+0), getFloat16(-0.5)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+0), getFloat16(+0.5)),
+  (getInt16(+127), getFloat16(+127.5)),
+  (getInt16(+255), getFloat16(+255.5)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int16(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768.5)),
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(-128), getFloat32(-128.5)),
+  (getInt16(+0), getFloat32(-0.5)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+0), getFloat32(+0.5)),
+  (getInt16(+127), getFloat32(+127.5)),
+  (getInt16(+255), getFloat32(+255.5)),
+  (getInt16(+32767), getFloat32(+32767)),
+  (getInt16(+32767), getFloat32(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+32767), getFloat32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-32769)_AlwaysTraps") {
-  let input = getFloat32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-32769)_AlwaysFails") {
-  let input = getFloat32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-32768)_NeverTraps") {
-  let input = getFloat32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-32768)_NeverFails") {
-  let input = getFloat32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(32767)_NeverTraps") {
-  let input = getFloat32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(32767)_NeverFails") {
-  let input = getFloat32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(32768)_AlwaysTraps") {
-  let input = getFloat32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(32768)_AlwaysFails") {
-  let input = getFloat32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768.5)),
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(-128), getFloat64(-128.5)),
+  (getInt16(+0), getFloat64(-0.5)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+0), getFloat64(+0.5)),
+  (getInt16(+127), getFloat64(+127.5)),
+  (getInt16(+255), getFloat64(+255.5)),
+  (getInt16(+32767), getFloat64(+32767)),
+  (getInt16(+32767), getFloat64(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+32767), getFloat64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-32769)_AlwaysTraps") {
-  let input = getFloat64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-32769)_AlwaysFails") {
-  let input = getFloat64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-32768)_NeverTraps") {
-  let input = getFloat64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-32768)_NeverFails") {
-  let input = getFloat64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(32767)_NeverTraps") {
-  let input = getFloat64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(32767)_NeverFails") {
-  let input = getFloat64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(32768)_AlwaysTraps") {
-  let input = getFloat64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(32768)_AlwaysFails") {
-  let input = getFloat64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768.5)),
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(-128), getFloat80(-128.5)),
+  (getInt16(+0), getFloat80(-0.5)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+0), getFloat80(+0.5)),
+  (getInt16(+127), getFloat80(+127.5)),
+  (getInt16(+255), getFloat80(+255.5)),
+  (getInt16(+32767), getFloat80(+32767)),
+  (getInt16(+32767), getFloat80(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+32767), getFloat80(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-32769)_AlwaysTraps") {
-  let input = getFloat80(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-32769)_AlwaysFails") {
-  let input = getFloat80(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-32768)_NeverTraps") {
-  let input = getFloat80(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-32768)_NeverFails") {
-  let input = getFloat80(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(32767)_NeverTraps") {
-  let input = getFloat80(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(32767)_NeverFails") {
-  let input = getFloat80(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(32768)_AlwaysTraps") {
-  let input = getFloat80(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(32768)_AlwaysFails") {
-  let input = getFloat80(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt32.swift
@@ -14,1498 +14,612 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToInt32 = TestSuite("FixedPointConversion_Debug32_ToInt32")
+let FixedPointConversion_Debug32_ToInt32 = TestSuite(
+   "FixedPointConversion_Debug32_ToInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int32(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int32(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(2147483647)_NeverTraps") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(2147483647)_NeverFails") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(2147483648)_AlwaysTraps") {
-  let input = getUInt32(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(2147483648)_AlwaysFails") {
-  let input = getUInt32(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(2147483647)_NeverTraps") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(2147483647)_NeverFails") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(2147483648)_AlwaysTraps") {
-  let input = getUInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(2147483648)_AlwaysFails") {
-  let input = getUInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(-2147483649)_AlwaysTraps") {
-  let input = getInt64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(-2147483649)_AlwaysFails") {
-  let input = getInt64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(-2147483648)_NeverTraps") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(-2147483648)_NeverFails") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(2147483647)_NeverTraps") {
-  let input = getInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(2147483647)_NeverFails") {
-  let input = getInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(2147483648)_AlwaysTraps") {
-  let input = getInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(2147483648)_AlwaysFails") {
-  let input = getInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(2147483647)_NeverTraps") {
-  let input = getUInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(2147483647)_NeverFails") {
-  let input = getUInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(2147483648)_AlwaysTraps") {
-  let input = getUInt(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(2147483648)_AlwaysFails") {
-  let input = getUInt(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int32(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(-128), getFloat16(-128.5)),
+  (getInt32(+0), getFloat16(-0.5)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+0), getFloat16(+0.5)),
+  (getInt32(+127), getFloat16(+127.5)),
+  (getInt32(+255), getFloat16(+255.5)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int32(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(-32768), getFloat32(-32768.5)),
+  (getInt32(-128), getFloat32(-128.5)),
+  (getInt32(+0), getFloat32(-0.5)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+0), getFloat32(+0.5)),
+  (getInt32(+127), getFloat32(+127.5)),
+  (getInt32(+255), getFloat32(+255.5)),
+  (getInt32(+32767), getFloat32(+32767.5)),
+  (getInt32(+65535), getFloat32(+65535.5)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(-32768), getFloat64(-32768.5)),
+  (getInt32(-128), getFloat64(-128.5)),
+  (getInt32(+0), getFloat64(-0.5)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+0), getFloat64(+0.5)),
+  (getInt32(+127), getFloat64(+127.5)),
+  (getInt32(+255), getFloat64(+255.5)),
+  (getInt32(+32767), getFloat64(+32767.5)),
+  (getInt32(+65535), getFloat64(+65535.5)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-2147483649)_AlwaysTraps") {
-  let input = getFloat64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-2147483649)_AlwaysFails") {
-  let input = getFloat64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-2147483648)_NeverTraps") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-2147483648)_NeverFails") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(2147483647)_NeverTraps") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(2147483647)_NeverFails") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(2147483648)_AlwaysTraps") {
-  let input = getFloat64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(2147483648)_AlwaysFails") {
-  let input = getFloat64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(-32768), getFloat80(-32768.5)),
+  (getInt32(-128), getFloat80(-128.5)),
+  (getInt32(+0), getFloat80(-0.5)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+0), getFloat80(+0.5)),
+  (getInt32(+127), getFloat80(+127.5)),
+  (getInt32(+255), getFloat80(+255.5)),
+  (getInt32(+32767), getFloat80(+32767.5)),
+  (getInt32(+65535), getFloat80(+65535.5)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-2147483649)_AlwaysTraps") {
-  let input = getFloat80(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-2147483649)_AlwaysFails") {
-  let input = getFloat80(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-2147483648)_NeverTraps") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-2147483648)_NeverFails") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(2147483647)_NeverTraps") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(2147483647)_NeverFails") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(2147483648)_AlwaysTraps") {
-  let input = getFloat80(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(2147483648)_AlwaysFails") {
-  let input = getFloat80(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt64.swift
@@ -14,1330 +14,543 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToInt64 = TestSuite("FixedPointConversion_Debug32_ToInt64")
+let FixedPointConversion_Debug32_ToInt64 = TestSuite(
+   "FixedPointConversion_Debug32_ToInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int64(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int64(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(9223372036854775807)_NeverTraps") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(9223372036854775807)_NeverFails") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt64(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysFails") {
-  let input = getUInt64(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt64(-9223372036854775808)_NeverTraps") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt64(-9223372036854775808)_NeverFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = Int64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = Int64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int64(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt64(-2147483648), getInt(-2147483648)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int64(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt64(-2147483648), getInt(-2147483648)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int64(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(-128), getFloat16(-128.5)),
+  (getInt64(+0), getFloat16(-0.5)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+0), getFloat16(+0.5)),
+  (getInt64(+127), getFloat16(+127.5)),
+  (getInt64(+255), getFloat16(+255.5)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int64(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(-32768), getFloat32(-32768.5)),
+  (getInt64(-128), getFloat32(-128.5)),
+  (getInt64(+0), getFloat32(-0.5)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+0), getFloat32(+0.5)),
+  (getInt64(+127), getFloat32(+127.5)),
+  (getInt64(+255), getFloat32(+255.5)),
+  (getInt64(+32767), getFloat32(+32767.5)),
+  (getInt64(+65535), getFloat32(+65535.5)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-9007199254740991)_NeverTraps") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(-32768), getFloat64(-32768.5)),
+  (getInt64(-128), getFloat64(-128.5)),
+  (getInt64(+0), getFloat64(-0.5)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+0), getFloat64(+0.5)),
+  (getInt64(+127), getFloat64(+127.5)),
+  (getInt64(+255), getFloat64(+255.5)),
+  (getInt64(+32767), getFloat64(+32767.5)),
+  (getInt64(+65535), getFloat64(+65535.5)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-9007199254740991)_NeverFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(-32768), getFloat80(-32768.5)),
+  (getInt64(-128), getFloat80(-128.5)),
+  (getInt64(+0), getFloat80(-0.5)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+0), getFloat80(+0.5)),
+  (getInt64(+127), getFloat80(+127.5)),
+  (getInt64(+255), getFloat80(+255.5)),
+  (getInt64(+32767), getFloat80(+32767.5)),
+  (getInt64(+65535), getFloat80(+65535.5)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysTraps") {
-  let input = getFloat80(-9223372036854775809)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysFails") {
-  let input = getFloat80(-9223372036854775809)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-9223372036854775808)_NeverTraps") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-9223372036854775808)_NeverFails") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(9223372036854775807)_NeverTraps") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(9223372036854775807)_NeverFails") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysTraps") {
-  let input = getFloat80(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysFails") {
-  let input = getFloat80(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToInt8.swift
@@ -14,1860 +14,735 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToInt8 = TestSuite("FixedPointConversion_Debug32_ToInt8")
+let FixedPointConversion_Debug32_ToInt8 = TestSuite(
+   "FixedPointConversion_Debug32_ToInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(127)_NeverTraps") {
-  let input = getUInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt8_AlwaysTraps")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(127)_NeverFails") {
-  let input = getUInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(128)_AlwaysTraps") {
-  let input = getUInt8(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(128)_AlwaysFails") {
-  let input = getUInt8(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(255)_AlwaysTraps") {
-  let input = getUInt8(255)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt8(255)_AlwaysFails") {
-  let input = getUInt8(255)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt8_AlwaysFails")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(127)_NeverTraps") {
-  let input = getUInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(127)_NeverFails") {
-  let input = getUInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(128)_AlwaysTraps") {
-  let input = getUInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(128)_AlwaysFails") {
-  let input = getUInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(-129)_AlwaysTraps") {
-  let input = getInt16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(-129)_AlwaysFails") {
-  let input = getInt16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(-128)_NeverTraps") {
-  let input = getInt16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(-128)_NeverFails") {
-  let input = getInt16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(127)_NeverTraps") {
-  let input = getInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(127)_NeverFails") {
-  let input = getInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(128)_AlwaysTraps") {
-  let input = getInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(128)_AlwaysFails") {
-  let input = getInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(127)_NeverTraps") {
-  let input = getUInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(127)_NeverFails") {
-  let input = getUInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(128)_AlwaysTraps") {
-  let input = getUInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(128)_AlwaysFails") {
-  let input = getUInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(-129)_AlwaysTraps") {
-  let input = getInt32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(-129)_AlwaysFails") {
-  let input = getInt32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(-128)_NeverTraps") {
-  let input = getInt32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(-128)_NeverFails") {
-  let input = getInt32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(127)_NeverTraps") {
-  let input = getInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(127)_NeverFails") {
-  let input = getInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(128)_AlwaysTraps") {
-  let input = getInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(128)_AlwaysFails") {
-  let input = getInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(127)_NeverTraps") {
-  let input = getUInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(127)_NeverFails") {
-  let input = getUInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(128)_AlwaysTraps") {
-  let input = getUInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(128)_AlwaysFails") {
-  let input = getUInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(-129)_AlwaysTraps") {
-  let input = getInt64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(-129)_AlwaysFails") {
-  let input = getInt64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(-128)_NeverTraps") {
-  let input = getInt64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(-128)_NeverFails") {
-  let input = getInt64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(127)_NeverTraps") {
-  let input = getInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(127)_NeverFails") {
-  let input = getInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(128)_AlwaysTraps") {
-  let input = getInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(128)_AlwaysFails") {
-  let input = getInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(127)_NeverTraps") {
-  let input = getUInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(127)_NeverFails") {
-  let input = getUInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(128)_AlwaysTraps") {
-  let input = getUInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(128)_AlwaysFails") {
-  let input = getUInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt(-129)_AlwaysTraps") {
-  let input = getInt(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-129),
+  getInt(+128),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromInt(-129)_AlwaysFails") {
-  let input = getInt(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(-128)_NeverTraps") {
-  let input = getInt(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(-128)_NeverFails") {
-  let input = getInt(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(127)_NeverTraps") {
-  let input = getInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(127)_NeverFails") {
-  let input = getInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(128)_AlwaysTraps") {
-  let input = getInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(128)_AlwaysFails") {
-  let input = getInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-129),
+  getInt(+128),
+  getInt(+2147483647),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128.5)),
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0.5)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+0), getFloat16(+0.5)),
+  (getInt8(+127), getFloat16(+127)),
+  (getInt8(+127), getFloat16(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+127), getFloat16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-129)_AlwaysTraps") {
-  let input = getFloat16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-129)_AlwaysFails") {
-  let input = getFloat16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-128)_NeverTraps") {
-  let input = getFloat16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-128)_NeverFails") {
-  let input = getFloat16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(127)_NeverTraps") {
-  let input = getFloat16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(127)_NeverFails") {
-  let input = getFloat16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(128)_AlwaysTraps") {
-  let input = getFloat16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(128)_AlwaysFails") {
-  let input = getFloat16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(255.5)_AlwaysTraps") {
-  let input = getFloat16(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128.5)),
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(-0.5)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+0), getFloat32(+0.5)),
+  (getInt8(+127), getFloat32(+127)),
+  (getInt8(+127), getFloat32(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+127), getFloat32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-129)_AlwaysTraps") {
-  let input = getFloat32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-129)_AlwaysFails") {
-  let input = getFloat32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-128)_NeverTraps") {
-  let input = getFloat32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-128)_NeverFails") {
-  let input = getFloat32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(127)_NeverTraps") {
-  let input = getFloat32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(127)_NeverFails") {
-  let input = getFloat32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(128)_AlwaysTraps") {
-  let input = getFloat32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(128)_AlwaysFails") {
-  let input = getFloat32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(255.5)_AlwaysTraps") {
-  let input = getFloat32(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128.5)),
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(-0.5)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+0), getFloat64(+0.5)),
+  (getInt8(+127), getFloat64(+127)),
+  (getInt8(+127), getFloat64(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+127), getFloat64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-129)_AlwaysTraps") {
-  let input = getFloat64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-129)_AlwaysFails") {
-  let input = getFloat64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-128)_NeverTraps") {
-  let input = getFloat64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-128)_NeverFails") {
-  let input = getFloat64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(127)_NeverTraps") {
-  let input = getFloat64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(127)_NeverFails") {
-  let input = getFloat64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(128)_AlwaysTraps") {
-  let input = getFloat64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(128)_AlwaysFails") {
-  let input = getFloat64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(255.5)_AlwaysTraps") {
-  let input = getFloat64(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128.5)),
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0.5)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+0), getFloat80(+0.5)),
+  (getInt8(+127), getFloat80(+127)),
+  (getInt8(+127), getFloat80(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+127), getFloat80(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-129)_AlwaysTraps") {
-  let input = getFloat80(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-129)_AlwaysFails") {
-  let input = getFloat80(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-128)_NeverTraps") {
-  let input = getFloat80(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-128)_NeverFails") {
-  let input = getFloat80(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(127)_NeverTraps") {
-  let input = getFloat80(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(127)_NeverFails") {
-  let input = getFloat80(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(128)_AlwaysTraps") {
-  let input = getFloat80(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(128)_AlwaysFails") {
-  let input = getFloat80(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(255.5)_AlwaysTraps") {
-  let input = getFloat80(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt.swift
@@ -14,1564 +14,640 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToUInt = TestSuite("FixedPointConversion_Debug32_ToUInt")
+let FixedPointConversion_Debug32_ToUInt = TestSuite(
+   "FixedPointConversion_Debug32_ToUInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(4294967295)_NeverTraps") {
-  let input = getUInt64(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(4294967295)_NeverFails") {
-  let input = getUInt64(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(4294967296)_AlwaysTraps") {
-  let input = getUInt64(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(4294967296)_AlwaysFails") {
-  let input = getUInt64(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(4294967295)_NeverTraps") {
-  let input = getInt64(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(4294967295)_NeverFails") {
-  let input = getInt64(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(4294967296)_AlwaysTraps") {
-  let input = getInt64(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(4294967296)_AlwaysFails") {
-  let input = getInt64(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = UInt(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = UInt(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat16(-0.5)),
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+0), getFloat16(+0.5)),
+  (getUInt(+127), getFloat16(+127.5)),
+  (getUInt(+255), getFloat16(+255.5)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat32(-0.5)),
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+0), getFloat32(+0.5)),
+  (getUInt(+127), getFloat32(+127.5)),
+  (getUInt(+255), getFloat32(+255.5)),
+  (getUInt(+32767), getFloat32(+32767.5)),
+  (getUInt(+65535), getFloat32(+65535.5)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat64(-0.5)),
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+0), getFloat64(+0.5)),
+  (getUInt(+127), getFloat64(+127.5)),
+  (getUInt(+255), getFloat64(+255.5)),
+  (getUInt(+32767), getFloat64(+32767.5)),
+  (getUInt(+65535), getFloat64(+65535.5)),
+  (getUInt(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(4294967295)_NeverTraps") {
-  let input = getFloat64(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(4294967295)_NeverFails") {
-  let input = getFloat64(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(4294967296)_AlwaysTraps") {
-  let input = getFloat64(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(4294967296)_AlwaysFails") {
-  let input = getFloat64(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat80(-0.5)),
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+0), getFloat80(+0.5)),
+  (getUInt(+127), getFloat80(+127.5)),
+  (getUInt(+255), getFloat80(+255.5)),
+  (getUInt(+32767), getFloat80(+32767.5)),
+  (getUInt(+65535), getFloat80(+65535.5)),
+  (getUInt(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(4294967295)_NeverTraps") {
-  let input = getFloat80(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(4294967295)_NeverFails") {
-  let input = getFloat80(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(4294967296)_AlwaysTraps") {
-  let input = getFloat80(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(4294967296)_AlwaysFails") {
-  let input = getFloat80(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt16.swift
@@ -14,1704 +14,690 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToUInt16 = TestSuite("FixedPointConversion_Debug32_ToUInt16")
+let FixedPointConversion_Debug32_ToUInt16 = TestSuite(
+   "FixedPointConversion_Debug32_ToUInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(65535)_NeverTraps") {
-  let input = getUInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(65535)_NeverFails") {
-  let input = getUInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(65536)_AlwaysTraps") {
-  let input = getUInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(65536)_AlwaysFails") {
-  let input = getUInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(65535)_NeverTraps") {
-  let input = getInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(65535)_NeverFails") {
-  let input = getInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(65536)_AlwaysTraps") {
-  let input = getInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(65536)_AlwaysFails") {
-  let input = getInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(65535)_NeverTraps") {
-  let input = getUInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(65535)_NeverFails") {
-  let input = getUInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(65536)_AlwaysTraps") {
-  let input = getUInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(65536)_AlwaysFails") {
-  let input = getUInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(65535)_NeverTraps") {
-  let input = getInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(65535)_NeverFails") {
-  let input = getInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(65536)_AlwaysTraps") {
-  let input = getInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(65536)_AlwaysFails") {
-  let input = getInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(65535)_NeverTraps") {
-  let input = getUInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(65535)_NeverFails") {
-  let input = getUInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(65536)_AlwaysTraps") {
-  let input = getUInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(65536)_AlwaysFails") {
-  let input = getUInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+4294967295),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(65535)_NeverTraps") {
-  let input = getInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(65535)_NeverFails") {
-  let input = getInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(65536)_AlwaysTraps") {
-  let input = getInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(65536)_AlwaysFails") {
-  let input = getInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+2147483647),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(-0.5)),
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+0), getFloat16(+0.5)),
+  (getUInt16(+127), getFloat16(+127.5)),
+  (getUInt16(+255), getFloat16(+255.5)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(-0.5)),
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+0), getFloat32(+0.5)),
+  (getUInt16(+127), getFloat32(+127.5)),
+  (getUInt16(+255), getFloat32(+255.5)),
+  (getUInt16(+32767), getFloat32(+32767.5)),
+  (getUInt16(+65535), getFloat32(+65535)),
+  (getUInt16(+65535), getFloat32(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+65535), getFloat32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(65535)_NeverTraps") {
-  let input = getFloat32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(65535)_NeverFails") {
-  let input = getFloat32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(65536)_AlwaysTraps") {
-  let input = getFloat32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(65536)_AlwaysFails") {
-  let input = getFloat32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(-0.5)),
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+0), getFloat64(+0.5)),
+  (getUInt16(+127), getFloat64(+127.5)),
+  (getUInt16(+255), getFloat64(+255.5)),
+  (getUInt16(+32767), getFloat64(+32767.5)),
+  (getUInt16(+65535), getFloat64(+65535)),
+  (getUInt16(+65535), getFloat64(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+65535), getFloat64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(65535)_NeverTraps") {
-  let input = getFloat64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(65535)_NeverFails") {
-  let input = getFloat64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(65536)_AlwaysTraps") {
-  let input = getFloat64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(65536)_AlwaysFails") {
-  let input = getFloat64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(-0.5)),
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+0), getFloat80(+0.5)),
+  (getUInt16(+127), getFloat80(+127.5)),
+  (getUInt16(+255), getFloat80(+255.5)),
+  (getUInt16(+32767), getFloat80(+32767.5)),
+  (getUInt16(+65535), getFloat80(+65535)),
+  (getUInt16(+65535), getFloat80(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+65535), getFloat80(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(65535)_NeverTraps") {
-  let input = getFloat80(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(65535)_NeverFails") {
-  let input = getFloat80(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(65536)_AlwaysTraps") {
-  let input = getFloat80(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(65536)_AlwaysFails") {
-  let input = getFloat80(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt32.swift
@@ -14,1564 +14,640 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToUInt32 = TestSuite("FixedPointConversion_Debug32_ToUInt32")
+let FixedPointConversion_Debug32_ToUInt32 = TestSuite(
+   "FixedPointConversion_Debug32_ToUInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(4294967295)_NeverTraps") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(4294967295)_NeverFails") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(4294967296)_AlwaysTraps") {
-  let input = getUInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(4294967296)_AlwaysFails") {
-  let input = getUInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(4294967295)_NeverTraps") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(4294967295)_NeverFails") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(4294967296)_AlwaysTraps") {
-  let input = getInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(4294967296)_AlwaysFails") {
-  let input = getInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = UInt32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = UInt32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(-0.5)),
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+0), getFloat16(+0.5)),
+  (getUInt32(+127), getFloat16(+127.5)),
+  (getUInt32(+255), getFloat16(+255.5)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(-0.5)),
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+0), getFloat32(+0.5)),
+  (getUInt32(+127), getFloat32(+127.5)),
+  (getUInt32(+255), getFloat32(+255.5)),
+  (getUInt32(+32767), getFloat32(+32767.5)),
+  (getUInt32(+65535), getFloat32(+65535.5)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(-0.5)),
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+0), getFloat64(+0.5)),
+  (getUInt32(+127), getFloat64(+127.5)),
+  (getUInt32(+255), getFloat64(+255.5)),
+  (getUInt32(+32767), getFloat64(+32767.5)),
+  (getUInt32(+65535), getFloat64(+65535.5)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(4294967295)_NeverTraps") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(4294967295)_NeverFails") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(4294967296)_AlwaysTraps") {
-  let input = getFloat64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(4294967296)_AlwaysFails") {
-  let input = getFloat64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(-0.5)),
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+0), getFloat80(+0.5)),
+  (getUInt32(+127), getFloat80(+127.5)),
+  (getUInt32(+255), getFloat80(+255.5)),
+  (getUInt32(+32767), getFloat80(+32767.5)),
+  (getUInt32(+65535), getFloat80(+65535.5)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(4294967295)_NeverTraps") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(4294967295)_NeverFails") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(4294967296)_AlwaysTraps") {
-  let input = getFloat80(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(4294967296)_AlwaysFails") {
-  let input = getFloat80(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt64.swift
@@ -14,1464 +14,609 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToUInt64 = TestSuite("FixedPointConversion_Debug32_ToUInt64")
+let FixedPointConversion_Debug32_ToUInt64 = TestSuite(
+   "FixedPointConversion_Debug32_ToUInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt64(18446744073709551615)_NeverTraps") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt64(18446744073709551615)_NeverFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = UInt64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = UInt64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(-0.5)),
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+0), getFloat16(+0.5)),
+  (getUInt64(+127), getFloat16(+127.5)),
+  (getUInt64(+255), getFloat16(+255.5)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(-0.5)),
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+0), getFloat32(+0.5)),
+  (getUInt64(+127), getFloat32(+127.5)),
+  (getUInt64(+255), getFloat32(+255.5)),
+  (getUInt64(+32767), getFloat32(+32767.5)),
+  (getUInt64(+65535), getFloat32(+65535.5)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(-0.5)),
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+0), getFloat64(+0.5)),
+  (getUInt64(+127), getFloat64(+127.5)),
+  (getUInt64(+255), getFloat64(+255.5)),
+  (getUInt64(+32767), getFloat64(+32767.5)),
+  (getUInt64(+65535), getFloat64(+65535.5)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(-0.5)),
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+0), getFloat80(+0.5)),
+  (getUInt64(+127), getFloat80(+127.5)),
+  (getUInt64(+255), getFloat80(+255.5)),
+  (getUInt64(+32767), getFloat80(+32767.5)),
+  (getUInt64(+65535), getFloat80(+65535.5)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug32_ToUInt8.swift
@@ -14,1800 +14,717 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug32_ToUInt8 = TestSuite("FixedPointConversion_Debug32_ToUInt8")
+let FixedPointConversion_Debug32_ToUInt8 = TestSuite(
+   "FixedPointConversion_Debug32_ToUInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(255)_NeverTraps") {
-  let input = getUInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(255)_NeverFails") {
-  let input = getUInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(256)_AlwaysTraps") {
-  let input = getUInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(256)_AlwaysFails") {
-  let input = getUInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(255)_NeverTraps") {
-  let input = getInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(255)_NeverFails") {
-  let input = getInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(256)_AlwaysTraps") {
-  let input = getInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(256)_AlwaysFails") {
-  let input = getInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(255)_NeverTraps") {
-  let input = getUInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(255)_NeverFails") {
-  let input = getUInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(256)_AlwaysTraps") {
-  let input = getUInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(256)_AlwaysFails") {
-  let input = getUInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(255)_NeverTraps") {
-  let input = getInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(255)_NeverFails") {
-  let input = getInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(256)_AlwaysTraps") {
-  let input = getInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(256)_AlwaysFails") {
-  let input = getInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(255)_NeverTraps") {
-  let input = getUInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(255)_NeverFails") {
-  let input = getUInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(256)_AlwaysTraps") {
-  let input = getUInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(256)_AlwaysFails") {
-  let input = getUInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(255)_NeverTraps") {
-  let input = getInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(255)_NeverFails") {
-  let input = getInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(256)_AlwaysTraps") {
-  let input = getInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(256)_AlwaysFails") {
-  let input = getInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(255)_NeverTraps") {
-  let input = getUInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(255)_NeverFails") {
-  let input = getUInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(256)_AlwaysTraps") {
-  let input = getUInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(256)_AlwaysFails") {
-  let input = getUInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+4294967295),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+256),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(255)_NeverTraps") {
-  let input = getInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(255)_NeverFails") {
-  let input = getInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(256)_AlwaysTraps") {
-  let input = getInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(256)_AlwaysFails") {
-  let input = getInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+256),
+  getInt(+2147483647),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0.5)),
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+0), getFloat16(+0.5)),
+  (getUInt8(+127), getFloat16(+127.5)),
+  (getUInt8(+255), getFloat16(+255)),
+  (getUInt8(+255), getFloat16(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+255), getFloat16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(255)_NeverTraps") {
-  let input = getFloat16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(255)_NeverFails") {
-  let input = getFloat16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(256)_AlwaysTraps") {
-  let input = getFloat16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(256)_AlwaysFails") {
-  let input = getFloat16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(-0.5)),
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+0), getFloat32(+0.5)),
+  (getUInt8(+127), getFloat32(+127.5)),
+  (getUInt8(+255), getFloat32(+255)),
+  (getUInt8(+255), getFloat32(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+255), getFloat32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(255)_NeverTraps") {
-  let input = getFloat32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(255)_NeverFails") {
-  let input = getFloat32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(256)_AlwaysTraps") {
-  let input = getFloat32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(256)_AlwaysFails") {
-  let input = getFloat32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(-0.5)),
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+0), getFloat64(+0.5)),
+  (getUInt8(+127), getFloat64(+127.5)),
+  (getUInt8(+255), getFloat64(+255)),
+  (getUInt8(+255), getFloat64(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+255), getFloat64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(255)_NeverTraps") {
-  let input = getFloat64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(255)_NeverFails") {
-  let input = getFloat64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(256)_AlwaysTraps") {
-  let input = getFloat64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(256)_AlwaysFails") {
-  let input = getFloat64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0.5)),
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+0), getFloat80(+0.5)),
+  (getUInt8(+127), getFloat80(+127.5)),
+  (getUInt8(+255), getFloat80(+255)),
+  (getUInt8(+255), getFloat80(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+255), getFloat80(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(255)_NeverTraps") {
-  let input = getFloat80(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(255)_NeverFails") {
-  let input = getFloat80(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(256)_AlwaysTraps") {
-  let input = getFloat80(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(256)_AlwaysFails") {
-  let input = getFloat80(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug32_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug32_ToUInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt.swift
@@ -14,1358 +14,562 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToInt = TestSuite("FixedPointConversion_Debug64_ToInt")
+let FixedPointConversion_Debug64_ToInt = TestSuite(
+   "FixedPointConversion_Debug64_ToInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = Int(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(9223372036854775807)_NeverTraps") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(9223372036854775807)_NeverFails") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt64(9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(9223372036854775808)_AlwaysFails") {
-  let input = getUInt64(9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromInt64(-9223372036854775808)_NeverTraps") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromInt64(-9223372036854775808)_NeverFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt(9223372036854775807)_NeverTraps") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromUInt(9223372036854775807)_NeverFails") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt(9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt(9223372036854775808)_AlwaysFails") {
-  let input = getUInt(9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromInt(-9223372036854775808)_NeverTraps") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromInt(-9223372036854775808)_NeverFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(-128), getFloat16(-128.5)),
+  (getInt(+0), getFloat16(-0.5)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+0), getFloat16(+0.5)),
+  (getInt(+127), getFloat16(+127.5)),
+  (getInt(+255), getFloat16(+255.5)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(-32768), getFloat32(-32768.5)),
+  (getInt(-128), getFloat32(-128.5)),
+  (getInt(+0), getFloat32(-0.5)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+0), getFloat32(+0.5)),
+  (getInt(+127), getFloat32(+127.5)),
+  (getInt(+255), getFloat32(+255.5)),
+  (getInt(+32767), getFloat32(+32767.5)),
+  (getInt(+65535), getFloat32(+65535.5)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-9007199254740991)_NeverTraps") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int(input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt(-32768), getFloat64(-32768.5)),
+  (getInt(-128), getFloat64(-128.5)),
+  (getInt(+0), getFloat64(-0.5)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+0), getFloat64(+0.5)),
+  (getInt(+127), getFloat64(+127.5)),
+  (getInt(+255), getFloat64(+255.5)),
+  (getInt(+32767), getFloat64(+32767.5)),
+  (getInt(+65535), getFloat64(+65535.5)),
+  (getInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-9007199254740991)_NeverFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int(exactly: input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt(-32768), getFloat80(-32768.5)),
+  (getInt(-128), getFloat80(-128.5)),
+  (getInt(+0), getFloat80(-0.5)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+0), getFloat80(+0.5)),
+  (getInt(+127), getFloat80(+127.5)),
+  (getInt(+255), getFloat80(+255.5)),
+  (getInt(+32767), getFloat80(+32767.5)),
+  (getInt(+65535), getFloat80(+65535.5)),
+  (getInt(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-9223372036854775809)_AlwaysTraps") {
-  let input = getFloat80(-9223372036854775809)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-9223372036854775809)_AlwaysFails") {
-  let input = getFloat80(-9223372036854775809)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-9223372036854775808)_NeverTraps") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int(input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-9223372036854775808)_NeverFails") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(9223372036854775807)_NeverTraps") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(9223372036854775807)_NeverFails") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(9223372036854775808)_AlwaysTraps") {
-  let input = getFloat80(9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(9223372036854775808)_AlwaysFails") {
-  let input = getFloat80(9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt16.swift
@@ -14,1700 +14,685 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToInt16 = TestSuite("FixedPointConversion_Debug64_ToInt16")
+let FixedPointConversion_Debug64_ToInt16 = TestSuite(
+   "FixedPointConversion_Debug64_ToInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int16(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(32767)_NeverTraps") {
-  let input = getUInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(32767)_NeverFails") {
-  let input = getUInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(32768)_AlwaysTraps") {
-  let input = getUInt16(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(32768)_AlwaysFails") {
-  let input = getUInt16(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(32767)_NeverTraps") {
-  let input = getUInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(32767)_NeverFails") {
-  let input = getUInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(32768)_AlwaysTraps") {
-  let input = getUInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(32768)_AlwaysFails") {
-  let input = getUInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(-32769)_AlwaysTraps") {
-  let input = getInt32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(-32769)_AlwaysFails") {
-  let input = getInt32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(-32768)_NeverTraps") {
-  let input = getInt32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(-32768)_NeverFails") {
-  let input = getInt32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(32767)_NeverTraps") {
-  let input = getInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(32767)_NeverFails") {
-  let input = getInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(32768)_AlwaysTraps") {
-  let input = getInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(32768)_AlwaysFails") {
-  let input = getInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(32767)_NeverTraps") {
-  let input = getUInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(32767)_NeverFails") {
-  let input = getUInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(32768)_AlwaysTraps") {
-  let input = getUInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(32768)_AlwaysFails") {
-  let input = getUInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(-32769)_AlwaysTraps") {
-  let input = getInt64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(-32769)_AlwaysFails") {
-  let input = getInt64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(-32768)_NeverTraps") {
-  let input = getInt64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(-32768)_NeverFails") {
-  let input = getInt64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(32767)_NeverTraps") {
-  let input = getInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(32767)_NeverFails") {
-  let input = getInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(32768)_AlwaysTraps") {
-  let input = getInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(32768)_AlwaysFails") {
-  let input = getInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(32767)_NeverTraps") {
-  let input = getUInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(32767)_NeverFails") {
-  let input = getUInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(32768)_AlwaysTraps") {
-  let input = getUInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(32768)_AlwaysFails") {
-  let input = getUInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt(-32769)_AlwaysTraps") {
-  let input = getInt(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromInt(-32769)_AlwaysFails") {
-  let input = getInt(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(-32768)_NeverTraps") {
-  let input = getInt(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(-32768)_NeverFails") {
-  let input = getInt(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(32767)_NeverTraps") {
-  let input = getInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(32767)_NeverFails") {
-  let input = getInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(32768)_AlwaysTraps") {
-  let input = getInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(32768)_AlwaysFails") {
-  let input = getInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int16(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(-128), getFloat16(-128.5)),
+  (getInt16(+0), getFloat16(-0.5)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+0), getFloat16(+0.5)),
+  (getInt16(+127), getFloat16(+127.5)),
+  (getInt16(+255), getFloat16(+255.5)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int16(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768.5)),
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(-128), getFloat32(-128.5)),
+  (getInt16(+0), getFloat32(-0.5)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+0), getFloat32(+0.5)),
+  (getInt16(+127), getFloat32(+127.5)),
+  (getInt16(+255), getFloat32(+255.5)),
+  (getInt16(+32767), getFloat32(+32767)),
+  (getInt16(+32767), getFloat32(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+32767), getFloat32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-32769)_AlwaysTraps") {
-  let input = getFloat32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-32769)_AlwaysFails") {
-  let input = getFloat32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-32768)_NeverTraps") {
-  let input = getFloat32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-32768)_NeverFails") {
-  let input = getFloat32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(32767)_NeverTraps") {
-  let input = getFloat32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(32767)_NeverFails") {
-  let input = getFloat32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(32768)_AlwaysTraps") {
-  let input = getFloat32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(32768)_AlwaysFails") {
-  let input = getFloat32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768.5)),
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(-128), getFloat64(-128.5)),
+  (getInt16(+0), getFloat64(-0.5)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+0), getFloat64(+0.5)),
+  (getInt16(+127), getFloat64(+127.5)),
+  (getInt16(+255), getFloat64(+255.5)),
+  (getInt16(+32767), getFloat64(+32767)),
+  (getInt16(+32767), getFloat64(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+32767), getFloat64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-32769)_AlwaysTraps") {
-  let input = getFloat64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-32769)_AlwaysFails") {
-  let input = getFloat64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-32768)_NeverTraps") {
-  let input = getFloat64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-32768)_NeverFails") {
-  let input = getFloat64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(32767)_NeverTraps") {
-  let input = getFloat64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(32767)_NeverFails") {
-  let input = getFloat64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(32768)_AlwaysTraps") {
-  let input = getFloat64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(32768)_AlwaysFails") {
-  let input = getFloat64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768.5)),
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(-128), getFloat80(-128.5)),
+  (getInt16(+0), getFloat80(-0.5)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+0), getFloat80(+0.5)),
+  (getInt16(+127), getFloat80(+127.5)),
+  (getInt16(+255), getFloat80(+255.5)),
+  (getInt16(+32767), getFloat80(+32767)),
+  (getInt16(+32767), getFloat80(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+32767), getFloat80(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-32769)_AlwaysTraps") {
-  let input = getFloat80(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-32769)_AlwaysFails") {
-  let input = getFloat80(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-32768)_NeverTraps") {
-  let input = getFloat80(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-32768)_NeverFails") {
-  let input = getFloat80(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(32767)_NeverTraps") {
-  let input = getFloat80(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(32767)_NeverFails") {
-  let input = getFloat80(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(32768)_AlwaysTraps") {
-  let input = getFloat80(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(32768)_AlwaysFails") {
-  let input = getFloat80(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt32.swift
@@ -14,1554 +14,635 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToInt32 = TestSuite("FixedPointConversion_Debug64_ToInt32")
+let FixedPointConversion_Debug64_ToInt32 = TestSuite(
+   "FixedPointConversion_Debug64_ToInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int32(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int32(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(2147483647)_NeverTraps") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(2147483647)_NeverFails") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(2147483648)_AlwaysTraps") {
-  let input = getUInt32(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(2147483648)_AlwaysFails") {
-  let input = getUInt32(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(2147483647)_NeverTraps") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(2147483647)_NeverFails") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(2147483648)_AlwaysTraps") {
-  let input = getUInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(2147483648)_AlwaysFails") {
-  let input = getUInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(-2147483649)_AlwaysTraps") {
-  let input = getInt64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(-2147483649)_AlwaysFails") {
-  let input = getInt64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(-2147483648)_NeverTraps") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(-2147483648)_NeverFails") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(2147483647)_NeverTraps") {
-  let input = getInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(2147483647)_NeverFails") {
-  let input = getInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(2147483648)_AlwaysTraps") {
-  let input = getInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(2147483648)_AlwaysFails") {
-  let input = getInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(2147483647)_NeverTraps") {
-  let input = getUInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(2147483647)_NeverFails") {
-  let input = getUInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(2147483648)_AlwaysTraps") {
-  let input = getUInt(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(2147483648)_AlwaysFails") {
-  let input = getUInt(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt(-2147483649)_AlwaysTraps") {
-  let input = getInt(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-2147483649),
+  getInt(+2147483648),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromInt(-2147483649)_AlwaysFails") {
-  let input = getInt(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(2147483648)_AlwaysTraps") {
-  let input = getInt(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(2147483648)_AlwaysFails") {
-  let input = getInt(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-2147483649),
+  getInt(+2147483648),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int32(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(-128), getFloat16(-128.5)),
+  (getInt32(+0), getFloat16(-0.5)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+0), getFloat16(+0.5)),
+  (getInt32(+127), getFloat16(+127.5)),
+  (getInt32(+255), getFloat16(+255.5)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int32(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(-32768), getFloat32(-32768.5)),
+  (getInt32(-128), getFloat32(-128.5)),
+  (getInt32(+0), getFloat32(-0.5)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+0), getFloat32(+0.5)),
+  (getInt32(+127), getFloat32(+127.5)),
+  (getInt32(+255), getFloat32(+255.5)),
+  (getInt32(+32767), getFloat32(+32767.5)),
+  (getInt32(+65535), getFloat32(+65535.5)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(-32768), getFloat64(-32768.5)),
+  (getInt32(-128), getFloat64(-128.5)),
+  (getInt32(+0), getFloat64(-0.5)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+0), getFloat64(+0.5)),
+  (getInt32(+127), getFloat64(+127.5)),
+  (getInt32(+255), getFloat64(+255.5)),
+  (getInt32(+32767), getFloat64(+32767.5)),
+  (getInt32(+65535), getFloat64(+65535.5)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-2147483649)_AlwaysTraps") {
-  let input = getFloat64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-2147483649)_AlwaysFails") {
-  let input = getFloat64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-2147483648)_NeverTraps") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-2147483648)_NeverFails") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(2147483647)_NeverTraps") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(2147483647)_NeverFails") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(2147483648)_AlwaysTraps") {
-  let input = getFloat64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(2147483648)_AlwaysFails") {
-  let input = getFloat64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(-32768), getFloat80(-32768.5)),
+  (getInt32(-128), getFloat80(-128.5)),
+  (getInt32(+0), getFloat80(-0.5)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+0), getFloat80(+0.5)),
+  (getInt32(+127), getFloat80(+127.5)),
+  (getInt32(+255), getFloat80(+255.5)),
+  (getInt32(+32767), getFloat80(+32767.5)),
+  (getInt32(+65535), getFloat80(+65535.5)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-2147483649)_AlwaysTraps") {
-  let input = getFloat80(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-2147483649)_AlwaysFails") {
-  let input = getFloat80(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-2147483648)_NeverTraps") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-2147483648)_NeverFails") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(2147483647)_NeverTraps") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(2147483647)_NeverFails") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(2147483648)_AlwaysTraps") {
-  let input = getFloat80(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(2147483648)_AlwaysFails") {
-  let input = getFloat80(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt64.swift
@@ -14,1358 +14,562 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToInt64 = TestSuite("FixedPointConversion_Debug64_ToInt64")
+let FixedPointConversion_Debug64_ToInt64 = TestSuite(
+   "FixedPointConversion_Debug64_ToInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int64(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int64(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(9223372036854775807)_NeverTraps") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(9223372036854775807)_NeverFails") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt64(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysFails") {
-  let input = getUInt64(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt64(-9223372036854775808)_NeverTraps") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt64(-9223372036854775808)_NeverFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(9223372036854775807)_NeverTraps") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(9223372036854775807)_NeverFails") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(9223372036854775808)_AlwaysFails") {
-  let input = getUInt(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt(-9223372036854775808)_NeverTraps") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromInt(-9223372036854775808)_NeverFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int64(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(-128), getFloat16(-128.5)),
+  (getInt64(+0), getFloat16(-0.5)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+0), getFloat16(+0.5)),
+  (getInt64(+127), getFloat16(+127.5)),
+  (getInt64(+255), getFloat16(+255.5)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int64(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(-32768), getFloat32(-32768.5)),
+  (getInt64(-128), getFloat32(-128.5)),
+  (getInt64(+0), getFloat32(-0.5)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+0), getFloat32(+0.5)),
+  (getInt64(+127), getFloat32(+127.5)),
+  (getInt64(+255), getFloat32(+255.5)),
+  (getInt64(+32767), getFloat32(+32767.5)),
+  (getInt64(+65535), getFloat32(+65535.5)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-9007199254740991)_NeverTraps") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(-32768), getFloat64(-32768.5)),
+  (getInt64(-128), getFloat64(-128.5)),
+  (getInt64(+0), getFloat64(-0.5)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+0), getFloat64(+0.5)),
+  (getInt64(+127), getFloat64(+127.5)),
+  (getInt64(+255), getFloat64(+255.5)),
+  (getInt64(+32767), getFloat64(+32767.5)),
+  (getInt64(+65535), getFloat64(+65535.5)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-9007199254740991)_NeverFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(-32768), getFloat80(-32768.5)),
+  (getInt64(-128), getFloat80(-128.5)),
+  (getInt64(+0), getFloat80(-0.5)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+0), getFloat80(+0.5)),
+  (getInt64(+127), getFloat80(+127.5)),
+  (getInt64(+255), getFloat80(+255.5)),
+  (getInt64(+32767), getFloat80(+32767.5)),
+  (getInt64(+65535), getFloat80(+65535.5)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysTraps") {
-  let input = getFloat80(-9223372036854775809)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysFails") {
-  let input = getFloat80(-9223372036854775809)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-9223372036854775808)_NeverTraps") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-9223372036854775808)_NeverFails") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(9223372036854775807)_NeverTraps") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(9223372036854775807)_NeverFails") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysTraps") {
-  let input = getFloat80(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysFails") {
-  let input = getFloat80(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt8.swift
@@ -14,1860 +14,735 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToInt8 = TestSuite("FixedPointConversion_Debug64_ToInt8")
+let FixedPointConversion_Debug64_ToInt8 = TestSuite(
+   "FixedPointConversion_Debug64_ToInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(127)_NeverTraps") {
-  let input = getUInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt8_AlwaysTraps")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(127)_NeverFails") {
-  let input = getUInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(128)_AlwaysTraps") {
-  let input = getUInt8(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(128)_AlwaysFails") {
-  let input = getUInt8(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(255)_AlwaysTraps") {
-  let input = getUInt8(255)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt8(255)_AlwaysFails") {
-  let input = getUInt8(255)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt8_AlwaysFails")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(127)_NeverTraps") {
-  let input = getUInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(127)_NeverFails") {
-  let input = getUInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(128)_AlwaysTraps") {
-  let input = getUInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(128)_AlwaysFails") {
-  let input = getUInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(-129)_AlwaysTraps") {
-  let input = getInt16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(-129)_AlwaysFails") {
-  let input = getInt16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(-128)_NeverTraps") {
-  let input = getInt16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(-128)_NeverFails") {
-  let input = getInt16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(127)_NeverTraps") {
-  let input = getInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(127)_NeverFails") {
-  let input = getInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(128)_AlwaysTraps") {
-  let input = getInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(128)_AlwaysFails") {
-  let input = getInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(127)_NeverTraps") {
-  let input = getUInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(127)_NeverFails") {
-  let input = getUInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(128)_AlwaysTraps") {
-  let input = getUInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(128)_AlwaysFails") {
-  let input = getUInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(-129)_AlwaysTraps") {
-  let input = getInt32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(-129)_AlwaysFails") {
-  let input = getInt32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(-128)_NeverTraps") {
-  let input = getInt32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(-128)_NeverFails") {
-  let input = getInt32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(127)_NeverTraps") {
-  let input = getInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(127)_NeverFails") {
-  let input = getInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(128)_AlwaysTraps") {
-  let input = getInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(128)_AlwaysFails") {
-  let input = getInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(127)_NeverTraps") {
-  let input = getUInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(127)_NeverFails") {
-  let input = getUInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(128)_AlwaysTraps") {
-  let input = getUInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(128)_AlwaysFails") {
-  let input = getUInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(-129)_AlwaysTraps") {
-  let input = getInt64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(-129)_AlwaysFails") {
-  let input = getInt64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(-128)_NeverTraps") {
-  let input = getInt64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(-128)_NeverFails") {
-  let input = getInt64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(127)_NeverTraps") {
-  let input = getInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(127)_NeverFails") {
-  let input = getInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(128)_AlwaysTraps") {
-  let input = getInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(128)_AlwaysFails") {
-  let input = getInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(127)_NeverTraps") {
-  let input = getUInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(127)_NeverFails") {
-  let input = getUInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(128)_AlwaysTraps") {
-  let input = getUInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(128)_AlwaysFails") {
-  let input = getUInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt(-129)_AlwaysTraps") {
-  let input = getInt(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-129),
+  getInt(+128),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromInt(-129)_AlwaysFails") {
-  let input = getInt(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(-128)_NeverTraps") {
-  let input = getInt(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(-128)_NeverFails") {
-  let input = getInt(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(127)_NeverTraps") {
-  let input = getInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(127)_NeverFails") {
-  let input = getInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(128)_AlwaysTraps") {
-  let input = getInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(128)_AlwaysFails") {
-  let input = getInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-129),
+  getInt(+128),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128.5)),
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0.5)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+0), getFloat16(+0.5)),
+  (getInt8(+127), getFloat16(+127)),
+  (getInt8(+127), getFloat16(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+127), getFloat16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-129)_AlwaysTraps") {
-  let input = getFloat16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-129)_AlwaysFails") {
-  let input = getFloat16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-128)_NeverTraps") {
-  let input = getFloat16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-128)_NeverFails") {
-  let input = getFloat16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(127)_NeverTraps") {
-  let input = getFloat16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(127)_NeverFails") {
-  let input = getFloat16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(128)_AlwaysTraps") {
-  let input = getFloat16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(128)_AlwaysFails") {
-  let input = getFloat16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(255.5)_AlwaysTraps") {
-  let input = getFloat16(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128.5)),
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(-0.5)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+0), getFloat32(+0.5)),
+  (getInt8(+127), getFloat32(+127)),
+  (getInt8(+127), getFloat32(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+127), getFloat32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-129)_AlwaysTraps") {
-  let input = getFloat32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-129)_AlwaysFails") {
-  let input = getFloat32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-128)_NeverTraps") {
-  let input = getFloat32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-128)_NeverFails") {
-  let input = getFloat32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(127)_NeverTraps") {
-  let input = getFloat32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(127)_NeverFails") {
-  let input = getFloat32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(128)_AlwaysTraps") {
-  let input = getFloat32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(128)_AlwaysFails") {
-  let input = getFloat32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(255.5)_AlwaysTraps") {
-  let input = getFloat32(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128.5)),
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(-0.5)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+0), getFloat64(+0.5)),
+  (getInt8(+127), getFloat64(+127)),
+  (getInt8(+127), getFloat64(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+127), getFloat64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-129)_AlwaysTraps") {
-  let input = getFloat64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-129)_AlwaysFails") {
-  let input = getFloat64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-128)_NeverTraps") {
-  let input = getFloat64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-128)_NeverFails") {
-  let input = getFloat64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(127)_NeverTraps") {
-  let input = getFloat64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(127)_NeverFails") {
-  let input = getFloat64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(128)_AlwaysTraps") {
-  let input = getFloat64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(128)_AlwaysFails") {
-  let input = getFloat64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(255.5)_AlwaysTraps") {
-  let input = getFloat64(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128.5)),
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0.5)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+0), getFloat80(+0.5)),
+  (getInt8(+127), getFloat80(+127)),
+  (getInt8(+127), getFloat80(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+127), getFloat80(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-129)_AlwaysTraps") {
-  let input = getFloat80(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-129)_AlwaysFails") {
-  let input = getFloat80(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-128)_NeverTraps") {
-  let input = getFloat80(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-128)_NeverFails") {
-  let input = getFloat80(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(127)_NeverTraps") {
-  let input = getFloat80(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(127)_NeverFails") {
-  let input = getFloat80(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(128)_AlwaysTraps") {
-  let input = getFloat80(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(128)_AlwaysFails") {
-  let input = getFloat80(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(255.5)_AlwaysTraps") {
-  let input = getFloat80(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt.swift
@@ -14,1464 +14,609 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToUInt = TestSuite("FixedPointConversion_Debug64_ToUInt")
+let FixedPointConversion_Debug64_ToUInt = TestSuite(
+   "FixedPointConversion_Debug64_ToUInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt64(18446744073709551615)_NeverTraps") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt64(18446744073709551615)_NeverFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt(18446744073709551615)_NeverTraps") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromUInt(18446744073709551615)_NeverFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat16(-0.5)),
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+0), getFloat16(+0.5)),
+  (getUInt(+127), getFloat16(+127.5)),
+  (getUInt(+255), getFloat16(+255.5)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat32(-0.5)),
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+0), getFloat32(+0.5)),
+  (getUInt(+127), getFloat32(+127.5)),
+  (getUInt(+255), getFloat32(+255.5)),
+  (getUInt(+32767), getFloat32(+32767.5)),
+  (getUInt(+65535), getFloat32(+65535.5)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat64(-0.5)),
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+0), getFloat64(+0.5)),
+  (getUInt(+127), getFloat64(+127.5)),
+  (getUInt(+255), getFloat64(+255.5)),
+  (getUInt(+32767), getFloat64(+32767.5)),
+  (getUInt(+65535), getFloat64(+65535.5)),
+  (getUInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat80(-0.5)),
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+0), getFloat80(+0.5)),
+  (getUInt(+127), getFloat80(+127.5)),
+  (getUInt(+255), getFloat80(+255.5)),
+  (getUInt(+32767), getFloat80(+32767.5)),
+  (getUInt(+65535), getFloat80(+65535.5)),
+  (getUInt(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt16.swift
@@ -14,1704 +14,690 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToUInt16 = TestSuite("FixedPointConversion_Debug64_ToUInt16")
+let FixedPointConversion_Debug64_ToUInt16 = TestSuite(
+   "FixedPointConversion_Debug64_ToUInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(65535)_NeverTraps") {
-  let input = getUInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(65535)_NeverFails") {
-  let input = getUInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(65536)_AlwaysTraps") {
-  let input = getUInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(65536)_AlwaysFails") {
-  let input = getUInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(65535)_NeverTraps") {
-  let input = getInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(65535)_NeverFails") {
-  let input = getInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(65536)_AlwaysTraps") {
-  let input = getInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(65536)_AlwaysFails") {
-  let input = getInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(65535)_NeverTraps") {
-  let input = getUInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(65535)_NeverFails") {
-  let input = getUInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(65536)_AlwaysTraps") {
-  let input = getUInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(65536)_AlwaysFails") {
-  let input = getUInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(65535)_NeverTraps") {
-  let input = getInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(65535)_NeverFails") {
-  let input = getInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(65536)_AlwaysTraps") {
-  let input = getInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(65536)_AlwaysFails") {
-  let input = getInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(65535)_NeverTraps") {
-  let input = getUInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(65535)_NeverFails") {
-  let input = getUInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(65536)_AlwaysTraps") {
-  let input = getUInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(65536)_AlwaysFails") {
-  let input = getUInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(65535)_NeverTraps") {
-  let input = getInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(65535)_NeverFails") {
-  let input = getInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(65536)_AlwaysTraps") {
-  let input = getInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(65536)_AlwaysFails") {
-  let input = getInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(-0.5)),
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+0), getFloat16(+0.5)),
+  (getUInt16(+127), getFloat16(+127.5)),
+  (getUInt16(+255), getFloat16(+255.5)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(-0.5)),
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+0), getFloat32(+0.5)),
+  (getUInt16(+127), getFloat32(+127.5)),
+  (getUInt16(+255), getFloat32(+255.5)),
+  (getUInt16(+32767), getFloat32(+32767.5)),
+  (getUInt16(+65535), getFloat32(+65535)),
+  (getUInt16(+65535), getFloat32(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+65535), getFloat32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(65535)_NeverTraps") {
-  let input = getFloat32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(65535)_NeverFails") {
-  let input = getFloat32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(65536)_AlwaysTraps") {
-  let input = getFloat32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(65536)_AlwaysFails") {
-  let input = getFloat32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(-0.5)),
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+0), getFloat64(+0.5)),
+  (getUInt16(+127), getFloat64(+127.5)),
+  (getUInt16(+255), getFloat64(+255.5)),
+  (getUInt16(+32767), getFloat64(+32767.5)),
+  (getUInt16(+65535), getFloat64(+65535)),
+  (getUInt16(+65535), getFloat64(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+65535), getFloat64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(65535)_NeverTraps") {
-  let input = getFloat64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(65535)_NeverFails") {
-  let input = getFloat64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(65536)_AlwaysTraps") {
-  let input = getFloat64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(65536)_AlwaysFails") {
-  let input = getFloat64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(-0.5)),
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+0), getFloat80(+0.5)),
+  (getUInt16(+127), getFloat80(+127.5)),
+  (getUInt16(+255), getFloat80(+255.5)),
+  (getUInt16(+32767), getFloat80(+32767.5)),
+  (getUInt16(+65535), getFloat80(+65535)),
+  (getUInt16(+65535), getFloat80(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+65535), getFloat80(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(65535)_NeverTraps") {
-  let input = getFloat80(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(65535)_NeverFails") {
-  let input = getFloat80(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(65536)_AlwaysTraps") {
-  let input = getFloat80(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(65536)_AlwaysFails") {
-  let input = getFloat80(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt32.swift
@@ -14,1620 +14,663 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToUInt32 = TestSuite("FixedPointConversion_Debug64_ToUInt32")
+let FixedPointConversion_Debug64_ToUInt32 = TestSuite(
+   "FixedPointConversion_Debug64_ToUInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(4294967295)_NeverTraps") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(4294967295)_NeverFails") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(4294967296)_AlwaysTraps") {
-  let input = getUInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(4294967296)_AlwaysFails") {
-  let input = getUInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(4294967295)_NeverTraps") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(4294967295)_NeverFails") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(4294967296)_AlwaysTraps") {
-  let input = getInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(4294967296)_AlwaysFails") {
-  let input = getInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+4294967296),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(4294967296)_AlwaysTraps") {
-  let input = getUInt(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(4294967296)_AlwaysFails") {
-  let input = getUInt(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+4294967296),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+4294967295), getInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+4294967295), getInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+4294967296),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(4294967295)_NeverTraps") {
-  let input = getInt(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(4294967295)_NeverFails") {
-  let input = getInt(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(4294967296)_AlwaysTraps") {
-  let input = getInt(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(4294967296)_AlwaysFails") {
-  let input = getInt(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+4294967296),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(-0.5)),
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+0), getFloat16(+0.5)),
+  (getUInt32(+127), getFloat16(+127.5)),
+  (getUInt32(+255), getFloat16(+255.5)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(-0.5)),
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+0), getFloat32(+0.5)),
+  (getUInt32(+127), getFloat32(+127.5)),
+  (getUInt32(+255), getFloat32(+255.5)),
+  (getUInt32(+32767), getFloat32(+32767.5)),
+  (getUInt32(+65535), getFloat32(+65535.5)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(-0.5)),
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+0), getFloat64(+0.5)),
+  (getUInt32(+127), getFloat64(+127.5)),
+  (getUInt32(+255), getFloat64(+255.5)),
+  (getUInt32(+32767), getFloat64(+32767.5)),
+  (getUInt32(+65535), getFloat64(+65535.5)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(4294967295)_NeverTraps") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(4294967295)_NeverFails") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(4294967296)_AlwaysTraps") {
-  let input = getFloat64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(4294967296)_AlwaysFails") {
-  let input = getFloat64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(-0.5)),
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+0), getFloat80(+0.5)),
+  (getUInt32(+127), getFloat80(+127.5)),
+  (getUInt32(+255), getFloat80(+255.5)),
+  (getUInt32(+32767), getFloat80(+32767.5)),
+  (getUInt32(+65535), getFloat80(+65535.5)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(4294967295)_NeverTraps") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(4294967295)_NeverFails") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(4294967296)_AlwaysTraps") {
-  let input = getFloat80(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(4294967296)_AlwaysFails") {
-  let input = getFloat80(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt64.swift
@@ -14,1464 +14,609 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToUInt64 = TestSuite("FixedPointConversion_Debug64_ToUInt64")
+let FixedPointConversion_Debug64_ToUInt64 = TestSuite(
+   "FixedPointConversion_Debug64_ToUInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt64(18446744073709551615)_NeverTraps") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt64(18446744073709551615)_NeverFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt(18446744073709551615)_NeverTraps") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromUInt(18446744073709551615)_NeverFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(-0.5)),
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+0), getFloat16(+0.5)),
+  (getUInt64(+127), getFloat16(+127.5)),
+  (getUInt64(+255), getFloat16(+255.5)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(-0.5)),
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+0), getFloat32(+0.5)),
+  (getUInt64(+127), getFloat32(+127.5)),
+  (getUInt64(+255), getFloat32(+255.5)),
+  (getUInt64(+32767), getFloat32(+32767.5)),
+  (getUInt64(+65535), getFloat32(+65535.5)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(-0.5)),
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+0), getFloat64(+0.5)),
+  (getUInt64(+127), getFloat64(+127.5)),
+  (getUInt64(+255), getFloat64(+255.5)),
+  (getUInt64(+32767), getFloat64(+32767.5)),
+  (getUInt64(+65535), getFloat64(+65535.5)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(-0.5)),
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+0), getFloat80(+0.5)),
+  (getUInt64(+127), getFloat80(+127.5)),
+  (getUInt64(+255), getFloat80(+255.5)),
+  (getUInt64(+32767), getFloat80(+32767.5)),
+  (getUInt64(+65535), getFloat80(+65535.5)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt8.swift
@@ -14,1800 +14,717 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Debug64_ToUInt8 = TestSuite("FixedPointConversion_Debug64_ToUInt8")
+let FixedPointConversion_Debug64_ToUInt8 = TestSuite(
+   "FixedPointConversion_Debug64_ToUInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(255)_NeverTraps") {
-  let input = getUInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(255)_NeverFails") {
-  let input = getUInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(256)_AlwaysTraps") {
-  let input = getUInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(256)_AlwaysFails") {
-  let input = getUInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(255)_NeverTraps") {
-  let input = getInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(255)_NeverFails") {
-  let input = getInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(256)_AlwaysTraps") {
-  let input = getInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(256)_AlwaysFails") {
-  let input = getInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(255)_NeverTraps") {
-  let input = getUInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(255)_NeverFails") {
-  let input = getUInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(256)_AlwaysTraps") {
-  let input = getUInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(256)_AlwaysFails") {
-  let input = getUInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(255)_NeverTraps") {
-  let input = getInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(255)_NeverFails") {
-  let input = getInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(256)_AlwaysTraps") {
-  let input = getInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(256)_AlwaysFails") {
-  let input = getInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(255)_NeverTraps") {
-  let input = getUInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(255)_NeverFails") {
-  let input = getUInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(256)_AlwaysTraps") {
-  let input = getUInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(256)_AlwaysFails") {
-  let input = getUInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(255)_NeverTraps") {
-  let input = getInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(255)_NeverFails") {
-  let input = getInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(256)_AlwaysTraps") {
-  let input = getInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(256)_AlwaysFails") {
-  let input = getInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(255)_NeverTraps") {
-  let input = getUInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(255)_NeverFails") {
-  let input = getUInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(256)_AlwaysTraps") {
-  let input = getUInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(256)_AlwaysFails") {
-  let input = getUInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+256),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(255)_NeverTraps") {
-  let input = getInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(255)_NeverFails") {
-  let input = getInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(256)_AlwaysTraps") {
-  let input = getInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(256)_AlwaysFails") {
-  let input = getInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+256),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0.5)),
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+0), getFloat16(+0.5)),
+  (getUInt8(+127), getFloat16(+127.5)),
+  (getUInt8(+255), getFloat16(+255)),
+  (getUInt8(+255), getFloat16(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+255), getFloat16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(255)_NeverTraps") {
-  let input = getFloat16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(255)_NeverFails") {
-  let input = getFloat16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(256)_AlwaysTraps") {
-  let input = getFloat16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(256)_AlwaysFails") {
-  let input = getFloat16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(-0.5)),
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+0), getFloat32(+0.5)),
+  (getUInt8(+127), getFloat32(+127.5)),
+  (getUInt8(+255), getFloat32(+255)),
+  (getUInt8(+255), getFloat32(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+255), getFloat32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(255)_NeverTraps") {
-  let input = getFloat32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(255)_NeverFails") {
-  let input = getFloat32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(256)_AlwaysTraps") {
-  let input = getFloat32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(256)_AlwaysFails") {
-  let input = getFloat32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(-0.5)),
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+0), getFloat64(+0.5)),
+  (getUInt8(+127), getFloat64(+127.5)),
+  (getUInt8(+255), getFloat64(+255)),
+  (getUInt8(+255), getFloat64(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+255), getFloat64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(255)_NeverTraps") {
-  let input = getFloat64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(255)_NeverFails") {
-  let input = getFloat64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(256)_AlwaysTraps") {
-  let input = getFloat64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(256)_AlwaysFails") {
-  let input = getFloat64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0.5)),
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+0), getFloat80(+0.5)),
+  (getUInt8(+127), getFloat80(+127.5)),
+  (getUInt8(+255), getFloat80(+255)),
+  (getUInt8(+255), getFloat80(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+255), getFloat80(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(255)_NeverTraps") {
-  let input = getFloat80(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(255)_NeverFails") {
-  let input = getFloat80(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(256)_AlwaysTraps") {
-  let input = getFloat80(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(256)_AlwaysFails") {
-  let input = getFloat80(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Debug64_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Debug64_ToUInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1498 +14,612 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToInt = TestSuite("FixedPointConversion_Release32_ToInt")
+let FixedPointConversion_Release32_ToInt = TestSuite(
+   "FixedPointConversion_Release32_ToInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt32(2147483647)_NeverTraps") {
-  let input = getUInt32(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt32(2147483647)_NeverFails") {
-  let input = getUInt32(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt32(2147483648)_AlwaysTraps") {
-  let input = getUInt32(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt32(2147483648)_AlwaysFails") {
-  let input = getUInt32(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt64(2147483647)_NeverTraps") {
-  let input = getUInt64(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt64(2147483647)_NeverFails") {
-  let input = getUInt64(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt64(2147483648)_AlwaysTraps") {
-  let input = getUInt64(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt64(2147483648)_AlwaysFails") {
-  let input = getUInt64(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt64(-2147483648)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt64(-2147483648)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromInt64(-2147483649)_AlwaysTraps") {
-  let input = getInt64(-2147483649)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromInt64(-2147483649)_AlwaysFails") {
-  let input = getInt64(-2147483649)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(-2147483648)_NeverTraps") {
-  let input = getInt64(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(-2147483648)_NeverFails") {
-  let input = getInt64(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(2147483647)_NeverTraps") {
-  let input = getInt64(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(2147483647)_NeverFails") {
-  let input = getInt64(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(2147483648)_AlwaysTraps") {
-  let input = getInt64(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(2147483648)_AlwaysFails") {
-  let input = getInt64(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt(2147483647)_NeverTraps") {
-  let input = getUInt(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromUInt(2147483647)_NeverFails") {
-  let input = getUInt(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt(2147483648)_AlwaysTraps") {
-  let input = getUInt(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt(2147483648)_AlwaysFails") {
-  let input = getUInt(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt(-2147483648)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt(-2147483648)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(-128), getFloat16(-128.5)),
+  (getInt(+0), getFloat16(-0.5)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+0), getFloat16(+0.5)),
+  (getInt(+127), getFloat16(+127.5)),
+  (getInt(+255), getFloat16(+255.5)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(-32768), getFloat32(-32768.5)),
+  (getInt(-128), getFloat32(-128.5)),
+  (getInt(+0), getFloat32(-0.5)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+0), getFloat32(+0.5)),
+  (getInt(+127), getFloat32(+127.5)),
+  (getInt(+255), getFloat32(+255.5)),
+  (getInt(+32767), getFloat32(+32767.5)),
+  (getInt(+65535), getFloat32(+65535.5)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getFloat64(-2147483648)),
+  (getInt(-32768), getFloat64(-32768.5)),
+  (getInt(-128), getFloat64(-128.5)),
+  (getInt(+0), getFloat64(-0.5)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+0), getFloat64(+0.5)),
+  (getInt(+127), getFloat64(+127.5)),
+  (getInt(+255), getFloat64(+255.5)),
+  (getInt(+32767), getFloat64(+32767.5)),
+  (getInt(+65535), getFloat64(+65535.5)),
+  (getInt(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getFloat64(-2147483648)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-2147483649)_AlwaysTraps") {
-  let input = getFloat64(-2147483649)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-2147483649)_AlwaysFails") {
-  let input = getFloat64(-2147483649)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-2147483648)_NeverTraps") {
-  let input = getFloat64(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-2147483648)_NeverFails") {
-  let input = getFloat64(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(2147483647)_NeverTraps") {
-  let input = getFloat64(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(2147483647)_NeverFails") {
-  let input = getFloat64(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(2147483648)_AlwaysTraps") {
-  let input = getFloat64(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(2147483648)_AlwaysFails") {
-  let input = getFloat64(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getFloat80(-2147483648)),
+  (getInt(-32768), getFloat80(-32768.5)),
+  (getInt(-128), getFloat80(-128.5)),
+  (getInt(+0), getFloat80(-0.5)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+0), getFloat80(+0.5)),
+  (getInt(+127), getFloat80(+127.5)),
+  (getInt(+255), getFloat80(+255.5)),
+  (getInt(+32767), getFloat80(+32767.5)),
+  (getInt(+65535), getFloat80(+65535.5)),
+  (getInt(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getFloat80(-2147483648)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-2147483649)_AlwaysTraps") {
-  let input = getFloat80(-2147483649)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-2147483649)_AlwaysFails") {
-  let input = getFloat80(-2147483649)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-2147483648)_NeverTraps") {
-  let input = getFloat80(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-2147483648)_NeverFails") {
-  let input = getFloat80(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(2147483647)_NeverTraps") {
-  let input = getFloat80(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(2147483647)_NeverFails") {
-  let input = getFloat80(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(2147483648)_AlwaysTraps") {
-  let input = getFloat80(2147483648)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(2147483648)_AlwaysFails") {
-  let input = getFloat80(2147483648)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt16.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1700 +14,685 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToInt16 = TestSuite("FixedPointConversion_Release32_ToInt16")
+let FixedPointConversion_Release32_ToInt16 = TestSuite(
+   "FixedPointConversion_Release32_ToInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int16(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(32767)_NeverTraps") {
-  let input = getUInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(32767)_NeverFails") {
-  let input = getUInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(32768)_AlwaysTraps") {
-  let input = getUInt16(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(32768)_AlwaysFails") {
-  let input = getUInt16(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(32767)_NeverTraps") {
-  let input = getUInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(32767)_NeverFails") {
-  let input = getUInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(32768)_AlwaysTraps") {
-  let input = getUInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(32768)_AlwaysFails") {
-  let input = getUInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt32(-32769)_AlwaysTraps") {
-  let input = getInt32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt32(-32769)_AlwaysFails") {
-  let input = getInt32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(-32768)_NeverTraps") {
-  let input = getInt32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(-32768)_NeverFails") {
-  let input = getInt32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(32767)_NeverTraps") {
-  let input = getInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(32767)_NeverFails") {
-  let input = getInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(32768)_AlwaysTraps") {
-  let input = getInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(32768)_AlwaysFails") {
-  let input = getInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(32767)_NeverTraps") {
-  let input = getUInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(32767)_NeverFails") {
-  let input = getUInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(32768)_AlwaysTraps") {
-  let input = getUInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(32768)_AlwaysFails") {
-  let input = getUInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt64(-32769)_AlwaysTraps") {
-  let input = getInt64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt64(-32769)_AlwaysFails") {
-  let input = getInt64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(-32768)_NeverTraps") {
-  let input = getInt64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(-32768)_NeverFails") {
-  let input = getInt64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(32767)_NeverTraps") {
-  let input = getInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(32767)_NeverFails") {
-  let input = getInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(32768)_AlwaysTraps") {
-  let input = getInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(32768)_AlwaysFails") {
-  let input = getInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt(32767)_NeverTraps") {
-  let input = getUInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromUInt(32767)_NeverFails") {
-  let input = getUInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt(32768)_AlwaysTraps") {
-  let input = getUInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt(32768)_AlwaysFails") {
-  let input = getUInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt(-32769)_AlwaysTraps") {
-  let input = getInt(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromInt(-32769)_AlwaysFails") {
-  let input = getInt(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(-32768)_NeverTraps") {
-  let input = getInt(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(-32768)_NeverFails") {
-  let input = getInt(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(32767)_NeverTraps") {
-  let input = getInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(32767)_NeverFails") {
-  let input = getInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(32768)_AlwaysTraps") {
-  let input = getInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(32768)_AlwaysFails") {
-  let input = getInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+2147483647),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int16(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(-128), getFloat16(-128.5)),
+  (getInt16(+0), getFloat16(-0.5)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+0), getFloat16(+0.5)),
+  (getInt16(+127), getFloat16(+127.5)),
+  (getInt16(+255), getFloat16(+255.5)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int16(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768.5)),
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(-128), getFloat32(-128.5)),
+  (getInt16(+0), getFloat32(-0.5)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+0), getFloat32(+0.5)),
+  (getInt16(+127), getFloat32(+127.5)),
+  (getInt16(+255), getFloat32(+255.5)),
+  (getInt16(+32767), getFloat32(+32767)),
+  (getInt16(+32767), getFloat32(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+32767), getFloat32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-32769)_AlwaysTraps") {
-  let input = getFloat32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-32769)_AlwaysFails") {
-  let input = getFloat32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-32768)_NeverTraps") {
-  let input = getFloat32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-32768)_NeverFails") {
-  let input = getFloat32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(32767)_NeverTraps") {
-  let input = getFloat32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(32767)_NeverFails") {
-  let input = getFloat32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(32768)_AlwaysTraps") {
-  let input = getFloat32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(32768)_AlwaysFails") {
-  let input = getFloat32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768.5)),
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(-128), getFloat64(-128.5)),
+  (getInt16(+0), getFloat64(-0.5)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+0), getFloat64(+0.5)),
+  (getInt16(+127), getFloat64(+127.5)),
+  (getInt16(+255), getFloat64(+255.5)),
+  (getInt16(+32767), getFloat64(+32767)),
+  (getInt16(+32767), getFloat64(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+32767), getFloat64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-32769)_AlwaysTraps") {
-  let input = getFloat64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-32769)_AlwaysFails") {
-  let input = getFloat64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-32768)_NeverTraps") {
-  let input = getFloat64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-32768)_NeverFails") {
-  let input = getFloat64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(32767)_NeverTraps") {
-  let input = getFloat64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(32767)_NeverFails") {
-  let input = getFloat64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(32768)_AlwaysTraps") {
-  let input = getFloat64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(32768)_AlwaysFails") {
-  let input = getFloat64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768.5)),
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(-128), getFloat80(-128.5)),
+  (getInt16(+0), getFloat80(-0.5)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+0), getFloat80(+0.5)),
+  (getInt16(+127), getFloat80(+127.5)),
+  (getInt16(+255), getFloat80(+255.5)),
+  (getInt16(+32767), getFloat80(+32767)),
+  (getInt16(+32767), getFloat80(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+32767), getFloat80(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-32769)_AlwaysTraps") {
-  let input = getFloat80(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-32769)_AlwaysFails") {
-  let input = getFloat80(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-32768)_NeverTraps") {
-  let input = getFloat80(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-32768)_NeverFails") {
-  let input = getFloat80(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(32767)_NeverTraps") {
-  let input = getFloat80(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(32767)_NeverFails") {
-  let input = getFloat80(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(32768)_AlwaysTraps") {
-  let input = getFloat80(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(32768)_AlwaysFails") {
-  let input = getFloat80(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt32.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1498 +14,612 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToInt32 = TestSuite("FixedPointConversion_Release32_ToInt32")
+let FixedPointConversion_Release32_ToInt32 = TestSuite(
+   "FixedPointConversion_Release32_ToInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int32(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int32(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(2147483647)_NeverTraps") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(2147483647)_NeverFails") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(2147483648)_AlwaysTraps") {
-  let input = getUInt32(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(2147483648)_AlwaysFails") {
-  let input = getUInt32(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(2147483647)_NeverTraps") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(2147483647)_NeverFails") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(2147483648)_AlwaysTraps") {
-  let input = getUInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(2147483648)_AlwaysFails") {
-  let input = getUInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromInt64(-2147483649)_AlwaysTraps") {
-  let input = getInt64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromInt64(-2147483649)_AlwaysFails") {
-  let input = getInt64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(-2147483648)_NeverTraps") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(-2147483648)_NeverFails") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(2147483647)_NeverTraps") {
-  let input = getInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(2147483647)_NeverFails") {
-  let input = getInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(2147483648)_AlwaysTraps") {
-  let input = getInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(2147483648)_AlwaysFails") {
-  let input = getInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt(2147483647)_NeverTraps") {
-  let input = getUInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromUInt(2147483647)_NeverFails") {
-  let input = getUInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt(2147483648)_AlwaysTraps") {
-  let input = getUInt(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt(2147483648)_AlwaysFails") {
-  let input = getUInt(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int32(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(-128), getFloat16(-128.5)),
+  (getInt32(+0), getFloat16(-0.5)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+0), getFloat16(+0.5)),
+  (getInt32(+127), getFloat16(+127.5)),
+  (getInt32(+255), getFloat16(+255.5)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int32(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(-32768), getFloat32(-32768.5)),
+  (getInt32(-128), getFloat32(-128.5)),
+  (getInt32(+0), getFloat32(-0.5)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+0), getFloat32(+0.5)),
+  (getInt32(+127), getFloat32(+127.5)),
+  (getInt32(+255), getFloat32(+255.5)),
+  (getInt32(+32767), getFloat32(+32767.5)),
+  (getInt32(+65535), getFloat32(+65535.5)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(-32768), getFloat64(-32768.5)),
+  (getInt32(-128), getFloat64(-128.5)),
+  (getInt32(+0), getFloat64(-0.5)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+0), getFloat64(+0.5)),
+  (getInt32(+127), getFloat64(+127.5)),
+  (getInt32(+255), getFloat64(+255.5)),
+  (getInt32(+32767), getFloat64(+32767.5)),
+  (getInt32(+65535), getFloat64(+65535.5)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-2147483649)_AlwaysTraps") {
-  let input = getFloat64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-2147483649)_AlwaysFails") {
-  let input = getFloat64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-2147483648)_NeverTraps") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-2147483648)_NeverFails") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(2147483647)_NeverTraps") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(2147483647)_NeverFails") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(2147483648)_AlwaysTraps") {
-  let input = getFloat64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(2147483648)_AlwaysFails") {
-  let input = getFloat64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(-32768), getFloat80(-32768.5)),
+  (getInt32(-128), getFloat80(-128.5)),
+  (getInt32(+0), getFloat80(-0.5)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+0), getFloat80(+0.5)),
+  (getInt32(+127), getFloat80(+127.5)),
+  (getInt32(+255), getFloat80(+255.5)),
+  (getInt32(+32767), getFloat80(+32767.5)),
+  (getInt32(+65535), getFloat80(+65535.5)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-2147483649)_AlwaysTraps") {
-  let input = getFloat80(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-2147483649)_AlwaysFails") {
-  let input = getFloat80(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-2147483648)_NeverTraps") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-2147483648)_NeverFails") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(2147483647)_NeverTraps") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(2147483647)_NeverFails") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(2147483648)_AlwaysTraps") {
-  let input = getFloat80(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(2147483648)_AlwaysFails") {
-  let input = getFloat80(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt64.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1330 +14,543 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToInt64 = TestSuite("FixedPointConversion_Release32_ToInt64")
+let FixedPointConversion_Release32_ToInt64 = TestSuite(
+   "FixedPointConversion_Release32_ToInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int64(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int64(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(9223372036854775807)_NeverTraps") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(9223372036854775807)_NeverFails") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt64(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysFails") {
-  let input = getUInt64(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromInt64(-9223372036854775808)_NeverTraps") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromInt64(-9223372036854775808)_NeverFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = Int64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = Int64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int64(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt64(-2147483648), getInt(-2147483648)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int64(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt64(-2147483648), getInt(-2147483648)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int64(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(-128), getFloat16(-128.5)),
+  (getInt64(+0), getFloat16(-0.5)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+0), getFloat16(+0.5)),
+  (getInt64(+127), getFloat16(+127.5)),
+  (getInt64(+255), getFloat16(+255.5)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int64(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(-32768), getFloat32(-32768.5)),
+  (getInt64(-128), getFloat32(-128.5)),
+  (getInt64(+0), getFloat32(-0.5)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+0), getFloat32(+0.5)),
+  (getInt64(+127), getFloat32(+127.5)),
+  (getInt64(+255), getFloat32(+255.5)),
+  (getInt64(+32767), getFloat32(+32767.5)),
+  (getInt64(+65535), getFloat32(+65535.5)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-9007199254740991)_NeverTraps") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(-32768), getFloat64(-32768.5)),
+  (getInt64(-128), getFloat64(-128.5)),
+  (getInt64(+0), getFloat64(-0.5)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+0), getFloat64(+0.5)),
+  (getInt64(+127), getFloat64(+127.5)),
+  (getInt64(+255), getFloat64(+255.5)),
+  (getInt64(+32767), getFloat64(+32767.5)),
+  (getInt64(+65535), getFloat64(+65535.5)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-9007199254740991)_NeverFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(-32768), getFloat80(-32768.5)),
+  (getInt64(-128), getFloat80(-128.5)),
+  (getInt64(+0), getFloat80(-0.5)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+0), getFloat80(+0.5)),
+  (getInt64(+127), getFloat80(+127.5)),
+  (getInt64(+255), getFloat80(+255.5)),
+  (getInt64(+32767), getFloat80(+32767.5)),
+  (getInt64(+65535), getFloat80(+65535.5)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysTraps") {
-  let input = getFloat80(-9223372036854775809)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysFails") {
-  let input = getFloat80(-9223372036854775809)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-9223372036854775808)_NeverTraps") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-9223372036854775808)_NeverFails") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(9223372036854775807)_NeverTraps") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(9223372036854775807)_NeverFails") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysTraps") {
-  let input = getFloat80(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysFails") {
-  let input = getFloat80(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToInt8.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1860 +14,735 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToInt8 = TestSuite("FixedPointConversion_Release32_ToInt8")
+let FixedPointConversion_Release32_ToInt8 = TestSuite(
+   "FixedPointConversion_Release32_ToInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(127)_NeverTraps") {
-  let input = getUInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt8_AlwaysTraps")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(127)_NeverFails") {
-  let input = getUInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(128)_AlwaysTraps") {
-  let input = getUInt8(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(128)_AlwaysFails") {
-  let input = getUInt8(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(255)_AlwaysTraps") {
-  let input = getUInt8(255)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt8(255)_AlwaysFails") {
-  let input = getUInt8(255)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt8_AlwaysFails")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(127)_NeverTraps") {
-  let input = getUInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(127)_NeverFails") {
-  let input = getUInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(128)_AlwaysTraps") {
-  let input = getUInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(128)_AlwaysFails") {
-  let input = getUInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt16(-129)_AlwaysTraps") {
-  let input = getInt16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt16(-129)_AlwaysFails") {
-  let input = getInt16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(-128)_NeverTraps") {
-  let input = getInt16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(-128)_NeverFails") {
-  let input = getInt16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(127)_NeverTraps") {
-  let input = getInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(127)_NeverFails") {
-  let input = getInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(128)_AlwaysTraps") {
-  let input = getInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(128)_AlwaysFails") {
-  let input = getInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(127)_NeverTraps") {
-  let input = getUInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(127)_NeverFails") {
-  let input = getUInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(128)_AlwaysTraps") {
-  let input = getUInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(128)_AlwaysFails") {
-  let input = getUInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt32(-129)_AlwaysTraps") {
-  let input = getInt32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt32(-129)_AlwaysFails") {
-  let input = getInt32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(-128)_NeverTraps") {
-  let input = getInt32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(-128)_NeverFails") {
-  let input = getInt32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(127)_NeverTraps") {
-  let input = getInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(127)_NeverFails") {
-  let input = getInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(128)_AlwaysTraps") {
-  let input = getInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(128)_AlwaysFails") {
-  let input = getInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(127)_NeverTraps") {
-  let input = getUInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(127)_NeverFails") {
-  let input = getUInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(128)_AlwaysTraps") {
-  let input = getUInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(128)_AlwaysFails") {
-  let input = getUInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt64(-129)_AlwaysTraps") {
-  let input = getInt64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt64(-129)_AlwaysFails") {
-  let input = getInt64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(-128)_NeverTraps") {
-  let input = getInt64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(-128)_NeverFails") {
-  let input = getInt64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(127)_NeverTraps") {
-  let input = getInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(127)_NeverFails") {
-  let input = getInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(128)_AlwaysTraps") {
-  let input = getInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(128)_AlwaysFails") {
-  let input = getInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt(127)_NeverTraps") {
-  let input = getUInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromUInt(127)_NeverFails") {
-  let input = getUInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt(128)_AlwaysTraps") {
-  let input = getUInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt(128)_AlwaysFails") {
-  let input = getUInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+4294967295),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt(-129)_AlwaysTraps") {
-  let input = getInt(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-129),
+  getInt(+128),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromInt(-129)_AlwaysFails") {
-  let input = getInt(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(-128)_NeverTraps") {
-  let input = getInt(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(-128)_NeverFails") {
-  let input = getInt(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(127)_NeverTraps") {
-  let input = getInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(127)_NeverFails") {
-  let input = getInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(128)_AlwaysTraps") {
-  let input = getInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(128)_AlwaysFails") {
-  let input = getInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-129),
+  getInt(+128),
+  getInt(+2147483647),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128.5)),
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0.5)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+0), getFloat16(+0.5)),
+  (getInt8(+127), getFloat16(+127)),
+  (getInt8(+127), getFloat16(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+127), getFloat16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-129)_AlwaysTraps") {
-  let input = getFloat16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-129)_AlwaysFails") {
-  let input = getFloat16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-128)_NeverTraps") {
-  let input = getFloat16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-128)_NeverFails") {
-  let input = getFloat16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(127)_NeverTraps") {
-  let input = getFloat16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(127)_NeverFails") {
-  let input = getFloat16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(128)_AlwaysTraps") {
-  let input = getFloat16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(128)_AlwaysFails") {
-  let input = getFloat16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(255.5)_AlwaysTraps") {
-  let input = getFloat16(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128.5)),
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(-0.5)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+0), getFloat32(+0.5)),
+  (getInt8(+127), getFloat32(+127)),
+  (getInt8(+127), getFloat32(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+127), getFloat32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-129)_AlwaysTraps") {
-  let input = getFloat32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-129)_AlwaysFails") {
-  let input = getFloat32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-128)_NeverTraps") {
-  let input = getFloat32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-128)_NeverFails") {
-  let input = getFloat32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(127)_NeverTraps") {
-  let input = getFloat32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(127)_NeverFails") {
-  let input = getFloat32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(128)_AlwaysTraps") {
-  let input = getFloat32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(128)_AlwaysFails") {
-  let input = getFloat32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(255.5)_AlwaysTraps") {
-  let input = getFloat32(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128.5)),
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(-0.5)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+0), getFloat64(+0.5)),
+  (getInt8(+127), getFloat64(+127)),
+  (getInt8(+127), getFloat64(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+127), getFloat64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-129)_AlwaysTraps") {
-  let input = getFloat64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-129)_AlwaysFails") {
-  let input = getFloat64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-128)_NeverTraps") {
-  let input = getFloat64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-128)_NeverFails") {
-  let input = getFloat64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(127)_NeverTraps") {
-  let input = getFloat64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(127)_NeverFails") {
-  let input = getFloat64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(128)_AlwaysTraps") {
-  let input = getFloat64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(128)_AlwaysFails") {
-  let input = getFloat64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(255.5)_AlwaysTraps") {
-  let input = getFloat64(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128.5)),
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0.5)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+0), getFloat80(+0.5)),
+  (getInt8(+127), getFloat80(+127)),
+  (getInt8(+127), getFloat80(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+127), getFloat80(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-129)_AlwaysTraps") {
-  let input = getFloat80(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-129)_AlwaysFails") {
-  let input = getFloat80(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-128)_NeverTraps") {
-  let input = getFloat80(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-128)_NeverFails") {
-  let input = getFloat80(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(127)_NeverTraps") {
-  let input = getFloat80(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(127)_NeverFails") {
-  let input = getFloat80(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(128)_AlwaysTraps") {
-  let input = getFloat80(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(128)_AlwaysFails") {
-  let input = getFloat80(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(255.5)_AlwaysTraps") {
-  let input = getFloat80(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1564 +14,640 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToUInt = TestSuite("FixedPointConversion_Release32_ToUInt")
+let FixedPointConversion_Release32_ToUInt = TestSuite(
+   "FixedPointConversion_Release32_ToUInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(4294967295)_NeverTraps") {
-  let input = getUInt64(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(4294967295)_NeverFails") {
-  let input = getUInt64(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(4294967296)_AlwaysTraps") {
-  let input = getUInt64(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(4294967296)_AlwaysFails") {
-  let input = getUInt64(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(4294967295)_NeverTraps") {
-  let input = getInt64(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(4294967295)_NeverFails") {
-  let input = getInt64(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(4294967296)_AlwaysTraps") {
-  let input = getInt64(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(4294967296)_AlwaysFails") {
-  let input = getInt64(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = UInt(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = UInt(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat16(-0.5)),
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+0), getFloat16(+0.5)),
+  (getUInt(+127), getFloat16(+127.5)),
+  (getUInt(+255), getFloat16(+255.5)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat32(-0.5)),
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+0), getFloat32(+0.5)),
+  (getUInt(+127), getFloat32(+127.5)),
+  (getUInt(+255), getFloat32(+255.5)),
+  (getUInt(+32767), getFloat32(+32767.5)),
+  (getUInt(+65535), getFloat32(+65535.5)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat64(-0.5)),
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+0), getFloat64(+0.5)),
+  (getUInt(+127), getFloat64(+127.5)),
+  (getUInt(+255), getFloat64(+255.5)),
+  (getUInt(+32767), getFloat64(+32767.5)),
+  (getUInt(+65535), getFloat64(+65535.5)),
+  (getUInt(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(4294967295)_NeverTraps") {
-  let input = getFloat64(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(4294967295)_NeverFails") {
-  let input = getFloat64(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(4294967296)_AlwaysTraps") {
-  let input = getFloat64(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(4294967296)_AlwaysFails") {
-  let input = getFloat64(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat80(-0.5)),
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+0), getFloat80(+0.5)),
+  (getUInt(+127), getFloat80(+127.5)),
+  (getUInt(+255), getFloat80(+255.5)),
+  (getUInt(+32767), getFloat80(+32767.5)),
+  (getUInt(+65535), getFloat80(+65535.5)),
+  (getUInt(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(4294967295)_NeverTraps") {
-  let input = getFloat80(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(4294967295)_NeverFails") {
-  let input = getFloat80(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(4294967296)_AlwaysTraps") {
-  let input = getFloat80(4294967296)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(4294967296)_AlwaysFails") {
-  let input = getFloat80(4294967296)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt16.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1704 +14,690 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToUInt16 = TestSuite("FixedPointConversion_Release32_ToUInt16")
+let FixedPointConversion_Release32_ToUInt16 = TestSuite(
+   "FixedPointConversion_Release32_ToUInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(65535)_NeverTraps") {
-  let input = getUInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(65535)_NeverFails") {
-  let input = getUInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(65536)_AlwaysTraps") {
-  let input = getUInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(65536)_AlwaysFails") {
-  let input = getUInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(65535)_NeverTraps") {
-  let input = getInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(65535)_NeverFails") {
-  let input = getInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(65536)_AlwaysTraps") {
-  let input = getInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(65536)_AlwaysFails") {
-  let input = getInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(65535)_NeverTraps") {
-  let input = getUInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(65535)_NeverFails") {
-  let input = getUInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(65536)_AlwaysTraps") {
-  let input = getUInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(65536)_AlwaysFails") {
-  let input = getUInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(65535)_NeverTraps") {
-  let input = getInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(65535)_NeverFails") {
-  let input = getInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(65536)_AlwaysTraps") {
-  let input = getInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(65536)_AlwaysFails") {
-  let input = getInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(65535)_NeverTraps") {
-  let input = getUInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(65535)_NeverFails") {
-  let input = getUInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(65536)_AlwaysTraps") {
-  let input = getUInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(65536)_AlwaysFails") {
-  let input = getUInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+4294967295),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(65535)_NeverTraps") {
-  let input = getInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(65535)_NeverFails") {
-  let input = getInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(65536)_AlwaysTraps") {
-  let input = getInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(65536)_AlwaysFails") {
-  let input = getInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+2147483647),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(-0.5)),
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+0), getFloat16(+0.5)),
+  (getUInt16(+127), getFloat16(+127.5)),
+  (getUInt16(+255), getFloat16(+255.5)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(-0.5)),
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+0), getFloat32(+0.5)),
+  (getUInt16(+127), getFloat32(+127.5)),
+  (getUInt16(+255), getFloat32(+255.5)),
+  (getUInt16(+32767), getFloat32(+32767.5)),
+  (getUInt16(+65535), getFloat32(+65535)),
+  (getUInt16(+65535), getFloat32(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+65535), getFloat32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(65535)_NeverTraps") {
-  let input = getFloat32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(65535)_NeverFails") {
-  let input = getFloat32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(65536)_AlwaysTraps") {
-  let input = getFloat32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(65536)_AlwaysFails") {
-  let input = getFloat32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(-0.5)),
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+0), getFloat64(+0.5)),
+  (getUInt16(+127), getFloat64(+127.5)),
+  (getUInt16(+255), getFloat64(+255.5)),
+  (getUInt16(+32767), getFloat64(+32767.5)),
+  (getUInt16(+65535), getFloat64(+65535)),
+  (getUInt16(+65535), getFloat64(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+65535), getFloat64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(65535)_NeverTraps") {
-  let input = getFloat64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(65535)_NeverFails") {
-  let input = getFloat64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(65536)_AlwaysTraps") {
-  let input = getFloat64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(65536)_AlwaysFails") {
-  let input = getFloat64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(-0.5)),
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+0), getFloat80(+0.5)),
+  (getUInt16(+127), getFloat80(+127.5)),
+  (getUInt16(+255), getFloat80(+255.5)),
+  (getUInt16(+32767), getFloat80(+32767.5)),
+  (getUInt16(+65535), getFloat80(+65535)),
+  (getUInt16(+65535), getFloat80(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+65535), getFloat80(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(65535)_NeverTraps") {
-  let input = getFloat80(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(65535)_NeverFails") {
-  let input = getFloat80(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(65536)_AlwaysTraps") {
-  let input = getFloat80(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(65536)_AlwaysFails") {
-  let input = getFloat80(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt32.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1564 +14,640 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToUInt32 = TestSuite("FixedPointConversion_Release32_ToUInt32")
+let FixedPointConversion_Release32_ToUInt32 = TestSuite(
+   "FixedPointConversion_Release32_ToUInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(4294967295)_NeverTraps") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(4294967295)_NeverFails") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(4294967296)_AlwaysTraps") {
-  let input = getUInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(4294967296)_AlwaysFails") {
-  let input = getUInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(4294967295)_NeverTraps") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(4294967295)_NeverFails") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(4294967296)_AlwaysTraps") {
-  let input = getInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(4294967296)_AlwaysFails") {
-  let input = getInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = UInt32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = UInt32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(-0.5)),
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+0), getFloat16(+0.5)),
+  (getUInt32(+127), getFloat16(+127.5)),
+  (getUInt32(+255), getFloat16(+255.5)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(-0.5)),
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+0), getFloat32(+0.5)),
+  (getUInt32(+127), getFloat32(+127.5)),
+  (getUInt32(+255), getFloat32(+255.5)),
+  (getUInt32(+32767), getFloat32(+32767.5)),
+  (getUInt32(+65535), getFloat32(+65535.5)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(-0.5)),
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+0), getFloat64(+0.5)),
+  (getUInt32(+127), getFloat64(+127.5)),
+  (getUInt32(+255), getFloat64(+255.5)),
+  (getUInt32(+32767), getFloat64(+32767.5)),
+  (getUInt32(+65535), getFloat64(+65535.5)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(4294967295)_NeverTraps") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(4294967295)_NeverFails") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(4294967296)_AlwaysTraps") {
-  let input = getFloat64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(4294967296)_AlwaysFails") {
-  let input = getFloat64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(-0.5)),
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+0), getFloat80(+0.5)),
+  (getUInt32(+127), getFloat80(+127.5)),
+  (getUInt32(+255), getFloat80(+255.5)),
+  (getUInt32(+32767), getFloat80(+32767.5)),
+  (getUInt32(+65535), getFloat80(+65535.5)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(4294967295)_NeverTraps") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(4294967295)_NeverFails") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(4294967296)_AlwaysTraps") {
-  let input = getFloat80(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(4294967296)_AlwaysFails") {
-  let input = getFloat80(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt64.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1464 +14,609 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToUInt64 = TestSuite("FixedPointConversion_Release32_ToUInt64")
+let FixedPointConversion_Release32_ToUInt64 = TestSuite(
+   "FixedPointConversion_Release32_ToUInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt64(18446744073709551615)_NeverTraps") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt64(18446744073709551615)_NeverFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = UInt64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = UInt64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(-0.5)),
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+0), getFloat16(+0.5)),
+  (getUInt64(+127), getFloat16(+127.5)),
+  (getUInt64(+255), getFloat16(+255.5)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(-0.5)),
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+0), getFloat32(+0.5)),
+  (getUInt64(+127), getFloat32(+127.5)),
+  (getUInt64(+255), getFloat32(+255.5)),
+  (getUInt64(+32767), getFloat32(+32767.5)),
+  (getUInt64(+65535), getFloat32(+65535.5)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(-0.5)),
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+0), getFloat64(+0.5)),
+  (getUInt64(+127), getFloat64(+127.5)),
+  (getUInt64(+255), getFloat64(+255.5)),
+  (getUInt64(+32767), getFloat64(+32767.5)),
+  (getUInt64(+65535), getFloat64(+65535.5)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(-0.5)),
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+0), getFloat80(+0.5)),
+  (getUInt64(+127), getFloat80(+127.5)),
+  (getUInt64(+255), getFloat80(+255.5)),
+  (getUInt64(+32767), getFloat80(+32767.5)),
+  (getUInt64(+65535), getFloat80(+65535.5)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release32_ToUInt8.swift
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test, long_test
+// REQUIRES: executable_test
 // REQUIRES: PTRSIZE=32
 // RUN: %target-run-simple-swift(-O)
 // END.
@@ -14,1800 +14,717 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release32_ToUInt8 = TestSuite("FixedPointConversion_Release32_ToUInt8")
+let FixedPointConversion_Release32_ToUInt8 = TestSuite(
+   "FixedPointConversion_Release32_ToUInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(255)_NeverTraps") {
-  let input = getUInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(255)_NeverFails") {
-  let input = getUInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(256)_AlwaysTraps") {
-  let input = getUInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(256)_AlwaysFails") {
-  let input = getUInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(255)_NeverTraps") {
-  let input = getInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(255)_NeverFails") {
-  let input = getInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(256)_AlwaysTraps") {
-  let input = getInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(256)_AlwaysFails") {
-  let input = getInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(255)_NeverTraps") {
-  let input = getUInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(255)_NeverFails") {
-  let input = getUInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(256)_AlwaysTraps") {
-  let input = getUInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(256)_AlwaysFails") {
-  let input = getUInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(255)_NeverTraps") {
-  let input = getInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(255)_NeverFails") {
-  let input = getInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(256)_AlwaysTraps") {
-  let input = getInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(256)_AlwaysFails") {
-  let input = getInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(255)_NeverTraps") {
-  let input = getUInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(255)_NeverFails") {
-  let input = getUInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(256)_AlwaysTraps") {
-  let input = getUInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(256)_AlwaysFails") {
-  let input = getUInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(255)_NeverTraps") {
-  let input = getInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(255)_NeverFails") {
-  let input = getInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(256)_AlwaysTraps") {
-  let input = getInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(256)_AlwaysFails") {
-  let input = getInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(4294967295)
+// MARK: UInt: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(255)_NeverTraps") {
-  let input = getUInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(255)_NeverFails") {
-  let input = getUInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(256)_AlwaysTraps") {
-  let input = getUInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(256)_AlwaysFails") {
-  let input = getUInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(4294967295)_AlwaysTraps") {
-  let input = getUInt(4294967295)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromUInt(4294967295)_AlwaysFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+4294967295),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-2147483648)...(2147483647)
+// MARK: Int: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt(-2147483648)_AlwaysTraps") {
-  let input = getInt(-2147483648)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt(-2147483648)_AlwaysFails") {
-  let input = getInt(-2147483648)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+256),
+  getInt(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(255)_NeverTraps") {
-  let input = getInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(255)_NeverFails") {
-  let input = getInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(256)_AlwaysTraps") {
-  let input = getInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(256)_AlwaysFails") {
-  let input = getInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(2147483647)_AlwaysTraps") {
-  let input = getInt(2147483647)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromInt(2147483647)_AlwaysFails") {
-  let input = getInt(2147483647)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-2147483648),
+  getInt(-1),
+  getInt(+256),
+  getInt(+2147483647),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0.5)),
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+0), getFloat16(+0.5)),
+  (getUInt8(+127), getFloat16(+127.5)),
+  (getUInt8(+255), getFloat16(+255)),
+  (getUInt8(+255), getFloat16(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+255), getFloat16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(255)_NeverTraps") {
-  let input = getFloat16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(255)_NeverFails") {
-  let input = getFloat16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(256)_AlwaysTraps") {
-  let input = getFloat16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(256)_AlwaysFails") {
-  let input = getFloat16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(-0.5)),
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+0), getFloat32(+0.5)),
+  (getUInt8(+127), getFloat32(+127.5)),
+  (getUInt8(+255), getFloat32(+255)),
+  (getUInt8(+255), getFloat32(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+255), getFloat32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(255)_NeverTraps") {
-  let input = getFloat32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(255)_NeverFails") {
-  let input = getFloat32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(256)_AlwaysTraps") {
-  let input = getFloat32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(256)_AlwaysFails") {
-  let input = getFloat32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(-0.5)),
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+0), getFloat64(+0.5)),
+  (getUInt8(+127), getFloat64(+127.5)),
+  (getUInt8(+255), getFloat64(+255)),
+  (getUInt8(+255), getFloat64(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+255), getFloat64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(255)_NeverTraps") {
-  let input = getFloat64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(255)_NeverFails") {
-  let input = getFloat64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(256)_AlwaysTraps") {
-  let input = getFloat64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(256)_AlwaysFails") {
-  let input = getFloat64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0.5)),
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+0), getFloat80(+0.5)),
+  (getUInt8(+127), getFloat80(+127.5)),
+  (getUInt8(+255), getFloat80(+255)),
+  (getUInt8(+255), getFloat80(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+255), getFloat80(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(255)_NeverTraps") {
-  let input = getFloat80(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(255)_NeverFails") {
-  let input = getFloat80(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(256)_AlwaysTraps") {
-  let input = getFloat80(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(256)_AlwaysFails") {
-  let input = getFloat80(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release32_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release32_ToUInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt.swift
@@ -14,1358 +14,562 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToInt = TestSuite("FixedPointConversion_Release64_ToInt")
+let FixedPointConversion_Release64_ToInt = TestSuite(
+   "FixedPointConversion_Release64_ToInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt8(+0)),
+  (getInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt(-128), getInt8(-128)),
+  (getInt(+0), getInt8(+0)),
+  (getInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt16(+0)),
+  (getInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt(-32768), getInt16(-32768)),
+  (getInt(+0), getInt16(+0)),
+  (getInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = Int(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt32(+0)),
+  (getInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt(-2147483648), getInt32(-2147483648)),
+  (getInt(+0), getInt32(+0)),
+  (getInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt64(+0)),
+  (getInt(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt64(9223372036854775807)_NeverTraps") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt64(9223372036854775807)_NeverFails") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt64(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt64(9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt64(9223372036854775808)_AlwaysFails") {
-  let input = getUInt64(9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromInt64(-9223372036854775808)_NeverTraps") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromInt64(-9223372036854775808)_NeverFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt(+0), getInt64(+0)),
+  (getInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt(+0), getUInt(+0)),
+  (getInt(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt(9223372036854775807)_NeverTraps") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromUInt(9223372036854775807)_NeverFails") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt(9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt(9223372036854775808)_AlwaysFails") {
-  let input = getUInt(9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromInt(-9223372036854775808)_NeverTraps") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromInt(-9223372036854775808)_NeverFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt(+0), getInt(+0)),
+  (getInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(-128), getFloat16(-128.5)),
+  (getInt(+0), getFloat16(-0.5)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+0), getFloat16(+0.5)),
+  (getInt(+127), getFloat16(+127.5)),
+  (getInt(+255), getFloat16(+255.5)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt(-2047), getFloat16(-2047)),
+  (getInt(+0), getFloat16(+0)),
+  (getInt(+0), getFloat16(-0)),
+  (getInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(-32768), getFloat32(-32768.5)),
+  (getInt(-128), getFloat32(-128.5)),
+  (getInt(+0), getFloat32(-0.5)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+0), getFloat32(+0.5)),
+  (getInt(+127), getFloat32(+127.5)),
+  (getInt(+255), getFloat32(+255.5)),
+  (getInt(+32767), getFloat32(+32767.5)),
+  (getInt(+65535), getFloat32(+65535.5)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt(-16777215), getFloat32(-16777215)),
+  (getInt(+0), getFloat32(+0)),
+  (getInt(+0), getFloat32(-0)),
+  (getInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-9007199254740991)_NeverTraps") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int(input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt(-32768), getFloat64(-32768.5)),
+  (getInt(-128), getFloat64(-128.5)),
+  (getInt(+0), getFloat64(-0.5)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+0), getFloat64(+0.5)),
+  (getInt(+127), getFloat64(+127.5)),
+  (getInt(+255), getFloat64(+255.5)),
+  (getInt(+32767), getFloat64(+32767.5)),
+  (getInt(+65535), getFloat64(+65535.5)),
+  (getInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-9007199254740991)_NeverFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int(exactly: input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt(+0), getFloat64(+0)),
+  (getInt(+0), getFloat64(-0)),
+  (getInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt(-32768), getFloat80(-32768.5)),
+  (getInt(-128), getFloat80(-128.5)),
+  (getInt(+0), getFloat80(-0.5)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+0), getFloat80(+0.5)),
+  (getInt(+127), getFloat80(+127.5)),
+  (getInt(+255), getFloat80(+255.5)),
+  (getInt(+32767), getFloat80(+32767.5)),
+  (getInt(+65535), getFloat80(+65535.5)),
+  (getInt(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int($0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt(+0), getFloat80(-0)),
+  (getInt(+0), getFloat80(+0)),
+  (getInt(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-9223372036854775809)_AlwaysTraps") {
-  let input = getFloat80(-9223372036854775809)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int($0))
 }
 
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-9223372036854775809)_AlwaysFails") {
-  let input = getFloat80(-9223372036854775809)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-9223372036854775808)_NeverTraps") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int(input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-9223372036854775808)_NeverFails") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(9223372036854775807)_NeverTraps") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(9223372036854775807)_NeverFails") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(9223372036854775808)_AlwaysTraps") {
-  let input = getFloat80(9223372036854775808)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(9223372036854775808)_AlwaysFails") {
-  let input = getFloat80(9223372036854775808)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt16.swift
@@ -14,1700 +14,685 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToInt16 = TestSuite("FixedPointConversion_Release64_ToInt16")
+let FixedPointConversion_Release64_ToInt16 = TestSuite(
+   "FixedPointConversion_Release64_ToInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt8(+0)),
+  (getInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int16(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt16(-128), getInt8(-128)),
+  (getInt16(+0), getInt8(+0)),
+  (getInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt16(+0)),
+  (getInt16(+32767), getUInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(32767)_NeverTraps") {
-  let input = getUInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(32767)_NeverFails") {
-  let input = getUInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(32768)_AlwaysTraps") {
-  let input = getUInt16(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(32768)_AlwaysFails") {
-  let input = getUInt16(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+32768),
+  getUInt16(+65535),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt16(-32768)),
+  (getInt16(+0), getInt16(+0)),
+  (getInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt32(+0)),
+  (getInt16(+32767), getUInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(32767)_NeverTraps") {
-  let input = getUInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(32767)_NeverFails") {
-  let input = getUInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(32768)_AlwaysTraps") {
-  let input = getUInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(32768)_AlwaysFails") {
-  let input = getUInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+32768),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt32(-32768)),
+  (getInt16(+0), getInt32(+0)),
+  (getInt16(+32767), getInt32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt32(-32769)_AlwaysTraps") {
-  let input = getInt32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt32(-32769)_AlwaysFails") {
-  let input = getInt32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(-32768)_NeverTraps") {
-  let input = getInt32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(-32768)_NeverFails") {
-  let input = getInt32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(32767)_NeverTraps") {
-  let input = getInt32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(32767)_NeverFails") {
-  let input = getInt32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(32768)_AlwaysTraps") {
-  let input = getInt32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(32768)_AlwaysFails") {
-  let input = getInt32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-32769),
+  getInt32(+32768),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt64(+0)),
+  (getInt16(+32767), getUInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(32767)_NeverTraps") {
-  let input = getUInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(32767)_NeverFails") {
-  let input = getUInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(32768)_AlwaysTraps") {
-  let input = getUInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(32768)_AlwaysFails") {
-  let input = getUInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+32768),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt64(-32768)),
+  (getInt16(+0), getInt64(+0)),
+  (getInt16(+32767), getInt64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt64(-32769)_AlwaysTraps") {
-  let input = getInt64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt64(-32769)_AlwaysFails") {
-  let input = getInt64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(-32768)_NeverTraps") {
-  let input = getInt64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(-32768)_NeverFails") {
-  let input = getInt64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(32767)_NeverTraps") {
-  let input = getInt64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(32767)_NeverFails") {
-  let input = getInt64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(32768)_AlwaysTraps") {
-  let input = getInt64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(32768)_AlwaysFails") {
-  let input = getInt64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-32769),
+  getInt64(+32768),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt16(+0), getUInt(+0)),
+  (getInt16(+32767), getUInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt(32767)_NeverTraps") {
-  let input = getUInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromUInt(32767)_NeverFails") {
-  let input = getUInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt(32768)_AlwaysTraps") {
-  let input = getUInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt(32768)_AlwaysFails") {
-  let input = getUInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+32768),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getInt(-32768)),
+  (getInt16(+0), getInt(+0)),
+  (getInt16(+32767), getInt(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt(-32769)_AlwaysTraps") {
-  let input = getInt(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromInt(-32769)_AlwaysFails") {
-  let input = getInt(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(-32768)_NeverTraps") {
-  let input = getInt(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(-32768)_NeverFails") {
-  let input = getInt(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(32767)_NeverTraps") {
-  let input = getInt(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(32767)_NeverFails") {
-  let input = getInt(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(32768)_AlwaysTraps") {
-  let input = getInt(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(32768)_AlwaysFails") {
-  let input = getInt(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-32769),
+  getInt(+32768),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int16(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(-128), getFloat16(-128.5)),
+  (getInt16(+0), getFloat16(-0.5)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+0), getFloat16(+0.5)),
+  (getInt16(+127), getFloat16(+127.5)),
+  (getInt16(+255), getFloat16(+255.5)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int16(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt16(-2047), getFloat16(-2047)),
+  (getInt16(+0), getFloat16(+0)),
+  (getInt16(+0), getFloat16(-0)),
+  (getInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768.5)),
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(-128), getFloat32(-128.5)),
+  (getInt16(+0), getFloat32(-0.5)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+0), getFloat32(+0.5)),
+  (getInt16(+127), getFloat32(+127.5)),
+  (getInt16(+255), getFloat32(+255.5)),
+  (getInt16(+32767), getFloat32(+32767)),
+  (getInt16(+32767), getFloat32(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat32(-32768)),
+  (getInt16(+0), getFloat32(+0)),
+  (getInt16(+0), getFloat32(-0)),
+  (getInt16(+32767), getFloat32(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-32769)_AlwaysTraps") {
-  let input = getFloat32(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-32769)_AlwaysFails") {
-  let input = getFloat32(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-32768)_NeverTraps") {
-  let input = getFloat32(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-32768)_NeverFails") {
-  let input = getFloat32(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(32767)_NeverTraps") {
-  let input = getFloat32(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(32767)_NeverFails") {
-  let input = getFloat32(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(32768)_AlwaysTraps") {
-  let input = getFloat32(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(32768)_AlwaysFails") {
-  let input = getFloat32(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32769),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+32768),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768.5)),
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(-128), getFloat64(-128.5)),
+  (getInt16(+0), getFloat64(-0.5)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+0), getFloat64(+0.5)),
+  (getInt16(+127), getFloat64(+127.5)),
+  (getInt16(+255), getFloat64(+255.5)),
+  (getInt16(+32767), getFloat64(+32767)),
+  (getInt16(+32767), getFloat64(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat64(-32768)),
+  (getInt16(+0), getFloat64(+0)),
+  (getInt16(+0), getFloat64(-0)),
+  (getInt16(+32767), getFloat64(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-32769)_AlwaysTraps") {
-  let input = getFloat64(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-32769)_AlwaysFails") {
-  let input = getFloat64(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-32768)_NeverTraps") {
-  let input = getFloat64(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-32768)_NeverFails") {
-  let input = getFloat64(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(32767)_NeverTraps") {
-  let input = getFloat64(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(32767)_NeverFails") {
-  let input = getFloat64(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(32768)_AlwaysTraps") {
-  let input = getFloat64(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(32768)_AlwaysFails") {
-  let input = getFloat64(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32769),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+32768),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768.5)),
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(-128), getFloat80(-128.5)),
+  (getInt16(+0), getFloat80(-0.5)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+0), getFloat80(+0.5)),
+  (getInt16(+127), getFloat80(+127.5)),
+  (getInt16(+255), getFloat80(+255.5)),
+  (getInt16(+32767), getFloat80(+32767)),
+  (getInt16(+32767), getFloat80(+32767.5)),
+]) {
+  expectEqual($0.0, Int16($0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt16(-32768), getFloat80(-32768)),
+  (getInt16(+0), getFloat80(+0)),
+  (getInt16(+0), getFloat80(-0)),
+  (getInt16(+32767), getFloat80(+32767)),
+]) {
+  expectEqual($0.0, Int16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-32769)_AlwaysTraps") {
-  let input = getFloat80(-32769)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int16($0))
 }
 
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-32769)_AlwaysFails") {
-  let input = getFloat80(-32769)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-32768)_NeverTraps") {
-  let input = getFloat80(-32768)
-  let actual = Int16(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-32768)_NeverFails") {
-  let input = getFloat80(-32768)
-  let actual = Int16(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(32767)_NeverTraps") {
-  let input = getFloat80(32767)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(32767)_NeverFails") {
-  let input = getFloat80(32767)
-  let actual = Int16(exactly: input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(32768)_AlwaysTraps") {
-  let input = getFloat80(32768)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(32768)_AlwaysFails") {
-  let input = getFloat80(32768)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32769),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+32768),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt32.swift
@@ -14,1554 +14,635 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToInt32 = TestSuite("FixedPointConversion_Release64_ToInt32")
+let FixedPointConversion_Release64_ToInt32 = TestSuite(
+   "FixedPointConversion_Release64_ToInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt8(+0)),
+  (getInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int32(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt32(-128), getInt8(-128)),
+  (getInt32(+0), getInt8(+0)),
+  (getInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt16(+0)),
+  (getInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int32(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt32(-32768), getInt16(-32768)),
+  (getInt32(+0), getInt16(+0)),
+  (getInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt32(+0)),
+  (getInt32(+2147483647), getUInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(2147483647)_NeverTraps") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(2147483647)_NeverFails") {
-  let input = getUInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(2147483648)_AlwaysTraps") {
-  let input = getUInt32(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(2147483648)_AlwaysFails") {
-  let input = getUInt32(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+2147483648),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt32(-2147483648)),
+  (getInt32(+0), getInt32(+0)),
+  (getInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt64(+0)),
+  (getInt32(+2147483647), getUInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(2147483647)_NeverTraps") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(2147483647)_NeverFails") {
-  let input = getUInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(2147483648)_AlwaysTraps") {
-  let input = getUInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(2147483648)_AlwaysFails") {
-  let input = getUInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+2147483648),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt64(-2147483648)),
+  (getInt32(+0), getInt64(+0)),
+  (getInt32(+2147483647), getInt64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt64(-2147483649)_AlwaysTraps") {
-  let input = getInt64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt64(-2147483649)_AlwaysFails") {
-  let input = getInt64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(-2147483648)_NeverTraps") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(-2147483648)_NeverFails") {
-  let input = getInt64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(2147483647)_NeverTraps") {
-  let input = getInt64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(2147483647)_NeverFails") {
-  let input = getInt64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(2147483648)_AlwaysTraps") {
-  let input = getInt64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(2147483648)_AlwaysFails") {
-  let input = getInt64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-2147483649),
+  getInt64(+2147483648),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt32(+0), getUInt(+0)),
+  (getInt32(+2147483647), getUInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt(2147483647)_NeverTraps") {
-  let input = getUInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromUInt(2147483647)_NeverFails") {
-  let input = getUInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt(2147483648)_AlwaysTraps") {
-  let input = getUInt(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt(2147483648)_AlwaysFails") {
-  let input = getUInt(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+2147483648),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getInt(-2147483648)),
+  (getInt32(+0), getInt(+0)),
+  (getInt32(+2147483647), getInt(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt(-2147483649)_AlwaysTraps") {
-  let input = getInt(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-2147483649),
+  getInt(+2147483648),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromInt(-2147483649)_AlwaysFails") {
-  let input = getInt(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(-2147483648)_NeverTraps") {
-  let input = getInt(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(-2147483648)_NeverFails") {
-  let input = getInt(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(2147483647)_NeverTraps") {
-  let input = getInt(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(2147483647)_NeverFails") {
-  let input = getInt(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(2147483648)_AlwaysTraps") {
-  let input = getInt(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(2147483648)_AlwaysFails") {
-  let input = getInt(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-2147483649),
+  getInt(+2147483648),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int32(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(-128), getFloat16(-128.5)),
+  (getInt32(+0), getFloat16(-0.5)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+0), getFloat16(+0.5)),
+  (getInt32(+127), getFloat16(+127.5)),
+  (getInt32(+255), getFloat16(+255.5)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int32(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt32(-2047), getFloat16(-2047)),
+  (getInt32(+0), getFloat16(+0)),
+  (getInt32(+0), getFloat16(-0)),
+  (getInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(-32768), getFloat32(-32768.5)),
+  (getInt32(-128), getFloat32(-128.5)),
+  (getInt32(+0), getFloat32(-0.5)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+0), getFloat32(+0.5)),
+  (getInt32(+127), getFloat32(+127.5)),
+  (getInt32(+255), getFloat32(+255.5)),
+  (getInt32(+32767), getFloat32(+32767.5)),
+  (getInt32(+65535), getFloat32(+65535.5)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt32(-16777215), getFloat32(-16777215)),
+  (getInt32(+0), getFloat32(+0)),
+  (getInt32(+0), getFloat32(-0)),
+  (getInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(-32768), getFloat64(-32768.5)),
+  (getInt32(-128), getFloat64(-128.5)),
+  (getInt32(+0), getFloat64(-0.5)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+0), getFloat64(+0.5)),
+  (getInt32(+127), getFloat64(+127.5)),
+  (getInt32(+255), getFloat64(+255.5)),
+  (getInt32(+32767), getFloat64(+32767.5)),
+  (getInt32(+65535), getFloat64(+65535.5)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat64(-2147483648)),
+  (getInt32(+0), getFloat64(-0)),
+  (getInt32(+0), getFloat64(+0)),
+  (getInt32(+2147483647), getFloat64(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-2147483649)_AlwaysTraps") {
-  let input = getFloat64(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-2147483649)_AlwaysFails") {
-  let input = getFloat64(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-2147483648)_NeverTraps") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-2147483648)_NeverFails") {
-  let input = getFloat64(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(2147483647)_NeverTraps") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(2147483647)_NeverFails") {
-  let input = getFloat64(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(2147483648)_AlwaysTraps") {
-  let input = getFloat64(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(2147483648)_AlwaysFails") {
-  let input = getFloat64(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-2147483649),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+2147483648),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(-32768), getFloat80(-32768.5)),
+  (getInt32(-128), getFloat80(-128.5)),
+  (getInt32(+0), getFloat80(-0.5)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+0), getFloat80(+0.5)),
+  (getInt32(+127), getFloat80(+127.5)),
+  (getInt32(+255), getFloat80(+255.5)),
+  (getInt32(+32767), getFloat80(+32767.5)),
+  (getInt32(+65535), getFloat80(+65535.5)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32($0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt32(-2147483648), getFloat80(-2147483648)),
+  (getInt32(+0), getFloat80(-0)),
+  (getInt32(+0), getFloat80(+0)),
+  (getInt32(+2147483647), getFloat80(+2147483647)),
+]) {
+  expectEqual($0.0, Int32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-2147483649)_AlwaysTraps") {
-  let input = getFloat80(-2147483649)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int32($0))
 }
 
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-2147483649)_AlwaysFails") {
-  let input = getFloat80(-2147483649)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-2147483648)_NeverTraps") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-2147483648)_NeverFails") {
-  let input = getFloat80(-2147483648)
-  let actual = Int32(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(2147483647)_NeverTraps") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(2147483647)_NeverFails") {
-  let input = getFloat80(2147483647)
-  let actual = Int32(exactly: input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(2147483648)_AlwaysTraps") {
-  let input = getFloat80(2147483648)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(2147483648)_AlwaysFails") {
-  let input = getFloat80(2147483648)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-2147483649),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+2147483648),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt64.swift
@@ -14,1358 +14,562 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToInt64 = TestSuite("FixedPointConversion_Release64_ToInt64")
+let FixedPointConversion_Release64_ToInt64 = TestSuite(
+   "FixedPointConversion_Release64_ToInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = Int64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt8(+0)),
+  (getInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int64(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt64(-128), getInt8(-128)),
+  (getInt64(+0), getInt8(+0)),
+  (getInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = Int64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt16(+0)),
+  (getInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromInt16(-32768)_NeverTraps") {
-  let input = getInt16(-32768)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromInt16(-32768)_NeverFails") {
-  let input = getInt16(-32768)
-  let actual = Int64(exactly: input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = Int64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt64(-32768), getInt16(-32768)),
+  (getInt64(+0), getInt16(+0)),
+  (getInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt32(+0)),
+  (getInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromInt32(-2147483648)_NeverTraps") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(input)
-  expectEqual(-2147483648, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromInt32(-2147483648)_NeverFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int64(exactly: input)
-  expectEqual(-2147483648, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = Int64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = Int64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt64(-2147483648), getInt32(-2147483648)),
+  (getInt64(+0), getInt32(+0)),
+  (getInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt64(+0)),
+  (getInt64(+9223372036854775807), getUInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(9223372036854775807)_NeverTraps") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(9223372036854775807)_NeverFails") {
-  let input = getUInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt64(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(9223372036854775808)_AlwaysFails") {
-  let input = getUInt64(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+9223372036854775808),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromInt64(-9223372036854775808)_NeverTraps") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromInt64(-9223372036854775808)_NeverFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt64(-9223372036854775808)),
+  (getInt64(+0), getInt64(+0)),
+  (getInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt64(+0), getUInt(+0)),
+  (getInt64(+9223372036854775807), getUInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt(9223372036854775807)_NeverTraps") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromUInt(9223372036854775807)_NeverFails") {
-  let input = getUInt(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt(9223372036854775808)_AlwaysTraps") {
-  let input = getUInt(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt(9223372036854775808)_AlwaysFails") {
-  let input = getUInt(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+9223372036854775808),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromInt(-9223372036854775808)_NeverTraps") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromInt(-9223372036854775808)_NeverFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getInt(-9223372036854775808)),
+  (getInt64(+0), getInt(+0)),
+  (getInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-2047)_NeverTraps") {
-  let input = getFloat16(-2047)
-  let actual = Int64(input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(-128), getFloat16(-128.5)),
+  (getInt64(+0), getFloat16(-0.5)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+0), getFloat16(+0.5)),
+  (getInt64(+127), getFloat16(+127.5)),
+  (getInt64(+255), getFloat16(+255.5)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-2047)_NeverFails") {
-  let input = getFloat16(-2047)
-  let actual = Int64(exactly: input)
-  expectEqual(-2047, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt64(-2047), getFloat16(-2047)),
+  (getInt64(+0), getFloat16(+0)),
+  (getInt64(+0), getFloat16(-0)),
+  (getInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = Int64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = Int64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-16777215)_NeverTraps") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(-32768), getFloat32(-32768.5)),
+  (getInt64(-128), getFloat32(-128.5)),
+  (getInt64(+0), getFloat32(-0.5)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+0), getFloat32(+0.5)),
+  (getInt64(+127), getFloat32(+127.5)),
+  (getInt64(+255), getFloat32(+255.5)),
+  (getInt64(+32767), getFloat32(+32767.5)),
+  (getInt64(+65535), getFloat32(+65535.5)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-16777215)_NeverFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(-16777215, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt64(-16777215), getFloat32(-16777215)),
+  (getInt64(+0), getFloat32(+0)),
+  (getInt64(+0), getFloat32(-0)),
+  (getInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-32768.5)_NeverTraps") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = Int64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = Int64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-9007199254740991)_NeverTraps") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(-32768), getFloat64(-32768.5)),
+  (getInt64(-128), getFloat64(-128.5)),
+  (getInt64(+0), getFloat64(-0.5)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+0), getFloat64(+0.5)),
+  (getInt64(+127), getFloat64(+127.5)),
+  (getInt64(+255), getFloat64(+255.5)),
+  (getInt64(+32767), getFloat64(+32767.5)),
+  (getInt64(+65535), getFloat64(+65535.5)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-9007199254740991)_NeverFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(-9007199254740991, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt64(-9007199254740991), getFloat64(-9007199254740991)),
+  (getInt64(+0), getFloat64(+0)),
+  (getInt64(+0), getFloat64(-0)),
+  (getInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-32768.5)_NeverTraps") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(-32768), getFloat80(-32768.5)),
+  (getInt64(-128), getFloat80(-128.5)),
+  (getInt64(+0), getFloat80(-0.5)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+0), getFloat80(+0.5)),
+  (getInt64(+127), getFloat80(+127.5)),
+  (getInt64(+255), getFloat80(+255.5)),
+  (getInt64(+32767), getFloat80(+32767.5)),
+  (getInt64(+65535), getFloat80(+65535.5)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64($0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt64(-9223372036854775808), getFloat80(-9223372036854775808)),
+  (getInt64(+0), getFloat80(-0)),
+  (getInt64(+0), getFloat80(+0)),
+  (getInt64(+9223372036854775807), getFloat80(+9223372036854775807)),
+]) {
+  expectEqual($0.0, Int64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysTraps") {
-  let input = getFloat80(-9223372036854775809)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int64($0))
 }
 
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-9223372036854775809)_AlwaysFails") {
-  let input = getFloat80(-9223372036854775809)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-9223372036854775808)_NeverTraps") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-9223372036854775808)_NeverFails") {
-  let input = getFloat80(-9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectEqual(-9223372036854775808, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-32768.5)_NeverTraps") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(input)
-  expectEqual(-32768, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = Int64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(9223372036854775807)_NeverTraps") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(9223372036854775807)_NeverFails") {
-  let input = getFloat80(9223372036854775807)
-  let actual = Int64(exactly: input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysTraps") {
-  let input = getFloat80(9223372036854775808)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(9223372036854775808)_AlwaysFails") {
-  let input = getFloat80(9223372036854775808)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-9223372036854775809),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+9223372036854775808),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt8.swift
@@ -14,1860 +14,735 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToInt8 = TestSuite("FixedPointConversion_Release64_ToInt8")
+let FixedPointConversion_Release64_ToInt8 = TestSuite(
+   "FixedPointConversion_Release64_ToInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt8(+0)),
+  (getInt8(+127), getUInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(127)_NeverTraps") {
-  let input = getUInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt8_AlwaysTraps")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(127)_NeverFails") {
-  let input = getUInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(128)_AlwaysTraps") {
-  let input = getUInt8(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(128)_AlwaysFails") {
-  let input = getUInt8(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(255)_AlwaysTraps") {
-  let input = getUInt8(255)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt8(255)_AlwaysFails") {
-  let input = getUInt8(255)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt8_AlwaysFails")
+.forEach(in: [
+  getUInt8(+128),
+  getUInt8(+255),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromInt8(-128)_NeverTraps") {
-  let input = getInt8(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt8(-128)_NeverFails") {
-  let input = getInt8(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt8(-128)),
+  (getInt8(+0), getInt8(+0)),
+  (getInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt16(+0)),
+  (getInt8(+127), getUInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(127)_NeverTraps") {
-  let input = getUInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(127)_NeverFails") {
-  let input = getUInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(128)_AlwaysTraps") {
-  let input = getUInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(128)_AlwaysFails") {
-  let input = getUInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+128),
+  getUInt16(+65535),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt16(-128)),
+  (getInt8(+0), getInt16(+0)),
+  (getInt8(+127), getInt16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt16(-129)_AlwaysTraps") {
-  let input = getInt16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt16(-129)_AlwaysFails") {
-  let input = getInt16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(-128)_NeverTraps") {
-  let input = getInt16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(-128)_NeverFails") {
-  let input = getInt16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(127)_NeverTraps") {
-  let input = getInt16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(127)_NeverFails") {
-  let input = getInt16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(128)_AlwaysTraps") {
-  let input = getInt16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(128)_AlwaysFails") {
-  let input = getInt16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-129),
+  getInt16(+128),
+  getInt16(+32767),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt32(+0)),
+  (getInt8(+127), getUInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(127)_NeverTraps") {
-  let input = getUInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(127)_NeverFails") {
-  let input = getUInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(128)_AlwaysTraps") {
-  let input = getUInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(128)_AlwaysFails") {
-  let input = getUInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+128),
+  getUInt32(+4294967295),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt32(-128)),
+  (getInt8(+0), getInt32(+0)),
+  (getInt8(+127), getInt32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt32(-129)_AlwaysTraps") {
-  let input = getInt32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt32(-129)_AlwaysFails") {
-  let input = getInt32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(-128)_NeverTraps") {
-  let input = getInt32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(-128)_NeverFails") {
-  let input = getInt32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(127)_NeverTraps") {
-  let input = getInt32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(127)_NeverFails") {
-  let input = getInt32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(128)_AlwaysTraps") {
-  let input = getInt32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(128)_AlwaysFails") {
-  let input = getInt32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-129),
+  getInt32(+128),
+  getInt32(+2147483647),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt64(+0)),
+  (getInt8(+127), getUInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(127)_NeverTraps") {
-  let input = getUInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(127)_NeverFails") {
-  let input = getUInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(128)_AlwaysTraps") {
-  let input = getUInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(128)_AlwaysFails") {
-  let input = getUInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+128),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt64(-128)),
+  (getInt8(+0), getInt64(+0)),
+  (getInt8(+127), getInt64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt64(-129)_AlwaysTraps") {
-  let input = getInt64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt64(-129)_AlwaysFails") {
-  let input = getInt64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(-128)_NeverTraps") {
-  let input = getInt64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(-128)_NeverFails") {
-  let input = getInt64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(127)_NeverTraps") {
-  let input = getInt64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(127)_NeverFails") {
-  let input = getInt64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(128)_AlwaysTraps") {
-  let input = getInt64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(128)_AlwaysFails") {
-  let input = getInt64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-129),
+  getInt64(+128),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getInt8(+0), getUInt(+0)),
+  (getInt8(+127), getUInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt(127)_NeverTraps") {
-  let input = getUInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromUInt(127)_NeverFails") {
-  let input = getUInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt(128)_AlwaysTraps") {
-  let input = getUInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt(128)_AlwaysFails") {
-  let input = getUInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+128),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getInt(-128)),
+  (getInt8(+0), getInt(+0)),
+  (getInt8(+127), getInt(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt(-129)_AlwaysTraps") {
-  let input = getInt(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-129),
+  getInt(+128),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromInt(-129)_AlwaysFails") {
-  let input = getInt(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(-128)_NeverTraps") {
-  let input = getInt(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(-128)_NeverFails") {
-  let input = getInt(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(127)_NeverTraps") {
-  let input = getInt(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(127)_NeverFails") {
-  let input = getInt(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(128)_AlwaysTraps") {
-  let input = getInt(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(128)_AlwaysFails") {
-  let input = getInt(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-129),
+  getInt(+128),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128.5)),
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0.5)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+0), getFloat16(+0.5)),
+  (getInt8(+127), getFloat16(+127)),
+  (getInt8(+127), getFloat16(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat16(-128)),
+  (getInt8(+0), getFloat16(-0)),
+  (getInt8(+0), getFloat16(+0)),
+  (getInt8(+127), getFloat16(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-129)_AlwaysTraps") {
-  let input = getFloat16(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-129)_AlwaysFails") {
-  let input = getFloat16(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-128.5)_NeverTraps") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-128)_NeverTraps") {
-  let input = getFloat16(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-128)_NeverFails") {
-  let input = getFloat16(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(127)_NeverTraps") {
-  let input = getFloat16(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(127)_NeverFails") {
-  let input = getFloat16(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(128)_AlwaysTraps") {
-  let input = getFloat16(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(128)_AlwaysFails") {
-  let input = getFloat16(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(255.5)_AlwaysTraps") {
-  let input = getFloat16(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-129),
+  getFloat16(-128.5),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+128),
+  getFloat16(+255.5),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128.5)),
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(-0.5)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+0), getFloat32(+0.5)),
+  (getInt8(+127), getFloat32(+127)),
+  (getInt8(+127), getFloat32(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat32(-128)),
+  (getInt8(+0), getFloat32(+0)),
+  (getInt8(+0), getFloat32(-0)),
+  (getInt8(+127), getFloat32(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-129)_AlwaysTraps") {
-  let input = getFloat32(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-129)_AlwaysFails") {
-  let input = getFloat32(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-128.5)_NeverTraps") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-128)_NeverTraps") {
-  let input = getFloat32(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-128)_NeverFails") {
-  let input = getFloat32(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(127)_NeverTraps") {
-  let input = getFloat32(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(127)_NeverFails") {
-  let input = getFloat32(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(128)_AlwaysTraps") {
-  let input = getFloat32(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(128)_AlwaysFails") {
-  let input = getFloat32(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(255.5)_AlwaysTraps") {
-  let input = getFloat32(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-129),
+  getFloat32(-128.5),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+128),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128.5)),
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(-0.5)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+0), getFloat64(+0.5)),
+  (getInt8(+127), getFloat64(+127)),
+  (getInt8(+127), getFloat64(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat64(-128)),
+  (getInt8(+0), getFloat64(+0)),
+  (getInt8(+0), getFloat64(-0)),
+  (getInt8(+127), getFloat64(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-129)_AlwaysTraps") {
-  let input = getFloat64(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-129)_AlwaysFails") {
-  let input = getFloat64(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-128.5)_NeverTraps") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-128)_NeverTraps") {
-  let input = getFloat64(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-128)_NeverFails") {
-  let input = getFloat64(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(127)_NeverTraps") {
-  let input = getFloat64(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(127)_NeverFails") {
-  let input = getFloat64(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(128)_AlwaysTraps") {
-  let input = getFloat64(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(128)_AlwaysFails") {
-  let input = getFloat64(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(255.5)_AlwaysTraps") {
-  let input = getFloat64(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-129),
+  getFloat64(-128.5),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+128),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128.5)),
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0.5)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+0), getFloat80(+0.5)),
+  (getInt8(+127), getFloat80(+127)),
+  (getInt8(+127), getFloat80(+127.5)),
+]) {
+  expectEqual($0.0, Int8($0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getInt8(-128), getFloat80(-128)),
+  (getInt8(+0), getFloat80(-0)),
+  (getInt8(+0), getFloat80(+0)),
+  (getInt8(+127), getFloat80(+127)),
+]) {
+  expectEqual($0.0, Int8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(Int8($0))
 }
 
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-129)_AlwaysTraps") {
-  let input = getFloat80(-129)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-129)_AlwaysFails") {
-  let input = getFloat80(-129)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-128.5)_NeverTraps") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-128)_NeverTraps") {
-  let input = getFloat80(-128)
-  let actual = Int8(input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-128)_NeverFails") {
-  let input = getFloat80(-128)
-  let actual = Int8(exactly: input)
-  expectEqual(-128, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = Int8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = Int8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(127)_NeverTraps") {
-  let input = getFloat80(127)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(127)_NeverFails") {
-  let input = getFloat80(127)
-  let actual = Int8(exactly: input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = Int8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(128)_AlwaysTraps") {
-  let input = getFloat80(128)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(128)_AlwaysFails") {
-  let input = getFloat80(128)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(255.5)_AlwaysTraps") {
-  let input = getFloat80(255.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = Int8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = Int8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-129),
+  getFloat80(-128.5),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+128),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(Int8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt.swift
@@ -14,1464 +14,609 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToUInt = TestSuite("FixedPointConversion_Release64_ToUInt")
+let FixedPointConversion_Release64_ToUInt = TestSuite(
+   "FixedPointConversion_Release64_ToUInt"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt8(+0)),
+  (getUInt(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt8(+0)),
+  (getUInt(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt16(+0)),
+  (getUInt(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt16(+0)),
+  (getUInt(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt32(+0)),
+  (getUInt(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt32(+0)),
+  (getUInt(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt64(18446744073709551615)_NeverTraps") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt64(18446744073709551615)_NeverFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt64(+0)),
+  (getUInt(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt64(+0)),
+  (getUInt(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt(18446744073709551615)_NeverTraps") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromUInt(18446744073709551615)_NeverFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getUInt(+0)),
+  (getUInt(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getInt(+0)),
+  (getUInt(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat16(-0.5)),
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+0), getFloat16(+0.5)),
+  (getUInt(+127), getFloat16(+127.5)),
+  (getUInt(+255), getFloat16(+255.5)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat16(+0)),
+  (getUInt(+0), getFloat16(-0)),
+  (getUInt(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat32(-0.5)),
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+0), getFloat32(+0.5)),
+  (getUInt(+127), getFloat32(+127.5)),
+  (getUInt(+255), getFloat32(+255.5)),
+  (getUInt(+32767), getFloat32(+32767.5)),
+  (getUInt(+65535), getFloat32(+65535.5)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat32(+0)),
+  (getUInt(+0), getFloat32(-0)),
+  (getUInt(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat64(-0.5)),
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+0), getFloat64(+0.5)),
+  (getUInt(+127), getFloat64(+127.5)),
+  (getUInt(+255), getFloat64(+255.5)),
+  (getUInt(+32767), getFloat64(+32767.5)),
+  (getUInt(+65535), getFloat64(+65535.5)),
+  (getUInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat64(+0)),
+  (getUInt(+0), getFloat64(-0)),
+  (getUInt(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt(+0), getFloat80(-0.5)),
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+0), getFloat80(+0.5)),
+  (getUInt(+127), getFloat80(+127.5)),
+  (getUInt(+255), getFloat80(+255.5)),
+  (getUInt(+32767), getFloat80(+32767.5)),
+  (getUInt(+65535), getFloat80(+65535.5)),
+  (getUInt(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt(+0), getFloat80(+0)),
+  (getUInt(+0), getFloat80(-0)),
+  (getUInt(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt($0))
 }
 
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt16.swift
@@ -14,1704 +14,690 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToUInt16 = TestSuite("FixedPointConversion_Release64_ToUInt16")
+let FixedPointConversion_Release64_ToUInt16 = TestSuite(
+   "FixedPointConversion_Release64_ToUInt16"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt16(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt8(+0)),
+  (getUInt16(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt8(+0)),
+  (getUInt16(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt16(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt16(+0)),
+  (getUInt16(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt16(+0)),
+  (getUInt16(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt16(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt32(+0)),
+  (getUInt16(+65535), getUInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(65535)_NeverTraps") {
-  let input = getUInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(65535)_NeverFails") {
-  let input = getUInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(65536)_AlwaysTraps") {
-  let input = getUInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(65536)_AlwaysFails") {
-  let input = getUInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+65536),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt32(+0)),
+  (getUInt16(+65535), getInt32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(65535)_NeverTraps") {
-  let input = getInt32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(65535)_NeverFails") {
-  let input = getInt32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(65536)_AlwaysTraps") {
-  let input = getInt32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(65536)_AlwaysFails") {
-  let input = getInt32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+65536),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt64(+0)),
+  (getUInt16(+65535), getUInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(65535)_NeverTraps") {
-  let input = getUInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(65535)_NeverFails") {
-  let input = getUInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(65536)_AlwaysTraps") {
-  let input = getUInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(65536)_AlwaysFails") {
-  let input = getUInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+65536),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt64(+0)),
+  (getUInt16(+65535), getInt64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(65535)_NeverTraps") {
-  let input = getInt64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(65535)_NeverFails") {
-  let input = getInt64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(65536)_AlwaysTraps") {
-  let input = getInt64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(65536)_AlwaysFails") {
-  let input = getInt64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+65536),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getUInt(+0)),
+  (getUInt16(+65535), getUInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(65535)_NeverTraps") {
-  let input = getUInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(65535)_NeverFails") {
-  let input = getUInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(65536)_AlwaysTraps") {
-  let input = getUInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(65536)_AlwaysFails") {
-  let input = getUInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+65536),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getInt(+0)),
+  (getUInt16(+65535), getInt(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(65535)_NeverTraps") {
-  let input = getInt(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(65535)_NeverFails") {
-  let input = getInt(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(65536)_AlwaysTraps") {
-  let input = getInt(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(65536)_AlwaysFails") {
-  let input = getInt(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+65536),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(-0.5)),
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+0), getFloat16(+0.5)),
+  (getUInt16(+127), getFloat16(+127.5)),
+  (getUInt16(+255), getFloat16(+255.5)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat16(+0)),
+  (getUInt16(+0), getFloat16(-0)),
+  (getUInt16(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt16(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt16(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(-0.5)),
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+0), getFloat32(+0.5)),
+  (getUInt16(+127), getFloat32(+127.5)),
+  (getUInt16(+255), getFloat32(+255.5)),
+  (getUInt16(+32767), getFloat32(+32767.5)),
+  (getUInt16(+65535), getFloat32(+65535)),
+  (getUInt16(+65535), getFloat32(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat32(+0)),
+  (getUInt16(+0), getFloat32(-0)),
+  (getUInt16(+65535), getFloat32(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(65535)_NeverTraps") {
-  let input = getFloat32(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(65535)_NeverFails") {
-  let input = getFloat32(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(65536)_AlwaysTraps") {
-  let input = getFloat32(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(65536)_AlwaysFails") {
-  let input = getFloat32(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+65536),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(-0.5)),
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+0), getFloat64(+0.5)),
+  (getUInt16(+127), getFloat64(+127.5)),
+  (getUInt16(+255), getFloat64(+255.5)),
+  (getUInt16(+32767), getFloat64(+32767.5)),
+  (getUInt16(+65535), getFloat64(+65535)),
+  (getUInt16(+65535), getFloat64(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat64(+0)),
+  (getUInt16(+0), getFloat64(-0)),
+  (getUInt16(+65535), getFloat64(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(65535)_NeverTraps") {
-  let input = getFloat64(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(65535)_NeverFails") {
-  let input = getFloat64(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(65536)_AlwaysTraps") {
-  let input = getFloat64(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(65536)_AlwaysFails") {
-  let input = getFloat64(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+65536),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(-0.5)),
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+0), getFloat80(+0.5)),
+  (getUInt16(+127), getFloat80(+127.5)),
+  (getUInt16(+255), getFloat80(+255.5)),
+  (getUInt16(+32767), getFloat80(+32767.5)),
+  (getUInt16(+65535), getFloat80(+65535)),
+  (getUInt16(+65535), getFloat80(+65535.5)),
+]) {
+  expectEqual($0.0, UInt16($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt16(+0), getFloat80(+0)),
+  (getUInt16(+0), getFloat80(-0)),
+  (getUInt16(+65535), getFloat80(+65535)),
+]) {
+  expectEqual($0.0, UInt16(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt16($0))
 }
 
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt16(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(65535)_NeverTraps") {
-  let input = getFloat80(65535)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(65535)_NeverFails") {
-  let input = getFloat80(65535)
-  let actual = UInt16(exactly: input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(65536)_AlwaysTraps") {
-  let input = getFloat80(65536)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(65536)_AlwaysFails") {
-  let input = getFloat80(65536)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt16(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt16.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt16(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt16
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+65536),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt16(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt32.swift
@@ -14,1620 +14,663 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToUInt32 = TestSuite("FixedPointConversion_Release64_ToUInt32")
+let FixedPointConversion_Release64_ToUInt32 = TestSuite(
+   "FixedPointConversion_Release64_ToUInt32"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt32(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt8(+0)),
+  (getUInt32(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt8(+0)),
+  (getUInt32(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt32(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt32(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt16(+0)),
+  (getUInt32(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt16(+0)),
+  (getUInt32(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt32(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt32(+0)),
+  (getUInt32(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt32(+0)),
+  (getUInt32(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt32(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt64(+0)),
+  (getUInt32(+4294967295), getUInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(4294967295)_NeverTraps") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(4294967295)_NeverFails") {
-  let input = getUInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(4294967296)_AlwaysTraps") {
-  let input = getUInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(4294967296)_AlwaysFails") {
-  let input = getUInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+4294967296),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt64(+0)),
+  (getUInt32(+4294967295), getInt64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(4294967295)_NeverTraps") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(4294967295)_NeverFails") {
-  let input = getInt64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(4294967296)_AlwaysTraps") {
-  let input = getInt64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(4294967296)_AlwaysFails") {
-  let input = getInt64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+4294967296),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getUInt(+0)),
+  (getUInt32(+4294967295), getUInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(4294967295)_NeverTraps") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+4294967296),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(4294967295)_NeverFails") {
-  let input = getUInt(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(4294967296)_AlwaysTraps") {
-  let input = getUInt(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(4294967296)_AlwaysFails") {
-  let input = getUInt(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+4294967296),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+4294967295), getInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getInt(+0)),
+  (getUInt32(+4294967295), getInt(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+4294967296),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(4294967295)_NeverTraps") {
-  let input = getInt(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(4294967295)_NeverFails") {
-  let input = getInt(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(4294967296)_AlwaysTraps") {
-  let input = getInt(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(4294967296)_AlwaysFails") {
-  let input = getInt(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+4294967296),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(-0.5)),
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+0), getFloat16(+0.5)),
+  (getUInt32(+127), getFloat16(+127.5)),
+  (getUInt32(+255), getFloat16(+255.5)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat16(+0)),
+  (getUInt32(+0), getFloat16(-0)),
+  (getUInt32(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt32(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt32(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(-0.5)),
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+0), getFloat32(+0.5)),
+  (getUInt32(+127), getFloat32(+127.5)),
+  (getUInt32(+255), getFloat32(+255.5)),
+  (getUInt32(+32767), getFloat32(+32767.5)),
+  (getUInt32(+65535), getFloat32(+65535.5)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat32(+0)),
+  (getUInt32(+0), getFloat32(-0)),
+  (getUInt32(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt32(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(-0.5)),
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+0), getFloat64(+0.5)),
+  (getUInt32(+127), getFloat64(+127.5)),
+  (getUInt32(+255), getFloat64(+255.5)),
+  (getUInt32(+32767), getFloat64(+32767.5)),
+  (getUInt32(+65535), getFloat64(+65535.5)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat64(+0)),
+  (getUInt32(+0), getFloat64(-0)),
+  (getUInt32(+4294967295), getFloat64(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(4294967295)_NeverTraps") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(4294967295)_NeverFails") {
-  let input = getFloat64(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(4294967296)_AlwaysTraps") {
-  let input = getFloat64(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(4294967296)_AlwaysFails") {
-  let input = getFloat64(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+4294967296),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(-0.5)),
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+0), getFloat80(+0.5)),
+  (getUInt32(+127), getFloat80(+127.5)),
+  (getUInt32(+255), getFloat80(+255.5)),
+  (getUInt32(+32767), getFloat80(+32767.5)),
+  (getUInt32(+65535), getFloat80(+65535.5)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt32(+0), getFloat80(+0)),
+  (getUInt32(+0), getFloat80(-0)),
+  (getUInt32(+4294967295), getFloat80(+4294967295)),
+]) {
+  expectEqual($0.0, UInt32(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt32($0))
 }
 
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt32(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(4294967295)_NeverTraps") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(4294967295)_NeverFails") {
-  let input = getFloat80(4294967295)
-  let actual = UInt32(exactly: input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(4294967296)_AlwaysTraps") {
-  let input = getFloat80(4294967296)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(4294967296)_AlwaysFails") {
-  let input = getFloat80(4294967296)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt32(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt32.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt32(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt32
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+4294967296),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt32(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt64.swift
@@ -14,1464 +14,609 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToUInt64 = TestSuite("FixedPointConversion_Release64_ToUInt64")
+let FixedPointConversion_Release64_ToUInt64 = TestSuite(
+   "FixedPointConversion_Release64_ToUInt64"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt64(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt8(+0)),
+  (getUInt64(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt8(+0)),
+  (getUInt64(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt64(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt16(65535)_NeverTraps") {
-  let input = getUInt16(65535)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt16(65535)_NeverFails") {
-  let input = getUInt16(65535)
-  let actual = UInt64(exactly: input)
-  expectEqual(65535, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt16(+0)),
+  (getUInt64(+65535), getUInt16(+65535)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt16(+0)),
+  (getUInt64(+32767), getInt16(+32767)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(32767)_NeverTraps") {
-  let input = getInt16(32767)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt16(32767)_NeverFails") {
-  let input = getInt16(32767)
-  let actual = UInt64(exactly: input)
-  expectEqual(32767, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt32(4294967295)_NeverTraps") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(input)
-  expectEqual(4294967295, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt32(4294967295)_NeverFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt64(exactly: input)
-  expectEqual(4294967295, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt32(+0)),
+  (getUInt64(+4294967295), getUInt32(+4294967295)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt32(+0)),
+  (getUInt64(+2147483647), getInt32(+2147483647)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(2147483647)_NeverTraps") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(input)
-  expectEqual(2147483647, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt32(2147483647)_NeverFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt64(exactly: input)
-  expectEqual(2147483647, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt64(18446744073709551615)_NeverTraps") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt64(18446744073709551615)_NeverFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt64(+0)),
+  (getUInt64(+18446744073709551615), getUInt64(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt64(+0)),
+  (getUInt64(+9223372036854775807), getInt64(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(9223372036854775807)_NeverTraps") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt64(9223372036854775807)_NeverFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt(18446744073709551615)_NeverTraps") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromUInt(18446744073709551615)_NeverFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getUInt(+0)),
+  (getUInt64(+18446744073709551615), getUInt(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getInt(+0)),
+  (getUInt64(+9223372036854775807), getInt(+9223372036854775807)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt(9223372036854775807)_NeverTraps") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt64(input)
-  expectEqual(9223372036854775807, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromInt(9223372036854775807)_NeverFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt64(exactly: input)
-  expectEqual(9223372036854775807, actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(-0.5)),
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+0), getFloat16(+0.5)),
+  (getUInt64(+127), getFloat16(+127.5)),
+  (getUInt64(+255), getFloat16(+255.5)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat16(+0)),
+  (getUInt64(+0), getFloat16(-0)),
+  (getUInt64(+2047), getFloat16(+2047)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(2047)_NeverTraps") {
-  let input = getFloat16(2047)
-  let actual = UInt64(input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(2047)_NeverFails") {
-  let input = getFloat16(2047)
-  let actual = UInt64(exactly: input)
-  expectEqual(2047, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(-0.5)),
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+0), getFloat32(+0.5)),
+  (getUInt64(+127), getFloat32(+127.5)),
+  (getUInt64(+255), getFloat32(+255.5)),
+  (getUInt64(+32767), getFloat32(+32767.5)),
+  (getUInt64(+65535), getFloat32(+65535.5)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat32(+0)),
+  (getUInt64(+0), getFloat32(-0)),
+  (getUInt64(+16777215), getFloat32(+16777215)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(32767.5)_NeverTraps") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(65535.5)_NeverTraps") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(16777215)_NeverTraps") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(16777215)_NeverFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt64(exactly: input)
-  expectEqual(16777215, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(-0.5)),
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+0), getFloat64(+0.5)),
+  (getUInt64(+127), getFloat64(+127.5)),
+  (getUInt64(+255), getFloat64(+255.5)),
+  (getUInt64(+32767), getFloat64(+32767.5)),
+  (getUInt64(+65535), getFloat64(+65535.5)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat64(+0)),
+  (getUInt64(+0), getFloat64(-0)),
+  (getUInt64(+9007199254740991), getFloat64(+9007199254740991)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(32767.5)_NeverTraps") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(65535.5)_NeverTraps") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(9007199254740991)_NeverTraps") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(9007199254740991)_NeverFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt64(exactly: input)
-  expectEqual(9007199254740991, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(-0.5)),
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+0), getFloat80(+0.5)),
+  (getUInt64(+127), getFloat80(+127.5)),
+  (getUInt64(+255), getFloat80(+255.5)),
+  (getUInt64(+32767), getFloat80(+32767.5)),
+  (getUInt64(+65535), getFloat80(+65535.5)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt64(+0), getFloat80(+0)),
+  (getUInt64(+0), getFloat80(-0)),
+  (getUInt64(+18446744073709551615), getFloat80(+18446744073709551615)),
+]) {
+  expectEqual($0.0, UInt64(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt64($0))
 }
 
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt64(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(32767.5)_NeverTraps") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(input)
-  expectEqual(32767, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(65535.5)_NeverTraps") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(input)
-  expectEqual(65535, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverTraps") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(18446744073709551615)_NeverFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt64(exactly: input)
-  expectEqual(18446744073709551615, actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt64(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt64.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt64(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt64
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt64(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt8.swift
@@ -14,1800 +14,717 @@
 
 import StdlibUnittest
 
-let FixedPointConversion_Release64_ToUInt8 = TestSuite("FixedPointConversion_Release64_ToUInt8")
+let FixedPointConversion_Release64_ToUInt8 = TestSuite(
+   "FixedPointConversion_Release64_ToUInt8"
+)
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt8: (0)...(255)
+// MARK: UInt8: (+0)...(+255)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt8(0)_NeverTraps") {
-  let input = getUInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt8(0)_NeverFails") {
-  let input = getUInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt8(255)_NeverTraps") {
-  let input = getUInt8(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt8(255)_NeverFails") {
-  let input = getUInt8(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt8(+0)),
+  (getUInt8(+255), getUInt8(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int8: (-128)...(127)
+// MARK: Int8: (-128)...(+127)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(-128)_AlwaysTraps") {
-  let input = getInt8(-128)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt8_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(-128)_AlwaysFails") {
-  let input = getInt8(-128)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt8_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt8(+0)),
+  (getUInt8(+127), getInt8(+127)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(-1)_AlwaysTraps") {
-  let input = getInt8(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt8_AlwaysTraps")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(-1)_AlwaysFails") {
-  let input = getInt8(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(0)_NeverTraps") {
-  let input = getInt8(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(0)_NeverFails") {
-  let input = getInt8(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(127)_NeverTraps") {
-  let input = getInt8(127)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt8(127)_NeverFails") {
-  let input = getInt8(127)
-  let actual = UInt8(exactly: input)
-  expectEqual(127, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt8_AlwaysFails")
+.forEach(in: [
+  getInt8(-128),
+  getInt8(-1),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt16: (0)...(65535)
+// MARK: UInt16: (+0)...(+65535)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(0)_NeverTraps") {
-  let input = getUInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(0)_NeverFails") {
-  let input = getUInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt16(+0)),
+  (getUInt8(+255), getUInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(255)_NeverTraps") {
-  let input = getUInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt16_AlwaysTraps")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(255)_NeverFails") {
-  let input = getUInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(256)_AlwaysTraps") {
-  let input = getUInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(256)_AlwaysFails") {
-  let input = getUInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(65535)_AlwaysTraps") {
-  let input = getUInt16(65535)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt16(65535)_AlwaysFails") {
-  let input = getUInt16(65535)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt16_AlwaysFails")
+.forEach(in: [
+  getUInt16(+256),
+  getUInt16(+65535),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int16: (-32768)...(32767)
+// MARK: Int16: (-32768)...(+32767)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(-32768)_AlwaysTraps") {
-  let input = getInt16(-32768)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(-32768)_AlwaysFails") {
-  let input = getInt16(-32768)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt16(+0)),
+  (getUInt8(+255), getInt16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(-1)_AlwaysTraps") {
-  let input = getInt16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt16_AlwaysTraps")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(-1)_AlwaysFails") {
-  let input = getInt16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(0)_NeverTraps") {
-  let input = getInt16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(0)_NeverFails") {
-  let input = getInt16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(255)_NeverTraps") {
-  let input = getInt16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(255)_NeverFails") {
-  let input = getInt16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(256)_AlwaysTraps") {
-  let input = getInt16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(256)_AlwaysFails") {
-  let input = getInt16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(32767)_AlwaysTraps") {
-  let input = getInt16(32767)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt16(32767)_AlwaysFails") {
-  let input = getInt16(32767)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt16_AlwaysFails")
+.forEach(in: [
+  getInt16(-32768),
+  getInt16(-1),
+  getInt16(+256),
+  getInt16(+32767),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt32: (0)...(4294967295)
+// MARK: UInt32: (+0)...(+4294967295)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(0)_NeverTraps") {
-  let input = getUInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(0)_NeverFails") {
-  let input = getUInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt32(+0)),
+  (getUInt8(+255), getUInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(255)_NeverTraps") {
-  let input = getUInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt32_AlwaysTraps")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(255)_NeverFails") {
-  let input = getUInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(256)_AlwaysTraps") {
-  let input = getUInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(256)_AlwaysFails") {
-  let input = getUInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(4294967295)_AlwaysTraps") {
-  let input = getUInt32(4294967295)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt32(4294967295)_AlwaysFails") {
-  let input = getUInt32(4294967295)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt32_AlwaysFails")
+.forEach(in: [
+  getUInt32(+256),
+  getUInt32(+4294967295),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int32: (-2147483648)...(2147483647)
+// MARK: Int32: (-2147483648)...(+2147483647)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(-2147483648)_AlwaysTraps") {
-  let input = getInt32(-2147483648)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(-2147483648)_AlwaysFails") {
-  let input = getInt32(-2147483648)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt32(+0)),
+  (getUInt8(+255), getInt32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(-1)_AlwaysTraps") {
-  let input = getInt32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt32_AlwaysTraps")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(-1)_AlwaysFails") {
-  let input = getInt32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(0)_NeverTraps") {
-  let input = getInt32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(0)_NeverFails") {
-  let input = getInt32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(255)_NeverTraps") {
-  let input = getInt32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(255)_NeverFails") {
-  let input = getInt32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(256)_AlwaysTraps") {
-  let input = getInt32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(256)_AlwaysFails") {
-  let input = getInt32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(2147483647)_AlwaysTraps") {
-  let input = getInt32(2147483647)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt32(2147483647)_AlwaysFails") {
-  let input = getInt32(2147483647)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt32_AlwaysFails")
+.forEach(in: [
+  getInt32(-2147483648),
+  getInt32(-1),
+  getInt32(+256),
+  getInt32(+2147483647),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt64: (0)...(18446744073709551615)
+// MARK: UInt64: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(0)_NeverTraps") {
-  let input = getUInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(0)_NeverFails") {
-  let input = getUInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt64(+0)),
+  (getUInt8(+255), getUInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(255)_NeverTraps") {
-  let input = getUInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt64_AlwaysTraps")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(255)_NeverFails") {
-  let input = getUInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(256)_AlwaysTraps") {
-  let input = getUInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(256)_AlwaysFails") {
-  let input = getUInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt64(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt64(18446744073709551615)_AlwaysFails") {
-  let input = getUInt64(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt64_AlwaysFails")
+.forEach(in: [
+  getUInt64(+256),
+  getUInt64(+18446744073709551615),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int64: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int64: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt64(-9223372036854775808)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(-9223372036854775808)_AlwaysFails") {
-  let input = getInt64(-9223372036854775808)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt64(+0)),
+  (getUInt8(+255), getInt64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(-1)_AlwaysTraps") {
-  let input = getInt64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt64_AlwaysTraps")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(-1)_AlwaysFails") {
-  let input = getInt64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(0)_NeverTraps") {
-  let input = getInt64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(0)_NeverFails") {
-  let input = getInt64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(255)_NeverTraps") {
-  let input = getInt64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(255)_NeverFails") {
-  let input = getInt64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(256)_AlwaysTraps") {
-  let input = getInt64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(256)_AlwaysFails") {
-  let input = getInt64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysTraps") {
-  let input = getInt64(9223372036854775807)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt64(9223372036854775807)_AlwaysFails") {
-  let input = getInt64(9223372036854775807)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt64_AlwaysFails")
+.forEach(in: [
+  getInt64(-9223372036854775808),
+  getInt64(-1),
+  getInt64(+256),
+  getInt64(+9223372036854775807),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: UInt: (0)...(18446744073709551615)
+// MARK: UInt: (+0)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(0)_NeverTraps") {
-  let input = getUInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(0)_NeverFails") {
-  let input = getUInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getUInt(+0)),
+  (getUInt8(+255), getUInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(255)_NeverTraps") {
-  let input = getUInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt_AlwaysTraps")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+18446744073709551615),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(255)_NeverFails") {
-  let input = getUInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(256)_AlwaysTraps") {
-  let input = getUInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(256)_AlwaysFails") {
-  let input = getUInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(18446744073709551615)_AlwaysTraps") {
-  let input = getUInt(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromUInt(18446744073709551615)_AlwaysFails") {
-  let input = getUInt(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromUInt_AlwaysFails")
+.forEach(in: [
+  getUInt(+256),
+  getUInt(+18446744073709551615),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Int: (-9223372036854775808)...(9223372036854775807)
+// MARK: Int: (-9223372036854775808)...(+9223372036854775807)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt(-9223372036854775808)_AlwaysTraps") {
-  let input = getInt(-9223372036854775808)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt(-9223372036854775808)_AlwaysFails") {
-  let input = getInt(-9223372036854775808)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getInt(+0)),
+  (getUInt8(+255), getInt(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt(-1)_AlwaysTraps") {
-  let input = getInt(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt_AlwaysTraps")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+256),
+  getInt(+9223372036854775807),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromInt(-1)_AlwaysFails") {
-  let input = getInt(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(0)_NeverTraps") {
-  let input = getInt(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(0)_NeverFails") {
-  let input = getInt(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(255)_NeverTraps") {
-  let input = getInt(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(255)_NeverFails") {
-  let input = getInt(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(256)_AlwaysTraps") {
-  let input = getInt(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(256)_AlwaysFails") {
-  let input = getInt(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(9223372036854775807)_AlwaysTraps") {
-  let input = getInt(9223372036854775807)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromInt(9223372036854775807)_AlwaysFails") {
-  let input = getInt(9223372036854775807)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromInt_AlwaysFails")
+.forEach(in: [
+  getInt(-9223372036854775808),
+  getInt(-1),
+  getInt(+256),
+  getInt(+9223372036854775807),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float16: (-2047)...(2047)
+// MARK: Float16: (-2047)...(+2047)
 //===----------------------------------------------------------------------===//
 
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-2047)_AlwaysTraps") {
-  let input = getFloat16(-2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat16_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0.5)),
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+0), getFloat16(+0.5)),
+  (getUInt8(+127), getFloat16(+127.5)),
+  (getUInt8(+255), getFloat16(+255)),
+  (getUInt8(+255), getFloat16(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-2047)_AlwaysFails") {
-  let input = getFloat16(-2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat16_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat16(-0)),
+  (getUInt8(+0), getFloat16(+0)),
+  (getUInt8(+255), getFloat16(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-128.5)_AlwaysTraps") {
-  let input = getFloat16(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat16_AlwaysTraps")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-128.5)_AlwaysFails") {
-  let input = getFloat16(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-1)_AlwaysTraps") {
-  let input = getFloat16(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-1)_AlwaysFails") {
-  let input = getFloat16(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-0.5)_NeverTraps") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-0.5)_AlwaysFails") {
-  let input = getFloat16(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(0)_NeverTraps") {
-  let input = getFloat16(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(0)_NeverFails") {
-  let input = getFloat16(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-0.0)_NeverTraps") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-0.0)_NeverFails") {
-  let input = getFloat16(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(0.0)_NeverTraps") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(0.0)_NeverFails") {
-  let input = getFloat16(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(0.5)_NeverTraps") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(0.5)_AlwaysFails") {
-  let input = getFloat16(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(127.5)_NeverTraps") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(127.5)_AlwaysFails") {
-  let input = getFloat16(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(255)_NeverTraps") {
-  let input = getFloat16(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(255)_NeverFails") {
-  let input = getFloat16(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(255.5)_NeverTraps") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(255.5)_AlwaysFails") {
-  let input = getFloat16(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(256)_AlwaysTraps") {
-  let input = getFloat16(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(256)_AlwaysFails") {
-  let input = getFloat16(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(2047)_AlwaysTraps") {
-  let input = getFloat16(2047)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(2047)_AlwaysFails") {
-  let input = getFloat16(2047)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-.infinity)_AlwaysTraps") {
-  let input = getFloat16(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-.infinity)_AlwaysFails") {
-  let input = getFloat16(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(+.infinity)_AlwaysTraps") {
-  let input = getFloat16(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(+.infinity)_AlwaysFails") {
-  let input = getFloat16(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-.nan)_AlwaysTraps") {
-  let input = getFloat16(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-.nan)_AlwaysFails") {
-  let input = getFloat16(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(+.nan)_AlwaysTraps") {
-  let input = getFloat16(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(+.nan)_AlwaysFails") {
-  let input = getFloat16(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat16(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat16(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat16(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat16_AlwaysFails")
+.forEach(in: [
+  getFloat16(-2047),
+  getFloat16(-128.5),
+  getFloat16(-1),
+  getFloat16(-0.5),
+  getFloat16(+0.5),
+  getFloat16(+127.5),
+  getFloat16(+255.5),
+  getFloat16(+256),
+  getFloat16(+2047),
+  getFloat16(-.infinity),
+  getFloat16(-.nan),
+  getFloat16(-.signalingNaN),
+  getFloat16(+.infinity),
+  getFloat16(+.nan),
+  getFloat16(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 }
 #endif // Float16
 
 //===----------------------------------------------------------------------===//
-// MARK: Float32: (-16777215)...(16777215)
+// MARK: Float32: (-16777215)...(+16777215)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-16777215)_AlwaysTraps") {
-  let input = getFloat32(-16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat32_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(-0.5)),
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+0), getFloat32(+0.5)),
+  (getUInt8(+127), getFloat32(+127.5)),
+  (getUInt8(+255), getFloat32(+255)),
+  (getUInt8(+255), getFloat32(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-16777215)_AlwaysFails") {
-  let input = getFloat32(-16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat32_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat32(+0)),
+  (getUInt8(+0), getFloat32(-0)),
+  (getUInt8(+255), getFloat32(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-32768.5)_AlwaysTraps") {
-  let input = getFloat32(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat32_AlwaysTraps")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-32768.5)_AlwaysFails") {
-  let input = getFloat32(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-128.5)_AlwaysTraps") {
-  let input = getFloat32(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-128.5)_AlwaysFails") {
-  let input = getFloat32(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-1)_AlwaysTraps") {
-  let input = getFloat32(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-1)_AlwaysFails") {
-  let input = getFloat32(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-0.5)_NeverTraps") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-0.5)_AlwaysFails") {
-  let input = getFloat32(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(0)_NeverTraps") {
-  let input = getFloat32(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(0)_NeverFails") {
-  let input = getFloat32(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-0.0)_NeverTraps") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-0.0)_NeverFails") {
-  let input = getFloat32(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(0.0)_NeverTraps") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(0.0)_NeverFails") {
-  let input = getFloat32(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(0.5)_NeverTraps") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(0.5)_AlwaysFails") {
-  let input = getFloat32(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(127.5)_NeverTraps") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(127.5)_AlwaysFails") {
-  let input = getFloat32(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(255)_NeverTraps") {
-  let input = getFloat32(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(255)_NeverFails") {
-  let input = getFloat32(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(255.5)_NeverTraps") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(255.5)_AlwaysFails") {
-  let input = getFloat32(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(256)_AlwaysTraps") {
-  let input = getFloat32(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(256)_AlwaysFails") {
-  let input = getFloat32(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(32767.5)_AlwaysTraps") {
-  let input = getFloat32(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(32767.5)_AlwaysFails") {
-  let input = getFloat32(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(65535.5)_AlwaysTraps") {
-  let input = getFloat32(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(65535.5)_AlwaysFails") {
-  let input = getFloat32(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(16777215)_AlwaysTraps") {
-  let input = getFloat32(16777215)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(16777215)_AlwaysFails") {
-  let input = getFloat32(16777215)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-.infinity)_AlwaysTraps") {
-  let input = getFloat32(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-.infinity)_AlwaysFails") {
-  let input = getFloat32(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(+.infinity)_AlwaysTraps") {
-  let input = getFloat32(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(+.infinity)_AlwaysFails") {
-  let input = getFloat32(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-.nan)_AlwaysTraps") {
-  let input = getFloat32(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-.nan)_AlwaysFails") {
-  let input = getFloat32(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(+.nan)_AlwaysTraps") {
-  let input = getFloat32(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(+.nan)_AlwaysFails") {
-  let input = getFloat32(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat32(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat32(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat32(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat32_AlwaysFails")
+.forEach(in: [
+  getFloat32(-16777215),
+  getFloat32(-32768.5),
+  getFloat32(-128.5),
+  getFloat32(-1),
+  getFloat32(-0.5),
+  getFloat32(+0.5),
+  getFloat32(+127.5),
+  getFloat32(+255.5),
+  getFloat32(+256),
+  getFloat32(+32767.5),
+  getFloat32(+65535.5),
+  getFloat32(+16777215),
+  getFloat32(-.infinity),
+  getFloat32(-.nan),
+  getFloat32(-.signalingNaN),
+  getFloat32(+.infinity),
+  getFloat32(+.nan),
+  getFloat32(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float64: (-9007199254740991)...(9007199254740991)
+// MARK: Float64: (-9007199254740991)...(+9007199254740991)
 //===----------------------------------------------------------------------===//
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(-9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat64_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(-0.5)),
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+0), getFloat64(+0.5)),
+  (getUInt8(+127), getFloat64(+127.5)),
+  (getUInt8(+255), getFloat64(+255)),
+  (getUInt8(+255), getFloat64(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-9007199254740991)_AlwaysFails") {
-  let input = getFloat64(-9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat64_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat64(+0)),
+  (getUInt8(+0), getFloat64(-0)),
+  (getUInt8(+255), getFloat64(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-32768.5)_AlwaysTraps") {
-  let input = getFloat64(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat64_AlwaysTraps")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-32768.5)_AlwaysFails") {
-  let input = getFloat64(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-128.5)_AlwaysTraps") {
-  let input = getFloat64(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-128.5)_AlwaysFails") {
-  let input = getFloat64(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-1)_AlwaysTraps") {
-  let input = getFloat64(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-1)_AlwaysFails") {
-  let input = getFloat64(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-0.5)_NeverTraps") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-0.5)_AlwaysFails") {
-  let input = getFloat64(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(0)_NeverTraps") {
-  let input = getFloat64(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(0)_NeverFails") {
-  let input = getFloat64(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-0.0)_NeverTraps") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-0.0)_NeverFails") {
-  let input = getFloat64(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(0.0)_NeverTraps") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(0.0)_NeverFails") {
-  let input = getFloat64(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(0.5)_NeverTraps") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(0.5)_AlwaysFails") {
-  let input = getFloat64(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(127.5)_NeverTraps") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(127.5)_AlwaysFails") {
-  let input = getFloat64(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(255)_NeverTraps") {
-  let input = getFloat64(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(255)_NeverFails") {
-  let input = getFloat64(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(255.5)_NeverTraps") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(255.5)_AlwaysFails") {
-  let input = getFloat64(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(256)_AlwaysTraps") {
-  let input = getFloat64(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(256)_AlwaysFails") {
-  let input = getFloat64(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(32767.5)_AlwaysTraps") {
-  let input = getFloat64(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(32767.5)_AlwaysFails") {
-  let input = getFloat64(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(65535.5)_AlwaysTraps") {
-  let input = getFloat64(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(65535.5)_AlwaysFails") {
-  let input = getFloat64(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysTraps") {
-  let input = getFloat64(9007199254740991)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(9007199254740991)_AlwaysFails") {
-  let input = getFloat64(9007199254740991)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-.infinity)_AlwaysTraps") {
-  let input = getFloat64(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-.infinity)_AlwaysFails") {
-  let input = getFloat64(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(+.infinity)_AlwaysTraps") {
-  let input = getFloat64(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(+.infinity)_AlwaysFails") {
-  let input = getFloat64(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-.nan)_AlwaysTraps") {
-  let input = getFloat64(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-.nan)_AlwaysFails") {
-  let input = getFloat64(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(+.nan)_AlwaysTraps") {
-  let input = getFloat64(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(+.nan)_AlwaysFails") {
-  let input = getFloat64(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat64(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat64(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat64(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat64_AlwaysFails")
+.forEach(in: [
+  getFloat64(-9007199254740991),
+  getFloat64(-32768.5),
+  getFloat64(-128.5),
+  getFloat64(-1),
+  getFloat64(-0.5),
+  getFloat64(+0.5),
+  getFloat64(+127.5),
+  getFloat64(+255.5),
+  getFloat64(+256),
+  getFloat64(+32767.5),
+  getFloat64(+65535.5),
+  getFloat64(+9007199254740991),
+  getFloat64(-.infinity),
+  getFloat64(-.nan),
+  getFloat64(-.signalingNaN),
+  getFloat64(+.infinity),
+  getFloat64(+.nan),
+  getFloat64(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Float80: (-18446744073709551615)...(18446744073709551615)
+// MARK: Float80: (-18446744073709551615)...(+18446744073709551615)
 //===----------------------------------------------------------------------===//
 
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(-18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat80_NeverTraps")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0.5)),
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+0), getFloat80(+0.5)),
+  (getUInt8(+127), getFloat80(+127.5)),
+  (getUInt8(+255), getFloat80(+255)),
+  (getUInt8(+255), getFloat80(+255.5)),
+]) {
+  expectEqual($0.0, UInt8($0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(-18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat80_NeverFails")
+.forEach(in: [
+  (getUInt8(+0), getFloat80(-0)),
+  (getUInt8(+0), getFloat80(+0)),
+  (getUInt8(+255), getFloat80(+255)),
+]) {
+  expectEqual($0.0, UInt8(exactly: $0.1))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-32768.5)_AlwaysTraps") {
-  let input = getFloat80(-32768.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat80_AlwaysTraps")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectCrashLater()
+  _blackHole(UInt8($0))
 }
 
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-32768.5)_AlwaysFails") {
-  let input = getFloat80(-32768.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-128.5)_AlwaysTraps") {
-  let input = getFloat80(-128.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-128.5)_AlwaysFails") {
-  let input = getFloat80(-128.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-1)_AlwaysTraps") {
-  let input = getFloat80(-1)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-1)_AlwaysFails") {
-  let input = getFloat80(-1)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-0.5)_NeverTraps") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-0.5)_AlwaysFails") {
-  let input = getFloat80(-0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(0)_NeverTraps") {
-  let input = getFloat80(0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(0)_NeverFails") {
-  let input = getFloat80(0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-0.0)_NeverTraps") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-0.0)_NeverFails") {
-  let input = getFloat80(-0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(0.0)_NeverTraps") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(0.0)_NeverFails") {
-  let input = getFloat80(0.0)
-  let actual = UInt8(exactly: input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(0.5)_NeverTraps") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(input)
-  expectEqual(0, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(0.5)_AlwaysFails") {
-  let input = getFloat80(0.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(127.5)_NeverTraps") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(input)
-  expectEqual(127, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(127.5)_AlwaysFails") {
-  let input = getFloat80(127.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(255)_NeverTraps") {
-  let input = getFloat80(255)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(255)_NeverFails") {
-  let input = getFloat80(255)
-  let actual = UInt8(exactly: input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(255.5)_NeverTraps") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(input)
-  expectEqual(255, actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(255.5)_AlwaysFails") {
-  let input = getFloat80(255.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(256)_AlwaysTraps") {
-  let input = getFloat80(256)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(256)_AlwaysFails") {
-  let input = getFloat80(256)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(32767.5)_AlwaysTraps") {
-  let input = getFloat80(32767.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(32767.5)_AlwaysFails") {
-  let input = getFloat80(32767.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(65535.5)_AlwaysTraps") {
-  let input = getFloat80(65535.5)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(65535.5)_AlwaysFails") {
-  let input = getFloat80(65535.5)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysTraps") {
-  let input = getFloat80(18446744073709551615)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(18446744073709551615)_AlwaysFails") {
-  let input = getFloat80(18446744073709551615)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-.infinity)_AlwaysTraps") {
-  let input = getFloat80(-.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-.infinity)_AlwaysFails") {
-  let input = getFloat80(-.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(+.infinity)_AlwaysTraps") {
-  let input = getFloat80(+.infinity)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(+.infinity)_AlwaysFails") {
-  let input = getFloat80(+.infinity)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-.nan)_AlwaysTraps") {
-  let input = getFloat80(-.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-.nan)_AlwaysFails") {
-  let input = getFloat80(-.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(+.nan)_AlwaysTraps") {
-  let input = getFloat80(+.nan)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(+.nan)_AlwaysFails") {
-  let input = getFloat80(+.nan)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(-.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(-.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(-.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysTraps") {
-  let input = getFloat80(+.signalingNaN)
-  expectCrash {
-    let actual = UInt8(input)
-    _blackHole(actual)
-  }
-}
-
-FixedPointConversion_Release64_ToUInt8.test("FromFloat80(+.signalingNaN)_AlwaysFails") {
-  let input = getFloat80(+.signalingNaN)
-  let actual = UInt8(exactly: input)
-  expectNil(actual)
+FixedPointConversion_Release64_ToUInt8
+.test("FromFloat80_AlwaysFails")
+.forEach(in: [
+  getFloat80(-18446744073709551615),
+  getFloat80(-32768.5),
+  getFloat80(-128.5),
+  getFloat80(-1),
+  getFloat80(-0.5),
+  getFloat80(+0.5),
+  getFloat80(+127.5),
+  getFloat80(+255.5),
+  getFloat80(+256),
+  getFloat80(+32767.5),
+  getFloat80(+65535.5),
+  getFloat80(+18446744073709551615),
+  getFloat80(-.infinity),
+  getFloat80(-.nan),
+  getFloat80(-.signalingNaN),
+  getFloat80(+.infinity),
+  getFloat80(+.nan),
+  getFloat80(+.signalingNaN),
+]) {
+  expectNil(UInt8(exactly: $0))
 }
 
 #endif // Float80

--- a/validation-test/stdlib/FixedPointConversion/Inputs/FixedPointConversion.swift.gyb
+++ b/validation-test/stdlib/FixedPointConversion/Inputs/FixedPointConversion.swift.gyb
@@ -1,6 +1,7 @@
 % # FIXME(integers): add tests that perform the same checks in generic code.
 % #
 % # cd validation-test/stdlib/FixedPointConversion/
+% #
 % # ../../../utils/gyb --line-directive="" \
 % #   ./Inputs/FixedPointConversion.swift.gyb | ../../../utils/split_file.py
 %
@@ -10,18 +11,18 @@
 % from itertools import product
 %
 % # Generate a test-suite file for each integer type.
-% for (configuration, ptrsize) in product(['Debug', 'Release'], [32, 64]):
-%   long_test = ', long_test' if (configuration, ptrsize) == ('Release', 32) else ''
+% for (configuration, bitWidth) in product(['Debug', 'Release'], [32, 64]):
 %   optimizations = '-Onone' if configuration == 'Debug' else '-O'
 %
-%   for self_type in all_integer_types(ptrsize):
-%     SelfName = self_type.stdlib_name
-%     selfMin = self_type.min
-%     selfMax = self_type.max
+%   for selfType in all_integer_types(bitWidth):
+%     SelfName = selfType.stdlib_name
+%     selfMin = selfType.min
+%     selfMax = selfType.max
 %
-%     test_suite = 'FixedPointConversion_' + configuration + str(ptrsize) + '_To' + SelfName
+%     testSuite = 'FixedPointConversion_{configuration}{bitWidth}_To{SelfName}'\
+%       .format(**locals()) # TODO(python3): use f-string (PEP 498).
 %
-// BEGIN ${test_suite}.swift
+// BEGIN ${testSuite}.swift
 //===----------------------------------------------------------------------===//
 //
 // Automatically Generated From ./Inputs/FixedPointConversion.swift.gyb
@@ -29,8 +30,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// REQUIRES: executable_test${long_test}
-// REQUIRES: PTRSIZE=${str(ptrsize)}
+// REQUIRES: executable_test
+// REQUIRES: PTRSIZE=${format(bitWidth)}
 // RUN: %target-run-simple-swift(${optimizations})
 // END.
 //
@@ -38,196 +39,298 @@
 
 import StdlibUnittest
 
-let ${test_suite} = TestSuite("${test_suite}")
+let ${testSuite} = TestSuite(
+   "${testSuite}"
+)
 
 %     # Test conversion behaviors for all integer types.
-%     for other_type in all_integer_types(ptrsize):
-%       OtherName = other_type.stdlib_name
-%       otherMin = other_type.min
-%       otherMax = other_type.max
+%     for otherType in all_integer_types(bitWidth):
+%       OtherName = otherType.stdlib_name
+%       otherMin = otherType.min
+%       otherMax = otherType.max
 %
 //===----------------------------------------------------------------------===//
-// MARK: ${OtherName}: (${str(otherMin)})...(${str(otherMax)})
+// MARK: ${OtherName}: (${format(otherMin, '+')})...(${format(otherMax, '+')})
 //===----------------------------------------------------------------------===//
 
-%       intValues = [
-%         selfMin,
-%         selfMax,
-%         selfMin - 1,
-%         selfMax + 1,
-%         otherMin,
-%         otherMax,
-%         0,
-%       ]
-%       for intValue in sorted(set(intValues)):
-%         if otherMin <= intValue <= otherMax:
+%       otherValues = sorted(
+%         set(
+%           filter(
+%             lambda otherValue: (otherMin <= otherValue <= otherMax),
+%             [
+%               selfMin,
+%               selfMax,
+%               selfMin - 1,
+%               selfMax + 1,
+%               otherMin,
+%               otherMax,
+%               0,
+%             ]
+%           )
+%         )
+%       )
+%       otherValues_NeverTraps = otherValues_NeverFails = list(
+%         filter(
+%           lambda otherValue: (selfMin <= otherValue <= selfMax),
+%           otherValues
+%         )
+%       )
+%       otherValues_AlwaysTraps = otherValues_AlwaysFails = list(
+%         filter(
+%           lambda otherValue: not (selfMin <= otherValue <= selfMax),
+%           otherValues
+%         )
+%       )
 %
-%           intLiteral = str(intValue)
+%       if len(otherValues_NeverTraps) > 0:
 %
-%           if selfMin <= intValue <= selfMax:
+${testSuite}
+.test("From${OtherName}_NeverTraps")
+.forEach(in: [
 %
-${test_suite}.test("From${OtherName}(${intLiteral})_NeverTraps") {
-  let input = get${OtherName}(${intLiteral})
-  let actual = ${SelfName}(input)
-  expectEqual(${intLiteral}, actual)
+%         for otherValue in otherValues_NeverTraps:
+%           selfLiteral = otherLiteral = format(otherValue, '+')
+%
+  (get${SelfName}(${selfLiteral}), get${OtherName}(${otherLiteral})),
+%
+%         end # for
+]) {
+  expectEqual($0.0, ${SelfName}($0.1))
 }
 
-${test_suite}.test("From${OtherName}(${intLiteral})_NeverFails") {
-  let input = get${OtherName}(${intLiteral})
-  let actual = ${SelfName}(exactly: input)
-  expectEqual(${intLiteral}, actual)
-}
-
-%           else:
+%       end # if
 %
-${test_suite}.test("From${OtherName}(${intLiteral})_AlwaysTraps") {
-  let input = get${OtherName}(${intLiteral})
-  expectCrash {
-    let actual = ${SelfName}(input)
-    _blackHole(actual)
-  }
+%       if len(otherValues_NeverFails) > 0:
+%
+${testSuite}
+.test("From${OtherName}_NeverFails")
+.forEach(in: [
+%
+%         for otherValue in otherValues_NeverFails:
+%           selfLiteral = otherLiteral = format(otherValue, '+')
+%
+  (get${SelfName}(${selfLiteral}), get${OtherName}(${otherLiteral})),
+%
+%         end # for
+]) {
+  expectEqual($0.0, ${SelfName}(exactly: $0.1))
 }
 
-${test_suite}.test("From${OtherName}(${intLiteral})_AlwaysFails") {
-  let input = get${OtherName}(${intLiteral})
-  let actual = ${SelfName}(exactly: input)
-  expectNil(actual)
+%       end # if
+%
+%       if len(otherValues_AlwaysTraps) > 0:
+%
+${testSuite}
+.test("From${OtherName}_AlwaysTraps")
+.forEach(in: [
+%
+%         for otherValue in otherValues_AlwaysTraps:
+%           otherLiteral = format(otherValue, '+')
+%
+  get${OtherName}(${otherLiteral}),
+%
+%         end # for
+]) {
+  expectCrashLater()
+  _blackHole(${SelfName}($0))
 }
 
-%           end # if
-%         end # if
-%       end # for intValue in ...
-%     end # for other_type in ...
+%       end # if
+%
+%       if len(otherValues_AlwaysFails) > 0:
+%
+${testSuite}
+.test("From${OtherName}_AlwaysFails")
+.forEach(in: [
+%
+%         for otherValue in otherValues_AlwaysFails:
+%           otherLiteral = format(otherValue, '+')
+%
+  get${OtherName}(${otherLiteral}),
+%
+%         end # for
+]) {
+  expectNil(${SelfName}(exactly: $0))
+}
+
+%       end # if
+%
+%     end # for otherType in ...
 %
 %     # Test conversion behaviors for all floating-point types.
-%     for float_type in all_floating_point_types():
-%       FloatName = "Float" + str(float_type.bits)
-%       floatMax = int_max(bits=float_type.explicit_significand_bits, signed=False)
-%       floatMin = -floatMax
+%     for otherType in all_floating_point_types():
+%       OtherName = 'Float{}'.format(otherType.bits)
+%       otherMax = int_max(bits=otherType.explicit_significand_bits, signed=False)
+%       otherMin = -otherMax
 %
 //===----------------------------------------------------------------------===//
-// MARK: ${FloatName}: (${str(floatMin)})...(${str(floatMax)})
+// MARK: ${OtherName}: (${format(otherMin, '+')})...(${format(otherMax, '+')})
 //===----------------------------------------------------------------------===//
 
-%       if FloatName == 'Float16':
+%       if OtherName == 'Float16':
 %
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
 
-%       elif FloatName == 'Float80':
+%       elif OtherName == 'Float80':
 %
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 
 %       end # if
 %
-%       floatValues = [
-%         Decimal(selfMin),
-%         Decimal(selfMax),
-%         Decimal(selfMin - 1),
-%         Decimal(selfMax + 1),
-%         Decimal(floatMin),
-%         Decimal(floatMax),
-%         Decimal('-0.0'),
-%         Decimal('+0.0'),
-%         Decimal('-0.5'),
-%         Decimal('+0.5'),
-%         Decimal('-128.5'),
-%         Decimal('+127.5'),
-%         Decimal('+255.5'),
-%         Decimal('-32768.5'),
-%         Decimal('+32767.5'),
-%         Decimal('+65535.5'),
-%       ]
-%       for floatValue in sorted(floatValues):
-%         if floatMin <= floatValue <= floatMax:
+%       otherValues = sorted(
+%         map(
+%           lambda otherLiteral: Decimal(otherLiteral).normalize(),
+%           set(
+%             map(
+%               lambda otherValue: format(otherValue.normalize(), '+'),
+%               filter(
+%                 lambda otherValue: (otherMin <= otherValue <= otherMax),
+%                 [
+%                   Decimal(selfMin),
+%                   Decimal(selfMax),
+%                   Decimal(selfMin - 1),
+%                   Decimal(selfMax + 1),
+%                   Decimal(otherMin),
+%                   Decimal(otherMax),
+%                   Decimal('-0.0'),
+%                   Decimal('+0.0'),
+%                   Decimal('-0.5'),
+%                   Decimal('+0.5'),
+%                   Decimal('-128.5'),
+%                   Decimal('+127.5'),
+%                   Decimal('+255.5'),
+%                   Decimal('-32768.5'),
+%                   Decimal('+32767.5'),
+%                   Decimal('+65535.5'),
+%                 ]
+%               )
+%             )
+%           )
+%         )
+%       )
+%       otherValues_NeverTraps = list(
+%         filter(
+%           lambda otherValue: (selfMin <= int(otherValue) <= selfMax),
+%           otherValues
+%         )
+%       )
+%       otherValues_NeverFails = list(
+%         filter(
+%           lambda otherValue: (otherValue == int(otherValue)) and \
+%                              (selfMin <= int(otherValue) <= selfMax),
+%           otherValues
+%         )
+%       )
+%       otherValues_AlwaysTraps = list(
+%         filter(
+%           lambda otherValue: not (selfMin <= int(otherValue) <= selfMax),
+%           otherValues
+%         )
+%       )
+%       otherValues_AlwaysFails = list(
+%         filter(
+%           lambda otherValue: (otherValue != int(otherValue)) or \
+%                              not (selfMin <= int(otherValue) <= selfMax),
+%           otherValues
+%         )
+%       )
+%       signs = ['-', '+']
+%       nonFinites = ['infinity', 'nan', 'signalingNaN']
 %
-%           intValue = int(floatValue)
-%           intLiteral = str(intValue)
-%           floatLiteral = str(floatValue)
+%       if len(otherValues_NeverTraps) > 0:
 %
-%           if selfMin <= intValue <= selfMax:
+${testSuite}
+.test("From${OtherName}_NeverTraps")
+.forEach(in: [
 %
-${test_suite}.test("From${FloatName}(${floatLiteral})_NeverTraps") {
-  let input = get${FloatName}(${floatLiteral})
-  let actual = ${SelfName}(input)
-  expectEqual(${intLiteral}, actual)
+%         for otherValue in otherValues_NeverTraps:
+%           selfLiteral = format(int(otherValue), '+')
+%           otherLiteral = format(otherValue, '+')
+%
+  (get${SelfName}(${selfLiteral}), get${OtherName}(${otherLiteral})),
+%
+%         end # for
+]) {
+  expectEqual($0.0, ${SelfName}($0.1))
 }
 
-%             if floatValue == intValue:
+%       end # if
 %
-${test_suite}.test("From${FloatName}(${floatLiteral})_NeverFails") {
-  let input = get${FloatName}(${floatLiteral})
-  let actual = ${SelfName}(exactly: input)
-  expectEqual(${intLiteral}, actual)
+%       if len(otherValues_NeverFails) > 0:
+%
+${testSuite}
+.test("From${OtherName}_NeverFails")
+.forEach(in: [
+%
+%         for otherValue in otherValues_NeverFails:
+%           selfLiteral = format(int(otherValue), '+')
+%           otherLiteral = format(otherValue, '+')
+%
+  (get${SelfName}(${selfLiteral}), get${OtherName}(${otherLiteral})),
+%
+%         end # for
+]) {
+  expectEqual($0.0, ${SelfName}(exactly: $0.1))
 }
 
-%             else:
+%       end # if
 %
-${test_suite}.test("From${FloatName}(${floatLiteral})_AlwaysFails") {
-  let input = get${FloatName}(${floatLiteral})
-  let actual = ${SelfName}(exactly: input)
-  expectNil(actual)
+${testSuite}
+.test("From${OtherName}_AlwaysTraps")
+.forEach(in: [
+%
+%       for otherValue in otherValues_AlwaysTraps:
+%         otherLiteral = format(otherValue, '+')
+%
+  get${OtherName}(${otherLiteral}),
+%
+%       end # for
+%
+%       for (sign, nonFinite) in product(signs, nonFinites):
+%
+  get${OtherName}(${sign}.${nonFinite}),
+%
+%       end # for
+]) {
+  expectCrashLater()
+  _blackHole(${SelfName}($0))
 }
 
-%             end # if
-%           else:
+${testSuite}
+.test("From${OtherName}_AlwaysFails")
+.forEach(in: [
 %
-${test_suite}.test("From${FloatName}(${floatLiteral})_AlwaysTraps") {
-  let input = get${FloatName}(${floatLiteral})
-  expectCrash {
-    let actual = ${SelfName}(input)
-    _blackHole(actual)
-  }
+%       for otherValue in otherValues_AlwaysFails:
+%         otherLiteral = format(otherValue, '+')
+%
+  get${OtherName}(${otherLiteral}),
+%
+%       end # for
+%
+%       for (sign, nonFinite) in product(signs, nonFinites):
+%
+  get${OtherName}(${sign}.${nonFinite}),
+%
+%       end # for
+]) {
+  expectNil(${SelfName}(exactly: $0))
 }
 
-${test_suite}.test("From${FloatName}(${floatLiteral})_AlwaysFails") {
-  let input = get${FloatName}(${floatLiteral})
-  let actual = ${SelfName}(exactly: input)
-  expectNil(actual)
-}
-
-%           end # if
-%         end # if
-%       end # for floatValue in ...
-%
-%       nonFinites = [
-%         '-.infinity',
-%         '+.infinity',
-%         '-.nan',
-%         '+.nan',
-%         '-.signalingNaN',
-%         '+.signalingNaN',
-%       ]
-%       for nonFinite in nonFinites:
-%
-${test_suite}.test("From${FloatName}(${nonFinite})_AlwaysTraps") {
-  let input = get${FloatName}(${nonFinite})
-  expectCrash {
-    let actual = ${SelfName}(input)
-    _blackHole(actual)
-  }
-}
-
-${test_suite}.test("From${FloatName}(${nonFinite})_AlwaysFails") {
-  let input = get${FloatName}(${nonFinite})
-  let actual = ${SelfName}(exactly: input)
-  expectNil(actual)
-}
-
-%       end # for nonFinite in ...
-%
-%       if FloatName == 'Float16':
+%       if OtherName == 'Float16':
 }
 #endif // Float16
 
-%       elif FloatName == 'Float80':
+%       elif OtherName == 'Float80':
 %
 #endif // Float80
 
 %       end # if
-%     end # for float_type in ...
+%
+%     end # for otherType in ...
 %
 runAllTests()
 
-%   end # for self_type in ...
-% end # for (configuration, ptrsize) in ...
+%   end # for selfType in ...
+%
+% end # for (configuration, bitWidth) in ...


### PR DESCRIPTION
Follow-up to: apple/swift#36205

* Added python3 compatibility.
* Added `.forEach` parameterized code.
* Removed `long_test` requirements.
* Tested on macOS and watchOS simulator.

```shell
utils/run-test \
  --build-dir ../build/Ninja-RelWithDebInfoAssert \
  --subset all \
  --target macosx-x86_64 \
  --verbose \
  validation-test/stdlib/FixedPointConversion/*.swift

********************

Testing Time: 16.77s (old), 13.82s (new)
  Unsupported: 20
  Passed     : 20
```

```shell
utils/run-test \
  --build-dir ../build/Ninja-RelWithDebInfoAssert \
  --subset all \
  --target watchsimulator-i386 \
  --verbose \
  validation-test/stdlib/FixedPointConversion/*.swift

********************

Testing Time: 60.25s (old), 14.37s (new)
  Unsupported: 20
  Passed     : 20
```