### PR TITLE
Change the async ABI to not pass the active task and executor

### DIFF
--- a/include/swift/ABI/Executor.h
+++ b/include/swift/ABI/Executor.h
@@ -114,11 +114,11 @@ public:
 
 using JobInvokeFunction =
   SWIFT_CC(swiftasync)
-  void (Job *, ExecutorRef);
+  void (Job *);
 
 using TaskContinuationFunction =
   SWIFT_CC(swiftasync)
-  void (AsyncTask *, ExecutorRef, SWIFT_ASYNC_CONTEXT AsyncContext *);
+  void (SWIFT_ASYNC_CONTEXT AsyncContext *);
 
 template <class AsyncSignature>
 class AsyncFunctionPointer;

--- a/include/swift/ABI/TaskGroup.h
+++ b/include/swift/ABI/TaskGroup.h
@@ -38,7 +38,7 @@ public:
   void *PrivateData[NumWords_TaskGroup];
 
   /// Upon a future task's completion, offer it to the task group it belongs to.
-  void offer(AsyncTask *completed, AsyncContext *context, ExecutorRef executor);
+  void offer(AsyncTask *completed, AsyncContext *context);
 };
 
 } // end namespace swift

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1478,20 +1478,28 @@ FUNCTION(GetTypeByMangledNameInContextInMetadataState,
               Int8PtrPtrTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
-// void *swift_task_alloc(AsyncTask *task, size_t size);
+// AsyncTask *swift_task_getCurrent();s
+FUNCTION(GetCurrentTask,
+         swift_task_getCurrent, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(SwiftTaskPtrTy),
+         ARGS(),
+         ATTRS(NoUnwind, ReadNone))
+
+// void *swift_task_alloc(size_t size);
 FUNCTION(TaskAlloc,
          swift_task_alloc, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(Int8PtrTy),
-         ARGS(SwiftTaskPtrTy, SizeTy),
+         ARGS(SizeTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
-// void swift_task_dealloc(AsyncTask *task, void *ptr);
+// void swift_task_dealloc(void *ptr);
 FUNCTION(TaskDealloc,
          swift_task_dealloc, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(VoidTy),
-         ARGS(SwiftTaskPtrTy, Int8PtrTy),
+         ARGS(Int8PtrTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
 // void swift_task_cancel(AsyncTask *task);
@@ -1503,74 +1511,74 @@ FUNCTION(TaskCancel,
          ATTRS(NoUnwind, ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create_f(
-//     size_t flags, AsyncTask *task,
+//     size_t flags,
 //     TaskContinuationFunction* function,
 //     size_t contextSize);
 FUNCTION(TaskCreateFunc,
          swift_task_create_f, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(AsyncTaskAndContextTy),
-         ARGS(SizeTy, SwiftTaskPtrTy, TaskContinuationFunctionPtrTy, SizeTy),
+         ARGS(SizeTy, TaskContinuationFunctionPtrTy, SizeTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create_future(
-//     size_t flags, AsyncTask *task,
+//     size_t flags,
 //     const Metadata *futureResultType,
 //     void *closureEntry, HeapObject *closureContext);
 FUNCTION(TaskCreateFuture,
          swift_task_create_future, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(AsyncTaskAndContextTy),
-         ARGS(SizeTy, SwiftTaskPtrTy, TypeMetadataPtrTy,
+         ARGS(SizeTy, TypeMetadataPtrTy,
               Int8PtrTy, RefCountedPtrTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create_future_f(
-//     size_t flags, AsyncTask *task,
+//     size_t flags,
 //     const Metadata *futureResultType,
 //     TaskContinuationFunction *function, size_t contextSize);
 FUNCTION(TaskCreateFutureFunc,
          swift_task_create_future_f, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(AsyncTaskAndContextTy),
-         ARGS(SizeTy, SwiftTaskPtrTy, TypeMetadataPtrTy,
+         ARGS(SizeTy, TypeMetadataPtrTy,
               TaskContinuationFunctionPtrTy, SizeTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create_group_future(
-//     size_t flags, AsyncTask *task, TaskGroup *group,
+//     size_t flags, TaskGroup *group,
 //     const Metadata *futureResultType,
 //     void *closureEntry, HeapObject *closureContext);
 FUNCTION(TaskCreateGroupFuture,
          swift_task_create_group_future, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(AsyncTaskAndContextTy),
-         ARGS(SizeTy, SwiftTaskPtrTy, SwiftTaskGroupPtrTy,
+         ARGS(SizeTy, SwiftTaskGroupPtrTy,
               TypeMetadataPtrTy,
               Int8PtrTy, RefCountedPtrTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create_group_future_f(
-//     size_t flags, AsyncTask *task, TaskGroup *group,
+//     size_t flags, TaskGroup *group,
 //     const Metadata *futureResultType,
 //     TaskContinuationFunction *function, size_t contextSize);
 FUNCTION(TaskCreateGroupFutureFunc,
          swift_task_create_group_future_f, SwiftCC,
          ConcurrencyAvailability,
          RETURNS(AsyncTaskAndContextTy),
-         ARGS(SizeTy, SwiftTaskPtrTy, SwiftTaskGroupPtrTy,
+         ARGS(SizeTy, SwiftTaskGroupPtrTy,
               TypeMetadataPtrTy,
               TaskContinuationFunctionPtrTy, SizeTy),
          ATTRS(NoUnwind, ArgMemOnly))
 
-// void swift_task_switch(AsyncTask *task,
-//                        ExecutorRef currentExecutor,
+// void swift_task_switch(AsyncContext *resumeContext,
+//                        TaskContinuationFunction *resumeFunction,
 //                        ExecutorRef newExecutor);
 FUNCTION(TaskSwitchFunc,
          swift_task_switch, SwiftAsyncCC,
          ConcurrencyAvailability,
          RETURNS(VoidTy),
-         ARGS(SwiftTaskPtrTy, SwiftExecutorPtrTy, SwiftExecutorPtrTy),
+         ARGS(SwiftContextPtrTy, Int8PtrTy, SwiftExecutorPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_defaultActor_initialize(DefaultActor *actor);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1361,8 +1361,6 @@ static ValueDecl *getCreateAsyncTaskFuture(ASTContext &ctx, Identifier id) {
   auto genericParam = makeGenericParam().build(builder);
   builder.addParameter(
       makeConcrete(ctx.getIntDecl()->getDeclaredInterfaceType()));
-  builder.addParameter(
-      makeConcrete(OptionalType::get(ctx.TheNativeObjectType)));
   auto extInfo = ASTExtInfoBuilder().withAsync().withThrows().build();
   builder.addParameter(
      makeConcrete(FunctionType::get({ }, genericParam, extInfo)));
@@ -1375,8 +1373,6 @@ static ValueDecl *getCreateAsyncTaskGroupFuture(ASTContext &ctx, Identifier id) 
   auto genericParam = makeGenericParam().build(builder);
   builder.addParameter(
       makeConcrete(ctx.getIntDecl()->getDeclaredInterfaceType())); // flags
-  builder.addParameter(
-      makeConcrete(OptionalType::get(ctx.TheNativeObjectType))); // parent
   builder.addParameter(
       makeConcrete(OptionalType::get(ctx.TheRawPointerType))); // group
   auto extInfo = ASTExtInfoBuilder().withAsync().withThrows().build();

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -230,7 +230,6 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
       Builtin.ID == BuiltinValueKind::CreateAsyncTaskGroupFuture) {
 
     auto flags = args.claimNext();
-    auto parentTask = args.claimNext();
     auto taskGroup =
         (Builtin.ID == BuiltinValueKind::CreateAsyncTaskGroupFuture)
         ? args.claimNext()
@@ -244,7 +243,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     auto taskContext = args.claimNext();
 
     auto newTaskAndContext = emitTaskCreate(
-        IGF, flags, parentTask, taskGroup, futureResultType, taskFunction, taskContext,
+        IGF, flags, taskGroup, futureResultType, taskFunction, taskContext,
         substitutions);
 
     // Cast back to NativeObject/RawPointer.

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -409,7 +409,7 @@ namespace irgen {
   /// a future.
   llvm::Value *emitTaskCreate(
     IRGenFunction &IGF, llvm::Value *flags,
-    llvm::Value *parentTask, llvm::Value *taskGroup,
+    llvm::Value *taskGroup,
     llvm::Value *futureResultType,
     llvm::Value *taskFunction, llvm::Value *localContextInfo,
     SubstitutionMap subs);
@@ -431,9 +431,7 @@ namespace irgen {
                          Explosion &yieldedValues);
 
   enum class AsyncFunctionArgumentIndex : unsigned {
-    Task = 0,
-    Executor = 1,
-    Context = 2,
+    Context = 0,
   };
 
   void emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &layout,

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -494,7 +494,7 @@ void IRGenFunction::emitTrap(StringRef failureMessage, bool EmitUnreachable) {
 }
 
 Address IRGenFunction::emitTaskAlloc(llvm::Value *size, Alignment alignment) {
-  auto *call = Builder.CreateCall(IGM.getTaskAllocFn(), {getAsyncTask(), size});
+  auto *call = Builder.CreateCall(IGM.getTaskAllocFn(), {size});
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
   auto address = Address(call, alignment);
@@ -503,7 +503,7 @@ Address IRGenFunction::emitTaskAlloc(llvm::Value *size, Alignment alignment) {
 
 void IRGenFunction::emitTaskDealloc(Address address) {
   auto *call = Builder.CreateCall(IGM.getTaskDeallocFn(),
-                                  {getAsyncTask(), address.getAddress()});
+                                  {address.getAddress()});
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
 }
@@ -528,8 +528,7 @@ void IRGenFunction::emitGetAsyncContinuation(SILType resumeTy,
                                              StackAddress resultAddr,
                                              Explosion &out) {
   // Create the continuation.
-  // void current_sil_function(AsyncTask *currTask, Executor *currExecutor,
-  //                           AsyncContext *currCtxt) {
+  // void current_sil_function(AsyncContext *currCtxt) {
   //
   // A continuation is the current AsyncTask 'currTask' with:
   //   currTask->ResumeTask = @llvm.coro.async.resume();
@@ -555,7 +554,7 @@ void IRGenFunction::emitGetAsyncContinuation(SILType resumeTy,
 
   // Create and setup the continuation context.
   // continuation_context.resumeCtxt = currCtxt;
-  // continuation_context.errResult = nulllptr;
+  // continuation_context.errResult = nullptr;
   // continuation_context.result = ... // local alloca T
   auto pointerAlignment = IGM.getPointerAlignment();
   auto continuationContext =
@@ -594,14 +593,8 @@ void IRGenFunction::emitGetAsyncContinuation(SILType resumeTy,
                             contResultAddr->getType()->getPointerElementType()),
                         Address(contResultAddr, pointerAlignment));
   }
-  // continuation_context.resumeExecutor = // current executor
-  auto contExecutorRefAddr =
-      Builder.CreateStructGEP(continuationContext.getAddress(), 4);
-  Builder.CreateStore(
-      Builder.CreateBitOrPointerCast(
-          getAsyncExecutor(),
-          contExecutorRefAddr->getType()->getPointerElementType()),
-      Address(contExecutorRefAddr, pointerAlignment));
+  // FIXME: 
+  //   continuation_context.resumeExecutor = // current executor
 
   // Fill the current task (i.e the continuation) with the continuation
   // information.
@@ -687,7 +680,7 @@ void IRGenFunction::emitAwaitAsyncContinuation(
   {
     // Setup the suspend point.
     SmallVector<llvm::Value *, 8> arguments;
-    arguments.push_back(IGM.getInt32(2)); // swiftasync context index
+    arguments.push_back(IGM.getInt32(0)); // swiftasync context index
     arguments.push_back(AsyncCoroutineCurrentResume);
     auto resumeProjFn = getOrCreateResumePrjFn();
     arguments.push_back(
@@ -696,14 +689,9 @@ void IRGenFunction::emitAwaitAsyncContinuation(
     auto resumeFnPtr =
         getFunctionPointerForResumeIntrinsic(AsyncCoroutineCurrentResume);
     arguments.push_back(Builder.CreateBitOrPointerCast(
-        createAsyncDispatchFn(resumeFnPtr,
-                              {IGM.Int8PtrTy, IGM.Int8PtrTy, IGM.Int8PtrTy}),
+        createAsyncDispatchFn(resumeFnPtr, {IGM.Int8PtrTy}),
         IGM.Int8PtrTy));
     arguments.push_back(AsyncCoroutineCurrentResume);
-    arguments.push_back(
-        Builder.CreateBitOrPointerCast(getAsyncTask(), IGM.Int8PtrTy));
-    arguments.push_back(
-        Builder.CreateBitOrPointerCast(getAsyncExecutor(), IGM.Int8PtrTy));
     arguments.push_back(Builder.CreateBitOrPointerCast(
         AsyncCoroutineCurrentContinuationContext, IGM.Int8PtrTy));
     emitSuspendAsyncCall(arguments);

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -133,7 +133,6 @@ public:
   }
 
   llvm::Value *getAsyncTask();
-  llvm::Value *getAsyncExecutor();
   llvm::Value *getAsyncContext();
 
   llvm::CallInst *emitSuspendAsyncCall(ArrayRef<llvm::Value *> args);
@@ -175,8 +174,6 @@ private:
   llvm::Value *AsyncCoroutineCurrentResume = nullptr;
   llvm::Value *AsyncCoroutineCurrentContinuationContext = nullptr;
 
-  Address asyncTaskLocation;
-  Address asyncExecutorLocation;
   Address asyncContextLocation;
 
   /// The unique block that calls @llvm.coro.end.
@@ -198,7 +195,7 @@ public:
   }
 
   void setupAsync();
-  bool isAsync() const { return asyncTaskLocation.isValid(); }
+  bool isAsync() const { return asyncContextLocation.isValid(); }
 
   Address createAlloca(llvm::Type *ty, Alignment align,
                        const llvm::Twine &name = "");

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -634,8 +634,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   //   SWIFT_CC(swift)
   //   void (AsyncTask *, ExecutorRef, AsyncContext *);
   TaskContinuationFunctionTy = llvm::FunctionType::get(
-      VoidTy, {SwiftTaskPtrTy, SwiftExecutorPtrTy, SwiftContextPtrTy},
-      /*isVarArg*/ false);
+      VoidTy, {SwiftContextPtrTy}, /*isVarArg*/ false);
   TaskContinuationFunctionPtrTy = TaskContinuationFunctionTy->getPointerTo();
 
   AsyncTaskAndContextTy = createStructType(

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1512,8 +1512,6 @@ public:
 class AsyncNativeCCEntryPointArgumentEmission final
     : public NativeCCEntryPointArgumentEmission,
       public AsyncEntryPointArgumentEmission {
-  llvm::Value *task;
-  llvm::Value *executor;
   llvm::Value *context;
   /*const*/ AsyncContextLayout layout;
   const Address dataAddr;
@@ -1536,7 +1534,6 @@ public:
                                           SILBasicBlock &entry,
                                           Explosion &allParamValues)
       : AsyncEntryPointArgumentEmission(IGF, entry, allParamValues),
-        task(allParamValues.claimNext()), executor(allParamValues.claimNext()),
         context(allParamValues.claimNext()), layout(getAsyncContextLayout(IGF)),
         dataAddr(layout.emitCastTo(IGF, context)){};
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -751,7 +751,7 @@ OperandOwnership
 OperandOwnershipBuiltinClassifier::visitCreateAsyncTaskFuture(BuiltinInst *bi,
                                                               StringRef attr) {
   // The function operand is consumed by the new task.
-  if (&op == &bi->getOperandRef(3))
+  if (&op == &bi->getOperandRef(2))
     return OperandOwnership::DestroyingConsume;
   
   // FIXME: These are considered InteriorPointer because they may propagate a
@@ -765,7 +765,7 @@ OperandOwnership
 OperandOwnershipBuiltinClassifier::visitCreateAsyncTaskGroupFuture(BuiltinInst *bi,
                                                                    StringRef attr) {
   // The function operand is consumed by the new task.
-  if (&op == &bi->getOperandRef(4))
+  if (&op == &bi->getOperandRef(3))
     return OperandOwnership::DestroyingConsume;
   
   // FIXME: These are considered InteriorPointer because they may propagate a

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1393,7 +1393,6 @@ static ManagedValue emitBuiltinCreateAsyncTaskFuture(
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto flags = args[0].forward(SGF);
-  auto parentTask = args[1].borrow(SGF, loc).forward(SGF);
 
   // Form the metatype of the result type.
   CanType futureResultType =
@@ -1429,7 +1428,7 @@ static ManagedValue emitBuiltinCreateAsyncTaskFuture(
   AbstractionPattern origParam(genericSig, functionTy);
   CanType substParamType = functionTy.subst(subs)->getCanonicalType();
   auto reabstractedFun =
-      SGF.emitSubstToOrigValue(loc, args[2], origParam, substParamType);
+      SGF.emitSubstToOrigValue(loc, args[1], origParam, substParamType);
 
   auto function = emitFunctionArgumentForAsyncTaskEntryPoint(
       SGF, loc, reabstractedFun, futureResultType);
@@ -1439,7 +1438,7 @@ static ManagedValue emitBuiltinCreateAsyncTaskFuture(
       ctx.getIdentifier(
           getBuiltinName(BuiltinValueKind::CreateAsyncTaskFuture)),
       SGF.getLoweredType(getAsyncTaskAndContextType(ctx)), subs,
-      { flags, parentTask, futureResultMetadata, function.forward(SGF) });
+      { flags, futureResultMetadata, function.forward(SGF) });
   return SGF.emitManagedRValueWithCleanup(apply);
 }
 
@@ -1449,8 +1448,7 @@ static ManagedValue emitBuiltinCreateAsyncTaskGroupFuture(
     ArrayRef<ManagedValue> args, SGFContext C) {
   ASTContext &ctx = SGF.getASTContext();
   auto flags = args[0].forward(SGF);
-  auto parentTask = args[1].borrow(SGF, loc).forward(SGF);
-  auto group = args[2].borrow(SGF, loc).forward(SGF);
+  auto group = args[1].borrow(SGF, loc).forward(SGF);
 
   // Form the metatype of the result type.
   CanType futureResultType =
@@ -1468,14 +1466,14 @@ static ManagedValue emitBuiltinCreateAsyncTaskGroupFuture(
       SGF.B.createMetatype(loc, SGF.getLoweredType(futureResultType)));
   }).borrow(SGF, loc).forward(SGF);
 
-  auto function = emitFunctionArgumentForAsyncTaskEntryPoint(SGF, loc, args[3],
+  auto function = emitFunctionArgumentForAsyncTaskEntryPoint(SGF, loc, args[2],
                                                              futureResultType);
   auto apply = SGF.B.createBuiltin(
       loc,
       ctx.getIdentifier(
           getBuiltinName(BuiltinValueKind::CreateAsyncTaskGroupFuture)),
       SGF.getLoweredType(getAsyncTaskAndContextType(ctx)), subs,
-      { flags, parentTask, group, futureResultMetadata, function.forward(SGF) });
+      { flags, group, futureResultMetadata, function.forward(SGF) });
   return SGF.emitManagedRValueWithCleanup(apply);
 }
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -110,6 +110,12 @@ public:
     return ActiveExecutor;
   }
 
+  static ExecutorRef getActiveExecutorInThread() {
+    if (auto activeInfo = ActiveInfoInThread.get())
+      return activeInfo->getActiveExecutor();
+    return ExecutorRef::generic();
+  }
+
   void leave() {
     ActiveInfoInThread.set(SavedInfo);
   }
@@ -139,12 +145,12 @@ void swift::swift_job_run(Job *job, ExecutorRef executor) {
   ExecutorTrackingInfo trackingInfo;
   trackingInfo.enterAndShadow(executor);
 
-  runJobInExecutorContext(job, executor);
+  runJobInEstablishedExecutorContext(job);
 
   trackingInfo.leave();
 }
 
-void swift::runJobInExecutorContext(Job *job, ExecutorRef executor) {
+void swift::runJobInEstablishedExecutorContext(Job *job) {
   _swift_tsan_acquire(job);
 
   if (auto task = dyn_cast<AsyncTask>(job)) {
@@ -156,13 +162,13 @@ void swift::runJobInExecutorContext(Job *job, ExecutorRef executor) {
     // on an actor, it should update the task status appropriately;
     // we don't need to update it afterwards.
 
-    task->runInFullyEstablishedContext(executor);
+    task->runInFullyEstablishedContext();
 
     // Clear the active task.
     ActiveTask::set(nullptr);
   } else {
     // There's no extra bookkeeping to do for simple jobs.
-    job->runSimpleInFullyEstablishedContext(executor);
+    job->runSimpleInFullyEstablishedContext();
   }
 
   _swift_tsan_release(job);
@@ -172,9 +178,16 @@ AsyncTask *swift::swift_task_getCurrent() {
   return ActiveTask::get();
 }
 
-void swift::_swift_task_clearCurrent() {
+AsyncTask *swift::_swift_task_clearCurrent() {
+  auto task = ActiveTask::get();
   ActiveTask::set(nullptr);
+  return task;
 }
+
+ExecutorRef swift::swift_task_getCurrentExecutor() {
+  return ExecutorTrackingInfo::getActiveExecutorInThread();
+}
+
 
 /*****************************************************************************/
 /*********************** DEFAULT ACTOR IMPLEMENTATION ************************/
@@ -191,7 +204,7 @@ public:
     : Job({JobKind::DefaultActorInline, priority}, &process) {}
 
   SWIFT_CC(swiftasync)
-  static void process(Job *job, ExecutorRef executor);
+  static void process(Job *job);
 
   static bool classof(const Job *job) {
     return job->Flags.getKind() == JobKind::DefaultActorInline;
@@ -208,7 +221,7 @@ public:
       Actor(actor) {}
 
   SWIFT_CC(swiftasync)
-  static void process(Job *job, ExecutorRef executor);
+  static void process(Job *job);
 
   static bool classof(const Job *job) {
     return job->Flags.getKind() == JobKind::DefaultActorSeparate;
@@ -664,7 +677,7 @@ public:
   }
 
   SWIFT_CC(swiftasync)
-  static void process(Job *job, ExecutorRef _executor);
+  static void process(Job *job);
 
   static bool classof(const Job *job) {
     return job->Flags.getKind() == JobKind::DefaultActorOverride;
@@ -1133,8 +1146,7 @@ static void processDefaultActor(DefaultActorImpl *currentActor,
     }
 
     // Run the job.
-    auto executor = ExecutorRef::forDefaultActor(asAbstract(currentActor));
-    runJobInExecutorContext(job, executor);
+    runJobInEstablishedExecutorContext(job);
 
     // The current actor may have changed after the job.
     // If it's become nil, or not a default actor, we have nothing to do.
@@ -1157,7 +1169,7 @@ static void processDefaultActor(DefaultActorImpl *currentActor,
   swift_release(actor);
 }
 
-void ProcessInlineJob::process(Job *job, ExecutorRef _executor) {
+void ProcessInlineJob::process(Job *job) {
   DefaultActorImpl *actor = DefaultActorImpl::fromInlineJob(job);
 
   // Pull the priority out of the job before we do anything that might
@@ -1170,7 +1182,7 @@ void ProcessInlineJob::process(Job *job, ExecutorRef _executor) {
   return processDefaultActor(actor, runner);
 }
 
-void ProcessOutOfLineJob::process(Job *job, ExecutorRef _executor) {
+void ProcessOutOfLineJob::process(Job *job) {
   auto self = cast<ProcessOutOfLineJob>(job);
   DefaultActorImpl *actor = self->Actor;
 
@@ -1186,7 +1198,7 @@ void ProcessOutOfLineJob::process(Job *job, ExecutorRef _executor) {
   return processDefaultActor(actor, runner);
 }
 
-void ProcessOverrideJob::process(Job *job, ExecutorRef _executor) {
+void ProcessOverrideJob::process(Job *job) {
   auto self = cast<ProcessOverrideJob>(job);
 
   // Pull the actor and priority out of the job.
@@ -1382,11 +1394,11 @@ static void runOnAssumedThread(AsyncTask *task, ExecutorRef executor,
   // want these frames to potentially accumulate linearly.
   if (activeTrackingInfo != &trackingInfo) {
     // FIXME: force tail call
-    return task->runInFullyEstablishedContext(executor);
+    return task->runInFullyEstablishedContext();
   }
 
   // Otherwise, run the new task.
-  task->runInFullyEstablishedContext(executor);
+  task->runInFullyEstablishedContext();
 
   // Leave the tracking frame, and give up the current actor if
   // we have one.
@@ -1402,16 +1414,26 @@ static void runOnAssumedThread(AsyncTask *task, ExecutorRef executor,
 }
 
 SWIFT_CC(swiftasync)
-void swift::swift_task_switch(AsyncTask *task, ExecutorRef currentExecutor,
+void swift::swift_task_switch(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContext,
+                              TaskContinuationFunction *resumeFunction,
                               ExecutorRef newExecutor) {
-  assert(task && "no task provided");
+  auto currentExecutor = ExecutorTrackingInfo::getActiveExecutorInThread();
 
   // If the current executor is compatible with running the new executor,
-  // just continue running.
+  // we can just immediately continue running with the resume function
+  // we were passed in.
   if (!currentExecutor.mustSwitchToRun(newExecutor)) {
     // FIXME: force tail call
-    return task->runInFullyEstablishedContext(currentExecutor);
+    return resumeFunction(resumeContext);
   }
+
+  auto task = swift_task_getCurrent();
+  assert(task && "no current task!");
+
+  // Park the task for simplicity instead of trying to thread the
+  // initial resumption information into everything below.
+  task->ResumeContext = resumeContext;
+  task->ResumeTask = resumeFunction;
 
   // Okay, we semantically need to switch.
   auto runner = RunningJobInfo::forOther(task->getPriority());

--- a/stdlib/public/Concurrency/AsyncCall.h
+++ b/stdlib/public/Concurrency/AsyncCall.h
@@ -104,11 +104,10 @@ struct AsyncFrameStorage<AsyncSignature<ResultTy(ArgTys...),
 
   AsyncFrameStorage(AsyncContextFlags flags,
                     TaskContinuationFunction *resumeFunction,
-                    ExecutorRef resumeToExecutor,
                     AsyncContext *resumeToContext,
                     ArgTys... args)
       : AsyncFrameStorageHelper<FrameLayout::BasicLayout::size>(
-          flags, resumeFunction, resumeToExecutor, resumeToContext) {
+          flags, resumeFunction, resumeToContext) {
     initializeHelper<FrameLayout::firstArgIndex>(this->data(), args...);
   }
 
@@ -135,11 +134,10 @@ struct AsyncCalleeContext : AsyncFrameStorage<CalleeSignature> {
 
   template <class... Args>
   AsyncCalleeContext(TaskContinuationFunction *resumeFunction,
-                     ExecutorRef resumeToExecutor,
                      CallerContext *resumeToContext,
                      Args... args)
     : AsyncFrameStorage<CalleeSignature>(AsyncContextKind::Ordinary,
-                                         resumeFunction, resumeToExecutor,
+                                         resumeFunction,
                                          resumeToContext, args...) {}
 
   CallerContext *getParent() const {
@@ -150,33 +148,30 @@ struct AsyncCalleeContext : AsyncFrameStorage<CalleeSignature> {
 /// Push a context to call a function.
 template <class CalleeSignature, class CallerContext, class... Args>
 static AsyncCalleeContext<CallerContext, CalleeSignature> *
-pushAsyncContext(AsyncTask *task, ExecutorRef executor,
-                 CallerContext *callerContext, size_t calleeContextSize,
+pushAsyncContext(CallerContext *callerContext, size_t calleeContextSize,
                  TaskContinuationFunction *resumeFunction,
                  Args... args) {
   using CalleeContext =
     AsyncCalleeContext<CallerContext, CalleeSignature>;
   assert(calleeContextSize >= sizeof(CalleeContext));
 
-  void *rawCalleeContext = swift_task_alloc(task, calleeContextSize);
-  return new (rawCalleeContext) CalleeContext(resumeFunction, executor,
+  void *rawCalleeContext = swift_task_alloc(calleeContextSize);
+  return new (rawCalleeContext) CalleeContext(resumeFunction,
                                               callerContext, args...);
 }
 
 /// Make an asynchronous call.
 template <class CalleeSignature, class CallerContext, class... Args>
 SWIFT_CC(swiftasync)
-static void callAsync(AsyncTask *task,
-                      ExecutorRef executor,
-                      CallerContext *callerContext,
+static void callAsync(CallerContext *callerContext,
                       TaskContinuationFunction *resumeFunction,
                 const typename CalleeSignature::FunctionPointer *function,
                       Args... args) {
   auto calleeContextSize = function->ExpectedContextSize;
-  auto calleeContext = pushAsyncContext(task, executor, callerContext,
+  auto calleeContext = pushAsyncContext(callerContext,
                                         calleeContextSize, resumeFunction,
                                         args...);
-  return function->Function(task, executor, calleeContext);
+  return function->Function(calleeContext);
 }
 
 /// Given that that we've just entered the caller's continuation function
@@ -184,9 +179,9 @@ static void callAsync(AsyncTask *task,
 /// callee's context and return the caller's context.
 template <class CalleeContext>
 static typename CalleeContext::CallerContext *
-popAsyncContext(AsyncTask *task, CalleeContext *calleeContext) {
+popAsyncContext(CalleeContext *calleeContext) {
   auto callerContext = calleeContext->getParent();
-  swift_task_dealloc(task, calleeContext);
+  swift_task_dealloc(calleeContext);
   return callerContext;
 }
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -402,7 +402,7 @@ extension Task {
     flags.isFuture = true
 
     // Create the asynchronous task future.
-    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, nil, operation)
+    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, operation)
 
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(task))
@@ -454,7 +454,7 @@ extension Task {
     flags.isFuture = true
 
     // Create the asynchronous task future.
-    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, nil, operation)
+    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, operation)
 
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(task))
@@ -487,7 +487,7 @@ extension Task {
     flags.isFuture = true
 
     // Create the asynchronous task future.
-    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, nil, {})
+    let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, {})
 
     // Enqueue the resulting job.
     _enqueueJobGlobalWithDelay(duration, Builtin.convertTaskToJob(task))
@@ -657,7 +657,7 @@ public func _runChildTask<T>(
 
   // Create the asynchronous task future.
   let (task, _) = Builtin.createAsyncTaskFuture(
-      flags.bits, currentTask, operation)
+      flags.bits, operation)
 
   // Enqueue the resulting job.
   _enqueueJobGlobal(Builtin.convertTaskToJob(task))

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -66,10 +66,18 @@ void swift::_swift_task_alloc_destroy(AsyncTask *task) {
   allocator(task).~TaskAllocator();
 }
 
-void *swift::swift_task_alloc(AsyncTask *task, size_t size) {
+void *swift::swift_task_alloc(size_t size) {
+  return allocator(swift_task_getCurrent()).alloc(size);
+}
+
+void *swift::_swift_task_alloc_specific(AsyncTask *task, size_t size) {
   return allocator(task).alloc(size);
 }
 
-void swift::swift_task_dealloc(AsyncTask *task, void *ptr) {
+void swift::swift_task_dealloc(void *ptr) {
+  allocator(swift_task_getCurrent()).dealloc(ptr);
+}
+
+void swift::_swift_task_dealloc_specific(AsyncTask *task, void *ptr) {
   allocator(task).dealloc(ptr);
 }

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -78,8 +78,8 @@ extension Task {
       return try await operation()
     }
 
-    let record = _taskAddCancellationHandler(task: task, handler: handler)
-    defer { _taskRemoveCancellationHandler(task: task, record: record) }
+    let record = _taskAddCancellationHandler(handler: handler)
+    defer { _taskRemoveCancellationHandler(record: record) }
 
     return try await operation()
   }
@@ -96,13 +96,9 @@ extension Task {
 }
 
 @_silgen_name("swift_task_addCancellationHandler")
-func _taskAddCancellationHandler(
-  task: Builtin.NativeObject,
-  handler: @concurrent () -> ()
-) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
+func _taskAddCancellationHandler(handler: @concurrent () -> ()) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
 
 @_silgen_name("swift_task_removeCancellationHandler")
 func _taskRemoveCancellationHandler(
-  task: Builtin.NativeObject,
   record: UnsafeRawPointer /*CancellationNotificationStatusRecord*/
 )

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -14,6 +14,7 @@
 #include "swift/Runtime/Concurrency.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/Metadata.h"
+#include "TaskPrivate.h"
 
 using namespace swift;
 
@@ -51,7 +52,7 @@ TaskLocal::Item*
 TaskLocal::Item::createParentLink(AsyncTask *task, AsyncTask *parent) {
   size_t amountToAllocate = Item::itemSize(/*valueType*/nullptr);
   // assert(amountToAllocate % MaximumAlignment == 0); // TODO: do we need this?
-  void *allocation = swift_task_alloc(task, amountToAllocate);
+  void *allocation = _swift_task_alloc_specific(task, amountToAllocate);
   Item *item = new(allocation) Item();
 
   auto parentHead = parent->Local.head;
@@ -95,7 +96,7 @@ TaskLocal::Item::createLink(AsyncTask *task,
   assert(task);
   size_t amountToAllocate = Item::itemSize(valueType);
   // assert(amountToAllocate % MaximumAlignment == 0); // TODO: do we need this?
-  void *allocation = swift_task_alloc(task, amountToAllocate);
+  void *allocation = _swift_task_alloc_specific(task, amountToAllocate);
   Item *item = new(allocation) Item(keyType, valueType);
 
   auto next = task->Local.head;
@@ -115,7 +116,7 @@ void TaskLocal::Item::destroy(AsyncTask *task) {
     valueType->vw_destroy(getStoragePtr());
   }
 
-  swift_task_dealloc(task, this);
+  _swift_task_dealloc_specific(task, this);
 }
 
 void TaskLocal::Storage::destroy(AsyncTask *task) {

--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -10,21 +10,21 @@ func forceSplit() async {
 func withGenericArg<T>(_ msg: T) async {
   // This odd debug info is part of a contract with CoroSplit/CoroFrame to fix
   // this up after coroutine splitting.
-  // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYlF"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %2,
+  // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYlF"(%swift.context* swiftasync %0)
+  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %0,
   // CHECK-SAME:   metadata ![[MSG:[0-9]+]], metadata !DIExpression(
   // CHECK-SAME:     DW_OP_plus_uconst, {{[0-9]+}}, DW_OP_deref))
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %2,
+  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %0,
   // CHECK-SAME:   metadata ![[TAU:[0-9]+]], metadata !DIExpression(
   // CHECK-SAME:     DW_OP_plus_uconst, {{[0-9]+}}))
 
   await forceSplit()
-  // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYlF.resume.0"(i8* %0, i8* %1, i8* swiftasync %2)
-  // CHECK: call void @llvm.dbg.declare(metadata i8* %2,
+  // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYlF.resume.0"(i8* swiftasync %0)
+  // CHECK: call void @llvm.dbg.declare(metadata i8* %0,
   // CHECK-SAME:   metadata ![[TAU_R:[0-9]+]], metadata !DIExpression(
   // CHECK-SAME:     DW_OP_plus_uconst, [[OFFSET:[0-9]+]],
   // CHECK-SAME:     DW_OP_plus_uconst, {{[0-9]+}}))
-  // CHECK: call void @llvm.dbg.declare(metadata i8* %2,
+  // CHECK: call void @llvm.dbg.declare(metadata i8* %0,
   // CHECK-SAME:   metadata ![[MSG_R:[0-9]+]], metadata !DIExpression(
   // CHECK-SAME:     DW_OP_plus_uconst, [[OFFSET]],
   // CHECK-SAME:     DW_OP_plus_uconst, {{[0-9]+}}, DW_OP_deref))

--- a/test/DebugInfo/async-direct-arg.swift
+++ b/test/DebugInfo/async-direct-arg.swift
@@ -11,9 +11,9 @@
 // CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.0"
 // CHECK: call void @llvm.dbg.declare
 // CHECK: call void @llvm.dbg.declare
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[X0:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[X0:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-LABEL: define {{.*}} void @"$s1a3fibyS2iYF.resume.1"
-// FIXME: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[X1:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// FIXME: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[X1:[0-9]+]], {{.*}}!DIExpression(DW_OP
 
 // CHECK: ![[X0]] = !DILocalVariable(name: "x"
 // FIXME: ![[X1]] = !DILocalVariable(name: "x"

--- a/test/DebugInfo/async-let-await.swift
+++ b/test/DebugInfo/async-let-await.swift
@@ -12,7 +12,7 @@ public func getVegetables() async -> [String] {
 public func chopVegetables() async throws -> [String] {
   let veggies = await getVegetables()
   // CHECK-NOT: {{^define }}
-  // CHECK:  call void @llvm.dbg.declare(metadata i8* %2, metadata ![[V:[0-9]+]], metadata !DIExpression(DW_OP_deref
+  // CHECK:  call void @llvm.dbg.declare(metadata i8* %0, metadata ![[V:[0-9]+]], metadata !DIExpression(DW_OP_deref
   // CHECK: ![[V]] = !DILocalVariable(name: "veggies"
   return veggies.map { "chopped \($0)" }
 }

--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -10,10 +10,10 @@
 
 // CHECK-LABEL: define {{.*}} void @"$s1a4fiboyS2iYF.resume.0"
 // CHECK-NEXT: entryresume.0:
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[RHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[LHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[RHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NOT: {{ ret }}
 // CHECK: call void asm sideeffect ""
 // CHECK: ![[RHS]] = !DILocalVariable(name: "rhs"

--- a/test/DebugInfo/async-local-var.swift
+++ b/test/DebugInfo/async-local-var.swift
@@ -17,7 +17,7 @@ public func makeDinner() async throws -> String {
 // CHECK-LABEL: define {{.*}} void @"$s1a10makeDinnerSSyYKF.resume.0"
 // CHECK-NEXT: entryresume.0:
 // CHECK-NOT: {{ ret }}
-// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%2, metadata ![[LOCAL:[0-9]+]], {{.*}}!DIExpression(DW_OP_deref
+// CHECK: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LOCAL:[0-9]+]], {{.*}}!DIExpression(DW_OP_deref
 // CHECK: ![[LOCAL]] = !DILocalVariable(name: "local"
   return local
 }

--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -16,8 +16,8 @@ public class SomeClass {}
 @_silgen_name("swift_task_future_wait")
 public func task_future_wait(_ task: __owned SomeClass) async throws -> Int
 
-// CHECK: define{{.*}} swift{{(tail)?}}cc void @"$s5async8testThisyyAA9SomeClassCnYF"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
-// CHECK-64: call swiftcc i8* @swift_task_alloc(%swift.task* %{{[0-9]+}}, i64 64)
+// CHECK: define{{.*}} swift{{(tail)?}}cc void @"$s5async8testThisyyAA9SomeClassCnYF"(%swift.context* swiftasync %0)
+// CHECK-64: call swiftcc i8* @swift_task_alloc(i64 64)
 // CHECK: {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_future_wait(
 public func testThis(_ task: __owned SomeClass) async {
   do {

--- a/test/IRGen/async/Inputs/class_open-1instance-void_to_void.swift
+++ b/test/IRGen/async/Inputs/class_open-1instance-void_to_void.swift
@@ -6,8 +6,8 @@ func printGeneric<T>(_ t: T) {
 // CHECK-LL: @"$s4main6call_fyyAA1CCYFTu" = {{(dllexport )?}}{{(protected )?}}global %swift.async_func_pointer 
 // CHECK-LL: @"$s4main1CC1fyyYFTu" = {{(dllexport )?}}{{(protected )?}}global %swift.async_func_pointer 
 
-// CHECK-LL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s4main6call_fyyAA1CCYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s4main1CC1fyyYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s4main6call_fyyAA1CCYF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s4main1CC1fyyYF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 public func call_f(_ c: C) async {
   print("entering call_f")
   await c.f()

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -8,12 +8,10 @@ sil_stage canonical
 import Builtin
 import Swift
 
-// CHECK-LABEL: define hidden swift{{(tail)?}}cc void @get_task(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
+// CHECK-LABEL: define hidden swift{{(tail)?}}cc void @get_task(%swift.context* swiftasync %0)
 sil hidden [ossa] @get_task : $@async @convention(thin) () -> @owned Builtin.NativeObject {
 bb0:
-  // CHECK: [[TASKLOC:%.*]] = alloca %swift.task*
-  // CHECK: store %swift.task* %0, %swift.task** [[TASKLOC]]
-  // CHECK: [[TASK:%.*]] = load %swift.task*, %swift.task** [[TASKLOC]]
+  // CHECK: [[TASK:%.*]] = call swiftcc %swift.task* @swift_task_getCurrent()
   // CHECK: [[TASKRC:%.*]] = bitcast %swift.task* [[TASK]] to %swift.refcounted*
   %0 = builtin "getCurrentAsyncTask"() : $Builtin.NativeObject
   // CHECK-NEXT: [[TASK_COPY:%.*]] = call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[TASKRC]])
@@ -33,42 +31,28 @@ bb0(%0 : @guaranteed $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_future
-sil hidden [ossa] @launch_future : $@convention(method) <T> (Int, Optional<Builtin.NativeObject>, @guaranteed @async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>, @in_guaranteed T) -> () {
-bb0(%0 : $Int, %1: @unowned $Optional<Builtin.NativeObject>, %2: @guaranteed $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>, %3: $*T):
-  %copy = copy_value %1 : $Optional<Builtin.NativeObject>
-  // CHECK-32: [[TEMP:%.*]] = inttoptr i32 %1 to %swift.refcounted*
-  // CHECK-64: [[TEMP:%.*]] = inttoptr i64 %1 to %swift.refcounted*
-  %4 = begin_borrow %copy : $Optional<Builtin.NativeObject>
-  %5 = copy_value %2 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>
-  // CHECK: call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[TEMP]])
-  // CHECK: call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[FN_CONTEXT:%.*]])
+sil hidden [ossa] @launch_future : $@convention(method) <T> (Int, @guaranteed @async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>, @in_guaranteed T) -> () {
+bb0(%0 : $Int, %1: @guaranteed $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>, %3: $*T):
+  %5 = copy_value %1 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>
+  // CHECK: call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[FN_CONTEXT:%2]])
   %9 = metatype $@thick T.Type
   %10 = init_existential_metatype %9 : $@thick T.Type, $@thick Any.Type
   // CHECK: [[NEW_TASK_AND_CONTEXT:%.*]] = call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create_future(
-  %20 = builtin "createAsyncTaskFuture"<T>(%0 : $Int, %4 : $Optional<Builtin.NativeObject>, %10 : $@thick Any.Type, %5 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
-  end_borrow %4 : $Optional<Builtin.NativeObject>
-  destroy_value %copy : $Optional<Builtin.NativeObject>
+  %20 = builtin "createAsyncTaskFuture"<T>(%0 : $Int, %10 : $@thick Any.Type, %5 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
   destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
   %21 = tuple ()
   return %21 : $()
 }
 
 // CHECK-LABEL: define hidden swift{{(tail)?}}cc void @launch_void_future
-sil hidden [ossa] @launch_void_future : $@convention(method) (Int, Optional<Builtin.NativeObject>, @guaranteed @async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) -> () {
-bb0(%0 : $Int, %1: @unowned $Optional<Builtin.NativeObject>, %2: @guaranteed $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>):
-  %copy = copy_value %1 : $Optional<Builtin.NativeObject>
-  %4 = begin_borrow %copy : $Optional<Builtin.NativeObject>
-  %5 = copy_value %2 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>
-  // CHECK-32: [[TEMP:%.*]] = inttoptr i32 %1 to %swift.refcounted*
-  // CHECK-64: [[TEMP:%.*]] = inttoptr i64 %1 to %swift.refcounted*
-  // CHECK: call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[TEMP]])
-  // CHECK: call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[FN_CONTEXT:%.*]])
+sil hidden [ossa] @launch_void_future : $@convention(method) (Int, @guaranteed @async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) -> () {
+bb0(%0 : $Int, %1: @guaranteed $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>):
+  %5 = copy_value %1 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>
+  // CHECK: call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[FN_CONTEXT:%2]])
   %8 = metatype $@thick ().Type                   // user: %9
   %9 = init_existential_metatype %8 : $@thick ().Type, $@thick Any.Type // user: %10
   // CHECK: [[NEW_TASK_AND_CONTEXT:%.*]] = call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create_future(
-  %20 = builtin "createAsyncTaskFuture"<()>(%0 : $Int, %4 : $Optional<Builtin.NativeObject>, %9 : $@thick Any.Type, %5 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
-  end_borrow %4 : $Optional<Builtin.NativeObject>
-  destroy_value %copy : $Optional<Builtin.NativeObject>
+  %20 = builtin "createAsyncTaskFuture"<()>(%0 : $Int, %9 : $@thick Any.Type, %5 : $@async @callee_owned @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <()>) : $(Builtin.NativeObject, Builtin.RawPointer)
   destroy_value %20 : $(Builtin.NativeObject, Builtin.RawPointer)
   %21 = tuple ()
   return %21 : $()

--- a/test/IRGen/async/class_resilience.swift
+++ b/test/IRGen/async/class_resilience.swift
@@ -41,14 +41,14 @@ open class MyBaseClass<T> {
 // CHECK-LABEL: @"$s16class_resilience9MyDerivedCMn" = hidden constant
 // CHECK-SAME: %swift.async_func_pointer* @"$s16class_resilience9MyDerivedC4waitSiyYF010resilient_A09BaseClassCADxyYFTVTu"
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience14callsAwaitableyx010resilient_A09BaseClassCyxGYlF"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience14callsAwaitableyx010resilient_A09BaseClassCyxGYlF"(%swift.context* swiftasync %0)
 // CHECK: %swift.async_func_pointer* @"$s15resilient_class9BaseClassC4waitxyYFTjTu"
 // CHECK: ret void
 public func callsAwaitable<T>(_ c: BaseClass<T>) async -> T {
   return await c.wait()
 }
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience11MyBaseClassC4waitxyYFTj"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2) #0 {
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s16class_resilience11MyBaseClassC4waitxyYFTj"(%swift.context* swiftasync %0) #0 {
 
 class MyDerived : BaseClass<Int> {
   override func wait() async -> Int {

--- a/test/IRGen/async/get_async_continuation.sil
+++ b/test/IRGen/async/get_async_continuation.sil
@@ -14,15 +14,13 @@ bb0:
 }
 
 // CHECK-LABEL: define{{.*}} @async_continuation(
-// CHECK: [[tsk_addr:%.*]] = alloca %swift.task*
-// CHECK: [[exe_addr:%.*]] = alloca %swift.executor*
 // CHECK: [[ctxt_addr:%.*]] = alloca %swift.context*
 // CHECK: [[cont_context:%.*]] = alloca %swift.async_continuation_context
 // CHECK: [[result_storage:%.*]] = alloca i32
 // CHECK: call token @llvm.coro.id.async
 // CHECK: call i8* @llvm.coro.begin(
 //   Create a Builtin.RawUnsafeContinuation.
-// CHECK: [[tsk:%.*]] = load %swift.task*, %swift.task** [[tsk_addr]]
+// CHECK: [[tsk:%.*]] = call swiftcc %swift.task* @swift_task_getCurrent()
 // CHECK: [[continuation:%.*]] = bitcast %swift.task* [[tsk]] to i8*
 //   Initialize the async  continuation context.
 // CHECK: [[context_addr:%.*]] = getelementptr inbounds %swift.async_continuation_context, %swift.async_continuation_context* [[cont_context]], i32 0, i32 0
@@ -41,9 +39,6 @@ bb0:
 // CHECK: [[result_addr:%.*]] = getelementptr inbounds %swift.async_continuation_context, %swift.async_continuation_context* [[cont_context]], i32 0, i32 3
 // CHECK: [[result_storage_as_opaque:%.*]] = bitcast i32* [[result_storage]] to %swift.opaque*
 // CHECK: store %swift.opaque* [[result_storage_as_opaque]], %swift.opaque** [[result_addr]]
-// CHECK:  [[exectuor_addr:%.*]] = getelementptr inbounds %swift.async_continuation_context, %swift.async_continuation_context* [[cont_context]], i32 0, i32 4
-// CHECK:  [[exe:%.*]] = load %swift.executor*, %swift.executor** [[exe_addr]]
-// CHECK:  store %swift.executor* [[exe]], %swift.executor** [[exectuor_addr]]
 //   Initialize the async task with the continuation function and async continuation context.
 // CHECK: [[continuation_fn_addr:%.*]] = getelementptr inbounds %swift.task, %swift.task* [[tsk]], i32 0, i32 4
 // CHECK: [[continuation_fn:%.*]] = call i8* @llvm.coro.async.resume()
@@ -88,7 +83,7 @@ bb0:
 // CHECK:   unreachable
 
 // CHECK: await.async.maybe.resume:
-// CHECK:   call { i8*, i8*, i8* } (i32, i8*, i8*, ...) @llvm.coro.suspend.async{{.*}}({{.*}} @__swift_async_resume_project_context
+// CHECK:   call { i8* } (i32, i8*, i8*, ...) @llvm.coro.suspend.async{{.*}}({{.*}} @__swift_async_resume_project_context
 //  Abort if we are the first to arrive at the continuation point we must wait
 //  on the await to arrive.
 // CHECK:   [[first_at_sync_pt:%.*]] = cmpxchg {{(i64|i32)}}* [[synchronization_addr_before_await]], {{(i64|i32)}} 0, {{(i64|i32)}} 1 release acquire

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -11,25 +11,16 @@ import _Concurrency
 final actor MyActor {
 }
 
-// CHECK-LABEL: define{{.*}} void @test_simple(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
-// CHECK: [[TASK_LOC:%[0-9]+]] = alloca %swift.task*
-// CHECK: [[CTX:%[0-9]+]] = bitcast %swift.context* %2
-// CHECK-32: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, %swift.error**, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 5
-// CHECK-64: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.task*, %swift.executor*, %swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error**, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 6
+// CHECK-LABEL: define{{.*}} void @test_simple(%swift.context* swiftasync %0)
+// CHECK: [[CTX:%[0-9]+]] = bitcast %swift.context* %0
+// CHECK-32: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.context*)*, %swift.executor*, i32, %swift.error**, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 5
+// CHECK-64: [[ACTOR_ADDR:%[0-9]+]] = getelementptr inbounds <{ %swift.context*, void (%swift.context*)*, %swift.executor*, i32, [4 x i8], %swift.error**, %T4test7MyActorC* }>, {{.*}} [[CTX]], i32 0, i32 6
 // CHECK: [[ACTOR:%[0-9]+]] = load %T4test7MyActorC*, %T4test7MyActorC** [[ACTOR_ADDR]]
 // CHECK: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
-// CHECK: [[TASK:%[0-9]+]] = load %swift.task*, %swift.task** [[TASK_LOC]]
-// CHECK-arm64e: [[RESUME_ADDR:%[0-9]+]]     = getelementptr inbounds %swift.task, %swift.task* [[TASK]], i32 0, i32 4
-// CHECK-arm64e: [[RESUME_ADDR_INT:%[0-9]+]] = ptrtoint i8** [[RESUME_ADDR]] to i64
-// CHECK-arm64e: [[PTRAUTH_BLEND:%[0-9]+]]   = call i64 @llvm.ptrauth.blend.i64(i64 [[RESUME_ADDR_INT]], i64 11330)
-// CHECK-arm64e: [[RESUME_INT:%[0-9]+]]      = ptrtoint i8* [[RESUME]] to i64
-// CHECK-arm64e: [[SIGNED_INT:%[0-9]+]]      = call i64 @llvm.ptrauth.sign.i64(i64 [[RESUME_INT]], i32 0, i64 [[PTRAUTH_BLEND]])
-// CHECK-arm64e: [[SIGNED_RESUME:%[0-9]+]]   = inttoptr i64 [[SIGNED_INT]] to i8*
 // CHECK: [[CAST_ACTOR:%[0-9]+]] = bitcast %T4test7MyActorC* [[ACTOR]] to %swift.executor*
-// CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 2, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
-// CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 2, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.task*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[SIGNED_RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.task* [[TASK]], %swift.executor* {{%[0-9]+}}, %swift.context* {{%[0-9]+}})
-// CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.task*, %swift.executor*, %swift.context*)* {{.*}} to i8*
-// CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.task*, %swift.executor*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
+// CHECK: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* [[CAST_ACTOR]], %swift.context* {{%[0-9]+}})
+// CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.context*)* {{.*}} to i8*
+// CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
 // CHECK: unreachable
 
 sil @test_simple : $@convention(method) @async (@guaranteed MyActor) -> () {
@@ -40,22 +31,16 @@ bb0(%0 : $MyActor):
 }
 
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @__swift_suspend_point
-// CHECK-SAME:  (i8* %0, %swift.executor* %1, %swift.task* %2, %swift.executor* %3, %swift.context* [[CTXT:%[^,]+]])
-// CHECK:    [[RESUME_ADDR:%[0-9]+]] = getelementptr inbounds %swift.task, %swift.task* %2, i32 0, i32 4
-// CHECK:    store i8* %0, i8** [[RESUME_ADDR]]
-// CHECK:    [[CTXT_ADDR:%[0-9]+]] = getelementptr inbounds %swift.task, %swift.task* %2, i32 0, i32 5
-// CHECK-arm64e: [[CTXT_ADDR_INT:%[^,]+]] = ptrtoint %swift.context** [[CTXT_ADDR]] to i64
-// CHECK-arm64e: [[PTRAUTH_BLEND:%[^,]+]] = call i64 @llvm.ptrauth.blend.i64(i64 [[CTXT_ADDR_INT]], i64 30010)
-// CHECK-arm64e: [[CTXT_INT:%[^,]+]] = ptrtoint %swift.context* [[CTXT]] to i64
-// CHECK-arm64e: [[PTRAUTH_SIGN:%[^,]+]] = call i64 @llvm.ptrauth.sign.i64(i64 [[CTXT_INT]], i32 2, i64 [[PTRAUTH_BLEND]])
-// CHECK-arm64e: [[CTXT:%[^,]+]] = inttoptr i64 [[PTRAUTH_SIGN]] to %swift.context*
-// CHECK:    store %swift.context* [[CTXT]], %swift.context** [[CTXT_ADDR]]
-// CHECK:    {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_switch(%swift.task* %2, %swift.executor* %3, %swift.executor* %1)
+// CHECK-SAME:  (i8* [[RESUME_FN:%0]], %swift.executor* %1, %swift.context* [[CTXT:%[^,]+]])
+// CHECK-arm64e: [[RESUME_FN_INT:%[^,]+]] = ptrtoint i8* [[RESUME_FN]] to i64
+// CHECK-arm64e: [[PTRAUTH_SIGN:%[^,]+]] = call i64 @llvm.ptrauth.sign.i64(i64 [[RESUME_FN_INT]], i32 0, i64 0)
+// CHECK-arm64e: [[RESUME_FN:%[^,]+]] = inttoptr i64 [[PTRAUTH_SIGN]] to i8*
+// CHECK:    {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_switch(%swift.context* swiftasync [[CTXT]], i8* [[RESUME_FN]], %swift.executor* %1)
 // CHECK:    ret void
 
-// CHECK: define{{.*}} void @[[TAIL_CALL_FUNC]](i8* %0, %swift.task* %1, %swift.executor* %2, %swift.context* %3)
-// CHECK:   %4 = bitcast i8* %0 to void (%swift.task*, %swift.executor*, %swift.context*)*
-// CHECK:   {{(must)?}}tail call swift{{(tail)?}}cc void %4(%swift.task* %1, %swift.executor* %2, %swift.context* swiftasync %3)
+// CHECK: define{{.*}} void @[[TAIL_CALL_FUNC]](i8* %0, %swift.context* %1)
+// CHECK:   %2 = bitcast i8* %0 to void (%swift.context*)*
+// CHECK:   {{(must)?}}tail call swift{{(tail)?}}cc void %2(%swift.context* swiftasync %1)
 // CHECK:   ret void
 // CHECK: }
 

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -26,7 +26,7 @@ entry(%c : $SwiftClass, %d : $SwiftClass):
 
 sil @use_closure : $@async @convention(thin) (@noescape @async @callee_guaranteed () -> ()) -> ()
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_class : $@async @convention(thin) (SwiftClass) -> @async @callee_owned () -> () {
 entry(%c : $SwiftClass):
   %f = function_ref @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
@@ -34,7 +34,7 @@ entry(%c : $SwiftClass):
   return %g : $@async @callee_owned () -> ()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class_on_stack(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_class_on_stack(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_class_on_stack : $@async @convention(thin) (@owned SwiftClass) -> () {
 entry(%a : $SwiftClass):
   %f = function_ref @partially_applyable_to_class : $@async @convention(thin) (@owned SwiftClass) -> ()
@@ -47,7 +47,7 @@ entry(%a : $SwiftClass):
   return %t : $()
 }
 
-// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_two_classes_on_stack(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_two_classes_on_stack(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_two_classes_on_stack : $@async @convention(thin) (@owned SwiftClass, @owned SwiftClass) -> () {
 entry(%a : $SwiftClass, %b: $SwiftClass):
@@ -61,7 +61,7 @@ entry(%a : $SwiftClass, %b: $SwiftClass):
   %t = tuple()
   return %t : $()
 }
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s22generic_captured_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s22generic_captured_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @generic_captured_param : $@async @convention(thin) <T> (Int, @inout T) -> Int {
 entry(%i : $Int, %t : $*T):
 return %i : $Int
@@ -83,7 +83,7 @@ entry(%o : $*T, %i : $*T, %io : $*T):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_open_generic_capture(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_open_generic_capture(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_open_generic_capture : $@async @convention(thin) <T> (@inout T) -> @async @callee_owned (@in T) -> @out T {
 entry(%a : $*T):
   %f = function_ref @generic_captured_and_open_param : $@async @convention(thin) <U> (@in U, @inout U) -> @out U
@@ -102,7 +102,7 @@ entry(%i : $Int, %c : $SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_guaranteed_class_param : $@async @convention(thin) (@owned SwiftClass) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $SwiftClass):
@@ -117,8 +117,9 @@ entry(%i : $Int, %c : $*SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s40indirect_guaranteed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s40indirect_guaranteed_captured_class_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_guaranteed_class_param : $@async @convention(thin) (@in SwiftClass) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClass):
@@ -133,8 +134,8 @@ entry(%i : $Int, %c : $*SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[1-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s38indirect_consumed_captured_class_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s38indirect_consumed_captured_class_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_consumed_class_param : $@async @convention(thin) (@in SwiftClass) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClass):
@@ -157,8 +158,8 @@ entry(%i : $Int, %c : $SwiftClassPair):
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s36guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_guaranteed_class_pair_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s36guaranteed_captured_class_pair_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_guaranteed_class_pair_param : $@async @convention(thin) (@owned SwiftClassPair) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $SwiftClassPair):
@@ -173,8 +174,8 @@ entry(%i : $Int, %c : $*SwiftClassPair):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_guaranteed_class_pair_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClassPair):
@@ -190,8 +191,8 @@ entry(%i : $Int, %c : $*SwiftClassPair):
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s43indirect_consumed_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_consumed_class_pair_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s43indirect_consumed_captured_class_pair_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_indirect_consumed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @async @callee_owned (Int) -> Int {
 bb0(%x : $*SwiftClassPair):
@@ -206,8 +207,8 @@ entry(%c : $SwiftClass, %a : $*A, %i : $Int):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_non_fixed_layout(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s35captured_fixed_and_dependent_paramsTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_indirect_non_fixed_layout(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s35captured_fixed_and_dependent_paramsTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_indirect_non_fixed_layout : $@async @convention(thin) <T> (@owned SwiftClass, @in T, Int) -> @async @callee_owned () -> () {
 bb0(%a : $SwiftClass, %b : $*T, %c : $Int):
   %f = function_ref @captured_fixed_and_dependent_params : $@async @convention(thin) <B> (@owned SwiftClass, @in B, Int) -> ()
@@ -228,7 +229,7 @@ bb0(%x : $*T):
   return %p : $@async @callee_owned () -> @out T
 }
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s28captured_dependent_out_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s28captured_dependent_out_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_dynamic_with_out_param : $@async @convention(thin) <T> (Int32, @owned @async @callee_owned (Int32) -> @out T) -> @async @callee_owned () -> @out T {
 bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
@@ -236,7 +237,7 @@ bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
   return %p : $@async @callee_owned () -> @out T
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_dynamic_with_out_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_dynamic_with_out_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 class Base {
 }
@@ -255,7 +256,7 @@ bb0(%0 : $Base):
 
 sil public_external @receive_closure : $@async @convention(thin) <C where C : Base> (@owned @async @callee_owned () -> (@owned C)) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_partial_apply(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_partial_apply(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @test_partial_apply : $@async @convention(thin) (@owned Base) -> () {
 bb0(%0 : $Base):
@@ -267,6 +268,7 @@ bb0(%0 : $Base):
  %5 = tuple ()
  return %5 : $()
 }
+
 
 protocol P0 {}
 protocol P1 { associatedtype X : P0 }
@@ -285,7 +287,8 @@ bb0(%0 : $Int):
   %result = tuple ()
   return %result : $()
 }
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_complex_generic_function(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_complex_generic_function(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+
 struct ComplexBoundedType<T: P2> {}
 
 // SR-901: Ensure that a partial_apply which captures bound generic type
@@ -329,7 +332,7 @@ entry(%i : $Int):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_generic_indirect_return : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum<Int> {
   bb0(%0 : $Int):
   %fn = function_ref @generic_indirect_return :$@async @convention(thin) <T> (Int) -> @owned GenericEnum<T>
@@ -348,7 +351,7 @@ entry(%i : $Int):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return2(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_generic_indirect_return2(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @partial_apply_generic_indirect_return2 : $@async @convention(thin) (Int) -> @async @callee_owned () -> @owned GenericEnum2<Int> {
   bb0(%0 : $Int):
   %fn = function_ref @generic_indirect_return2 :$@async @convention(thin) <T> (Int) -> @owned GenericEnum2<T>
@@ -364,7 +367,7 @@ entry(%t : $@thin SwiftStruct.Type, %c : $SwiftClass):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_thin_type(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_thin_type(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_thin_type : $@async @convention(thin) (@thin SwiftStruct.Type, @owned SwiftClass) -> @async @callee_owned () -> () {
 entry(%0: $@thin SwiftStruct.Type, %1: $SwiftClass):
@@ -376,7 +379,7 @@ entry(%0: $@thin SwiftStruct.Type, %1: $SwiftClass):
 sil @afun : $@async @convention(thin) (Int) -> @error Error
 
 // Check that we don't assert on a thin noescape function.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @convert_thin_test(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @convert_thin_test(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil @convert_thin_test : $@async @convention(thin) (Int) -> () {
 bb(%0 : $Int):
   %f = function_ref @afun : $@async @convention(thin) (Int) -> @error Error
@@ -443,7 +446,7 @@ bb0(%0 : $*A2<A3>):
 sil_vtable A3 {}
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in SwiftClassPair) -> @owned @async @callee_guaranteed (Int) -> Int {
 bb0(%x : $*SwiftClassPair):
@@ -454,7 +457,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @use_closure2 : $@async @convention(thin) (@noescape @async @callee_guaranteed (Int) -> Int) -> ()
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @partial_apply_stack_callee_guaranteed_indirect_guaranteed_class_pair_param : $@async @convention(thin) (@in_guaranteed SwiftClassPair) -> () {
 bb0(%x : $*SwiftClassPair):
@@ -467,7 +470,7 @@ bb0(%x : $*SwiftClassPair):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_class_pair_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @indirect_in_captured_class_pair_param : $@async @convention(thin) (Int, @in SwiftClassPair) -> Int {
 entry(%i : $Int, %p : $*SwiftClassPair):
@@ -488,7 +491,7 @@ bb0(%x : $*SwiftClassPair):
 }
 
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @partial_apply_stack_callee_guaranteed_indirect_in_constant_class_pair_param(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @indirect_in_constant_captured_class_pair_param : $@async @convention(thin) (Int, @in_constant SwiftClassPair) -> Int {
 entry(%i : $Int, %ic : $*SwiftClassPair):
@@ -515,7 +518,7 @@ entry(%i : $*ResilientInt, %c : $SwiftClass):
 }
 
 // Make sure that we use the heap header size (16) for the initial offset.
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_initial_offset(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_initial_offset(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @test_initial_offset : $@async @convention(thin) (@in_guaranteed ResilientInt, @guaranteed SwiftClass) -> () {
 bb0(%x : $*ResilientInt, %y : $SwiftClass):
@@ -541,7 +544,7 @@ entry(%z : $*τ_0_0, %o : $*τ_0_1):
   unreachable
 }
 
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @empty_followed_by_non_fixed(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @empty_followed_by_non_fixed : $@async @convention(thin)  (EmptyType, @in_guaranteed SomeType) -> () {
 entry(%0 : $EmptyType, %1: $*SomeType):
@@ -564,7 +567,7 @@ entry(%0 : $EmptyType, %1: $*SomeType):
 struct FixedType {
   var f: Int32
 }
-// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @fixed_followed_by_empty_followed_by_non_fixed(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @fixed_followed_by_empty_followed_by_non_fixed(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil @foo2 : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> () {
 entry(%z : $*τ_0_0, %o : $*τ_0_1, %t : $*τ_0_2):
@@ -600,14 +603,14 @@ bb0(%thick : $@callee_guaranteed @async @convention(thick) (Int64, Int32) -> Int
   return %pa_f : $@async @callee_guaranteed (Int64) -> Int64
 }
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24complex_generic_functionTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23generic_indirect_returnTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24generic_indirect_return2TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s12create_pa_f2Tw_"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s12create_pa_f2Tw0_"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s26parametric_casting_closureTA.{{[0-9]+}}"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24complex_generic_functionTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23generic_indirect_returnTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s24generic_indirect_return2TA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s45indirect_guaranteed_captured_class_pair_paramTA.{{[0-9]+}}"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s37indirect_in_captured_class_pair_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s46indirect_in_constant_captured_class_pair_paramTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s12create_pa_f2Tw_"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s12create_pa_f2Tw0_"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 

--- a/test/IRGen/async/partial_apply_forwarder.sil
+++ b/test/IRGen/async/partial_apply_forwarder.sil
@@ -89,7 +89,7 @@ entry(%e : $EmptyType, %b : $WeakBox<τ_0_0>):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @bind_polymorphic_param_from_context : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @owned @async @callee_owned () -> () {
 bb0(%0 : $*τ_0_1):
@@ -99,7 +99,7 @@ bb0(%0 : $*τ_0_1):
   return %9 : $@async @callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context_2(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context_2(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil public @bind_polymorphic_param_from_context_2 : $@async @convention(thin) <τ_0_1>(@in τ_0_1, EmptyType) -> @owned @async @callee_owned () -> () {
 bb0(%0 : $*τ_0_1, %2: $EmptyType):
   %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
@@ -108,7 +108,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
   return %9 : $@async @callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context_3(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context_3(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil public @bind_polymorphic_param_from_context_3 : $@async @convention(thin) <τ_0_1>(@in τ_0_1, EmptyType) -> @owned @async @callee_owned () -> () {
 bb0(%0 : $*τ_0_1, %2: $EmptyType):
   %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
@@ -117,7 +117,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
   return %9 : $@async @callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_forwarder_parameter(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_forwarder_parameter(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 
 sil public @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> () {
 bb0(%0 : $*τ_0_1):
@@ -138,7 +138,7 @@ entry(%s : $S, %b : $WeakBox<τ_0_0>):
   unreachable
 }
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context_with_layout(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @bind_polymorphic_param_from_context_with_layout(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil public @bind_polymorphic_param_from_context_with_layout : $@async @convention(thin) <τ_0_1>(@in τ_0_1, S) -> @owned @async @callee_owned () -> () {
 bb0(%0 : $*τ_0_1, %1: $S):
   %2 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>
@@ -169,7 +169,7 @@ bb0:
   return %1 : $@async @callee_guaranteed (Empty<S>) -> (@owned Empty<S>, @owned @async @callee_guaranteed (Empty<S>) -> @owned Empty<S>)
 }
 
-// CHECK-LABEL: define hidden swift{{(tail)?}}cc void @specializes_closure_returning_closure(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define hidden swift{{(tail)?}}cc void @specializes_closure_returning_closure(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 protocol MyEquatable {
   static func isEqual (lhs: Self, rhs: Self) -> Builtin.Int1
 }
@@ -256,10 +256,10 @@ sil_vtable E {}
 sil_vtable Empty {}
 sil_witness_table C: P module main {}
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23unspecialized_uncurriedTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingPTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA.{{[0-9]+}}"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s11takingQAndSTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s15returns_closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s23unspecialized_uncurriedTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingPTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s7takingQTA.{{[0-9]+}}"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s11takingQAndSTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @"$s15returns_closureTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 

--- a/test/IRGen/async/protocol_resilience.swift
+++ b/test/IRGen/async/protocol_resilience.swift
@@ -26,14 +26,14 @@ public protocol MyAwaitable {
 // CHECK-LABEL: @"$s19protocol_resilience19ConformsToAwaitableVyxG010resilient_A00E0AAMc" = hidden constant
 // CHECK-SAME: %swift.async_func_pointer* @"$s19protocol_resilience19ConformsToAwaitableVyxG010resilient_A00E0AaeFP4wait6ResultQzyYFTWTu"
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience14callsAwaitabley6ResultQzxY010resilient_A00D0RzlF"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience14callsAwaitabley6ResultQzxY010resilient_A00D0RzlF"(%swift.context* swiftasync %0)
 // CHECK: %swift.async_func_pointer* @"$s18resilient_protocol9AwaitableP4wait6ResultQzyYFTjTu"
 // CHECK: ret void
 public func callsAwaitable<T : Awaitable>(_ t: T) async -> T.Result {
   return await t.wait()
 }
 
-// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience11MyAwaitableP4wait6ResultQzyYFTj"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2)
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swift{{(tail)?}}cc void @"$s19protocol_resilience11MyAwaitableP4wait6ResultQzyYFTj"(%swift.context* swiftasync %0)
 
 struct ConformsToAwaitable<T> : Awaitable {
   var value: T

--- a/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
+++ b/test/IRGen/async/run-call-class-witnessmethod-void-to-void.swift
@@ -31,7 +31,7 @@ protocol P {
 // CHECK-LL: @"$s4main1XCAA1PA2aDP1fyyYFTWTu" = internal global %swift.async_func_pointer
 
 extension P {
-  // CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main1PPAAE1fyyYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+  // CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main1PPAAE1fyyYF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
   func f() async {
     print("entering f")
     printGeneric(Self.self)
@@ -40,10 +40,10 @@ extension P {
   }
 }
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s4main1XCAA1PA2aDP1fyyYFTW"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s4main1XCAA1PA2aDP1fyyYFTW"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 extension X : P {}
 
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main6call_fyyxYAA1PRzlF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main6call_fyyxYAA1PRzlF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 func call_f<T : P>(_ t: T) async {
   print("entering call_f")
   await t.f()

--- a/test/IRGen/async/run-call-classinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-int64-to-void.sil
@@ -30,7 +30,7 @@ class S {
 }
 
 // CHECK-LL: @classinstanceSInt64ToVoidTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @classinstanceSInt64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @classinstanceSInt64ToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]+}}
 sil hidden @classinstanceSInt64ToVoid : $@async @convention(method) (Int64, @guaranteed S) -> () {
 bb0(%int : $Int64, %instance : $S):
   %take_s = function_ref @take_S : $@async @convention(thin) (@guaranteed S) -> ()

--- a/test/IRGen/async/run-call-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-classinstance-void-to-void.sil
@@ -30,7 +30,7 @@ class S {
 }
 
 // CHECK-LL: @classinstanceSVoidToVoidTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @classinstanceSVoidToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @classinstanceSVoidToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @classinstanceSVoidToVoid : $@async @convention(method) (@guaranteed S) -> () {
 bb0(%instance : $S):
   %take_s = function_ref @take_S : $@async @convention(thin) (@guaranteed S) -> ()

--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -16,7 +16,7 @@ import _Concurrency
 
 // CHECK-LL: @"$s4main3runyyYFTu" = hidden global %swift.async_func_pointer
 
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main3runyyYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main3runyyYF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 dynamic func run() async {
   print("running")
 }

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -38,7 +38,7 @@ bb0(%int : $Int64, %S_type : $@thin S.Type):
 }
 
 // CHECK-LL: @existentialToVoidTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @existentialToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @existentialToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @existentialToVoid : $@async @convention(thin) (@in_guaranteed P) -> () {
 bb0(%existential : $*P):
   %existential_addr = open_existential_addr immutable_access %existential : $*P to $*@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77") P

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -20,7 +20,7 @@ import _Concurrency
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
 // CHECK-LL: @genericToGenericTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @genericToGeneric(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @genericToGeneric(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @genericToGeneric : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T {
 bb0(%out : $*T, %in : $*T):
   copy_addr %in to [initialization] %out : $*T

--- a/test/IRGen/async/run-call-generic-to-void.swift
+++ b/test/IRGen/async/run-call-generic-to-void.swift
@@ -12,7 +12,7 @@
 import _Concurrency
 
 // CHECK-LL: @genericToVoidTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @genericToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @genericToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 @_silgen_name("genericToVoid")
 func genericToVoid<T>(_ t: T) async {
   print(t) // CHECK: 922337203685477580

--- a/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
+++ b/test/IRGen/async/run-call-genericEquatable-x2-to-bool.sil
@@ -20,7 +20,7 @@ import _Concurrency
 sil public_external @printBool : $@convention(thin) (Bool) -> ()
 
 // CHECK-LL: @genericEquatableAndGenericEquatableToBoolTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @genericEquatableAndGenericEquatableToBool(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @genericEquatableAndGenericEquatableToBool(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @genericEquatableAndGenericEquatableToBool : $@async @convention(thin) <T where T : Equatable> (@in_guaranteed T, @in_guaranteed T) -> Bool {
 bb0(%0 : $*T, %1 : $*T):
   %4 = metatype $@thick T.Type

--- a/test/IRGen/async/run-call-int64-and-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-and-int64-to-void.sil
@@ -20,7 +20,7 @@ import _Concurrency
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
 // CHECK-LL: @int64AndInt64ToVoidTu =
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @int64AndInt64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @int64AndInt64ToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @int64AndInt64ToVoid : $@async @convention(thin) (Int64, Int64) -> () {
 entry(%int1: $Int64, %int2: $Int64):
   %print = function_ref @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-call-int64-to-void.sil
+++ b/test/IRGen/async/run-call-int64-to-void.sil
@@ -20,7 +20,7 @@ import _Concurrency
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
 // CHECK-LL: @int64ToVoidTu =
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @int64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @int64ToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @int64ToVoid : $@async @convention(thin) (Int64) -> () {
 entry(%int: $Int64):
   %print = function_ref @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolextension_instance-void-to-int64.sil
@@ -34,7 +34,7 @@ struct I : P {
 }
 
 // CHECK-LL: @callPrintMeTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @callPrintMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @callPrintMe(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @callPrintMe : $@async @convention(method) <Self where Self : P> (@in_guaranteed Self) -> Int64 {
 bb0(%self : $*Self):
   %P_printMe = witness_method $Self, #P.printMe : <Self where Self : P> (Self) -> () -> Int64 : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64

--- a/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call-protocolwitness_instance-void-to-int64.sil
@@ -30,7 +30,7 @@ struct I : P {
 }
 
 // CHECK-LL: @I_printMeTu =
-// CHECK-LL-LABEL: define hidden swift{{(tail)?}}cc void @I_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL-LABEL: define hidden swift{{(tail)?}}cc void @I_printMe(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @I_printMe : $@async @convention(method) (I) -> Int64 {
 bb0(%self : $I):
   %self_addr = alloc_stack $I
@@ -42,7 +42,7 @@ bb0(%self : $I):
   return %result : $Int64
 }
 
-// CHECK-LL-LABEL: define internal swift{{(tail)?}}cc void @I_P_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL-LABEL: define internal swift{{(tail)?}}cc void @I_P_printMe(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil private [transparent] [thunk] @I_P_printMe : $@async @convention(witness_method: P) (@in_guaranteed I) -> Int64 {
 bb0(%self_addr : $*I):
   %self = load %self_addr : $*I

--- a/test/IRGen/async/run-call-resilient-classinstance-void-to-void.sil
+++ b/test/IRGen/async/run-call-resilient-classinstance-void-to-void.sil
@@ -22,7 +22,7 @@ import ResilientClass
 
 sil public_external [exact_self_class] @$s14ResilientClass5ClazzCACycfC : $@convention(method) (@thick Clazz.Type) -> @owned Clazz
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_case(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_case(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @test_case : $@convention(thin) @async () -> () {
   %s_type = metatype $@thick Clazz.Type
   %allocating_init = function_ref @$s14ResilientClass5ClazzCACycfC : $@convention(method) (@thick Clazz.Type) -> @owned Clazz

--- a/test/IRGen/async/run-call-resilient-protocolinstance-void-to-void.swift
+++ b/test/IRGen/async/run-call-resilient-protocolinstance-void-to-void.swift
@@ -20,7 +20,7 @@ func call<T : Protokol>(_ t: T) async {
   await t.protocolinstanceVoidToVoid()
 }
 
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main4callyyxY17ResilientProtocol8ProtokolRzlF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main4callyyxY17ResilientProtocol8ProtokolRzlF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 func test_case() async {
   let impl = Impl()
   await call(impl) // CHECK: Impl()

--- a/test/IRGen/async/run-call-struct-instance_generic-mutating-generic_1-to-generic_1.swift
+++ b/test/IRGen/async/run-call-struct-instance_generic-mutating-generic_1-to-generic_1.swift
@@ -13,7 +13,7 @@ import _Concurrency
 
 struct G<T> {
   // CHECK-LL: @"$s4main1GV19theMutatingFunctionyqd__qd__YlFTu" = hidden global %swift.async_func_pointer
-  // CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main1GV19theMutatingFunctionyqd__qd__YlF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+  // CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main1GV19theMutatingFunctionyqd__qd__YlF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
   mutating func theMutatingFunction<U>(_ u: U) async -> U {
     return u
   }

--- a/test/IRGen/async/run-call-struct_five_bools-to-void.sil
+++ b/test/IRGen/async/run-call-struct_five_bools-to-void.sil
@@ -40,7 +40,7 @@ entry(%pack : $Pack):
   return %printGeneric_result1 : $()
 }
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_case(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_case(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @test_case : $@async @convention(thin) () -> () {
   
   %a_literal = integer_literal $Builtin.Int1, -1

--- a/test/IRGen/async/run-call-structinstance-int64-to-void.sil
+++ b/test/IRGen/async/run-call-structinstance-int64-to-void.sil
@@ -26,7 +26,7 @@ struct S {
 }
 
 // CHECK-LL: @structinstanceSInt64ToVoidTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @structinstanceSInt64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @structinstanceSInt64ToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @structinstanceSInt64ToVoid : $@async @convention(method) (Int64, S) -> () {
 bb0(%int : $Int64, %self : $S):
   %takeSAndInt64 = function_ref @takeSAndInt64 : $@async @convention(thin) (S, Int64) -> ()

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing.sil
@@ -100,7 +100,7 @@ bb5:
 }
 
 // CHECK-LL: @voidThrowsToIntTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:
   %e_type = metatype $@thin E.Type

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-nothrow_call-sync-throw.sil
@@ -99,7 +99,7 @@ bb5:
 }
 
 // CHECK-LL: @voidThrowsToIntTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
 entry:
   %asyncVoidThrowsToInt = function_ref @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-async-throw.sil
@@ -100,7 +100,7 @@ bb5:
 }
 
 // CHECK-LL: @voidThrowsToIntTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:
   %asyncVoidThrowsToInt = function_ref @asyncVoidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-nothrow_call-async-throw.sil
@@ -100,7 +100,7 @@ bb5:
 }
 
 // CHECK-LL: @voidThrowsToIntTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error) {
 entry:
   %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int64, @error Error)

--- a/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
+++ b/test/IRGen/async/run-call-void-throws-to-int-throwing_call-sync-throw.sil
@@ -101,7 +101,7 @@ bb5:
 }
 
 // CHECK-LL: @voidThrowsToIntTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidThrowsToInt(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @voidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error) {
 bb0:
   %syncVoidThrowsToInt = function_ref @syncVoidThrowsToInt : $@async @convention(thin) () -> (Int, @error Error)

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -37,7 +37,7 @@ bb0(%int : $Int64, %S_type : $@thin S.Type):
 }
 
 // CHECK-LL: @voidToExistentialTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidToExistential(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidToExistential(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @voidToExistential : $@async @convention(thin) () -> @out P {
 bb0(%out : $*P):
   %S_type = metatype $@thin S.Type

--- a/test/IRGen/async/run-call-void-to-int64-and-int64.sil
+++ b/test/IRGen/async/run-call-void-to-int64-and-int64.sil
@@ -20,7 +20,7 @@ import _Concurrency
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
 // CHECK-LL: @voidToInt64AndInt64Tu =
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @voidToInt64AndInt64(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @voidToInt64AndInt64(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @voidToInt64AndInt64 : $@async @convention(thin) () -> (Int64, Int64) {
   %int_literal1 = integer_literal $Builtin.Int64, 42
   %int1 = struct $Int64 (%int_literal1 : $Builtin.Int64)

--- a/test/IRGen/async/run-call-void-to-int64.swift
+++ b/test/IRGen/async/run-call-void-to-int64.swift
@@ -13,7 +13,7 @@ import Swift
 import _Concurrency
 
 // CHECK-LL: @voidToInt64Tu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidToInt64(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @voidToInt64(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 @_silgen_name("voidToInt64")
 func voidToInt64() async -> Int64 { return 42 }
 

--- a/test/IRGen/async/run-call-void-to-struct_large.sil
+++ b/test/IRGen/async/run-call-void-to-struct_large.sil
@@ -102,7 +102,7 @@ bb0(%0 : $@thin Big.Type):
 }
 
 // CHECK-LL: @getBigTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @getBig(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @getBig(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @getBig : $@async @convention(thin) () -> Big {
 bb0:
   %0 = metatype $@thin Big.Type

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -46,7 +46,7 @@ bb0(%out_addr : $*T, %in_addr : $*T, %self : $I):
 }
 
 // CHECK-LL: @I_P_printMeTu =
-// CHECK-LL: define internal swift{{(tail)?}}cc void @I_P_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @I_P_printMe(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil private [transparent] [thunk] @I_P_printMe : $@convention(witness_method: P) @async <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed I) -> (Int64, @out τ_0_0) {
 bb0(%out_addr : $*τ_0_0, %in_addr : $*τ_0_0, %self_addr : $*I):
   %self = load %self_addr : $*I

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-void-to-int64.sil
@@ -32,7 +32,7 @@ struct I : P {
 // CHECK-LL: @I_printMeTu =
 // CHECK-LL: @I_P_printMeTu =
 
-// CHECK-LL-LABEL: define hidden swift{{(tail)?}}cc void @I_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL-LABEL: define hidden swift{{(tail)?}}cc void @I_printMe(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @I_printMe : $@async @convention(method) (I) -> Int64 {
 bb0(%self : $I):
   %self_addr = alloc_stack $I
@@ -44,7 +44,7 @@ bb0(%self : $I):
   return %result : $Int64
 }
 
-// CHECK-LL-LABEL: define internal swift{{(tail)?}}cc void @I_P_printMe(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL-LABEL: define internal swift{{(tail)?}}cc void @I_P_printMe(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil private [transparent] [thunk] @I_P_printMe : $@async @convention(witness_method: P) (@in_guaranteed I) -> Int64 {
 bb0(%self_addr : $*I):
   %self = load %self_addr : $*I

--- a/test/IRGen/async/run-convertfunction-int64-to-void.sil
+++ b/test/IRGen/async/run-convertfunction-int64-to-void.sil
@@ -18,7 +18,7 @@ import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @int64ToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @int64ToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @int64ToVoid : $@async @convention(thin) (Int64) -> () {
 entry(%int : $Int64):
   %printInt64 = function_ref @printInt64 : $@convention(thin) (Int64) -> ()

--- a/test/IRGen/async/run-partialapply-capture-class-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-class-to-void.sil
@@ -58,7 +58,7 @@ sil_vtable S {
 }
 
 // CHECK-LL: @classinstanceSToVoidTu =
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @classinstanceSToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @classinstanceSToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @classinstanceSToVoid : $@async @convention(thin) (@owned S) -> () {
 entry(%c : $S):
   %class_addr = alloc_stack $S

--- a/test/IRGen/async/run-partialapply-capture-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-classinstance-to-void.sil
@@ -58,7 +58,7 @@ sil_vtable S {
 }
 
 // CHECK-LL: @classinstanceSToVoidTu =
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @classinstanceSToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @classinstanceSToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @classinstanceSToVoid : $@async @convention(method) (@owned S) -> () {
 entry(%c : $S):
   %class_addr = alloc_stack $S

--- a/test/IRGen/async/run-partialapply-capture-classinstance_generic-and-int-to-string.sil
+++ b/test/IRGen/async/run-partialapply-capture-classinstance_generic-and-int-to-string.sil
@@ -62,7 +62,7 @@ bb0(%value : $String, %instance : $Super):
   return %instance : $Super
 }
 
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @Super_run(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2) #0 {
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @Super_run(%swift.context* swiftasync %0) #0 {
 sil hidden @Super_run : $@convention(method) @async <U where U : Q> (@in_guaranteed U, Int64, @guaranteed Super) -> @owned String {
 bb0(%generic_addr : $*U, %int_arg : $Int64, %int : $Super):
   %printGeneric = function_ref @printGeneric : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -107,7 +107,7 @@ bb0(%instance : $Super):
   return %out : $()
 }
 
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @Sub_run(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2) #0 {
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @Sub_run(%swift.context* swiftasync %0) #0 {
 sil hidden @Sub_run : $@convention(method) @async <U where U : Q> (@in_guaranteed U, Int64, @guaranteed Sub) -> @owned String {
 bb0(%U_addr : $*U, %int : $Int64, %sub : $Sub):
   strong_retain %sub : $Sub
@@ -199,7 +199,7 @@ bb0(%initialized : $Sub):
 //       CHECK-SIL:   return [[RESULT]] : $String
 // CHECK-SIL-LABEL: } // end sil function '$s20partial_apply_methodTw_'
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s20partial_apply_methodTw_TA"(%swift.task* %0, %swift.executor* %1, %swift.context* swiftasync %2) #0 {
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s20partial_apply_methodTw_TA"(%swift.context* swiftasync %0) #0 {
 sil hidden @partial_apply_method : $@convention(thin) <U where U : Q> (@guaranteed Super, @convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String) -> @callee_guaranteed @async (@in_guaranteed U, Int64) -> @owned String {
 entry(%int : $Super, %fn : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String):
     %pa = partial_apply [callee_guaranteed] %fn<U>(%int) : $@convention(method) @async <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0, Int64, @guaranteed Super) -> @owned String

--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -29,7 +29,7 @@ class ObservableImpl : Observable {
 }
 sil_vtable ObservableImpl {
 }
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @subscribe_ObservableImpl_Observable(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @subscribe_ObservableImpl_Observable(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @subscribe_ObservableImpl_Observable : $@convention(witness_method: Observable) @async <τ_0_0 where τ_0_0 : Observer> (@in_guaranteed τ_0_0, @in_guaranteed ObservableImpl) -> () {
 bb0(%observer : $*τ_0_0, %self : $*ObservableImpl):
   %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
@@ -121,7 +121,7 @@ sil_witness_table ObserverImpl : Observer module main {
 //       CHECK-SIL:   return [[RESULT]] : $()                                 
 // CHECK-SIL-LABEL: } // end sil function '$s14witness_methodTw_'
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s14witness_methodTw_TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s14witness_methodTw_TA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @witness_method : $@async @convention(thin) <S where S : Observable><O where O : Observer, S.Result == O.Result> (@in S) -> @owned @async @callee_guaranteed (@in O) -> () {
 bb0(%0 : $*S):
   %1 = witness_method $S, #Observable.subscribe : $@async @convention(witness_method: Observable) <τ_0_0 where τ_0_0 : Observable><τ_1_0 where τ_1_0 : Observer, τ_0_0.Result == τ_1_0.Result> (@in τ_1_0, @in_guaranteed τ_0_0) -> ()

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -20,8 +20,8 @@ sil public_external @printGeneric : $@convention(thin) <T> (@in_guaranteed T) ->
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
 // CHECK-LL: @inGenericAndInoutGenericToGenericTu =
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @inGenericAndInoutGenericToGeneric(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s017inGenericAndInoutb2ToB0TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @inGenericAndInoutGenericToGeneric(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s017inGenericAndInoutb2ToB0TA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @inGenericAndInoutGenericToGeneric : $@async @convention(thin) <T> (@in T, @inout T) -> @out T {
 entry(%out : $*T, %in : $*T, %inout : $*T):
   %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-throws-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-throws-to-int64.sil
@@ -46,8 +46,8 @@ exit:
 }
 
 // CHECK-LL: @closureTu =
-// CHECK-LL: define internal swift{{(tail)?}}cc void @closure(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @closure(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7closureTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @createPartialApply : $@async @convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> (Int64, @error Error) {
 bb0(%captured : $Int64):
   %closure = function_ref @closure : $@async @convention(thin) (Int64, Int64) -> (Int64, @error Error)

--- a/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-int64-to-int64.sil
@@ -37,8 +37,8 @@ bb0:
 }
 
 // CHECK-LL: @closureTu =
-// CHECK-LL: define internal swift{{(tail)?}}cc void @closure(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7closureTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @closure(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7closureTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @createPartialApply : $@async @convention(thin) (Int64) -> @owned @async @callee_guaranteed (Int64) -> Int64 {
 bb0(%captured : $Int64):
   %closure = function_ref @closure : $@async @convention(thin) (Int64, Int64) -> Int64

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -25,8 +25,8 @@ bb0(%x : $Int32, %f : $@async @callee_owned (Int32) -> @out T):
   return %p : $@async @callee_owned () -> @out T
 }
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s36partial_apply_dynamic_with_out_paramTw_TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s6calleeTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s36partial_apply_dynamic_with_out_paramTw_TA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s6calleeTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @callee : $@async @convention(thin) <T> (Int32, @in_guaranteed T) -> @out T {
 entry(%out_t : $*T, %x : $Int32, %in_t : $*T):
   %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()

--- a/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
+++ b/test/IRGen/async/run-partialapply-capture-struct_classinstance_classinstance-and-int64-to-int64.sil
@@ -62,8 +62,8 @@ sil_vtable C {
 struct S { var x: C, y: C }
 
 // CHECK-LL: @structClassInstanceClassInstanceAndInt64ToInt64Tu =
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @structClassInstanceClassInstanceAndInt64ToInt64(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s019structClassInstancebc10AndInt64ToE0TA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @structClassInstanceClassInstanceAndInt64ToInt64(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s019structClassInstancebc10AndInt64ToE0TA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @structClassInstanceClassInstanceAndInt64ToInt64 : $@async @convention(thin) (Int64, @guaranteed S) -> Int64 {
 entry(%in : $Int64, %s : $S):
   %s_addr = alloc_stack $S

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_classinstance_to_struct_and_error.sil
@@ -42,7 +42,7 @@ entry(%value : $A2<A3>):
 // CHECK-LL: @amethodTu =
 // CHECK-LL: @repoTu =
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @amethod(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @amethod(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @amethod : $@async @convention(method) (@in_guaranteed A2<A3>) -> (@owned A1, @error Error) {
 entry(%a2_at_a3_addr : $*A2<A3>):
   %a2_at_a3 = load %a2_at_a3_addr : $*A2<A3>
@@ -52,8 +52,8 @@ entry(%a2_at_a3_addr : $*A2<A3>):
   return %result : $A1
 }
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @repo(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7amethodTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @repo(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7amethodTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @repo : $@async @convention(thin) (@in_guaranteed A2<A3>) -> @owned @async @callee_guaranteed () -> (@owned A1, @error Error) {
 bb0(%0 : $*A2<A3>):
   %1 = load %0 : $*A2<A3>

--- a/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-structgeneric_polymorphic_constrained-to-void.sil
@@ -32,7 +32,7 @@ sil_witness_table <T> BaseProducer<T> : Q module main {
 public class WeakBox<T> {}
 sil_vtable WeakBox {}
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> () {
 entry(%box : $WeakBox<τ_0_0>):
   %box_addr = alloc_stack $WeakBox<τ_0_0>

--- a/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_structgeneric_polymorphic_constrained-to-void.sil
@@ -33,7 +33,7 @@ public class WeakBox<T> {}
 sil_vtable WeakBox {}
 
 // CHECK-LL: @takingQTu =
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @takingQ(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define hidden swift{{(tail)?}}cc void @takingQ(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil hidden @takingQ : $@async @convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>) -> () {
 entry(%box : $WeakBox<τ_0_0>):
   %box_addr = alloc_stack $WeakBox<τ_0_0>
@@ -45,7 +45,7 @@ entry(%box : $WeakBox<τ_0_0>):
 }
 
 
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s7takingQTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil public @bind_polymorphic_param_from_forwarder_parameter : $@async @convention(thin) <τ_0_1>(@in τ_0_1) -> @callee_owned @async (@owned WeakBox<BaseProducer<τ_0_1>>) -> () {
 bb0(%0 : $*τ_0_1):
   %1 = alloc_ref $WeakBox<BaseProducer<τ_0_1>>

--- a/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-type_thin-and-classinstance-to-void.sil
@@ -60,8 +60,8 @@ sil_vtable C {
 
 struct S {}
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @structtypeSAndClassinstanceCToVoid(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
-// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s34structtypeSAndClassinstanceCToVoidTA"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @structtypeSAndClassinstanceCToVoid(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define internal swift{{(tail)?}}cc void @"$s34structtypeSAndClassinstanceCToVoidTA"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @structtypeSAndClassinstanceCToVoid : $@async @convention(thin) (@thin S.Type, @owned C) -> () {
 entry(%S_type: $@thin S.Type, %C_instance: $C):
   %S_type_addr = alloc_stack $@thick S.Type

--- a/test/IRGen/async/run-structinstance_generic-void-to-void-constrained.swift
+++ b/test/IRGen/async/run-structinstance_generic-void-to-void-constrained.swift
@@ -16,7 +16,7 @@ extension String: Fooable {}
 
 extension Optional where Wrapped: Fooable {
   // CHECK-LL: @"$sSq4mainAA7FooableRzlE22theConstrainedFunctionyyYFTu" = hidden global %swift.async_func_pointer
-  // CHECK-LL: define hidden swift{{(tail)?}}cc void @"$sSq4mainAA7FooableRzlE22theConstrainedFunctionyyYF"(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+  // CHECK-LL: define hidden swift{{(tail)?}}cc void @"$sSq4mainAA7FooableRzlE22theConstrainedFunctionyyYF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
   func theConstrainedFunction() async {
     // CHECK: running Optional<String>.theConstrainedFunction
     print("running \(Self.self).theConstrainedFunction")

--- a/test/IRGen/async/run-thintothick-int64-to-void.sil
+++ b/test/IRGen/async/run-thintothick-int64-to-void.sil
@@ -18,7 +18,7 @@ import _Concurrency
 
 sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @afun2(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @afun2(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @afun2 : $@async @convention(thin) (Int64) -> () {
 entry(%int : $Int64):
   %print = function_ref @printInt64 : $@convention(thin) (Int64) -> ()
@@ -26,7 +26,7 @@ entry(%int : $Int64):
   return %result : $()
 }
 
-// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_apply_of_thin_to_thick(%swift.task* {{%[0-9]+}}, %swift.executor* {{%[0-9]+}}, %swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define{{( dllexport)?}}{{( protected)?}} swift{{(tail)?}}cc void @test_apply_of_thin_to_thick(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 sil @test_apply_of_thin_to_thick : $@async @convention(thin) () -> () {
 entry:
   %f = function_ref @afun2 : $@async @convention(thin) (Int64) -> ()

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -18,22 +18,22 @@ public struct X {
 
   // CHECK-LABEL: sil hidden [ossa] @$s4test1XV12launchFutureyyxlF : $@convention(method) <T> (@in_guaranteed T, X) -> ()
   func launchFuture<T>(_ value: T) {
-    // CHECK: builtin "createAsyncTaskFuture"<T>([[ZERO:%.*]] : $Int, [[NIL:%.*]] : $Optional<Builtin.NativeObject>, [[FN:%.*]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
-    let task = Builtin.createAsyncTaskFuture(0, nil) { () async throws -> T in
+    // CHECK: builtin "createAsyncTaskFuture"<T>([[ZERO:%.*]] : $Int, [[FN:%.*]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+    let task = Builtin.createAsyncTaskFuture(0) { () async throws -> T in
       return value
     }
   }
 
   // CHECK-LABEL: sil hidden [ossa] @$s4test1XV16launchGroupChildyyxlF : $@convention(method) <T> (@in_guaranteed T, X) -> () {
   func launchGroupChild<T>(_ value: T) {
-    // CHECK: builtin "createAsyncTaskGroupFuture"<T>([[ZERO:%.*]] : $Int, [[NIL:%.*]] : $Optional<Builtin.NativeObject>, [[NIL:%.*]] : $Optional<Builtin.RawPointer>, [[FN:%.*]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
-    let task = Builtin.createAsyncTaskGroupFuture(0, nil, nil) { () async throws -> T in
+    // CHECK: builtin "createAsyncTaskGroupFuture"<T>([[ZERO:%.*]] : $Int, [[NIL:%.*]] : $Optional<Builtin.RawPointer>, [[FN:%.*]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <T>) : $(Builtin.NativeObject, Builtin.RawPointer)
+    let task = Builtin.createAsyncTaskGroupFuture(0, nil) { () async throws -> T in
       return value
     }
   }
 
   public func launchRocker<T>(closure: @escaping () async throws -> T) {
-    _ = Builtin.createAsyncTaskFuture(0, nil, closure)
+    _ = Builtin.createAsyncTaskFuture(0, closure)
   }
 }
 

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -118,9 +118,8 @@ class TaskContinuationFromLambda {
   static llvm::Optional<Fn> lambdaStorage;
 
   SWIFT_CC(swiftasync)
-  static void invoke(AsyncTask *task, ExecutorRef executor,
-                     SWIFT_ASYNC_CONTEXT AsyncContext *context) {
-    (*lambdaStorage)(task, executor, static_cast<Context*>(context));
+  static void invoke(SWIFT_ASYNC_CONTEXT AsyncContext *context) {
+    (*lambdaStorage)(static_cast<Context*>(context));
   }
 
 public:
@@ -142,7 +141,6 @@ createTaskWithContext(JobPriority priority, Fn &&fn) {
     TaskContinuationFromLambda<Fn, Context>::get(std::move(fn));
 
   auto pair = swift_task_create_f(JobFlags(JobKind::Task, priority),
-                                  /*parent*/ nullptr,
                                   invoke,
                                   sizeof(Context));
   return std::make_pair(pair.Task,
@@ -161,6 +159,11 @@ static void parkTask(AsyncTask *task, Context *context, Fn &&fn) {
     TaskContinuationFromLambda<Fn, Context>::get(std::move(fn));
   task->ResumeTask = invoke;
   task->ResumeContext = context;
+}
+
+template <class Context, class Fn>
+static TaskContinuationFunction *prepareContinuation(Fn &&fn) {
+  return TaskContinuationFromLambda<Fn, Context>::get(std::move(fn));
 }
 
 namespace {
@@ -216,23 +219,23 @@ static AsyncTask *createTaskStoring(JobPriority priority,
 TEST(ActorTest, validateTestHarness) {
   run([] {
     auto task0 = createTask(JobPriority::Background,
-      [](AsyncTask *task, ExecutorRef executor, AsyncContext *context) {
+      [](AsyncContext *context) {
         EXPECT_PROGRESS(5);
         EXPECT_PROGRESS(6);
         finishTest();
-        return context->resumeParent(task, executor);
+        return context->resumeParent();
       });
     auto task1 = createTask(JobPriority::Default,
-      [](AsyncTask *task, ExecutorRef executor, AsyncContext *context) {
+      [](AsyncContext *context) {
         EXPECT_PROGRESS(1);
         EXPECT_PROGRESS(2);
-        return context->resumeParent(task, executor);
+        return context->resumeParent();
       });
     auto task2 = createTask(JobPriority::Default,
-      [](AsyncTask *task, ExecutorRef executor, AsyncContext *context) {
+      [](AsyncContext *context) {
         EXPECT_PROGRESS(3);
         EXPECT_PROGRESS(4);
-        return context->resumeParent(task, executor);
+        return context->resumeParent();
       });
 
     swift_task_enqueueGlobal(task0);
@@ -250,30 +253,32 @@ TEST(ActorTest, actorSwitch) {
     auto actor = createActor();
     auto task0 = createTaskStoring(JobPriority::Default,
                                    (AsyncTask*) nullptr, actor,
-      [](AsyncTask *task, ExecutorRef executor, Context *context) {
+      [](Context *context) {
         EXPECT_PROGRESS(1);
-        EXPECT_TRUE(executor.isGeneric());
+        EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
         EXPECT_EQ(nullptr, context->get<0>());
-        std::get<0>(context->values) = task;
+        std::get<0>(context->values) = swift_task_getCurrent();
 
-        parkTask(task, context,
-          [](AsyncTask *task, ExecutorRef executor, Context *context) {
+        auto continuation = prepareContinuation<Context>(
+          [](Context *context) {
             EXPECT_PROGRESS(2);
+            auto executor = swift_task_getCurrentExecutor();
             EXPECT_FALSE(executor.isGeneric());
             EXPECT_EQ(ExecutorRef::forDefaultActor(context->get<1>()),
                       executor);
-            EXPECT_EQ(task, context->get<0>());
-            parkTask(task, context,
-              [](AsyncTask *task, ExecutorRef executor, Context *context) {
+            EXPECT_EQ(swift_task_getCurrent(), context->get<0>());
+            auto continuation = prepareContinuation<Context>(
+              [](Context *context) {
                 EXPECT_PROGRESS(3);
-                EXPECT_TRUE(executor.isGeneric());
-                EXPECT_EQ(task, context->get<0>());
+                EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
+                EXPECT_EQ(swift_task_getCurrent(), context->get<0>());
                 finishTest();
-                return context->resumeParent(task, executor);
+                return context->resumeParent();
               });
-            return swift_task_switch(task, executor, ExecutorRef::generic());
+            return swift_task_switch(context, continuation,
+                                     ExecutorRef::generic());
           });
-        return swift_task_switch(task, executor,
+        return swift_task_switch(context, continuation,
                  ExecutorRef::forDefaultActor(context->get<1>()));
       });
     swift_task_enqueueGlobal(task0);
@@ -290,25 +295,29 @@ TEST(ActorTest, actorContention) {
 
     auto task0 = createTaskStoring(JobPriority::Default,
                                    (AsyncTask*) nullptr, actor,
-      [](AsyncTask *task, ExecutorRef executor, Context *context) {
+      [](Context *context) {
         EXPECT_PROGRESS(1);
-        EXPECT_TRUE(executor.isGeneric());
+        EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
         EXPECT_EQ(nullptr, context->get<0>());
+        auto task = swift_task_getCurrent();
+        EXPECT_FALSE(task == nullptr);
         std::get<0>(context->values) = task;
 
         parkTask(task, context,
-          [](AsyncTask *task, ExecutorRef executor, Context *context) {
+          [](Context *context) {
             EXPECT_PROGRESS(3);
+            auto executor = swift_task_getCurrentExecutor();
             EXPECT_FALSE(executor.isGeneric());
             EXPECT_EQ(ExecutorRef::forDefaultActor(context->get<1>()),
                       executor);
+            auto task = swift_task_getCurrent();
             EXPECT_EQ(task, context->get<0>());
             parkTask(task, context,
-              [](AsyncTask *task, ExecutorRef executor, Context *context) {
+              [](Context *context) {
                 EXPECT_PROGRESS(4);
-                EXPECT_TRUE(executor.isGeneric());
-                EXPECT_EQ(task, context->get<0>());
-                return context->resumeParent(task, executor);
+                EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
+                EXPECT_EQ(swift_task_getCurrent(), context->get<0>());
+                return context->resumeParent();
               });
             swift_task_enqueue(task, ExecutorRef::generic());
           });
@@ -319,21 +328,23 @@ TEST(ActorTest, actorContention) {
 
     auto task1 = createTaskStoring(JobPriority::Background,
                                    (AsyncTask*) nullptr, actor,
-      [](AsyncTask *task, ExecutorRef executor, Context *context) {
+      [](Context *context) {
         EXPECT_PROGRESS(2);
+        auto executor = swift_task_getCurrentExecutor();
         EXPECT_FALSE(executor.isGeneric());
         EXPECT_EQ(ExecutorRef::forDefaultActor(context->get<1>()),
                   executor);
         EXPECT_EQ(nullptr, context->get<0>());
+        auto task = swift_task_getCurrent();
         std::get<0>(context->values) = task;
 
         parkTask(task, context,
-          [](AsyncTask *task, ExecutorRef executor, Context *context) {
+          [](Context *context) {
             EXPECT_PROGRESS(5);
-            EXPECT_TRUE(executor.isGeneric());
-            EXPECT_EQ(task, context->get<0>());
+            EXPECT_TRUE(swift_task_getCurrentExecutor().isGeneric());
+            EXPECT_EQ(swift_task_getCurrent(), context->get<0>());
             finishTest();
-            return context->resumeParent(task, executor);
+            return context->resumeParent();
           });
 
         swift_task_enqueue(task, ExecutorRef::generic());

--- a/unittests/runtime/TaskStatus.cpp
+++ b/unittests/runtime/TaskStatus.cpp
@@ -21,9 +21,7 @@ template <class T> struct ValueContext;
 
 template <class T>
 using InvokeFunctionRef =
-  llvm::function_ref<void(AsyncTask *task,
-                          ExecutorRef executor,
-                          ValueContext<T> *context)>;
+  llvm::function_ref<void(ValueContext<T> *context)>;
 using BodyFunctionRef =
   llvm::function_ref<void(AsyncTask *task)>;
 
@@ -39,10 +37,9 @@ using undeduced =
 
 template <class T>
 SWIFT_CC(swiftasync)
-static void simpleTaskInvokeFunction(AsyncTask *task, ExecutorRef executor,
-                                     SWIFT_ASYNC_CONTEXT AsyncContext *context) {
+static void simpleTaskInvokeFunction(SWIFT_ASYNC_CONTEXT AsyncContext *context) {
   auto valueContext = static_cast<ValueContext<T>*>(context);
-  valueContext->StoredInvokeFn(task, executor, valueContext);
+  valueContext->StoredInvokeFn(valueContext);
 
   // Destroy the stored value.
   valueContext->Value.T::~T();
@@ -50,7 +47,7 @@ static void simpleTaskInvokeFunction(AsyncTask *task, ExecutorRef executor,
   // Return to finish off the task.
   // In a normal situation we'd need to free the context, but here
   // we know we're at the top level.
-  valueContext->ResumeParent(task, executor, valueContext->Parent);
+  valueContext->ResumeParent(valueContext->Parent);
 }
 
 template <class T>
@@ -58,8 +55,7 @@ static void withSimpleTask(JobFlags flags, T &&value,
                            undeduced<InvokeFunctionRef<T>> invokeFn,
                            BodyFunctionRef body) {
   auto taskAndContext =
-    swift_task_create_f(flags, /*parent*/ nullptr,
-                        &simpleTaskInvokeFunction<T>,
+    swift_task_create_f(flags, &simpleTaskInvokeFunction<T>,
                         sizeof(ValueContext<T>));
 
   auto valueContext =
@@ -92,13 +88,12 @@ TEST(TaskStatusTest, basicTasks) {
 
   struct Storage { int value; };
   withSimpleTask(Storage{47},
-    [&](AsyncTask *task, ExecutorRef executor,
-        ValueContext<Storage> *context) {
+    [&](ValueContext<Storage> *context) {
     // The task passed in should be the task we created.
-    EXPECT_EQ(createdTask, task);
+    EXPECT_EQ(createdTask, swift_task_getCurrent());
 
     // The executor passed in should be the executor we created.
-    EXPECT_EQ(createdExecutor, executor);
+    //EXPECT_EQ(createdExecutor, executor);
 
     // We shouldn't have run yet.
     EXPECT_FALSE(hasRun);
@@ -112,7 +107,7 @@ TEST(TaskStatusTest, basicTasks) {
     createdTask = task;
 
     EXPECT_FALSE(hasRun);
-    createdTask->runInFullyEstablishedContext(createdExecutor);
+    swift_job_run(task, createdExecutor);
     EXPECT_TRUE(hasRun);
 
     createdTask = nullptr;
@@ -125,15 +120,15 @@ TEST(TaskStatusTest, basicTasks) {
 TEST(TaskStatusTest, cancellation_simple) {
   struct Storage { int value; };
   withSimpleTask(Storage{47},
-    [&](AsyncTask *task, ExecutorRef executor,
-        ValueContext<Storage> *context) {
+    [&](ValueContext<Storage> *context) {
+    auto task = swift_task_getCurrent();
     EXPECT_FALSE(task->isCancelled());
     swift_task_cancel(task);
     EXPECT_TRUE(task->isCancelled());
     swift_task_cancel(task);
     EXPECT_TRUE(task->isCancelled());
   }, [&](AsyncTask *task) {
-    task->runInFullyEstablishedContext(createFakeExecutor(1234));
+    swift_job_run(task, createFakeExecutor(1234));
   });
 }
 
@@ -143,8 +138,8 @@ TEST(TaskStatusTest, cancellation_simple) {
 TEST(TaskStatusTest, deadline) {
   struct Storage { int value; };
   withSimpleTask(Storage{47},
-    [&](AsyncTask *task, ExecutorRef executor,
-        ValueContext<Storage> *context) {
+    [&](ValueContext<Storage> *context) {
+    auto task = swift_task_getCurrent();
     EXPECT_FALSE(task->isCancelled());
 
     TaskDeadline deadlineOne = { 1234 };
@@ -157,7 +152,7 @@ TEST(TaskStatusTest, deadline) {
     EXPECT_EQ(NearestTaskDeadline::None, nearest.ValueKind);
 
     // Add deadline 1.  Check that we haven't been cancelled yet.
-    result = swift_task_addStatusRecord(task, &recordOne);
+    result = swift_task_addStatusRecord(&recordOne);
     EXPECT_TRUE(result);
 
     // There should now be an active deadline.
@@ -166,7 +161,7 @@ TEST(TaskStatusTest, deadline) {
     EXPECT_EQ(deadlineOne, nearest.Value);
 
     // Remove deadline 1.  Check that we haven't been cancelled yet.
-    result = swift_task_removeStatusRecord(task, &recordOne);
+    result = swift_task_removeStatusRecord(&recordOne);
     EXPECT_TRUE(result);
 
     // There shouldn't be an active deadline anymore.
@@ -174,9 +169,9 @@ TEST(TaskStatusTest, deadline) {
     EXPECT_EQ(NearestTaskDeadline::None, nearest.ValueKind);
 
     // Add deadline 1, then 2.
-    result = swift_task_addStatusRecord(task, &recordOne);
+    result = swift_task_addStatusRecord(&recordOne);
     EXPECT_TRUE(result);
-    result = swift_task_addStatusRecord(task, &recordTwo);
+    result = swift_task_addStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
 
     // The nearest deadline should be deadline 1.
@@ -185,13 +180,13 @@ TEST(TaskStatusTest, deadline) {
     EXPECT_EQ(deadlineOne, nearest.Value);
 
     // Remove the deadlines.
-    result = swift_task_removeStatusRecord(task, &recordTwo);
+    result = swift_task_removeStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
-    result = swift_task_removeStatusRecord(task, &recordOne);
+    result = swift_task_removeStatusRecord(&recordOne);
     EXPECT_TRUE(result);
 
     // Add deadline 2, then 1s.
-    result = swift_task_addStatusRecord(task, &recordTwo);
+    result = swift_task_addStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
 
     // In the middle, the nearest deadline should be deadline 2.
@@ -199,7 +194,7 @@ TEST(TaskStatusTest, deadline) {
     EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
     EXPECT_EQ(deadlineTwo, nearest.Value);
 
-    result = swift_task_addStatusRecord(task, &recordOne);
+    result = swift_task_addStatusRecord(&recordOne);
     EXPECT_TRUE(result);
 
     // The nearest deadline should be deadline 1.
@@ -208,41 +203,41 @@ TEST(TaskStatusTest, deadline) {
     EXPECT_EQ(deadlineOne, nearest.Value);
 
     // Remove the deadlines.
-    result = swift_task_removeStatusRecord(task, &recordOne);
+    result = swift_task_removeStatusRecord(&recordOne);
     EXPECT_TRUE(result);
-    result = swift_task_removeStatusRecord(task, &recordTwo);
+    result = swift_task_removeStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
 
     // Do the same thing with tryAddStatus.
-    result = swift_task_tryAddStatusRecord(task, &recordTwo);
+    result = swift_task_tryAddStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
-    result = swift_task_tryAddStatusRecord(task, &recordOne);
+    result = swift_task_tryAddStatusRecord(&recordOne);
     EXPECT_TRUE(result);
     // The nearest deadline should be deadline 1.
     nearest = swift_task_getNearestDeadline(task);
     EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
     EXPECT_EQ(deadlineOne, nearest.Value);
-    result = swift_task_removeStatusRecord(task, &recordOne);
+    result = swift_task_removeStatusRecord(&recordOne);
     EXPECT_TRUE(result);
-    result = swift_task_removeStatusRecord(task, &recordTwo);
+    result = swift_task_removeStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
 
     // Remove out of order.
-    result = swift_task_addStatusRecord(task, &recordTwo);
+    result = swift_task_addStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
-    result = swift_task_addStatusRecord(task, &recordOne);
+    result = swift_task_addStatusRecord(&recordOne);
     EXPECT_TRUE(result);
     // The nearest deadline should be deadline 1.
     nearest = swift_task_getNearestDeadline(task);
     EXPECT_EQ(NearestTaskDeadline::Active, nearest.ValueKind);
     EXPECT_EQ(deadlineOne, nearest.Value);
-    result = swift_task_removeStatusRecord(task, &recordTwo);
+    result = swift_task_removeStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
-    result = swift_task_removeStatusRecord(task, &recordOne);
+    result = swift_task_removeStatusRecord(&recordOne);
     EXPECT_TRUE(result);
 
     // Add deadline 2, then cancel.
-    result = swift_task_addStatusRecord(task, &recordTwo);
+    result = swift_task_addStatusRecord(&recordTwo);
     EXPECT_TRUE(result);
 
     // The nearest deadline should be deadline 2.
@@ -259,19 +254,19 @@ TEST(TaskStatusTest, deadline) {
     EXPECT_EQ(NearestTaskDeadline::AlreadyCancelled, nearest.ValueKind);
 
     // Add deadline 1.
-    result = swift_task_addStatusRecord(task, &recordOne);
+    result = swift_task_addStatusRecord(&recordOne);
     EXPECT_FALSE(result);
 
     nearest = swift_task_getNearestDeadline(task);
     EXPECT_EQ(NearestTaskDeadline::AlreadyCancelled, nearest.ValueKind);
 
-    result = swift_task_removeStatusRecord(task, &recordOne);
+    result = swift_task_removeStatusRecord(&recordOne);
     EXPECT_FALSE(result);
 
-    result = swift_task_tryAddStatusRecord(task, &recordOne);
+    result = swift_task_tryAddStatusRecord(&recordOne);
     EXPECT_FALSE(result);
 
-    result = swift_task_removeStatusRecord(task, &recordTwo);
+    result = swift_task_removeStatusRecord(&recordTwo);
     EXPECT_FALSE(result);
 
     nearest = swift_task_getNearestDeadline(task);
@@ -279,6 +274,6 @@ TEST(TaskStatusTest, deadline) {
 
     EXPECT_TRUE(task->isCancelled());
   }, [&](AsyncTask *task) {
-    task->runInFullyEstablishedContext(createFakeExecutor(1234));
+    swift_job_run(task, createFakeExecutor(1234));
   });
 }


### PR DESCRIPTION
Most of the async runtime functions have been changed to not expect the task and executor to be passed in.  When knowing the task and executor is necessary, there are runtime functions available to recover them.

The biggest change I had to make to a runtime function signature was to swift_task_switch, which has been altered to expect to be passed the context and resumption function instead of requiring the caller to park the task.  This has the pleasant consequence of allowing the implementation to very quickly turn around when it recognizes that the current executor is satisfactory.  It does mean that on arm64e we have to sign the continuation function pointer as an argument and then potentially resign it when assigning into the task's resume slot.

rdar://70546948