### PR TITLE
test: fix typo in class-class-flags-run.swift

### DIFF
--- a/test/IRGen/prespecialized-metadata/class-class-flags-run.swift
+++ b/test/IRGen/prespecialized-metadata/class-class-flags-run.swift
@@ -40,7 +40,7 @@ class Clazz<T> {
 
 func doit() {
   assertIsPrespecialized(Clazz<Int>.self, is: true)
-  assertIsPrespecialized(clazzArgument: Int.self, is: true) // Clazz<Int> is prespecialized by the preceeding call
+  assertIsPrespecialized(clazzArgument: Int.self, is: true) // Clazz<Int> is prespecialized by the preceding call
 
   assertIsPrespecialized(clazzArgument: Double.self, is: false) // Clazz<Double> is not prespecialized
 }


### PR DESCRIPTION
preceeding -> preceding
