### PR TITLE
Remove unnecessary retain/release/initialization overhead from lookup table Arrays.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2634,6 +2634,23 @@ void IRGenSILFunction::visitGlobalAddrInst(GlobalAddrInst *i) {
   setLoweredAddress(i, addr);
 }
 
+/// Returns true if \p val has no other uses than ref_element_addr or
+/// ref_tail_addr.
+static bool hasOnlyProjections(SILValue val) {
+  for (Operand *use : val->getUses()) {
+    SILInstruction *user = use->getUser();
+    if (auto *upCast = dyn_cast<UpcastInst>(user)) {
+      if (!hasOnlyProjections(upCast))
+        return false;
+      continue;
+    }
+    if (isa<RefElementAddrInst>(user) || isa<RefTailAddrInst>(user))
+      continue;
+    return false;
+  }
+  return true;
+}
+
 void IRGenSILFunction::visitGlobalValueInst(GlobalValueInst *i) {
   SILGlobalVariable *var = i->getReferencedGlobal();
   assert(var->isInitializedObject() &&
@@ -2645,17 +2662,19 @@ void IRGenSILFunction::visitGlobalValueInst(GlobalValueInst *i) {
 
   llvm::Value *Ref = IGM.getAddrOfSILGlobalVariable(var, ti,
                                                 NotForDefinition).getAddress();
-
-  auto ClassType = loweredTy.getASTType();
-  llvm::Value *Metadata =
-    emitClassHeapMetadataRef(*this, ClassType, MetadataValueType::TypeMetadata,
-                             MetadataState::Complete);
-  llvm::Value *CastAddr = Builder.CreateBitCast(Ref, IGM.RefCountedPtrTy);
-  llvm::Value *InitRef = emitInitStaticObjectCall(Metadata, CastAddr, "staticref");
-  InitRef = Builder.CreateBitCast(InitRef, Ref->getType());
-
+  // We don't need to initialize the global object if it's never used for
+  // something which can access the object header.
+  if (!hasOnlyProjections(i)) {
+    auto ClassType = loweredTy.getASTType();
+    llvm::Value *Metadata =
+      emitClassHeapMetadataRef(*this, ClassType, MetadataValueType::TypeMetadata,
+                               MetadataState::Complete);
+    llvm::Value *CastAddr = Builder.CreateBitCast(Ref, IGM.RefCountedPtrTy);
+    llvm::Value *InitRef = emitInitStaticObjectCall(Metadata, CastAddr, "staticref");
+    Ref = Builder.CreateBitCast(InitRef, Ref->getType());
+  }
   Explosion e;
-  e.add(InitRef);
+  e.add(Ref);
   setLoweredExplosion(i, e);
 }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -301,6 +301,7 @@ public:
       
   SILInstruction *visitMarkDependenceInst(MarkDependenceInst *MDI);
   SILInstruction *visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *CBOI);
+  SILInstruction *visitGlobalValueInst(GlobalValueInst *globalValue);
   SILInstruction *visitConvertFunctionInst(ConvertFunctionInst *CFI);
   SILInstruction *
   visitConvertEscapeToNoEscapeInst(ConvertEscapeToNoEscapeInst *Cvt);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -2283,3 +2283,40 @@ SILCombiner::visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *cboi) {
 
   return nullptr;
 }
+
+/// Returns true if reference counting and debug_value users of a global_value
+/// can be deleted.
+static bool checkGlobalValueUsers(SILValue val,
+                                  SmallVectorImpl<SILInstruction *> &toDelete) {
+  for (Operand *use : val->getUses()) {
+    SILInstruction *user = use->getUser();
+    if (isa<RefCountingInst>(user) || isa<DebugValueInst>(user)) {
+      toDelete.push_back(user);
+      continue;
+    }
+    if (auto *upCast = dyn_cast<UpcastInst>(user)) {
+      if (!checkGlobalValueUsers(upCast, toDelete))
+        return false;
+      continue;
+    }
+    // Projection instructions don't access the object header, so they don't
+    // prevent deleting reference counting instructions.
+    if (isa<RefElementAddrInst>(user) || isa<RefTailAddrInst>(user))
+      continue;
+    return false;
+  }
+  return true;
+}
+
+SILInstruction *
+SILCombiner::visitGlobalValueInst(GlobalValueInst *globalValue) {
+  // Delete all reference count instructions on a global_value if the only other
+  // users are projections (ref_element_addr and ref_tail_addr).
+  SmallVector<SILInstruction *, 8> toDelete;
+  if (!checkGlobalValueUsers(globalValue, toDelete))
+    return nullptr;
+  for (SILInstruction *inst : toDelete) {
+    eraseInstFromFunction(*inst);
+  }
+  return nullptr;
+}

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -4204,3 +4204,25 @@ bb1(%result : $Builtin.NativeObject):
 bb2(%error : $Error):
   unreachable
 }
+
+sil_global private @outlined_global : $_ContiguousArrayStorage<Int>
+
+// CHECK-LABEL: sil @test_global_value
+// CHECK-NOT:   retain
+// CHECK-NOT:   release
+// CHECK-NOT:   debug_value
+// CHECK:     } // end sil function 'test_global_value'
+sil @test_global_value : $@convention(thin) () -> Int {
+bb0:
+  %0 = global_value @outlined_global : $_ContiguousArrayStorage<Int>
+  strong_retain %0 : $_ContiguousArrayStorage<Int>
+  debug_value %0 : $_ContiguousArrayStorage<Int>, let, name "x"
+  %2 = upcast %0 : $_ContiguousArrayStorage<Int> to $__ContiguousArrayStorageBase
+  strong_retain %2 : $__ContiguousArrayStorageBase
+  %13 = ref_tail_addr [immutable] %2 : $__ContiguousArrayStorageBase, $Int
+  %16 = load %13 : $*Int
+  strong_release %2 : $__ContiguousArrayStorageBase
+  strong_release %0 : $_ContiguousArrayStorage<Int>
+  return %16 : $Int
+} // end sil function 'test_global_value'
+

--- a/test/SILOptimizer/static_arrays.swift
+++ b/test/SILOptimizer/static_arrays.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -Xllvm -sil-disable-pass=FunctionSignatureOpts -module-name=test -emit-ir | %FileCheck %s -check-prefix=CHECK-LLVM
 
 // Also do an end-to-end test to check all components, including IRGen.
 // RUN: %empty-directory(%t) 
@@ -98,9 +99,18 @@
 // CHECK:   return
 public let globalVariable = [ 100, 101, 102 ]
 
-// CHECK-LABEL: sil {{.*}}arrayLookup{{.*}} : $@convention(thin) (Int) -> Int {
-// CHECK:   global_value @{{.*}}arrayLookup{{.*}}
-// CHECK:   return
+// CHECK-LABEL: sil [noinline] @$s4test11arrayLookupyS2iF
+// CHECK:   global_value @$s4test11arrayLookupyS2iFTv_
+// CHECK-NOT: retain
+// CHECK-NOT: release
+// CHECK:   } // end sil function '$s4test11arrayLookupyS2iF'
+
+// CHECK-LLVM-LABEL: define {{.*}} @"$s4test11arrayLookupyS2iF"
+// CHECK-LLVM-NOT:  call
+// CHECK-LLVM:      [[E:%[0-9]+]] = getelementptr {{.*}} @"$s4test11arrayLookupyS2iFTv_"
+// CHECK-LLVM-NEXT: [[L:%[0-9]+]] = load {{.*}} [[E]]
+// CHECK-LLVM-NEXT: ret {{.*}} [[L]]
+// CHECK-LLVM:   }
 @inline(never)
 public func arrayLookup(_ i: Int) -> Int {
   let lookupTable = [10, 11, 12]


### PR DESCRIPTION
For example:
```
public func foo(_ i: Int) -> Int {
  let lookupTable = [10, 11, 12]
  return lookupTable[i]
}
```
The Array overhead can be completely eliminated (except for the range check - which makes sense).
It compiles down to a getelementptr + a load. No initialization of the array's metadata and no retain/release traffic is needed.

https://bugs.swift.org/browse/SR-12289
rdar://59874359