### PR TITLE
 [Diagnostics] Check whether missing conformance could be fixed by using `.rawValue`

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6842,7 +6842,7 @@ AbstractRawRepresentableFailure::getDiagnostic() const {
   } else if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
     return diag::cannot_convert_argument_value;
   } else if (locator->isLastElement<LocatorPathElt::AnyRequirement>()) {
-    return diag::cannot_convert_initializer_value_protocol;
+    return diag::type_does_not_conform;
   }
 
   return None;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6841,6 +6841,8 @@ AbstractRawRepresentableFailure::getDiagnostic() const {
     return diag::cannot_convert_assign;
   } else if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
     return diag::cannot_convert_argument_value;
+  } else if (locator->isLastElement<LocatorPathElt::AnyRequirement>()) {
+    return diag::cannot_convert_initializer_value_protocol;
   }
 
   return None;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2273,6 +2273,8 @@ public:
   Type getFromType() const override { return RawReprType; }
   Type getToType() const override { return ExpectedType; }
 
+  bool diagnoseAsError() override;
+
 private:
   void fixIt(InFlightDiagnostic &diagnostic) const override;
 };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3243,7 +3243,14 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
   // behind itself which we can use to better understand
   // how many levels of optionality have to be unwrapped.
   if (auto *OEE = dyn_cast<OptionalEvaluationExpr>(anchor)) {
-    auto type = cs.getType(OEE->getSubExpr());
+    auto *subExpr = OEE->getSubExpr();
+
+    // First, let's check whether it has been determined that
+    // it was incorrect to use `?` in this position.
+    if (cs.hasFixFor(cs.getConstraintLocator(subExpr), FixKind::RemoveUnwrap))
+      return true;
+
+    auto type = cs.getType(subExpr);
     // If the type of sub-expression is optional, type of the
     // `OptionalEvaluationExpr` could be safely ignored because
     // it doesn't add any type information.

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -20,7 +20,7 @@ func acceptComparable<T: Comparable>(_: T) {}
 func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name) {
   acceptEquatable(x)
   acceptHashable(x)
-  acceptComparable(x) // expected-error {{value of type 'NSNotification.Name' does not conform to specified type 'Comparable'}} {{19-19=.rawValue}}
+  acceptComparable(x) // expected-error {{type 'NSNotification.Name' does not conform to protocol 'Comparable'}} {{19-19=.rawValue}}
 
   _ = x == y
   _ = x != y

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -16,12 +16,11 @@ func acceptHashable<T: Hashable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'WrappedRef'}}
 // expected-note@-2 {{where 'T' = 'WrappedValue'}}
 func acceptComparable<T: Comparable>(_: T) {}
-// expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
 
 func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name) {
   acceptEquatable(x)
   acceptHashable(x)
-  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
+  acceptComparable(x) // expected-error {{value of type 'NSNotification.Name' does not conform to specified type 'Comparable'}} {{19-19=.rawValue}}
 
   _ = x == y
   _ = x != y

--- a/test/ClangImporter/newtype_conformance.swift
+++ b/test/ClangImporter/newtype_conformance.swift
@@ -16,11 +16,13 @@ func acceptHashable<T: Hashable>(_: T) {}
 // expected-note@-1 {{where 'T' = 'WrappedRef'}}
 // expected-note@-2 {{where 'T' = 'WrappedValue'}}
 func acceptComparable<T: Comparable>(_: T) {}
+// expected-note@-1 {{where 'T' = 'NSNotification.Name'}}
 
 func testNewTypeWrapper(x: NSNotification.Name, y: NSNotification.Name) {
   acceptEquatable(x)
   acceptHashable(x)
-  acceptComparable(x) // expected-error {{type 'NSNotification.Name' does not conform to protocol 'Comparable'}} {{19-19=.rawValue}}
+  acceptComparable(x) // expected-error {{global function 'acceptComparable' requires that 'NSNotification.Name' conform to 'Comparable'}}
+  // expected-note@-1 {{did you mean to use '.rawValue'?}} {{19-19=.rawValue}}
 
   _ = x == y
   _ = x != y

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -359,5 +359,5 @@ func testKeyPathSubscriptArgFixes(_ fn: @escaping () -> Int) {
 
 func sr12426(a: Any, _ str: String?) {
   a == str // expected-error {{binary operator '==' cannot be applied to operands of type 'Any' and 'String?'}}
-  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (CodingUserInfoKey, CodingUserInfoKey), (String, String)}}
+  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (String, String)}}
 }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -425,8 +425,9 @@ func test_force_unwrap_not_being_too_eager() {
 
 // rdar://problem/57097401
 func invalidOptionalChaining(a: Any) {
-  a == "="? // expected-error {{binary operator '==' cannot be applied to operands of type 'Any' and 'String?'}}
-  // expected-note@-1 {{overloads for '==' exist with these partially matching parameter lists: (CodingUserInfoKey, CodingUserInfoKey), (FloatingPointSign, FloatingPointSign), (String, String), (Unicode.CanonicalCombiningClass, Unicode.CanonicalCombiningClass)}}
+  a == "="? // expected-error {{cannot use optional chaining on non-optional value of type 'String'}}
+  // expected-error@-1 {{protocol 'Any' as a type cannot conform to 'Equatable'}}
+  // expected-note@-2 {{requirement from conditional conformance of 'Any?' to 'Equatable'}} expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
 }
 
 // SR-12309 - Force unwrapping 'nil' compiles without warning

--- a/validation-test/Sema/SwiftUI/rdar75367157.swift
+++ b/validation-test/Sema/SwiftUI/rdar75367157.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+enum E : String {
+  case a
+  case b
+
+  var description: String { get { "" } }
+}
+
+struct S : View {
+  var test: E = .a
+
+  func check(_: String) -> Bool {}
+
+  var body: some View {
+    List {
+      if test != E.b.description { // expected-error {{cannot convert value of type 'E' to expected argument type 'String'}} {{14-14=.rawValue}}
+        EmptyView()
+      }
+
+      if (check(self.test)) { // expected-error {{cannot convert value of type 'E' to expected argument type 'String'}} {{26-26=.rawValue}}
+        Spacer()
+      }
+    }
+  }
+}


### PR DESCRIPTION
A lot of operators (and most likely regular functions a well) have
overloads that accept i.e. a generic parameter that conforms to
`StringProtocol`, so the best fix in situations when argument is
a raw representable type would be to check whether `.rawValue`
conforms to the expected protocol and use it if so.

Resolves rdar://problem/75367157

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
