### PR TITLE
SILOptimizer: fix a compiler crash when optimizing a global variable with an empty tuple.

### DIFF
--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -111,6 +111,11 @@ BuiltinInst *SILGlobalVariable::getOffsetSubtract(const TupleExtractInst *TE,
 
 bool SILGlobalVariable::isValidStaticInitializerInst(const SILInstruction *I,
                                                      SILModule &M) {
+  for (const Operand &op : I->getAllOperands()) {
+    // Rule out SILUndef and SILArgument.
+    if (!isa<SingleValueInstruction>(op.get()))
+      return false;
+  }
   switch (I->getKind()) {
     case SILInstructionKind::BuiltinInst: {
       auto *bi = cast<BuiltinInst>(I);

--- a/test/SILOptimizer/globalopt_let_propagation.swift
+++ b/test/SILOptimizer/globalopt_let_propagation.swift
@@ -72,6 +72,10 @@ var VPI = 3.1415
 var VI = 100
 var VS = "String2"
 
+struct GenericStruct<T> {
+  var x: T
+}
+
 // Define some static let variables inside a struct.
 struct B {
  static let PI = 3.1415
@@ -109,6 +113,8 @@ struct B {
  static let IT1 = ((10, 20), 30, 40)
 
  static let IT2 = (100, 200, 300)
+
+ static let emptyStruct = GenericStruct(x: ())
 }
 
 // Define some static let variables inside a class.

--- a/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
+++ b/test/SILOptimizer/globalopt_trivial_nontrivial_ossa.sil
@@ -18,6 +18,10 @@ public class TClass {
   deinit
 }
 
+struct GenericStruct<T> {
+  var x: T
+}
+
 let nontrivialglobal: TClass
 
 // CHECK-LABEL: sil_global hidden [let] @$trivialglobal : $TStruct = {
@@ -31,6 +35,9 @@ sil_global hidden [let] @$trivialglobal : $TStruct
 sil_global private @globalinit_nontrivialglobal_token : $Builtin.Word
 
 sil_global hidden [let] @$nontrivialglobal : $TClass
+
+sil_global hidden [let] @empty_global : $GenericStruct<()>
+sil_global private @empty_global_token : $Builtin.Word
 
 sil private [global_init_once_fn] [ossa] @globalinit_trivialglobal_func : $@convention(c) () -> () {
 bb0:
@@ -124,5 +131,30 @@ bb0:
   end_borrow %3b : $TClass
   destroy_value %3 : $TClass 
   return %5 : $Int32                              
+}
+
+// Check that we don't crash on an initializer struct with an "undef" operand.
+// CHECK-LABEL: sil hidden [global_init_once_fn] [ossa] @globalinit_empty_global :
+// CHECK: struct $GenericStruct<()> (undef : $())
+// CHECK-LABEL: } // end sil function 'globalinit_empty_global'
+sil hidden [global_init_once_fn] [ossa] @globalinit_empty_global : $@convention(c) () -> () {
+bb0:
+  alloc_global @empty_global
+  %1 = global_addr @empty_global : $*GenericStruct<()>
+  %2 = struct $GenericStruct<()> (undef : $())
+  store %2 to [trivial] %1 : $*GenericStruct<()>
+  %4 = tuple ()
+  return %4 : $()
+}
+
+sil hidden [global_init] [ossa] @empty_global_accessor : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @empty_global_token : $*Builtin.Word
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
+  %2 = function_ref @globalinit_empty_global : $@convention(c) () -> ()
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @empty_global : $*GenericStruct<()>
+  %5 = address_to_pointer %4 : $*GenericStruct<()> to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
 }
 

--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -438,8 +438,8 @@ bb3(%20 : $((), ())):
 }
 
 // CHECK-LABEL: sil @load_tuple_of_void
-// CHECK-NOT: alloc_stack
-// CHECK:   return undef : $((), ())
+// CHECK:   [[T:%[0-9]+]] = tuple (%{{[0-9]+}} : $(), %{{[0-9]+}} : $())
+// CHECK:   return [[T]] : $((), ())
 // CHECK: } // end sil function 'load_tuple_of_void'
 sil @load_tuple_of_void : $@convention(thin) () -> ((), ()) {
 bb0:

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -478,7 +478,8 @@ bb3(%20 : $((), ())):
 
 // CHECK-LABEL: sil [ossa] @load_tuple_of_void :
 // CHECK-NOT: alloc_stack
-// CHECK:   return undef : $((), ())
+// CHECK:   [[T:%[0-9]+]] = tuple (%{{[0-9]+}} : $(), %{{[0-9]+}} : $())
+// CHECK:   return [[T]] : $((), ())
 // CHECK: } // end sil function 'load_tuple_of_void'
 sil [ossa] @load_tuple_of_void : $@convention(thin) () -> ((), ()) {
 bb0:


### PR DESCRIPTION
The first fix is in GlobalOpt: bail is the initializer instructions of a global variable contain "undef"

But also fix SILMem2Reg to not create an "undef" as a replacement of a load of an empty tuple.
In general, it's not a good idea to create undef values in SIL.

https://bugs.swift.org/browse/SR-14342
rdar://75364429