### PR TITLE
Don't crash in RawSILInstLowering if DI produced an error.

### DIFF
--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -179,8 +179,11 @@ static void lowerAssignByWrapperInstruction(SILBuilderWithScope &b,
   
   switch (inst->getMode()) {
     case AssignByWrapperInst::Unknown:
-      llvm_unreachable("assign_by_wrapper must have a valid mode");
-
+      assert(b.getModule().getASTContext().hadError() &&
+             "assign_by_wrapper must have a valid mode");
+      // In case DefiniteInitialization already gave up with an error, just
+      // treat the assign_by_wrapper as an "init".
+      LLVM_FALLTHROUGH;
     case AssignByWrapperInst::Initialization:
     case AssignByWrapperInst::Assign: {
       SILValue initFn = inst->getInitializer();

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
-// RUN: %target-swift-frontend -emit-sil -primary-file %s -o /dev/null -verify
 
 import Swift
 
@@ -1606,4 +1605,29 @@ class A {
       self.init(x: i)
     }
   } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
- }
+}
+
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+
+  init(wrappedValue initialValue: T) {
+    self.wrappedValue = initialValue
+  }
+}
+
+func foo(_ d: DerivedWrappedProperty) {
+  print(d)
+}
+
+class DerivedWrappedProperty : SomeClass {
+  @Wrapper var y: String
+  var z : String
+
+  init(s: String) {
+    y = s
+    z = s
+    foo(self)  // expected-error {{'self' used in method call 'foo' before 'super.init' call}}
+  }  // expected-error {{'super.init' isn't called on all paths before returning from initializer}}
+
+}


### PR DESCRIPTION
In case DI doesn't classify assign_by_wrapper (because of another error), make sure that RawSILInstLowering can handle this.

rdar://75433096
