### PR TITLE
Temporarily move FixedPoint.swift.gyb into long_test

### DIFF
--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -1,6 +1,11 @@
 // RUN: %target-run-stdlib-swiftgyb
 // REQUIRES: executable_test
 
+// FIXME: [SR-14363]
+//   FixedPoint.swift.gyb slowed down with -Onone copy propagation
+//   We should be able to move this out of long_test once fixed.
+// REQUIRES: long_test
+
 import StdlibUnittest
 
 


### PR DESCRIPTION
[SR-14363] FixedPoint.swift.gyb slowed down with -Onone copy propagation
