### PR TITLE
[Driver] Emit the `-new-driver-path` option before actual compiler arguments

### DIFF
--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -221,14 +221,15 @@ static int run_driver(StringRef ExecName,
         assert(ExecName == "swift");
         subCommandArgs.push_back("--driver-mode=swift");
       }
-      subCommandArgs.insert(subCommandArgs.end(), argv.begin() + 1, argv.end());
-
       // Push these non-op frontend arguments so the build log can indicate
       // the new driver is used.
       subCommandArgs.push_back("-Xfrontend");
       subCommandArgs.push_back("-new-driver-path");
       subCommandArgs.push_back("-Xfrontend");
       subCommandArgs.push_back(NewDriverPath.c_str());
+
+      // Push on the source program arguments
+      subCommandArgs.insert(subCommandArgs.end(), argv.begin() + 1, argv.end());
 
       // Execute the subcommand.
       subCommandArgs.push_back(nullptr);


### PR DESCRIPTION
Otherwise, if it is last then it will come after the input input source-file arguments. And in immediate (`swift`) mode, things that come after input source-file arguments are considered to be arguments to the underlying script and are placed after the `--`.

For example, for the following Swift script:
```
print(CommandLine.argc)
print(CommandLine.arguments)
```
When run with `swift swift.script`, before this change, we see:
```
5
["script.swift", "-Xfrontend", "-new-driver-path", "-Xfrontend", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-driver-new"]
```
Whereas with this change, we print the expected output:
```
1
["script.swift"]
```

Resolves rdar://75039518