### PR TITLE
[build-script] Ensure the sccache server is started before building

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -1319,6 +1319,12 @@ def main_normal():
         toolchain.libtool = args.host_libtool
     if args.cmake is not None:
         toolchain.cmake = args.cmake
+    if args.sccache:
+        print("Ensuring the sccache server is running...")
+        # Use --show-stats to ensure the server is started, because using
+        # --start-server will fail if the server is already running.
+        # Capture the output because we don't want to see the stats.
+        shell.capture([toolchain.sccache, "--show-stats"])
 
     cmake = CMake(args=args, toolchain=toolchain)
     # Check the CMake version is sufficient on Linux and build from source


### PR DESCRIPTION
Sometimes with the `--sccache` flag passed to build-script, the first round of compiler invocations will time-out waiting for the sccache server to start. Here we ensure the server is started ahead of time to avoid this failure.

Resolves rdar://74951999