### PR TITLE
[Driver] Don't validate arclite linking if the driver is only set up to get the swift-frontend invocation

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -200,6 +200,11 @@ private:
   /// Indicates whether the driver should check that the input files exist.
   bool CheckInputFilesExist = true;
 
+  /// Indicates that this driver never actually executes any commands but is
+  /// just set up to retrieve the swift-frontend invocation that would be
+  /// executed during compilation.
+  bool IsDummyDriverForFrontendInvocation = false;
+
 public:
   Driver(StringRef DriverExecutable, StringRef Name,
          ArrayRef<const char *> Args, DiagnosticEngine &Diags);
@@ -225,6 +230,14 @@ public:
   bool getCheckInputFilesExist() const { return CheckInputFilesExist; }
 
   void setCheckInputFilesExist(bool Value) { CheckInputFilesExist = Value; }
+
+  bool isDummyDriverForFrontendInvocation() const {
+    return IsDummyDriverForFrontendInvocation;
+  }
+
+  void setIsDummyDriverForFrontendInvocation(bool Value) {
+    IsDummyDriverForFrontendInvocation = Value;
+  }
 
   /// Creates an appropriate ToolChain for a given driver, given the target
   /// specified in \p Args (or the default target). Sets the value of \c

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -901,9 +901,15 @@ void
 toolchains::Darwin::validateArguments(DiagnosticEngine &diags,
                                       const llvm::opt::ArgList &args,
                                       StringRef defaultTarget) const {
-  // Validating arclite library path when link-objc-runtime.
-  validateLinkObjcRuntimeARCLiteLib(*this, diags, args);
-  
+  if (!getDriver().isDummyDriverForFrontendInvocation()) {
+    // Validating arclite library path when link-objc-runtime.
+    // If the driver is just set up to retrieve the swift-frontend invocation,
+    // we don't care about link-time, so we can skip this step, which may be
+    // expensive since it might call to `xcrun` to find `clang` and `arclite`
+    // relative to `clang`.
+    validateLinkObjcRuntimeARCLiteLib(*this, diags, args);
+  }
+
   // Validating apple platforms deployment targets.
   validateDeploymentTarget(*this, diags, args);
   validateTargetVariant(*this, diags, args, defaultTarget);

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -75,6 +75,8 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
   // CompilerInvocation may wish to remap inputs to source buffers.
   TheDriver.setCheckInputFilesExist(false);
 
+  TheDriver.setIsDummyDriverForFrontendInvocation(true);
+
   std::unique_ptr<llvm::opt::InputArgList> ArgList =
     TheDriver.parseArgStrings(ArrayRef<const char *>(Args).slice(1));
   if (Diags.hadAnyError())


### PR DESCRIPTION
If the driver is only set up to get the frontend invocation (e.g. from `sourcekitd`), don't validate that we can link against ARCLite because
a) we don't care about link-time when we are only interested in the frontend invocation
b) finding arclite might cause us to find clang using xcrun which in turn can cause sourcekitd to hang.

rdar://50659268