### PR TITLE
[ConstraintSystem] Teach `getFunctionArgApplyInfo` about `inout` expr…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3449,6 +3449,13 @@ static bool repairOutOfOrderArgumentsInBinaryFunction(
 
   bool isOperatorRef = overload->choice.getDecl()->isOperator();
 
+  // If one of the parameters is `inout`, we can't flip the arguments.
+  {
+    auto params = fnType->getParams();
+    if (params[0].isInOut() != params[1].isInOut())
+      return false;
+  }
+
   auto matchArgToParam = [&](Type argType, Type paramType, ASTNode anchor) {
     auto *loc = cs.getConstraintLocator(anchor);
     // If argument (and/or parameter) is a generic type let's not even try this

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4542,6 +4542,59 @@ Type Solution::resolveInterfaceType(Type type) const {
 
 Optional<FunctionArgApplyInfo>
 Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
+  auto &cs = getConstraintSystem();
+
+  // It's only valid to use `&` in argument positions, but we need
+  // to figure out exactly where it was used.
+  if (auto *argExpr = getAsExpr<InOutExpr>(locator->getAnchor())) {
+    auto *argList = cs.getParentExpr(argExpr);
+    assert(argList);
+
+    // `inout` expression might be wrapped in a number of
+    // parens e.g. `test(((&x)))`.
+    if (isa<ParenExpr>(argList)) {
+      for (;;) {
+        auto nextParent = cs.getParentExpr(argList);
+        assert(nextParent && "Incorrect use of `inout` expression");
+
+        // e.g. `test((&x), x: ...)`
+        if (isa<TupleExpr>(nextParent)) {
+          argList = nextParent;
+          break;
+        }
+
+        // e.g. `test(((&x)))`
+        if (isa<ParenExpr>(nextParent)) {
+          argList = nextParent;
+          continue;
+        }
+
+        break;
+      }
+    }
+
+    unsigned argIdx = 0;
+    if (auto *tuple = dyn_cast<TupleExpr>(argList)) {
+      auto arguments = tuple->getElements();
+
+      for (auto idx : indices(arguments)) {
+        if (arguments[idx]->getSemanticsProvidingExpr() == argExpr) {
+          argIdx = idx;
+          break;
+        }
+      }
+    }
+
+    auto *call = cs.getParentExpr(argList);
+    assert(call);
+
+    ParameterTypeFlags flags;
+    locator = cs.getConstraintLocator(
+        call, {ConstraintLocator::ApplyArgument,
+               LocatorPathElt::ApplyArgToParam(argIdx, argIdx,
+                                               flags.withInOut(true))});
+  }
+
   auto anchor = locator->getAnchor();
   auto path = locator->getPath();
 
@@ -4635,7 +4688,6 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   auto argIdx = applyArgElt->getArgIdx();
   auto paramIdx = applyArgElt->getParamIdx();
 
-  auto &cs = getConstraintSystem();
   return FunctionArgApplyInfo(cs.getParentExpr(argExpr), argExpr, argIdx,
                               simplifyType(getType(argExpr)), paramIdx,
                               fnInterfaceType, fnType, callee);

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -459,3 +459,27 @@ func sr_12309() {
     return (((nil))) // Ok
   }
 }
+
+// rdar://75146811 - crash due to incrrect inout type
+func rdar75146811() {
+  func test(_: UnsafeMutablePointer<Double>) {}
+  func test_tuple(_: UnsafeMutablePointer<Double>, x: Int) {}
+  func test_named(x: UnsafeMutablePointer<Double>) {}
+
+  var arr: [Double]! = []
+
+  test(&arr) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test((&arr)) // expected-error {{use of extraneous '&'}}
+  // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test(&(arr)) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+
+  test_tuple(&arr, x: 0) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_tuple((&arr), x: 0) // expected-error {{use of extraneous '&'}}
+  // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_tuple(&(arr), x: 0) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+
+  test_named(x: &arr) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_named(x: (&arr)) // expected-error {{use of extraneous '&'}}
+  // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+  test_named(x: &(arr)) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
+}


### PR DESCRIPTION
…essions

Currently `getFunctionArgApplyInfo` expects a locator with `ApplyArgToParam`
element to identify location of the argument. `InOutExpr` could only be used
in argument positions but it doesn't have the same locator format as non-inout
arguments, so `getFunctionArgApplyInfo` needs to do some digging in the AST
to retrieve that information.

Resolves: rdar://75146811

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
