### PR TITLE
Rescue the ValueLifetimeAnalysis utility.

### DIFF
--- a/lib/SILOptimizer/Utils/ValueLifetime.cpp
+++ b/lib/SILOptimizer/Utils/ValueLifetime.cpp
@@ -90,28 +90,21 @@ SILInstruction *ValueLifetimeAnalysis::findLastUserInBlock(SILBasicBlock *bb) {
   llvm_unreachable("Expected to find use of value in block!");
 }
 
-bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
-                                            DeadEndBlocks *deBlocks) {
+// FIXME: remove the visitBlock callback once DeadEndBlocks is removed.
+void ValueLifetimeAnalysis::computeLifetime(
+    llvm::function_ref<bool(SILBasicBlock *)> visitBlock,
+    llvm::function_ref<void(SILInstruction *)> visitLastUser,
+    llvm::function_ref<void(SILBasicBlock *predBB, SILBasicBlock *succBB)>
+        visitBoundaryEdge) {
   assert(!isAliveAtBeginOfBlock(getFunction()->getEntryBlock()) &&
          "Can't compute frontier for def which does not dominate all uses");
 
-  bool noCriticalEdges = true;
-
-  // Exit-blocks from the lifetime region. The value is live at the end of
-  // a predecessor block but not in the frontier block itself.
-  BasicBlockSetVector<16> frontierBlocks(getFunction());
-
-  // Blocks where the value is live at the end of the block and which have
-  // a frontier block as successor.
-  BasicBlockSetVector<16> liveOutBlocks(getFunction());
-
   /// The lifetime ends if we have a live block and a not-live successor.
   for (SILBasicBlock *bb : liveBlocks) {
-    if (deBlocks && deBlocks->isDeadEnd(bb))
+    if (!visitBlock(bb))
       continue;
 
     bool liveInSucc = false;
-    bool deadInSucc = false;
     bool usedAndRedefinedInSucc = false;
     for (const SILSuccessor &succ : bb->getSuccessors()) {
       if (isAliveAtBeginOfBlock(succ)) {
@@ -128,63 +121,120 @@ bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
                  "blocks");
           usedAndRedefinedInSucc = true;
         }
-      } else if (!deBlocks || !deBlocks->isDeadEnd(succ)) {
-        deadInSucc = true;
       }
     }
     if (usedAndRedefinedInSucc) {
       // Here, the basic block bb uses the value and later redefines the value.
       // Therefore, this value's lifetime ends after its last use preceding the
       // re-definition of the value.
-      //
-      // We know that we can not have a SILArgument here since the SILArgument
-      // dominates all instructions in the same block.
       auto ii = defValue.get<SILInstruction *>()->getReverseIterator();
       for (; ii != bb->rend(); ++ii) {
         if (userSet.count(&*ii)) {
-          frontier.push_back(&*std::next(ii));
+          visitLastUser(&*ii);
           break;
         }
       }
       assert(ii != bb->rend() &&
              "There must be a user in bb before definition");
     }
-    if (!liveInSucc) {
-      // The value is not live in any of the successor blocks. This means the
-      // block contains a last use of the value. The next instruction after
-      // the last use is part of the frontier.
-      SILInstruction *lastUser = findLastUserInBlock(bb);
-      if (!isa<TermInst>(lastUser)) {
-        frontier.push_back(&*std::next(lastUser->getIterator()));
-        continue;
-      }
-      // In case the last user is a TermInst there is no further instruction in
-      // the block which can be the frontier. Instead we add all successor
-      // blocks to the frontier (see below).
-      // If the TermInst exits the function (e.g. 'return' or 'throw'), there
-      // are no successors and we have to bail.
-      if (!deadInSucc) {
-        assert(cast<TermInst>(lastUser)->isFunctionExiting() &&
-               "The final using TermInst must have successors");
-        assert(mode != AllowToModifyCFG &&
-               "Cannot bail if the mode is AllowToModifyCFG");
-        return false;
-      }
-    }
-    if (deadInSucc) {
-      if (mode == UsersMustPostDomDef)
-        return false;
-
-      // The value is not live in some of the successor blocks.
-      liveOutBlocks.insert(bb);
+    if (liveInSucc) {
       for (const SILSuccessor &succ : bb->getSuccessors()) {
-        if (!isAliveAtBeginOfBlock(succ)) {
-          // It's an "exit" edge from the lifetime region.
-          frontierBlocks.insert(succ);
-        }
+        if (!isAliveAtBeginOfBlock(succ))
+          visitBoundaryEdge(bb, succ);
       }
+    } else {
+      // The value is not live in any of the successor blocks. This means the
+      // block contains a last use of the value.
+      visitLastUser(findLastUserInBlock(bb));
     }
   }
+}
+
+// Compute a LifetimeBoundary.
+//
+// Precondition: no critical edges.
+void ValueLifetimeAnalysis::computeLifetimeBoundary(
+    ValueLifetimeBoundary &boundary) {
+  auto visitBlock = [&](SILBasicBlock *) { return true; };
+  auto visitLastUser = [&](SILInstruction *lastUser) {
+    boundary.lastUsers.push_back(lastUser);
+  };
+  auto visitBoundaryEdge = [&](SILBasicBlock *, SILBasicBlock *succBB) {
+    boundary.boundaryEdges.push_back(succBB);
+  };
+  computeLifetime(visitBlock, visitLastUser, visitBoundaryEdge);
+}
+
+// FIXME: There is no need for a Mode within the algorithm once critical edges
+// are universally prohibited.
+//
+// FIXME: DeadEndBlocks does not affect value lifetime. It
+// should be completely removed and handled by the client.
+bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
+                                            DeadEndBlocks *deBlocks) {
+  bool noCriticalEdges = true;
+
+  // Exit-blocks from the lifetime region. The value is live at the end of
+  // a predecessor block but not in the frontier block itself.
+  BasicBlockSetVector<16> frontierBlocks(getFunction());
+
+  // Blocks where the value is live at the end of the block and which have
+  // a frontier block as successor.
+  BasicBlockSetVector<16> liveOutBlocks(getFunction());
+
+  auto visitBlock = [&](SILBasicBlock *bb) {
+    return !deBlocks || !deBlocks->isDeadEnd(bb);
+  };
+
+  bool foundInvalidLastUser = false;
+  auto visitLastUser = [&](SILInstruction *lastUser) {
+    if (!isa<TermInst>(lastUser)) {
+      // The next instruction after the last use is part of the frontier.
+      frontier.push_back(&*std::next(lastUser->getIterator()));
+      return;
+    }
+    // FIXME: DeadObjectElimination and StackPromotion don't currently handle
+    // last use terminators, for no good reason. Fix them, then remove the silly
+    // UsersMustPostDomDef mode.
+    if (mode == UsersMustPostDomDef) {
+      foundInvalidLastUser = true;
+      return;
+    }
+    // The last user is a TermInst, and the value is not live into any successor
+    // blocks (the usedAndRedefinedInSucc case is never a terminator).  Since
+    // there is no further instruction in the block which can be the
+    // frontier, add all successor blocks to the frontier.
+    auto *termBB = lastUser->getParent();
+    for (const SILSuccessor &succ : termBB->getSuccessors()) {
+      assert(!isAliveAtBeginOfBlock(succ)
+             && "out-of-sync with computeLifetime");
+
+      if (deBlocks && deBlocks->isDeadEnd(succ))
+        continue;
+
+      // The successor's first instruction will be added to the frontier. Fake
+      // this block as live-out so edge splitting works.
+      liveOutBlocks.insert(termBB);
+      frontierBlocks.insert(succ);
+    }
+  };
+  auto visitBoundaryEdge = [&](SILBasicBlock *predBB, SILBasicBlock *succBB) {
+    if (deBlocks && deBlocks->isDeadEnd(succBB))
+      return;
+    
+    if (mode == UsersMustPostDomDef) {
+      foundInvalidLastUser = true;
+      return;
+    }
+    liveOutBlocks.insert(predBB);
+    frontierBlocks.insert(succBB);
+  };
+
+  // Populate frontierBlocks and call visitLastUser().
+  computeLifetime(visitBlock, visitLastUser, visitBoundaryEdge);
+  if (foundInvalidLastUser)
+    return false;
+
   // Handle "exit" edges from the lifetime region.
   BasicBlockSet unhandledFrontierBlocks(getFunction());
   bool unhandledFrontierBlocksFound = false;

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -820,3 +820,37 @@ bb14:                                             // Preds: bb12 bb1
   %32 = struct $Int32 (%31 : $Builtin.Int32)      // user: %33
   return %32 : $Int32                             // id: %33
 } // end sil function 'promote_with_unreachable_block_nest_bug'
+
+// Take XX as an argument, but don't actually return or escape it. I'm
+// not sure how this happens in practice, but stack promotion requires
+// that the argument does not escape.
+sil @tryInitXX : $@convention(method) (@owned XX) -> (@owned XX, @error Error) {
+bb0(%0 : $XX):
+  %1 = alloc_ref $XX
+  strong_release %0 : $XX
+  return %1 : $XX
+}
+
+// FIXME: Stack promotion currently fails whenever the last use is a
+// terminator. This is a ridiculous limitation.
+//
+// CHECK-LABEL: sil @testUsedByTryApply : $@convention(thin) () -> (@owned XX, @error Error) {
+// CHECK:        alloc_ref $XX
+// CHECK:        try_apply
+// CHECK:      bb1(%{{.*}} : $XX):
+// CHECK-NEXT:   return
+// CHECK:      bb2(%{{.*}}: $Error):
+// CHECK-NEXT:   throw
+// CHECK-LABEL: } // end sil function 'testUsedByTryApply'
+sil @testUsedByTryApply : $@convention(thin) () -> (@owned XX, @error Error) {
+bb0:
+  %0 = alloc_ref $XX
+  %1 = function_ref @tryInitXX : $@convention(method) (@owned XX) -> (@owned XX, @error Error)
+  try_apply %1(%0) : $@convention(method) (@owned XX) -> (@owned XX, @error Error), normal bb1, error bb2
+
+bb1(%4 : $XX):
+  return %4 : $XX
+
+bb2(%5 : $Error):
+  throw %5 : $Error
+}


### PR DESCRIPTION
This is a basic SSA-based liveness algorithm. It should just do what
it says. This change rescues the core logic from the nonsense that's
been hacked in. There are now two APIs:

(1) computeLifetimeBoundary (new) only does lifetime analysis.  It
provides a new API that always succeeds and provides the last use
points so clients can do the right thing based on the user. I need
this for OSSA utilities.

(2) computeFrontier (old) emulates the original API with a simplified
version of the original logic.

Next steps:

- replace the old API with a separate utility that computes destroy
  insertion points. Completely remove DeadEndBlocks from lifetime
  analysis, because it simply has nothing to do with liveness.

- Gradually migrate clients to either the new lifetime API provided
  here or the new destroy insertion API to be provided later.

