### PR TITLE
[DependencyScanner] Migrate to llvm::json::OStream for dependency serialization

### DIFF
--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -43,7 +43,6 @@
 // CHECK-PCM110-NEXT:    },
 // CHECK-PCM110-NEXT:    {
 // CHECK-PCM110-NEXT:      "modulePath": "G.pcm",
-// CHECK-PCM110:       "directDependencies": [
-// CHECK-PCM110-NEXT:  ],
+// CHECK-PCM110:       "directDependencies": [],
 // CHECK-PCM110-NOT: "clang": "X"
 // CHECK-PCM110: "-I

--- a/test/ScanDependencies/binary_module_only.swift
+++ b/test/ScanDependencies/binary_module_only.swift
@@ -10,7 +10,7 @@ import Foo
 
 // BINARY_MODULE_ONLY: "swiftPrebuiltExternal": "Foo"
 // BINARY_MODULE_ONLY:  "swiftPrebuiltExternal": {
-// BINARY_MODULE_ONLY-NEXT:  "compiledModulePath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/binary_module_only.swift.tmp/binaryModuleOnly/Foo.swiftmodule",
+// BINARY_MODULE_ONLY-NEXT:  "compiledModulePath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/binary_module_only.swift.tmp/binaryModuleOnly/Foo.swiftmodule"
 
 // HAS_NO_COMPILED-NOT: "{{.*}}Foo.swiftmodule{{.*}}.swiftmodule"
 

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -133,8 +133,7 @@ import SubE
 
 /// --------Swift module F
 // CHECK:      "modulePath": "F.swiftmodule",
-// CHECK-NEXT: "sourceFiles": [
-// CHECK-NEXT: ],
+// CHECK-NEXT: "sourceFiles": [],
 // CHECK-NEXT: "directDependencies": [
 // CHECK-NEXT:   {
 // CHECK-NEXT:     "clang": "F"

--- a/test/ScanDependencies/placholder_overlay_deps.swift
+++ b/test/ScanDependencies/placholder_overlay_deps.swift
@@ -23,8 +23,7 @@ import Metal
 // Ensure the dependency on Darwin is captured even though it is a placeholder
 
 // CHECK:   "modulePath": "Metal.swiftmodule",
-// CHECK-NEXT:   "sourceFiles": [
-// CHECK-NEXT:   ],
+// CHECK-NEXT:   "sourceFiles": [],
 // CHECK:     {
 // CHECK:       "swiftPlaceholder": "Darwin"
 // CHECK:     },


### PR DESCRIPTION
By relying on the LLVM APIs, we no longer need to worry about indentation and delimiters. In addition to cleaning up the code a bit, this also fixes a couple small bugs where we were inadvertently generating technically invalid (but harmless in practice) JSON with trailing commas.
