### PR TITLE
[Runtime] Fixed shared cache protocol conformance lookup with subclasses.

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -53,6 +53,10 @@ VARIABLE(SWIFT_DEBUG_VALIDATE_SHARED_CACHE_PROTOCOL_CONFORMANCES, bool, false,
          "Validate shared cache protocol conformance results against the "
          "lists of conformances in the shared cache images.")
 
+VARIABLE(SWIFT_DEBUG_ENABLE_SHARED_CACHE_PROTOCOL_CONFORMANCES, bool, true,
+         "Enable querying precomputed protocol conformances in the shared "
+         "cache.")
+
 #endif
 
 #undef VARIABLE


### PR DESCRIPTION
Match the logic used in the non-shared-cache case, where we walk up the class hierarchy to find the class where the conformance actually applies. This is important in cases like:

  class Super<T> : Proto {}
  class Sub: Super<Int> {}

Looking up the conformance `Sub: Proto` without this logic causes it to attempt to find the witness table for `Sub<Int>`, which fails. The correct logic looks up the witness table for `Super<Int>`.

While we're in there, fix a bug in the shared cache validation code (std::find wasn't checked for failure correctly) and add a `SWIFT_DEBUG_ENABLE_SHARED_CACHE_PROTOCOL_CONFORMANCES` environment variable to allow us to turn the shared cache integration off at runtime.

rdar://75431771