### PR TITLE
Casting from AnyHashable to AnyHashable should never create another wrapper

### DIFF
--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -260,6 +260,13 @@ extension AnyHashable: CustomReflectable {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
+extension AnyHashable: _HasCustomAnyHashableRepresentation {
+  public __consuming func _toCustomAnyHashable() -> AnyHashable? {
+    return self
+  }
+}
+
 /// Returns a default (non-custom) representation of `self`
 /// as `AnyHashable`.
 ///

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -924,4 +924,27 @@ CastsTests.test("Optional cast to AnyHashable") {
   expectNotEqual(xh, yh)
 }
 
+// Repeatedly casting to AnyHashable should still test equal.
+// (This was broken for a while because repeatedly casting to
+// AnyHashable could end up with multiple nested AnyHashables.)
+// rdar://75180619
+CastsTests.test("Recursive AnyHashable") {
+  struct P: Hashable {
+    var x: Int
+  }
+  struct S {
+    var x: AnyHashable?
+    init<T: Hashable>(_ x: T?) {
+      self.x = x
+    }
+  }
+  let p = P(x: 0)
+  let hp = p as AnyHashable?
+  print(hp.debugDescription)
+  let s = S(hp)
+  print(s.x.debugDescription)
+  expectEqual(s.x, hp)
+  expectEqual(s.x, p)
+}
+
 runAllTests()

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -41,6 +41,7 @@ Func _collectReferencesInsideObject(_:) is a new API without @available attribut
 Func _loadDestroyTLSCounter() is a new API without @available attribute
 Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @available attribute
 Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
+Struct AnyHashable has added a conformance to an existing protocol _HasCustomAnyHashableRepresentation
 Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
 Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
 Struct _RuntimeFunctionCounters is a new API without @available attribute

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -41,7 +41,6 @@ Func _collectReferencesInsideObject(_:) is a new API without @available attribut
 Func _loadDestroyTLSCounter() is a new API without @available attribute
 Func _measureRuntimeFunctionCountersDiffs(objects:_:) is a new API without @available attribute
 Protocol _RuntimeFunctionCountersStats is a new API without @available attribute
-Struct AnyHashable has added a conformance to an existing protocol _HasCustomAnyHashableRepresentation
 Struct _GlobalRuntimeFunctionCountersState is a new API without @available attribute
 Struct _ObjectRuntimeFunctionCountersState is a new API without @available attribute
 Struct _RuntimeFunctionCounters is a new API without @available attribute

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -48,6 +48,7 @@ Func Collection.subranges(where:) has been removed
 Func MutableCollection.moveSubranges(_:to:) has been removed
 Func MutableCollection.removeSubranges(_:) has been removed
 Func RangeReplaceableCollection.removeSubranges(_:) has been removed
+Struct AnyHashable has added a conformance to an existing protocol _HasCustomAnyHashableRepresentation
 Struct DiscontiguousSlice has been removed
 Struct RangeSet has been removed
 Subscript Collection.subscript(_:) has been removed


### PR DESCRIPTION
This adds a conformance for _HasCustomAnyHashableRepresentation to
AnyHashable that simply returns self.  This ensures that anytime
you try to create a new AnyHashable wrapper for an existing
AnyHashable, you just get back the original.

Resolves rdar://75180619