### PR TITLE
[WIP] Initial draft at a yielding continuation type

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -175,8 +175,8 @@ public:
 
   /// Reserved for the use of the task-local stack allocator.
   void *AllocatorPrivate[4];
-  
-  std::atomic<void *> activeContinuation;
+
+  std::atomic<void *> ActiveContinuation;
 
   /// Task local values storage container.
   TaskLocal::Storage Local;
@@ -187,6 +187,7 @@ public:
     : Job(flags, run, metadata),
       ResumeContext(initialContext),
       Status(ActiveTaskStatus()),
+      ActiveContinuation(nullptr),
       Local(TaskLocal::Storage()) {
     assert(flags.isAsyncTask());
   }

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -175,6 +175,8 @@ public:
 
   /// Reserved for the use of the task-local stack allocator.
   void *AllocatorPrivate[4];
+  
+  std::atomic<void *> activeContinuation;
 
   /// Task local values storage container.
   TaskLocal::Storage Local;

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -540,6 +540,9 @@ void swift_continuation_throwingResumeWithError(/* +1 */ SwiftError *error,
                                                 void *continuation,
                                                 const Metadata *resumeType);
 
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void *swift_continuation_exchange(AsyncTask *task, void *continuation);
+
 /// SPI helper to log a misuse of a `CheckedContinuation` to the appropriate places in the OS.
 extern "C" SWIFT_CC(swift)
 void swift_continuation_logFailedCheck(const char *message);

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -68,6 +68,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   TaskLocal.swift
   ThreadSanitizer.cpp
   Mutex.cpp
+  YieldingContinuation.swift
   ${swift_concurrency_objc_sources}
 
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -808,6 +808,12 @@ static void swift_task_removeCancellationHandlerImpl(
 }
 
 SWIFT_CC(swift)
+void *swift_continuation_exchange(AsyncTask *task, void *continuation) {
+  return task->activeContinuation.exchange(
+      continuation, std::memory_order_acquire);
+}
+
+SWIFT_CC(swift)
 void swift::swift_continuation_logFailedCheck(const char *message) {
   swift_reportError(0, message);
 }

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -809,7 +809,7 @@ static void swift_task_removeCancellationHandlerImpl(
 
 SWIFT_CC(swift)
 void *swift_continuation_exchange(AsyncTask *task, void *continuation) {
-  return task->activeContinuation.exchange(
+  return task->ActiveContinuation.exchange(
       continuation, std::memory_order_acquire);
 }
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -808,7 +808,7 @@ static void swift_task_removeCancellationHandlerImpl(
 }
 
 SWIFT_CC(swift)
-void *swift_continuation_exchange(AsyncTask *task, void *continuation) {
+void *swift::swift_continuation_exchange(AsyncTask *task, void *continuation) {
   return task->ActiveContinuation.exchange(
       continuation, std::memory_order_acquire);
 }

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+public struct YieldingContinuation<T, E: Error>: ConcurrentValue {
+  @_fixed_layout
+  @usableFromInline
+  internal final class Storage: UnsafeConcurrentValue {
+    @usableFromInline
+    var continuation: UnsafeContinuation<T, Error>?
+  }
+  
+  @usableFromInline
+  let storage = Storage()
+
+  public init(producing: T.Type, throwing: E.Type) { }
+
+  @inlinable
+  @inline(__always)
+  internal func _extract() -> UnsafeContinuation<T, Error>? {
+    let raw = Builtin.atomicrmw_xchg_seqcst_Word(
+      Builtin.addressof(&storage.continuation), 
+      UInt(bitPattern: 0)._builtinWordValue)
+    return unsafeBitCast(raw, to: UnsafeContinuation<T, Error>?.self)
+  }
+  
+  @inlinable
+  @inline(__always)
+  internal func _inject(
+    _ continuation: UnsafeContinuation<T, Error>
+  ) -> UnsafeContinuation<T, Error>? {
+    let rawContinuation = unsafeBitCast(continuation, to: Builtin.Word.self)
+    let raw = Builtin.atomicrmw_xchg_seqcst_Word(
+      Builtin.addressof(&storage.continuation), rawContinuation)
+    return unsafeBitCast(raw, to: UnsafeContinuation<T, Error>?.self)
+  }
+  
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// - Parameter value: The value to return from the continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than 
+  /// once. However if there are no potential awaiting calls to `next` this 
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  ///
+  /// After `resume` enqueues the task, control is immediately returned to
+  /// the caller. The task will continue executing when its executor is
+  /// able to reschedule it.
+  public func resume(yielding value: __owned T) -> Bool {
+    if let continuation = _extract() {
+      continuation.resume(returning: value)
+      _fixLifetime(storage)
+      return true
+    }
+    return false
+  }
+  
+  /// Resume the task awaiting the continuation by having it throw an error
+  /// from its suspension point.
+  ///
+  /// - Parameter error: The error to throw from the continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than 
+  /// once. However if there are no potential awaiting calls to `next` this 
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  ///
+  /// After `resume` enqueues the task, control is immediately returned to
+  /// the caller. The task will continue executing when its executor is
+  /// able to reschedule it.
+  public func resume(throwing error: __owned E) -> Bool {
+    if let continuation = _extract() {
+      continuation.resume(throwing: error)
+      _fixLifetime(storage)
+      return true
+    }
+    return false
+  }
+
+  public func next() async throws -> T {
+    var existing: UnsafeContinuation<T, Error>?
+    do {
+      let result = try await withUnsafeThrowingContinuation { 
+        (continuation: UnsafeContinuation<T, Error>) in
+        existing = _inject(continuation)
+      }
+      existing?.resume(returning: result)
+      _fixLifetime(storage)
+      return result
+    } catch {
+      existing?.resume(throwing: error)
+      _fixLifetime(storage)
+      throw error
+    }
+  }
+}
+
+extension YieldingContinuation where E == Never {
+  public init(producing: T.Type) { }
+
+  public func next() async -> T {
+    var existing: UnsafeContinuation<T, Error>?
+    let result = try! await withUnsafeThrowingContinuation { 
+      (continuation: UnsafeContinuation<T, Error>) in
+      existing = _inject(continuation)
+    }
+    existing?.resume(returning: result)
+    _fixLifetime(storage)
+    return result
+  }
+}
+
+extension YieldingContinuation {
+  /// Resume the task awaiting the continuation by having it either
+  /// return normally or throw an error based on the state of the given
+  /// `Result` value.
+  ///
+  /// - Parameter result: A value to either return or throw from the
+  ///   continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than 
+  /// once. However if there are no potential awaiting calls to `next` this 
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  ///
+  /// After `resume` enqueues the task, control is immediately returned to
+  /// the caller. The task will continue executing when its executor is
+  /// able to reschedule it.
+  public func resume<Er: Error>(
+    with result: Result<T, Er>
+  ) -> Bool where E == Error {
+    switch result {
+      case .success(let val):
+        return self.resume(yielding: val)
+      case .failure(let err):
+        return self.resume(throwing: err)
+    }
+  }
+  
+  /// Resume the task awaiting the continuation by having it either
+  /// return normally or throw an error based on the state of the given
+  /// `Result` value.
+  ///
+  /// - Parameter result: A value to either return or throw from the
+  ///   continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than 
+  /// once. However if there are no potential awaiting calls to `next` this 
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  ///
+  /// After `resume` enqueues the task, control is immediately returned to
+  /// the caller. The task will continue executing when its executor is
+  /// able to reschedule it.
+  public func resume(with result: Result<T, E>) -> Bool {
+    switch result {
+      case .success(let val):
+        return self.resume(yielding: val)
+      case .failure(let err):
+        return self.resume(throwing: err)
+    }
+  }
+  
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than 
+  /// once. However if there are no potential awaiting calls to `next` this 
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  ///
+  /// After `resume` enqueues the task, control is immediately returned to
+  /// the caller. The task will continue executing when its executor is
+  /// able to reschedule it.
+  public func resume() -> Bool where T == Void {
+    return self.resume(yielding: ())
+  }
+}


### PR DESCRIPTION
This is a draft at a new continuation type that instead of having undefined behavior on repeated invocation of resume it populates a pending continuation primitive atomically to satisfy any awaiting call to next.

The primary focus of this type is to provide a safe interface for creating interface layers between callbacks that occur more than once and async sequence iterators.