### PR TITLE
[Mangling] Don't mangle global actor types in declarations.

### DIFF
--- a/test/SILGen/global_actor_function_mangling.swift
+++ b/test/SILGen/global_actor_function_mangling.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 -enable-experimental-concurrency | %FileCheck %s
+// REQUIRES: concurrency
+
+// Declarations don't mangle global actor types.
+// CHECK: @$s4test10returnsOptyxycSgAClF
+func returnsOpt<R>(_ fn: (@MainActor () -> R)?) -> (() -> R)? {
+  typealias Fn = (() -> R)?
+  return unsafeBitCast(fn, to: Fn.self)
+}


### PR DESCRIPTION
We'll get a real mangling soon; this is a temporary hack.
