### PR TITLE
Refactor FixedWidthInteger init

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -3160,20 +3160,25 @@ extension FixedWidthInteger {
       self = Self(_truncatingBits: source._lowWord)
     }
     else {
-      let neg = source < (0 as T)
-      var result: Self = neg ? ~0 : 0
-      var shift: Self = 0
-      let width = Self(_truncatingBits: Self.bitWidth._lowWord)
-      for word in source.words {
-        guard shift < width else { break }
-        // Masking shift is OK here because we have already ensured
-        // that shift < Self.bitWidth. Not masking results in
-        // infinite recursion.
-        result ^= Self(_truncatingBits: neg ? ~word : word) &<< shift
-        shift += Self(_truncatingBits: Int.bitWidth._lowWord)
-      }
-      self = result
+      self = Self._truncatingInit(source)
     }
+  }
+
+  @_alwaysEmitIntoClient
+  internal static func _truncatingInit<T: BinaryInteger>(_ source: T) -> Self {
+    let neg = source < (0 as T)
+    var result: Self = neg ? ~0 : 0
+    var shift: Self = 0
+    let width = Self(_truncatingBits: Self.bitWidth._lowWord)
+    for word in source.words {
+      guard shift < width else { break }
+      // Masking shift is OK here because we have already ensured
+      // that shift < Self.bitWidth. Not masking results in
+      // infinite recursion.
+      result ^= Self(_truncatingBits: neg ? ~word : word) &<< shift
+      shift += Self(_truncatingBits: Int.bitWidth._lowWord)
+    }
+    return result
   }
 
   @_transparent

--- a/test/SILOptimizer/jumpthreadtest.swift
+++ b/test/SILOptimizer/jumpthreadtest.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -O -parse-as-library -emit-sil -enable-ossa-modules %s | %FileCheck %s
+// REQUIRES: PTRSIZE=32,swift_stdlib_asserts
+
+import Swift
+
+// CHECK-LABEL: sil [noinline] @$s14jumpthreadtest3fooys6UInt64Vs5UInt8VF :
+// CHECK: bb0
+// CHECK:  [[FUNC:%.*]] = function_ref @$ss17FixedWidthIntegerPsE15_truncatingInityxqd__SzRd__lFZs6UInt64V_s5UInt8VTgq5Tf4nd_n : 
+// CHECK: apply [[FUNC]]
+// CHECK-NOT: bb1
+// CHECK-LABEL: } // end sil function '$s14jumpthreadtest3fooys6UInt64Vs5UInt8VF'
+@inlinable
+@inline(never)
+public func foo(_ p:UInt8) -> UInt64 {
+  let q = UInt64(truncatingIfNeeded: p)
+  return q
+}


### PR DESCRIPTION
Without jump threading enabled in ossa, the FixedWidthInteger's init function which is an inline always function causes large cfgs due to the truncation case. This PR separates the truncation case into a different function with no always inlining.