### PR TITLE
[SourceKit] Fix crash in syntax model

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2303,7 +2303,13 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       if (Status.isErrorOrHasCompletion())
         return false;
 
-      AttrRange = SourceRange(Loc, Tok.getLoc());
+      if (!consumeIf(tok::r_paren)) {
+        diagnose(Tok.getLoc(), diag::attr_expected_rparen, AttrName,
+                 DeclAttribute::isDeclModifier(DK));
+        return false;
+      }
+
+      AttrRange = SourceRange(Loc, PreviousLoc);
       // For each platform version spec in the spec list, create an
       // implicit AvailableAttr for the platform with the introduced
       // version from the spec. For example, if we have
@@ -2365,12 +2371,6 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                      /*ObsoletedRange=*/SourceRange(),
                                      PlatformAgnostic,
                                      /*Implicit=*/false));
-      }
-
-      if (!consumeIf(tok::r_paren)) {
-        diagnose(Tok.getLoc(), diag::attr_expected_rparen, AttrName,
-                 DeclAttribute::isDeclModifier(DK));
-        return false;
       }
 
       break;

--- a/test/SourceKit/Misc/rdar64304839.swift
+++ b/test/SourceKit/Misc/rdar64304839.swift
@@ -1,0 +1,6 @@
+// RUN: %sourcekitd-test -req=open %s -- %s
+// Test that this doesn't crash sourcekitd
+
+@available(macOS 10.12
+@available(macOS 10.13
+func foo() {} {code}


### PR DESCRIPTION
The end location of an attribute used to point to the next token after the attribute's content, which is the closing parenthesis in valid Swift code. But when the parenthesis is missing, it points to the next token, which is most likely no longer part of the attribute.

Fix by parsting the closing parenthesis (conditionally) first and using the location of last token parsed for the attribute (`PreviuosLoc`) as the attribute range's end location.

Resolves rdar://64304839 [SR-12993]