### PR TITLE
[ABI] Added signedAsData bit to method descriptor flags.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -317,6 +317,7 @@ private:
     KindMask = 0x0F,                // 16 kinds should be enough for anybody
     IsInstanceMask = 0x10,
     IsDynamicMask = 0x20,
+    IsSignedAsDataMask = 0x40,
     ExtraDiscriminatorShift = 16,
     ExtraDiscriminatorMask = 0xFFFF0000,
   };
@@ -345,6 +346,15 @@ public:
     return copy;
   }
 
+  MethodDescriptorFlags withIsSignedAsData(bool isSignedAsData) const {
+    auto copy = *this;
+    if (isSignedAsData)
+      copy.Value |= IsSignedAsDataMask;
+    else
+      copy.Value &= ~IsSignedAsDataMask;
+    return copy;
+  }
+
   MethodDescriptorFlags withExtraDiscriminator(uint16_t value) const {
     auto copy = *this;
     copy.Value = (copy.Value & ~ExtraDiscriminatorMask)
@@ -361,6 +371,8 @@ public:
   ///
   /// Note that 'init' is not considered an instance member.
   bool isInstance() const { return Value & IsInstanceMask; }
+
+  bool isSignedAsData() const { return Value & IsSignedAsDataMask; }
 
   uint16_t getExtraDiscriminator() const {
     return (Value >> ExtraDiscriminatorShift);
@@ -527,6 +539,7 @@ private:
   enum : int_type {
     KindMask = 0x0F,                // 16 kinds should be enough for anybody
     IsInstanceMask = 0x10,
+    IsSignedAsDataMask = 0x20,
     ExtraDiscriminatorShift = 16,
     ExtraDiscriminatorMask = 0xFFFF0000,
   };
@@ -546,6 +559,15 @@ public:
     return copy;
   }
 
+  ProtocolRequirementFlags withIsSignedAsData(bool isSignedAsData) const {
+    auto copy = *this;
+    if (isSignedAsData)
+      copy.Value |= IsSignedAsDataMask;
+    else
+      copy.Value &= ~IsSignedAsDataMask;
+    return copy;
+  }
+
   ProtocolRequirementFlags withExtraDiscriminator(uint16_t value) const {
     auto copy = *this;
     copy.Value = (copy.Value & ~ExtraDiscriminatorMask)
@@ -559,6 +581,8 @@ public:
   ///
   /// Note that 'init' is not considered an instance member.
   bool isInstance() const { return Value & IsInstanceMask; }
+
+  bool isSignedAsData() const { return Value & IsSignedAsDataMask; }
 
   bool isSignedWithAddress() const {
     return getKind() != Kind::BaseProtocol;


### PR DESCRIPTION
It is necessary to determine whether a given method in a vtable or a
witness table is async in order to decide whether to auth/sign as data
or as code.
