### PR TITLE
[Sema] Fix rdar://75219757

### DIFF
--- a/test/SourceKit/CodeComplete/rdar75219757.swift
+++ b/test/SourceKit/CodeComplete/rdar75219757.swift
@@ -1,0 +1,3 @@
+// RUN: %sourcekitd-test -req=complete -pos=3:14 %s -- %s
+
+0odd.foo.bar /*HERE*/


### PR DESCRIPTION
I don’t actually know what I’m changing here, but https://github.com/apple/swift/pull/36028 appears to have been to optimistic to declare the restored branch as unreachable, which causes a crash in the added test case. I’m just restoring the old behavior to prevent the crash. Please let me know if you think the code path should really be unreachable and we need to fix a deeper issue the way code completion sets up the constraint system.

Fixes rdar://75219757 [SR-14319]