### PR TITLE
[Sema] Fix rdar://75200446

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7577,7 +7577,11 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   // FIXME: handle unwrapping everywhere else
   assert(!unwrapResult);
 
-  assert(!cs.getType(fn)->is<UnresolvedType>());
+  // If this is an UnresolvedType in the system, preserve it.
+  if (cs.getType(fn)->is<UnresolvedType>()) {
+    cs.setType(apply, cs.getType(fn));
+    return apply;
+  }
 
   // We have a type constructor.
   auto metaTy = cs.getType(fn)->castTo<AnyMetatypeType>();

--- a/test/SourceKit/CodeComplete/rdar75200446.swift
+++ b/test/SourceKit/CodeComplete/rdar75200446.swift
@@ -1,0 +1,3 @@
+// RUN: %sourcekitd-test -req=complete -pos=3:14 %s -- %s
+
+.undefined() /*HERE*/


### PR DESCRIPTION
Similar to #36493, I don’t actually know what I’m changing here, but #36028 appears to have been to optimistic to declare the restored branch as unreachable, which causes a crash in the added test case. I’m just restoring the old behavior to prevent the crash. Please let me know if you think the code path should really be unreachable and we need to fix a deeper issue the way code completion sets up the constraint system.

Fixes rdar://75200446 [SR-14318]