### PR TITLE
Revert "arm64e: Workaround ptrauth-returns failure for swifttailcc"

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4863,9 +4863,8 @@ IRGenFunction::getFunctionPointerForResumeIntrinsic(llvm::Value *resume) {
   auto *fnTy = llvm::FunctionType::get(
       IGM.VoidTy, {IGM.Int8PtrTy},
       false /*vaargs*/);
-  auto signature = Signature(
-      fnTy, IGM.constructInitialAttributes(true /*disable ptrauth-returns*/),
-      IGM.SwiftAsyncCC);
+  auto signature =
+      Signature(fnTy, IGM.constructInitialAttributes(), IGM.SwiftAsyncCC);
   auto fnPtr = FunctionPointer(
       FunctionPointer::Kind::Function,
       Builder.CreateBitOrPointerCast(resume, fnTy->getPointerTo()),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2100,11 +2100,7 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM,
       .to(fn, linkInfo.isForDefinition());
 
   llvm::AttrBuilder initialAttrs;
-  // Workaround an llvm bug that does not handle this case correctly.
-  bool disablePtrAuthReturns =
-      signature.getCallingConv() == llvm::CallingConv::SwiftTail;
-  IGM.constructInitialFnAttributes(initialAttrs, disablePtrAuthReturns,
-                                   FuncOptMode);
+  IGM.constructInitialFnAttributes(initialAttrs, FuncOptMode);
   // Merge initialAttrs with attrs.
   auto updatedAttrs =
     signature.getAttributes().addAttributes(IGM.getLLVMContext(),
@@ -2815,7 +2811,7 @@ llvm::Constant *swift::irgen::emitCXXConstructorThunkIfNeeded(
   thunk->setCallingConv(llvm::CallingConv::C);
 
   llvm::AttrBuilder attrBuilder;
-  IGM.constructInitialFnAttributes(attrBuilder, false /*disablePtrAuthReturns*/);
+  IGM.constructInitialFnAttributes(attrBuilder);
   attrBuilder.addAttribute(llvm::Attribute::AlwaysInline);
   llvm::AttributeList attr = signature.getAttributes().addAttributes(
       IGM.getLLVMContext(), llvm::AttributeList::FunctionIndex, attrBuilder);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1198,9 +1198,7 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
   fwd->setAttributes(outAttrs);
   // Merge initial attributes with outAttrs.
   llvm::AttrBuilder b;
-  bool disablePtrAuthReturns =
-      outSig.getCallingConv() == llvm::CallingConv::SwiftTail;
-  IGM.constructInitialFnAttributes(b, disablePtrAuthReturns);
+  IGM.constructInitialFnAttributes(b);
   fwd->addAttributes(llvm::AttributeList::FunctionIndex, b);
 
   IRGenFunction subIGF(IGM, fwd);

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -717,7 +717,7 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
   fwd->setAttributes(attrs);
   // Merge initial attributes with attrs.
   llvm::AttrBuilder b;
-  IGM.constructInitialFnAttributes(b, false /*disable ptr auth returns*/);
+  IGM.constructInitialFnAttributes(b);
   fwd->addAttributes(llvm::AttributeList::FunctionIndex, b);
   
   IRGenFunction subIGF(IGM, fwd);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1111,17 +1111,10 @@ void IRGenModule::setHasNoFramePointer(llvm::Function *F) {
 }
 
 /// Construct initial function attributes from options.
-void IRGenModule::constructInitialFnAttributes(
-    llvm::AttrBuilder &Attrs, bool disablePtrAuthReturns,
-    OptimizationMode FuncOptMode) {
+void IRGenModule::constructInitialFnAttributes(llvm::AttrBuilder &Attrs,
+                                               OptimizationMode FuncOptMode) {
   // Add the default attributes for the Clang configuration.
   clang::CodeGen::addDefaultFunctionDefinitionAttributes(getClangCGM(), Attrs);
-
-  // Disable `ptrauth-returns`. It does not work for swifttailcc lowering atm.
-  // The `autibsp` instruction executed before a tail call that adjust the stack
-  // will currently fail.
-  if (disablePtrAuthReturns)
-    Attrs.removeAttribute("ptrauth-returns");
 
   // Add/remove MinSize based on the appropriate setting.
   if (FuncOptMode == OptimizationMode::NotSet)
@@ -1135,10 +1128,9 @@ void IRGenModule::constructInitialFnAttributes(
   }
 }
 
-llvm::AttributeList
-IRGenModule::constructInitialAttributes(bool disablePtrAuthReturns) {
+llvm::AttributeList IRGenModule::constructInitialAttributes() {
   llvm::AttrBuilder b;
-  constructInitialFnAttributes(b, disablePtrAuthReturns);
+  constructInitialFnAttributes(b);
   return llvm::AttributeList::get(getLLVMContext(),
                                   llvm::AttributeList::FunctionIndex, b);
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1362,13 +1362,11 @@ public:
   bool finalize();
 
   void constructInitialFnAttributes(llvm::AttrBuilder &Attrs,
-                                    bool disablePtrAuthReturns,
                                     OptimizationMode FuncOptMode =
                                       OptimizationMode::NotSet);
   void setHasNoFramePointer(llvm::AttrBuilder &Attrs);
   void setHasNoFramePointer(llvm::Function *F);
-  llvm::AttributeList
-  constructInitialAttributes(bool disablePtrAuthReturns = false);
+  llvm::AttributeList constructInitialAttributes();
 
   void emitProtocolDecl(ProtocolDecl *D);
   void emitEnumDecl(EnumDecl *D);


### PR DESCRIPTION
This reverts commit 3c125a74f0a851f775ceeb48efcdbd35cf88efa8.
