### PR TITLE
Platform: correct link dependency for WinSDK.User

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -423,6 +423,7 @@ module WinSDK [system] {
   module User {
     header "WinUser.h"
     export *
+    link "User32.Lib"
   }
 
   module WIC {


### PR DESCRIPTION
Add the User32 link dependency for uses of the User module.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
