### PR TITLE
[Sema] Correctly diagnose passing tuple as only argument to function with multiple parameters

### DIFF
--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1086,7 +1086,7 @@ func testUnlabeledParameterBindingPosition() {
     func f(aa: Int, bb: Int, _ cc: Int) {}
 
     f(0, 2)
-    // expected-error@-1:6 {{missing argument labels 'aa:bb:' in call}}
+    // expected-error@-1:6 {{missing argument labels 'aa:bb::' in call}}
     // expected-error@-2:8 {{missing argument for parameter 'bb' in call}}
 
     f(0, bb: 1, 2)
@@ -1191,7 +1191,7 @@ func testUnlabeledParameterBindingPosition() {
     // expected-error@-1:6 {{missing arguments for parameters 'aa', 'cc' in call}}
 
     f(1, 2, 3)
-    // expected-error@-1 {{missing argument labels 'aa:cc:' in call}}
+    // expected-error@-1 {{missing argument labels 'aa:cc::' in call}}
     // expected-error@-2:11 {{missing argument for parameter 'cc' in call}}
 
     f(1, 2, 3, 4)
@@ -1223,7 +1223,7 @@ func testUnlabeledParameterBindingPosition() {
     // expected-error@-1:12 {{missing argument for parameter 'bb' in call}}
 
     f(aa: 1, xx: 2, 3)
-    // expected-error@-1 {{incorrect argument label in call (have 'aa:xx:_:', expected 'aa:bb:_:_:')}}
+    // expected-error@-1 {{incorrect argument labels in call (have 'aa:xx:_:', expected 'aa:bb:_:_:')}}
     // expected-error@-2:12 {{missing argument for parameter 'bb' in call}}
 
     f(aa: 1, bb: 2, 3, xx: 4)

--- a/test/Sema/call_function_with_tuple.swift
+++ b/test/Sema/call_function_with_tuple.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+func twoArgs(_ a: Int, _ b: Int) -> Void { //expected-note{{'twoArgs' declared here}}
+}
+
+func call() {
+  // Call a function that takes two unnamed arguments with a tuple that has two
+  // named arguments
+  let namedTuple: (x: Int, y: Int) = (1, 1)
+  twoArgs(namedTuple) // expected-error{{global function 'twoArgs' expects 2 separate arguments}} expected-error{{missing argument label ':' in call}}
+}


### PR DESCRIPTION
If a tuple is passed as the only argument to a function that takes two unnamed arguments, we try to diagnose the missing argument label. However, in the old diagnose code we didn’t distinguish between non-existing arguments and arguments without labels; both behaved the same.

Thus, the missing second argument in the function call would line up with the empty second argument label, not producing a diagnostic, but hitting an assertion later on.

Distinguish between the two to fix the issue.

Fixes rdar://64319340 [SR-13002]
