### PR TITLE
[Frontend] allow -emit-symbol-graph-dir and -supplementary-output-file-map at the same time

### DIFF
--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -597,8 +597,7 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
         options::OPT_emit_private_module_interface_path,
         options::OPT_emit_module_source_info_path,
         options::OPT_emit_tbd_path,
-        options::OPT_emit_ldadd_cfile_path,
-        options::OPT_emit_symbol_graph_dir)) {
+        options::OPT_emit_ldadd_cfile_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,
                    A->getSpelling(), "-supplementary-output-file-map");

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -72,7 +72,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   Opts.SkipUnderscoredStdlibProtocols = true;
   Opts.PrintGenericRequirements = true;
   Opts.PrintInherited = false;
-  Opts.ExplodeEnumCaseDecls = IsForSingleNode;
+  Opts.ExplodeEnumCaseDecls = true;
 
   Opts.ExclusiveAttrList.clear();
 

--- a/test/SymbolGraph/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/EmitWhileBuilding.swift
@@ -1,11 +1,18 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/ -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
 
 // also try without the trailing slash on `-emit-symbol-graph-dir` and make sure it works
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/ -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
+
+// also try while forcing the use of supplementary file maps to make sure the symbol graph path gets
+// added to the file map for the inner frontend call
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name EmitWhileBuilding -emit-module -emit-module-path %t/EmitWhileBuilding.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t -driver-filelist-threshold=0 -O -whole-module-optimization
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json
 
 /// Does a foo.


### PR DESCRIPTION
Resolves rdar://75155133

When the `-emit-symbol-graph[-dir]` flags were added, they were not completely integrated into the supplementary output file map structure. If a symbol graph is requested, these flags are passed to the frontend regardless of whether other supplementary outputs are collected into a file map. Because the frontend treats `-emit-symbol-graph-dir` and `-supplementary-output-file-map` as incompatible, this creates a situation where an error is reported through no fault of the user. This PR removes the check to disallow `-emit-symbol-graph-dir`, since this information is not being emitted in the file map right now.

A future PR will properly integrate `-emit-symbol-graph-dir` into the supplementary file map in the swift driver; this is meant as a stopgap for the meantime.