### PR TITLE
SIL: Gate checkForLeaksAfterDestruction to asserts builds

### DIFF
--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -167,6 +167,8 @@ void SILModule::checkForLeaks() const {
 }
 
 void SILModule::checkForLeaksAfterDestruction() {
+// Disabled in release (non-assert) builds because this check fails in rare
+// cases in lldb, causing crashes. rdar://70826934
 #ifndef NDEBUG
   int numAllocated = SILInstruction::getNumCreatedInstructions() -
                      SILInstruction::getNumDeletedInstructions();

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -167,6 +167,7 @@ void SILModule::checkForLeaks() const {
 }
 
 void SILModule::checkForLeaksAfterDestruction() {
+#ifndef NDEBUG
   int numAllocated = SILInstruction::getNumCreatedInstructions() -
                      SILInstruction::getNumDeletedInstructions();
 
@@ -174,6 +175,7 @@ void SILModule::checkForLeaksAfterDestruction() {
     llvm::errs() << "Leaking " << numAllocated << " instructions!\n";
     llvm_unreachable("leaking instructions");
   }
+#endif
 }
 
 std::unique_ptr<SILModule> SILModule::createEmptyModule(


### PR DESCRIPTION
A few lldb bug reports have shown that `SILModule::checkForLeaksAfterDestruction()` can fail. The root cause is TBD, possibly by calling `IRGenRequest::evaluate` concurrently (the leaks check uses counters that are not thread safe).

This leaks check should reasonably be performed only in asserts builds. That way end users won't face a crash if there's a race in how the check is performed, or if there is a leak. Note that `SILModule::checkForLeaks()` is called only in asserts builds.
 
rdar://70826934

(cherry picked from https://github.com/apple/swift/pull/35568)