### PR TITLE
[Concurrency] Computed properties can't be async, don't even try

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -133,7 +133,7 @@ static bool checkAsyncHandler(FuncDecl *func, bool diagnose) {
 
 void swift::addAsyncNotes(AbstractFunctionDecl const* func) {
   assert(func);
-  if (!isa<DestructorDecl>(func)) {
+  if (!isa<DestructorDecl>(func) && !isa<AccessorDecl>(func)) {
     auto note =
         func->diagnose(diag::note_add_async_to_function, func->getName());
 
@@ -143,8 +143,7 @@ void swift::addAsyncNotes(AbstractFunctionDecl const* func) {
                         : "async throws";
 
       note.fixItReplace(SourceRange(func->getThrowsLoc()), replacement);
-
-    } else {
+    } else if (func->getParameters()->getRParenLoc().isValid()) {
       note.fixItInsert(func->getParameters()->getRParenLoc().getAdvancedLoc(1),
                        " async");
     }

--- a/test/Concurrency/async_computed_property.swift
+++ b/test/Concurrency/async_computed_property.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+// REQUIRES: concurrency
+
+func asyncFunc(_ value: String) async {}
+
+class ComputedPropertyClass {
+  var meep: String {
+    //expected-error@+1:11{{'async' call in a function that does not support concurrency}}
+    await asyncFunc("Meep")
+    return "15"
+  }
+}


### PR DESCRIPTION
The fix-it was being a little too eager to label function decls async.
Computed properties, or AccessorDecls are function declarations, but
they don't have parentheses, so trying to add `async` to them causes
crashing. Furthermore, they can't be async at all, so suggesting that we
make them async is just wrong. We shouldn't give folks a glimmer of hope
where there is none to be had.

Resolves: rdar://75342132