### PR TITLE
[IDE] Explicitly specify 'SerializedOK=false' to 'getRawComment()'

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -261,7 +261,7 @@ public:
 
 void getSwiftDocKeyword(const Decl* D, CommandWordsPairs &Words) {
   auto Interested = false;
-  for (auto C : D->getRawComment().Comments) {
+  for (auto C : D->getRawComment(/*SerializedOK=*/false).Comments) {
     if (containsInterestedWords(C.RawText, "-", /*AllowWhitespace*/true)) {
       Interested = true;
       break;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -264,7 +264,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
                ExtensionDecl *EnablingExt, NormalProtocolConformance *Conf) {
     SynthesizedExtensionInfo Result(IsSynthesized, EnablingExt);
     ExtensionMergeInfo MergeInfo;
-    MergeInfo.Unmergable = !Ext->getRawComment().isEmpty() || // With comments
+    MergeInfo.Unmergable = !Ext->getRawComment(/*SerializedOK=*/false).isEmpty() || // With comments
                            Ext->getAttrs().hasAttribute<AvailableAttr>(); // With @available
     MergeInfo.InheritsCount = countInherits(Ext);
 

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -810,7 +810,7 @@ static SourceLoc getDeclStartPosition(SourceFile &File) {
   for (auto D : File.getTopLevelDecls()) {
     if (tryUpdateStart(D->getStartLoc())) {
       tryUpdateStart(D->getAttrs().getStartLoc());
-      auto RawComment = D->getRawComment();
+      auto RawComment = D->getRawComment(/*SerializedOK=*/false);
       if (!RawComment.isEmpty())
         tryUpdateStart(RawComment.Comments.front().Range.getStart());
     }

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -198,7 +198,7 @@ bool NameMatcher::handleCustomAttrs(Decl *D) {
 
 bool NameMatcher::walkToDeclPre(Decl *D) {
   // Handle occurrences in any preceding doc comments
-  RawComment R = D->getRawComment();
+  RawComment R = D->getRawComment(/*SerializedOK=*/false);
   if (!R.isEmpty()) {
     for(SingleRawComment C: R.Comments) {
       while(!shouldSkip(C.Range))

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -513,7 +513,7 @@ CharSourceRange parameterNameRangeOfCallArg(const TupleExpr *TE,
 static void setDecl(SyntaxStructureNode &N, Decl *D) {
   N.Dcl = D;
   N.Attrs = D->getAttrs();
-  N.DocRange = D->getRawComment().getCharSourceRange();
+  N.DocRange = D->getRawComment(/*SerializedOK=*/false).getCharSourceRange();
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This ensures that we don't try getRawComment() from serialized locations

rdar://problem/75010520
