### PR TITLE
[SourceKit/CursorInfo] Mark dynamic calls

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -621,6 +621,23 @@ ClangNode extensionGetClangNode(const ExtensionDecl *ext);
 /// or a curry thunk, etc.
 std::pair<Type, ConcreteDeclRef> getReferencedDecl(Expr *expr);
 
+/// Whether the last expression in \p ExprStack is being called.
+bool isBeingCalled(ArrayRef<Expr*> ExprStack);
+
+/// The base of the last expression in \p ExprStack (which may look up the
+/// stack in eg. the case of a `DotSyntaxCallExpr`).
+Expr *getBase(ArrayRef<Expr *> ExprStack);
+
+/// Assuming that we have a call, returns whether or not it is "dynamic" based
+/// on its base expression and decl of the callee. Note that this is not
+/// Swift's "dynamic" modifier (`ValueDecl::isDynamic`), but rathar "can call a
+/// function in a conformance/subclass".
+bool isDynamicCall(Expr *Base, ValueDecl *D);
+
+/// Adds the resolved nominal types of \p Base to \p Types.
+void getReceiverType(Expr *Base,
+                     SmallVectorImpl<NominalTypeDecl *> &Types);
+
 } // namespace ide
 } // namespace swift
 

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -164,6 +164,11 @@ struct ResolvedCursorInfo {
   Type ContainerType;
   Stmt *TrailingStmt = nullptr;
   Expr *TrailingExpr = nullptr;
+  /// If this is a call, whether it is "dynamic", see ide::isDynamicCall.
+  bool IsDynamic = false;
+  /// If this is a call, the types of the base (multiple in the case of
+  /// protocol composition).
+  SmallVector<NominalTypeDecl *, 1> ReceiverTypes;
 
   ResolvedCursorInfo() = default;
   ResolvedCursorInfo(SourceFile *SF) : SF(SF) {}
@@ -174,12 +179,9 @@ struct ResolvedCursorInfo {
       lhs.Loc.getOpaquePointerValue() == rhs.Loc.getOpaquePointerValue();
   }
 
-  void setValueRef(ValueDecl *ValueD,
-                   TypeDecl *CtorTyRef,
-                   ExtensionDecl *ExtTyRef,
-                   bool IsRef,
-                   Type Ty,
-                   Type ContainerType) {
+  void setValueRef(ValueDecl *ValueD, TypeDecl *CtorTyRef,
+                   ExtensionDecl *ExtTyRef, bool IsRef,
+                   Type Ty, Type ContainerType) {
     Kind = CursorInfoKind::ValueRef;
     this->ValueD = ValueD;
     this->CtorTyRef = CtorTyRef;

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -59,11 +59,11 @@ class CursorInfoResolver : public SourceEntityWalker {
   SourceLoc LocToResolve;
   ResolvedCursorInfo CursorInfo;
   Type ContainerType;
-  llvm::SmallVector<Expr*, 4> TrailingExprStack;
+  Expr *OutermostCursorExpr;
 
 public:
   explicit CursorInfoResolver(SourceFile &SrcFile) :
-    SrcFile(SrcFile), CursorInfo(&SrcFile) {}
+    SrcFile(SrcFile), CursorInfo(&SrcFile), OutermostCursorExpr(nullptr) {}
   ResolvedCursorInfo resolve(SourceLoc Loc);
   SourceManager &getSourceMgr() const;
 private:
@@ -221,44 +221,51 @@ bool CursorInfoResolver::visitDeclReference(ValueDecl *D,
   return !tryResolve(D, CtorTyRef, ExtTyRef, Range.getStart(), /*IsRef=*/true, T);
 }
 
-bool CursorInfoResolver::walkToExprPre(Expr *E) {
-  if (!isDone()) {
-    if (auto SAE = dyn_cast<SelfApplyExpr>(E)) {
-      if (SAE->getFn()->getStartLoc() == LocToResolve) {
-        ContainerType = SAE->getBase()->getType();
-      }
-    } else if (auto ME = dyn_cast<MemberRefExpr>(E)) {
-      SourceLoc MemberLoc = ME->getNameLoc().getBaseNameLoc();
-      if (MemberLoc.isValid() && MemberLoc == LocToResolve) {
-        ContainerType = ME->getBase()->getType();
-      }
-    }
-    auto IsProperCursorLocation = E->getStartLoc() == LocToResolve;
-    // Handle cursor placement after `try` in ForceTry and OptionalTry Expr.
-    auto CheckLocation = [&IsProperCursorLocation, this](SourceLoc Loc) {
-      IsProperCursorLocation = Loc == LocToResolve || IsProperCursorLocation;
-    };
-    if (auto *FTE = dyn_cast<ForceTryExpr>(E)) {
-      CheckLocation(FTE->getExclaimLoc());
-    }
-    if (auto *OTE = dyn_cast<OptionalTryExpr>(E)) {
-      CheckLocation(OTE->getQuestionLoc());
-    }
-    // Keep track of trailing expressions.
-    if (!E->isImplicit() && IsProperCursorLocation)
-      TrailingExprStack.push_back(E);
+static bool isCursorOn(Expr *E, SourceLoc Loc) {
+  if (E->isImplicit())
+    return false;
+
+  bool IsCursorOnLoc = E->getStartLoc() == Loc;
+  // Handle cursor placement after `try` in (ForceTry|OptionalTry)Expr
+  if (auto *FTE = dyn_cast<ForceTryExpr>(E)) {
+    IsCursorOnLoc |= FTE->getExclaimLoc() == Loc;
   }
+  if (auto *OTE = dyn_cast<OptionalTryExpr>(E)) {
+    IsCursorOnLoc |= OTE->getQuestionLoc() == Loc;
+  }
+  return IsCursorOnLoc;
+}
+
+bool CursorInfoResolver::walkToExprPre(Expr *E) {
+  if (isDone())
+    return true;
+
+  if (auto SAE = dyn_cast<SelfApplyExpr>(E)) {
+    if (SAE->getFn()->getStartLoc() == LocToResolve) {
+      ContainerType = SAE->getBase()->getType();
+    }
+  } else if (auto ME = dyn_cast<MemberRefExpr>(E)) {
+    SourceLoc MemberLoc = ME->getNameLoc().getBaseNameLoc();
+    if (MemberLoc.isValid() && MemberLoc == LocToResolve) {
+      ContainerType = ME->getBase()->getType();
+    }
+  }
+
+  if (!OutermostCursorExpr && isCursorOn(E, LocToResolve))
+    OutermostCursorExpr = E;
+
   return true;
 }
 
 bool CursorInfoResolver::walkToExprPost(Expr *E) {
   if (isDone())
     return false;
-  if (!TrailingExprStack.empty() && TrailingExprStack.back() == E) {
-    // We return the outtermost expression in the token info.
-    CursorInfo.setTrailingExpr(TrailingExprStack.front());
+
+  if (OutermostCursorExpr && isCursorOn(E, LocToResolve)) {
+    CursorInfo.setTrailingExpr(OutermostCursorExpr);
     return false;
   }
+
   return true;
 }
 

--- a/test/SourceKit/CursorInfo/cursor_dynamic.swift
+++ b/test/SourceKit/CursorInfo/cursor_dynamic.swift
@@ -1,0 +1,142 @@
+protocol ProtoA {
+  func method()
+  static func staticMethod()
+}
+
+class ClassB: ProtoA {
+  let immutableMember: Int = 1
+  var mutableMember: Int = 1
+  func method() {}
+  static func staticMethod() {}
+  class func classMethod() {}
+  final func finalMethod() {}
+}
+
+class ClassC: ClassB {}
+
+class ClassD: ClassC {
+  override var mutableMember: Int {
+    get {
+      return super.mutableMember
+    }
+    set {
+      super.mutableMember = newValue + 1
+    }
+  }
+
+  override func method() {
+    super.method()
+  }
+
+  override class func classMethod() {}
+}
+
+struct StructE: ProtoA {
+  func method() {}
+
+  static func staticMethod() {}
+}
+
+func direct() {
+  ClassB.staticMethod()
+  ClassB.classMethod()
+  ClassD.classMethod()
+  StructE.staticMethod()
+}
+
+func protoCalls(p: ProtoA) {
+  p.method()
+  type(of: p).staticMethod()
+}
+
+func classCalls(c: ClassC) {
+  _ = c.immutableMember
+  _ = c.mutableMember
+  c.mutableMember = 1
+  c.method()
+  type(of: c).staticMethod()
+  type(of: c).classMethod()
+  c.finalMethod()
+}
+
+func structCalls(e: StructE) {
+  e.method()
+  type(of: e).staticMethod()
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=28:11 %s -- %s | %FileCheck -check-prefix=CHECK-SUPER %s
+// CHECK-SUPER: s:14cursor_dynamic6ClassBC6methodyyF
+// CHECK-SUPER-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=41:10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSSTATIC %s
+// CHECK-CLASSSTATIC: s:14cursor_dynamic6ClassBC12staticMethodyyFZ
+// CHECK-CLASSSTATIC-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=42:10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCLASS %s
+// CHECK-CLASSCLASS: s:14cursor_dynamic6ClassBC11classMethodyyFZ
+// CHECK-CLASSCLASS-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=43:10 %s -- %s | %FileCheck -check-prefix=CHECK-SUBCLASSCLASS %s
+// CHECK-SUBCLASSCLASS: s:14cursor_dynamic6ClassDC11classMethodyyFZ
+// CHECK-SUBCLASSCLASS-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=44:11 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTSTATIC %s
+// CHECK-STRUCTSTATIC: s:14cursor_dynamic7StructEV12staticMethodyyFZ
+// CHECK-STRUCTSTATIC-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=48:5 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOMETHOD %s
+// CHECK-PROTOMETHOD: s:14cursor_dynamic6ProtoAP6methodyyF
+// CHECK-PROTOMETHOD: DYNAMIC
+// CHECK-PROTOMETHOD: RECEIVERS BEGIN
+// CHECK-PROTOMETHOD-NEXT: s:14cursor_dynamic6ProtoAP
+// CHECK-PROTOMETHOD-NEXT: RECEIVERS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=49:15 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOTOSTATIC %s
+// CHECK-PROTOTOSTATIC: s:14cursor_dynamic6ProtoAP12staticMethodyyFZ
+// CHECK-PROTOTOSTATIC: DYNAMIC
+// CHECK-PROTOSTATIC: RECEIVERS BEGIN
+// CHECK-PROTOSTATIC-NEXT: s:14cursor_dynamic6ProtoAP
+// CHECK-PROTOSTATIC-NEXT: RECEIVERS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=53:9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSIMMEMBER %s
+// CHECK-CLASSIMMEMBER: s:14cursor_dynamic6ClassBC15immutableMemberSivp
+// rdar://75645572 should include getter without dynamic (or maybe we just skip returning in that case
+// since it would only be used to find overrides)
+
+// RUN: %sourcekitd-test -req=cursor -pos=54:9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSMEMBERREAD %s
+// CHECK-CLASSMEMBERREAD: s:14cursor_dynamic6ClassBC13mutableMemberSivp
+// rdar://75645572 should include getter with dynamic
+
+// RUN: %sourcekitd-test -req=cursor -pos=55:5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSMEMBERWRITE %s
+// CHECK-CLASSMEMBERWRITE: s:14cursor_dynamic6ClassBC13mutableMemberSivp
+// rdar://75645572 should include setter with dynamic
+
+// RUN: %sourcekitd-test -req=cursor -pos=56:5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSMETHOD %s
+// CHECK-CLASSMETHOD: s:14cursor_dynamic6ClassBC6methodyyF
+// CHECK-CLASSMETHOD: DYNAMIC
+// CHECK-CLASSMETHOD: RECEIVERS BEGIN
+// CHECK-CLASSMETHOD-NEXT: s:14cursor_dynamic6ClassCC
+// CHECK-CLASSMETHOD-NEXT: RECEIVERS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=57:15 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSTOSTATIC %s
+// CHECK-CLASSTOSTATIC: s:14cursor_dynamic6ClassBC12staticMethodyyFZ
+// CHECK-CLASSTOSTATIC-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=58:15 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSTOCLASS %s
+// CHECK-CLASSTOCLASS: s:14cursor_dynamic6ClassBC11classMethodyyFZ
+// CHECK-CLASSTOCLASS: DYNAMIC
+// CHECK-CLASSTOCLASS: RECEIVERS BEGIN
+// CHECK-CLASSTOCLASS-NEXT: s:14cursor_dynamic6ClassCC
+// CHECK-CLASSTOCLASS-NEXT: RECEIVERS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=59:5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSFINAL %s
+// CHECK-CLASSFINAL: s:14cursor_dynamic6ClassBC11finalMethodyyF
+// CHECK-CLASSFINAL-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=63:5 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTMETHOD %s
+// CHECK-STRUCTMETHOD: s:14cursor_dynamic7StructEV6methodyyF
+// CHECK-STRUCTMETHOD-NOT: DYNAMIC
+
+// RUN: %sourcekitd-test -req=cursor -pos=64:15 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTTOSTATIC %s
+// CHECK-STRUCTTOSTATIC: s:14cursor_dynamic7StructEV12staticMethodyyFZ
+// CHECK-STRUCTOTSTATIC-NOT: DYNAMIC

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
@@ -89,7 +89,6 @@
               key.line: 5,
               key.column: 20,
               key.receiver_usr: "s:16forbid_typecheck6ClsSecC",
-              key.is_dynamic: 1,
               key.is_implicit: 1
             }
           ]

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -431,8 +431,13 @@ struct CursorInfoData {
   /// Stores the Symbol Graph title, kind, and USR of the parent contexts of the
   /// symbol under the cursor.
   ArrayRef<ParentInfo> ParentContexts;
+  /// For calls this lists the USRs of the receiver types (multiple only in the
+  /// case that the base is a protocol composition).
+  ArrayRef<StringRef> ReceiverUSRs;
 
   bool IsSystem = false;
+  bool IsDynamic = false;
+
   llvm::Optional<unsigned> ParentNameOffset;
 };
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1817,6 +1817,13 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
       RelDecl.set(KeyAnnotatedDecl, AnnotDecl);
     }
   }
+  if (!Info.ReceiverUSRs.empty()) {
+    auto Receivers = Elem.setArray(KeyReceivers);
+    for (auto USR : Info.ReceiverUSRs) {
+      auto Receiver = Receivers.appendDictionary();
+      Receiver.set(KeyUSR, USR);
+    }
+  }
   if (Info.IsSystem)
     Elem.setBool(KeyIsSystem, true);
   if (!Info.TypeInterface.empty())
@@ -1836,6 +1843,8 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
       Parent.set(KeyUSR, ParentTy.USR);
     }
   }
+  if (Info.IsDynamic)
+    Elem.setBool(KeyIsDynamic, true);
 
   return Rec(RespBuilder.createResponse());
 }

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -38,6 +38,7 @@ UID_KEYS = [
     KEY('Line', 'key.line'),
     KEY('Column', 'key.column'),
     KEY('ReceiverUSR', 'key.receiver_usr'),
+    KEY('Receivers', 'key.receivers'),
     KEY('IsDynamic', 'key.is_dynamic'),
     KEY('IsImplicit', 'key.is_implicit'),
     KEY('FilePath', 'key.filepath'),


### PR DESCRIPTION
Adds two new fields to the cursor info response:
  1. is_dynamic: whether a call is dynamic
  2. receivers: receivers of the call (USRs)

Users of the CursorInfo request can use "is_dynamic" to decide whether
to lookup overrides or not, and then the "receivers" as the starting
point of the lookup.

Resolves rdar://75385900