### PR TITLE
build: build parser-lib by default on Windows

### DIFF
--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -40,6 +40,8 @@ set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
 
 # This requires perl which may not be available on Windows
 set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")
+set(SWIFT_BUILD_ENABLE_PARSER_LIB YES CACHE BOOL "")
+# static linking is not supported on Windows yet
 set(SWIFT_BUILD_STATIC_STDLIB NO CACHE BOOL "")
 set(SWIFT_BUILD_STATIC_SDK_OVERLAY NO CACHE BOOL "")
 
@@ -117,6 +119,7 @@ set(SWIFT_INSTALL_COMPONENTS
       sourcekit-inproc
       swift-remote-mirror
       swift-remote-mirror-headers
+      parser-lib
     CACHE STRING "")
 
 set(LLVM_DISTRIBUTION_COMPONENTS


### PR DESCRIPTION
Add parser-lib to the default build configuration on Windows.  This is
useful for building additional tooling.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
