### PR TITLE
[CodeComplete] Fix code completion of initialization for variable wrapped by generic property wrapper

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4108,6 +4108,13 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
       continue;
     }
 
+    // There are no subtitutions to apply if the type is still unbound,
+    // continue looking into the parent.
+    if (auto unboundGeneric = baseTy->getAs<UnboundGenericType>()) {
+      baseTy = unboundGeneric->getParent();
+      continue;
+    }
+
     // Assert and break to avoid hanging if we get an unexpected baseTy.
     assert(0 && "Bad base type");
     break;

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -565,6 +565,8 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
     (void)var->getInterfaceType();
     if (!binding->isInitializerChecked(index))
       TypeChecker::typeCheckPatternBinding(binding, index);
+    if (binding->isInvalid())
+      return Type();
   } else {
     using namespace constraints;
     auto dc = var->getInnermostDeclContext();

--- a/validation-test/IDE/crashers_2_fixed/rdar64141399-complete_generic_property_wrapper_initialization.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar64141399-complete_generic_property_wrapper_initialization.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE_GENERIC -source-filename=%s
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE_IN_GENERIC_CONTEXT -source-filename=%s
+
+struct Foo {
+  static let bar: Foo
+}
+
+@propertyWrapper public struct GenericWrapper<Value> {
+  public var wrappedValue: Value
+  public var projectedValue: Int
+
+  public init(wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+    self.projectedValue = 1
+  }
+}
+
+public struct GenericContext<T> {
+  @propertyWrapper public struct GenericWrapper<Value> {
+    public var wrappedValue: Value
+    public var projectedValue: Int
+
+    public init(wrappedValue: Value) {
+      self.wrappedValue = wrappedValue
+      self.projectedValue = 1
+    }
+  }
+}
+
+public struct MyStruct {
+  @GenericWrapper var someProperty = #^COMPLETE_GENERIC^#
+}
+public struct MyStruct2 {
+  @GenericContext<Foo>.GenericWrapper var someProperty2 = #^COMPLETE_IN_GENERIC_CONTEXT^#
+}


### PR DESCRIPTION
If completing the initialization of a variable that’s wrapped in a generic, unbound property wrapper, the expression's type is an `UnboundGenericType`. AFAICT that’s expected and the correct type to assign.

We hit the first assertion failure by trying to retrieve that type's substitution map. `UnboundGenericType`s were not handled here, so we hit an assertion. AFAICT we can't get any substitutions out of an unbound generic type, so we should just continue looking into the parent type.

We hit the second assertion when trying to retrieve the property wrapper’s backing type, which is null (becuase it couldn't be resolved). However, we haven’t emitted a diagnostic because the variable declaration is perfectly valid. Hence I’m removing the assertion.

Fixes rdar://64141399
