### PR TITLE
Diag: Carry over the constraint in opaque_type_in_protocol_requirement fix-it

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -105,11 +105,20 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
       fixitLoc = originatingDecl->getStartLoc();
     }
 
-    ctx.Diags.diagnose(repr->getLoc(),
-                       diag::opaque_type_in_protocol_requirement)
-      .fixItInsert(fixitLoc, "associatedtype <#AssocType#>\n")
-      .fixItReplace(repr->getSourceRange(), "<#AssocType#>");
-    
+    std::string result;
+    const char *const placeholder = "<#AssocType#>";
+    {
+      llvm::raw_string_ostream out(result);
+      out << "associatedtype " << placeholder << ": ";
+      repr->getConstraint()->print(out);
+      out << "\n";
+    }
+
+    ctx.Diags
+        .diagnose(repr->getLoc(), diag::opaque_type_in_protocol_requirement)
+        .fixItInsert(fixitLoc, result)
+        .fixItReplace(repr->getSourceRange(), placeholder);
+
     return nullptr;
   }
   

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -390,13 +390,19 @@ func rdar_51641323() {
 
 // Protocol requirements cannot have opaque return types
 protocol OpaqueProtocolRequirement {
-  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>\n}}{{20-26=<#AssocType#>}}
-  func method() -> some P
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>: P\n}}{{21-27=<#AssocType#>}}
+  func method1() -> some P
 
-  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>\n}}{{13-19=<#AssocType#>}}
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>: C & P & Q\n}}{{21-35=<#AssocType#>}}
+  func method2() -> some C & P & Q
+
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>: Nonsense\n}}{{21-34=<#AssocType#>}}
+  func method3() -> some Nonsense
+
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>: P\n}}{{13-19=<#AssocType#>}}
   var prop: some P { get }
 
-  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>\n}}{{18-24=<#AssocType#>}}
+  // expected-error@+1 {{cannot be the return type of a protocol requirement}}{{3-3=associatedtype <#AssocType#>: P\n}}{{18-24=<#AssocType#>}}
   subscript() -> some P { get }
 }
 


### PR DESCRIPTION
Do our best to preserve user code integrity, even if the constraint may turn out invalid on the next iteration.