### PR TITLE
[SR-14311] Error out when swift-api-extract failed to load module

### DIFF
--- a/test/APIJSON/Inputs/NativeDep.h
+++ b/test/APIJSON/Inputs/NativeDep.h
@@ -1,0 +1,1 @@
+void my_native_c ();

--- a/test/APIJSON/Inputs/module.modulemap
+++ b/test/APIJSON/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+framework module NativeDep [extern_c] {
+  umbrella header "NativeDep.h"
+  export *
+}

--- a/test/APIJSON/non-swift-api.swift
+++ b/test/APIJSON/non-swift-api.swift
@@ -1,0 +1,30 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/NativeDep.framework/Headers %t/NativeDep.framework/Modules %t/cache
+// RUN: cp %S/Inputs/module.modulemap %t/NativeDep.framework/Modules
+// RUN: cp %S/Inputs/NativeDep.h %t/NativeDep.framework/Headers
+
+// RUN: %target-swift-frontend %s -emit-module -emit-module-interface-path %t/MyModule.swiftinterface -emit-module-path %t/MyModule.swiftmodule -F %t -enable-library-evolution -module-cache-path %t/cache -module-name MyModule -swift-version 5
+
+/// Check that both swiftmodule and swiftinterface can be used as input.
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftmodule -module-name MyModule -module-cache-path %t/cache -F %t | %FileCheck %s
+// RUN: %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftinterface -module-name MyModule -module-cache-path %t/cache -F %t | %FileCheck %s
+
+/// Check that if a dependency is missing, error message is emitted and not crashed.
+// RUN: rm -rf %t/NativeDep.framework
+// RUN: not %target-swift-api-extract -o - -pretty-print %t/MyModule.swiftmodule -module-name MyModule -module-cache-path %t/cache 2>&1 | %FileCheck %s --check-prefix=CHECK-ERROR
+
+import NativeDep
+
+public func callNative ()
+{
+      my_native_c()      
+}
+
+// CHECK:        "target": "x86_64-apple-macosx10.9",
+// CHECK-NEXT:   "globals": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule10callNativeyyF",
+// CHECK-NEXT:       "access": "public",
+
+// CHECK-ERROR: error: missing required module 'NativeDep'

--- a/tools/driver/swift_api_extract_main.cpp
+++ b/tools/driver/swift_api_extract_main.cpp
@@ -103,6 +103,8 @@ public:
       }
     }
 
+    Invocation.getLangOptions().EnableModuleLoadingRemarks = true;
+
     if (auto *A = ParsedArgs.getLastArg(OPT_sdk))
       Invocation.setSDKPath(A->getValue());
 
@@ -206,6 +208,10 @@ public:
                                    InputModuleName);
       return 1;
     }
+
+    // If there are errors emitted when loading module, exit with error.
+    if (Instance.getASTContext().hadError())
+      return 1;
 
     if (OutputFilename == "-") {
       writeAPIJSONFile(M, llvm::outs(), PrettyPrint);


### PR DESCRIPTION
Emit diagnostics and error out when swift-api-extract failed to load
module.

<!-- What's in this pull request? -->
Emit diagnostics and error out when swift-api-extract failed to load
module.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14311

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
