### PR TITLE
[Concurrency] Make asyncMainDrainQueue noreturn

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -541,7 +541,7 @@ void swift_continuation_logFailedCheck(const char *message);
 /// If the binary links CoreFoundation, uses CFRunLoopRun
 /// Otherwise it uses dispatchMain.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-void swift_task_asyncMainDrainQueue();
+void swift_task_asyncMainDrainQueue [[noreturn]]();
 
 /// Establish that the current thread is running as the given
 /// executor, then run a job.

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -744,6 +744,7 @@ void swift::swift_task_asyncMainDrainQueue() {
     abort();
 
   pfndispatch_main();
+  exit(0);
 #else
   // CFRunLoop is not available on non-Darwin targets.  Foundation has an
   // implementation, but CoreFoundation is not meant to be exposed.  We can only
@@ -752,8 +753,10 @@ void swift::swift_task_asyncMainDrainQueue() {
 #if defined(__APPLE__)
   auto runLoop =
       reinterpret_cast<void (*)(void)>(dlsym(RTLD_DEFAULT, "CFRunLoopRun"));
-  if (runLoop)
-    return runLoop();
+  if (runLoop) {
+    runLoop();
+    exit(0);
+  }
 #endif
 
     dispatch_main();


### PR DESCRIPTION
CFRunLoopRun returns once it finishes, though the kernel may clean us up
before we get there. We effectively have a race condition between the
kernel cleaning us up and returning from a never returning function.

Small programs likely get cleaned up before reaching the ud2 instruction
emitted after the never returning function in swift, so they don't
notice, but programs of a sufficient size do. At that size, the program
will crash after what the programmer expects to be the end of their
program. Actually exiting cleanly will stop those programs from crashing.

Resolves: rdar://75631587