### PR TITLE
[IRGen] Add protocol reflection field records

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -42,6 +42,7 @@
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
 #include "MetadataRequest.h"
+#include "ProtocolInfo.h"
 
 using namespace swift;
 using namespace irgen;
@@ -783,7 +784,62 @@ private:
       Kind = FieldDescriptorKind::Protocol;
     B.addInt16(uint16_t(Kind));
     B.addInt16(FieldRecordSize);
-    B.addInt32(0);
+
+    auto &pi = IGM.getProtocolInfo(const_cast<ProtocolDecl *>(PD),
+                                   ProtocolInfoKind::Full);
+
+    // The number of fields are the number of "witneses" this protocol defines.
+    B.addInt32(pi.getNumWitnesses()); // num fields
+
+    for (auto entry : pi.getWitnessEntries()) {
+      // All protocol "fields" don't have any flags.
+      B.addInt32(0);
+
+      // Only emit mangled types names and names for a "function" witness.
+      // Associated types, associated conformances, and base protocols already
+      // have their mangled type name in the protocol descriptor/their names
+      // in an associatedtype name pointer there too. Don't emit redundant
+      // information.
+      if (!entry.isFunction()) {
+        B.addInt32(0); // mangled type name
+        B.addInt32(0); // name
+        continue;
+      }
+
+      auto funcRef = entry.getFunction();
+      auto func = funcRef.getAbstractFunctionDecl();
+
+      auto type = func->getMethodInterfaceType();
+      auto genericSig = func->getGenericSignature();
+      auto name = StringRef();
+
+      if (!func->getName().isSpecial()) {
+        name = func->getBaseIdentifier().str();
+      }
+
+      // Look through accessor because we want to make changes to vars.
+      if (auto accessor = dyn_cast<AccessorDecl>(func)) {
+        // Var decls have a more meaningful name that we can grab. Also, use
+        // their return type as the mangled type name here.
+        if (auto var = dyn_cast<VarDecl>(accessor->getStorage())) {
+          type = var->getValueInterfaceType();
+          name = var->getNameStr();
+        }
+      }
+
+      if (!type) {
+        B.addInt32(0);
+      } else {
+        addTypeRef(type, genericSig, MangledTypeRefRole::Metadata);
+      }
+
+      if (IGM.IRGen.Opts.EnableReflectionNames && !name.empty()) {
+        auto nameAddr = IGM.getAddrOfFieldName(name);
+        B.addRelativeAddress(nameAddr);
+      } else {
+        B.addInt32(0);
+      }
+    }
   }
 
   void layout() override {


### PR DESCRIPTION
This addresses a TODO found here: <https://github.com/apple/swift/blob/main/include/swift/ABI/Metadata.h#L1935> also inspired by the tweet: <https://twitter.com/aalonso128/status/1284979441521823744>. Instead of making a new section that @slavapestov suggested, this pr includes the necessary information in the field descriptor of protocols. I couldn't seem to find any tests that tested against the field descriptor (besides maybe the Mirror tests, but Mirror wouldn't look at a protocol's field descriptor anyway). Would love suggestions on types of tests to add for this, or if this is a good idea at all.

For example:
```swift
protocol Person {
  var name: String { get set }
  var age: Int { get set }
  init()
  func sayHello(to other: Person) -> String
}
```

Would produce something like the following:
```
// ... start of reflection field records
0 // flags for name getter
TypeRef to String
Ref to "name"
...
0 // flags for age getter
TypeRef to Int
Ref to "age"
...
0 // flags for init
TypeRef to () -> ()
0 // name
...
0 // flags for sayHello
TypeRef to (Person) -> String
Ref to "sayHello"
```
Maybe function naming could be better so we could include parameter names somewhere? 

This layout mimics the order in the protocol descriptor, so it would be fairly easy to map types and names back to protocol requirements. It also feels unfortunate that there is a bunch of empty data for associatedtype requirement and friends, but if we only included function requirements, then it might be difficult to make that mapping from requirement to field record.

cc: @jckarter @aschwaighofer @slavapestov 