### PR TITLE
[AutoDiff] Fix falsely triggered precondition in Array.DifferentiableView.+ and .move

### DIFF
--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -73,12 +73,15 @@ where Element: Differentiable {
     Array<Element.TangentVector>.DifferentiableView
 
   public mutating func move(by offset: TangentVector) {
+    if offset.base.isEmpty {
+      return
+    }
     precondition(
       base.count == offset.base.count, """
         Count mismatch: \(base.count) ('self') and \(offset.base.count) \
         ('direction')
         """)
-    for i in base.indices {
+    for i in offset.base.indices {
       base[i].move(by: offset.base[i])
     }
   }
@@ -217,10 +220,13 @@ extension Array where Element: Differentiable {
     pullback: (TangentVector) -> (TangentVector, TangentVector)
   ) {
     func pullback(_ v: TangentVector) -> (TangentVector, TangentVector) {
+      if v.base.isEmpty {
+        return (.zero, .zero)
+      }
       precondition(
         v.base.count == lhs.count + rhs.count, """
-          Tangent vector with invalid count; expected to equal the sum of \
-          operand counts \(lhs.count) and \(rhs.count)
+          Tangent vector with invalid count \(v.base.count); expected to \
+          equal the sum of operand counts \(lhs.count) and \(rhs.count)
           """)
       return (
         TangentVector([Element.TangentVector](v.base[0..<lhs.count])),

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -344,6 +344,10 @@ ArrayAutoDiffTests.test("Array.+") {
   }
   let v = FloatArrayTan([4, -5, 6])
   expectEqual(v, pullback(at: [1, 2, 3], of: identity)(v))
+  
+  let v1: [Float] = [1, 1]
+  let v2: [Float] = [1, 1, 1]
+  expectEqual((.zero, .zero), pullback(at: v1, v2, of: +)(.zero))
 }
 
 ArrayAutoDiffTests.test("Array.+=") {
@@ -436,6 +440,16 @@ ArrayAutoDiffTests.test("Array.DifferentiableView.base") {
   expectEqual(
     FloatArrayTan([1, 2, 3, 4]),
     backprop(FloatArrayTan([1, 2, 3, 4])))
+}
+
+ArrayAutoDiffTests.test("Array.DifferentiableView.move") {
+  var v: [Float] = [1, 2, 3]
+  v.move(by: .zero)
+  expectEqual(v, [1, 2, 3])
+
+  var z: [Float] = []
+  z.move(by: .zero)
+  expectEqual(z, [])
 }
 
 runAllTests()


### PR DESCRIPTION
Dear everyone,

This PR adds a fix and tests that exercise falsely triggered preconditions in the `Array.DifferentiableView.+` and `.move(by:)` methods in the standard library.

The fix implements a correct handling of `.zero` tangent vector, i.e. an empty `[]` array, in the back-propagation pass of the aforementioned methods. It avoids count mis-match when the de-concatenated gradient passed to `+(...)` pullback happens to be zero. I've also bundled-in a small rewording of the precondition error messages that now includes the invalid count besides the expected one.

I didn't bother fixing nor testing the forward-propagation pass `Array.DifferentiableView._jvpContatenate` since the plan is to remove these from the repository anyway. Is this assumption correct?

Resolves [SR-14297](https://bugs.swift.org/browse/SR-14297).

Cheers,

  Vojta


@rxwei or whoever happens to be the reviewer. This is my first PR, so I apologize for violating any standards upfront. I did my best to follow the [Getting started](https://github.com/apple/swift/blob/main/docs/HowToGuides/GettingStarted.md#running-tests) and [First PR](https://github.com/apple/swift/blob/main/docs/HowToGuides/FirstPullRequest.md) guides but some things may have slipped through.

@vguerra I hope you like the improved precondition messages that now contain the invalid lengths! Thanks for the suggestion ;)
