### PR TITLE
Sema: Stop checking @main if no decl synthesized.

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1419,6 +1419,7 @@ bool ModuleDecl::isBuiltinModule() const {
 }
 
 bool SourceFile::registerMainDecl(Decl *mainDecl, SourceLoc diagLoc) {
+  assert(mainDecl);
   if (mainDecl == MainDecl)
     return false;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2012,6 +2012,9 @@ void AttributeChecker::visitMainTypeAttr(MainTypeAttr *attr) {
                                  SynthesizeMainFunctionRequest{D},
                                  nullptr);
 
+  if (!func)
+    return;
+
   // Register the func as the main decl in the module. If there are multiples
   // they will be diagnosed.
   if (file->registerMainDecl(func, attr->getLocation()))

--- a/validation-test/compiler_crashers_2_fixed/rdar75547146.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar75547146.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -c -parse-as-library
+
+@main struct M1 {
+  static func main() {}
+}
+
+@main struct M2<T> {
+  static func main() {}
+}
+


### PR DESCRIPTION
When requestifying the synthesis of the main function for the type annotated @main via SynthesizeMainFunctionRequest, what were previously were bailouts from AttributeChecker::visitMainTypeAttr had to become returns of nullptr from SynthesizeMainFunctionRequest::evaluate.  Consequently, AttributeChecker::visitMainTypeAttr must check whether synthesis actually succeeded before proceeding to to register the main decl for a file.

In simple cases, this happened to work because SourceFile::registerMainDecl would return early if the decl being registered was the same as the already registered main decl and in particular if the decl being registered was nullptr and the previously registered one was nullptr as well.  When, however, there are multiple types annotated @main, if a function is successfully synthesized for one type but synthesis fails for the second, an attempt will be made to register nullptr as the main decl and will move past the check at the beginning of SourceFile::registerMainDecl, resulting in a crash.

Here, we bail from AttributeChecker::visitMainTypeAttr if function synthesis fails and add an assert to SourceFile::registerMainDecl that the provided decl is non-null.

rdar://75547146