### PR TITLE
[windows][vs2017] Mark flaky test as unsupported.

### DIFF
--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -3,6 +3,9 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
+// This test is flaky on VS2017 (unknown reasons)
+// UNSUPPORTED: MSVC_VER=15.0
+
 @main struct Main {
   static func main() async {
     let handle = Task.runDetached {


### PR DESCRIPTION
The test has been flaky for the last couple of weeks. It almost always
fails, but from time to time the Windows VS2017 CI machine passes the
test (recent example: https://ci-external.swift.org/job/oss-swift-windows-x86_64/6996/).

Mark it as unsupported (since XFAIL will create random failures when the
test pass), to avoid noise in the CI machine.

The VS2019 machine seems to be more resilent to the failure (either the different compiler, or the different speed/processors of the machine), but also fails from time to time (example that will disappear soon because it is the oldest build at the moment: https://ci-external.swift.org/job/oss-swift-windows-x86_64-vs2019/4716). I think the noise in that case is not enough to require disabling the test.

/cc @compnerd 