### PR TITLE
[Sema][SR-14096] Change conditions in which key path component mismatch fix are diagnosed

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1909,6 +1909,12 @@ public:
   /// closures being passed to non-closure parameters.
   bool diagnoseTrailingClosureMismatch() const;
 
+  /// Tailored key path as function diagnostics for argument mismatches where
+  /// argument is a keypath expression that has a root type that matches a
+  /// function parameter, but keypath value don't match the function parameter
+  /// result value.
+  bool diagnoseKeyPathAsFunctionResultMismatch() const;
+
 protected:
   /// \returns The position of the argument being diagnosed, starting at 1.
   unsigned getArgPosition() const { return Info.getArgPosition(); }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3795,10 +3795,13 @@ bool ConstraintSystem::repairFailures(
     // there is going to be a constraint to match result of the
     // member lookup to the generic parameter `V` of *KeyPath<R, V>
     // type associated with key path expression, which we need to
-    // fix-up here.
-    if (isExpr<KeyPathExpr>(anchor)) {
-      auto *fnType = lhs->getAs<FunctionType>();
-      if (fnType && fnType->getResult()->isEqual(rhs))
+    // fix-up here unless last component has already a invalid type or
+    // instance fix recorded.
+    if (auto *kpExpr = getAsExpr<KeyPathExpr>(anchor)) {
+      auto i = kpExpr->getComponents().size() - 1;
+      auto lastCompLoc = getConstraintLocator(
+          locator.withPathElement(LocatorPathElt::KeyPathComponent(i)));
+      if (hasFixFor(lastCompLoc, FixKind::AllowTypeOrInstanceMember))
         return true;
 
       auto lastComponentType = lhs->lookThroughAllOptionalTypes();

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -795,6 +795,7 @@ func test_keypath_with_method_refs() {
   }
 
   let _: KeyPath<S, Int> = \.foo // expected-error {{key path cannot refer to instance method 'foo()'}}
+  // expected-error@-1 {{key path value type '() -> Int' cannot be converted to contextual type 'Int'}}
   let _: KeyPath<S, Int> = \.bar // expected-error {{key path cannot refer to static member 'bar()'}}
   let _ = \S.Type.bar // expected-error {{key path cannot refer to static method 'bar()'}}
 
@@ -1093,4 +1094,20 @@ func rdar74711236() {
       return []
     }()
   }
+}
+
+extension String {
+  var filterOut : (Self) throws -> Bool {
+    { $0.contains("a") }
+  }
+}
+
+func test_kp_as_function_mismatch() {
+  let a : [String] = [ "asd", "bcd", "def" ]
+
+  let _ : (String) ->  Bool = \.filterOut // expected-error{{key path value type '(String) throws -> Bool' cannot be converted to contextual type 'Bool'}}
+  _ = a.filter(\.filterOut) // expected-error{{key path value type '(String) throws -> Bool' cannot be converted to contextual type 'Bool'}}
+  let _ : (String) ->  Bool = \String.filterOut // expected-error{{key path value type '(String) throws -> Bool' cannot be converted to contextual type 'Bool'}}
+  _ = a.filter(\String.filterOut) // expected-error{{key path value type '(String) throws -> Bool' cannot be converted to contextual type 'Bool'}}
+
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
We were [skipping](https://github.com/apple/swift/blob/c5a751212d3ec8c144c5022733eeb05c44958dc3/lib/Sema/CSSimplify.cpp#L3801) diagnostics for cases where the key path type was a function which result was equal the contextual key path value or function result type (key path as function). So in cases where this is the only constraint failing, that would lead type check an incorrect value type, leading to hit an assertion is `CSApply`.
Example:
```swift
extension String {
  var boolean : (Self) throws -> Bool {
    { $0.contains("a") }
  }
  var integer : (Self) throws -> Int {
    { $0.count }
  }
}
let a : [String] = [ "asd", "bcd", "def" ]

_ = a.filter(\.integer) // correctly diagnosed 
_ = a.filter(\.boolean) // diagnostic skipped since (String)-> Bool result Bool is equal contextual type expected 
}
```

So in this PR we remove this check (in fact we change the check) to make sure this is diagnosed correctly.
Also, a tailored diagnostic on argument mismatch for key path as function. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14096.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
