### PR TITLE
[libSyntax] Eliminate loop in RawSyntax constructor

### DIFF
--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -199,8 +199,8 @@ template <> struct MappingTraits<const swift::RawSyntax *> {
       StringRef nodeIdString;
       in.mapRequired("id", nodeIdString);
       unsigned nodeId = std::atoi(nodeIdString.data());
-      value = swift::RawSyntax::makeAndCalcLength(kind, layout, presence,
-                                                  input->Arena, nodeId);
+      value =
+          swift::RawSyntax::make(kind, layout, presence, input->Arena, nodeId);
     }
   }
 };

--- a/include/swift/Syntax/SyntaxCollection.h
+++ b/include/swift/Syntax/SyntaxCollection.h
@@ -60,12 +60,11 @@ class SyntaxCollection : public Syntax {
 private:
   static RC<const SyntaxData> makeData(std::initializer_list<Element> &Elements,
                                        const RC<SyntaxArena> &Arena) {
-    std::vector<const RawSyntax *> List;
-    List.reserve(Elements.size());
-    for (auto &Elt : Elements)
-      List.push_back(Elt.getRaw());
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, List,
-                                            SourcePresence::Present, Arena);
+    auto RawElements = llvm::map_iterator(
+        Elements.begin(),
+        [](const Element &Elt) -> const RawSyntax * { return Elt.getRaw(); });
+    auto Raw = RawSyntax::make(CollectionKind, RawElements, Elements.size(),
+                               SourcePresence::Present, Arena);
     return SyntaxData::makeRoot(AbsoluteRawSyntax::forRoot(Raw));
   }
 
@@ -121,9 +120,8 @@ public:
     NewLayout.reserve(OldLayout.size() + 1);
     std::copy(OldLayout.begin(), OldLayout.end(), back_inserter(NewLayout));
     NewLayout.push_back(E.getRaw());
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
-                                            getRaw()->getPresence(),
-                                            getRaw()->getArena());
+    auto Raw = RawSyntax::make(CollectionKind, NewLayout,
+                               getRaw()->getPresence(), getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
@@ -133,9 +131,8 @@ public:
   SyntaxCollection<CollectionKind, Element> removingLast() const {
     assert(!empty());
     auto NewLayout = getRaw()->getLayout().drop_back();
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
-                                            getRaw()->getPresence(),
-                                            getRaw()->getArena());
+    auto Raw = RawSyntax::make(CollectionKind, NewLayout,
+                               getRaw()->getPresence(), getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
@@ -146,9 +143,8 @@ public:
     std::vector<const RawSyntax *> NewLayout = {E.getRaw()};
     std::copy(OldLayout.begin(), OldLayout.end(),
               std::back_inserter(NewLayout));
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
-                                            getRaw()->getPresence(),
-                                            getRaw()->getArena());
+    auto Raw = RawSyntax::make(CollectionKind, NewLayout,
+                               getRaw()->getPresence(), getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
@@ -158,9 +154,8 @@ public:
   SyntaxCollection<CollectionKind, Element> removingFirst() const {
     assert(!empty());
     auto NewLayout = getRaw()->getLayout().drop_front();
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
-                                            getRaw()->getPresence(),
-                                            getRaw()->getArena());
+    auto Raw = RawSyntax::make(CollectionKind, NewLayout,
+                               getRaw()->getPresence(), getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
@@ -179,9 +174,8 @@ public:
     NewLayout.push_back(E.getRaw());
     std::copy(OldLayout.begin() + i, OldLayout.end(),
               std::back_inserter(NewLayout));
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
-                                            getRaw()->getPresence(),
-                                            getRaw()->getArena());
+    auto Raw = RawSyntax::make(CollectionKind, NewLayout,
+                               getRaw()->getPresence(), getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
@@ -192,16 +186,15 @@ public:
     auto iterator = NewLayout.begin();
     std::advance(iterator, i);
     NewLayout.erase(iterator);
-    auto Raw = RawSyntax::makeAndCalcLength(CollectionKind, NewLayout,
-                                            getRaw()->getPresence(),
-                                            getRaw()->getArena());
+    auto Raw = RawSyntax::make(CollectionKind, NewLayout,
+                               getRaw()->getPresence(), getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 
   /// Return an empty syntax collection of this type.
   SyntaxCollection<CollectionKind, Element> cleared() const {
-    auto Raw = RawSyntax::makeAndCalcLength(
-        CollectionKind, {}, getRaw()->getPresence(), getRaw()->getArena());
+    auto Raw = RawSyntax::make(CollectionKind, {}, getRaw()->getPresence(),
+                               getRaw()->getArena());
     return SyntaxCollection<CollectionKind, Element>(Data->replacingSelf(Raw));
   }
 

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -104,8 +104,7 @@ const RawSyntax *RawSyntax::append(const RawSyntax *NewLayoutElement) const {
   NewLayout.reserve(Layout.size() + 1);
   std::copy(Layout.begin(), Layout.end(), std::back_inserter(NewLayout));
   NewLayout.push_back(NewLayoutElement);
-  return RawSyntax::makeAndCalcLength(getKind(), NewLayout,
-                                      SourcePresence::Present, Arena);
+  return RawSyntax::make(getKind(), NewLayout, SourcePresence::Present, Arena);
 }
 
 const RawSyntax *
@@ -123,8 +122,7 @@ RawSyntax::replacingChild(CursorIndex Index,
   std::copy(Layout.begin() + Index + 1, Layout.end(),
             std::back_inserter(NewLayout));
 
-  return RawSyntax::makeAndCalcLength(getKind(), NewLayout, getPresence(),
-                                      Arena);
+  return RawSyntax::make(getKind(), NewLayout, getPresence(), Arena);
 }
 
 void RawSyntax::print(llvm::raw_ostream &OS, SyntaxPrintOptions Opts) const {

--- a/lib/Syntax/SyntaxBuilders.cpp.gyb
+++ b/lib/Syntax/SyntaxBuilders.cpp.gyb
@@ -45,9 +45,9 @@ ${node.name}Builder &
 ${node.name}Builder::add${child_elt}(${child_elt_type} ${child_elt}) {
   auto &raw = Layout[cursorIndex(${node.name}::Cursor::${child.name})];
   if (!raw)
-    raw = RawSyntax::makeAndCalcLength(SyntaxKind::${child_node.syntax_kind},
-                                       {${child_elt}.getRaw()},
-                                       SourcePresence::Present, Arena);
+    raw = RawSyntax::make(SyntaxKind::${child_node.syntax_kind},
+                          {${child_elt}.getRaw()}, SourcePresence::Present,
+                          Arena);
   else
     raw = raw->append(${child_elt}.getRaw());
   return *this;
@@ -64,8 +64,8 @@ ${node.name}Builder::build() {
 %     end
 %   end
 % end
-  auto raw = RawSyntax::makeAndCalcLength(SyntaxKind::${node.syntax_kind},
-    Layout, SourcePresence::Present, Arena);
+  auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, Layout,
+                             SourcePresence::Present, Arena);
   return makeRoot<${node.name}>(raw);
 }
 

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -37,13 +37,12 @@ TokenSyntax SyntaxFactory::makeToken(tok Kind, StringRef Text,
 
 UnknownSyntax
 SyntaxFactory::makeUnknownSyntax(llvm::ArrayRef<TokenSyntax> Tokens) {
-  std::vector<const RawSyntax *> Layout;
-  Layout.reserve(Tokens.size());
-  for (auto &Token : Tokens) {
-    Layout.push_back(Token.getRaw());
-  }
-  auto Raw = RawSyntax::makeAndCalcLength(SyntaxKind::Unknown, Layout,
-                                          SourcePresence::Present, Arena);
+  auto RawTokens = llvm::map_iterator(Tokens.begin(),
+    [](const TokenSyntax &Token) -> const RawSyntax * {
+      return Token.getRaw();
+    });
+  auto Raw = RawSyntax::make(SyntaxKind::Unknown, RawTokens, Tokens.size(),
+                             SourcePresence::Present, Arena);
   return makeRoot<UnknownSyntax>(Raw);
 }
 
@@ -135,15 +134,13 @@ const RawSyntax *SyntaxFactory::createRaw(
 %   end
     if (I != Elements.size())
       return nullptr;
-    return RawSyntax::makeAndCalcLength(Kind, Layout, SourcePresence::Present,
-                                        Arena);
+    return RawSyntax::make(Kind, Layout, SourcePresence::Present, Arena);
 % elif node.is_syntax_collection():
     for (auto &E : Elements) {
       if (!canServeAsCollectionMemberRaw(SyntaxKind::${node.syntax_kind}, E))
         return nullptr;
     }
-    return RawSyntax::makeAndCalcLength(Kind, Elements, SourcePresence::Present,
-                                        Arena);
+    return RawSyntax::make(Kind, Elements, SourcePresence::Present, Arena);
 % else:
     return nullptr;
 % end
@@ -178,7 +175,7 @@ Optional<Syntax> SyntaxFactory::createSyntax(SyntaxKind Kind,
 %     child_params = ', '.join(child_params)
 ${node.name}
 SyntaxFactory::make${node.syntax_kind}(${child_params}) {
-  auto Raw = RawSyntax::makeAndCalcLength(SyntaxKind::${node.syntax_kind}, {
+  auto Raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, {
 %     for child in node.children:
 %       if child.is_optional:
     ${child.name}.hasValue() ? ${child.name}->getRaw() : nullptr,
@@ -198,8 +195,8 @@ SyntaxFactory::make${node.syntax_kind}(
   for (auto &element : elements) {
     layout.push_back(element.getRaw());
   }
-  auto raw = RawSyntax::makeAndCalcLength(SyntaxKind::${node.syntax_kind},
-    layout, SourcePresence::Present, Arena);
+  auto raw = RawSyntax::make(SyntaxKind::${node.syntax_kind}, layout,
+    SourcePresence::Present, Arena);
   return makeRoot<${node.name}>(raw);
 }
 %   end
@@ -214,7 +211,7 @@ SyntaxFactory::makeBlank${node.syntax_kind}() {
     ${make_missing_child(child)},
 %       end
 %   end
-  }, /*TextLength=*/0, SourcePresence::Present, Arena);
+  }, SourcePresence::Present, Arena);
   return makeRoot<${node.name}>(raw);
 }
 % end

--- a/lib/Syntax/SyntaxNodes.cpp.gyb
+++ b/lib/Syntax/SyntaxNodes.cpp.gyb
@@ -86,7 +86,7 @@ ${node.name} ${node.name}::add${child_elt}(${child_elt_type} ${child_elt}) {
   if (raw)
     raw = raw->append(${child_elt}.getRaw());
   else
-    raw = RawSyntax::makeAndCalcLength(SyntaxKind::${child_node.syntax_kind},
+    raw = RawSyntax::make(SyntaxKind::${child_node.syntax_kind},
       {${child_elt}.getRaw()}, SourcePresence::Present, raw->getArena());
   return ${node.name}(Data->replacingChild(raw, Cursor::${child.name}));
 }


### PR DESCRIPTION
Currently, when creating a `RawSyntax` layout node, the `RawSyntax` constructor needs to iterate over all child nodes to
a) sum up their sub node count
b) add their arena as a child arena of the new node's arena

But we are already iterating over all child nodes in every place that calls these constructors. So instead of looping twice, we can perform the above operations in the loop that already exists and pass the parameters to the `RawSyntax` constructor, which spees up `RawSyntax` node creation.

To ensure the integrity of the `RawSyntax` tree, the passed in values are still validated in release builds.
