### PR TITLE
Sema: Fix effect checking bug with 'for try await'

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2598,6 +2598,10 @@ private:
       auto classification = classifier.classifyConformance(
           S->getSequenceConformance(), EffectKind::Throws);
       auto throwsKind = classification.getConditionalKind(EffectKind::Throws);
+
+      if (throwsKind != ConditionalEffectKind::None)
+        Flags.set(ContextFlags::HasAnyThrowSite);
+
       if (!CurContext.handlesThrows(throwsKind))
         CurContext.diagnoseUnhandledThrowStmt(Ctx.Diags, S);
     }
@@ -2605,6 +2609,10 @@ private:
     auto classification = classifier.classifyConformance(
         S->getSequenceConformance(), EffectKind::Async);
     auto asyncKind = classification.getConditionalKind(EffectKind::Async);
+
+    if (asyncKind != ConditionalEffectKind::None)
+      Flags.set(ContextFlags::HasAnyAsyncSite);
+
     if (!CurContext.handlesAsync(asyncKind))
       CurContext.diagnoseUnhandledAsyncSite(Ctx.Diags, S, Context::Unspecified);
 

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -55,3 +55,12 @@ func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
   // expected-error@+1{{call can throw, but it is not marked with 'try' and the error is not handled}}
   let _ = await it.next()
 }
+
+// rdar://75274975
+func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
+  do {
+    for try await item in source {
+      print(item)
+    }
+  } catch {} // no-warning
+}


### PR DESCRIPTION
Previously we diagnosed here if a thrown error was
unhandled, but we also have to set the flag, otherwise
we produce a warning saying that a 'do/catch' has
no throwing operations in its body.

Fixes rdar://problem/75274975.