### PR TITLE
Sema: Fix some holes in 'existential type unsupported' checking

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4844,7 +4844,7 @@ findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
   }
 
   // Most bound generic types are invariant.
-  if (auto *const bgt = type->getAs<BoundGenericType>()) {
+  if (auto *bgt = type->getAs<BoundGenericType>()) {
     auto info = SelfReferenceInfo();
 
     const auto &ctx = bgt->getDecl()->getASTContext();
@@ -4866,6 +4866,12 @@ findProtocolSelfReferences(const ProtocolDecl *proto, Type type,
     }
 
     return info;
+  }
+
+  // Nominal types might have a bound generic type parent.
+  if (auto *nominalTy = type->getAs<NominalType>()) {
+    return findProtocolSelfReferences(proto, nominalTy->getParent(),
+                                      SelfReferencePosition::Invariant);
   }
 
   // Opaque result types of protocol extension members contain an invariant

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3930,7 +3930,16 @@ public:
     if (auto compound = dyn_cast<CompoundIdentTypeRepr>(T)) {
       // Only visit the last component to check, because nested typealiases in
       // existentials are okay.
-      visit(compound->getComponentRange().back());
+      visit(compound->getComponents().back());
+
+      // ... but still visit generic arguments in parent components.
+      for (auto comp : compound->getComponents().drop_back()) {
+        if (auto *genericComp = dyn_cast<GenericIdentTypeRepr>(comp)) {
+          for (auto *arg : genericComp->getGenericArgs()) {
+            visit(arg);
+          }
+        }
+      }
       return false;
     }
     // Arbitrary protocol constraints are OK on opaque types.

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -142,4 +142,20 @@ struct BadSubscript {
 struct OuterGeneric<T> {
   func contextuallyGenericMethod() where T == HasAssoc {}
   // expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+
+  struct Inner {}
+}
+
+func returnsNestedType() -> OuterGeneric<HasAssoc>.Inner {}
+// expected-error@-1 {{protocol 'HasAssoc' can only be used as a generic constraint because it has Self or associated type requirements}}
+
+protocol ProtocolWithNestedTypeResult {}
+
+extension ProtocolWithNestedTypeResult {
+  func returnsNestedTypeSelf() -> OuterGeneric<Self>.Inner {}
+}
+
+func callsNestedTypeSelf(_ p: ProtocolWithNestedTypeResult) {
+  _ = p.returnsNestedTypeSelf()
+  // expected-error@-1 {{member 'returnsNestedTypeSelf' cannot be used on value of protocol type 'ProtocolWithNestedTypeResult'; use a generic constraint instead}}
 }


### PR DESCRIPTION
A generic nominal type might have a non-generic nested type.
In this case, we were not visiting the generic arguments of
the parent type.

I noticed this by inspection while working else, so there's no
radar or JIRA here.