### PR TITLE
[ConstraintSystem] Bind external closure parameter type to a concrete…

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -377,7 +377,7 @@ func rdar21078316() {
 
 // <rdar://problem/20978044> QoI: Poor diagnostic when using an incorrect tuple element in a closure
 var numbers = [1, 2, 3]
-zip(numbers, numbers).filter { $0.2 > 1 }  // expected-error {{value of tuple type '(Int, Int)' has no member '2'}}
+zip(numbers, numbers).filter { $0.2 > 1 }  // expected-error {{value of tuple type '(Array<Int>.Element, Array<Int>.Element)' has no member '2'}}
 
 
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19357292.swift
@@ -4,6 +4,5 @@
 func test(strings: [String]) {
   for string in strings {
     let _ = string.split(omittingEmptySubsequences: false) { $0 == "C" || $0 == "D" || $0 == "H" || $0 == "S"}
-    // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time}}
   }
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19836070.swift
@@ -1,7 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
 
-// expected-error@+1 {{the compiler is unable to type-check this expression in reasonable time}}
 let _: (Character) -> Bool = { c in
   ("a" <= c && c <= "z") || ("A" <= c && c <= "Z") || c == "_"
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar75476311.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar75476311.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -solver-expression-time-threshold=1 -swift-version 5
+// REQUIRES: tools-release,no_asan,objc_interop
+// REQUIRES: OS=macosx
+
+import Combine
+import Foundation
+import simd
+
+class Entry : NSObject {}
+
+class Query : NSObject {
+}
+
+class Test {
+  typealias QueryPublisher = AnyPublisher<Query, Never>
+
+  @Published var tokens: [Entry] = []
+  @Published var text: String = ""
+
+  var test: QueryPublisher {
+    $tokens
+     .combineLatest($text)
+     .debounce(for: 0.2, scheduler: RunLoop.main)
+     .removeDuplicates(by: { (first, second) -> Bool in
+       first.0 == second.0 && first.1 == second.1 // Ok (lot of overloads here) and first `==` is different from second
+     })
+     .map { _ in
+       Query()
+     }
+     .eraseToAnyPublisher()
+  }
+}

--- a/validation-test/Sema/type_checker_perf/slow/mixed_string_array_addition.swift
+++ b/validation-test/Sema/type_checker_perf/slow/mixed_string_array_addition.swift
@@ -6,7 +6,7 @@ func test(str: String, properties: [String]) {
   // expected-error@+1 {{the compiler is unable to type-check this expression in reasonable time}}
   method(str + "" + str + "") {
     properties.map { param in
-      "" + param + "" + param + ""
+      "" + param + "" + param + "" + param + ""
     } + [""]
   }
 }


### PR DESCRIPTION
… contextual type

Performance optimization.

If there is a concrete contextual type we could use, let's bind
it to the external type right away because internal type has to
be equal to that type anyway (through `BindParam` on external type
i.e. <internal> bind param <external> conv <concrete contextual>).

```swift
func test(_: ([String]) -> Void) {}

test { $0 == ["a", "b"] }
```

Without this optimization for almost all overloads of `==`
expect for one on `Equatable` and one on `Array` solver would
have to repeatedly try the same `[String]` type for `$0` and
fail, which does nothing expect hurts performance.

Resolves: rdar://19836070
Resolves: rdar://19357292
Resolves: rdar://75476311

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
