### PR TITLE
[SourceKit/CursorInfo] Add constructor to call results

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -166,7 +166,7 @@ public:
     return None;
   }
 
-  virtual void collectAllGroups(std::vector<StringRef> &Names) const {}
+  virtual void collectAllGroups(SmallVectorImpl<StringRef> &Names) const {}
 
   /// Returns an implementation-defined "discriminator" for \p D, which
   /// distinguishes \p D from other declarations in the same module with the

--- a/include/swift/IDE/ModuleInterfacePrinting.h
+++ b/include/swift/IDE/ModuleInterfacePrinting.h
@@ -42,8 +42,7 @@ enum class ModuleTraversal : unsigned {
 /// Options used to describe the traversal of a module for printing.
 using ModuleTraversalOptions = OptionSet<ModuleTraversal>;
 
-ArrayRef<StringRef> collectModuleGroups(ModuleDecl *M,
-                                        std::vector<StringRef> &Scratch);
+void collectModuleGroups(ModuleDecl *M, SmallVectorImpl<StringRef> &Into);
 
 Optional<StringRef>
 findGroupNameForUSR(ModuleDecl *M, StringRef USR);

--- a/include/swift/IDE/Refactoring.h
+++ b/include/swift/IDE/Refactoring.h
@@ -81,13 +81,14 @@ enum class RenameAvailableKind {
   Unavailable_decl_from_clang,
 };
 
-struct RenameAvailabiliyInfo {
+struct RenameAvailabilityInfo {
   RefactoringKind Kind;
   RenameAvailableKind AvailableKind;
-  RenameAvailabiliyInfo(RefactoringKind Kind, RenameAvailableKind AvailableKind) :
-    Kind(Kind), AvailableKind(AvailableKind) {}
-  RenameAvailabiliyInfo(RefactoringKind Kind) :
-    RenameAvailabiliyInfo(Kind, RenameAvailableKind::Available) {}
+  RenameAvailabilityInfo(RefactoringKind Kind,
+                         RenameAvailableKind AvailableKind)
+      : Kind(Kind), AvailableKind(AvailableKind) {}
+  RenameAvailabilityInfo(RefactoringKind Kind)
+      : RenameAvailabilityInfo(Kind, RenameAvailableKind::Available) {}
 };
 
 class FindRenameRangesConsumer {
@@ -130,17 +131,14 @@ int findLocalRenameRanges(SourceFile *SF, RangeConfig Range,
                           FindRenameRangesConsumer &RenameConsumer,
                           DiagnosticConsumer &DiagConsumer);
 
-ArrayRef<RefactoringKind>
-collectAvailableRefactorings(SourceFile *SF, RangeConfig Range,
-                             bool &RangeStartMayNeedRename,
-                             std::vector<RefactoringKind> &Scratch,
-                             llvm::ArrayRef<DiagnosticConsumer*> DiagConsumers);
+void collectAvailableRefactorings(
+    SourceFile *SF, RangeConfig Range, bool &RangeStartMayNeedRename,
+    llvm::SmallVectorImpl<RefactoringKind> &Kinds,
+    llvm::ArrayRef<DiagnosticConsumer *> DiagConsumers);
 
-ArrayRef<RefactoringKind>
-collectAvailableRefactorings(SourceFile *SF,
-                             const ResolvedCursorInfo &CursorInfo,
-                             std::vector<RefactoringKind> &Scratch,
-                             bool ExcludeRename);
+void collectAvailableRefactorings(const ResolvedCursorInfo &CursorInfo,
+                                  llvm::SmallVectorImpl<RefactoringKind> &Kinds,
+                                  bool ExcludeRename);
 
 /// Stores information about the reference that rename availability is being
 /// queried on.
@@ -150,10 +148,9 @@ struct RenameRefInfo {
   bool IsArgLabel; ///< Whether Loc is on an arg label, rather than base name.
 };
 
-ArrayRef<RenameAvailabiliyInfo>
-collectRenameAvailabilityInfo(const ValueDecl *VD,
-                              Optional<RenameRefInfo> RefInfo,
-                              std::vector<RenameAvailabiliyInfo> &Scratch);
+void collectRenameAvailabilityInfo(
+    const ValueDecl *VD, Optional<RenameRefInfo> RefInfo,
+    llvm::SmallVectorImpl<RenameAvailabilityInfo> &Infos);
 
 } // namespace ide
 } // namespace swift

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -394,7 +394,7 @@ public:
 
   Optional<BasicDeclLocs> getBasicLocsForDecl(const Decl *D) const override;
 
-  void collectAllGroups(std::vector<StringRef> &Names) const override;
+  void collectAllGroups(SmallVectorImpl<StringRef> &Names) const override;
 
   virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
 

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -202,15 +202,13 @@ static void adjustPrintOptions(PrintOptions &AdjustedOptions) {
   AdjustedOptions.VarInitializers = false;
 }
 
-ArrayRef<StringRef>
-swift::ide::collectModuleGroups(ModuleDecl *M, std::vector<StringRef> &Scratch) {
+void swift::ide::collectModuleGroups(ModuleDecl *M,
+                                     SmallVectorImpl<StringRef> &Into) {
   for (auto File : M->getFiles()) {
-    File->collectAllGroups(Scratch);
+    File->collectAllGroups(Into);
   }
-  std::sort(Scratch.begin(), Scratch.end(), [](StringRef L, StringRef R) {
-    return L.compare_lower(R) < 0;
-  });
-  return llvm::makeArrayRef(Scratch);
+  std::sort(Into.begin(), Into.end(),
+            [](StringRef L, StringRef R) { return L.compare_lower(R) < 0; });
 }
 
 /// Determine whether the given extension has a Clang node that

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1157,7 +1157,7 @@ ModuleFile::getSourceOrderForDecl(const Decl *D) const {
   return Triple.getValue().SourceOrder;
 }
 
-void ModuleFile::collectAllGroups(std::vector<StringRef> &Names) const {
+void ModuleFile::collectAllGroups(SmallVectorImpl<StringRef> &Names) const {
   if (!Core->GroupNamesMap)
     return;
   for (auto It = Core->GroupNamesMap->begin(); It != Core->GroupNamesMap->end();

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -696,7 +696,7 @@ public:
   Optional<StringRef> getGroupNameForDecl(const Decl *D) const;
   Optional<StringRef> getSourceFileNameForDecl(const Decl *D) const;
   Optional<unsigned> getSourceOrderForDecl(const Decl *D) const;
-  void collectAllGroups(std::vector<StringRef> &Names) const;
+  void collectAllGroups(SmallVectorImpl<StringRef> &Names) const;
   Optional<CommentInfo> getCommentForDecl(const Decl *D) const;
   Optional<CommentInfo> getCommentForDeclByUSR(StringRef USR) const;
   Optional<StringRef> getGroupNameByUSR(StringRef USR) const;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1264,8 +1264,8 @@ SerializedASTFile::getSourceOrderForDecl(const Decl *D) const {
   return File.getSourceOrderForDecl(D);
 }
 
-void
-SerializedASTFile::collectAllGroups(std::vector<StringRef> &Names) const {
+void SerializedASTFile::collectAllGroups(
+    SmallVectorImpl<StringRef> &Names) const {
   File.collectAllGroups(Names);
 };
 

--- a/test/SourceKit/CursorInfo/cursor_callargs.swift
+++ b/test/SourceKit/CursorInfo/cursor_callargs.swift
@@ -8,6 +8,14 @@ c1.meth(0, passFloat: 0)
 
 // RUN: %sourcekitd-test -req=cursor -pos=6:11 %s -- %s | %FileCheck -check-prefix=CHECK-CLASS %s
 // CHECK-CLASS: source.lang.swift.ref.class (2:7-2:9)
+// CHECK-CLASS: s:15cursor_callargs2C1C
+// CHECK-CLASS: SECONDARY SYMBOLS BEGIN
+// CHECK-CLASS-NEXT: source.lang.swift.ref.function.constructor {{[^|]*}}
+// CHECK-CLASS-NEXT: init(passInt:andThis:)
+// CHECK-CLASS-NEXT: s:15cursor_callargs2C1C7passInt7andThisACSi_Sftcfc
+// CHECK-CLASS-NEXT: source.lang.swift
+// CHECK-CLASS: -----
+// CHECK-CLASS-NEXT: SECONDARY SYMBOLS END
 
 // RUN: %sourcekitd-test -req=cursor -pos=6:17 %s -- %s | %FileCheck -check-prefix=CHECK-INIT %s
 // RUN: %sourcekitd-test -req=cursor -pos=6:31 %s -- %s | %FileCheck -check-prefix=CHECK-INIT %s

--- a/test/SourceKit/CursorInfo/cursor_init.swift
+++ b/test/SourceKit/CursorInfo/cursor_init.swift
@@ -1,0 +1,31 @@
+struct A {
+  init(arg: Int) {}
+  init(arg: Bool) {}
+}
+
+func test() {
+  _ = A(arg: 1)
+  _ = A(arg: true)
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=7:7 %s -- %s | %FileCheck -check-prefix=CHECK-INT %s
+// CHECK-INT: source.lang.swift.ref.struct
+// CHECK-INT: s:11cursor_init1AV
+// CHECK-INT: SECONDARY SYMBOLS BEGIN
+// CHECK-INT-NEXT: source.lang.swift.ref.function.constructor {{[^|]*}}
+// CHECK-INT-NEXT: init(arg:)
+// CHECK-INT-NEXT: s:11cursor_init1AV3argACSi_tcfc
+// CHECK-INT-NEXT: source.lang.swift
+// CHECK-INT: -----
+// CHECK-INT-NEXT: SECONDARY SYMBOLS END
+
+// RUN: %sourcekitd-test -req=cursor -pos=8:7 %s -- %s | %FileCheck -check-prefix=CHECK-BOOL %s
+// CHECK-BOOL: source.lang.swift.ref.struct
+// CHECK-BOOL: s:11cursor_init1AV
+// CHECK-BOOL: SECONDARY SYMBOLS BEGIN
+// CHECK-BOOL-NEXT: source.lang.swift.ref.function.constructor {{[^|]*}}
+// CHECK-BOOL-NEXT: init(arg:)
+// CHECK-BOOL-NEXT: s:11cursor_init1AV3argACSb_tcfc
+// CHECK-BOOL-NEXT: source.lang.swift
+// CHECK-BOOL: -----
+// CHECK-BOOL-NEXT: SECONDARY SYMBOLS END

--- a/test/SourceKit/CursorInfo/rdar_36305791.swift
+++ b/test/SourceKit/CursorInfo/rdar_36305791.swift
@@ -3,6 +3,7 @@ public class Observable<Element> {
 }
 Observable.create { }
 
+// Check that cursor info on create doesn't crash
 // RUN: %sourcekitd-test -req=cursor -cursor-action -pos=4:12 -length 10 %s -- %s | %FileCheck %s
-
-// CHECK: source.lang.swift.ref.module ()
+// CHECK: ACTIONS BEGIN
+// CHECK: ACTIONS END

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -376,20 +376,21 @@ struct RefactoringInfo {
   UIdent Kind;
   StringRef KindName;
   StringRef UnavailableReason;
+
+  RefactoringInfo(UIdent Kind, StringRef KindName, StringRef UnavailableReason)
+      : Kind(Kind), KindName(KindName), UnavailableReason(UnavailableReason) {}
 };
 
 struct ParentInfo {
   StringRef Title;
   StringRef KindName;
   StringRef USR;
+
+  ParentInfo(StringRef Title, StringRef KindName, StringRef USR)
+      : Title(Title), KindName(KindName), USR(USR) {}
 };
 
-struct CursorInfoData {
-  // If nonempty, a proper Info could not be resolved (and the rest of the Info
-  // will be empty). Clients can potentially use this to show a diagnostic
-  // message to the user in lieu of using the empty response.
-  StringRef InternalDiagnostic;
-
+struct CursorSymbolInfo {
   UIdent Kind;
   UIdent DeclarationLang;
   StringRef Name;
@@ -398,7 +399,6 @@ struct CursorInfoData {
   StringRef TypeUSR;
   StringRef ContainerTypeUSR;
   StringRef DocComment;
-  StringRef TypeInterface;
   StringRef GroupName;
   /// A key for documentation comment localization, if it exists in the doc
   /// comment for the declaration.
@@ -415,8 +415,8 @@ struct CursorInfoData {
   /// Non-empty if a generated interface editor document has previously been
   /// opened for the module the symbol came from.
   StringRef ModuleInterfaceName;
-  /// This is an (offset,length) pair.
-  /// It is set only if the declaration has a source location.
+  /// This is an (offset,length) pair. It is set only if the declaration has a
+  /// source location.
   llvm::Optional<std::pair<unsigned, unsigned>> DeclarationLoc = None;
   /// Set only if the declaration has a source location.
   StringRef Filename;
@@ -426,8 +426,6 @@ struct CursorInfoData {
   ArrayRef<StringRef> AnnotatedRelatedDeclarations;
   /// All groups of the module name under cursor.
   ArrayRef<StringRef> ModuleGroupArray;
-  /// All available actions on the code under cursor.
-  ArrayRef<RefactoringInfo> AvailableActions;
   /// Stores the Symbol Graph title, kind, and USR of the parent contexts of the
   /// symbol under the cursor.
   ArrayRef<ParentInfo> ParentContexts;
@@ -439,6 +437,16 @@ struct CursorInfoData {
   bool IsDynamic = false;
 
   llvm::Optional<unsigned> ParentNameOffset;
+};
+
+struct CursorInfoData {
+  // If nonempty, a proper Info could not be resolved (and the rest of the Info
+  // will be empty). Clients can potentially use this to show a diagnostic
+  // message to the user in lieu of using the empty response.
+  StringRef InternalDiagnostic;
+  llvm::ArrayRef<CursorSymbolInfo> Symbols;
+  /// All available actions on the code under cursor.
+  llvm::ArrayRef<RefactoringInfo> AvailableActions;
 };
 
 struct RangeInfo {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1524,7 +1524,6 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
   CI.addDiagnosticConsumer(&PrintDiags);
-  std::vector<StringRef> Groups;
   std::string Error;
   if (getASTManager()->initCompilerInvocationNoInputs(Invocation, Args,
                                                      CI.getDiags(), Error)) {
@@ -1551,7 +1550,8 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
     Receiver(RequestResult<ArrayRef<StringRef>>::fromError(Error));
     return;
   }
-  std::vector<StringRef> Scratch;
-  Receiver(RequestResult<ArrayRef<StringRef>>::fromResult(
-      collectModuleGroups(M, Scratch)));
+
+  llvm::SmallVector<StringRef, 0> Groups;
+  collectModuleGroups(M, Groups);
+  Receiver(RequestResult<ArrayRef<StringRef>>::fromResult(Groups));
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -639,70 +639,51 @@ static bool passCursorInfoForModule(ModuleEntity Mod,
                                     SwiftInterfaceGenMap &IFaceGenContexts,
                                     const CompilerInvocation &Invok,
                        std::function<void(const RequestResult<CursorInfoData> &)> Receiver) {
-  std::string Name = Mod.getName().str();
   std::string FullName = Mod.getFullName();
-  CursorInfoData Info;
-  Info.Kind = SwiftLangSupport::getUIDForModuleRef();
-  Info.Name = Name;
-  Info.ModuleName = FullName;
-  if (auto IFaceGenRef = IFaceGenContexts.find(Info.ModuleName, Invok))
-    Info.ModuleInterfaceName = IFaceGenRef->getDocumentName();
-  Info.IsSystem = Mod.isSystemModule();
-  std::vector<StringRef> Groups;
+  SmallVector<CursorSymbolInfo, 1> Symbols;
+  SmallVector<StringRef, 4> ModuleGroups;
+
+  CursorSymbolInfo &Symbol = Symbols.emplace_back();
+  Symbol.Kind = SwiftLangSupport::getUIDForModuleRef();
+  Symbol.Name = Mod.getName();
+  Symbol.ModuleName = FullName;
+  if (auto IFaceGenRef = IFaceGenContexts.find(Symbol.ModuleName, Invok))
+    Symbol.ModuleInterfaceName = IFaceGenRef->getDocumentName();
+  Symbol.IsSystem = Mod.isSystemModule();
   if (auto MD = Mod.getAsSwiftModule()) {
-    Info.ModuleGroupArray = ide::collectModuleGroups(const_cast<ModuleDecl*>(MD),
-                                                     Groups);
+    ide::collectModuleGroups(const_cast<ModuleDecl *>(MD), ModuleGroups);
+    Symbol.ModuleGroupArray = llvm::makeArrayRef(ModuleGroups);
   }
-  Receiver(RequestResult<CursorInfoData>::fromResult(Info));
+
+  CursorInfoData Data;
+  Data.Symbols = llvm::makeArrayRef(Symbols);
+  Receiver(RequestResult<CursorInfoData>::fromResult(Data));
   return false;
 }
 
 static void
-collectAvailableRenameInfo(const ValueDecl *VD,
-                           Optional<RenameRefInfo> RefInfo,
-                           std::vector<UIdent> &RefactoringIds,
-                           DelayedStringRetriever &RefactroingNameOS,
-                           DelayedStringRetriever &RefactoringReasonOS) {
-  std::vector<ide::RenameAvailabiliyInfo> Scratch;
-  for (auto Info : ide::collectRenameAvailabilityInfo(VD, RefInfo,
-                                                      Scratch)){
-    RefactoringIds.push_back(SwiftLangSupport::
-      getUIDForRefactoringKind(Info.Kind));
-    RefactroingNameOS.startPiece();
-    RefactroingNameOS << ide::getDescriptiveRefactoringKindName(Info.Kind);
-    RefactroingNameOS.endPiece();
-    RefactoringReasonOS.startPiece();
-    RefactoringReasonOS << ide::getDescriptiveRenameUnavailableReason(Info.
-      AvailableKind);
-    RefactoringReasonOS.endPiece();
+collectAvailableRenameInfo(const ValueDecl *VD, Optional<RenameRefInfo> RefInfo,
+                           SmallVectorImpl<RefactoringInfo> &Refactorings) {
+  SmallVector<RenameAvailabilityInfo, 2> Renames;
+  collectRenameAvailabilityInfo(VD, RefInfo, Renames);
+  for (auto Info : Renames) {
+    Refactorings.emplace_back(
+        SwiftLangSupport::getUIDForRefactoringKind(Info.Kind),
+        ide::getDescriptiveRefactoringKindName(Info.Kind),
+        ide::getDescriptiveRenameUnavailableReason(Info.AvailableKind));
   }
 }
 
-static void
-serializeRefactoringKinds(ArrayRef<RefactoringKind> AllKinds,
-                          std::vector<UIdent> &RefactoringIds,
-                          DelayedStringRetriever &RefactroingNameOS,
-                          DelayedStringRetriever &RefactoringReasonOS) {
-  for (auto Kind : AllKinds) {
-    RefactoringIds.push_back(SwiftLangSupport::getUIDForRefactoringKind(Kind));
-    RefactroingNameOS.startPiece();
-    RefactroingNameOS << ide::getDescriptiveRefactoringKindName(Kind);
-    RefactroingNameOS.endPiece();
-    RefactoringReasonOS.startPiece();
-    RefactoringReasonOS.endPiece();
+static void collectAvailableRefactoringsOtherThanRename(
+    ResolvedCursorInfo CursorInfo,
+    SmallVectorImpl<RefactoringInfo> &Refactorings) {
+  SmallVector<RefactoringKind, 8> Kinds;
+  collectAvailableRefactorings(CursorInfo, Kinds, /*ExcludeRename*/ true);
+  for (auto Kind : Kinds) {
+    Refactorings.emplace_back(SwiftLangSupport::getUIDForRefactoringKind(Kind),
+                              ide::getDescriptiveRefactoringKindName(Kind),
+                              StringRef());
   }
-}
-
-static void
-collectAvailableRefactoringsOtherThanRename(SourceFile *SF,
-                                            ResolvedCursorInfo CursorInfo,
-                                            std::vector<UIdent> &RefactoringIds,
-                                      DelayedStringRetriever &RefactroingNameOS,
-                                  DelayedStringRetriever &RefactoringReasonOS) {
-  std::vector<RefactoringKind> Scratch;
-  serializeRefactoringKinds(collectAvailableRefactorings(SF, CursorInfo, Scratch,
-    /*ExcludeRename*/true), RefactoringIds, RefactroingNameOS,
-    RefactoringReasonOS);
 }
 
 static Optional<unsigned>
@@ -733,351 +714,311 @@ getParamParentNameOffset(const ValueDecl *VD, SourceLoc Cursor) {
   return SM.getLocOffsetInBuffer(Loc, SM.findBufferContainingLoc(Loc));
 }
 
+struct DeclInfo {
+  const ValueDecl *VD;
+  Type ContainerType;
+  bool IsRef;
+  bool IsDynamic;
+  ArrayRef<NominalTypeDecl *> ReceiverTypes;
+
+  /// If VD is a synthesized property wrapper backing storage (_foo) or
+  /// projected value ($foo) of a property (foo), the property instead.
+  /// Otherwise, VD.
+  const ValueDecl *OriginalProperty = nullptr;
+  bool Unavailable = true;
+  Type BaseType;
+  bool InSynthesizedExtension = false;
+
+  DeclInfo(const ValueDecl *VD, Type ContainerType, bool IsRef, bool IsDynamic,
+           ArrayRef<NominalTypeDecl *> ReceiverTypes,
+           const CompilerInvocation &Invoc)
+      : VD(VD), ContainerType(ContainerType), IsRef(IsRef),
+        IsDynamic(IsDynamic), ReceiverTypes(ReceiverTypes) {
+    if (VD == nullptr)
+      return;
+
+    // The synthesized properties $foo and _foo aren't unavailable even if
+    // the original property foo is, so check them rather than the original
+    // property.
+    Unavailable = AvailableAttr::isUnavailable(VD);
+    // No point computing the rest since they won't be used anyway.
+    if (Unavailable)
+      return;
+
+    OriginalProperty = VD;
+    if (auto *VarD = dyn_cast<VarDecl>(VD)) {
+      if (auto *Wrapped = VarD->getOriginalWrappedProperty())
+        OriginalProperty = Wrapped;
+    }
+
+    BaseType = findBaseTypeForReplacingArchetype(VD, ContainerType);
+    InSynthesizedExtension = false;
+    if (BaseType) {
+      if (auto Target = BaseType->getAnyNominal()) {
+        SynthesizedExtensionAnalyzer Analyzer(
+            Target, PrintOptions::printModuleInterface(
+                        Invoc.getFrontendOptions().PrintFullConvention));
+        InSynthesizedExtension = Analyzer.isInSynthesizedExtension(VD);
+      }
+    }
+  }
+};
+
+static StringRef copyAndClearString(llvm::BumpPtrAllocator &Allocator,
+                                    SmallVectorImpl<char> &Str) {
+  auto Ref = copyString(Allocator, StringRef(Str.data(), Str.size()));
+  Str.clear();
+  return Ref;
+}
+
+template <typename T>
+static ArrayRef<T> copyAndClearArray(llvm::BumpPtrAllocator &Allocator,
+                                     SmallVectorImpl<T> &Array) {
+  auto Ref = copyArray(Allocator, llvm::makeArrayRef(Array));
+  Array.clear();
+  return Ref;
+}
+
+static llvm::Error
+fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
+               ModuleDecl *MainModule, SourceLoc CursorLoc, bool AddSymbolGraph,
+               SwiftLangSupport &Lang, const CompilerInvocation &Invoc,
+               ArrayRef<ImmutableTextSnapshotRef> PreviousSnaps,
+               llvm::BumpPtrAllocator &Allocator) {
+  SmallString<256> Buffer;
+  SmallVector<StringRef, 4> Strings;
+  llvm::raw_svector_ostream OS(Buffer);
+
+  Symbol.DeclarationLang = SwiftLangSupport::getUIDForDeclLanguage(DInfo.VD);
+  Symbol.Kind = SwiftLangSupport::getUIDForDecl(DInfo.VD, DInfo.IsRef);
+
+  SwiftLangSupport::printDisplayName(DInfo.VD, OS);
+  Symbol.Name = copyAndClearString(Allocator, Buffer);
+
+  SwiftLangSupport::printUSR(DInfo.OriginalProperty, OS);
+  if (DInfo.InSynthesizedExtension) {
+    OS << LangSupport::SynthesizedUSRSeparator;
+    SwiftLangSupport::printUSR(DInfo.BaseType->getAnyNominal(), OS);
+  }
+  Symbol.USR = copyAndClearString(Allocator, Buffer);
+
+  {
+    PrintOptions Options;
+    Options.PrintTypeAliasUnderlyingType = true;
+    DInfo.VD->getInterfaceType().print(OS, Options);
+  }
+  Symbol.TypeName = copyAndClearString(Allocator, Buffer);
+
+  SwiftLangSupport::printDeclTypeUSR(DInfo.VD, OS);
+  Symbol.TypeUSR = copyAndClearString(Allocator, Buffer);
+
+  if (DInfo.ContainerType && !DInfo.ContainerType->hasArchetype()) {
+    SwiftLangSupport::printTypeUSR(DInfo.ContainerType, OS);
+  }
+  Symbol.ContainerTypeUSR = copyAndClearString(Allocator, Buffer);
+
+  ide::getDocumentationCommentAsXML(DInfo.OriginalProperty, OS);
+  Symbol.DocComment = copyAndClearString(Allocator, Buffer);
+
+  {
+    auto *Group = DInfo.InSynthesizedExtension ? DInfo.BaseType->getAnyNominal()
+                                               : DInfo.VD;
+    if (auto Name = Group->getGroupName())
+      Symbol.GroupName = Name.getValue();
+  }
+
+  ide::getLocalizationKey(DInfo.VD, OS);
+  Symbol.LocalizationKey = copyAndClearString(Allocator, Buffer);
+
+  printAnnotatedDeclaration(DInfo.VD, DInfo.BaseType, OS);
+  Symbol.AnnotatedDeclaration = copyAndClearString(Allocator, Buffer);
+
+  SwiftLangSupport::printFullyAnnotatedDeclaration(DInfo.VD, DInfo.BaseType,
+                                                   OS);
+  Symbol.FullyAnnotatedDeclaration = copyAndClearString(Allocator, Buffer);
+
+  if (AddSymbolGraph) {
+    SmallVector<symbolgraphgen::PathComponent, 4> PathComponents;
+    symbolgraphgen::SymbolGraphOptions Options{
+        "",
+        Invoc.getLangOptions().Target,
+        /*PrettyPrint=*/false,
+        AccessLevel::Private,
+        /*EmitSynthesizedMembers*/ false,
+    };
+
+    symbolgraphgen::printSymbolGraphForDecl(DInfo.VD, DInfo.BaseType,
+                                            DInfo.InSynthesizedExtension,
+                                            Options, OS, PathComponents);
+    Symbol.SymbolGraph = copyAndClearString(Allocator, Buffer);
+
+    SmallVector<ParentInfo, 4> Parents;
+    for (auto &Component : PathComponents) {
+      SwiftLangSupport::printUSR(Component.VD, OS);
+      Parents.emplace_back(copyString(Allocator, Component.Title),
+                           Component.Kind,
+                           copyAndClearString(Allocator, Buffer));
+    };
+    Symbol.ParentContexts = copyArray(Allocator, llvm::makeArrayRef(Parents));
+  }
+
+  {
+    ASTContext &Ctx = DInfo.VD->getASTContext();
+    ClangImporter *Importer =
+        static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
+    auto ClangNode = DInfo.VD->getClangNode();
+    if (ClangNode) {
+      auto ClangMod = Importer->getClangOwningModule(ClangNode);
+      if (ClangMod) {
+        Symbol.ModuleName =
+            copyString(Allocator, ClangMod->getFullModuleName());
+      }
+    } else if (DInfo.VD->getModuleContext() != MainModule) {
+      ModuleDecl *MD = DInfo.VD->getModuleContext();
+      // If the decl is from a cross-import overlay module, report the
+      // overlay's declaring module as the owning module.
+      if (ModuleDecl *Declaring = MD->getDeclaringModuleIfCrossImportOverlay())
+        MD = Declaring;
+      Symbol.ModuleName = MD->getNameStr();
+    }
+  }
+
+  if (auto IFaceGenRef =
+          Lang.getIFaceGenContexts().find(Symbol.ModuleName, Invoc))
+    Symbol.ModuleInterfaceName = IFaceGenRef->getDocumentName();
+
+  getLocationInfo(DInfo.OriginalProperty, Symbol.DeclarationLoc,
+                  Symbol.Filename);
+  if (Symbol.DeclarationLoc.hasValue()) {
+    Symbol.DeclarationLoc = tryRemappingLocToLatestSnapshot(
+        Lang, *Symbol.DeclarationLoc, Symbol.Filename, PreviousSnaps);
+    if (!Symbol.DeclarationLoc.hasValue()) {
+      return llvm::createStringError(
+          llvm::inconvertibleErrorCode(),
+          "Failed to remap declaration to latest snapshot.");
+    }
+  }
+
+  ide::walkOverriddenDecls(
+      DInfo.VD,
+      [&](llvm::PointerUnion<const ValueDecl *, const clang::NamedDecl *> D) {
+        // Could have junk in from previous failing USR print
+        Buffer.clear();
+        if (auto VD = D.dyn_cast<const ValueDecl *>()) {
+          if (SwiftLangSupport::printUSR(VD, OS))
+            return;
+        } else {
+          if (clang::index::generateUSRForDecl(
+                  D.get<const clang::NamedDecl *>(), Buffer))
+            return;
+        }
+        Strings.push_back(copyAndClearString(Allocator, Buffer));
+      });
+  Symbol.OverrideUSRs = copyAndClearArray(Allocator, Strings);
+
+  walkRelatedDecls(DInfo.VD, [&](const ValueDecl *RelatedDecl,
+                                 bool UseOriginalBase, bool DuplicateName) {
+    OS << "<RelatedName usr=\"";
+    SwiftLangSupport::printUSR(RelatedDecl, OS);
+    OS << "\">";
+    if (isa<AbstractFunctionDecl>(RelatedDecl) && DuplicateName) {
+      // Related decls are generally overloads, so print parameter types to
+      // differentiate them.
+      PrintOptions PO;
+      PO.SkipAttributes = true;
+      PO.SkipIntroducerKeywords = true;
+      PO.ArgAndParamPrinting =
+          PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
+      XMLEscapingPrinter Printer(OS);
+      if (UseOriginalBase && DInfo.BaseType) {
+        PO.setBaseType(DInfo.BaseType);
+        PO.PrintAsMember = true;
+      }
+      RelatedDecl->print(Printer, PO);
+    } else {
+      SmallString<128> RelatedBuffer;
+      llvm::raw_svector_ostream RelatedOS(RelatedBuffer);
+      SwiftLangSupport::printDisplayName(RelatedDecl, RelatedOS);
+      swift::markup::appendWithXMLEscaping(OS, RelatedBuffer);
+    }
+    OS << "</RelatedName>";
+
+    Strings.push_back(copyAndClearString(Allocator, Buffer));
+  });
+  Symbol.AnnotatedRelatedDeclarations = copyAndClearArray(Allocator, Strings);
+
+  for (auto *ReceiverTy : DInfo.ReceiverTypes) {
+    if (!SwiftLangSupport::printUSR(ReceiverTy, OS))
+      Strings.push_back(copyAndClearString(Allocator, Buffer));
+  }
+  Symbol.ReceiverUSRs = copyAndClearArray(Allocator, Strings);
+
+  Symbol.IsSystem = DInfo.VD->getModuleContext()->isSystemModule();
+  Symbol.IsDynamic = DInfo.IsDynamic;
+  Symbol.ParentNameOffset = getParamParentNameOffset(DInfo.VD, CursorLoc);
+
+  return llvm::Error::success();
+}
+
 /// Returns true on success, false on error (and sets `Diagnostic` accordingly).
-static bool passCursorInfoForDecl(SourceFile* SF,
-                                  const ValueDecl *VD,
-                                  ModuleDecl *MainModule,
-                                  const Type ContainerTy,
-                                  bool IsRef,
-                                  bool RetrieveRefactoring,
-                                  bool SymbolGraph,
-                                  ResolvedCursorInfo TheTok,
-                                  Optional<unsigned> OrigBufferID,
-                                  SourceLoc CursorLoc,
-                  ArrayRef<RefactoringInfo> KownRefactoringInfoFromRange,
-                                  SwiftLangSupport &Lang,
-                                  const CompilerInvocation &Invoc,
-                                  std::string &Diagnostic,
-                      ArrayRef<ImmutableTextSnapshotRef> PreviousASTSnaps,
-                  std::function<void(const RequestResult<CursorInfoData> &)> Receiver) {
-  if (AvailableAttr::isUnavailable(VD)) {
+static bool passCursorInfoForDecl(
+    const ResolvedCursorInfo &Info, ModuleDecl *MainModule,
+    bool AddRefactorings, bool AddSymbolGraph,
+    ArrayRef<RefactoringInfo> KnownRefactoringInfo, SwiftLangSupport &Lang,
+    const CompilerInvocation &Invoc, std::string &Diagnostic,
+    ArrayRef<ImmutableTextSnapshotRef> PreviousSnaps,
+    std::function<void(const RequestResult<CursorInfoData> &)> Receiver) {
+  DeclInfo OrigInfo(Info.ValueD, Info.ContainerType, Info.IsRef, Info.IsDynamic,
+                    Info.ReceiverTypes, Invoc);
+  DeclInfo CtorTypeInfo(Info.CtorTyRef, Type(), true, false,
+                        ArrayRef<NominalTypeDecl *>(), Invoc);
+  DeclInfo &MainInfo = CtorTypeInfo.VD ? CtorTypeInfo : OrigInfo;
+  if (MainInfo.Unavailable) {
     Diagnostic = "Unavailable in the current compilation context.";
     return false;
   }
 
-  SmallString<64> SS;
-  auto BaseType = findBaseTypeForReplacingArchetype(VD, ContainerTy);
-  bool InSynthesizedExtension = false;
-  if (BaseType) {
-    if (auto Target = BaseType->getAnyNominal()) {
-      SynthesizedExtensionAnalyzer Analyzer(
-          Target, PrintOptions::printModuleInterface(
-                      Invoc.getFrontendOptions().PrintFullConvention));
-      InSynthesizedExtension = Analyzer.isInSynthesizedExtension(VD);
+  llvm::BumpPtrAllocator Allocator;
+
+  SmallVector<CursorSymbolInfo, 2> Symbols;
+  CursorSymbolInfo &MainSymbol = Symbols.emplace_back();
+  // The primary result for constructor calls, eg. `MyType()` should be
+  // the type itself, rather than the constructor. The constructor will be
+  // added as a secondary result.
+  if (auto Err = fillSymbolInfo(MainSymbol, MainInfo, MainModule, Info.Loc,
+                                AddSymbolGraph, Lang, Invoc, PreviousSnaps,
+                                Allocator)) {
+    llvm::handleAllErrors(std::move(Err), [&](const llvm::StringError &E) {
+      Diagnostic = E.message();
+    });
+    return false;
+  }
+  if (MainInfo.VD != OrigInfo.VD && !OrigInfo.Unavailable) {
+    CursorSymbolInfo &CtorSymbol = Symbols.emplace_back();
+    if (auto Err = fillSymbolInfo(CtorSymbol, OrigInfo, MainModule, Info.Loc,
+                                  AddSymbolGraph, Lang, Invoc, PreviousSnaps,
+                                  Allocator)) {
+      // Ignore but make sure to remove the partially-filled symbol
+      llvm::handleAllErrors(std::move(Err), [&](const llvm::StringError &E) {});
+      Symbols.pop_back();
     }
   }
 
-  unsigned NameBegin = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    SwiftLangSupport::printDisplayName(VD, OS);
-  }
-  unsigned NameEnd = SS.size();
-
-  // If VD is the syntehsized property wrapper backing storage (_foo) or
-  // projected value ($foo) of a property (foo), use that property's USR instead
-  // so that a rename refactoring renames all three (foo, $foo, and _foo).
-  const ValueDecl* OriginalProperty = VD;
-  if (auto *VarD = dyn_cast<VarDecl>(VD)) {
-    if (auto *Wrapped = VarD->getOriginalWrappedProperty())
-        OriginalProperty = Wrapped;
-  }
-
-  unsigned USRBegin = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    SwiftLangSupport::printUSR(OriginalProperty, OS);
-    if (InSynthesizedExtension) {
-        OS << LangSupport::SynthesizedUSRSeparator;
-        SwiftLangSupport::printUSR(BaseType->getAnyNominal(), OS);
-    }
-  }
-  unsigned USREnd = SS.size();
-
-  unsigned TypenameBegin = SS.size();
-  llvm::raw_svector_ostream OS(SS);
-  PrintOptions Options;
-  Options.PrintTypeAliasUnderlyingType = true;
-  VD->getInterfaceType().print(OS, Options);
-
-  unsigned TypenameEnd = SS.size();
-
-  unsigned MangledTypeStart = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    SwiftLangSupport::printDeclTypeUSR(VD, OS);
-  }
-  unsigned MangledTypeEnd = SS.size();
-
-  unsigned MangledContainerTypeStart = SS.size();
-  if (ContainerTy && !ContainerTy->hasArchetype()) {
-    llvm::raw_svector_ostream OS(SS);
-    SwiftLangSupport::printTypeUSR(ContainerTy, OS);
-  }
-  unsigned MangledContainerTypeEnd = SS.size();
-
-  // If VD is the syntehsized property wrapper backing storage (_foo) or
-  // projected value ($foo) of a property (foo), use that property's
-  // documentation instead.
-
-  unsigned DocCommentBegin = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    ide::getDocumentationCommentAsXML(OriginalProperty, OS);
-  }
-  unsigned DocCommentEnd = SS.size();
-
-  unsigned DeclBegin = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    printAnnotatedDeclaration(VD, BaseType, OS);
-  }
-  unsigned DeclEnd = SS.size();
-
-  SmallVector<symbolgraphgen::PathComponent, 4> PathComponents;
-  unsigned SymbolGraphBegin = SS.size();
-  if (SymbolGraph) {
-    symbolgraphgen::SymbolGraphOptions Options {
-      "",
-      Invoc.getLangOptions().Target,
-      /*PrettyPrint=*/false,
-      AccessLevel::Private,
-      /*EmitSynthesizedMembers*/false,
-    };
-    llvm::raw_svector_ostream OS(SS);
-    symbolgraphgen::printSymbolGraphForDecl(VD, BaseType,
-                                            InSynthesizedExtension, Options, OS,
-                                            PathComponents);
-  }
-  unsigned SymbolGraphEnd = SS.size();
-
-  DelayedStringRetriever ParentUSRsOS(SS);
-  for (auto &Component: PathComponents) {
-    ParentUSRsOS.startPiece();
-    if (SwiftLangSupport::printUSR(Component.VD, OS))
-      ParentUSRsOS.startPiece(); // ignore any output if invalid
-    ParentUSRsOS.endPiece();
-  };
-
-  unsigned FullDeclBegin = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    SwiftLangSupport::printFullyAnnotatedDeclaration(VD, BaseType, OS);
-  }
-  unsigned FullDeclEnd = SS.size();
-
-  unsigned GroupBegin = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    auto *GroupVD = InSynthesizedExtension ? BaseType->getAnyNominal() : VD;
-    if (auto OP = GroupVD->getGroupName())
-      OS << OP.getValue();
-  }
-  unsigned GroupEnd = SS.size();
-
-  unsigned LocalizationBegin = SS.size();
-  {
-    llvm::raw_svector_ostream OS(SS);
-    ide::getLocalizationKey(VD, OS);
-  }
-  unsigned LocalizationEnd = SS.size();
-
-  std::vector<UIdent> RefactoringIds;
-  DelayedStringRetriever RefactoringNameOS(SS);
-  DelayedStringRetriever RefactoringReasonOS(SS);
-
-  if (RetrieveRefactoring) {
+  SmallVector<RefactoringInfo, 8> Refactorings;
+  if (AddRefactorings) {
     Optional<RenameRefInfo> RefInfo;
-    if (TheTok.IsRef)
-      RefInfo = {TheTok.SF, TheTok.Loc, TheTok.IsKeywordArgument};
-    collectAvailableRenameInfo(VD, RefInfo,
-                               RefactoringIds, RefactoringNameOS,
-                               RefactoringReasonOS);
-    collectAvailableRefactoringsOtherThanRename(SF, TheTok, RefactoringIds,
-      RefactoringNameOS, RefactoringReasonOS);
+    if (Info.IsRef)
+      RefInfo = {Info.SF, Info.Loc, Info.IsKeywordArgument};
+    collectAvailableRenameInfo(MainInfo.VD, RefInfo, Refactorings);
+    collectAvailableRefactoringsOtherThanRename(Info, Refactorings);
   }
+  Refactorings.insert(Refactorings.end(), KnownRefactoringInfo.begin(),
+                      KnownRefactoringInfo.end());
 
-  DelayedStringRetriever OverUSRsStream(SS);
-
-  ide::walkOverriddenDecls(VD,
-    [&](llvm::PointerUnion<const ValueDecl*, const clang::NamedDecl*> D) {
-      OverUSRsStream.startPiece();
-      if (auto VD = D.dyn_cast<const ValueDecl*>()) {
-        if (SwiftLangSupport::printUSR(VD, OverUSRsStream))
-          return;
-      } else {
-        llvm::SmallString<128> Buf;
-        if (clang::index::generateUSRForDecl(
-            D.get<const clang::NamedDecl*>(), Buf))
-          return;
-        OverUSRsStream << Buf.str();
-      }
-      OverUSRsStream.endPiece();
-  });
-
-  DelayedStringRetriever RelDeclsStream(SS);
-  walkRelatedDecls(VD, [&](const ValueDecl *RelatedDecl, bool UseOriginalBase, bool DuplicateName) {
-    RelDeclsStream.startPiece();
-    {
-      RelDeclsStream<<"<RelatedName usr=\"";
-      SwiftLangSupport::printUSR(RelatedDecl, RelDeclsStream);
-      RelDeclsStream<<"\">";
-      if (isa<AbstractFunctionDecl>(RelatedDecl) && DuplicateName) {
-        // Related decls are generally overloads, so print parameter types to
-        // differentiate them.
-        PrintOptions PO;
-        PO.SkipAttributes = true;
-        PO.SkipIntroducerKeywords = true;
-        PO.ArgAndParamPrinting = PrintOptions::ArgAndParamPrintingMode::ArgumentOnly;
-        XMLEscapingPrinter Printer(RelDeclsStream);
-        if (UseOriginalBase && BaseType) {
-          PO.setBaseType(BaseType);
-          PO.PrintAsMember = true;
-        }
-        RelatedDecl->print(Printer, PO);
-      } else {
-        llvm::SmallString<128> Buf;
-        {
-          llvm::raw_svector_ostream OSBuf(Buf);
-          SwiftLangSupport::printDisplayName(RelatedDecl, OSBuf);
-        }
-        swift::markup::appendWithXMLEscaping(RelDeclsStream, Buf);
-      }
-      RelDeclsStream<<"</RelatedName>";
-    }
-    RelDeclsStream.endPiece();
-  });
-
-  DelayedStringRetriever ReceiverUSRsStream(SS);
-  for (auto *ReceiverTy : TheTok.ReceiverTypes) {
-    ReceiverUSRsStream.startPiece();
-    if (SwiftLangSupport::printUSR(ReceiverTy, OS))
-      ReceiverUSRsStream.startPiece();
-    ReceiverUSRsStream.endPiece();
-  }
-
-  ASTContext &Ctx = VD->getASTContext();
-
-  ClangImporter *Importer = static_cast<ClangImporter*>(
-      Ctx.getClangModuleLoader());
-  std::string ModuleName;
-  auto ClangNode = VD->getClangNode();
-  if (ClangNode) {
-    auto ClangMod = Importer->getClangOwningModule(ClangNode);
-    if (ClangMod)
-      ModuleName = ClangMod->getFullModuleName();
-  } else if (VD->getModuleContext() != MainModule) {
-    ModuleDecl *MD = VD->getModuleContext();
-    // If the decl is from a cross-import overlay module, report the overlay's
-    // declaring module as the owning module.
-    if (ModuleDecl *Declaring = MD->getDeclaringModuleIfCrossImportOverlay())
-      MD = Declaring;
-    ModuleName = MD->getNameStr().str();
-  }
-  StringRef ModuleInterfaceName;
-  if (auto IFaceGenRef = Lang.getIFaceGenContexts().find(ModuleName, Invoc))
-    ModuleInterfaceName = IFaceGenRef->getDocumentName();
-
-  UIdent DeclLang = SwiftLangSupport::getUIDForDeclLanguage(VD);
-  UIdent Kind = SwiftLangSupport::getUIDForDecl(VD, IsRef);
-  StringRef Name = StringRef(SS.begin()+NameBegin, NameEnd-NameBegin);
-  StringRef USR = StringRef(SS.begin()+USRBegin, USREnd-USRBegin);
-  StringRef TypeName = StringRef(SS.begin()+TypenameBegin,
-                                 TypenameEnd-TypenameBegin);
-  StringRef TypeUsr = StringRef(SS.begin()+MangledTypeStart,
-                                MangledTypeEnd - MangledTypeStart);
-
-  StringRef ContainerTypeUsr = StringRef(SS.begin()+MangledContainerTypeStart,
-                            MangledContainerTypeEnd - MangledContainerTypeStart);
-  StringRef DocComment = StringRef(SS.begin()+DocCommentBegin,
-                                   DocCommentEnd-DocCommentBegin);
-  StringRef AnnotatedDecl = StringRef(SS.begin()+DeclBegin,
-                                      DeclEnd-DeclBegin);
-  StringRef FullyAnnotatedDecl =
-      StringRef(SS.begin() + FullDeclBegin, FullDeclEnd - FullDeclBegin);
-  StringRef GroupName = StringRef(SS.begin() + GroupBegin, GroupEnd - GroupBegin);
-  StringRef LocalizationKey = StringRef(SS.begin() + LocalizationBegin,
-                                        LocalizationEnd - LocalizationBegin);
-  StringRef SymbolGraphJSON = StringRef(SS.begin()+SymbolGraphBegin,
-                                        SymbolGraphEnd-SymbolGraphBegin);
-
-  SmallVector<ParentInfo, 4> Parents;
-  auto ParentIt = PathComponents.begin();
-  ParentUSRsOS.retrieve([&](StringRef ParentUSR) {
-    assert(ParentIt != PathComponents.end());
-    if (!ParentUSR.empty())
-      Parents.push_back({ParentIt->Title, ParentIt->Kind, ParentUSR});
-    ++ParentIt;
-  });
-
-  // If VD is the syntehsized property wrapper backing storage (_foo) or
-  // projected value ($foo) of a property (foo), base the location on that
-  // property instead.
-  llvm::Optional<std::pair<unsigned, unsigned>> DeclarationLoc;
-  StringRef Filename;
-  getLocationInfo(OriginalProperty, DeclarationLoc, Filename);
-  if (DeclarationLoc.hasValue()) {
-    DeclarationLoc = tryRemappingLocToLatestSnapshot(Lang,
-                                                     *DeclarationLoc,
-                                                     Filename,
-                                                     PreviousASTSnaps);
-    if (!DeclarationLoc.hasValue()) {
-      Diagnostic = "Failed to remap declaration to latest snapshot.";
-      return false;
-    }
-  }
-
-  SmallVector<StringRef, 4> OverUSRs;
-  OverUSRsStream.retrieve([&](StringRef S) { OverUSRs.push_back(S); });
-
-  SmallVector<StringRef, 4> AnnotatedRelatedDecls;
-  RelDeclsStream.retrieve([&](StringRef S) { AnnotatedRelatedDecls.push_back(S); });
-
-  SmallVector<StringRef, 4> ReceiverUSRs;
-  ReceiverUSRsStream.retrieve([&](StringRef S) { ReceiverUSRs.push_back(S); });
-
-  SmallVector<RefactoringInfo, 4> RefactoringInfoBuffer;
-  for (unsigned I = 0, N = RefactoringIds.size(); I < N; I ++) {
-    RefactoringInfoBuffer.push_back({RefactoringIds[I], RefactoringNameOS[I],
-                                     RefactoringReasonOS[I]});
-  }
-
-  // Add available refactoring inheritted from range.
-  RefactoringInfoBuffer.insert(RefactoringInfoBuffer.end(),
-    KownRefactoringInfoFromRange.begin(),
-    KownRefactoringInfoFromRange.end());
-
-  bool IsSystem = VD->getModuleContext()->isSystemModule();
-  std::string TypeInterface;
-
-  CursorInfoData Info;
-  Info.DeclarationLang = DeclLang;
-  Info.Kind = Kind;
-  Info.Name = Name;
-  Info.USR = USR;
-  Info.TypeName = TypeName;
-  Info.TypeUSR = TypeUsr;
-  Info.ContainerTypeUSR = ContainerTypeUsr;
-  Info.DocComment = DocComment;
-  Info.AnnotatedDeclaration = AnnotatedDecl;
-  Info.FullyAnnotatedDeclaration = FullyAnnotatedDecl;
-  Info.ModuleName = ModuleName;
-  Info.ModuleInterfaceName = ModuleInterfaceName;
-  Info.DeclarationLoc = DeclarationLoc;
-  Info.Filename = Filename;
-  Info.OverrideUSRs = OverUSRs;
-  Info.AnnotatedRelatedDeclarations = AnnotatedRelatedDecls;
-  Info.GroupName = GroupName;
-  Info.LocalizationKey = LocalizationKey;
-  Info.IsSystem = IsSystem;
-  Info.TypeInterface = StringRef();
-  Info.AvailableActions = llvm::makeArrayRef(RefactoringInfoBuffer);
-  Info.ParentNameOffset = getParamParentNameOffset(VD, CursorLoc);
-  Info.SymbolGraph = SymbolGraphJSON;
-  Info.ParentContexts = llvm::makeArrayRef(Parents);
-  Info.IsDynamic = TheTok.IsDynamic;
-  Info.ReceiverUSRs = ReceiverUSRs;
-  Receiver(RequestResult<CursorInfoData>::fromResult(Info));
+  CursorInfoData Data;
+  Data.Symbols = llvm::makeArrayRef(Symbols);
+  Data.AvailableActions = llvm::makeArrayRef(Refactorings);
+  Receiver(RequestResult<CursorInfoData>::fromResult(Data));
   return true;
 }
 
@@ -1365,10 +1306,10 @@ static void resolveCursor(
           Length = 0;
       }
 
-      // Retrive relevant actions on the code under selection.
-      std::vector<RefactoringInfo> AvailableRefactorings;
+      // Retrieve relevant actions on the code under selection.
+      llvm::SmallVector<RefactoringInfo, 8> Actions;
       if (Actionables && Length) {
-        std::vector<RefactoringKind> Scratch;
+        SmallVector<RefactoringKind, 8> Kinds;
         RangeConfig Range;
         Range.BufferId = BufferID;
         auto Pair = SM.getPresumedLineAndColumnForLoc(Loc);
@@ -1376,25 +1317,19 @@ static void resolveCursor(
         Range.Column = Pair.second;
         Range.Length = Length;
         bool RangeStartMayNeedRename = false;
-        for (RefactoringKind Kind :
-             collectAvailableRefactorings(&AstUnit->getPrimarySourceFile(),
-                                Range, RangeStartMayNeedRename, Scratch, {})) {
-          AvailableRefactorings.push_back({
-            SwiftLangSupport::getUIDForRefactoringKind(Kind),
-            getDescriptiveRefactoringKindName(Kind),
-            /*UnavailableReason*/ StringRef()
-          });
+        collectAvailableRefactorings(&AstUnit->getPrimarySourceFile(), Range,
+                                     RangeStartMayNeedRename, Kinds, {});
+        for (RefactoringKind Kind : Kinds) {
+          Actions.emplace_back(SwiftLangSupport::getUIDForRefactoringKind(Kind),
+                               getDescriptiveRefactoringKindName(Kind),
+                               /*UnavailableReason*/ StringRef());
         }
         if (!RangeStartMayNeedRename) {
-          CursorInfoData Info;
-
-          // FIXME: This Kind does not mean anything.
-          Info.Kind = SwiftLangSupport::getUIDForModuleRef();
-          Info.AvailableActions = llvm::makeArrayRef(AvailableRefactorings);
-
           // If Length is given, then the cursor-info request should only about
           // collecting available refactorings for the range.
-          Receiver(RequestResult<CursorInfoData>::fromResult(Info));
+          CursorInfoData Data;
+          Data.AvailableActions = llvm::makeArrayRef(Actions);
+          Receiver(RequestResult<CursorInfoData>::fromResult(Data));
           return;
         }
         // If the range start may need rename, we fall back to a regular cursor
@@ -1422,27 +1357,10 @@ static void resolveCursor(
                                 CompInvok, Receiver);
         return;
       case CursorInfoKind::ValueRef: {
-        ValueDecl *VD = CursorInfo.ValueD;
-        Type ContainerType = CursorInfo.ContainerType;
-        if (CursorInfo.CtorTyRef) {
-          // Treat constructor calls, e.g. MyType(), as the type itself,
-          // rather than its constructor.
-          VD = CursorInfo.CtorTyRef;
-          ContainerType = Type();
-        }
         std::string Diagnostic;
-        bool Success = passCursorInfoForDecl(&AstUnit->getPrimarySourceFile(),
-                                             VD, MainModule,
-                                             ContainerType,
-                                             CursorInfo.IsRef,
-                                             Actionables,
-                                             SymbolGraph,
-                                             CursorInfo,
-                                             BufferID, Loc,
-                                             AvailableRefactorings,
-                                             Lang, CompInvok, Diagnostic,
-                                             getPreviousASTSnaps(),
-                                             Receiver);
+        bool Success = passCursorInfoForDecl(
+            CursorInfo, MainModule, Actionables, SymbolGraph, Actions, Lang,
+            CompInvok, Diagnostic, getPreviousASTSnaps(), Receiver);
         if (!Success) {
           if (!getPreviousASTSnaps().empty()) {
             // Attempt again using the up-to-date AST.
@@ -1461,24 +1379,11 @@ static void resolveCursor(
       case CursorInfoKind::ExprStart:
       case CursorInfoKind::StmtStart: {
         if (Actionables) {
-          SmallString<64> SS;
-          std::vector<UIdent> RefactoringIds;
-          DelayedStringRetriever NameRetriever(SS);
-          DelayedStringRetriever ReasonRetriever(SS);
-          collectAvailableRefactoringsOtherThanRename(
-            &AstUnit->getPrimarySourceFile(), CursorInfo, RefactoringIds,
-            NameRetriever, ReasonRetriever);
-          if (auto Size = RefactoringIds.size()) {
-            CursorInfoData Info;
-
-            // FIXME: This Kind does not mean anything.
-            Info.Kind = SwiftLangSupport::getUIDForModuleRef();
-            for (unsigned I = 0; I < Size; I ++) {
-              AvailableRefactorings.push_back({RefactoringIds[I],
-                NameRetriever[I], ReasonRetriever[I]});
-            }
-            Info.AvailableActions = llvm::makeArrayRef(AvailableRefactorings);
-            Receiver(RequestResult<CursorInfoData>::fromResult(Info));
+          collectAvailableRefactoringsOtherThanRename(CursorInfo, Actions);
+          if (!Actions.empty()) {
+            CursorInfoData Data;
+            Data.AvailableActions = llvm::makeArrayRef(Actions);
+            Receiver(RequestResult<CursorInfoData>::fromResult(Data));
             return;
           }
         }
@@ -1733,11 +1638,11 @@ void SwiftLangSupport::getCursorInfo(
         } else {
           std::string Diagnostic;  // Unused.
           ModuleDecl *MainModule = IFaceGenRef->getModuleDecl();
-          passCursorInfoForDecl(
-              /*SourceFile*/nullptr, Entity.Dcl, MainModule, Type(),
-              Entity.IsRef, Actionables, SymbolGraph, ResolvedCursorInfo(),
-              /*OrigBufferID=*/None, SourceLoc(), {}, *this, Invok, Diagnostic,
-              {}, Receiver);
+          ResolvedCursorInfo Info;
+          Info.ValueD = const_cast<ValueDecl *>(Entity.Dcl);
+          Info.IsRef = Entity.IsRef;
+          passCursorInfoForDecl(Info, MainModule, Actionables, SymbolGraph, {},
+                                *this, Invok, Diagnostic, {}, Receiver);
         }
       } else {
         CursorInfoData Info;
@@ -1877,9 +1782,6 @@ static void resolveCursorFromUSR(
       auto &CompIns = AstUnit->getCompilerInstance();
       ModuleDecl *MainModule = CompIns.getMainModule();
 
-      unsigned BufferID =
-          AstUnit->getPrimarySourceFile().getBufferID().getValue();
-
       if (USR.startswith("c:")) {
         LOG_WARN_FUNC("lookup for C/C++/ObjC USRs not implemented");
         CursorInfoData Info;
@@ -1905,18 +1807,22 @@ static void resolveCursorFromUSR(
         passCursorInfoForModule(M, Lang.getIFaceGenContexts(), CompInvok,
                                 Receiver);
       } else {
+        ResolvedCursorInfo Info;
+        Info.ValueD = D;
+        Info.IsRef = false;
+
         auto *DC = D->getDeclContext();
         Type selfTy;
         if (DC->isTypeContext()) {
-          selfTy = DC->getSelfInterfaceType();
-          selfTy = D->getInnermostDeclContext()->mapTypeIntoContext(selfTy);
+          Info.ContainerType = DC->getSelfInterfaceType();
+          Info.ContainerType = D->getInnermostDeclContext()->mapTypeIntoContext(
+              Info.ContainerType);
         }
+
         std::string Diagnostic;
         bool Success =
-            passCursorInfoForDecl(/*SourceFile*/nullptr, D, MainModule, selfTy,
-                                  /*IsRef=*/false, /*Actionables*/false,
-                                  /*SymbolGraph*/false, ResolvedCursorInfo(),
-                                  BufferID, SourceLoc(), {}, Lang, CompInvok,
+            passCursorInfoForDecl(Info, MainModule, /*AddRefactorings*/ false,
+                                  /*AddSymbolGraph*/ false, {}, Lang, CompInvok,
                                   Diagnostic, PreviousASTSnaps, Receiver);
         if (!Success) {
           if (!PreviousASTSnaps.empty()) {
@@ -2139,7 +2045,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
         if (CursorInfo.IsKeywordArgument)
           return;
 
-        ValueDecl *VD = CursorInfo.CtorTyRef ? CursorInfo.CtorTyRef : CursorInfo.ValueD;
+        ValueDecl *VD = CursorInfo.typeOrValue();
         if (!VD)
           return; // This was a module reference.
 

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1568,6 +1568,211 @@ static std::vector<const char *> readStringArray(
   });
 }
 
+struct ResponseSymbolInfo {
+  struct ParentInfo {
+    const char *Title;
+    const char *Kind;
+    const char *USR;
+  };
+
+  const char *Kind = nullptr;
+  const char *Lang = nullptr;
+  const char *Name = nullptr;
+  const char *USR = nullptr;
+  const char *TypeName = nullptr;
+  const char *TypeUSR = nullptr;
+  const char *ContainerTypeUSR = nullptr;
+  const char *DocComment = nullptr;
+  const char *GroupName = nullptr;
+  const char *LocalizationKey = nullptr;
+  const char *AnnotatedDeclaration = nullptr;
+  const char *FullyAnnotatedDeclaration = nullptr;
+  const char *SymbolGraph = nullptr;
+  const char *ModuleName = nullptr;
+  const char *ModuleInterfaceName = nullptr;
+  llvm::Optional<int64_t> Offset;
+  unsigned Length = 0;
+  const char *FilePath = nullptr;
+  std::vector<const char *> OverrideUSRs;
+  std::vector<const char *> AnnotatedRelatedDeclarations;
+  std::vector<const char *> ModuleGroups;
+  std::vector<ParentInfo> ParentContexts;
+  std::vector<const char *> ReceiverUSRs;
+  bool IsSystem = false;
+  bool IsDynamic = false;
+  unsigned ParentOffset = 0;
+
+  static ResponseSymbolInfo read(sourcekitd_variant_t Info) {
+    ResponseSymbolInfo Symbol;
+
+    sourcekitd_uid_t KindUID =
+        sourcekitd_variant_dictionary_get_uid(Info, KeyKind);
+    if (KindUID == nullptr)
+      return Symbol;
+    Symbol.Kind = sourcekitd_uid_get_string_ptr(KindUID);
+
+    sourcekitd_uid_t LangUID =
+        sourcekitd_variant_dictionary_get_uid(Info, KeyDeclarationLang);
+    if (LangUID)
+      Symbol.Lang = sourcekitd_uid_get_string_ptr(LangUID);
+
+    Symbol.Name = sourcekitd_variant_dictionary_get_string(Info, KeyName);
+    Symbol.USR = sourcekitd_variant_dictionary_get_string(Info, KeyUSR);
+
+    Symbol.TypeName =
+        sourcekitd_variant_dictionary_get_string(Info, KeyTypeName);
+    Symbol.TypeUSR = sourcekitd_variant_dictionary_get_string(Info, KeyTypeUsr);
+    Symbol.ContainerTypeUSR =
+        sourcekitd_variant_dictionary_get_string(Info, KeyContainerTypeUsr);
+
+    Symbol.DocComment =
+        sourcekitd_variant_dictionary_get_string(Info, KeyDocFullAsXML);
+    Symbol.GroupName =
+        sourcekitd_variant_dictionary_get_string(Info, KeyGroupName);
+    Symbol.LocalizationKey =
+        sourcekitd_variant_dictionary_get_string(Info, KeyLocalizationKey);
+
+    Symbol.AnnotatedDeclaration =
+        sourcekitd_variant_dictionary_get_string(Info, KeyAnnotatedDecl);
+    Symbol.FullyAnnotatedDeclaration =
+        sourcekitd_variant_dictionary_get_string(Info, KeyFullyAnnotatedDecl);
+    Symbol.SymbolGraph =
+        sourcekitd_variant_dictionary_get_string(Info, KeySymbolGraph);
+
+    Symbol.ModuleName =
+        sourcekitd_variant_dictionary_get_string(Info, KeyModuleName);
+    Symbol.ModuleInterfaceName =
+        sourcekitd_variant_dictionary_get_string(Info, KeyModuleInterfaceName);
+
+    sourcekitd_variant_t OffsetObj =
+        sourcekitd_variant_dictionary_get_value(Info, KeyOffset);
+    if (sourcekitd_variant_get_type(OffsetObj) !=
+        SOURCEKITD_VARIANT_TYPE_NULL) {
+      Symbol.Offset = sourcekitd_variant_int64_get_value(OffsetObj);
+      Symbol.Length = sourcekitd_variant_dictionary_get_int64(Info, KeyLength);
+    }
+    Symbol.FilePath =
+        sourcekitd_variant_dictionary_get_string(Info, KeyFilePath);
+
+    Symbol.OverrideUSRs = readStringArray(Info, KeyOverrides, KeyUSR);
+    Symbol.AnnotatedRelatedDeclarations =
+        readStringArray(Info, KeyRelatedDecls, KeyAnnotatedDecl);
+    Symbol.ModuleGroups = readStringArray(Info, KeyModuleGroups, KeyGroupName);
+
+    Symbol.ParentContexts = readArray<ParentInfo>(
+        Info, KeyParentContexts, [&](sourcekitd_variant_t Entry) {
+          return ParentInfo{
+              sourcekitd_variant_dictionary_get_string(Entry, KeyName),
+              sourcekitd_variant_dictionary_get_string(Entry, KeyKind),
+              sourcekitd_variant_dictionary_get_string(Entry, KeyUSR)};
+        });
+
+    Symbol.ReceiverUSRs = readStringArray(Info, KeyReceivers, KeyUSR);
+
+    Symbol.IsSystem = sourcekitd_variant_dictionary_get_bool(Info, KeyIsSystem);
+    Symbol.IsDynamic =
+        sourcekitd_variant_dictionary_get_bool(Info, KeyIsDynamic);
+
+    Symbol.ParentOffset =
+        sourcekitd_variant_dictionary_get_int64(Info, KeyParentLoc);
+
+    return Symbol;
+  }
+
+  void print(llvm::raw_ostream &OS, StringRef CurrentFilename,
+             const llvm::StringMap<TestOptions::VFSFile> &VFSFiles) {
+    if (Kind == nullptr) {
+      OS << "<empty symbol info>\n";
+      return;
+    }
+
+    OS << Kind << " (";
+    if (Offset.hasValue()) {
+      if (CurrentFilename != StringRef(FilePath))
+        OS << FilePath << ":";
+      auto LineCol = resolveToLineCol(Offset.getValue(), FilePath, VFSFiles);
+      OS << LineCol.first << ':' << LineCol.second;
+      auto EndLineCol =
+          resolveToLineCol(Offset.getValue() + Length, FilePath, VFSFiles);
+      OS << '-' << EndLineCol.first << ':' << EndLineCol.second;
+    }
+    OS << ")" << '\n';
+
+    OS << Name << '\n';
+    if (USR)
+      OS << USR << '\n';
+    if (Lang)
+      OS << Lang << '\n';
+    if (TypeName)
+      OS << TypeName << '\n';
+    if (TypeUSR)
+      OS << TypeUSR << '\n';
+    if (ContainerTypeUSR)
+      OS << "<Container>" << ContainerTypeUSR << "</Container>" << '\n';
+    if (ModuleName)
+      OS << ModuleName << '\n';
+    if (GroupName)
+      OS << "<Group>" << GroupName << "</Group>" << '\n';
+    if (ModuleInterfaceName)
+      OS << ModuleInterfaceName << '\n';
+    if (IsSystem)
+      OS << "SYSTEM" << '\n';
+    if (AnnotatedDeclaration)
+      OS << AnnotatedDeclaration << '\n';
+    if (FullyAnnotatedDeclaration)
+      OS << FullyAnnotatedDeclaration << '\n';
+    if (DocComment)
+      OS << DocComment << '\n';
+    if (LocalizationKey) {
+      OS << "<LocalizationKey>" << LocalizationKey;
+      OS << "</LocalizationKey>" << '\n';
+    }
+    if (IsDynamic)
+      OS << "DYNAMIC\n";
+    if (ParentOffset) {
+      OS << "PARENT OFFSET: " << ParentOffset << "\n";
+    }
+
+    OS << "SYMBOL GRAPH BEGIN\n";
+    if (SymbolGraph) {
+      if (auto PrettyJsonOrErr = json::parse(StringRef(SymbolGraph))) {
+        OS << formatv("{0:2}", *PrettyJsonOrErr);
+      } else {
+        llvm::handleAllErrors(PrettyJsonOrErr.takeError(),
+                              [&](const llvm::ErrorInfoBase &E) {});
+        OS << SymbolGraph;
+      }
+      OS << "\n";
+    }
+    OS << "SYMBOL GRAPH END\n";
+
+    OS << "PARENT CONTEXTS BEGIN\n";
+    for (auto Parent : ParentContexts)
+      OS << Parent.Title << " " << Parent.Kind << " " << Parent.USR << '\n';
+    OS << "PARENT CONTEXTS END\n";
+
+    OS << "OVERRIDES BEGIN\n";
+    for (auto OverUSR : OverrideUSRs)
+      OS << OverUSR << '\n';
+    OS << "OVERRIDES END\n";
+
+    OS << "RELATED BEGIN\n";
+    for (auto RelDecl : AnnotatedRelatedDeclarations)
+      OS << RelDecl << '\n';
+    OS << "RELATED END\n";
+
+    OS << "MODULE GROUPS BEGIN\n";
+    for (auto Group : ModuleGroups)
+      OS << Group << '\n';
+    OS << "MODULE GROUPS END\n";
+
+    OS << "RECEIVERS BEGIN\n";
+    for (auto Receiver : ReceiverUSRs)
+      OS << Receiver << '\n';
+    OS << "RECEIVERS END\n";
+  }
+};
+
 static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
                             const llvm::StringMap<TestOptions::VFSFile> &VFSFiles,
                             llvm::raw_ostream &OS) {
@@ -1578,92 +1783,12 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
        << InternalDiagnostic << "\">\n";
     return;
   }
-  sourcekitd_uid_t KindUID = sourcekitd_variant_dictionary_get_uid(Info,
-                                      sourcekitd_uid_get_from_cstr("key.kind"));
-  if (KindUID == nullptr) {
-    OS << "<empty cursor info>\n";
-    return;
-  }
 
-  std::string Filename = FilenameIn.str();
-  llvm::SmallString<256> output;
-  if (!llvm::sys::fs::real_path(Filename, output))
-    Filename = std::string(output.str());
-
-  const char *Kind = sourcekitd_uid_get_string_ptr(KindUID);
-  const char *USR = sourcekitd_variant_dictionary_get_string(Info, KeyUSR);
-  const char *Name = sourcekitd_variant_dictionary_get_string(Info, KeyName);
-  const char *Typename = sourcekitd_variant_dictionary_get_string(Info,
-                                                                  KeyTypeName);
-  const char *TypeUsr = sourcekitd_variant_dictionary_get_string(Info,
-                                                                 KeyTypeUsr);
-  const char *ContainerTypeUsr = sourcekitd_variant_dictionary_get_string(Info,
-                                                          KeyContainerTypeUsr);
-  const char *ModuleName = sourcekitd_variant_dictionary_get_string(Info,
-                                                              KeyModuleName);
-  const char *GroupName = sourcekitd_variant_dictionary_get_string(Info,
-                                                                   KeyGroupName);
-  
-  sourcekitd_uid_t LangUID =
-      sourcekitd_variant_dictionary_get_uid(Info, KeyDeclarationLang);
-  const char *DeclLang = nullptr;
-  if (LangUID)
-    DeclLang = sourcekitd_uid_get_string_ptr(LangUID);
-
-  const char *LocalizationKey =
-    sourcekitd_variant_dictionary_get_string(Info, KeyLocalizationKey);
-  const char *ModuleInterfaceName =
-      sourcekitd_variant_dictionary_get_string(Info, KeyModuleInterfaceName);
-  const char *TypeInterface =
-      sourcekitd_variant_dictionary_get_string(Info, KeyTypeInterface);
-  bool IsSystem = sourcekitd_variant_dictionary_get_bool(Info, KeyIsSystem);
-  bool IsDynamic = sourcekitd_variant_dictionary_get_bool(Info, KeyIsDynamic);
-
-  const char *AnnotDecl = sourcekitd_variant_dictionary_get_string(Info,
-                                                              KeyAnnotatedDecl);
-  const char *FullAnnotDecl =
-      sourcekitd_variant_dictionary_get_string(Info, KeyFullyAnnotatedDecl);
-  const char *SymbolGraph =
-      sourcekitd_variant_dictionary_get_string(Info, KeySymbolGraph);
-  const char *DocFullAsXML =
-      sourcekitd_variant_dictionary_get_string(Info, KeyDocFullAsXML);
-  sourcekitd_variant_t OffsetObj =
-      sourcekitd_variant_dictionary_get_value(Info, KeyOffset);
-  llvm::Optional<int64_t> Offset;
-  unsigned Length = 0;
-  if (sourcekitd_variant_get_type(OffsetObj) != SOURCEKITD_VARIANT_TYPE_NULL) {
-    Offset = sourcekitd_variant_int64_get_value(OffsetObj);
-    Length = sourcekitd_variant_dictionary_get_int64(Info, KeyLength);
-  }
-  const char *FilePath = sourcekitd_variant_dictionary_get_string(Info, KeyFilePath);
-
-  std::vector<const char *> OverrideUSRs = readStringArray(Info, KeyOverrides,
-                                                           KeyUSR);
-
-  struct ParentInfo {
-    const char *Title;
-    const char *Kind;
-    const char *USR;
-  };
-  std::vector<ParentInfo> Parents = readArray<ParentInfo>(
-      Info,KeyParentContexts, [&](sourcekitd_variant_t Entry) {
-    return ParentInfo {
-      sourcekitd_variant_dictionary_get_string(Entry, KeyName),
-      sourcekitd_variant_dictionary_get_string(Entry, KeyKind),
-      sourcekitd_variant_dictionary_get_string(Entry, KeyUSR)
-    };
-  });
-
-  std::vector<const char *> GroupNames = readStringArray(Info, KeyModuleGroups,
-                                                         KeyGroupName);
-
-  std::vector<const char *> RelatedDecls = readStringArray(
-      Info, KeyRelatedDecls, KeyAnnotatedDecl);
-
+  auto SymbolInfo = ResponseSymbolInfo::read(Info);
   struct ActionInfo {
-    const char* KindUID;
-    const char* KindName;
-    const char* UnavailReason;
+    const char *KindUID;
+    const char *KindName;
+    const char *UnavailReason;
   };
   std::vector<ActionInfo> AvailableActions = readArray<ActionInfo>(
       Info, KeyRefactorActions, [&](sourcekitd_variant_t Entry) {
@@ -1676,85 +1801,18 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
     };
   });
 
-  std::vector<const char *> Receivers = readStringArray(
-      Info, KeyReceivers, KeyUSR);
+  std::vector<ResponseSymbolInfo> SecondarySymbols =
+      readArray<ResponseSymbolInfo>(Info, KeySecondarySymbols,
+                                    [&](sourcekitd_variant_t Entry) {
+                                      return ResponseSymbolInfo::read(Entry);
+                                    });
 
-  uint64_t ParentOffset =
-    sourcekitd_variant_dictionary_get_int64(Info, KeyParentLoc);
+  std::string Filename = FilenameIn.str();
+  llvm::SmallString<256> output;
+  if (!llvm::sys::fs::real_path(Filename, output))
+    Filename = std::string(output.str());
 
-  OS << Kind << " (";
-  if (Offset.hasValue()) {
-    if (Filename != FilePath)
-      OS << FilePath << ":";
-    auto LineCol = resolveToLineCol(Offset.getValue(), FilePath, VFSFiles);
-    OS << LineCol.first << ':' << LineCol.second;
-    auto EndLineCol =
-        resolveToLineCol(Offset.getValue() + Length, FilePath, VFSFiles);
-    OS << '-' << EndLineCol.first << ':' << EndLineCol.second;
-  }
-  OS << ")\n";
-  OS << Name << '\n';
-  if (USR)
-    OS << USR << '\n';
-  if (DeclLang)
-    OS << DeclLang << "\n";
-  if (Typename)
-    OS << Typename << '\n';
-  if (TypeUsr)
-    OS << TypeUsr << '\n';
-  if (ContainerTypeUsr)
-    OS << "<Container>" << ContainerTypeUsr << "</Container>" << '\n';
-  if (ModuleName)
-    OS << ModuleName << '\n';
-  if (GroupName)
-    OS << "<Group>" << GroupName << "</Group>" << '\n';
-  if (ModuleInterfaceName)
-    OS << ModuleInterfaceName << '\n';
-  if (IsSystem)
-    OS << "SYSTEM\n";
-  if (AnnotDecl)
-    OS << AnnotDecl << '\n';
-  if (FullAnnotDecl)
-    OS << FullAnnotDecl << '\n';
-  if (DocFullAsXML)
-    OS << DocFullAsXML << '\n';
-  if (LocalizationKey) {
-    OS << "<LocalizationKey>" << LocalizationKey;
-    OS << "</LocalizationKey>" << '\n';
-  }
-  if (IsDynamic)
-    OS << "DYNAMIC\n";
-  if (SymbolGraph) {
-    OS << "SYMBOL GRAPH BEGIN\n";
-    if (auto Val = json::parse(StringRef(SymbolGraph))) {
-      OS << formatv("{0:2}", Val.get());
-    } else {
-      OS << SymbolGraph;
-    }
-    OS << "\nSYMBOL GRAPH END\n";
-  }
-  if (!Parents.empty()) {
-    OS << "PARENT CONTEXTS BEGIN\n";
-    for (auto parent: Parents)
-      OS << parent.Title << " " << parent.Kind << " " << parent.USR << '\n';
-    OS << "PARENT CONTEXTS END\n";
-  }
-  OS << "OVERRIDES BEGIN\n";
-  for (auto OverUSR : OverrideUSRs)
-    OS << OverUSR << '\n';
-  OS << "OVERRIDES END\n";
-  OS << "RELATED BEGIN\n";
-  for (auto RelDecl : RelatedDecls)
-    OS << RelDecl << '\n';
-  OS << "RELATED END\n";
-  OS << "TYPE INTERFACE BEGIN\n";
-  if (TypeInterface)
-    OS << TypeInterface << '\n';
-  OS << "TYPE INTERFACE END\n";
-  OS << "MODULE GROUPS BEGIN\n";
-  for (auto Group : GroupNames)
-    OS << Group << '\n';
-  OS << "MODULE GROUPS END\n";
+  SymbolInfo.print(OS, Filename, VFSFiles);
   OS << "ACTIONS BEGIN\n";
   for (auto Action : AvailableActions) {
     OS << Action.KindUID << '\n';
@@ -1764,13 +1822,13 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
     }
   }
   OS << "ACTIONS END\n";
-  OS << "RECEIVERS BEGIN\n";
-  for (auto Receiver : Receivers)
-    OS << Receiver << '\n';
-  OS << "RECEIVERS END\n";
-  if (ParentOffset) {
-    OS << "PARENT OFFSET: " << ParentOffset << "\n";
+
+  OS << "SECONDARY SYMBOLS BEGIN\n";
+  for (auto Secondary : SecondarySymbols) {
+    Secondary.print(OS, Filename, VFSFiles);
+    OS << "-----\n";
   }
+  OS << "SECONDARY SYMBOLS END\n";
 }
 
 static void printRangeInfo(sourcekitd_variant_t Info, StringRef FilenameIn,

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1736,6 +1736,94 @@ bool SKDocConsumer::handleDiagnostic(const DiagnosticEntryInfo &Info) {
 // ReportCursorInfo
 //===----------------------------------------------------------------------===//
 
+static void addCursorSymbolInfo(const CursorSymbolInfo &Symbol,
+                                ResponseBuilder::Dictionary &Elem) {
+  Elem.set(KeyKind, Symbol.Kind);
+  if (Symbol.DeclarationLang.isValid())
+    Elem.set(KeyDeclarationLang, Symbol.DeclarationLang);
+  Elem.set(KeyName, Symbol.Name);
+  if (!Symbol.USR.empty())
+    Elem.set(KeyUSR, Symbol.USR);
+  if (!Symbol.TypeName.empty())
+    Elem.set(KeyTypeName, Symbol.TypeName);
+  if (!Symbol.TypeUSR.empty())
+    Elem.set(KeyTypeUsr, Symbol.TypeUSR);
+  if (!Symbol.ContainerTypeUSR.empty())
+    Elem.set(KeyContainerTypeUsr, Symbol.ContainerTypeUSR);
+  if (!Symbol.DocComment.empty())
+    Elem.set(KeyDocFullAsXML, Symbol.DocComment);
+  if (!Symbol.GroupName.empty())
+    Elem.set(KeyGroupName, Symbol.GroupName);
+  if (!Symbol.LocalizationKey.empty())
+    Elem.set(KeyLocalizationKey, Symbol.LocalizationKey);
+  if (!Symbol.AnnotatedDeclaration.empty())
+    Elem.set(KeyAnnotatedDecl, Symbol.AnnotatedDeclaration);
+  if (!Symbol.FullyAnnotatedDeclaration.empty())
+    Elem.set(KeyFullyAnnotatedDecl, Symbol.FullyAnnotatedDeclaration);
+  if (!Symbol.SymbolGraph.empty())
+    Elem.set(KeySymbolGraph, Symbol.SymbolGraph);
+  if (!Symbol.ModuleName.empty())
+    Elem.set(KeyModuleName, Symbol.ModuleName);
+  if (!Symbol.ModuleInterfaceName.empty())
+    Elem.set(KeyModuleInterfaceName, Symbol.ModuleInterfaceName);
+  if (Symbol.DeclarationLoc.hasValue()) {
+    Elem.set(KeyOffset, Symbol.DeclarationLoc.getValue().first);
+    Elem.set(KeyLength, Symbol.DeclarationLoc.getValue().second);
+    if (!Symbol.Filename.empty())
+      Elem.set(KeyFilePath, Symbol.Filename);
+  }
+
+  if (!Symbol.OverrideUSRs.empty()) {
+    auto Overrides = Elem.setArray(KeyOverrides);
+    for (auto USR : Symbol.OverrideUSRs) {
+      auto Override = Overrides.appendDictionary();
+      Override.set(KeyUSR, USR);
+    }
+  }
+
+  if (!Symbol.AnnotatedRelatedDeclarations.empty()) {
+    auto RelDecls = Elem.setArray(KeyRelatedDecls);
+    for (auto AnnotDecl : Symbol.AnnotatedRelatedDeclarations) {
+      auto RelDecl = RelDecls.appendDictionary();
+      RelDecl.set(KeyAnnotatedDecl, AnnotDecl);
+    }
+  }
+
+  if (!Symbol.ModuleGroupArray.empty()) {
+    auto Groups = Elem.setArray(KeyModuleGroups);
+    for (auto Name : Symbol.ModuleGroupArray) {
+      auto Entry = Groups.appendDictionary();
+      Entry.set(KeyGroupName, Name);
+    }
+  }
+
+  if (!Symbol.ParentContexts.empty()) {
+    auto Parents = Elem.setArray(KeyParentContexts);
+    for (const auto &ParentTy : Symbol.ParentContexts) {
+      auto Parent = Parents.appendDictionary();
+      Parent.set(KeyName, ParentTy.Title);
+      Parent.set(KeyKind, ParentTy.KindName);
+      Parent.set(KeyUSR, ParentTy.USR);
+    }
+  }
+
+  if (!Symbol.ReceiverUSRs.empty()) {
+    auto Receivers = Elem.setArray(KeyReceivers);
+    for (auto USR : Symbol.ReceiverUSRs) {
+      auto Receiver = Receivers.appendDictionary();
+      Receiver.set(KeyUSR, USR);
+    }
+  }
+
+  if (Symbol.IsSystem)
+    Elem.setBool(KeyIsSystem, true);
+  if (Symbol.IsDynamic)
+    Elem.setBool(KeyIsDynamic, true);
+
+  if (Symbol.ParentNameOffset)
+    Elem.set(KeyParentLoc, Symbol.ParentNameOffset.getValue());
+}
+
 static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
                              ResponseReceiver Rec) {
   if (Result.isCancelled())
@@ -1746,58 +1834,29 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
   const CursorInfoData &Info = Result.value();
 
   ResponseBuilder RespBuilder;
+  auto Elem = RespBuilder.getDictionary();
   if (!Info.InternalDiagnostic.empty()) {
-    auto Elem = RespBuilder.getDictionary();
     Elem.set(KeyInternalDiagnostic, Info.InternalDiagnostic);
     return Rec(RespBuilder.createResponse());
   }
-  if (Info.Kind.isInvalid())
-    return Rec(RespBuilder.createResponse());
 
-  auto Elem = RespBuilder.getDictionary();
-  Elem.set(KeyKind, Info.Kind);
-  Elem.set(KeyName, Info.Name);
-  if (Info.DeclarationLang.isValid())
-    Elem.set(KeyDeclarationLang, Info.DeclarationLang);
-  if (!Info.USR.empty())
-    Elem.set(KeyUSR, Info.USR);
-  if (!Info.TypeName.empty())
-    Elem.set(KeyTypeName, Info.TypeName);
-  if (!Info.DocComment.empty())
-    Elem.set(KeyDocFullAsXML, Info.DocComment);
-  if (!Info.AnnotatedDeclaration.empty())
-    Elem.set(KeyAnnotatedDecl, Info.AnnotatedDeclaration);
-  if (!Info.FullyAnnotatedDeclaration.empty())
-    Elem.set(KeyFullyAnnotatedDecl, Info.FullyAnnotatedDeclaration);
-  if (!Info.ModuleName.empty())
-    Elem.set(KeyModuleName, Info.ModuleName);
-  if (!Info.GroupName.empty())
-    Elem.set(KeyGroupName, Info.GroupName);
-  if (!Info.LocalizationKey.empty())
-    Elem.set(KeyLocalizationKey, Info.LocalizationKey);
-  if (!Info.ModuleInterfaceName.empty())
-    Elem.set(KeyModuleInterfaceName, Info.ModuleInterfaceName);
-  if (Info.DeclarationLoc.hasValue()) {
-    Elem.set(KeyOffset, Info.DeclarationLoc.getValue().first);
-    Elem.set(KeyLength, Info.DeclarationLoc.getValue().second);
-    if (!Info.Filename.empty())
-      Elem.set(KeyFilePath, Info.Filename);
-  }
-  if (!Info.OverrideUSRs.empty()) {
-    auto Overrides = Elem.setArray(KeyOverrides);
-    for (auto USR : Info.OverrideUSRs) {
-      auto Override = Overrides.appendDictionary();
-      Override.set(KeyUSR, USR);
+  if (!Info.Symbols.empty()) {
+    addCursorSymbolInfo(Info.Symbols[0], Elem);
+    if (Info.Symbols.size() > 1) {
+      auto SecondarySymbols = Elem.setArray(KeySecondarySymbols);
+      for (auto Secondary : makeArrayRef(Info.Symbols).drop_front()) {
+        auto SecondaryElem = SecondarySymbols.appendDictionary();
+        addCursorSymbolInfo(Secondary, SecondaryElem);
+      }
     }
   }
-  if (!Info.ModuleGroupArray.empty()) {
-    auto Groups = Elem.setArray(KeyModuleGroups);
-    for (auto Name : Info.ModuleGroupArray) {
-      auto Entry = Groups.appendDictionary();
-      Entry.set(KeyGroupName, Name);
-    }
-  }
+
   if (!Info.AvailableActions.empty()) {
+    // Clients rely on a kind being set to determine whether the cursor
+    // has any results or not. Add one if there's no symbols, ie. only actions
+    // were requested (even though it's meaningless).
+    if (Info.Symbols.empty())
+      Elem.set(KeyKind, KindRefModule);
     auto Actions = Elem.setArray(KeyRefactorActions);
     for (auto Info : Info.AvailableActions) {
       auto Entry = Actions.appendDictionary();
@@ -1807,44 +1866,6 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
         Entry.set(KeyActionUnavailableReason, Info.UnavailableReason);
     }
   }
-  if (Info.ParentNameOffset) {
-    Elem.set(KeyParentLoc, Info.ParentNameOffset.getValue());
-  }
-  if (!Info.AnnotatedRelatedDeclarations.empty()) {
-    auto RelDecls = Elem.setArray(KeyRelatedDecls);
-    for (auto AnnotDecl : Info.AnnotatedRelatedDeclarations) {
-      auto RelDecl = RelDecls.appendDictionary();
-      RelDecl.set(KeyAnnotatedDecl, AnnotDecl);
-    }
-  }
-  if (!Info.ReceiverUSRs.empty()) {
-    auto Receivers = Elem.setArray(KeyReceivers);
-    for (auto USR : Info.ReceiverUSRs) {
-      auto Receiver = Receivers.appendDictionary();
-      Receiver.set(KeyUSR, USR);
-    }
-  }
-  if (Info.IsSystem)
-    Elem.setBool(KeyIsSystem, true);
-  if (!Info.TypeInterface.empty())
-    Elem.set(KeyTypeInterface, Info.TypeInterface);
-  if (!Info.TypeUSR.empty())
-    Elem.set(KeyTypeUsr, Info.TypeUSR);
-  if (!Info.ContainerTypeUSR.empty())
-    Elem.set(KeyContainerTypeUsr, Info.ContainerTypeUSR);
-  if (!Info.SymbolGraph.empty())
-    Elem.set(KeySymbolGraph, Info.SymbolGraph);
-  if (!Info.ParentContexts.empty()) {
-    auto Parents = Elem.setArray(KeyParentContexts);
-    for (const auto &ParentTy: Info.ParentContexts) {
-      auto Parent = Parents.appendDictionary();
-      Parent.set(KeyName, ParentTy.Title);
-      Parent.set(KeyKind, ParentTy.KindName);
-      Parent.set(KeyUSR, ParentTy.USR);
-    }
-  }
-  if (Info.IsDynamic)
-    Elem.setBool(KeyIsDynamic, true);
 
   return Rec(RespBuilder.createResponse());
 }

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -374,13 +374,12 @@ int main(int argc, char *argv[]) {
   RangeConfig Range = getRange(BufferID, SM, StartLoc, EndLoc);
 
   if (options::Action == RefactoringKind::None) {
-    std::vector<RefactoringKind> Scratch;
-    ArrayRef<RefactoringKind> AllKinds;
+    llvm::SmallVector<RefactoringKind, 32> Kinds;
     bool RangeStartMayNeedRename = false;
-    AllKinds = collectAvailableRefactorings(SF, Range,RangeStartMayNeedRename,
-                                            Scratch, {&PrintDiags});
+    collectAvailableRefactorings(SF, Range, RangeStartMayNeedRename, Kinds,
+                                 {&PrintDiags});
     llvm::outs() << "Action begins\n";
-    for (auto Kind : AllKinds) {
+    for (auto Kind : Kinds) {
       llvm::outs() << getDescriptiveRefactoringKindName(Kind) << "\n";
     }
     llvm::outs() << "Action ends\n";

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -159,10 +159,13 @@ public:
           return;
         }
         const CursorInfoData &Info = Result.value();
-        TestInfo.Name = Info.Name.str();
-        TestInfo.Typename = Info.TypeName.str();
-        TestInfo.Filename = Info.Filename.str();
-        TestInfo.DeclarationLoc = Info.DeclarationLoc;
+        if (!Info.Symbols.empty()) {
+          const CursorSymbolInfo &MainSymbol = Info.Symbols[0];
+          TestInfo.Name = std::string(MainSymbol.Name.str());
+          TestInfo.Typename = MainSymbol.TypeName.str();
+          TestInfo.Filename = MainSymbol.Filename.str();
+          TestInfo.DeclarationLoc = MainSymbol.DeclarationLoc;
+        }
         sema.signal();
       });
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -113,7 +113,6 @@ UID_KEYS = [
     KEY('Deprecated', 'key.deprecated'),
     KEY('Obsoleted', 'key.obsoleted'),
     KEY('RemoveCache', 'key.removecache'),
-    KEY('TypeInterface', 'key.typeinterface'),
     KEY('TypeUsr', 'key.typeusr'),
     KEY('ContainerTypeUsr', 'key.containertypeusr'),
     KEY('ModuleGroups', 'key.modulegroups'),
@@ -190,6 +189,7 @@ UID_KEYS = [
     KEY('CompileOperation', 'key.compile_operation'),
     KEY('EffectiveAccess', 'key.effective_access'),
     KEY('DeclarationLang', 'key.decl_lang'),
+    KEY('SecondarySymbols', 'key.secondary_symbols'),
 ]
 
 


### PR DESCRIPTION
Cursor info for a constructor would previously give the cursor info for
the containing type only. It now also adds cursor info for the
constructor itself in a "secondaries" field.

Resolves rdar://75385556