### PR TITLE
SILVerifier: fix a wrong debug-scope verifier crash

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5468,13 +5468,6 @@ public:
     for (SILInstruction &SI : *BB) {
       if (SI.isMetaInstruction())
         continue;
-      LastSeenScope = SI.getDebugScope();
-      AlreadySeenScopes.insert(LastSeenScope);
-      break;
-    }
-    for (SILInstruction &SI : *BB) {
-      if (SI.isMetaInstruction())
-        continue;
       if (SI.getLoc().getKind() == SILLocation::CleanupKind)
         continue;
 

--- a/test/DebugInfo/guard-let-scope.swift
+++ b/test/DebugInfo/guard-let-scope.swift
@@ -11,3 +11,13 @@ func f(c: AnyObject?) {
   }
   print(x)
 }
+
+// Check that we don't crash with a verifier error on this.
+protocol P {}
+
+public func testit(_ x: AnyObject) -> Bool {
+  guard let _ = x as? P else {
+    return false
+  }
+  fatalError()
+}


### PR DESCRIPTION
Remove the "initialization loop" for LastSeenScope in verifyDebugScopeHoles.
It's not required because LastSeenScope is initialized the same way in the main loop.
And most importantly: this loop was missing the check for cleanup locations.

rdar://75374671
