### PR TITLE
[CodeComplete] Return true from canParseType if type contains code completion token

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -351,9 +351,13 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         param.FirstNameLoc = SourceLoc();
         param.SecondName = Identifier();
         param.SecondNameLoc = SourceLoc();
-      } else if (isBareType) {
+      } else if (isBareType && !Tok.is(tok::code_complete)) {
         // Otherwise, if this is a bare type, then the user forgot to name the
         // parameter, e.g. "func foo(Int) {}"
+        // Don't enter this case if the element could only be parsed as a bare
+        // type because a code completion token is positioned here. In this case
+        // the user is about to type the parameter label and we shouldn't
+        // suggest types.
         SourceLoc typeStartLoc = Tok.getLoc();
         auto type = parseType(diag::expected_parameter_type, false);
         status |= type;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1410,9 +1410,10 @@ bool Parser::canParseType() {
   switch (Tok.getKind()) {
   case tok::kw_Self:
   case tok::kw_Any:
-      if (!canParseTypeIdentifier())
-        return false;
-      break;
+  case tok::code_complete:
+    if (!canParseTypeIdentifier())
+      return false;
+    break;
   case tok::kw_protocol: // Deprecated composition syntax
   case tok::identifier:
     if (!canParseTypeIdentifierOrTypeComposition())
@@ -1500,7 +1501,7 @@ bool Parser::canParseTypeIdentifierOrTypeComposition() {
 
 bool Parser::canParseSimpleTypeIdentifier() {
   // Parse an identifier.
-  if (!Tok.isAny(tok::identifier, tok::kw_Self, tok::kw_Any))
+  if (!Tok.isAny(tok::identifier, tok::kw_Self, tok::kw_Any, tok::code_complete))
     return false;
   consumeToken();
 

--- a/test/IDE/complete_in_enum_decl.swift
+++ b/test/IDE/complete_in_enum_decl.swift
@@ -5,6 +5,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_CASE_5 | %FileCheck %s -check-prefix=NO_RESULTS
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_CASE_6 | %FileCheck %s -check-prefix=NO_RESULTS
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_ENUM_CASE_DECL | %FileCheck %s -check-prefix=TYPE_IN_ENUM_CASE_DECL
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=NESTED_TYPE_IN_ENUM_CASE_DECL | %FileCheck %s -check-prefix=NESTED_TYPE_IN_ENUM_CASE_DECL
+
 // NO_RESULTS: found code completion token
 // NO_RESULTS-NOT: Begin completions
 
@@ -33,3 +36,20 @@ enum EnumCase6 : Int {
   case Foo = super.#^ENUM_CASE_6^#
 }
 
+enum EnumCase7 {
+  case foo(#^TYPE_IN_ENUM_CASE_DECL^#)
+}
+// TYPE_IN_ENUM_CASE_DECL: Begin completions
+// TYPE_IN_ENUM_CASE_DECL-DAG: Decl[Enum]/CurrModule:                   EnumCase7[#EnumCase7#];
+// TYPE_IN_ENUM_CASE_DECL: End completions
+
+struct Wrapper {
+  struct Nested {}
+}
+enum EnumCase8 {
+  case foo(Wrapper.#^NESTED_TYPE_IN_ENUM_CASE_DECL^#)
+}
+// NESTED_TYPE_IN_ENUM_CASE_DECL: Begin completions, 2 items
+// NESTED_TYPE_IN_ENUM_CASE_DECL-DAG: Decl[Struct]/CurrNominal:           Nested[#Wrapper.Nested#];
+// NESTED_TYPE_IN_ENUM_CASE_DECL-DAG: Keyword/None:                       Type[#Wrapper.Type#];
+// NESTED_TYPE_IN_ENUM_CASE_DECL: End completions


### PR DESCRIPTION
From my point of view, a type that contains a code completion token can still be parsed as a type and as such, `canParseType` should return `true` for e.g. `#^COMPLETE^#` or `SomeType.#^COMPLETE^#`.

Changing this fixes an issue that caused no type completions to be shown inside a enum case decl.

Fixes rdar://71984715