### PR TITLE
[cxx-interop] Don't instantiate empty class template specializations.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3752,8 +3752,9 @@ namespace {
       // any instantiation errors.
       for (auto member : decl->decls()) {
         if (auto varDecl = dyn_cast<clang::VarDecl>(member)) {
-          Impl.getClangSema()
-            .InstantiateVariableDefinition(varDecl->getLocation(), varDecl);
+          if (varDecl->getTemplateInstantiationPattern())
+            Impl.getClangSema()
+              .InstantiateVariableDefinition(varDecl->getLocation(), varDecl);
         }
       }
 

--- a/test/Interop/Cxx/templates/Inputs/explicit-class-specialization.h
+++ b/test/Interop/Cxx/templates/Inputs/explicit-class-specialization.h
@@ -61,4 +61,16 @@ template <class T, class... Ts> class HasSpecializations<int, T, Ts...> {
   enum Maybe : int { No, Yes };
 };
 
+template <class>
+struct HasEmptySpecializationAndStaticDateMember {
+  inline static const bool value = false;
+};
+
+template <>
+struct HasEmptySpecializationAndStaticDateMember<char> {
+  inline static const bool value = true;
+};
+
+using HasEmptySpecializationAndStaticDateMemberInt = HasEmptySpecializationAndStaticDateMember<int>;
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_EXPLICIT_CLASS_SPECIALIZATION_H

--- a/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ExplicitClassSpecialization -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+
+// CHECK: struct __CxxTemplateInst41HasEmptySpecializationAndStaticDateMemberIiE {
+// CHECK:   static let value: Bool
+// CHECK: }
+
+// CHECK: struct __CxxTemplateInst41HasEmptySpecializationAndStaticDateMemberIcE {
+// CHECK:   static let value: Bool
+// CHECK: }


### PR DESCRIPTION
If we try to instantiate the var decl members of an empty class template specialization we'll crash because there is no template param pattern.