### PR TITLE
[concurrency] Expunge 'actor class' from diagnostics

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -40,7 +40,7 @@ public:
     /// The actor isolation has not been specified. It is assumed to be
     /// unsafe to interact with this declaration from any actor.
     Unspecified = 0,
-    /// The declaration is isolated to the instance of an actor class.
+    /// The declaration is isolated to the instance of an actor.
     /// For example, a mutable stored property or synchronous function within
     /// the actor is isolated to the instance of that actor.
     ActorInstance,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4323,7 +4323,7 @@ ERROR(async_objc_dynamic_self,none,
       "asynchronous method returning 'Self' cannot be '@objc'", ())
 
 ERROR(actor_with_nonactor_superclass,none,
-      "actor class cannot inherit from non-actor class %0", (DeclName))
+      "actor cannot inherit from non-actor class %0", (DeclName))
 
 ERROR(actor_isolated_non_self_reference,none,
         "actor-isolated %0 %1 can only be %select{referenced|mutated|used 'inout'}3 "
@@ -4500,7 +4500,7 @@ ERROR(multiple_global_actors,none,
 ERROR(global_actor_disallowed,none,
       "%0 cannot have a global actor", (DescriptiveDeclKind))
 ERROR(global_actor_on_actor_class,none,
-      "actor class %0 cannot have a global actor", (Identifier))
+      "actor %0 cannot have a global actor", (Identifier))
 ERROR(global_actor_on_local_variable,none,
       "local variable %0 cannot have a global actor", (DeclName))
 ERROR(global_actor_non_unsafe_init,none,

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -521,7 +521,7 @@ public:
     if (!printOptions.shouldPrint(nominal))
       return;
 
-    /// is this nominal specifically an 'actor class'?
+    /// is this nominal specifically an 'actor'?
     bool actorClass = false;
     if (auto klass = dyn_cast<ClassDecl>(nominal))
       actorClass = klass->isActor();

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -2095,7 +2095,7 @@ const TypeInfo *TypeConverter::convertType(CanType ty) {
   }
   case TypeKind::BuiltinDefaultActorStorage: {
     // Builtin.DefaultActorStorage represents the extra storage
-    // (beyond the heap header) of a default actor class.  It is
+    // (beyond the heap header) of a default actor.  It is
     // fixed-size and totally opaque.
     auto numWords = NumWords_DefaultActor;
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -290,18 +290,18 @@ bool IsActorRequest::evaluate(
 
 bool IsDefaultActorRequest::evaluate(
     Evaluator &evaluator, ClassDecl *classDecl) const {
-  // If the class isn't an actor class, it's not a default actor.
+  // If the class isn't an actor, it's not a default actor.
   if (!classDecl->isActor())
     return false;
 
-  // If there is a superclass, and it's an actor class, we defer
+  // If there is a superclass, and it's an actor, we defer
   // the decision to it.
   if (auto superclassDecl = classDecl->getSuperclassDecl()) {
     // If the superclass is an actor, we inherit its default-actor-ness.
     if (superclassDecl->isActor())
       return superclassDecl->isDefaultActor();
 
-    // If the superclass is not an actor class, it can only be
+    // If the superclass is not an actor, it can only be
     // a default actor if it's NSObject.  (For now, other classes simply
     // can't be actors at all.)  We don't need to diagnose this; we
     // should've done that already in isActor().
@@ -522,7 +522,7 @@ GlobalActorAttributeRequest::evaluate(
     // Nominal types are okay...
     if (auto classDecl = dyn_cast<ClassDecl>(nominal)){
       if (classDecl->isActor()) {
-        // ... except for actor classes.
+        // ... except for actors.
         nominal->diagnose(diag::global_actor_on_actor_class, nominal->getName())
             .highlight(globalActorAttr->getRangeWithAt());
         return None;

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -132,7 +132,7 @@ public:
     return data.actorType;
   }
 
-  /// Retrieve the actor class that the declaration is within.
+  /// Retrieve the actor that the declaration is within.
   Type getGlobalActor() const {
     assert(kind == GlobalActor || kind == GlobalActorUnsafe);
     return Type(data.globalActor);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -118,7 +118,7 @@ static void computeLoweredStoredProperties(NominalTypeDecl *decl) {
     }
   }
 
-  // If this is an actor class, check conformance to the Actor protocol to
+  // If this is an actor, check conformance to the Actor protocol to
   // ensure that the actor storage will get created (if needed).
   if (auto classDecl = dyn_cast<ClassDecl>(decl)) {
     if (classDecl->isActor()) {

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -13,7 +13,7 @@
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
-/// Common protocol to which all actor classes conform.
+/// Common protocol to which all actors conform.
 ///
 /// The \c Actor protocol generalizes over all actor types. Actor types
 /// implicitly conform to this protocol.

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -83,7 +83,7 @@ class SomeClass {
 
 @GA1 typealias Integer = Int // expected-error{{type alias cannot have a global actor}}
 
-@GA1 actor ActorInTooManyPlaces { } // expected-error{{actor class 'ActorInTooManyPlaces' cannot have a global actor}}
+@GA1 actor ActorInTooManyPlaces { } // expected-error{{actor 'ActorInTooManyPlaces' cannot have a global actor}}
 
 @GA1 @OtherGlobalActor func twoGlobalActors() { } // expected-error{{declaration can not have multiple global actor attributes ('OtherGlobalActor' and 'GA1')}}
 

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -13,7 +13,7 @@ actor class MyActorClass { }
 
 class NonActor { }
 
-actor NonActorSubclass : NonActor { } // expected-error{{actor class cannot inherit from non-actor class 'NonActor'}}
+actor NonActorSubclass : NonActor { } // expected-error{{actor cannot inherit from non-actor class 'NonActor'}}
 
 // expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{14-20=}}
 public actor class BobHope {}

--- a/unittests/runtime/Actor.cpp
+++ b/unittests/runtime/Actor.cpp
@@ -85,7 +85,7 @@ static void run(llvm::function_ref<void()> fn) {
 
 namespace {
 
-/// A simple actor class.
+/// A simple actor.
 class TestActor : public DefaultActor {
 public:
   TestActor();


### PR DESCRIPTION
This patch goes through and removes references to `actor class` from the comments and diagnostics, replacing them simply with `actor` or `actors`. This way we aren't confusing folks by calling them classes.

Resolves: rdar://74151370