### PR TITLE
[CSGen] Fallback to a type variable if preferred type for placeholder…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3034,10 +3034,12 @@ namespace {
 
     Type visitEditorPlaceholderExpr(EditorPlaceholderExpr *E) {
       if (auto *placeholderRepr = E->getPlaceholderTypeRepr()) {
-        // Just resolve the referenced type.
-        return resolveTypeReferenceInExpression(
-            placeholderRepr, TypeResolverContext::InExpression,
-            CS.getConstraintLocator(E));
+        // Let's try to use specified type, if that's impossible,
+        // fallback to a type variable.
+        if (auto preferredTy = resolveTypeReferenceInExpression(
+                placeholderRepr, TypeResolverContext::InExpression,
+                CS.getConstraintLocator(E)))
+          return preferredTy;
       }
 
       auto locator = CS.getConstraintLocator(E);

--- a/test/Sema/editor_placeholders.swift
+++ b/test/Sema/editor_placeholders.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
-func foo(_ x: Int) -> Int {}
-func foo(_ x: Float) -> Float {}
-func foo<T>(_ t: T) -> T {}
+func foo(_ x: Int) -> Int {} // expected-note {{found this candidate}}
+func foo(_ x: Float) -> Float {} // expected-note {{found this candidate}}
+func foo<T>(_ t: T) -> T {} // expected-note {{found this candidate}}
 
 var v = foo(<#T##x: Float##Float#>) // expected-error {{editor placeholder}}
 v = "" // expected-error {{cannot assign value of type 'String' to type 'Float'}}
@@ -11,7 +11,7 @@ if (true) {
   <#code#> // expected-error {{editor placeholder}}
 }
 
-foo(<#T##x: Undeclared##Undeclared#>) // expected-error {{editor placeholder}} expected-error {{cannot find type 'Undeclared' in scope}}
+foo(<#T##x: Undeclared##Undeclared#>) // expected-error {{editor placeholder}} expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{ambiguous use of 'foo'}}
 
 func f(_ n: Int) {}
 let a1 = <#T#> // expected-error{{editor placeholder in source file}}

--- a/validation-test/Sema/SwiftUI/sr14213.swift
+++ b/validation-test/Sema/SwiftUI/sr14213.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct Experiment: View {
+  var body: some View {
+    HStack { // expected-error {{generic parameter 'Content' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}emacs
+      Slider(value: <#T##Binding<BinaryFloatingPoint>#>, in: <#T##ClosedRange<BinaryFloatingPoint>#>, label: <#T##() -> _#>) // expected-error 3 {{editor placeholder in source file}} expected-error {{expected type for function result}}
+      // expected-error@-1 {{protocol 'BinaryFloatingPoint' as a type cannot conform to 'Comparable'}}
+      // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+    }
+  }
+}


### PR DESCRIPTION
… is invalid

Type inside of an editor placeholder is more of a hint than anything else,
so if it's incorrect let's diagnose that and use type variable instead to
allow solver to make forward progress.

Resolves: SR-14213
Resolves: rdar://74356736

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
