### PR TITLE
Make sure that imported @MainActor shows up in the interface.

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1020,7 +1020,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       type.print(Printer, Options);
     else
       attr->getTypeRepr()->print(Printer, Options);
-    if (attr->isArgUnsafe())
+    if (attr->isArgUnsafe() && Options.IsForSwiftInterface)
       Printer << "(unsafe)";
     Printer.printNamePost(PrintNameContext::Attribute);
     break;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8188,8 +8188,6 @@ void ClangImporter::Implementation::importAttributes(
           auto typeExpr = TypeExpr::createImplicit(mainActorType, SwiftContext);
           auto attr = CustomAttr::create(SwiftContext, SourceLoc(), typeExpr);
           attr->setArgIsUnsafe(isUnsafe);
-          if (isUnsafe)
-            attr->setImplicit();
           MappedDecl->getAttrs().add(attr);
         }
 

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -39,8 +39,8 @@ import _Concurrency
 // CHECK-LABEL: protocol ProtocolWithSwiftAttributes {
 // CHECK-NEXT: @actorIndependent func independentMethod()
 // CHECK-NEXT: @asyncHandler func asyncHandlerMethod()
-// CHECK-NEXT: {{^}}  func mainActorMethod()
-// CHECK-NEXT: {{^}}  func uiActorMethod()
+// CHECK-NEXT: {{^}}  @MainActor func mainActorMethod()
+// CHECK-NEXT: {{^}}  @MainActor func uiActorMethod()
 // CHECK-NEXT: {{^}}  optional func missingAtAttributeMethod()
 // CHECK-NEXT: {{^[}]$}}
 


### PR DESCRIPTION
... but don't show the (unsafe) part outside of Swift interfaces, because
it's messy and we don't want people to use it.
