### PR TITLE
[ConstraintSystem] Add a property-wrapper constraint to allow for inference of implicit property wrappers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5574,16 +5574,15 @@ ERROR(property_wrapper_param_not_supported,none,
       (DescriptiveDeclKind))
 NOTE(property_wrapper_declared_here,none,
      "property wrapper type %0 declared here", (Identifier))
-ERROR(property_wrapper_param_no_projection,none,
-      "cannot use property wrapper projection parameter; "
-      "wrapper %0 does not have a 'projectedValue'", (Type))
-ERROR(property_wrapper_param_no_wrapper,none,
-      "cannot use property wrapper projection argument; "
-      "parameter does not have an attached property wrapper",
-      ())
-ERROR(property_wrapper_param_projection_invalid,none,
-      "cannot use property wrapper projection argument; "
-      "pass wrapped value type %0 instead", (Type))
+ERROR(invalid_projection_argument,none,
+      "cannot use property wrapper projection argument", ())
+NOTE(property_wrapper_param_no_wrapper,none,
+     "parameter %0 does not have an attached property wrapper", (Identifier))
+NOTE(property_wrapper_param_attr_arg,none,
+     "property wrapper has arguments in the wrapper attribute", ())
+NOTE(property_wrapper_no_init_projected_value,none,
+     "property wrapper type %0 does not support initialization from a "
+     "projected value", (Type))
 ERROR(property_wrapper_param_mutating,none,
       "property wrapper applied to parameter must have a nonmutating "
       "'wrappedValue' getter", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5575,7 +5575,8 @@ ERROR(property_wrapper_param_not_supported,none,
 NOTE(property_wrapper_declared_here,none,
      "property wrapper type %0 declared here", (Identifier))
 ERROR(invalid_projection_argument,none,
-      "cannot use property wrapper projection argument", ())
+      "cannot use property wrapper projection %select{argument|parameter}0",
+      (bool))
 NOTE(property_wrapper_param_no_wrapper,none,
      "parameter %0 does not have an attached property wrapper", (Identifier))
 NOTE(property_wrapper_param_attr_arg,none,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3329,7 +3329,7 @@ END_CAN_TYPE_WRAPPER(FunctionType, AnyFunctionType)
 struct ParameterListInfo {
   SmallBitVector defaultArguments;
   SmallBitVector acceptsUnlabeledTrailingClosures;
-  SmallVector<const ParamDecl *, 4> propertyWrappers;
+  SmallBitVector propertyWrappers;
 
 public:
   ParameterListInfo() { }
@@ -3346,7 +3346,7 @@ public:
 
   /// The ParamDecl at the given index if the parameter has an applied
   /// property wrapper.
-  const ParamDecl *getPropertyWrapperParam(unsigned paramIdx) const;
+  bool hasExternalPropertyWrapper(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -122,6 +122,10 @@ enum class FixKind : uint8_t {
   /// the storage or property wrapper.
   UseWrappedValue,
 
+  /// Allow a type that is not a property wrapper to be used as a property
+  /// wrapper.
+  AllowInvalidPropertyWrapperType,
+
   /// Remove the '$' prefix from an argument label or parameter name.
   RemoveProjectedValueArgument,
 
@@ -978,6 +982,25 @@ public:
   static UseWrappedValue *create(ConstraintSystem &cs, VarDecl *propertyWrapper,
                                  Type base, Type wrapper,
                                  ConstraintLocator *locator);
+};
+
+class AllowInvalidPropertyWrapperType final : public ConstraintFix {
+  Type wrapperType;
+
+  AllowInvalidPropertyWrapperType(ConstraintSystem &cs, Type wrapperType,
+                                  ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowInvalidPropertyWrapperType, locator),
+        wrapperType(wrapperType) {}
+
+public:
+  static AllowInvalidPropertyWrapperType *create(ConstraintSystem &cs, Type wrapperType,
+                                                 ConstraintLocator *locator);
+
+  std::string getName() const override {
+    return "allow invalid property wrapper type";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
 };
 
 class RemoveProjectedValueArgument final : public ConstraintFix {

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -122,12 +122,8 @@ enum class FixKind : uint8_t {
   /// the storage or property wrapper.
   UseWrappedValue,
 
-  /// Add 'var projectedValue' to the property wrapper type to allow passing
-  /// a projection argument.
-  AddProjectedValue,
-
-  /// Add '@propertyWrapper' to a nominal type declaration.
-  AddPropertyWrapperAttribute,
+  /// Remove the '$' prefix from an argument label or parameter name.
+  RemoveProjectedValueArgument,
 
   /// Instead of spelling out `subscript` directly, use subscript operator.
   UseSubscriptOperator,
@@ -984,37 +980,21 @@ public:
                                  ConstraintLocator *locator);
 };
 
-class AddProjectedValue final : public ConstraintFix {
+class RemoveProjectedValueArgument final : public ConstraintFix {
   Type wrapperType;
+  ParamDecl *param;
 
-  AddProjectedValue(ConstraintSystem &cs, Type wrapper,
-                    ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AddProjectedValue, locator), wrapperType(wrapper) {}
+  RemoveProjectedValueArgument(ConstraintSystem &cs, Type wrapper,
+                               ParamDecl *param, ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::RemoveProjectedValueArgument, locator),
+        wrapperType(wrapper), param(param) {}
 
 public:
-  static AddProjectedValue *create(ConstraintSystem &cs, Type wrapper,
-                                   ConstraintLocator *locator);
+  static RemoveProjectedValueArgument *create(ConstraintSystem &cs, Type wrapper,
+                                              ParamDecl *param, ConstraintLocator *locator);
 
   std::string getName() const override {
-    return "add 'var projectedValue' to pass a projection argument";
-  }
-
-  bool diagnose(const Solution &solution, bool asNote = false) const override;
-};
-
-class AddPropertyWrapperAttribute final : public ConstraintFix {
-  Type wrapperType;
-
-  AddPropertyWrapperAttribute(ConstraintSystem &cs, Type wrapper,
-                              ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AddPropertyWrapperAttribute, locator), wrapperType(wrapper) {}
-
-public:
-  static AddPropertyWrapperAttribute *create(ConstraintSystem &cs, Type wrapper,
-                                             ConstraintLocator *locator);
-
-  std::string getName() const override {
-    return "add '@propertyWrapper'";
+    return "remove '$' from argument label";
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -187,6 +187,9 @@ enum class ConstraintKind : char {
   /// - If base is a protocol metatype, this constraint becomes a conformance
   ///   check instead of an equality.
   UnresolvedMemberChainBase,
+  /// The first type is a property wrapper with a wrapped-value type
+  /// equal to the second type.
+  PropertyWrapper,
 };
 
 /// Classification of the different kinds of constraints.
@@ -586,6 +589,7 @@ public:
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
     case ConstraintKind::ValueWitness:
+    case ConstraintKind::PropertyWrapper:
       return ConstraintClassification::Member;
 
     case ConstraintKind::DynamicTypeOf:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4595,6 +4595,11 @@ private:
       ArrayRef<TypeVariableType *> referencedOuterParameters,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
+  /// Attempt to simplify a property wrapper constraint.
+  SolutionKind simplifyPropertyWrapperConstraint(Type wrapperType, Type wrappedValueType,
+                                                 TypeMatchOptions flags,
+                                                 ConstraintLocatorBuilder locator);
+
   /// Attempt to simplify a one-way constraint.
   SolutionKind simplifyOneWayConstraint(ConstraintKind kind,
                                         Type first, Type second,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -967,7 +967,7 @@ ParameterListInfo::ParameterListInfo(
     }
 
     if (param->hasAttachedPropertyWrapper()) {
-      propertyWrappers[i] = param;
+      propertyWrappers.set(i);
     }
   }
 }
@@ -983,9 +983,8 @@ bool ParameterListInfo::acceptsUnlabeledTrailingClosureArgument(
       acceptsUnlabeledTrailingClosures[paramIdx];
 }
 
-const ParamDecl *
-ParameterListInfo::getPropertyWrapperParam(unsigned paramIdx) const {
-  return paramIdx < propertyWrappers.size() ? propertyWrappers[paramIdx] : nullptr;
+bool ParameterListInfo::hasExternalPropertyWrapper(unsigned paramIdx) const {
+  return paramIdx < propertyWrappers.size() ? propertyWrappers[paramIdx] : false;
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5895,7 +5895,8 @@ Expr *ExprRewriter::coerceCallArguments(
       return true;
     };
 
-    if (auto *param = paramInfo.getPropertyWrapperParam(paramIdx)) {
+    if (paramInfo.hasExternalPropertyWrapper(paramIdx)) {
+      auto *param = getParameterAt(callee.getDecl(), paramIdx);
       auto appliedWrapper = appliedPropertyWrappers[appliedWrapperIndex++];
       auto wrapperType = solution.simplifyType(appliedWrapper.wrapperType);
       auto initKind = appliedWrapper.initKind;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1251,7 +1251,6 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
-  case ConstraintKind::PropertyWrapper:
     // Constraints from which we can't do anything.
     break;
 
@@ -1314,7 +1313,8 @@ void PotentialBindings::infer(Constraint *constraint) {
 
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
-  case ConstraintKind::ValueWitness: {
+  case ConstraintKind::ValueWitness:
+  case ConstraintKind::PropertyWrapper: {
     // If current type variable represents a member type of some reference,
     // it would be bound once member is resolved either to a actual member
     // type or to a hole if member couldn't be found.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1251,6 +1251,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::FunctionInput:
   case ConstraintKind::FunctionResult:
   case ConstraintKind::OpaqueUnderlyingType:
+  case ConstraintKind::PropertyWrapper:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1079,6 +1079,17 @@ public:
   bool diagnoseAsError() override;
 };
 
+class InvalidPropertyWrapperType final : public FailureDiagnostic {
+  Type wrapperType;
+
+public:
+  InvalidPropertyWrapperType(const Solution &solution, Type wrapper,
+                             ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), wrapperType(resolveType(wrapper)) {}
+
+  bool diagnoseAsError() override;
+};
+
 class InvalidProjectedValueArgument final : public FailureDiagnostic {
   Type wrapperType;
   ParamDecl *param;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1079,24 +1079,15 @@ public:
   bool diagnoseAsError() override;
 };
 
-class MissingProjectedValueFailure final : public FailureDiagnostic {
+class InvalidProjectedValueArgument final : public FailureDiagnostic {
   Type wrapperType;
+  ParamDecl *param;
 
 public:
-  MissingProjectedValueFailure(const Solution &solution, Type wrapper,
-                               ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator), wrapperType(resolveType(wrapper)) {}
-
-  bool diagnoseAsError() override;
-};
-
-class MissingPropertyWrapperAttributeFailure final : public FailureDiagnostic {
-  Type wrapperType;
-
-public:
-  MissingPropertyWrapperAttributeFailure(const Solution &solution, Type wrapper,
-                                         ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator), wrapperType(resolveType(wrapper)) {}
+  InvalidProjectedValueArgument(const Solution &solution, Type wrapper,
+                                ParamDecl *param, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), wrapperType(resolveType(wrapper)),
+        param(param) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -646,25 +646,15 @@ UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
       UseWrappedValue(cs, propertyWrapper, base, wrapper, locator);
 }
 
-bool AddProjectedValue::diagnose(const Solution &solution, bool asNote) const {
-  MissingProjectedValueFailure failure(solution, wrapperType, getLocator());
+bool RemoveProjectedValueArgument::diagnose(const Solution &solution, bool asNote) const {
+  InvalidProjectedValueArgument failure(solution, wrapperType, param, getLocator());
   return failure.diagnose(asNote);
 }
 
-AddProjectedValue *AddProjectedValue::create(ConstraintSystem &cs, Type wrapperType,
-                                             ConstraintLocator *locator) {
-  return new (cs.getAllocator()) AddProjectedValue(cs, wrapperType, locator);
-}
-
-bool AddPropertyWrapperAttribute::diagnose(const Solution &solution, bool asNote) const {
-  MissingPropertyWrapperAttributeFailure failure(solution, wrapperType, getLocator());
-  return failure.diagnose(asNote);
-}
-
-AddPropertyWrapperAttribute *AddPropertyWrapperAttribute::create(ConstraintSystem &cs,
-                                                                 Type wrapperType,
-                                                                 ConstraintLocator *locator) {
-  return new (cs.getAllocator()) AddPropertyWrapperAttribute(cs, wrapperType, locator);
+RemoveProjectedValueArgument *
+RemoveProjectedValueArgument::create(ConstraintSystem &cs, Type wrapperType,
+                                      ParamDecl *param, ConstraintLocator *locator) {
+  return new (cs.getAllocator()) RemoveProjectedValueArgument(cs, wrapperType, param, locator);
 }
 
 bool UseSubscriptOperator::diagnose(const Solution &solution,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -646,6 +646,17 @@ UseWrappedValue *UseWrappedValue::create(ConstraintSystem &cs,
       UseWrappedValue(cs, propertyWrapper, base, wrapper, locator);
 }
 
+bool AllowInvalidPropertyWrapperType::diagnose(const Solution &solution, bool asNote) const {
+  InvalidPropertyWrapperType failure(solution, wrapperType, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowInvalidPropertyWrapperType *
+AllowInvalidPropertyWrapperType::create(ConstraintSystem &cs, Type wrapperType,
+                                        ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowInvalidPropertyWrapperType(cs, wrapperType, locator);
+}
+
 bool RemoveProjectedValueArgument::diagnose(const Solution &solution, bool asNote) const {
   InvalidProjectedValueArgument failure(solution, wrapperType, param, getLocator());
   return failure.diagnose(asNote);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4104,6 +4104,12 @@ ConstraintSystem::applyPropertyWrapperToParameter(
   if (argLabel.hasDollarPrefix()) {
     Type projectionType = computeProjectedValueType(param, wrapperType);
     addConstraint(matchKind, paramType, projectionType, locator);
+    if (param->hasImplicitPropertyWrapper()) {
+      auto wrappedValueType = getType(param->getPropertyWrapperWrappedValueVar());
+      addConstraint(ConstraintKind::PropertyWrapper, projectionType, wrappedValueType,
+                    getConstraintLocator(param));
+    }
+
     initKind = PropertyWrapperInitKind::ProjectedValue;
   } else {
     generateWrappedPropertyTypeConstraints(*this, wrapperType, param, paramType);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4071,12 +4071,29 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     anchor = apply->getFn();
   }
 
-  if (argLabel.hasDollarPrefix() && (!param || !param->hasAttachedPropertyWrapper())) {
+  auto supportsProjectedValueInit = [&](ParamDecl *param) -> bool {
+    if (!param->hasAttachedPropertyWrapper())
+      return false;
+
+    if (param->hasImplicitPropertyWrapper())
+      return true;
+
+    if (param->getAttachedPropertyWrappers().front()->getArg())
+      return false;
+
+    auto wrapperInfo = param->getAttachedPropertyWrapperTypeInfo(0);
+    return wrapperInfo.projectedValueVar && wrapperInfo.hasProjectedValueInit;
+  };
+
+  if (argLabel.hasDollarPrefix() && (!param || !supportsProjectedValueInit(param))) {
     if (!shouldAttemptFixes())
       return getTypeMatchFailure(locator);
 
-    addConstraint(matchKind, paramType, wrapperType, locator);
-    auto *fix = AddPropertyWrapperAttribute::create(*this, wrapperType, getConstraintLocator(locator));
+    if (paramType->hasTypeVariable())
+      recordPotentialHole(paramType);
+
+    auto *loc = getConstraintLocator(locator);
+    auto *fix = RemoveProjectedValueArgument::create(*this, wrapperType, param, loc);
     if (recordFix(fix))
       return getTypeMatchFailure(locator);
 
@@ -4085,34 +4102,8 @@ ConstraintSystem::applyPropertyWrapperToParameter(
 
   PropertyWrapperInitKind initKind;
   if (argLabel.hasDollarPrefix()) {
-    auto attemptProjectedValueFix = [&](ConstraintFix *fix) -> ConstraintSystem::TypeMatchResult {
-      if (shouldAttemptFixes()) {
-        if (paramType->hasTypeVariable())
-          recordPotentialHole(paramType);
-
-        if (!recordFix(fix))
-          return getTypeMatchSuccess();
-      }
-
-      return getTypeMatchFailure(locator);
-    };
-
-    auto typeInfo = wrapperType->getAnyNominal()->getPropertyWrapperTypeInfo();
-    if (!typeInfo.projectedValueVar) {
-      auto *fix = AddProjectedValue::create(*this, wrapperType, getConstraintLocator(locator));
-      return attemptProjectedValueFix(fix);
-    }
-
     Type projectionType = computeProjectedValueType(param, wrapperType);
     addConstraint(matchKind, paramType, projectionType, locator);
-
-    if (!param->hasImplicitPropertyWrapper() &&
-        param->getAttachedPropertyWrappers().front()->getArg()) {
-      auto *fix = UseWrappedValue::create(*this, param, /*base=*/Type(), wrapperType,
-                                          getConstraintLocator(locator));
-      return attemptProjectedValueFix(fix);
-    }
-
     initKind = PropertyWrapperInitKind::ProjectedValue;
   } else {
     generateWrappedPropertyTypeConstraints(*this, wrapperType, param, paramType);

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -68,6 +68,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::UnresolvedMemberChainBase:
+  case ConstraintKind::PropertyWrapper:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -144,6 +145,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
+  case ConstraintKind::PropertyWrapper:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -272,6 +274,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
+  case ConstraintKind::PropertyWrapper:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -369,6 +372,9 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     break;
   case ConstraintKind::UnresolvedMemberChainBase:
     Out << " unresolved member chain base ";
+    break;
+  case ConstraintKind::PropertyWrapper:
+    Out << " property wrapper with wrapped value of ";
     break;
   case ConstraintKind::KeyPath:
       Out << " key path from ";
@@ -597,6 +603,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
+  case ConstraintKind::PropertyWrapper:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -108,3 +108,20 @@ func testImplicitPropertyWrapper() {
     (_value, value, $value)
   }
 }
+
+@resultBuilder
+struct PairBuilder {
+  static func buildBlock<T1, T2>(_ t1: T1, _ t2: T2) -> (T1, T2) {
+    return (t1, t2)
+  }
+}
+
+func takesResultBuilder<Projection, T1, T2>(projection: Projection,
+                                            @PairBuilder _ closure: (Projection) -> (T1, T2)) {}
+
+func testResultBuilderWithImplicitWrapper(@ProjectionWrapper value: String) {
+  takesResultBuilder(projection: $value) { $value in
+    value
+    $value
+  }
+}

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -33,12 +33,13 @@ struct NoProjection<T> {
   var wrappedValue: T
 }
 
+// expected-note@+1 {{property wrapper type 'NoProjection<String>' does not support initialization from a projected value}}
 func takesNoProjectionWrapper(@NoProjection value: String) {}
 
 func testNoProjection(message: String) {
   takesNoProjectionWrapper(value: message) // okay
 
-  // expected-error@+1 {{cannot use property wrapper projection parameter; wrapper 'NoProjection<String>' does not have a 'projectedValue'}}
+  // expected-error@+1 {{cannot use property wrapper projection argument}}
   takesNoProjectionWrapper($value: message)
 }
 
@@ -60,12 +61,15 @@ struct Wrapper<T> {
   var projectedValue: Projection<T> { Projection(value: wrappedValue) }
 }
 
+// expected-note@+2 {{property wrapper has arguments in the wrapper attribute}}
+// expected-note@+1 {{in call to function 'hasWrapperAttributeArg(value:)'}}
 func hasWrapperAttributeArg<T>(@Wrapper() value: T) {}
 
 func testWrapperAttributeArg(projection: Projection<Int>) {
   hasWrapperAttributeArg(value: projection.value)
 
-  // expected-error@+1 {{cannot use property wrapper projection argument; pass wrapped value type 'Int' instead}}
+  // expected-error@+2 {{cannot use property wrapper projection argument}}
+  // expected-error@+1 {{generic parameter 'T' could not be inferred}}
   hasWrapperAttributeArg($value: projection)
 }
 
@@ -75,12 +79,13 @@ struct S {
 }
 
 func testInvalidArgLabel() {
+  // expected-note@+1 2 {{parameter 'argLabel' does not have an attached property wrapper}}
   func noWrappers(argLabel: Int) {}
 
-  // expected-error@+1 {{cannot use property wrapper projection argument; parameter does not have an attached property wrapper}}
+  // expected-error@+1 {{cannot use property wrapper projection argument}}
   let ref = noWrappers($argLabel:)
 
-  // expected-error@+1 {{cannot use property wrapper projection argument; parameter does not have an attached property wrapper}}
+  // expected-error@+1 {{cannot use property wrapper projection argument}}
   noWrappers($argLabel: 10)
 }
 

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -41,6 +41,12 @@ func testNoProjection(message: String) {
 
   // expected-error@+1 {{cannot use property wrapper projection argument}}
   takesNoProjectionWrapper($value: message)
+
+  // expected-error@+2 {{cannot use property wrapper projection parameter}}
+  // expected-note@+1 {{property wrapper type 'NoProjection<Int>' does not support initialization from a projected value}}
+  let _: (NoProjection<Int>) -> Int = { $value in
+    return value
+  }
 }
 
 struct Projection<T> {


### PR DESCRIPTION
Another handful of commits from https://github.com/apple/swift/pull/36344 that are independent from the revision.

* Add a property-wrapper constraint that is used to delay checking if an inferred property-wrapper type is actually a property wrapper.
* Improve diagnostics for invalid use of the `$` syntax with wrapped parameters and arguments.

Resolves: rdar://71902161