### PR TITLE
Concrete simd mask operations

### DIFF
--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -38,13 +38,32 @@ extension SIMDMask where Storage == ${Vector} {
     return zero .== zero
   }
   
-  /// A vector mask that is the boolean negation of the input.
+  /// A vector mask that is the pointwise logical negation of the input.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = !a[i]
+  /// }
+  /// ```
   @_alwaysEmitIntoClient
   public static prefix func .!(a: Self) -> Self {
     a .^ .allTrue
   }
     
-  /// A vector mask that is the boolean conjunction of the inputs.
+  /// A vector mask that is the pointwise logical conjunction of the inputs.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] && b[i]
+  /// }
+  /// ```
+  ///
+  /// Note that unlike the scalar `&&` operator, the SIMD `.&` operator
+  /// always fully evaluates both arguments.
   @_alwaysEmitIntoClient
   public static func .&(a: Self, b: Self) -> Self {
     Self(${Vector}(Builtin.and_${Builtin}(
@@ -52,8 +71,29 @@ extension SIMDMask where Storage == ${Vector} {
       b._storage._storage._value
     )))
   }
+    
+  /// Replaces `a` with the pointwise logical conjuction of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in a.indices {
+  ///   a[i] = a[i] && b[i]
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public static func .&=(a: inout Self, b: Self) {
+    a = a .& b
+  }
       
-  /// A vector mask that is the exclusive or of the inputs.
+  /// A vector mask that is the pointwise exclusive or of the inputs.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] != b[i]
+  /// }
+  /// ```
   @_alwaysEmitIntoClient
   public static func .^(a: Self, b: Self) -> Self {
     Self(${Vector}(Builtin.xor_${Builtin}(
@@ -61,14 +101,108 @@ extension SIMDMask where Storage == ${Vector} {
       b._storage._storage._value
     )))
   }
+    
+  /// Replaces `a` with the pointwise exclusive or of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in a.indices {
+  ///   a[i] = a[i] != b[i]
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public static func .^=(a: inout Self, b: Self) {
+    a = a .^ b
+  }
       
-  /// A vector mask that is the boolean disjunction of the inputs.
+  /// A vector mask that is the pointwise logical disjunction of the inputs.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] || b[i]
+  /// }
+  /// ```
+  ///
+  /// Note that unlike the scalar `||` operator, the SIMD `.|` operator
+  /// always fully evaluates both arguments.
   @_alwaysEmitIntoClient
   public static func .|(a: Self, b: Self) -> Self {
     Self(${Vector}(Builtin.or_${Builtin}(
       a._storage._storage._value,
       b._storage._storage._value
     )))
+  }
+    
+  /// Replaces `a` with the pointwise logical disjunction of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in a.indices {
+  ///   a[i] = a[i] || b[i]
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public static func .|=(a: inout Self, b: Self) {
+    a = a .| b
+  }
+    
+  /// A vector mask with the result of a pointwise equality comparison.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] == b[i]
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public static func .==(a: Self, b: Self) -> Self {
+    .!(a .^ b)
+  }
+  
+  /// A vector mask with the result of a pointwise inequality comparison.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] != b[i]
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public static func .!=(a: Self, b: Self) -> Self {
+    a .^ b
+  }
+    
+  /// Replaces elements of this vector with elements of `other` in the lanes
+  /// where `mask` is `true`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in indices {
+  ///   if mask[i] { self[i] = other[i] }
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public mutating func replace(with other: Self, where mask: Self) {
+    self = replacing(with: other, where: mask)
+  }
+    
+  /// Returns a copy of this vector, with elements replaced by elements of
+  /// `other` in the lanes where `mask` is `true`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = Self()
+  /// for i in indices {
+  ///   result[i] = mask[i] ? other[i] : self[i]
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public func replacing(with other: Self, where mask: Self) -> Self {
+    (self .& .!mask) .| (other .& mask)
   }
 }
 

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -97,9 +97,9 @@ extension SIMD {
   
   /// Returns a Boolean value indicating whether two vectors are equal.
   @_transparent
-  public static func ==(lhs: Self, rhs: Self) -> Bool {
+  public static func ==(a: Self, b: Self) -> Bool {
     var result = true
-    for i in lhs.indices { result = result && lhs[i] == rhs[i] }
+    for i in a.indices { result = result && a[i] == b[i] }
     return result
   }
   
@@ -154,18 +154,18 @@ extension SIMD {
   
   /// A vector mask with the result of a pointwise equality comparison.
   @_transparent
-  public static func .==(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
+  public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
-    for i in result.indices { result[i] = lhs[i] == rhs[i] }
+    for i in result.indices { result[i] = a[i] == b[i] }
     return result
   }
   
   /// Returns a vector mask with the result of a pointwise inequality
   /// comparison.
   @_transparent
-  public static func .!=(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
+  public static func .!=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
-    for i in result.indices { result[i] = lhs[i] != rhs[i] }
+    for i in result.indices { result[i] = a[i] != b[i] }
     return result
   }
   
@@ -319,18 +319,18 @@ extension SIMD where Scalar: Comparable {
   /// Returns a vector mask with the result of a pointwise less than
   /// comparison.
   @_transparent
-  public static func .<(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
+  public static func .<(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
-    for i in result.indices { result[i] = lhs[i] < rhs[i] }
+    for i in result.indices { result[i] = a[i] < b[i] }
     return result
   }
   
   /// Returns a vector mask with the result of a pointwise less than or equal
   /// comparison.
   @_transparent
-  public static func .<=(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
+  public static func .<=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
-    for i in result.indices { result[i] = lhs[i] <= rhs[i] }
+    for i in result.indices { result[i] = a[i] <= b[i] }
     return result
   }
   
@@ -352,26 +352,26 @@ extension SIMD where Scalar: Comparable {
 extension SIMD {
   /// Returns a vector mask with the result of a pointwise equality comparison.
   @_transparent
-  public static func .==(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> {
-    return Self(repeating: lhs) .== rhs
+  public static func .==(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    return Self(repeating: a) .== b
   }
 
   /// Returns a vector mask with the result of a pointwise inequality comparison.
   @_transparent
-  public static func .!=(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> {
-    return Self(repeating: lhs) .!= rhs
+  public static func .!=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    return Self(repeating: a) .!= b
   }
 
   /// Returns a vector mask with the result of a pointwise equality comparison.
   @_transparent
-  public static func .==(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> {
-    return lhs .== Self(repeating: rhs)
+  public static func .==(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    return a .== Self(repeating: b)
   }
 
   /// Returns a vector mask with the result of a pointwise inequality comparison.
   @_transparent
-  public static func .!=(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> {
-    return lhs .!= Self(repeating: rhs)
+  public static func .!=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    return a .!= Self(repeating: b)
   }
   
   /// Replaces elements of this vector with `other` in the lanes where `mask`
@@ -402,69 +402,69 @@ extension SIMD where Scalar: Comparable {
   /// Returns a vector mask with the result of a pointwise greater than or
   /// equal comparison.
   @_transparent
-  public static func .>=(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
-    return rhs .<= lhs
+  public static func .>=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    return b .<= a
   }
 
   /// Returns a vector mask with the result of a pointwise greater than
   /// comparison.
   @_transparent
-  public static func .>(lhs: Self, rhs: Self) -> SIMDMask<MaskStorage> {
-    return rhs .< lhs
+  public static func .>(a: Self, b: Self) -> SIMDMask<MaskStorage> {
+    return b .< a
   }
 
   /// Returns a vector mask with the result of a pointwise less than comparison.
   @_transparent
-  public static func .<(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> {
-    return Self(repeating: lhs) .< rhs
+  public static func .<(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    return Self(repeating: a) .< b
   }
 
   /// Returns a vector mask with the result of a pointwise less than or equal
   /// comparison.
   @_transparent
-  public static func .<=(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> {
-    return Self(repeating: lhs) .<= rhs
+  public static func .<=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    return Self(repeating: a) .<= b
   }
 
   /// Returns a vector mask with the result of a pointwise greater than or
   /// equal comparison.
   @_transparent
-  public static func .>=(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> {
-    return Self(repeating: lhs) .>= rhs
+  public static func .>=(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    return Self(repeating: a) .>= b
   }
 
   /// Returns a vector mask with the result of a pointwise greater than
   /// comparison.
   @_transparent
-  public static func .>(lhs: Scalar, rhs: Self) -> SIMDMask<MaskStorage> {
-    return Self(repeating: lhs) .> rhs
+  public static func .>(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
+    return Self(repeating: a) .> b
   }
 
   /// Returns a vector mask with the result of a pointwise less than comparison.
   @_transparent
-  public static func .<(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> {
-    return lhs .< Self(repeating: rhs)
+  public static func .<(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    return a .< Self(repeating: b)
   }
 
   /// Returns a vector mask with the result of a pointwise less than or equal
   /// comparison.
   @_transparent
-  public static func .<=(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> {
-    return lhs .<= Self(repeating: rhs)
+  public static func .<=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    return a .<= Self(repeating: b)
   }
   
   /// Returns a vector mask with the result of a pointwise greater than or
   /// equal comparison.
   @_transparent
-  public static func .>=(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> {
-    return lhs .>= Self(repeating: rhs)
+  public static func .>=(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    return a .>= Self(repeating: b)
   }
   
   /// Returns a vector mask with the result of a pointwise greater than
   /// comparison.
   @_transparent
-  public static func .>(lhs: Self, rhs: Scalar) -> SIMDMask<MaskStorage> {
-    return lhs .> Self(repeating: rhs)
+  public static func .>(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
+    return a .> Self(repeating: b)
   }
   
   @_alwaysEmitIntoClient
@@ -691,79 +691,79 @@ extension SIMD where Scalar: FixedWidthInteger {
   }
   
   @_transparent
-  public static prefix func ~(rhs: Self) -> Self {
+  public static prefix func ~(a: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = ~rhs[i] }
+    for i in result.indices { result[i] = ~a[i] }
     return result
   }
   
   @_transparent
-  public static func &(lhs: Self, rhs: Self) -> Self {
+  public static func &(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] & rhs[i] }
+    for i in result.indices { result[i] = a[i] & b[i] }
     return result
   }
   
   @_transparent
-  public static func ^(lhs: Self, rhs: Self) -> Self {
+  public static func ^(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] ^ rhs[i] }
+    for i in result.indices { result[i] = a[i] ^ b[i] }
     return result
   }
   
   @_transparent
-  public static func |(lhs: Self, rhs: Self) -> Self {
+  public static func |(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] | rhs[i] }
+    for i in result.indices { result[i] = a[i] | b[i] }
     return result
   }
   
   @_transparent
-  public static func &<<(lhs: Self, rhs: Self) -> Self {
+  public static func &<<(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] &<< rhs[i] }
+    for i in result.indices { result[i] = a[i] &<< b[i] }
     return result
   }
   
   @_transparent
-  public static func &>>(lhs: Self, rhs: Self) -> Self {
+  public static func &>>(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] &>> rhs[i] }
+    for i in result.indices { result[i] = a[i] &>> b[i] }
     return result
   }
   
   @_transparent
-  public static func &+(lhs: Self, rhs: Self) -> Self {
+  public static func &+(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] &+ rhs[i] }
+    for i in result.indices { result[i] = a[i] &+ b[i] }
     return result
   }
   
   @_transparent
-  public static func &-(lhs: Self, rhs: Self) -> Self {
+  public static func &-(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] &- rhs[i] }
+    for i in result.indices { result[i] = a[i] &- b[i] }
     return result
   }
   
   @_transparent
-  public static func &*(lhs: Self, rhs: Self) -> Self {
+  public static func &*(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] &* rhs[i] }
+    for i in result.indices { result[i] = a[i] &* b[i] }
     return result
   }
   
   @_transparent
-  public static func /(lhs: Self, rhs: Self) -> Self {
+  public static func /(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] / rhs[i] }
+    for i in result.indices { result[i] = a[i] / b[i] }
     return result
   }
   
   @_transparent
-  public static func %(lhs: Self, rhs: Self) -> Self {
+  public static func %(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] % rhs[i] }
+    for i in result.indices { result[i] = a[i] % b[i] }
     return result
   }
   
@@ -781,37 +781,37 @@ extension SIMD where Scalar: FixedWidthInteger {
 //  be replaced with @_semantics to lower directly to vector IR nodes.
 extension SIMD where Scalar: FloatingPoint {
   @_transparent
-  public static func +(lhs: Self, rhs: Self) -> Self {
+  public static func +(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] + rhs[i] }
+    for i in result.indices { result[i] = a[i] + b[i] }
     return result
   }
   
   @_transparent
-  public static func -(lhs: Self, rhs: Self) -> Self {
+  public static func -(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] - rhs[i] }
+    for i in result.indices { result[i] = a[i] - b[i] }
     return result
   }
   
   @_transparent
-  public static func *(lhs: Self, rhs: Self) -> Self {
+  public static func *(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] * rhs[i] }
+    for i in result.indices { result[i] = a[i] * b[i] }
     return result
   }
   
   @_transparent
-  public static func /(lhs: Self, rhs: Self) -> Self {
+  public static func /(a: Self, b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = lhs[i] / rhs[i] }
+    for i in result.indices { result[i] = a[i] / b[i] }
     return result
   }
   
   @_transparent
-  public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
+  public func addingProduct(_ a: Self, _ b: Self) -> Self {
     var result = Self()
-    for i in result.indices { result[i] = self[i].addingProduct(lhs[i], rhs[i]) }
+    for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
     return result
   }
   
@@ -856,23 +856,23 @@ extension SIMD where Scalar: FloatingPoint {
 
 extension SIMDMask {
   @_transparent
-  public static prefix func .!(rhs: SIMDMask) -> SIMDMask {
-    return SIMDMask(~rhs._storage)
+  public static prefix func .!(a: SIMDMask) -> SIMDMask {
+    return SIMDMask(~a._storage)
   }
   
   @_transparent
-  public static func .&(lhs: SIMDMask, rhs: SIMDMask) -> SIMDMask {
-    return SIMDMask(lhs._storage & rhs._storage)
+  public static func .&(a: SIMDMask, b: SIMDMask) -> SIMDMask {
+    return SIMDMask(a._storage & b._storage)
   }
   
   @_transparent
-  public static func .^(lhs: SIMDMask, rhs: SIMDMask) -> SIMDMask {
-    return SIMDMask(lhs._storage ^ rhs._storage)
+  public static func .^(a: SIMDMask, b: SIMDMask) -> SIMDMask {
+    return SIMDMask(a._storage ^ b._storage)
   }
   
   @_transparent
-  public static func .|(lhs: SIMDMask, rhs: SIMDMask) -> SIMDMask {
-    return SIMDMask(lhs._storage | rhs._storage)
+  public static func .|(a: SIMDMask, b: SIMDMask) -> SIMDMask {
+    return SIMDMask(a._storage | b._storage)
   }
 }
 
@@ -881,277 +881,277 @@ extension SIMDMask {
 extension SIMD where Scalar: FixedWidthInteger {
   
   @_transparent
-  public static func &(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) & rhs
+  public static func &(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) & b
   }
   
   @_transparent
-  public static func ^(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) ^ rhs
+  public static func ^(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) ^ b
   }
   
   @_transparent
-  public static func |(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) | rhs
+  public static func |(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) | b
   }
   
   @_transparent
-  public static func &<<(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) &<< rhs
+  public static func &<<(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) &<< b
   }
   
   @_transparent
-  public static func &>>(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) &>> rhs
+  public static func &>>(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) &>> b
   }
   
   @_transparent
-  public static func &+(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) &+ rhs
+  public static func &+(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) &+ b
   }
   
   @_transparent
-  public static func &-(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) &- rhs
+  public static func &-(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) &- b
   }
   
   @_transparent
-  public static func &*(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) &* rhs
+  public static func &*(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) &* b
   }
   
   @_transparent
-  public static func /(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) / rhs
+  public static func /(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) / b
   }
   
   @_transparent
-  public static func %(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) % rhs
+  public static func %(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) % b
   }
   
   @_transparent
-  public static func &(lhs: Self, rhs: Scalar) -> Self {
-    return lhs & Self(repeating: rhs)
+  public static func &(a: Self, b: Scalar) -> Self {
+    return a & Self(repeating: b)
   }
   
   @_transparent
-  public static func ^(lhs: Self, rhs: Scalar) -> Self {
-    return lhs ^ Self(repeating: rhs)
+  public static func ^(a: Self, b: Scalar) -> Self {
+    return a ^ Self(repeating: b)
   }
   
   @_transparent
-  public static func |(lhs: Self, rhs: Scalar) -> Self {
-    return lhs | Self(repeating: rhs)
+  public static func |(a: Self, b: Scalar) -> Self {
+    return a | Self(repeating: b)
   }
   
   @_transparent
-  public static func &<<(lhs: Self, rhs: Scalar) -> Self {
-    return lhs &<< Self(repeating: rhs)
+  public static func &<<(a: Self, b: Scalar) -> Self {
+    return a &<< Self(repeating: b)
   }
   
   @_transparent
-  public static func &>>(lhs: Self, rhs: Scalar) -> Self {
-    return lhs &>> Self(repeating: rhs)
+  public static func &>>(a: Self, b: Scalar) -> Self {
+    return a &>> Self(repeating: b)
   }
   
   @_transparent
-  public static func &+(lhs: Self, rhs: Scalar) -> Self {
-    return lhs &+ Self(repeating: rhs)
+  public static func &+(a: Self, b: Scalar) -> Self {
+    return a &+ Self(repeating: b)
   }
   
   @_transparent
-  public static func &-(lhs: Self, rhs: Scalar) -> Self {
-    return lhs &- Self(repeating: rhs)
+  public static func &-(a: Self, b: Scalar) -> Self {
+    return a &- Self(repeating: b)
   }
   
   @_transparent
-  public static func &*(lhs: Self, rhs: Scalar) -> Self {
-    return lhs &* Self(repeating: rhs)
+  public static func &*(a: Self, b: Scalar) -> Self {
+    return a &* Self(repeating: b)
   }
   
   @_transparent
-  public static func /(lhs: Self, rhs: Scalar) -> Self {
-    return lhs / Self(repeating: rhs)
+  public static func /(a: Self, b: Scalar) -> Self {
+    return a / Self(repeating: b)
   }
   
   @_transparent
-  public static func %(lhs: Self, rhs: Scalar) -> Self {
-    return lhs % Self(repeating: rhs)
+  public static func %(a: Self, b: Scalar) -> Self {
+    return a % Self(repeating: b)
   }
   
   @_transparent
-  public static func &=(lhs: inout Self, rhs: Self) {
-    lhs = lhs & rhs
+  public static func &=(a: inout Self, b: Self) {
+    a = a & b
   }
   
   @_transparent
-  public static func ^=(lhs: inout Self, rhs: Self) {
-    lhs = lhs ^ rhs
+  public static func ^=(a: inout Self, b: Self) {
+    a = a ^ b
   }
   
   @_transparent
-  public static func |=(lhs: inout Self, rhs: Self) {
-    lhs = lhs | rhs
+  public static func |=(a: inout Self, b: Self) {
+    a = a | b
   }
   
   @_transparent
-  public static func &<<=(lhs: inout Self, rhs: Self) {
-    lhs = lhs &<< rhs
+  public static func &<<=(a: inout Self, b: Self) {
+    a = a &<< b
   }
   
   @_transparent
-  public static func &>>=(lhs: inout Self, rhs: Self) {
-    lhs = lhs &>> rhs
+  public static func &>>=(a: inout Self, b: Self) {
+    a = a &>> b
   }
   
   @_transparent
-  public static func &+=(lhs: inout Self, rhs: Self) {
-    lhs = lhs &+ rhs
+  public static func &+=(a: inout Self, b: Self) {
+    a = a &+ b
   }
   
   @_transparent
-  public static func &-=(lhs: inout Self, rhs: Self) {
-    lhs = lhs &- rhs
+  public static func &-=(a: inout Self, b: Self) {
+    a = a &- b
   }
   
   @_transparent
-  public static func &*=(lhs: inout Self, rhs: Self) {
-    lhs = lhs &* rhs
+  public static func &*=(a: inout Self, b: Self) {
+    a = a &* b
   }
   
   @_transparent
-  public static func /=(lhs: inout Self, rhs: Self) {
-    lhs = lhs / rhs
+  public static func /=(a: inout Self, b: Self) {
+    a = a / b
   }
   
   @_transparent
-  public static func %=(lhs: inout Self, rhs: Self) {
-    lhs = lhs % rhs
+  public static func %=(a: inout Self, b: Self) {
+    a = a % b
   }
   
   @_transparent
-  public static func &=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs & rhs
+  public static func &=(a: inout Self, b: Scalar) {
+    a = a & b
   }
   
   @_transparent
-  public static func ^=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs ^ rhs
+  public static func ^=(a: inout Self, b: Scalar) {
+    a = a ^ b
   }
   
   @_transparent
-  public static func |=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs | rhs
+  public static func |=(a: inout Self, b: Scalar) {
+    a = a | b
   }
   
   @_transparent
-  public static func &<<=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs &<< rhs
+  public static func &<<=(a: inout Self, b: Scalar) {
+    a = a &<< b
   }
   
   @_transparent
-  public static func &>>=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs &>> rhs
+  public static func &>>=(a: inout Self, b: Scalar) {
+    a = a &>> b
   }
   
   @_transparent
-  public static func &+=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs &+ rhs
+  public static func &+=(a: inout Self, b: Scalar) {
+    a = a &+ b
   }
   
   @_transparent
-  public static func &-=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs &- rhs
+  public static func &-=(a: inout Self, b: Scalar) {
+    a = a &- b
   }
   
   @_transparent
-  public static func &*=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs &* rhs
+  public static func &*=(a: inout Self, b: Scalar) {
+    a = a &* b
   }
   
   @_transparent
-  public static func /=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs / rhs
+  public static func /=(a: inout Self, b: Scalar) {
+    a = a / b
   }
   
   @_transparent
-  public static func %=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs % rhs
+  public static func %=(a: inout Self, b: Scalar) {
+    a = a % b
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&+' instead")
-  public static func +(lhs: Self, rhs: Self) -> Self {
+  public static func +(a: Self, b: Self) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&-' instead")
-  public static func -(lhs: Self, rhs: Self) -> Self {
+  public static func -(a: Self, b: Self) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&*' instead")
-  public static func *(lhs: Self, rhs: Self) -> Self {
+  public static func *(a: Self, b: Self) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&+' instead")
-  public static func +(lhs: Self, rhs: Scalar) -> Self {
+  public static func +(a: Self, b: Scalar) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&-' instead")
-  public static func -(lhs: Self, rhs: Scalar) -> Self {
+  public static func -(a: Self, b: Scalar) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&*' instead")
-  public static func *(lhs: Self, rhs: Scalar) -> Self {
+  public static func *(a: Self, b: Scalar) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&+' instead")
-  public static func +(lhs: Scalar, rhs: Self) -> Self {
+  public static func +(a: Scalar, b: Self) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&-' instead")
-  public static func -(lhs: Scalar, rhs: Self) -> Self {
+  public static func -(a: Scalar, b: Self) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&*' instead")
-  public static func *(lhs: Scalar, rhs: Self) -> Self {
+  public static func *(a: Scalar, b: Self) -> Self {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&+=' instead")
-  public static func +=(lhs: inout Self, rhs: Self) {
+  public static func +=(a: inout Self, b: Self) {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&-=' instead")
-  public static func -=(lhs: inout Self, rhs: Self) {
+  public static func -=(a: inout Self, b: Self) {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&*=' instead")
-  public static func *=(lhs: inout Self, rhs: Self) {
+  public static func *=(a: inout Self, b: Self) {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&+=' instead")
-  public static func +=(lhs: inout Self, rhs: Scalar) {
+  public static func +=(a: inout Self, b: Scalar) {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&-=' instead")
-  public static func -=(lhs: inout Self, rhs: Scalar) {
+  public static func -=(a: inout Self, b: Scalar) {
     fatalError()
   }
   
   @available(*, unavailable, message: "integer vector types do not support checked arithmetic; use the wrapping operator '&*=' instead")
-  public static func *=(lhs: inout Self, rhs: Scalar) {
+  public static func *=(a: inout Self, b: Scalar) {
     fatalError()
   }
 }
@@ -1159,113 +1159,113 @@ extension SIMD where Scalar: FixedWidthInteger {
 extension SIMD where Scalar: FloatingPoint {
   
   @_transparent
-  public static prefix func -(rhs: Self) -> Self {
-    return 0 - rhs
+  public static prefix func -(a: Self) -> Self {
+    return 0 - a
   }
   
   @_transparent
-  public static func +(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) + rhs
+  public static func +(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) + b
   }
   
   @_transparent
-  public static func -(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) - rhs
+  public static func -(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) - b
   }
   
   @_transparent
-  public static func *(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) * rhs
+  public static func *(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) * b
   }
   
   @_transparent
-  public static func /(lhs: Scalar, rhs: Self) -> Self {
-    return Self(repeating: lhs) / rhs
+  public static func /(a: Scalar, b: Self) -> Self {
+    return Self(repeating: a) / b
   }
   
   @_transparent
-  public static func +(lhs: Self, rhs: Scalar) -> Self {
-    return lhs + Self(repeating: rhs)
+  public static func +(a: Self, b: Scalar) -> Self {
+    return a + Self(repeating: b)
   }
   
   @_transparent
-  public static func -(lhs: Self, rhs: Scalar) -> Self {
-    return lhs - Self(repeating: rhs)
+  public static func -(a: Self, b: Scalar) -> Self {
+    return a - Self(repeating: b)
   }
   
   @_transparent
-  public static func *(lhs: Self, rhs: Scalar) -> Self {
-    return lhs * Self(repeating: rhs)
+  public static func *(a: Self, b: Scalar) -> Self {
+    return a * Self(repeating: b)
   }
   
   @_transparent
-  public static func /(lhs: Self, rhs: Scalar) -> Self {
-    return lhs / Self(repeating: rhs)
+  public static func /(a: Self, b: Scalar) -> Self {
+    return a / Self(repeating: b)
   }
   
   @_transparent
-  public static func +=(lhs: inout Self, rhs: Self) {
-    lhs = lhs + rhs
+  public static func +=(a: inout Self, b: Self) {
+    a = a + b
   }
   
   @_transparent
-  public static func -=(lhs: inout Self, rhs: Self) {
-    lhs = lhs - rhs
+  public static func -=(a: inout Self, b: Self) {
+    a = a - b
   }
   
   @_transparent
-  public static func *=(lhs: inout Self, rhs: Self) {
-    lhs = lhs * rhs
+  public static func *=(a: inout Self, b: Self) {
+    a = a * b
   }
   
   @_transparent
-  public static func /=(lhs: inout Self, rhs: Self) {
-    lhs = lhs / rhs
+  public static func /=(a: inout Self, b: Self) {
+    a = a / b
   }
   
   @_transparent
-  public static func +=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs + rhs
+  public static func +=(a: inout Self, b: Scalar) {
+    a = a + b
   }
   
   @_transparent
-  public static func -=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs - rhs
+  public static func -=(a: inout Self, b: Scalar) {
+    a = a - b
   }
   
   @_transparent
-  public static func *=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs * rhs
+  public static func *=(a: inout Self, b: Scalar) {
+    a = a * b
   }
   
   @_transparent
-  public static func /=(lhs: inout Self, rhs: Scalar) {
-    lhs = lhs / rhs
+  public static func /=(a: inout Self, b: Scalar) {
+    a = a / b
   }
   
   @_transparent
-  public func addingProduct(_ lhs: Scalar, _ rhs: Self) -> Self {
-    return self.addingProduct(Self(repeating: lhs), rhs)
+  public func addingProduct(_ a: Scalar, _ b: Self) -> Self {
+    return self.addingProduct(Self(repeating: a), b)
   }
   
   @_transparent
-  public func addingProduct(_ lhs: Self, _ rhs: Scalar) -> Self {
-    return self.addingProduct(lhs, Self(repeating: rhs))
+  public func addingProduct(_ a: Self, _ b: Scalar) -> Self {
+    return self.addingProduct(a, Self(repeating: b))
   }
   
   @_transparent
-  public mutating func addProduct(_ lhs: Self, _ rhs: Self) {
-    self = self.addingProduct(lhs, rhs)
+  public mutating func addProduct(_ a: Self, _ b: Self) {
+    self = self.addingProduct(a, b)
   }
   
   @_transparent
-  public mutating func addProduct(_ lhs: Scalar, _ rhs: Self) {
-    self = self.addingProduct(lhs, rhs)
+  public mutating func addProduct(_ a: Scalar, _ b: Self) {
+    self = self.addingProduct(a, b)
   }
   
   @_transparent
-  public mutating func addProduct(_ lhs: Self, _ rhs: Scalar) {
-    self = self.addingProduct(lhs, rhs)
+  public mutating func addProduct(_ a: Self, _ b: Scalar) {
+    self = self.addingProduct(a, b)
   }
   
   @_transparent
@@ -1281,63 +1281,63 @@ extension SIMD where Scalar: FloatingPoint {
 
 extension SIMDMask {
   @_transparent
-  public static func .&(lhs: Bool, rhs: SIMDMask) -> SIMDMask {
-    return SIMDMask(repeating: lhs) .& rhs
+  public static func .&(a: Bool, b: SIMDMask) -> SIMDMask {
+    return SIMDMask(repeating: a) .& b
   }
   
   @_transparent
-  public static func .^(lhs: Bool, rhs: SIMDMask) -> SIMDMask {
-    return SIMDMask(repeating: lhs) .^ rhs
+  public static func .^(a: Bool, b: SIMDMask) -> SIMDMask {
+    return SIMDMask(repeating: a) .^ b
   }
   
   @_transparent
-  public static func .|(lhs: Bool, rhs: SIMDMask) -> SIMDMask {
-    return SIMDMask(repeating: lhs) .| rhs
+  public static func .|(a: Bool, b: SIMDMask) -> SIMDMask {
+    return SIMDMask(repeating: a) .| b
   }
   
   @_transparent
-  public static func .&(lhs: SIMDMask, rhs: Bool) -> SIMDMask {
-    return lhs .& SIMDMask(repeating: rhs)
+  public static func .&(a: SIMDMask, b: Bool) -> SIMDMask {
+    return a .& SIMDMask(repeating: b)
   }
   
   @_transparent
-  public static func .^(lhs: SIMDMask, rhs: Bool) -> SIMDMask {
-    return lhs .^ SIMDMask(repeating: rhs)
+  public static func .^(a: SIMDMask, b: Bool) -> SIMDMask {
+    return a .^ SIMDMask(repeating: b)
   }
   
   @_transparent
-  public static func .|(lhs: SIMDMask, rhs: Bool) -> SIMDMask {
-    return lhs .| SIMDMask(repeating: rhs)
+  public static func .|(a: SIMDMask, b: Bool) -> SIMDMask {
+    return a .| SIMDMask(repeating: b)
   }
   
   @_transparent
-  public static func .&=(lhs: inout SIMDMask, rhs: SIMDMask) {
-    lhs = lhs .& rhs
+  public static func .&=(a: inout SIMDMask, b: SIMDMask) {
+    a = a .& b
   }
   
   @_transparent
-  public static func .^=(lhs: inout SIMDMask, rhs: SIMDMask) {
-    lhs = lhs .^ rhs
+  public static func .^=(a: inout SIMDMask, b: SIMDMask) {
+    a = a .^ b
   }
   
   @_transparent
-  public static func .|=(lhs: inout SIMDMask, rhs: SIMDMask) {
-    lhs = lhs .| rhs
+  public static func .|=(a: inout SIMDMask, b: SIMDMask) {
+    a = a .| b
   }
   
   @_transparent
-  public static func .&=(lhs: inout SIMDMask, rhs: Bool) {
-    lhs = lhs .& rhs
+  public static func .&=(a: inout SIMDMask, b: Bool) {
+    a = a .& b
   }
   
   @_transparent
-  public static func .^=(lhs: inout SIMDMask, rhs: Bool) {
-    lhs = lhs .^ rhs
+  public static func .^=(a: inout SIMDMask, b: Bool) {
+    a = a .^ b
   }
   
   @_transparent
-  public static func .|=(lhs: inout SIMDMask, rhs: Bool) {
-    lhs = lhs .| rhs
+  public static func .|=(a: inout SIMDMask, b: Bool) {
+    a = a .| b
   }
 }
 
@@ -1413,12 +1413,12 @@ where T: SIMD, T.Scalar: FloatingPoint {
 // Break the ambiguity between AdditiveArithmetic and SIMD for += and -=
 extension SIMD where Self: AdditiveArithmetic, Self.Scalar: FloatingPoint {
   @_alwaysEmitIntoClient
-  public static func +=(lhs: inout Self, rhs: Self) {
-    lhs = lhs + rhs
+  public static func +=(a: inout Self, b: Self) {
+    a = a + b
   }
 
   @_alwaysEmitIntoClient
-  public static func -=(lhs: inout Self, rhs: Self) {
-    lhs = lhs - rhs
+  public static func -=(a: inout Self, b: Self) {
+    a = a - b
   }
 }

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -153,6 +153,14 @@ extension SIMD {
   }
   
   /// A vector mask with the result of a pointwise equality comparison.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<MaskStorage>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] == b[i]
+  /// }
+  /// ```
   @_transparent
   public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
@@ -160,8 +168,15 @@ extension SIMD {
     return result
   }
   
-  /// Returns a vector mask with the result of a pointwise inequality
-  /// comparison.
+  /// A vector mask with the result of a pointwise inequality comparison.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<MaskStorage>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] != b[i]
+  /// }
+  /// ```
   @_transparent
   public static func .!=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
     var result = SIMDMask<MaskStorage>()
@@ -171,6 +186,13 @@ extension SIMD {
   
   /// Replaces elements of this vector with elements of `other` in the lanes
   /// where `mask` is `true`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in indices {
+  ///   if mask[i] { self[i] = other[i] }
+  /// }
+  /// ```
   @_transparent
   public mutating func replace(with other: Self, where mask: SIMDMask<MaskStorage>) {
     for i in indices { self[i] = mask[i] ? other[i] : self[i] }
@@ -376,6 +398,13 @@ extension SIMD {
   
   /// Replaces elements of this vector with `other` in the lanes where `mask`
   /// is `true`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in indices {
+  ///   if mask[i] { self[i] = other }
+  /// }
+  /// ```
   @_transparent
   public mutating func replace(with other: Scalar, where mask: SIMDMask<MaskStorage>) {
     replace(with: Self(repeating: other), where: mask)
@@ -383,6 +412,14 @@ extension SIMD {
   
   /// Returns a copy of this vector, with elements replaced by elements of
   /// `other` in the lanes where `mask` is `true`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = Self()
+  /// for i in indices {
+  ///   result[i] = mask[i] ? other[i] : self[i]
+  /// }
+  /// ```
   @_transparent
   public func replacing(with other: Self, where mask: SIMDMask<MaskStorage>) -> Self {
     var result = self
@@ -392,6 +429,14 @@ extension SIMD {
   
   /// Returns a copy of this vector, with elements `other` in the lanes where
   /// `mask` is `true`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = Self()
+  /// for i in indices {
+  ///   result[i] = mask[i] ? other : self[i]
+  /// }
+  /// ```
   @_transparent
   public func replacing(with other: Scalar, where mask: SIMDMask<MaskStorage>) -> Self {
     return replacing(with: Self(repeating: other), where: mask)
@@ -855,21 +900,63 @@ extension SIMD where Scalar: FloatingPoint {
 }
 
 extension SIMDMask {
+  /// A vector mask that is the pointwise logical negation of the input.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = !a[i]
+  /// }
+  /// ```
   @_transparent
   public static prefix func .!(a: SIMDMask) -> SIMDMask {
     return SIMDMask(~a._storage)
   }
   
+  /// A vector mask that is the pointwise logical conjunction of the inputs.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] && b[i]
+  /// }
+  /// ```
+  ///
+  /// Note that unlike the scalar `&&` operator, the SIMD `.&` operator
+  /// always fully evaluates both arguments.
   @_transparent
   public static func .&(a: SIMDMask, b: SIMDMask) -> SIMDMask {
     return SIMDMask(a._storage & b._storage)
   }
   
+  /// A vector mask that is the pointwise exclusive or of the inputs.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] != b[i]
+  /// }
+  /// ```
   @_transparent
   public static func .^(a: SIMDMask, b: SIMDMask) -> SIMDMask {
     return SIMDMask(a._storage ^ b._storage)
   }
   
+  /// A vector mask that is the pointwise logical disjunction of the inputs.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// var result = SIMDMask<${Vector}>()
+  /// for i in result.indices {
+  ///   result[i] = a[i] || b[i]
+  /// }
+  /// ```
+  ///
+  /// Note that unlike the scalar `||` operator, the SIMD `.|` operator
+  /// always fully evaluates both arguments.
   @_transparent
   public static func .|(a: SIMDMask, b: SIMDMask) -> SIMDMask {
     return SIMDMask(a._storage | b._storage)
@@ -1280,61 +1367,121 @@ extension SIMD where Scalar: FloatingPoint {
 }
 
 extension SIMDMask {
+  /// A vector mask that is the pointwise logical conjunction of the inputs.
+  ///
+  /// Equivalent to `a ? b : SIMDMask(repeating: false)`.
   @_transparent
   public static func .&(a: Bool, b: SIMDMask) -> SIMDMask {
     return SIMDMask(repeating: a) .& b
   }
   
+  /// A vector mask that is the pointwise exclusive or of the inputs.
+  ///
+  /// Equivalent to `a ? .!b : b`.
   @_transparent
   public static func .^(a: Bool, b: SIMDMask) -> SIMDMask {
     return SIMDMask(repeating: a) .^ b
   }
   
+  /// A vector mask that is the pointwise logical disjunction of the inputs.
+  ///
+  /// Equivalent to `a ? SIMDMask(repeating: true) : b`.
   @_transparent
   public static func .|(a: Bool, b: SIMDMask) -> SIMDMask {
     return SIMDMask(repeating: a) .| b
   }
   
+  /// A vector mask that is the pointwise logical conjunction of the inputs.
+  ///
+  /// Equivalent to `b ? a : SIMDMask(repeating: false)`.
   @_transparent
   public static func .&(a: SIMDMask, b: Bool) -> SIMDMask {
     return a .& SIMDMask(repeating: b)
   }
   
+  /// A vector mask that is the pointwise exclusive or of the inputs.
+  ///
+  /// Equivalent to `b ? .!a : a`.
   @_transparent
   public static func .^(a: SIMDMask, b: Bool) -> SIMDMask {
     return a .^ SIMDMask(repeating: b)
   }
   
+  /// A vector mask that is the pointwise logical disjunction of the inputs.
+  ///
+  /// Equivalent to `b ? SIMDMask(repeating: true) : a`
   @_transparent
   public static func .|(a: SIMDMask, b: Bool) -> SIMDMask {
     return a .| SIMDMask(repeating: b)
   }
   
+  /// Replaces `a` with the pointwise logical conjuction of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in a.indices {
+  ///   a[i] = a[i] && b[i]
+  /// }
+  /// ```
   @_transparent
   public static func .&=(a: inout SIMDMask, b: SIMDMask) {
     a = a .& b
   }
   
+  /// Replaces `a` with the pointwise exclusive or of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in a.indices {
+  ///   a[i] = a[i] != b[i]
+  /// }
+  /// ```
   @_transparent
   public static func .^=(a: inout SIMDMask, b: SIMDMask) {
     a = a .^ b
   }
   
+  /// Replaces `a` with the pointwise logical disjunction of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// for i in a.indices {
+  ///   a[i] = a[i] || b[i]
+  /// }
+  /// ```
   @_transparent
   public static func .|=(a: inout SIMDMask, b: SIMDMask) {
     a = a .| b
   }
   
+  /// Replaces `a` with the pointwise logical conjuction of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// if !b { a = SIMDMask(repeating: false) }
+  /// ```
   @_transparent
   public static func .&=(a: inout SIMDMask, b: Bool) {
     a = a .& b
   }
   
+  /// Replaces `a` with the pointwise exclusive or of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// if b { a = .!a }
+  /// ```
   @_transparent
   public static func .^=(a: inout SIMDMask, b: Bool) {
     a = a .^ b
   }
   
+  /// Replaces `a` with the pointwise logical disjunction of `a` and `b`.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// if b { a = SIMDMask(repeating: true) }
+  /// ```
   @_transparent
   public static func .|=(a: inout SIMDMask, b: Bool) {
     a = a .| b

--- a/test/stdlib/SIMDConcreteMasks.swift.gyb
+++ b/test/stdlib/SIMDConcreteMasks.swift.gyb
@@ -26,7 +26,7 @@ storagescalarCounts = [2,4,8,16,32,64]
 vectorscalarCounts = storagescalarCounts + [3]
 }%
 
-func genericMaskOps<T>(
+func genericLogicalOps<T>(
   _ a: SIMDMask<T>, _ b: SIMDMask<T>
 ) -> (
   not: SIMDMask<T>,
@@ -40,6 +40,16 @@ func genericMaskOps<T>(
   xor: a .^ b
 )}
 
+func genericComparisons<T>(
+  _ a: SIMDMask<T>, _ b: SIMDMask<T>
+) -> (
+  eq: SIMDMask<T>,
+  ne: SIMDMask<T>
+) where T: SIMD, T.Scalar: SignedInteger & FixedWidthInteger {(
+  eq: a .== b,
+  ne: a .!= b
+)}
+
 %for int in all_integer_types(word_bits):
 % Scalar = int.stdlib_name
 % for n in vectorscalarCounts:
@@ -50,14 +60,39 @@ func genericMaskOps<T>(
 %  if int.is_signed:
 var ${Scalar}x${n}Mask_TestSuite = TestSuite("${Scalar}x${n}Mask")
 
-${Scalar}x${n}Mask_TestSuite.test("boolean operators") {
+${Scalar}x${n}Mask_TestSuite.test("logical operators") {
   let a = SIMDMask<${Vector}>.random()
   let b = SIMDMask<${Vector}>.random()
-  let (not,and,or,xor) = genericMaskOps(a, b)
+  let (not,and,or,xor) = genericLogicalOps(a, b)
   expectEqual(not, .!a)
   expectEqual(and, a .& b)
   expectEqual(or, a .| b)
   expectEqual(xor, a .^ b)
+}
+
+${Scalar}x${n}Mask_TestSuite.test("comparisons") {
+  let a = SIMDMask<${Vector}>.random()
+  let b = SIMDMask<${Vector}>.random()
+  let (eq,ne) = genericComparisons(a, b)
+  expectEqual(eq, a .== b)
+  expectEqual(ne, a .!= b)
+  expectTrue(all(a .== a))
+  expectTrue(all(a .!= .!a))
+  expectFalse(any(a .!= a))
+  expectFalse(any(a .== .!a))
+}
+  
+${Scalar}x${n}Mask_TestSuite.test("replacing") {
+  let a = SIMDMask<${Vector}>.random()
+  let b = SIMDMask<${Vector}>.random()
+  let t = SIMDMask<${Vector}>(repeating: true)
+  let f = SIMDMask<${Vector}>(repeating: false)
+  expectEqual(a.replacing(with: b, where: t), b)
+  expectEqual(a.replacing(with: b, where: f), a)
+  expectEqual(t.replacing(with: f, where: a), .!a)
+  expectEqual(f.replacing(with: t, where: a), a)
+  expectEqual(t.replacing(with: false, where: a), .!a)
+  expectEqual(f.replacing(with: true, where: a), a)
 }
 
 %  end


### PR DESCRIPTION
Concretize additional SIMDMask operations:
    
- .&=, .|=, .^=, .==, .!=, replac[e|ing](with:where:)
    
Also reflect documentation improvements back to generic implementations.