### PR TITLE
IRGen: Initialize the executor field in continuation contexts again.

### DIFF
--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -593,8 +593,11 @@ void IRGenFunction::emitGetAsyncContinuation(SILType resumeTy,
                             contResultAddr->getType()->getPointerElementType()),
                         Address(contResultAddr, pointerAlignment));
   }
-  // FIXME: 
-  //   continuation_context.resumeExecutor = // current executor
+  auto executorAddr =
+    Builder.CreateStructGEP(continuationContext.getAddress(), 4);
+  auto executor = Builder.CreateCall(IGM.getTaskGetCurrentExecutorFn(), {});
+  executorAddr = Builder.CreateBitCast(executorAddr, executor->getType()->getPointerTo());
+  Builder.CreateStore(executor, executorAddr, pointerAlignment);
 
   // Fill the current task (i.e the continuation) with the continuation
   // information.

--- a/test/Concurrency/Runtime/objc_async.swift
+++ b/test/Concurrency/Runtime/objc_async.swift
@@ -7,10 +7,6 @@
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 
-// This test is flaky and crashes sometimes, mostly when testing with swift_test_mode_optimize.
-// REQUIRES: rdar75783864
-
-
 @main struct Main {
   static func main() async {
   let butt = Butt()

--- a/test/Sanitizers/tsan/Inputs/objc_async.h
+++ b/test/Sanitizers/tsan/Inputs/objc_async.h
@@ -1,0 +1,9 @@
+#include <Foundation/Foundation.h>
+
+@interface Butt: NSObject
+
+- (instancetype _Nonnull)init;
+
+- (void)butt:(NSInteger)x completionHandler:(void (^ _Nonnull)(NSInteger))handler;
+
+@end

--- a/test/Sanitizers/tsan/Inputs/objc_async.m
+++ b/test/Sanitizers/tsan/Inputs/objc_async.m
@@ -1,0 +1,15 @@
+#include "objc_async.h"
+#include <stdio.h>
+
+@implementation Butt
+
+- (instancetype)init {
+  return [super init];
+}
+
+- (void)butt:(NSInteger)x completionHandler:(void (^)(NSInteger))handler {
+  printf("starting %ld\n", (long)x);
+  handler(679);
+}
+
+@end

--- a/test/Sanitizers/tsan/objc_async.swift
+++ b/test/Sanitizers/tsan/objc_async.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -fsanitize=thread %S/Inputs/objc_async.m -c -o %t/objc_async_objc.o
+// RUN: %target-build-swift -sanitize=thread -O -Xfrontend -enable-experimental-concurrency -parse-as-library -module-name main -import-objc-header %S/Inputs/objc_async.h %s %t/objc_async_objc.o -o %t/objc_async
+// RUN: %target-run %t/objc_async | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+// REQUIRES: tsan_runtime
+// UNSUPPORTED: linux
+// UNSUPPORTED: windows
+
+
+@main struct Main {
+  static func main() async {
+      let butt = Butt()
+      let result = await butt.butt(1738)
+      print("finishing \(result)")
+  }
+}
+
+// CHECK: starting 1738
+// CHECK-NEXT: finishing 679


### PR DESCRIPTION
Fixes rdar://75783864.