### PR TITLE
GSB: Introduce a list of explicit as-written requirements

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -362,8 +362,6 @@ public:
   /// Return the canonical version of the given type under this generic
   /// signature.
   CanType getCanonicalTypeInContext(Type type) const;
-  CanType getCanonicalTypeInContext(Type type,
-                                    GenericSignatureBuilder &builder) const;
 
   bool isCanonicalTypeInContext(Type type) const;
   bool isCanonicalTypeInContext(Type type,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -270,6 +270,7 @@ public:
     struct CachedNestedType {
       unsigned numConformancesPresent;
       CanType superclassPresent;
+      CanType concreteTypePresent;
       llvm::TinyPtrVector<TypeDecl *> types;
     };
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -794,6 +794,13 @@ public:
   /// Simplify the given dependent type down to its canonical representation.
   Type getCanonicalTypeParameter(Type type);
 
+  /// Replace any non-canonical dependent types in the given type with their
+  /// canonical representation. This is not a canonical type in the AST sense;
+  /// type sugar is preserved. The GenericSignature::getCanonicalTypeInContext()
+  /// method combines this with a subsequent getCanonicalType() call.
+  Type getCanonicalTypeInContext(Type type,
+                            TypeArrayView<GenericTypeParamType> genericParams);
+
   /// Verify the correctness of the given generic signature.
   ///
   /// This routine will test that the given generic signature is both minimal

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2124,7 +2124,9 @@ TypeDecl *EquivalenceClass::lookupNestedType(
   if (cached != nestedTypeNameCache.end() &&
       cached->second.numConformancesPresent == conformsTo.size() &&
       (!superclass ||
-       cached->second.superclassPresent == superclass->getCanonicalType())) {
+       cached->second.superclassPresent == superclass->getCanonicalType()) &&
+      (!concreteType ||
+        cached->second.concreteTypePresent == concreteType->getCanonicalType())) {
     ++NumNestedTypeCacheHits;
     return populateResult(cached->second);
   }
@@ -2176,6 +2178,8 @@ TypeDecl *EquivalenceClass::lookupNestedType(
   entry.numConformancesPresent = conformsTo.size();
   entry.superclassPresent =
     superclass ? superclass->getCanonicalType() : CanType();
+  entry.concreteTypePresent =
+    concreteType ? concreteType->getCanonicalType() : CanType();
   if (bestAssocType) {
     entry.types.push_back(bestAssocType);
     entry.types.insert(entry.types.end(),

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3777,12 +3777,10 @@ static Type resolveDependentMemberTypes(
       return concreteType;
 
     // Map the type parameter to an equivalence class.
-    auto equivClass = resolved.getEquivalenceClass(builder);
-    if (!equivClass)
-      return ErrorType::get(Type(type));
+    auto equivClass = resolved.getEquivalenceClassIfPresent();
 
     // If there is a concrete type in this equivalence class, use that.
-    if (equivClass->concreteType) {
+    if (equivClass && equivClass->concreteType) {
       // .. unless it's recursive.
       if (equivClass->recursiveConcreteType)
         return ErrorType::get(Type(type));
@@ -3797,7 +3795,7 @@ static Type resolveDependentMemberTypes(
                                          resolutionKind);
     }
 
-    return equivClass->getAnchor(builder, builder.getGenericParams());
+    return resolved.getDependentType(builder);
   });
 }
 

--- a/test/Generics/rdar75656022.swift
+++ b/test/Generics/rdar75656022.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype T
+}
+
+protocol P2 {
+  associatedtype T : P1
+}
+
+struct S1<A, B, C> : P2
+    where A : P1, C : P2, B == A.T.T, C.T == A.T {
+  typealias T = C.T
+}
+
+struct S2<D : P1> : P2 {
+  typealias T = D
+}
+
+// Make sure that we can resolve the nested type A.T
+// in the same-type requirement 'A.T == B.T'.
+//
+// A is concrete, and S1<C, E, S2<D>>.T resolves to
+// S2<D>.T, which is D. The typealias S1.T has a
+// structural type 'C.T'; since C is concrete, we
+// have to handle the case of an unresolved member
+// type with a concrete base.
+struct UnresolvedWithConcreteBase<A, B> {
+  // CHECK-LABEL: Generic signature: <A, B, C, D, E where A == S1<C, E, S2<D>>, B : P2, C : P1, D == B.T, E == D.T, B.T == C.T>
+  init<C, D, E>(_: C)
+    where A == S1<C, E, S2<D>>,
+          B : P2,
+          A.T == B.T,
+          C : P1,
+          D == C.T,
+          E == D.T { }
+}


### PR DESCRIPTION
Store the original explicit requirements (written by the user or inferred from concrete type constructors). This will eventually be used to simplify the code for forming the minimized signature, diagnosing redundant and conflicting requirements, and rebuilding a signature after dropping requirements.