### PR TITLE
Remove a small helper function that took a Builtin.VecNxInt1 type.

### DIFF
--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -25,11 +25,12 @@ vectorscalarCounts = storagescalarCounts + [3]
 %  storageN = 4 if n == 3 else n
 %  s = "s" if int.is_signed else "u"
 %  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
+%  MaskExt = "Builtin.sext_Vec" + str(storageN) + "xInt1_" + Builtin
 %  if int.is_signed:
 extension SIMDMask where Storage == ${Vector} {
   @_alwaysEmitIntoClient
-  internal init(_ _builtin: Builtin.Vec${storageN}xInt1) {
-    _storage = ${Vector}(Builtin.sext_Vec${storageN}xInt1_${Builtin}(_builtin))
+  internal init(_ _builtin: Builtin.${Builtin}) {
+    _storage = ${Vector}(_builtin)
   }
   
   @_alwaysEmitIntoClient
@@ -216,49 +217,49 @@ extension SIMD${n} where Scalar == ${Scalar} {
   /// A vector mask with the result of a pointwise equality comparison.
   @_alwaysEmitIntoClient
   public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_eq_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise inequality comparison.
   @_alwaysEmitIntoClient
   public static func .!=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_ne_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise less-than comparison.
   @_alwaysEmitIntoClient
   public static func .<(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}lt_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise less-than-or-equal-to comparison.
   @_alwaysEmitIntoClient
   public static func .<=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}le_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise greater-than comparison.
   @_alwaysEmitIntoClient
   public static func .>(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}gt_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise greater-than-or-equal-to comparison.
   @_alwaysEmitIntoClient
   public static func .>=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.cmp_${s}ge_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
     
   /// The wrapping sum of two vectors.
@@ -303,6 +304,8 @@ extension SIMD${n} where Scalar == ${Scalar} {
 %  Vector = "SIMD" + str(n) + "<" + Scalar + ">"
 %  storageN = 4 if n == 3 else n
 %  Builtin = "Vec" + str(storageN) + "xFPIEEE" + str(bits)
+%  VecPre = "Vec" + str(storageN) + "x"
+%  MaskExt = "Builtin.sext_" + VecPre + "Int1_" + VecPre + "Int" + str(bits)
 %  if bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
@@ -316,49 +319,49 @@ extension SIMD${n} where Scalar == ${Scalar} {
   /// A vector mask with the result of a pointwise equality comparison.
   @_alwaysEmitIntoClient
   public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_oeq_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise inequality comparison.
   @_alwaysEmitIntoClient
   public static func .!=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_une_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise less-than comparison.
   @_alwaysEmitIntoClient
   public static func .<(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_olt_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise less-than-or-equal-to comparison.
   @_alwaysEmitIntoClient
   public static func .<=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_ole_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise greater-than comparison.
   @_alwaysEmitIntoClient
   public static func .>(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_ogt_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
   
   /// A vector mask with the result of a pointwise greater-than-or-equal-to comparison.
   @_alwaysEmitIntoClient
   public static func .>=(a: Self, b: Self) -> SIMDMask<MaskStorage> {
-    SIMDMask<MaskStorage>(
+    SIMDMask<MaskStorage>(${MaskExt}(
       Builtin.fcmp_oge_${Builtin}(a._storage._value, b._storage._value)
-    )
+    ))
   }
 }
 %  if bits == 16:


### PR DESCRIPTION
It saved some boilerplate, but if it doesn't get inline (as in debug builds), Swift doesn't know how to legalize the type at the call boundary, and we crash.