### PR TITLE
Simd random mask benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -158,6 +158,7 @@ set(SWIFT_BENCH_MODULES
     single-source/RemoveWhere
     single-source/ReversedCollections
     single-source/RomanNumbers
+    single-source/SIMDRandomMask
     single-source/SIMDReduceInteger
     single-source/SequenceAlgos
     single-source/SetTests

--- a/benchmark/single-source/SIMDRandomMask.swift
+++ b/benchmark/single-source/SIMDRandomMask.swift
@@ -1,0 +1,92 @@
+//===--- SIMDRandomMask.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+public let SIMDRandomMask = [
+  BenchmarkInfo(
+    name: "SIMDRandomMask.Int8x16",
+    runFunction: run_SIMDRandomMaskInt8x16,
+    tags: [.validation, .SIMD]
+  ),
+  BenchmarkInfo(
+    name: "SIMDRandomMask.Int8x64",
+    runFunction: run_SIMDRandomMaskInt8x64,
+    tags: [.validation, .SIMD]
+  ),
+  BenchmarkInfo(
+    name: "SIMDRandomMask.Int64x2",
+    runFunction: run_SIMDRandomMaskInt64x2,
+    tags: [.validation, .SIMD]
+  ),
+  BenchmarkInfo(
+    name: "SIMDRandomMask.Int64x8",
+    runFunction: run_SIMDRandomMaskInt64x8,
+    tags: [.validation, .SIMD]
+  ),
+  BenchmarkInfo(
+    name: "SIMDRandomMask.Int64x64",
+    runFunction: run_SIMDRandomMaskInt64x64,
+    tags: [.validation, .SIMD]
+  )
+]
+
+@inline(never)
+public func run_SIMDRandomMaskInt8x16(_ N: Int) {
+  var g = SplitMix64(seed: 0)
+  var accum = SIMDMask<SIMD16<Int8>>()
+  for _ in 0 ..< 10000*N {
+    accum .^= SIMDMask.random(using: &g)
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt8x64(_ N: Int) {
+  var g = SplitMix64(seed: 0)
+  var accum = SIMDMask<SIMD64<Int8>>()
+  for _ in 0 ..< 10000*N {
+    accum .^= SIMDMask.random(using: &g)
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt64x2(_ N: Int) {
+  var g = SplitMix64(seed: 0)
+  var accum = SIMDMask<SIMD2<Int64>>()
+  for _ in 0 ..< 10000*N {
+    accum .^= SIMDMask.random(using: &g)
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt64x8(_ N: Int) {
+  var g = SplitMix64(seed: 0)
+  var accum = SIMDMask<SIMD8<Int64>>()
+  for _ in 0 ..< 10000*N {
+    accum .^= SIMDMask.random(using: &g)
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt64x64(_ N: Int) {
+  var g = SplitMix64(seed: 0)
+  var accum = SIMDMask<SIMD64<Int64>>()
+  for _ in 0 ..< 10000*N {
+    accum .^= SIMDMask.random(using: &g)
+  }
+  blackHole(accum)
+}
+ 

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -156,6 +156,7 @@ import ReduceInto
 import RemoveWhere
 import ReversedCollections
 import RomanNumbers
+import SIMDRandomMask
 import SIMDReduceInteger
 import SequenceAlgos
 import SetTests
@@ -353,6 +354,7 @@ registerBenchmark(ReduceInto)
 registerBenchmark(RemoveWhere)
 registerBenchmark(ReversedCollections)
 registerBenchmark(RomanNumbers)
+registerBenchmark(SIMDRandomMask)
 registerBenchmark(SIMDReduceInteger)
 registerBenchmark(SequenceAlgos)
 registerBenchmark(SetTests)

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -586,6 +586,14 @@ static ValueDecl *getCastOperation(ASTContext &Context, Identifier Id,
               BIT->isFixedWidth() &&
               BIT->getFixedWidth() == Vec->getNumElements())
             break;
+    // And IntN -> VecNxInt1 for SIMDMask random generators.
+    if (auto *Vec = CheckOutput->getAs<BuiltinVectorType>())
+      if (auto *BIT = CheckInput->getAs<BuiltinIntegerType>())
+        if (auto *Element = Vec->getElementType()->getAs<BuiltinIntegerType>())
+          if (Element->getFixedWidth() == 1 &&
+              BIT->isFixedWidth() &&
+              BIT->getFixedWidth() == Vec->getNumElements())
+            break;
 
     // FIXME: Implement bitcast typechecking.
     llvm_unreachable("Bitcast not supported yet!");

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -166,6 +166,12 @@ func vector_bitcast_test(_ src: Builtin.Vec16xInt8) -> Builtin.Int16 {
   return Builtin.bitcast_Vec16xInt1_Int16(mask) // CHECK: bitcast
 }
 
+func vector_bitcast_test_ii(_ src: Builtin.Int16) -> Builtin.Vec16xInt8 {
+  // CHECK: vector_bitcast_test_ii
+  let v16x1 = Builtin.bitcast_Int16_Vec16xInt1(src) // CHECK: bitcast
+  return Builtin.sext_Vec16xInt1_Vec16xInt8(v16x1)   // CHECK: sext
+}
+
 func intrinsic_test(_ i32: inout Builtin.Int32, i16: inout Builtin.Int16,
                     _ v8i16: Builtin.Vec8xInt16) {
   // CHECK: intrinsic_test


### PR DESCRIPTION
Adds a benchmark for SIMDMask.random() and does some groundwork for improving it. The actual change will have to wait a little while because it's dependent on new Builtin.bitcast support added in this PR.