### PR TITLE
[Clang importer] Import Concurrency-related attributes on C/ObjC parameters of closure type

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8010,6 +8010,19 @@ SourceFile &ClangImporter::Implementation::getClangSwiftAttrSourceFile(
   return *sourceFile;
 }
 
+Optional<bool> swift::importer::isMainActorAttr(
+    ASTContext &ctx, const clang::SwiftAttrAttr *swiftAttr) {
+  if (swiftAttr->getAttribute() == "@MainActor" ||
+      swiftAttr->getAttribute() == "@MainActor(unsafe)" ||
+      swiftAttr->getAttribute() == "@UIActor") {
+    bool isUnsafe = swiftAttr->getAttribute() == "@MainActor(unsafe)" ||
+        !ctx.LangOpts.isSwiftVersionAtLeast(6);
+    return isUnsafe;
+  }
+
+  return None;
+}
+
 /// Import Clang attributes as Swift attributes.
 void ClangImporter::Implementation::importAttributes(
     const clang::NamedDecl *ClangDecl,
@@ -8180,11 +8193,8 @@ void ClangImporter::Implementation::importAttributes(
     if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(*AI)) {
       // FIXME: Hard-core @MainActor and @UIActor, because we don't have a
       // point at which to do name lookup for imported entities.
-      if (swiftAttr->getAttribute() == "@MainActor" ||
-          swiftAttr->getAttribute() == "@MainActor(unsafe)" ||
-          swiftAttr->getAttribute() == "@UIActor") {
-        bool isUnsafe = swiftAttr->getAttribute() == "@MainActor(unsafe)" ||
-            !C.LangOpts.isSwiftVersionAtLeast(6);
+      if (auto isMainActor = isMainActorAttr(SwiftContext, swiftAttr)) {
+        bool isUnsafe = *isMainActor;
         if (Type mainActorType = getMainActorType()) {
           auto typeExpr = TypeExpr::createImplicit(mainActorType, SwiftContext);
           auto attr = CustomAttr::create(SwiftContext, SourceLoc(), typeExpr);

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1693,17 +1693,28 @@ ImportedType ClangImporter::Implementation::importPropertyType(
                     Bridgeability::Full, optionality);
 }
 
-/// Apply the @noescape attribute
-static Type applyNoEscape(Type type) {
+/// Apply an attribute to a function type.
+static Type applyToFunctionType(
+    Type type, llvm::function_ref<Type(FunctionType *)> transform) {
   // Recurse into optional types.
   if (Type objectType = type->getOptionalObjectType()) {
-    return OptionalType::get(applyNoEscape(objectType));
+    return OptionalType::get(applyToFunctionType(objectType, transform));
   }
 
   // Apply @noescape to function types.
-  if (auto funcType = type->getAs<FunctionType>()) {
-    return FunctionType::get(funcType->getParams(), funcType->getResult(),
-                             funcType->getExtInfo().withNoEscape());
+  if (auto funcType = type->getAs<FunctionType>())
+    return transform(funcType);
+
+  return type;
+}
+
+static Type applyParamAttributes(const clang::ParmVarDecl *param, Type type) {
+  // Map __attribute__((noescape)) to @noescape.
+  if (param->hasAttr<clang::NoEscapeAttr>()) {
+    type = applyToFunctionType(type, [](FunctionType *funcType) {
+      return FunctionType::get(funcType->getParams(), funcType->getResult(),
+                               funcType->getExtInfo().withNoEscape());
+    });
   }
 
   return type;
@@ -1883,13 +1894,8 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
       swiftParamTy = importedType.getType();
     }
 
-    // Map __attribute__((noescape)) to @noescape.
-    if (param->hasAttr<clang::NoEscapeAttr>()) {
-      Type newParamTy = applyNoEscape(swiftParamTy);
-      if (newParamTy.getPointer() != swiftParamTy.getPointer()) {
-        swiftParamTy = newParamTy;
-      }
-    }
+    // Apply attributes to the type.
+    swiftParamTy = applyParamAttributes(param, swiftParamTy);
 
     // Figure out the name for this parameter.
     Identifier bodyName = importFullName(param, CurrentVersion)
@@ -2384,15 +2390,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
       llvm_unreachable("async info computed incorrectly?");
     }
 
-    // Map __attribute__((noescape)) to @noescape.
-    bool addNoEscapeAttr = false;
-    if (param->hasAttr<clang::NoEscapeAttr>()) {
-      Type newParamTy = applyNoEscape(swiftParamTy);
-      if (newParamTy.getPointer() != swiftParamTy.getPointer()) {
-        swiftParamTy = newParamTy;
-        addNoEscapeAttr = true;
-      }
-    }
+    // Apply Clang attributes to the parameter type.
+    swiftParamTy = applyParamAttributes(param, swiftParamTy);
 
     // Figure out the name for this parameter.
     Identifier bodyName = importFullName(param, CurrentVersion)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1739,6 +1739,15 @@ Type ClangImporter::Implementation::applyParamAttributes(
 
       continue;
     }
+
+    // Map @Sendable.
+    if (swiftAttr->getAttribute() == "@Sendable") {
+      type = applyToFunctionType(type, [](ASTExtInfo extInfo) {
+        return extInfo.withConcurrent();
+      });
+
+      continue;
+    }
   }
 
   return type;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -830,6 +830,8 @@ public:
   void importAttributes(const clang::NamedDecl *ClangDecl, Decl *MappedDecl,
                         const clang::ObjCContainerDecl *NewContext = nullptr);
 
+  Type applyParamAttributes(const clang::ParmVarDecl *param, Type type);
+
   /// If we already imported a given decl, return the corresponding Swift decl.
   /// Otherwise, return nullptr.
   Decl *importDeclCached(const clang::NamedDecl *ClangDecl, Version version,
@@ -1561,6 +1563,14 @@ public:
                         clang::serialization::ModuleFile &mod,
                         const llvm::BitstreamCursor &stream) override;
 };
+
+/// Determines whether the given swift_attr attribute describes the main
+/// actor.
+///
+/// \returns None if this is not a main-actor attribute, and a Boolean
+/// indicating whether (unsafe) was provided in the attribute otherwise.
+Optional<bool> isMainActorAttr(
+    ASTContext &ctx, const clang::SwiftAttrAttr *swiftAttr);
 
 }
 }

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -82,6 +82,18 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
   _ = slowServer.allOperations
 }
 
+func testSendable(fn: () -> Void) { // expected-note{{parameter 'fn' is implicitly non-concurrent}}
+  doSomethingConcurrently(fn)
+  // expected-error@-1{{passing non-concurrent parameter 'fn' to function expecting a @Sendable closure}}
+
+  var x = 17
+  doSomethingConcurrently {
+    print(x) // expected-error{{reference to captured var 'x' in concurrently-executing code}}
+    x = x + 1 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    // expected-error@-1{{reference to captured var 'x' in concurrently-executing code}}
+  }
+}
+
 // Check import of attributes
 func globalAsync() async { }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -5,6 +5,8 @@
 import Foundation
 import ObjCConcurrency
 
+@MainActor func onlyOnMainActor() { }
+
 func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await slowServer.doSomethingSlow("mail")
   let _: Bool = await slowServer.checkAvailability()
@@ -49,6 +51,8 @@ func testSlowServer(slowServer: SlowServer) async throws {
 
 
   _ = await slowServer.operations()
+
+  _ = await slowServer.runOnMainThread()
 }
 
 func testSlowServerSynchronous(slowServer: SlowServer) {
@@ -63,6 +67,11 @@ func testSlowServerSynchronous(slowServer: SlowServer) {
 
   let s = slowServer.operations
   _ = s + []
+
+  slowServer.runOnMainThread { s in
+    print(s)
+    onlyOnMainActor() // okay because runOnMainThread has a @MainActor closure
+  }
 }
 
 func testSlowServerOldSchool(slowServer: SlowServer) {

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -26,6 +26,8 @@ import _Concurrency
 // CHECK-DAG:     func doSomethingFun(_ operation: String) async
 // CHECK-DAG:     func dance(_ step: String) async -> String
 // CHECK-DAG:     func __leap(_ height: Int) async -> String
+// CHECK-DAG:     func runOnMainThread(completionHandler completion: (@MainActor (String) -> Void)? = nil)
+// CHECK-DAG:     func runOnMainThread() async -> String
 // CHECK: {{^[}]$}}
 
 // CHECK-LABEL: protocol RefrigeratorDelegate

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -47,3 +47,5 @@ import _Concurrency
 // CHECK-NEXT: {{^[}]$}}
 
 // CHECK: {{^}}var MAGIC_NUMBER: Int32 { get }
+
+// CHECK: func doSomethingConcurrently(_ block: @Sendable () -> Void)

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -144,4 +144,7 @@ __attribute__((__swift_attr__("@MainActor(unsafe)")))
 -(void)onButtonPress;
 @end
 
+// Do something concurrently, but without escaping.
+void doSomethingConcurrently(__attribute__((noescape)) __attribute__((swift_attr("@Sendable"))) void (^block)(void));
+
 #pragma clang assume_nonnull end

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -3,6 +3,8 @@
 
 #pragma clang assume_nonnull begin
 
+#define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
+
 @protocol ServiceProvider
 @property(readonly) NSArray<NSString *> *allOperations;
 -(void)allOperationsWithCompletionHandler:(void (^)(NSArray<NSString *> *))completion;
@@ -66,6 +68,9 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)doSomethingFlaggyWithCompletionHandler:(void (^)(BOOL, NSString *_Nullable, NSError *_Nullable))completionHandler __attribute__((swift_async_error(nonzero_argument, 1)));
 -(void)doSomethingZeroFlaggyWithCompletionHandler:(void (^)(NSString *_Nullable, BOOL, NSError *_Nullable))completionHandler __attribute__((swift_async_error(zero_argument, 2)));
 -(void)doSomethingMultiResultFlaggyWithCompletionHandler:(void (^)(BOOL, NSString *_Nullable, NSError *_Nullable, NSString *_Nullable))completionHandler __attribute__((swift_async_error(zero_argument, 1)));
+
+
+-(void)runOnMainThreadWithCompletionHandler:(MAIN_ACTOR void (^ _Nullable)(NSString *))completion;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>


### PR DESCRIPTION
Allow C and Objective-C parameters to use `__attribute__(swift_attr("...")))` to create main-actor and sendable closure parameter types:

* `__attribute__((swift_attr("@MainActor")))` on the parameter becomes `@MainActor`
* `__attribute__((swift_attr("@Sendable")))` on the parameter becomes `@Sendable`