### PR TITLE
[Frontend] Always output (some) additional files when allowing errors

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6808,8 +6808,8 @@ const ParamDecl *swift::getParameterAt(const ValueDecl *source,
 Type AbstractFunctionDecl::getMethodInterfaceType() const {
   assert(getDeclContext()->isTypeContext());
   auto Ty = getInterfaceType();
-  if (Ty->hasError())
-    return ErrorType::get(getASTContext());
+  if (Ty->is<ErrorType>())
+    return Ty;
   return Ty->castTo<AnyFunctionType>()->getResult();
 }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -989,10 +989,11 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   if (!ctx.hadError()) {
     emitLoadedModuleTraceForAllPrimariesIfNeeded(
         Instance.getMainModule(), Instance.getDependencyTracker(), opts);
-    
-    emitAnyWholeModulePostTypeCheckSupplementaryOutputs(Instance);
 
     dumpAPIIfNeeded(Instance);
+  }
+  if (!ctx.hadError() || opts.AllowModuleWithCompilerErrors) {
+    emitAnyWholeModulePostTypeCheckSupplementaryOutputs(Instance);
   }
 
   // Verify reference dependencies of the current compilation job. Note this

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -640,7 +640,10 @@ static void emitSwiftdepsForAllPrimaryInputsIfNeeded(
   //
   // FIXME: It seems more appropriate for the driver to notice the early-exit
   // and react by always enqueuing the jobs it dropped in the other waves.
-  if (Instance.getDiags().hadAnyError())
+  //
+  // We will output a module if allowing errors, so ignore that case.
+  if (Instance.getDiags().hadAnyError() &&
+      !Invocation.getFrontendOptions().AllowModuleWithCompilerErrors)
     return;
 
   for (auto *SF : Instance.getPrimarySourceFiles()) {

--- a/lib/PrintAsObjC/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsObjC/DeclAndTypePrinter.cpp
@@ -1597,6 +1597,10 @@ private:
     os << " */";
   }
 
+  void visitErrorType(ErrorType *Ty, Optional<OptionalTypeKind> optionalKind) {
+    os << "/* error */id";
+  }
+
   bool isClangPointerType(const clang::TypeDecl *clangTypeDecl) const {
     ASTContext &ctx = getASTContext();
     auto &clangASTContext = ctx.getClangModuleLoader()->getClangASTContext();

--- a/test/Frontend/allow-errors.swift
+++ b/test/Frontend/allow-errors.swift
@@ -1,9 +1,12 @@
 // RUN: %empty-directory(%t)
 
 // The module should be generated regardless of errors and diagnostic should still be output
-// RUN: %target-swift-frontend -verify -emit-module -o %t/errors.swiftmodule -experimental-allow-module-with-compiler-errors -D ERROR_MODULE %s
+// RUN: %target-swift-frontend -verify -emit-module -o %t/errors.swiftmodule -emit-reference-dependencies-path %t/errors.swiftdeps -emit-dependencies-path %t/errors.d -experimental-allow-module-with-compiler-errors -D ERROR_MODULE -primary-file %s
 // RUN: llvm-bcanalyzer %t/errors.swiftmodule | %FileCheck -check-prefix=CHECK-BC %s
 // CHECK-BC-NOT: UnknownCode
+// RUN: ls %t/errors.swiftdeps
+// RUN: ls %t/errors.d
+
 #if ERROR_MODULE
 public struct ValidStructInvalidMember {
   public var member: String

--- a/test/PrintAsObjC/error.swift
+++ b/test/PrintAsObjC/error.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RdsagUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/error.h
+// RUadsgN: %FileCheck %s < %t/error.h
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module-path %t/error.swiftmodule -emit-objc-header-path %t/error.h -experimental-allow-module-with-compiler-errors %s
+// RUN: %FileCheck %s < %t/error.h
+// RUN: %check-in-clang %t/error.h
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class ErrorClass: NSObject {
+// CHECK: @interface ErrorClass
+  @objc let member: Int
+  // CHECK: @property {{.*}} NSInteger member;
+  @objc let invalidMember: undefined
+  // TODO: Not output on invalid type
+
+  @objc func method() {}
+  // CHECK: - (void)method;
+
+  @objc func methodParams(a: Int, b: Int) {}
+  // CHECK: - (void)methodParamsWithA:(NSInteger)a b:(NSInteger)b;
+
+  @objc class func classMethod() {}
+  // CHECK: + (void)classMethod;
+
+  @objc(objcMethod)
+  func renamedMethod() {}
+  // CHECK: - (void)objcMethod;
+
+  @objc func invalidBody() {
+  // CHECK: - (void)invalidBody;
+    undefined
+  }
+
+  @objc func invalidRet() -> undefined {}
+  // CHECK: - (/* error */id)invalidRet
+
+  @objc func invalidParams(a: undefined) {}
+  // TODO: Not output with invalid parameters
+
+  @objc(invalid::)
+  func invalidRenamedMethod() {}
+  // CHECK: - (void)invalidRenamedMethod;
+
+  @objc @undefined func invalidAttribute() {}
+  // CHECK: - (void)invalidAttribute;
+
+  @objc undefined func invalidModifier() {}
+  // TODO: Not output with invalid modifier
+
+  @objc @available
+  func invalidAvailability() {}
+  // CHECK: - (void)invalidAvailability;
+}
+
+@objc class InvalidParent: undefined {}
+// CHECK: @interface InvalidParent


### PR DESCRIPTION
Make sure both the generated ObjectiveC header and swiftdeps are output when allowing errors (and requested), even if there are errors. Note that there's cases that we could probably improve in the generated header, but this change at least outputs *something* for now (see TODOs).

Resolves rdar://75754282