### PR TITLE
Add more efficient SIMDMask.random.

### DIFF
--- a/benchmark/single-source/SIMDRandomMask.swift
+++ b/benchmark/single-source/SIMDRandomMask.swift
@@ -19,9 +19,21 @@ public let benchmarks = [
     tags: [.validation, .SIMD]
   ),
   BenchmarkInfo(
+    name: "SIMDRandomMask.Int8x16.Generic",
+    runFunction: run_SIMDRandomMaskInt8x16_generic,
+    tags: [.validation, .SIMD],
+    legacyFactor: 10
+  ),
+  BenchmarkInfo(
     name: "SIMDRandomMask.Int8x64",
     runFunction: run_SIMDRandomMaskInt8x64,
     tags: [.validation, .SIMD]
+  ),
+  BenchmarkInfo(
+    name: "SIMDRandomMask.Int8x64.Generic",
+    runFunction: run_SIMDRandomMaskInt8x64_generic,
+    tags: [.validation, .SIMD],
+    legacyFactor: 10
   ),
   BenchmarkInfo(
     name: "SIMDRandomMask.Int64x2",
@@ -29,14 +41,32 @@ public let benchmarks = [
     tags: [.validation, .SIMD]
   ),
   BenchmarkInfo(
+    name: "SIMDRandomMask.Int64x2.Generic",
+    runFunction: run_SIMDRandomMaskInt64x2_generic,
+    tags: [.validation, .SIMD],
+    legacyFactor: 10
+  ),
+  BenchmarkInfo(
     name: "SIMDRandomMask.Int64x8",
     runFunction: run_SIMDRandomMaskInt64x8,
     tags: [.validation, .SIMD]
   ),
   BenchmarkInfo(
+    name: "SIMDRandomMask.Int64x8.Generic",
+    runFunction: run_SIMDRandomMaskInt64x8_generic,
+    tags: [.validation, .SIMD],
+    legacyFactor: 10
+  ),
+  BenchmarkInfo(
     name: "SIMDRandomMask.Int64x64",
     runFunction: run_SIMDRandomMaskInt64x64,
     tags: [.validation, .SIMD]
+  ),
+  BenchmarkInfo(
+    name: "SIMDRandomMask.Int64x64.Generic",
+    runFunction: run_SIMDRandomMaskInt64x64_generic,
+    tags: [.validation, .SIMD],
+    legacyFactor: 10 
   )
 ]
 
@@ -86,6 +116,57 @@ public func run_SIMDRandomMaskInt64x64(_ n: Int) {
   var accum = SIMDMask<SIMD64<Int64>>()
   for _ in 0 ..< 10000*n {
     accum .^= SIMDMask.random(using: &g)
+  }
+  blackHole(accum)
+}
+
+@inline(__always)
+internal func generic_random<T>() -> SIMDMask<T>
+where T: SIMD, T.Scalar: FixedWidthInteger & SignedInteger {
+  SIMDMask<T>.random()
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt8x16_generic(_ N: Int) {
+  var accum = SIMDMask<SIMD16<Int8>>()
+  for _ in 0 ..< 1000*N {
+    accum .^= generic_random()
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt8x64_generic(_ N: Int) {
+  var accum = SIMDMask<SIMD64<Int8>>()
+  for _ in 0 ..< 1000*N {
+    accum .^= generic_random()
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt64x2_generic(_ N: Int) {
+  var accum = SIMDMask<SIMD2<Int64>>()
+  for _ in 0 ..< 1000*N {
+    accum .^= generic_random()
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt64x8_generic(_ N: Int) {
+  var accum = SIMDMask<SIMD8<Int64>>()
+  for _ in 0 ..< 1000*N {
+    accum .^= generic_random()
+  }
+  blackHole(accum)
+}
+
+@inline(never)
+public func run_SIMDRandomMaskInt64x64_generic(_ N: Int) {
+  var accum = SIMDMask<SIMD64<Int64>>()
+  for _ in 0 ..< 1000*N {
+    accum .^= generic_random()
   }
   blackHole(accum)
 }

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -204,6 +204,22 @@ extension SIMDMask where Storage == ${Vector} {
   public func replacing(with other: Self, where mask: Self) -> Self {
     (self .& .!mask) .| (other .& mask)
   }
+  
+  /// Returns a vector mask with `true` or `false` randomly assigned in each
+  /// lane, using the given generator as a source for randomness.
+  @_alwaysEmitIntoClient
+  public static func random<T: RandomNumberGenerator>(using generator: inout T) -> Self {
+    let data = Builtin.truncOrBitCast_Int64_Int${storageN}(generator.next()._value)
+    return Self(Builtin.bitcast_Int${storageN}_Vec${storageN}xInt1(data))
+  }
+  
+  /// Returns a vector mask with `true` or `false` randomly assigned in each
+  /// lane.
+  @_alwaysEmitIntoClient
+  public static func random() -> Self {
+    var g = SystemRandomNumberGenerator()
+    return Self.random(using: &g)
+  }
 }
 
 %  end

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -24,7 +24,8 @@ vectorscalarCounts = storagescalarCounts + [3]
 %  storageN = 4 if n == 3 else n
 %  s = "s" if int.is_signed else "u"
 %  Builtin = "Vec" + str(storageN) + "xInt" + str(int.bits)
-%  MaskExt = "Builtin.sext_Vec" + str(storageN) + "xInt1_" + Builtin
+%  Int1Vec = "Vec" + str(storageN) + "xInt1"
+%  MaskExt = "Builtin.sext_" + Int1Vec + "_" + Builtin
 %  if int.is_signed:
 extension SIMDMask where Storage == ${Vector} {
   @_alwaysEmitIntoClient
@@ -224,12 +225,48 @@ extension SIMDMask where Storage == ${Vector} {
   }
 }
 
+/// True if any lane of mask is true.
+@_alwaysEmitIntoClient
+public func any(_ mask: SIMDMask<${Vector}>) -> Bool {
+#if arch(i386) || arch(x86_64)
+% mask = hex((1 << n) - 1)
+  return mask._storage.movemask() & ${mask} != 0
+#else
+  return mask._storage.min() < 0
+#endif
+}
+
+/// True if every lane of mask is true.
+@_alwaysEmitIntoClient
+public func all(_ mask: SIMDMask<${Vector}>) -> Bool {
+#if arch(i386) || arch(x86_64)
+% mask = hex((1 << n) - 1)
+  return mask._storage.movemask() & ${mask} == ${mask}
+#else
+  return mask._storage.max() < 0
+#endif
+}
+
 %  end
 extension SIMD${n} where Scalar == ${Scalar} {
   @_alwaysEmitIntoClient
   internal init(_ _builtin: Builtin.${Builtin}) {
     _storage = ${Scalar}.SIMD${storageN}Storage(_builtin)
   }
+
+#if arch(i386) || arch(x86_64)
+  /// Implements the x86 PMOVMSKB / MOVMSKPS / MOVMSKPD instruction
+  /// semantics. Not available on other targets.
+  @_alwaysEmitIntoClient
+  internal func movemask() -> UInt${max(n, 8)} {
+    let zero: Builtin.${Builtin} = Builtin.zeroInitializer()
+    let mask = Builtin.cmp_slt_${Builtin}(_storage._value, zero)
+    let int = Builtin.bitcast_${Int1Vec}_Int${storageN}(mask)
+    return UInt${max(n, 8)}(
+      Builtin.zextOrBitCast_Int${storageN}_Int${max(n, 8)}(int)
+    )
+  }
+#endif
     
   /// A vector mask with the result of a pointwise equality comparison.
   @_alwaysEmitIntoClient
@@ -311,6 +348,72 @@ extension SIMD${n} where Scalar == ${Scalar} {
   /// vectors.
   @_alwaysEmitIntoClient
   public static func &*=(a: inout Self, b: Self) { a = a &* b }
+      
+  /// The least scalar in the vector.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// indices.reduce(into: Scalar.max) {
+  ///   $0 = min($0, self[$1])
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public func min() -> Scalar {
+  % if n == 3:
+    var storage = _storage
+    storage[3] = Scalar.max
+  % else:
+    let storage = _storage
+  % end
+  % if int.is_signed:
+    return Scalar(Builtin.int_vector_reduce_smin_${Builtin}(storage._value))
+  % else:
+    return Scalar(Builtin.int_vector_reduce_umin_${Builtin}(storage._value))
+  % end
+  }
+      
+  /// The greatest element in the vector.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// indices.reduce(into: Scalar.min) {
+  ///   $0 = max($0, self[$1])
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public func max() -> Scalar {
+  % if n == 3:
+    var storage = _storage
+    storage[3] = Scalar.min
+  % else:
+    let storage = _storage
+  % end
+  % if int.is_signed:
+    return Scalar(Builtin.int_vector_reduce_smax_${Builtin}(storage._value))
+  % else:
+    return Scalar(Builtin.int_vector_reduce_umax_${Builtin}(storage._value))
+  % end
+  }
+    
+  /// Returns the sum of the scalars in the vector, computed with wrapping
+  /// addition.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// indices.reduce(into: 0) {
+  ///   $0 &+= self[$1]
+  /// }
+  /// ```
+  @_alwaysEmitIntoClient
+  public func wrappedSum() -> Scalar {
+  % if n == 3:
+    var storage = _storage
+    storage[3] = 0
+  % else:
+    let storage = _storage
+  % end
+  return Scalar(Builtin.int_vector_reduce_add_${Builtin}(storage._value))
+  }
 }
 
 % end

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -32,6 +32,12 @@ extension SIMDMask where Storage == ${Vector} {
   internal init(_ _builtin: Builtin.${Builtin}) {
     _storage = ${Vector}(_builtin)
   }
+    
+  /// A vector with the specified value in all lanes.
+  @_alwaysEmitIntoClient
+  public init(repeating scalar: Bool) {
+    _storage = ${Vector}(repeating: scalar ? -1 : 0)
+  }
   
   @_alwaysEmitIntoClient
   internal static var allTrue: Self {
@@ -276,6 +282,17 @@ extension SIMD${n} where Scalar == ${Scalar} {
   }
 #endif
     
+  /// A vector with the specified value in all lanes.
+  @_alwaysEmitIntoClient
+  public init(repeating scalar: ${Scalar}) {
+    let vec = Builtin.insertelement_${Builtin}_Int${int.bits}_Int32(
+      Builtin.zeroInitializer(), scalar._value, Builtin.zeroInitializer()
+    )
+    self.init(Builtin.shufflevector_${Builtin}_Vec${storageN}xInt32(
+      vec, vec, Builtin.zeroInitializer()
+    ))
+  }
+    
   /// A vector mask with the result of a pointwise equality comparison.
   @_alwaysEmitIntoClient
   public static func .==(a: Self, b: Self) -> SIMDMask<MaskStorage> {
@@ -442,6 +459,17 @@ extension SIMD${n} where Scalar == ${Scalar} {
   @_alwaysEmitIntoClient
   internal init(_ _builtin: Builtin.${Builtin}) {
     _storage = ${Scalar}.SIMD${storageN}Storage(_builtin)
+  }
+    
+  /// A vector with the specified value in all lanes.
+  @_alwaysEmitIntoClient
+  public init(repeating scalar: ${Scalar}) {
+    let vec = Builtin.insertelement_${Builtin}_FPIEEE${bits}_Int32(
+      Builtin.zeroInitializer(), scalar._value, Builtin.zeroInitializer()
+    )
+    self.init(Builtin.shufflevector_${Builtin}_Vec${storageN}xInt32(
+      vec, vec, Builtin.zeroInitializer()
+    ))
   }
   
   /// A vector mask with the result of a pointwise equality comparison.

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -210,7 +210,9 @@ extension SIMDMask where Storage == ${Vector} {
   @_alwaysEmitIntoClient
   public static func random<T: RandomNumberGenerator>(using generator: inout T) -> Self {
     let data = Builtin.truncOrBitCast_Int64_Int${storageN}(generator.next()._value)
-    return Self(Builtin.bitcast_Int${storageN}_Vec${storageN}xInt1(data))
+    return Self(${MaskExt}(
+      Builtin.bitcast_Int${storageN}_Vec${storageN}xInt1(data)
+    ))
   }
   
   /// Returns a vector mask with `true` or `false` randomly assigned in each

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -212,11 +212,6 @@ extension SIMDMask where Storage == ${Vector} {
     (self .& .!mask) .| (other .& mask)
   }
   
-%   if n == 64:
-// sext <64 x i1> to <64 x iN> crashes LLVM on arm/arm64. Florian has a fix
-// for this, but only use the expansion on x86 for now.
-#if arch(x86_64) || arch(i386)
-%   end
   /// Returns a vector mask with `true` or `false` randomly assigned in each
   /// lane, using the given generator as a source for randomness.
   @_alwaysEmitIntoClient
@@ -234,9 +229,6 @@ extension SIMDMask where Storage == ${Vector} {
     var g = SystemRandomNumberGenerator()
     return Self.random(using: &g)
   }
-%   if n == 64:
-#endif
-%   end
 }
 
 /// True if any lane of mask is true.

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -206,6 +206,11 @@ extension SIMDMask where Storage == ${Vector} {
     (self .& .!mask) .| (other .& mask)
   }
   
+%   if n == 64:
+// sext <64 x i1> to <64 x iN> crashes LLVM on arm/arm64. Florian has a fix
+// for this, but only use the expansion on x86 for now.
+#if arch(x86_64) || arch(i386)
+%   end
   /// Returns a vector mask with `true` or `false` randomly assigned in each
   /// lane, using the given generator as a source for randomness.
   @_alwaysEmitIntoClient
@@ -223,6 +228,9 @@ extension SIMDMask where Storage == ${Vector} {
     var g = SystemRandomNumberGenerator()
     return Self.random(using: &g)
   }
+%   if n == 64:
+#endif
+%   end
 }
 
 /// True if any lane of mask is true.

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -701,7 +701,10 @@ extension SIMDMask {
   @inlinable
   public static func random<T: RandomNumberGenerator>(using generator: inout T) -> SIMDMask {
     var result = SIMDMask()
-    for i in result.indices { result[i] = Bool.random(using: &generator) }
+    let bits: UInt64 = generator.next()
+    for i in result.indices {
+      result[i] = bits & (1 &<< i) != 0
+    }
     return result
   }
   

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -360,12 +360,26 @@ extension SIMD where Scalar: Comparable {
   }
   
   /// The least element in the vector.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// indices.reduce(into: Scalar.max) {
+  ///   $0 = min($0, self[$1])
+  /// }
+  /// ```
   @_alwaysEmitIntoClient
   public func min() -> Scalar {
     return indices.reduce(into: self[0]) { $0 = Swift.min($0, self[$1]) }
   }
   
   /// The greatest element in the vector.
+  ///
+  /// Equivalent to:
+  /// ```
+  /// indices.reduce(into: Scalar.min) {
+  ///   $0 = max($0, self[$1])
+  /// }
+  /// ```
   @_alwaysEmitIntoClient
   public func max() -> Scalar {
     return indices.reduce(into: self[0]) { $0 = Swift.max($0, self[$1]) }
@@ -821,7 +835,12 @@ extension SIMD where Scalar: FixedWidthInteger {
   /// Returns the sum of the scalars in the vector, computed with wrapping
   /// addition.
   ///
-  /// Equivalent to `indices.reduce(into: 0) { $0 &+= self[$1] }`.
+  /// Equivalent to:
+  /// ```
+  /// indices.reduce(into: 0) {
+  ///   $0 &+= self[$1]
+  /// }
+  /// ```
   @_alwaysEmitIntoClient
   public func wrappedSum() -> Scalar {
     return indices.reduce(into: 0) { $0 &+= self[$1] }

--- a/test/stdlib/SIMDConcreteIntegers.swift.gyb
+++ b/test/stdlib/SIMDConcreteIntegers.swift.gyb
@@ -54,6 +54,18 @@ func genericArithmetic<T>(
   mul: a &* b
 )}
 
+func genericReduceMin<T>(_ a: T) -> T.Scalar where T: SIMD, T.Scalar: FixedWidthInteger {
+  a.min()
+}
+
+func genericReduceMax<T>(_ a: T) -> T.Scalar where T: SIMD, T.Scalar: FixedWidthInteger {
+  a.max()
+}
+
+func genericReduceSum<T>(_ a: T) -> T.Scalar where T: SIMD, T.Scalar: FixedWidthInteger {
+  a.wrappedSum()
+}
+
 %for int in all_integer_types(word_bits):
 % Scalar = int.stdlib_name
 % for n in vectorscalarCounts:
@@ -90,6 +102,18 @@ ${Scalar}x${n}_TestSuite.test("arithmetic") {
   expectEqual(add, a &+ b)
   expectEqual(sub, a &- b)
   expectEqual(mul, a &* b)
+}
+
+${Scalar}x${n}_TestSuite.test("reduction") {
+% if n == 3:
+  var a = ${Vector}.random(in: ${Scalar}.min ... .max)
+  a._storage[3] = ${Scalar}.random(in: .min ... .max)
+% else:
+  let a = ${Vector}.random(in: ${Scalar}.min ... .max)
+% end
+  expectEqual(genericReduceMin(a), a.min())
+  expectEqual(genericReduceMax(a), a.max())
+  expectEqual(genericReduceSum(a), a.wrappedSum())
 }
 
 % end

--- a/test/stdlib/SIMDConcreteMasks.swift.gyb
+++ b/test/stdlib/SIMDConcreteMasks.swift.gyb
@@ -50,6 +50,12 @@ func genericComparisons<T>(
   ne: a .!= b
 )}
 
+func genericAnyAll<T>(_ a: SIMDMask<T>) -> (any: Bool, all: Bool)
+where T: SIMD, T.Scalar: SignedInteger & FixedWidthInteger {(
+  any: any(a),
+  all: all(a)
+)}
+
 %for int in all_integer_types(word_bits):
 % Scalar = int.stdlib_name
 % for n in vectorscalarCounts:
@@ -93,6 +99,33 @@ ${Scalar}x${n}Mask_TestSuite.test("replacing") {
   expectEqual(f.replacing(with: t, where: a), a)
   expectEqual(t.replacing(with: false, where: a), .!a)
   expectEqual(f.replacing(with: true, where: a), a)
+}
+  
+${Scalar}x${n}Mask_TestSuite.test("any/all") {
+  let a = SIMDMask<${Vector}>.random()
+  let (anyA, allA) = genericAnyAll(a)
+  expectEqual(anyA, any(a))
+  expectEqual(allA, all(a))
+%   if n == 3:
+  var t = SIMDMask<${Vector}>(repeating: true)
+  t._storage._storage[3] = ${Scalar}.random(in: 0 ... .max)
+  var f = SIMDMask<${Vector}>(repeating: false)
+  f._storage._storage[3] = ${Scalar}.random(in: .min ... -1)
+%   else:
+  let t = SIMDMask<${Vector}>(repeating: true)
+  let f = SIMDMask<${Vector}>(repeating: false)
+%   end
+  expectTrue(all(t))
+  expectTrue(any(t))
+  expectFalse(all(f))
+  expectFalse(any(f))
+  
+  // Deliberately make a SIMDMask with non-canonical storage to make sure
+  // we still work.
+  let b = SIMDMask(${Vector}.random(in: (.min+1) ... (.max-1)))
+  let (anyB, allB) = genericAnyAll(b)
+  expectEqual(anyB, any(b))
+  expectEqual(allB, all(b))
 }
 
 %  end


### PR DESCRIPTION
(Opening this as a draft PR because it's dependent on new Builtins work that was just merged to main)

Implements a more efficient concrete algorithm for generating random SIMDMask objects. Because each lane of a SIMDMask only needs a single bit of randomness, we can get all the randomness we need from a single call to rng.next(), instead of using a call per lane as happens when we go through Bool.random() in the generic implementation. (We can _also_ improve the generic implementation, which I'll look at next).

SIMDMask.random() is not too heavily used, so we won't see any big wins from this anywhere, but it's a mostly trivial change with some nice speedups.