### PR TITLE
tests: remove some unused FileCheck prefix options

### DIFF
--- a/test/DebugInfo/value-witness-table.swift
+++ b/test/DebugInfo/value-witness-table.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -g -emit-ir %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK
+// RUN: %target-swift-frontend -g -emit-ir %s | %FileCheck %s --check-prefix=CHECK
 
 // Test that we don't generate debug info for hidden global variables.
 

--- a/test/Driver/actions.swift
+++ b/test/Driver/actions.swift
@@ -6,7 +6,7 @@
 // BASIC-COFF: 2: link, {1}, image
 // BASIC-ELF: 2: swift-autolink-extract, {1}, autolink
 // BASIC-ELF: 3: link, {1, 2}, image
-// BASIC-MACHO: 2: link, {1}, image
+// BASIC-macho: 2: link, {1}, image
 
 // RUN: %swiftc_driver -driver-print-actions -c %s 2>&1 | %FileCheck %s -check-prefix=BASICC
 // BASICC: 0: input, "{{.*}}actions.swift", swift
@@ -53,7 +53,7 @@
 // EXEC-AND-MODULE-COFF: 3: link, {1}, image
 // EXEC-AND-MODULE-ELF: 3: swift-autolink-extract, {1}, autolink
 // EXEC-AND-MODULE-ELF: 4: link, {1, 3}, image
-// EXEC-AND-MODULE-MACHO: 3: link, {1}, image
+// EXEC-AND-MODULE-macho: 3: link, {1}, image
 
 // RUN: %swiftc_driver -driver-print-actions -g %s 2>&1 | %FileCheck %s -check-prefix=DEBUG -check-prefix DEBUG-%target-object-format
 // RUN: %swiftc_driver -driver-print-actions -gnone -g %s 2>&1 | %FileCheck %s -check-prefix=DEBUG -check-prefix DEBUG-%target-object-format
@@ -64,7 +64,7 @@
 // DEBUG-COFF: 4: line, {1, 3}, image
 // DEBUG-ELF: 3: modulewrap, {2}, object
 // DEBUG-ELF: 4: line, {1, 3}, image
-// DEBUG-MACHO: 3: link, {1, 2}, image
+// DEBUG-macho: 3: link, {1, 2}, image
 
 // RUN: %swiftc_driver -driver-print-actions -gnone %s 2>&1 | %FileCheck %s -check-prefix=BASIC
 // RUN: %swiftc_driver -driver-print-actions -g -gnone %s 2>&1 | %FileCheck %s -check-prefix=BASIC

--- a/test/IDE/complete_pound_directive.swift
+++ b/test/IDE/complete_pound_directive.swift
@@ -9,7 +9,7 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_NOMINAL_1 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_NOMINAL_1 -D FOO -D BAR | %FileCheck %s -check-prefix=CONDITION -check-prefix=WITHFLAG
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_NOMINAL_2 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAGlll
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_NOMINAL_2 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_GLOBAL_1 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_GLOBAL_2 | %FileCheck %s -check-prefix=CONDITION -check-prefix=NOFLAG
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CONDITION_GLOBAL_2 -D FOO -D BAR | %FileCheck %s -check-prefix=CONDITION -check-prefix=WITHFLAG

--- a/test/IDE/complete_testable.swift
+++ b/test/IDE/complete_testable.swift
@@ -2,20 +2,20 @@
 // RUN: %target-swift-frontend -emit-module -enable-testing -o %t %S/Inputs/complete_testable_helper.swift
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TOP_LEVEL -I %t > %t.txt
-// RUN: %FileCheck %s -check-prefix=TOP_LEVEL -check-prefix=TOP_LEVEL-ALL < %t.txt
+// RUN: %FileCheck %s -check-prefix=TOP_LEVEL-ALL < %t.txt
 // RUN: %FileCheck %s -check-prefix=TOP_LEVEL-NEG -check-prefix=TOP_LEVEL-ALL-NEG < %t.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TOP_LEVEL -I %t -D TESTABLE > %t.testable.txt
 // RUN: %FileCheck %s -check-prefix=TOP_LEVEL-TESTABLE -check-prefix=TOP_LEVEL-ALL < %t.testable.txt
-// RUN: %FileCheck %s -check-prefix=TOP_LEVEL-TESTABLE-NEG -check-prefix=TOP_LEVEL-ALL-NEG < %t.testable.txt
+// RUN: %FileCheck %s -check-prefix=TOP_LEVEL-ALL-NEG < %t.testable.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBER -I %t > %t.txt
-// RUN: %FileCheck %s -check-prefix=MEMBER -check-prefix=MEMBER-ALL < %t.txt
+// RUN: %FileCheck %s -check-prefix=MEMBER-ALL < %t.txt
 // RUN: %FileCheck %s -check-prefix=MEMBER-NEG -check-prefix=MEMBER-ALL-NEG < %t.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=MEMBER -I %t -D TESTABLE > %t.testable.txt
 // RUN: %FileCheck %s -check-prefix=MEMBER-TESTABLE -check-prefix=MEMBER-ALL < %t.testable.txt
-// RUN: %FileCheck %s -check-prefix=MEMBER-TESTABLE-NEG -check-prefix=MEMBER-ALL-NEG < %t.testable.txt
+// RUN: %FileCheck %s -check-prefix=MEMBER-ALL-NEG < %t.testable.txt
 
 #if TESTABLE
 @testable import complete_testable_helper

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -75,10 +75,10 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SUBTYPE_1 | %FileCheck %s -check-prefix=SUBTYPE_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SUBTYPE_2 | %FileCheck %s -check-prefix=SUBTYPE_2
 
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_1 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_2 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_3 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_U
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_4 | %FileCheck %s -check-prefix=GENERIC_1 -check-prefix=GENERIC_1_INT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_1 | %FileCheck %s -check-prefix=GENERIC_1_INT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_2 | %FileCheck %s -check-prefix=GENERIC_1_INT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_3 | %FileCheck %s -check-prefix=GENERIC_1_U
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_4 | %FileCheck %s -check-prefix=GENERIC_1_INT
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STATIC_CLOSURE_1 | %FileCheck %s -check-prefix=STATIC_CLOSURE_1
 

--- a/test/IRGen/big_types_corner_cases_as_library.swift
+++ b/test/IRGen/big_types_corner_cases_as_library.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-type-layout %s -emit-ir  -parse-as-library | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -disable-type-layout %s -emit-ir  -parse-as-library | %FileCheck %s
 
 public struct BigStruct {
   var i0 : Int32 = 0

--- a/test/Interpreter/generic_casts_objc.swift
+++ b/test/Interpreter/generic_casts_objc.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Onone %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck --check-prefix CHECK --check-prefix CHECK-ONONE %s
+// RUN: %target-run %t/a.out | %FileCheck %s
 // RUN: %target-build-swift -O %s -o %t/a.out.optimized
 // RUN: %target-codesign %t/a.out.optimized
 // RUN: %target-run %t/a.out.optimized | %FileCheck %s

--- a/test/Interpreter/protocol_lookup.swift
+++ b/test/Interpreter/protocol_lookup.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
 // Note: JIT mode is checked in Interpreter/protocol_lookup_jit.swift.

--- a/test/Interpreter/protocol_lookup_jit.swift
+++ b/test/Interpreter/protocol_lookup_jit.swift
@@ -1,5 +1,5 @@
 // Test protocol_lookup.swift in JIT mode.
-// RUN: %swift -interpret %S/protocol_lookup.swift | %FileCheck %S/protocol_lookup.swift --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %swift -interpret %S/protocol_lookup.swift | %FileCheck %S/protocol_lookup.swift
 // REQUIRES: executable_test
 
 // REQUIRES: swift_interpreter

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-experimental-concurrency %s
-// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+// RUN: %FileCheck %s < %t/Test.swiftinterface
 // RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/Test.swiftinterface
 
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test -enable-experimental-concurrency
-// RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
+// RUN: %FileCheck %s < %t/TestFromModule.swiftinterface
 // RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/TestFromModule.swiftinterface
 
 // REQUIRES: concurrency

--- a/test/ModuleInterface/actor_objc.swift
+++ b/test/ModuleInterface/actor_objc.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-experimental-concurrency %s
-// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+// RUN: %FileCheck %s < %t/Test.swiftinterface
 // RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/Test.swiftinterface
 
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test -enable-experimental-concurrency
-// RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
+// RUN: %FileCheck %s < %t/TestFromModule.swiftinterface
 // RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/TestFromModule.swiftinterface
 
 // REQUIRES: concurrency

--- a/test/ModuleInterface/lazy-vars.swift
+++ b/test/ModuleInterface/lazy-vars.swift
@@ -6,10 +6,10 @@
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-module-interface-path - %t/Test.swiftmodule -module-name Test | %FileCheck %s --check-prefix CHECK --check-prefix NONRESILIENT
 
 // RUN: %target-swift-frontend -typecheck -module-name TestResilient -emit-module-interface-path %t/TestResilient.swiftinterface -enable-library-evolution %s
-// RUN: %FileCheck %s < %t/TestResilient.swiftinterface --check-prefix CHECK --check-prefix RESILIENT
+// RUN: %FileCheck %s < %t/TestResilient.swiftinterface
 
 // RUN: %target-swift-frontend -compile-module-from-interface %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s --check-prefix CHECK --check-prefix RESILIENT
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s
 
 // CHECK: @frozen public struct HasLazyVarsFixedLayout {
 // CHECK-NEXT: public var foo: Swift.Int {

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -typecheck -swift-version 5 -module-name TestResilient -emit-module-interface-path %t/TestResilient.swiftinterface -enable-library-evolution %s
-// RUN: %FileCheck %s < %t/TestResilient.swiftinterface --check-prefix CHECK --check-prefix RESILIENT
+// RUN: %FileCheck %s < %t/TestResilient.swiftinterface
 
 // RUN: %target-swift-frontend -compile-module-from-interface -swift-version 5 %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -swift-version 5  -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s --check-prefix CHECK --check-prefix RESILIENT
+// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -swift-version 5  -emit-module-interface-path - %t/TestResilient.swiftmodule -module-name TestResilient | %FileCheck %s
 
 @propertyWrapper
 public struct Wrapper<T> {

--- a/test/PrintAsObjC/imported-generic-typealias.swift
+++ b/test/PrintAsObjC/imported-generic-typealias.swift
@@ -2,7 +2,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %s -typecheck -emit-objc-header-path %t/imported-generic-typealias.h -import-objc-header %S/Inputs/imported-generic-typealias.h -disable-objc-attr-requires-foundation-module
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s < %t/imported-generic-typealias.h
+// RUN: %FileCheck %s < %t/imported-generic-typealias.h
 
 @objc public class MyRedBarn : Barn {
   @objc public func feed(_: Horse<NSObject>.Hay) {}

--- a/test/SILGen/async_handler_witness_table.swift
+++ b/test/SILGen/async_handler_witness_table.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-silgen -sdk %S/Inputs -I %S/Inputs -enable-source-import %s -enable-experimental-concurrency > %t.out
-// RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-ptrsize %s < %t.out
+// RUN: %FileCheck %s < %t.out
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/SILGen/default_arg_multiple_modules.swift
+++ b/test/SILGen/default_arg_multiple_modules.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path=%t/default_arg_other.swiftmodule -module-name=default_arg_other %S/Inputs/default_arg_other.swift
-// RUN: %target-swift-emit-silgen -module-name default_arg_multiple_modules -I %t %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+// RUN: %target-swift-emit-silgen -module-name default_arg_multiple_modules -I %t %s | %FileCheck %s
 
 import default_arg_other
 

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-emit-silgen -swift-version 5 -module-name generic_casts -Xllvm -sil-full-demangle %s | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-runtime %s
+// RUN: %target-swift-emit-silgen -swift-version 5 -module-name generic_casts -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 protocol ClassBound : class {}
 protocol NotClassBound {}

--- a/test/SILGen/objc_disable_brigding.swift
+++ b/test/SILGen/objc_disable_brigding.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-silgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t -I %S/../Inputs/ObjCBridging %S/../Inputs/ObjCBridging/Appliances.swift -I %t
-// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -I %S/../Inputs/ObjCBridging -disable-swift-bridge-attr -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-os-%target-cpu
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -I %S/../Inputs/ObjCBridging -disable-swift-bridge-attr -Xllvm -sil-full-demangle %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/SILOptimizer/OSLogMandatoryOptTest.sil
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -os-log-optimization -enable-sil-verify-all %s 2>&1 | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-sil-opt -os-log-optimization -enable-sil-verify-all %s 2>&1 | %FileCheck %s
 
 // SIL tests for the OSLogOptimization pass which performs compile-time analysis
 // and optimization of os log APIs. This test checks specific aspects of the

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/../Inputs/resilient_struct.swift -enable-library-evolution -emit-module -emit-module-path %t/resilient_struct.swiftmodule
 // RUN: %target-swift-frontend %S/../Inputs/resilient_enum.swift -I %t -enable-library-evolution -emit-module -emit-module-path %t/resilient_enum.swiftmodule
-// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -disable-copy-propagation -I %t -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=%target-os
+// RUN: %target-swift-frontend %s -sil-verify-all -emit-sil -disable-copy-propagation -I %t -o - | %FileCheck %s
 
 // Using -disable-copy-propagation to pattern match against older SIL
 // output. At least until -enable-copy-propagation has been around

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-OPT
+// RUN: %target-sil-opt -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all %s | %FileCheck %s
 //
 // Most CopyPropagation tests are still in copy_propagation_opaque.sil.
 //

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -1,11 +1,11 @@
-// RUN: %target-sil-opt -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-opaque-values -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-NDEBUG,CHECK-OPT
+// RUN: %target-sil-opt -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-opaque-values -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-OPT
 // RUN: %target-sil-opt -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-opaque-values -debug-only=copy-propagation %s -o /dev/null 2>&1 | %FileCheck %s --check-prefix=CHECK-TRACE
 //
 // Mandatory copy propagation does not currently handle address-only
 // types. It needs a visible layout to inject poison refs.
-//   %target-sil-opt -mandatory-copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-opaque-values -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-NDEBUG,CHECK-ONONE
+//   %target-sil-opt -mandatory-copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-opaque-values -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ONONE
 //
-// The CHECK-DEBUG/CHECK-NDEBUG prefixes are for the controlling the
+// The CHECK-DEBUG prefix is for the controlling the
 // debug_values preservation. CHECK-DEBUG are not currently tested
 // because we don't have a flag to enable debug_value preservation,
 // and it isn't clear that it's useful.

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s | %FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s -o %t.sil && %target-swift-frontend -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN --check-prefix=CHECK-IRGEN-%target-cpu %s
+// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s -o %t.sil && %target-swift-frontend -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN %s
 // RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer -sil-inline-generics=true -inline %s | %FileCheck --check-prefix=CHECK-EAGER-SPECIALIZE-AND-GENERICS-INLINE %s
 
 sil_stage canonical

--- a/test/SILOptimizer/eager_specialize_ossa.sil
+++ b/test/SILOptimizer/eager_specialize_ossa.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s | %FileCheck %s
-// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s -o %t.sil && %target-swift-frontend -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN --check-prefix=CHECK-IRGEN-%target-cpu %s
+// RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer  %s -o %t.sil && %target-swift-frontend -module-name=eager_specialize -emit-ir %t.sil | %FileCheck --check-prefix=CHECK-IRGEN %s
 // RUN: %target-sil-opt -enable-sil-verify-all -eager-specializer -sil-inline-generics=true -inline %s | %FileCheck --check-prefix=CHECK-EAGER-SPECIALIZE-AND-GENERICS-INLINE %s
 // rdar://problem/65373647
 // UNSUPPORTED: CPU=arm64e

--- a/test/SILOptimizer/switch_enum_resilient.swift
+++ b/test/SILOptimizer/switch_enum_resilient.swift
@@ -9,11 +9,11 @@
 // RUN: %target-swift-frontend -emit-sil -Osize -primary-file %s -emit-module-path %t/Osize-fragile.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix CHECK-FRAGILE -check-prefix CHECK-FRAGILE-NOINLINE %s
 // RUN: %target-sil-opt %t/Osize-fragile.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-FRAGILE %s
 
-// RUN: %target-swift-frontend -emit-sil -enable-library-evolution -O -primary-file %s -emit-module-path %t/O-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT -check-prefix=CHECK-RESILIENT-NOINLINE %s
-// RUN: %target-sil-opt %t/O-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
+// RUN: %target-swift-frontend -emit-sil -enable-library-evolution -O -primary-file %s -emit-module-path %t/O-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT-NOINLINE %s
+// RUN: %target-sil-opt %t/O-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-RESILIENT-INLINE %s
 
-// RUN: %target-swift-frontend -emit-sil -enable-library-evolution -Osize -primary-file %s -emit-module-path %t/Osize-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT -check-prefix=CHECK-RESILIENT-NOINLINE %s
-// RUN: %target-sil-opt %t/Osize-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix=CHECK-RESILIENT -check-prefix CHECK-RESILIENT-INLINE %s
+// RUN: %target-swift-frontend -emit-sil -enable-library-evolution -Osize -primary-file %s -emit-module-path %t/Osize-resilient.swiftmodule | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-NOINLINE -check-prefix=CHECK-RESILIENT-NOINLINE %s
+// RUN: %target-sil-opt %t/Osize-resilient.swiftmodule -module-name switch_enum_resilient -emit-sorted-sil | %FileCheck -check-prefix CHECK-ALL -check-prefix CHECK-RESILIENT-INLINE %s
 
 public enum Alpha : Int {
   case a, b, c, d, e

--- a/test/Sema/availability_nonoverlapping.swift
+++ b/test/Sema/availability_nonoverlapping.swift
@@ -1,10 +1,10 @@
 // RUN: not %target-swift-frontend -typecheck %s -swift-version 4 2> %t.4.txt
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-4 %s < %t.4.txt
-// RUN: %FileCheck -check-prefix=NEGATIVE -check-prefix=NEGATIVE-4 %s < %t.4.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.4.txt
 
 // RUN: not %target-swift-frontend -typecheck %s -swift-version 5 2> %t.5.txt
 // RUN: %FileCheck -check-prefix=CHECK -check-prefix=CHECK-5 %s < %t.5.txt
-// RUN: %FileCheck -check-prefix=NEGATIVE -check-prefix=NEGATIVE-5 %s < %t.5.txt
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.5.txt
 
 
 class NonOptToOpt {

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -9,13 +9,13 @@
 
 // RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module_inferred.swift -emit-module-path %t/autolinking_module_inferred.swiftmodule -module-link-name autolinking_module_inferred -I %t -swift-version 4
 
-// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D NORMAL_IMPORT | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -check-prefix CHECK-NORMAL-%target-os -implicit-check-not BAD %s
-// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D IMPLEMENTATION_ONLY_IMPORT | %FileCheck -check-prefix CHECK -check-prefix CHECK-IMPL_ONLY -check-prefix CHECK-IMPL_ONLY-%target-os -implicit-check-not BAD %s
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D NORMAL_IMPORT | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -implicit-check-not BAD %s
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D IMPLEMENTATION_ONLY_IMPORT | %FileCheck -check-prefix CHECK -check-prefix CHECK-IMPL_ONLY -implicit-check-not BAD %s
 
-// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D NORMAL_AND_IMPLEMENTATION_ONLY | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -check-prefix CHECK-NORMAL-%target-os -implicit-check-not BAD %s
-// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D IMPLEMENTATION_ONLY_AND_NORMAL | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -check-prefix CHECK-NORMAL-%target-os -implicit-check-not BAD %s
-// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D EXPORTED_AND_IMPLEMENTATION_ONLY | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -check-prefix CHECK-NORMAL-%target-os -implicit-check-not BAD %s
-// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D IMPLEMENTATION_ONLY_AND_EXPORTED | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -check-prefix CHECK-NORMAL-%target-os -implicit-check-not BAD %s
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D NORMAL_AND_IMPLEMENTATION_ONLY | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -implicit-check-not BAD %s
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D IMPLEMENTATION_ONLY_AND_NORMAL | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -implicit-check-not BAD %s
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D EXPORTED_AND_IMPLEMENTATION_ONLY | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -implicit-check-not BAD %s
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 -enable-objc-interop -D IMPLEMENTATION_ONLY_AND_EXPORTED | %FileCheck -check-prefix CHECK -check-prefix CHECK-NORMAL -implicit-check-not BAD %s
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.

--- a/test/Serialization/autolinking.swift
+++ b/test/Serialization/autolinking.swift
@@ -52,6 +52,6 @@ import someModule
 // FORCE-LOAD-CLIENT: @llvm.used = appending global [{{[0-9]+}} x i8*] [
 // FORCE-LOAD-CLIENT: i8* bitcast (void ()** @"_swift_FORCE_LOAD_$_module_$_autolinking" to i8*)
 // FORCE-LOAD-CLIENT: ], section "llvm.metadata"
-// FORCE-LOAD-CLIENT-MACHO: declare extern_weak {{(dllimport )?}}void @"_swift_FORCE_LOAD_$_module"()
+// FORCE-LOAD-CLIENT-macho: declare extern_weak {{(dllimport )?}}void @"_swift_FORCE_LOAD_$_module"()
 // FORCE-LOAD-CLIENT-COFF: declare extern {{(dllimport )?}}void @"_swift_FORCE_LOAD_$_module"()
 

--- a/test/Serialization/load-invalid-arch.swift
+++ b/test/Serialization/load-invalid-arch.swift
@@ -15,7 +15,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/new_module.swiftmodule
-// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix=CHECK-EMPTY -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%target
+// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%target
 
 // CHECK-ALL-NOT: error:
 // CHECK: {{.*}} error: could not find module 'new_module' for target '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}

--- a/test/multifile/require-layout-generic-arg-closure.swift
+++ b/test/multifile/require-layout-generic-arg-closure.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-objc %s
-// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-objc %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
 
 // RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-native %s
-// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-native %s
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/multifile/require-layout-generic-arg-subscript.swift
+++ b/test/multifile/require-layout-generic-arg-subscript.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-objc %s
-// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-objc %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
 
 // RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-native %s
-// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-native %s
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/multifile/require-layout-generic-arg.swift
+++ b/test/multifile/require-layout-generic-arg.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-objc %s
-// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-objc %s
+// RUN: %target-swift-frontend -module-name test -enable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
 
 // RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify -primary-file %s %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE1,FILE1-native %s
-// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefixes=FILE2,FILE2-native %s
+// RUN: %target-swift-frontend -module-name test -disable-objc-interop -emit-ir -verify %s -primary-file %S/Inputs/require-layout-generic-class.swift | %FileCheck --check-prefix=FILE2 %s
 
 // REQUIRES: CPU=x86_64
 


### PR DESCRIPTION
Such tests would fail with the -allow-unused-prefixes FileCheck option.
```
diff --git a/test/lit.cfg b/test/lit.cfg
-run_filecheck = '%s %s --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --use-filecheck %s %s' % (
+run_filecheck = '%s %s --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --use-filecheck %s %s -allow-unused-prefixes=false' % (
```
It helps avoiding some wrong CHECK patterns.
I just looked briefly at some of the fails. TODO: fix remaining tests, too.

rdar://74189761
