### PR TITLE
Extend compile-time constantness check to support constant Ranges

### DIFF
--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -105,7 +105,7 @@ static Expr *checkConstantness(Expr *expr) {
   expressionsToCheck.push_back(expr);
   while (!expressionsToCheck.empty()) {
     Expr *expr = expressionsToCheck.pop_back_val();
-    // Lookthrough identity_expr, tuple and inject_into_optional expressions.
+    // Lookthrough identity_expr, tuple, binary_expr and inject_into_optional expressions.
     if (IdentityExpr *identityExpr = dyn_cast<IdentityExpr>(expr)) {
       expressionsToCheck.push_back(identityExpr->getSubExpr());
       continue;
@@ -113,6 +113,10 @@ static Expr *checkConstantness(Expr *expr) {
     if (TupleExpr *tupleExpr = dyn_cast<TupleExpr>(expr)) {
       for (Expr *element : tupleExpr->getElements())
         expressionsToCheck.push_back(element);
+      continue;
+    }
+    if (BinaryExpr *binaryExpr = dyn_cast<BinaryExpr>(expr)) {
+      expressionsToCheck.push_back(binaryExpr->getArg());
       continue;
     }
     if (InjectIntoOptionalExpr *optionalExpr =

--- a/test/Sema/diag_constantness_check.swift
+++ b/test/Sema/diag_constantness_check.swift
@@ -328,3 +328,19 @@ func testAtomicOrderingConstantness(
   _ = atomicInt.load(ordering: myOrder)
     // expected-error@-1 {{ordering argument must be a static method or property of 'AtomicLoadOrdering'}}
 }
+
+// Test that the check can handle ranges
+@_semantics("oslog.requires_constant_arguments")
+func constantRange(x: Range<Int>) {}
+
+@_semantics("oslog.requires_constant_arguments")
+func constantClosedRange(x: ClosedRange<Int>) {}
+
+func testConstantRange(x: Int) {
+  constantRange(x: 0..<5)
+  constantRange(x: 0..<x)
+    // expected-error@-1 {{argument must be an integer literal}}
+  constantClosedRange(x: 0...10)
+  constantClosedRange(x: x...10)
+    // expected-error@-1 {{argument must be an integer literal}}
+}


### PR DESCRIPTION
Currently the function parameter constantness check for functions annotated with `@_semantics("oslog.requires_constant_arguments")` does not support ranges (e.g. `0...5`, `0..<5`). Ranges like this are considered binary expressions by the compiler. This change adds support for accepting binary expressions as constant arguments as long as both arguments to the expression are constant.

rdar://71822563