### PR TITLE
[Localization] Remove checking on unknownIDs from tests

### DIFF
--- a/test/diagnostics/Localization/Inputs/en.yaml
+++ b/test/diagnostics/Localization/Inputs/en.yaml
@@ -17,14 +17,8 @@
 # 
 #===----------------------------------------------------------------------===#
 
-- id: "not_available_in_def"
-  msg: "Shouldn't be produced"
-
 - id: "lex_unterminated_string"
   msg: "unterminated string literal"
-
-- id: "not_available_in_def_2"
-  msg: "Shouldn't be produced"
 
 - id: "var_init_self_referential"
   msg: "variable used within its own initial value"
@@ -32,14 +26,5 @@
 - id: "cannot_find_in_scope"
   msg: "cannot %select{find|find operator}1 %0 in scope"
 
-- id: "not_available_in_def_3"
-  msg: "Shouldn't be produced"
-
 - id: "warning_invalid_locale_code"
   msg: "unsupported locale code; supported locale codes are '%0'"
-
-- id: "not_available_in_def_4"
-  msg: "Shouldn't be produced"
-
-- id: "not_available_in_def_5"
-  msg: "Shouldn't be produced"

--- a/test/diagnostics/Localization/fr_debug_diagnostic_name.swift
+++ b/test/diagnostics/Localization/fr_debug_diagnostic_name.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/fr.yaml --output-directory=%t/
-// RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/en.yaml --output-directory=%t/ 2>&1 | %FileCheck %s
+// RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/en.yaml --output-directory=%t/
 // RUN: not %target-swift-frontend -debug-diagnostic-names -localization-path %S/Inputs -locale fr -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK_NAMES
 
-// CHECK: These diagnostic IDs are no longer availiable: 'not_available_in_def, not_available_in_def_2, not_available_in_def_3, not_available_in_def_4, not_available_in_def_5'
 _ = "HI!
 // CHECK_NAMES: error: chaîne non terminée littérale [lex_unterminated_string]{{$}}
 

--- a/test/diagnostics/Localization/fr_localization.swift
+++ b/test/diagnostics/Localization/fr_localization.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/fr.yaml --output-directory=%t/
-// RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/en.yaml --output-directory=%t/ 2>&1 | %FileCheck %s
+// RUN: swift-serialize-diagnostics --input-file-path=%S/Inputs/en.yaml --output-directory=%t/
 // RUN: %target-typecheck-verify-swift -localization-path %t -locale fr
 
-// CHECK: These diagnostic IDs are no longer availiable: 'not_available_in_def, not_available_in_def_2, not_available_in_def_3, not_available_in_def_4, not_available_in_def_5'
 _ = "HI!
 // expected-error@-1{{chaîne non terminée littérale}}
 


### PR DESCRIPTION
Remove checking on unknown diagnostic IDs from tests as well removing them from `yaml`. Since .def file is still a source of truth and if it doesn't have it that diagnostic is no longer viable.

cc @xedin 