### PR TITLE
[Frontend] Remove enable-experimental-enum-codable-derivation flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -256,9 +256,6 @@ namespace swift {
     /// Enable inference of Sendable conformances for public types.
     bool EnableInferPublicSendable = false;
 
-    /// Enable experimental derivation of `Codable` for enums.
-    bool EnableExperimentalEnumCodableDerivation = false;
-
     /// Disable the implicit import of the _Concurrency module.
     bool DisableImplicitConcurrencyModuleImport = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -233,10 +233,6 @@ def enable_experimental_flow_sensitive_concurrent_captures :
   Flag<["-"], "enable-experimental-flow-sensitive-concurrent-captures">,
   HelpText<"Enable flow-sensitive concurrent captures">;
 
-def enable_experimental_enum_codable_derivation :
-  Flag<["-"], "enable-experimental-enum-codable-derivation">,
-  HelpText<"Enable experimental derivation of Codable for enums">;
-
 def enable_resilience : Flag<["-"], "enable-resilience">,
      HelpText<"Deprecated, use -enable-library-evolution instead">;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -392,9 +392,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalFlowSensitiveConcurrentCaptures |=
     Args.hasArg(OPT_enable_experimental_flow_sensitive_concurrent_captures);
 
-  Opts.EnableExperimentalEnumCodableDerivation |=
-      Args.hasArg(OPT_enable_experimental_enum_codable_derivation);
-
   Opts.DisableImplicitConcurrencyModuleImport |=
     Args.hasArg(OPT_disable_implicit_concurrency_module_import);
 

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -2014,9 +2014,7 @@ static bool canDeriveCodable(NominalTypeDecl *NTD,
   // Structs, classes and enums can explicitly derive Encodable and Decodable
   // conformance (explicitly meaning we can synthesize an implementation if
   // a type conforms manually).
-  if (!isa<StructDecl>(NTD) && !isa<ClassDecl>(NTD) &&
-      !(NTD->getASTContext().LangOpts.EnableExperimentalEnumCodableDerivation
-        && isa<EnumDecl>(NTD))) {
+  if (!isa<StructDecl>(NTD) && !isa<ClassDecl>(NTD) && !isa<EnumDecl>(NTD)) {
     return false;
   }
 
@@ -2039,8 +2037,7 @@ bool DerivedConformance::canDeriveEncodable(NominalTypeDecl *NTD) {
 ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
   // We can only synthesize Encodable for structs and classes.
   if (!isa<StructDecl>(Nominal) && !isa<ClassDecl>(Nominal) &&
-      !(Context.LangOpts.EnableExperimentalEnumCodableDerivation
-        && isa<EnumDecl>(Nominal)))
+      !isa<EnumDecl>(Nominal))
     return nullptr;
 
   if (requirement->getBaseName() != Context.Id_encode) {
@@ -2070,8 +2067,7 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
 ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   // We can only synthesize Encodable for structs and classes.
   if (!isa<StructDecl>(Nominal) && !isa<ClassDecl>(Nominal) &&
-      !(Context.LangOpts.EnableExperimentalEnumCodableDerivation
-        && isa<EnumDecl>(Nominal)))
+      !isa<EnumDecl>(Nominal))
     return nullptr;
 
   if (requirement->getBaseName() != DeclBaseName::createConstructor()) {

--- a/test/IRGen/synthesized_conformance.swift
+++ b/test/IRGen/synthesized_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir %s -swift-version 4 -enable-experimental-enum-codable-derivation | %FileCheck %s
+// RUN: %target-swift-frontend -disable-generic-metadata-prespecialization -emit-ir %s -swift-version 4 | %FileCheck %s
 
 struct Struct<T> {
     var x: T

--- a/test/IRGen/synthesized_conformance_future.swift
+++ b/test/IRGen/synthesized_conformance_future.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -swift-version 4 -enable-experimental-enum-codable-derivation | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir %s -swift-version 4 | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 -enable-experimental-enum-codable-derivation | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
-// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 -enable-library-evolution -enable-experimental-enum-codable-derivation | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 | %FileCheck -check-prefix CHECK -check-prefix CHECK-FRAGILE %s
+// RUN: %target-swift-frontend -emit-silgen %s -swift-version 4 -enable-library-evolution | %FileCheck -check-prefix CHECK -check-prefix CHECK-RESILIENT %s
 
 enum Enum<T> {
     case a(T), b(T)

--- a/test/decl/protocol/special/coding/enum_codable_case_identifier_overloads.swift
+++ b/test/decl/protocol/special/coding/enum_codable_case_identifier_overloads.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // Simple enums with all Codable parameters whose CodingKeys come from a
 // typealias should get derived conformance to Codable.

--- a/test/decl/protocol/special/coding/enum_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/enum_codable_codingkeys_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // Simple enums with all Codable parameters whose CodingKeys come from a
 // typealias should get derived conformance to Codable.

--- a/test/decl/protocol/special/coding/enum_codable_conflicting_parameter_identifier.swift
+++ b/test/decl/protocol/special/coding/enum_codable_conflicting_parameter_identifier.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 enum Duplicate : Codable { // expected-error {{type 'Duplicate' does not conform to protocol 'Decodable'}}
   // expected-error@-1 {{type 'Duplicate' does not conform to protocol 'Encodable'}}

--- a/test/decl/protocol/special/coding/enum_codable_excluded_optional_properties.swift
+++ b/test/decl/protocol/special/coding/enum_codable_excluded_optional_properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift
 
 enum EnumWithNonExcludedOptionalParameters : Codable { // expected-error {{type 'EnumWithNonExcludedOptionalParameters' does not conform to protocol 'Decodable'}}
     // expected-error@-1 {{type 'EnumWithNonExcludedOptionalParameters' does not conform to protocol 'Encodable'}}

--- a/test/decl/protocol/special/coding/enum_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/enum_codable_failure_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify -enable-experimental-enum-codable-derivation
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
 
 // Codable enum with non-Codable parameter.
 enum E1 : Codable {

--- a/test/decl/protocol/special/coding/enum_codable_ignore_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/enum_codable_ignore_nonconforming_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 struct NonCodable {}
 

--- a/test/decl/protocol/special/coding/enum_codable_invalid_codingkeys.swift
+++ b/test/decl/protocol/special/coding/enum_codable_invalid_codingkeys.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // Enums with a CodingKeys entity which is not a type should not derive
 // conformance.

--- a/test/decl/protocol/special/coding/enum_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/enum_codable_member_type_lookup.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // MARK: - Synthesized CodingKeys Enum
 

--- a/test/decl/protocol/special/coding/enum_codable_nonconforming_property.swift
+++ b/test/decl/protocol/special/coding/enum_codable_nonconforming_property.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 enum NonCodable : Hashable {
     func hash(into hasher: inout Hasher) {}

--- a/test/decl/protocol/special/coding/enum_codable_reordered_codingkeys.swift
+++ b/test/decl/protocol/special/coding/enum_codable_reordered_codingkeys.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // The order of cases in the case specific CodingKeys enum should not matter
 enum SimpleEnum : Codable {

--- a/test/decl/protocol/special/coding/enum_codable_simple.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // Simple enums with all Codable parameters should get derived conformance to
 // Codable.

--- a/test/decl/protocol/special/coding/enum_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple_conditional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4 -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 enum Conditional<T> {
   case a(x: T, y: T?)

--- a/test/decl/protocol/special/coding/enum_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple_conditional_separate.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4 -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 enum Conditional<T> {
   case a(x: T, y: T?)

--- a/test/decl/protocol/special/coding/enum_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple_extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4 -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 // Simple enums where Codable conformance is added in extensions should derive
 // conformance.

--- a/test/decl/protocol/special/coding/enum_codable_simple_extension_flipped.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple_extension_flipped.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4 -enable-experimental-enum-codable-derivation
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 // Simple enums where Codable conformance is added in extensions should derive
 // conformance, no matter which order the extension and type occur in.

--- a/test/decl/protocol/special/coding/enum_codable_simple_multi.swift
+++ b/test/decl/protocol/special/coding/enum_codable_simple_multi.swift
@@ -1,2 +1,2 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation %S/Inputs/enum_codable_simple_multi1.swift %S/Inputs/enum_codable_simple_multi2.swift
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -enable-experimental-enum-codable-derivation %S/Inputs/enum_codable_simple_multi2.swift %S/Inputs/enum_codable_simple_multi1.swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown %S/Inputs/enum_codable_simple_multi1.swift %S/Inputs/enum_codable_simple_multi2.swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown %S/Inputs/enum_codable_simple_multi2.swift %S/Inputs/enum_codable_simple_multi1.swift


### PR DESCRIPTION
SE-295 has been accepted, so we don't need to hide the feature behind a flag anymore.