### PR TITLE
Preload standard library in ModuleInterfaceBuilder 

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -290,6 +290,11 @@ public:
   bool isLocInVirtualFile(SourceLoc Loc) const {
     return getVirtualFile(Loc) != nullptr;
   }
+
+  /// Return a SourceLoc in \c this corresponding to \p otherLoc, which must be
+  /// owned by \p otherManager. Returns an invalid SourceLoc if it cannot be
+  /// translated.
+  SourceLoc getLocForForeignLoc(SourceLoc otherLoc, SourceManager &otherMgr);
 };
 
 } // end namespace swift

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -307,6 +307,7 @@ bool CompilerInstance::setupDiagnosticVerifierIfNeeded() {
         Diagnostics.diagnose(SourceLoc(), diag::error_open_input_file,
                              filename, result.getError().message());
         hadError |= true;
+        continue;
       }
 
       auto bufferID = SourceMgr.addNewSourceBuffer(std::move(result.get()));

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -187,6 +187,13 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     InputInfo.getPrimarySpecificPaths().SupplementaryOutputs;
     StringRef OutPath = OutputInfo.ModuleOutputPath;
 
+    // Bail out if we're going to use the standard library but can't load it. If
+    // we don't do this before we try to build the interface, we could end up
+    // trying to rebuild a broken standard library dozens of times due to
+    // multiple calls to `ASTContext::getStdlibModule()`.
+    if (SubInstance.loadStdlibIfNeeded())
+      return std::make_error_code(std::errc::not_supported);
+
     // Build the .swiftmodule; this is a _very_ abridged version of the logic
     // in performCompile in libFrontendTool, specialized, to just the one
     // module-serialization task we're trying to do here.

--- a/test/ModuleInterface/BadStdlib.swiftinterface
+++ b/test/ModuleInterface/BadStdlib.swiftinterface
@@ -14,3 +14,6 @@
 import ClangMod
 
 public func useHasPointer(_: HasPointer)
+
+// FIXME: SR-14489
+// UNSUPPORTED: windows

--- a/test/ModuleInterface/BadStdlib.swiftinterface
+++ b/test/ModuleInterface/BadStdlib.swiftinterface
@@ -1,0 +1,16 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name BadStdlib
+
+// no-error@-3
+
+// Tests whether -compile-module-from-interface correctly stops early when the
+// standard library module interface is broken, rather than trying to limp along
+// without a standard library, which tends to cause ClangImporter crashes (among
+// other things.)
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: -sdk %/S/Inputs/BadStdlib.sdk -module-cache-path %/t/module-cache -resource-dir %/S/Inputs/BadStdlib.sdk) -compile-module-from-interface -o %/t/BadStdlib.swiftmodule %s -verify -verify-additional-file %/S/Inputs/BadStdlib.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
+
+import ClangMod
+
+public func useHasPointer(_: HasPointer)

--- a/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/include/ClangMod.h
+++ b/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/include/ClangMod.h
@@ -1,0 +1,1 @@
+typedef int * HasPointer;

--- a/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/include/module.modulemap
+++ b/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/include/module.modulemap
@@ -1,0 +1,4 @@
+module HasPointer {
+  header "HasPointer.h"
+  export *
+}

--- a/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,0 +1,9 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name Swift -parse-stdlib
+
+// If the test fails, this error will be emitted twice, not once.
+// expected-error@-4 {{failed to build module 'Swift' for importation due to the errors above}}
+
+public struct BadType {
+  public var property: UndeclaredType { get set } // expected-error {{cannot find type 'UndeclaredType' in scope}}
+}


### PR DESCRIPTION
Previously, when the standard library module interface was broken, Swift would try to rebuild it repeatedly during `-compile-module-from-interface` jobs because `ASTContext::getStdlibModule()` would try to load the standard library again each time it was called. This led to extremely slow compilations that repeatedly emitted the same errors, and sometimes to crashes in non-asserts compilers when they expected a standard library but couldn't find one.

To avoid this, we make `ModuleInterfaceBuilder` try to load the standard library right away and bail out if it can’t.

This PR also includes a couple of fixes for issues that occur when trying to use `-verify` mode with module interfaces. One of these (the SourceLoc translation issue) is implicitly exercised by the new test; the other is a simple command-line flag validation bug.

Fixes rdar://75669548.
