### PR TITLE
Loosen key path restrictions for global actor-isolated properties.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1944,6 +1944,12 @@ namespace {
             LLVM_FALLTHROUGH; // otherwise, perform checking
 
           case ActorIsolationRestriction::GlobalActor:
+            // Disable global actor checking for now.
+            if (!ctx.LangOpts.isSwiftVersionAtLeast(6))
+              break;
+
+            LLVM_FALLTHROUGH; // otherwise, it's invalid so diagnose it.
+
           case ActorIsolationRestriction::CrossActorSelf:
             // 'let'-bound decls with this isolation are OK, just check them.
             if (auto wasLetBound = checkLetBoundVarDecl(component)) {

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -57,7 +57,7 @@ func tryKeyPathsMisc(d : Door) {
 
 func tryKeyPathsFromAsync() async {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-error{{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'}}
+    _ = \Door.unsafeGlobActor_mutable // okay for now
 }
 
 func tryNonSendable() {
@@ -68,7 +68,7 @@ func tryNonSendable() {
 
 func tryKeypaths() {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-error{{cannot form key path to actor-isolated property 'unsafeGlobActor_mutable'}}
+    _ = \Door.unsafeGlobActor_mutable // okay for now
 
     _ = \Door.immutable
     _ = \Door.unsafeIndependent
@@ -84,7 +84,7 @@ func tryKeypaths() {
     let _ : PartialKeyPath<Door> = \.mutable // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
     let _ : AnyKeyPath = \Door.mutable  // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
 
-    _ = \Door.globActor_mutable // expected-error{{cannot form key path to actor-isolated property 'globActor_mutable'}}
+    _ = \Door.globActor_mutable // okay for now
     _ = \Door.[0] // expected-error{{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
-    _ = \Door.["hello"] // expected-error{{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
+    _ = \Door.["hello"] // okay for now
 }


### PR DESCRIPTION
We need to tie this in more deeply with Sendable for it to make sense.
Fixes rdar://75839460.
