### PR TITLE
Add support for @actorIndependent on closures. 

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5614,6 +5614,10 @@ public:
     // Nothing else to check.
   }
 
+  void visitActorIndependentAttr(ActorIndependentAttr *attr) {
+    // Nothing else to check.
+  }
+
   void visitCustomAttr(CustomAttr *attr) {
     // Check whether this custom attribute is the global actor attribute.
     auto globalActorAttr = evaluateOrDefault(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1544,55 +1544,21 @@ namespace {
     }
 
     /// Get the actor isolation of the innermost relevant context.
-    ActorIsolation getInnermostIsolatedContext(const DeclContext *constDC) {
-      // Retrieve the actor isolation for a declaration somewhere in our
-      // declaration context chain and map it into our own context so that
-      // the types can be compared.
-      auto getActorIsolation = [constDC](ValueDecl *value) {
-        switch (auto isolation = swift::getActorIsolation(value)) {
-        case ActorIsolation::ActorInstance:
-        case ActorIsolation::Independent:
-        case ActorIsolation::IndependentUnsafe:
-        case ActorIsolation::Unspecified:
-          return isolation;
+    ActorIsolation getInnermostIsolatedContext(DeclContext *dc) {
+      // Retrieve the actor isolation of the context.
+      switch (auto isolation = getActorIsolationOfContext(dc)) {
+      case ActorIsolation::ActorInstance:
+      case ActorIsolation::Independent:
+      case ActorIsolation::IndependentUnsafe:
+      case ActorIsolation::Unspecified:
+        return isolation;
 
-        case ActorIsolation::GlobalActor:
-        case ActorIsolation::GlobalActorUnsafe:
-          return ActorIsolation::forGlobalActor(
-              constDC->mapTypeIntoContext(isolation.getGlobalActor()),
-              isolation == ActorIsolation::GlobalActorUnsafe);
-        }
-      };
-
-      auto dc = const_cast<DeclContext *>(constDC);
-      while (!dc->isModuleScopeContext()) {
-        if (auto closure = dyn_cast<AbstractClosureExpr>(dc))
-          return getActorIsolationOfContext(dc);
-
-        // Functions have actor isolation defined on them.
-        if (auto func = dyn_cast<AbstractFunctionDecl>(dc))
-          return getActorIsolation(func);
-
-        // Subscripts have actor isolation defined on them.
-        if (auto subscript = dyn_cast<SubscriptDecl>(dc))
-          return getActorIsolation(subscript);
-
-        // Pattern binding declarations have actor isolation defined on their
-        // properties, if any.
-        if (auto init = dyn_cast<PatternBindingInitializer>(dc)) {
-          auto var = init->getBinding()->getAnchoringVarDecl(
-              init->getBindingIndex());
-          if (var)
-            return getActorIsolation(var);
-
-          return ActorIsolation::forUnspecified();
-        }
-
-        return ActorIsolation::forUnspecified();
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
+        return ActorIsolation::forGlobalActor(
+            dc->mapTypeIntoContext(isolation.getGlobalActor()),
+            isolation == ActorIsolation::GlobalActorUnsafe);
       }
-
-      // At module scope, actor independence with safety is assumed.
-      return ActorIsolation::forIndependent(ActorIndependentKind::Safe);
     }
 
     bool isInAsynchronousContext() const {
@@ -1704,7 +1670,7 @@ namespace {
         bool isCrossActor,
         Expr *context) {
       ValueDecl *value = valueRef.getDecl();
-      auto declContext = getDeclContext();
+      auto declContext = const_cast<DeclContext *>(getDeclContext());
 
       // Check whether we are within the same isolation context, in which
       // case there is nothing further to check,

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -196,7 +196,7 @@ struct MyGlobalActor {
 // expected-note@-3{{mutation of this var is only permitted within the actor}}
 
 // expected-error@+2{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-// expected-error@+1{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from this context}}
+// expected-error@+1{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
 let _ = Task.runDetached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
 
 // attempt to pass global state owned by the global actor to another async function

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -45,6 +45,8 @@ struct SomeGlobalActor {
 
 func someAsyncFunc() async { }
 
+@SomeGlobalActor func getGlobal7() -> Int { 7 }
+
 // CHECK-LABEL: someGlobalActorFunc
 @SomeGlobalActor func someGlobalActorFunc() async {
   // CHECK: acceptAsyncClosure
@@ -66,5 +68,4 @@ func someAsyncFunc() async { }
   // CHECK: closure_expr
   // CHECK-NOT:actor-isolated
   acceptEscapingAsyncClosure { () async in print("hello") }
-
 }

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -61,12 +61,12 @@ func callGlobalActor() {
 
 func fromClosure() {
   { () -> Void in
-    // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this context}}
+    // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from a non-isolated context}}
     let x = syncGlobActorFn
     x()
   }()
 
-  // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+  // expected-error@+1 {{global function 'syncGlobActorFn()' isolated to global actor 'SomeGlobalActor' can not be referenced from a non-isolated synchronous context}}
   let _ = { syncGlobActorFn() }()
 }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -426,3 +426,14 @@ struct HasWrapperOnUnsafeActor {
     synced = 17
   }
 }
+
+// ----------------------------------------------------------------------
+// Actor-independent closures
+// ----------------------------------------------------------------------
+@SomeGlobalActor func getGlobal7() -> Int { 7 } // expected-note{{calls to global function 'getGlobal7()' from outside of its actor context are implicitly asynchronous}}
+func acceptClosure<T>(_: () -> T) { }
+
+@SomeGlobalActor func someGlobalActorFunc() async {
+  acceptClosure { getGlobal7() } // okay
+  acceptClosure { @actorIndependent in getGlobal7() } // expected-error{{global function 'getGlobal7()' isolated to global actor 'SomeGlobalActor' can not be referenced from a non-isolated synchronous context}}
+}


### PR DESCRIPTION
Closures often end up being implicitly actor-isolated. Allow them to opt
out with `@actorIndependent`, as as other declarations can opt out of
actor isolation.