### PR TITLE
[CSGen] Avoid failing due to invalid explicit closure parameters

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7199,10 +7199,17 @@ bool MissingContextualTypeForNil::diagnoseAsError() {
 }
 
 bool ReferenceToInvalidDeclaration::diagnoseAsError() {
+  auto &DE = getASTContext().Diags;
+
+  // `resolveType` caches results, so there is no way
+  // to suppress and then re-request the diagnostic
+  // via calling `resolveType` on the same `TypeRepr`.
+  if (getAsDecl<ParamDecl>(getAnchor()))
+    return DE.hadAnyError();
+
   auto *decl = castToExpr<DeclRefExpr>(getAnchor())->getDecl();
   assert(decl);
 
-  auto &DE = getASTContext().Diags;
   // This problem should have been already diagnosed during
   // validation of the declaration.
   if (DE.hadAnyError())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1984,6 +1984,18 @@ namespace {
           Type externalType;
           if (param->getTypeRepr()) {
             auto declaredTy = CS.getVarType(param);
+
+            // If closure parameter couldn't be resolved, let's record
+            // a fix to make sure that type resolution diagnosed the
+            // problem and replace it with a placeholder, so that solver
+            // can make forward progress (especially important for result
+            // builders).
+            if (declaredTy->hasError()) {
+              CS.recordFix(AllowRefToInvalidDecl::create(
+                  CS, CS.getConstraintLocator(param)));
+              declaredTy = PlaceholderType::get(CS.getASTContext(), param);
+            }
+
             externalType = CS.replaceInferableTypesWithTypeVars(declaredTy,
                                                                 paramLoc);
           } else {

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1391,22 +1391,6 @@ namespace {
 /// Perform prechecking of a ClosureExpr before we dive into it.  This returns
 /// true when we want the body to be considered part of this larger expression.
 bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
-  auto *PL = closure->getParameters();
-
-  // Validate the parameters.
-  bool hadParameterError = false;
-
-  // If we encounter an error validating the parameter list, don't bail.
-  // Instead, go on to validate any potential result type, and bail
-  // afterwards.  This allows for better diagnostics, and keeps the
-  // closure expression type well-formed.
-  for (auto param : *PL) {
-    hadParameterError |= param->isInvalid();
-  }
-
-  if (hadParameterError)
-    return false;
-
   // If we won't be checking the body of the closure, don't walk into it here.
   if (!shouldTypeCheckInEnclosingExpression(closure))
     return false;

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -675,3 +675,41 @@ do {
     throw MyError.boom
   }
 }
+
+struct TuplifiedStructWithInvalidClosure {
+  var condition: Bool
+
+  @TupleBuilder var unknownParameter: some Any {
+    if let cond = condition {
+      let _ = { (arg: UnknownType) in // expected-error {{cannot find type 'UnknownType' in scope}}
+      }
+      42
+    } else {
+      0
+    }
+  }
+
+  @TupleBuilder var unknownResult: some Any {
+    if let cond = condition {
+      let _ = { () -> UnknownType in // expected-error {{cannot find type 'UnknownType' in scope}}
+      }
+      42
+    } else {
+      0
+    }
+  }
+
+  @TupleBuilder var multipleLevelsDeep: some Any {
+    if let cond = condition {
+      switch MyError.boom {
+      case .boom:
+        let _ = { () -> UnknownType in // expected-error {{cannot find type 'UnknownType' in scope}}
+        }
+      }
+
+      42
+    } else {
+      0
+    }
+  }
+}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1468,11 +1468,11 @@ let _ = sr4745.enumerated().map { (count, element) in "\(count): \(element)" }
 // SR-4738
 
 let sr4738 = (1, (2, 3))
-[sr4738].map { (x, (y, z)) -> Int in x + y + z }
+[sr4738].map { (x, (y, z)) -> Int in x + y + z } // expected-note 2 {{'x' declared here}}
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{20-26=arg1}} {{38-38=let (y, z) = arg1; }}
 // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'}} {{20-20=_: }}
-// expected-error@-3 {{cannot find type 'y' in scope}}
-// expected-error@-4 {{cannot find type 'z' in scope}}
+// expected-error@-3 {{cannot find 'y' in scope; did you mean 'x'?}}
+// expected-error@-4 {{cannot find 'z' in scope; did you mean 'x'?}}
 
 // rdar://problem/31892961
 let r31892961_1 = [1: 1, 2: 2]
@@ -1482,9 +1482,8 @@ let r31892961_2 = [1, 2, 3]
 let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
   // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{3-3=\n  let (index, val) = arg0\n  }}
   // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'}} {{48-48=_: }}
-  // expected-error@-3 {{cannot find type 'index' in scope}}
-  // expected-error@-4 {{cannot find type 'val' in scope}}
   val + 1
+  // expected-error@-1 {{cannot find 'val' in scope}}
 }
 
 let r31892961_3 = (x: 1, y: 42)
@@ -1695,7 +1694,7 @@ class Mappable<T> {
 }
 
 let x = Mappable(())
-// expected-note@-1 2{{'x' declared here}}
+// expected-note@-1 4{{'x' declared here}}
 x.map { (_: Void) in return () }
 x.map { (_: ()) in () }
 


### PR DESCRIPTION
If closure parameter has an explicit type, type resolution
would diagnose the issue and cache the resulting error type for
future use. Invalid types currently fail constraint generation,
which doesn't play well with result builders because constraint
generation for their bodies happens during solving.

Let's handle invalid parameters gracefully, replace them with
placeholders and let constraint generation proceed.

Resolves: rdar://75409111

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
