### PR TITLE
[ConstraintSystem] Fix a property wrapper constraint generation crash.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3560,9 +3560,7 @@ static bool generateWrappedPropertyTypeConstraints(
     Type propertyType) {
   auto dc = wrappedVar->getInnermostDeclContext();
 
-  Type wrapperType = LValueType::get(initializerType);
   Type wrappedValueType;
-
   auto wrapperAttributes = wrappedVar->getAttachedPropertyWrappers();
   for (unsigned i : indices(wrapperAttributes)) {
     // FIXME: We should somehow pass an OpenUnboundGenericTypeFn to
@@ -3573,16 +3571,20 @@ static bool generateWrappedPropertyTypeConstraints(
     if (rawWrapperType->hasError() || !wrapperInfo)
       return true;
 
-    // The former wrappedValue type must be equal to the current wrapper type
-    if (wrappedValueType) {
-      auto *typeRepr = wrapperAttributes[i]->getTypeRepr();
-      auto *locator =
-          cs.getConstraintLocator(typeRepr, LocatorPathElt::ContextualType());
-      wrapperType = cs.replaceInferableTypesWithTypeVars(rawWrapperType,
-                                                         locator);
+    auto *typeExpr = wrapperAttributes[i]->getTypeExpr();
+    auto *locator = cs.getConstraintLocator(typeExpr);
+    auto wrapperType = cs.replaceInferableTypesWithTypeVars(rawWrapperType, locator);
+    cs.setType(typeExpr, wrapperType);
+
+    if (!wrappedValueType) {
+      // Equate the outermost wrapper type to the initializer type.
+      if (initializerType)
+        cs.addConstraint(ConstraintKind::Equal, wrapperType, initializerType, locator);
+    } else {
+      // The former wrappedValue type must be equal to the current wrapper type
       cs.addConstraint(ConstraintKind::Equal, wrapperType, wrappedValueType,
-                       locator);
-      cs.setContextualType(typeRepr, TypeLoc::withoutLoc(wrappedValueType),
+                       cs.getConstraintLocator(locator, LocatorPathElt::ContextualType()));
+      cs.setContextualType(typeExpr, TypeLoc::withoutLoc(wrappedValueType),
                            CTP_ComposedPropertyWrapper);
     }
 
@@ -3888,19 +3890,12 @@ bool ConstraintSystem::generateConstraints(
 
   case SolutionApplicationTarget::Kind::uninitializedWrappedVar: {
     auto *wrappedVar = target.getAsUninitializedWrappedVar();
-    auto *outermostWrapper = wrappedVar->getAttachedPropertyWrappers().front();
-    auto *typeExpr = outermostWrapper->getTypeExpr();
-    auto backingType = replaceInferableTypesWithTypeVars(
-        outermostWrapper->getType(),getConstraintLocator(typeExpr));
-
-    setType(typeExpr, backingType);
-
     auto propertyType = getVarType(wrappedVar);
     if (propertyType->hasError())
       return true;
 
     return generateWrappedPropertyTypeConstraints(
-        *this, backingType, wrappedVar, propertyType);
+        *this, /*initializerType=*/Type(), wrappedVar, propertyType);
   }
   }
 }

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -2076,3 +2076,20 @@ struct OptionalWrapper<T> {
 struct UseOptionalWrapper {
   @OptionalWrapper var p: Int?? // Okay
 }
+
+@propertyWrapper
+struct WrapperWithFailableInit<Value> {
+  var wrappedValue: Value
+
+  init(_ base: WrapperWithFailableInit<Value>) { fatalError() }
+
+  init?(_ base: WrapperWithFailableInit<Value?>) { fatalError() }
+}
+
+struct TestInitError {
+  // FIXME: bad diagnostics when a wrapper does not support init from wrapped value
+
+  // expected-error@+2 {{extraneous argument label 'wrappedValue:' in call}}
+  // expected-error@+1 {{cannot convert value of type 'Int' to specified type 'WrapperWithFailableInit<Int>'}}
+  @WrapperWithFailableInit var value: Int = 10
+}


### PR DESCRIPTION
The property wrapper initializer type passed into `generateWrappedPropertyTypeConstraints` can be a type variable if the wrapper type has a failable initializer. To avoid attempting to lookup the wrapped value type on a type variable, always open the outermost wrapper attribute type and add an equality constraint to the initializer type.

Resolves: rdar://70238041