### PR TITLE
Use musttail when merging swifttail calls.

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1225,7 +1225,11 @@ void SwiftMergeFunctions::writeThunk(Function *ToFunc, Function *Thunk,
   }
 
   CallInst *CI = Builder.CreateCall(ToFunc, Args);
-  CI->setTailCall();
+  bool isSwiftTailCall =
+   ToFunc->getCallingConv() == CallingConv::SwiftTail &&
+   Thunk->getCallingConv() == CallingConv::SwiftTail;
+  CI->setTailCallKind(
+    isSwiftTailCall ? llvm::CallInst::TCK_MustTail : llvm::CallInst::TCK_Tail);
   CI->setCallingConv(ToFunc->getCallingConv());
   CI->setAttributes(ToFunc->getAttributes());
   if (Thunk->getReturnType()->isVoidTy()) {


### PR DESCRIPTION
Fixes rdar://75899459.

The LLVM function merging pass has the same bug, will submit a PR for that.

I don't know if it is ever possible that `ToFunc` and `Thunk` have different calling conventions, which is why I've added checks for them both.