### PR TITLE
Diagnose redundant and conflicting layout requirements using the explicit requirement graph

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2395,11 +2395,10 @@ ERROR(requires_generic_param_same_type_does_not_conform,none,
 ERROR(requires_same_concrete_type,none,
       "generic signature requires types %0 and %1 to be the same", (Type, Type))
 WARNING(redundant_conformance_constraint,none,
-        "redundant conformance constraint %0: %1", (Type, ProtocolDecl *))
+        "redundant conformance constraint %0 : %1", (Type, ProtocolDecl *))
 NOTE(redundant_conformance_here,none,
-     "conformance constraint %1: %2 %select{written here|implied here|"
-     "inferred from type here}0",
-     (unsigned, Type, ProtocolDecl *))
+     "conformance constraint %0 : %1 implied here",
+     (Type, ProtocolDecl *))
 
 ERROR(unsupported_recursive_requirements, none,
       "requirement involves recursion that is not currently supported", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2425,15 +2425,17 @@ NOTE(superclass_redundancy_here,none,
      (unsigned, Type, Type))
 
 ERROR(conflicting_layout_constraints,none,
-      "%select{generic parameter |protocol |}0%1 has conflicting "
-      "constraints %2 and %3",
-      (unsigned, Type, LayoutConstraint, LayoutConstraint))
+      "type %0 has conflicting constraints %1 and %2",
+      (Type, LayoutConstraint, LayoutConstraint))
+NOTE(conflicting_layout_constraint, none,
+     "constraint conflicts with %0 : %1",
+     (Type, LayoutConstraint))
 WARNING(redundant_layout_constraint,none,
-        "redundant constraint %0 : %1", (Type, LayoutConstraint))
+        "redundant constraint %0 : %1",
+        (Type, LayoutConstraint))
 NOTE(previous_layout_constraint, none,
-     "constraint %1 : %2 %select{written here|implied here|"
-     "inferred from type here}0",
-     (unsigned, Type, LayoutConstraint))
+     "constraint %0 : %1 implied here",
+     (Type, LayoutConstraint))
 
 WARNING(redundant_same_type_constraint,none,
         "redundant same-type constraint %0 == %1", (Type, Type))

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -7107,7 +7107,7 @@ void GenericSignatureBuilder::diagnoseRedundantRequirements() const {
           continue;
 
         Context.Diags.diagnose(otherLoc, diag::redundant_conformance_here,
-                               1, subjectType, proto);
+                               subjectType, proto);
       }
 
       break;

--- a/test/Compatibility/anyobject_class.swift
+++ b/test/Compatibility/anyobject_class.swift
@@ -3,4 +3,4 @@
 
 protocol P : class, AnyObject { } // expected-warning{{redundant inheritance from 'AnyObject' and Swift 3 'class' keyword}}{{14-21=}}
 // expected-warning@-1{{redundant constraint 'Self' : 'AnyObject'}}
-// expected-note@-2{{constraint 'Self' : 'AnyObject' written here}}
+// expected-note@-2{{constraint 'Self' : 'AnyObject' implied here}}

--- a/test/Generics/canonicalization.swift
+++ b/test/Generics/canonicalization.swift
@@ -12,9 +12,9 @@ protocol Q : P {
 }
 
 func f<T>(t: T) where T : P, T : Q, T.A : P0 { } // expected-note{{'f(t:)' previously declared here}}
-// expected-warning@-1{{redundant conformance constraint 'T': 'P'}}
-// expected-note@-2{{conformance constraint 'T': 'P' implied here}}
+// expected-warning@-1{{redundant conformance constraint 'T' : 'P'}}
+// expected-note@-2{{conformance constraint 'T' : 'P' implied here}}
 
 func f<T>(t: T) where T : Q, T : P, T.A : P0 { } // expected-error{{invalid redeclaration of 'f(t:)'}}
-// expected-warning@-1{{redundant conformance constraint 'T': 'P'}}
-// expected-note@-2{{conformance constraint 'T': 'P' implied here}}
+// expected-warning@-1{{redundant conformance constraint 'T' : 'P'}}
+// expected-note@-2{{conformance constraint 'T' : 'P' implied here}}

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -48,8 +48,8 @@ func testPaths3<V: P5>(_ v: V) {
 	acceptQ0(v.getAssocP3())
 }
 
-protocol P6Unordered: P5Unordered { // expected-note{{conformance constraint 'Self.A': 'P0' implied here}}
-	associatedtype A: P0 // expected-warning{{redundant conformance constraint 'Self.A': 'P0'}}
+protocol P6Unordered: P5Unordered { // expected-note{{conformance constraint 'Self.A' : 'P0' implied here}}
+	associatedtype A: P0 // expected-warning{{redundant conformance constraint 'Self.A' : 'P0'}}
                        // expected-warning@-1{{redeclaration of associated type 'A'}}
 }
 

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -58,9 +58,9 @@ protocol Q5: Q2, Q3, Q4 {}
 // CHECK-LABEL: .Q6@
 // CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0 : Q2, τ_0_0 : Q3, τ_0_0 : Q4>
-protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X': 'P1' implied here}}
+protocol Q6: Q2, // expected-note{{conformance constraint 'Self.X' : 'P1' implied here}}
              Q3, Q4 {
-    associatedtype X: P1 // expected-warning{{redundant conformance constraint 'Self.X': 'P1'}}
+    associatedtype X: P1 // expected-warning{{redundant conformance constraint 'Self.X' : 'P1'}}
                    // expected-warning@-1{{redeclaration of associated type 'X' from protocol 'Q4' is}}
 }
 

--- a/test/Generics/rdar62903491.swift
+++ b/test/Generics/rdar62903491.swift
@@ -7,26 +7,26 @@ protocol P {
 
 // Anything that mentions 'T : P' minimizes to 'U : P'.
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
-// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
 func oneProtocol1<T, U>(_: T, _: U) where T : P, U : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol1
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
-// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
 func oneProtocol2<T, U>(_: T, _: U) where U : P, T : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol2
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
-// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
 func oneProtocol3<T, U>(_: T, _: U) where T : P, T.X == U, U : P, U.X == T {}
 // CHECK-LABEL: oneProtocol3
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P'}}
-// expected-note@+1 {{conformance constraint 'U': 'P' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P' implied here}}
 func oneProtocol4<T, U>(_: T, _: U) where U : P, T.X == U, T : P, U.X == T {}
 // CHECK-LABEL: oneProtocol4
 // CHECK: Generic signature: <T, U where T : P, T == U.X, U == T.X>
@@ -59,38 +59,38 @@ protocol P2 {
   associatedtype Y : P1
 }
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
-// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
 func twoProtocols1<T, U>(_: T, _: U) where T : P1, U : P2, T.X == U, U.Y == T {}
 // CHECK-LABEL: twoProtocols1
 // CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
-// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
 func twoProtocols2<T, U>(_: T, _: U) where U : P2, T : P1, T.X == U, U.Y == T {}
 // CHECK-LABEL: twoProtocols2
 // CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
-// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
 func twoProtocols3<T, U>(_: T, _: U) where T : P1, T.X == U, U : P2, U.Y == T {}
 // CHECK-LABEL: twoProtocols3
 // CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
-// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
 func twoProtocols4<T, U>(_: T, _: U) where U : P2, T.X == U, T : P1, U.Y == T {}
 // CHECK-LABEL: twoProtocols4
 // CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'U': 'P2'}}
-// expected-note@+1 {{conformance constraint 'U': 'P2' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'U' : 'P2'}}
+// expected-note@+1 {{conformance constraint 'U' : 'P2' implied here}}
 func twoProtocols5<T, U>(_: T, _: U) where T : P1, T.X == U, U.Y == T, U : P2 {}
 // CHECK-LABEL: twoProtocols5
 // CHECK: Generic signature: <T, U where T : P1, T == U.Y, U == T.X>
 
-// expected-warning@+2 {{redundant conformance constraint 'T': 'P1'}}
-// expected-note@+1 {{conformance constraint 'T': 'P1' implied here}}
+// expected-warning@+2 {{redundant conformance constraint 'T' : 'P1'}}
+// expected-note@+1 {{conformance constraint 'T' : 'P1' implied here}}
 func twoProtocols6<T, U>(_: T, _: U) where U : P2, T.X == U, U.Y == T, T : P1 {}
 // CHECK-LABEL: twoProtocols6
 // CHECK: Generic signature: <T, U where T == U.Y, U : P2, U == T.X>

--- a/test/Generics/rdar65263302.swift
+++ b/test/Generics/rdar65263302.swift
@@ -11,10 +11,10 @@ public class C<O: P>: P {
 
 // CHECK: Generic signature: <T, O, E where T : C<E>, O : P, E : P, O.Element == E.Element>
 public func toe1<T, O, E>(_: T, _: O, _: E, _: T.Element)
-    where T : P, // expected-warning {{redundant conformance constraint 'T': 'P'}}
+    where T : P, // expected-warning {{redundant conformance constraint 'T' : 'P'}}
           O : P,
           O.Element == T.Element,
-          T : C<E> {} // expected-note {{conformance constraint 'T': 'P' implied here}}
+          T : C<E> {} // expected-note {{conformance constraint 'T' : 'P' implied here}}
 
 // CHECK: Generic signature: <T, O, E where T : C<E>, O : P, E : P, O.Element == E.Element>
 public func toe2<T, O, E>(_: T, _: O, _: E, _: T.Element)

--- a/test/Generics/rdar75656022.swift
+++ b/test/Generics/rdar75656022.swift
@@ -47,8 +47,8 @@ struct OriginalExampleWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C, D, E where A == S1<C, E, S2<D>>, B : P2, C : P1, D == B.T, E == D.T, B.T == C.T>
   init<C, D, E>(_: C)
     where C : P1,
-          D : P1, // expected-warning {{redundant conformance constraint 'D': 'P1'}}
-          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T': 'P1'}}
+          D : P1, // expected-warning {{redundant conformance constraint 'D' : 'P1'}}
+          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
           A == S1<C, C.T.T, S2<C.T>>,
           C.T == D,
           E == D.T { }
@@ -69,7 +69,7 @@ struct WithoutBogusGenericParametersWithWarning<A, B> where A : P2, B : P2, A.T 
   // CHECK-LABEL: Generic signature: <A, B, C where A == S1<C, B.T.T, S2<B.T>>, B : P2, C : P1, B.T == C.T>
   init<C>(_: C)
     where C : P1,
-          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T': 'P1'}}
+          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
           A == S1<C, C.T.T, S2<C.T>> {}
 }
 

--- a/test/Generics/redundant_requirement_self_conforming_protocol.swift
+++ b/test/Generics/redundant_requirement_self_conforming_protocol.swift
@@ -5,5 +5,5 @@ struct G<T> {}
 
 // CHECK-LABEL: Generic signature: <T where T == Error>
 extension G where T : Error, T == Error {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Error'}}
-// expected-note@-2 {{conformance constraint 'T': 'Error' implied here}}
+// expected-warning@-1 {{redundant conformance constraint 'T' : 'Error'}}
+// expected-note@-2 {{conformance constraint 'T' : 'Error' implied here}}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -114,8 +114,8 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) {
 }
 
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
-// expected-warning@-1{{redundant conformance constraint 'U.P4Assoc': 'P2'}}
-// expected-note@-2{{conformance constraint 'U.P4Assoc': 'P2' implied here}}
+// expected-warning@-1{{redundant conformance constraint 'U.P4Assoc' : 'P2'}}
+// expected-note@-2{{conformance constraint 'U.P4Assoc' : 'P2' implied here}}
 
 func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {
 }
@@ -134,8 +134,8 @@ protocol P7 : P6 {
 
 // CHECK-LABEL: P7@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P7, τ_0_0.AssocP6.Element : P6, τ_0_0.AssocP6.Element == τ_0_0.AssocP7.AssocP6.Element>
-extension P7 where AssocP6.Element : P6, // expected-note{{conformance constraint 'Self.AssocP7.AssocP6.Element': 'P6' implied here}}
-        AssocP7.AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP7.AssocP6.Element': 'P6'}}
+extension P7 where AssocP6.Element : P6, // expected-note{{conformance constraint 'Self.AssocP7.AssocP6.Element' : 'P6' implied here}}
+        AssocP7.AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP7.AssocP6.Element' : 'P6'}}
         AssocP6.Element == AssocP7.AssocP6.Element {
   func nestedSameType1() { }
 }
@@ -327,8 +327,8 @@ struct X24<T: P20> : P24 {
 // CHECK-NEXT: Requirement signature: <Self where Self.A == X24<Self.B>, Self.B : P20>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X24<τ_0_0.B>, τ_0_0.B : P20>
 protocol P25a {
-  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A': 'P24'}}
-  associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A': 'P24' implied here}}
+  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A' : 'P24'}}
+  associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A' : 'P24' implied here}}
 }
 
 // CHECK-LABEL: .P25b@
@@ -362,8 +362,8 @@ struct X26<T: X3> : P26 {
 // CHECK-NEXT: Requirement signature: <Self where Self.A == X26<Self.B>, Self.B : X3>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A == X26<τ_0_0.B>, τ_0_0.B : X3>
 protocol P27a {
-  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A': 'P26'}}
-  associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A': 'P26' implied here}}
+  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
+  associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
 }
 
 // CHECK-LABEL: .P27b@

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -69,16 +69,16 @@ class S : P2 {
 // CHECK: superclassConformance1
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance1<T>(t: T)
-  where T : C, // expected-note{{conformance constraint 'T': 'P3' implied here}}
-        T : P3 {} // expected-warning{{redundant conformance constraint 'T': 'P3'}}
+  where T : C, // expected-note{{conformance constraint 'T' : 'P3' implied here}}
+        T : P3 {} // expected-warning{{redundant conformance constraint 'T' : 'P3'}}
 
 
 
 // CHECK: superclassConformance2
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C>
 func superclassConformance2<T>(t: T)
-  where T : C, // expected-note{{conformance constraint 'T': 'P3' implied here}}
-   T : P3 {} // expected-warning{{redundant conformance constraint 'T': 'P3'}}
+  where T : C, // expected-note{{conformance constraint 'T' : 'P3' implied here}}
+   T : P3 {} // expected-warning{{redundant conformance constraint 'T' : 'P3'}}
 
 protocol P4 { }
 
@@ -89,8 +89,8 @@ class C2 : C, P4 { }
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'C'}}
 // expected-note@-2{{superclass constraint 'T' : 'C2' written here}}
-// expected-warning@-3{{redundant conformance constraint 'T': 'P4'}}
-// expected-note@-4{{conformance constraint 'T': 'P4' implied here}}
+// expected-warning@-3{{redundant conformance constraint 'T' : 'P4'}}
+// expected-note@-4{{conformance constraint 'T' : 'P4' implied here}}
 
 protocol P5: A { }
 
@@ -175,8 +175,8 @@ protocol Rump : Tail {
 class Horse<T>: Rump { }
 
 func hasRedundantConformanceConstraint<X : Horse<T>, T>(_: X) where X : Rump {}
-// expected-warning@-1 {{redundant conformance constraint 'X': 'Rump'}}
-// expected-note@-2 {{conformance constraint 'X': 'Rump' implied here}}
+// expected-warning@-1 {{redundant conformance constraint 'X' : 'Rump'}}
+// expected-note@-2 {{conformance constraint 'X' : 'Rump' implied here}}
 
 // SR-5862
 protocol X {

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -171,16 +171,17 @@ func funcWithForbiddenSpecializeRequirement<T>(_ t: T) {
 }
 
 @_specialize(where T: _Trivial(32), T: _Trivial(64), T: _Trivial, T: _RefCountedObject)
-// expected-error@-1{{generic parameter 'T' has conflicting constraints '_Trivial(64)' and '_Trivial(32)'}}
-// expected-error@-2{{generic parameter 'T' has conflicting constraints '_RefCountedObject' and '_Trivial(32)'}}
+// expected-error@-1{{type 'T' has conflicting constraints '_Trivial(64)' and '_Trivial(32)'}}
+// expected-error@-2{{type 'T' has conflicting constraints '_RefCountedObject' and '_Trivial(32)'}}
 // expected-warning@-3{{redundant constraint 'T' : '_Trivial'}}
-// expected-note@-4 3{{constraint 'T' : '_Trivial(32)' written here}}
+// expected-note@-4 {{constraint 'T' : '_Trivial' implied here}}
+// expected-note@-5 2{{constraint conflicts with 'T' : '_Trivial(32)'}}
 @_specialize(where T: _Trivial, T: _Trivial(64))
 // expected-warning@-1{{redundant constraint 'T' : '_Trivial'}}
-// expected-note@-2 1{{constraint 'T' : '_Trivial(64)' written here}}
+// expected-note@-2 1{{constraint 'T' : '_Trivial' implied here}}
 @_specialize(where T: _RefCountedObject, T: _NativeRefCountedObject)
 // expected-warning@-1{{redundant constraint 'T' : '_RefCountedObject'}}
-// expected-note@-2 1{{constraint 'T' : '_NativeRefCountedObject' written here}}
+// expected-note@-2 1{{constraint 'T' : '_RefCountedObject' implied here}}
 @_specialize(where Array<T> == Int) // expected-error{{generic signature requires types 'Array<T>' and 'Int' to be the same}}
 // expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
 // expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
@@ -193,14 +194,15 @@ public protocol Proto: class {
 }
 
 @_specialize(where T: _RefCountedObject)
-// expected-error@-1 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
-// expected-note@-2 {{missing constraint for 'T' in '_specialize' attribute}}
+// expected-warning@-1 {{redundant constraint 'T' : '_RefCountedObject'}}
+// expected-error@-2 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
+// expected-note@-3 {{missing constraint for 'T' in '_specialize' attribute}}
 @_specialize(where T: _Trivial)
-// expected-error@-1{{generic parameter 'T' has conflicting constraints '_Trivial' and '_NativeClass'}}
+// expected-error@-1{{type 'T' has conflicting constraints '_Trivial' and '_NativeClass'}}
 // expected-error@-2 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
 // expected-note@-3 {{missing constraint for 'T' in '_specialize' attribute}}
 @_specialize(where T: _Trivial(64))
-// expected-error@-1{{generic parameter 'T' has conflicting constraints '_Trivial(64)' and '_NativeClass'}}
+// expected-error@-1{{type 'T' has conflicting constraints '_Trivial(64)' and '_NativeClass'}}
 // expected-error@-2 {{too few generic parameters are specified in '_specialize' attribute (got 0, but expected 1)}}
 // expected-note@-3 {{missing constraint for 'T' in '_specialize' attribute}}
 public func funcWithABaseClassRequirement<T>(t: T) -> Int where T: C1 {

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -259,7 +259,7 @@ class JustAClass2: ImposeClassReq1 {
   var someProperty = 0
 }
 
-extension ImposeClassReq1 where Self: AnyObject {
+extension ImposeClassReq1 where Self: AnyObject { // expected-warning {{redundant constraint 'Self' : 'AnyObject'}}
   var wrappingProperty1: Int {
     get { return someProperty }
     set { someProperty = newValue }

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -52,8 +52,8 @@ protocol P3 {
 
 protocol P4 : P3 {}
 
-protocol DeclaredP : P3, // expected-warning{{redundant conformance constraint 'Self': 'P3'}}
-P4 {} // expected-note{{conformance constraint 'Self': 'P3' implied here}}
+protocol DeclaredP : P3, // expected-warning{{redundant conformance constraint 'Self' : 'P3'}}
+P4 {} // expected-note{{conformance constraint 'Self' : 'P3' implied here}}
 
 struct Y3 : DeclaredP {
 }
@@ -76,8 +76,8 @@ protocol Gamma {
   associatedtype Delta: Alpha
 }
 
-struct Epsilon<T: Alpha, // expected-note{{conformance constraint 'U': 'Gamma' implied here}}
-               U: Gamma> // expected-warning{{redundant conformance constraint 'U': 'Gamma'}}
+struct Epsilon<T: Alpha, // expected-note{{conformance constraint 'U' : 'Gamma' implied here}}
+               U: Gamma> // expected-warning{{redundant conformance constraint 'U' : 'Gamma'}}
   where T.Beta == U,
         U.Delta == T {}
 

--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -12,8 +12,8 @@ protocol P2 {
 // CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.Assoc == ConformsToP1>
 protocol P3 : P2 { }
 
-struct S0<M: P3> where M.Assoc: P1 { } // expected-warning{{redundant conformance constraint 'M.Assoc': 'P1'}}
-// expected-note@-1{{conformance constraint 'M.Assoc': 'P1' implied here}}
+struct S0<M: P3> where M.Assoc: P1 { } // expected-warning{{redundant conformance constraint 'M.Assoc' : 'P1'}}
+// expected-note@-1{{conformance constraint 'M.Assoc' : 'P1' implied here}}
 
 struct ConformsToP1: P1 { }
 


### PR DESCRIPTION
More goodness using the explicit requirement graph. Just like we already use it to diagnose redundant conformance requirements, we can use it for layout requirements, as well. Unlike conformance requirements, layout requirements can conflict with each other, so there's some additional logic here for that case. Next up, I'm going to redo superclass requirements.