### PR TITLE
[ClangImporter] Add @completionHandlerAsync for imported decls

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -625,7 +625,7 @@ SIMPLE_DECL_ATTR(reasync, AtReasync,
   110)
 
 DECL_ATTR(completionHandlerAsync, CompletionHandlerAsync,
-  OnAbstractFunction | ConcurrencyOnly |
+  OnAbstractFunction | ConcurrencyOnly | LongAttribute |
   ABIStableToAdd | ABIStableToRemove |
   APIStableToAdd | APIStableToRemove,
   111)

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2043,28 +2043,23 @@ public:
 /// alternative, optionally providing a name (for cases when the alternative
 /// has a different name).
 class CompletionHandlerAsyncAttr final : public DeclAttribute {
-private:
-  /// DeclName of the async function in the attribute
+public:
+  /// Reference to the async alternative function. Only set for deserialized
+  /// attributes or inferred attributes from ObjectiveC code.
+  AbstractFunctionDecl *AsyncFunctionDecl;
+
+  /// DeclName of the async function in the attribute. Only set from actual
+  /// Swift code, deserialization/ObjectiveC imports will set the decl instead.
   const DeclNameRef AsyncFunctionName;
 
-public:
   /// Source location of the async function name in the attribute
   const SourceLoc AsyncFunctionNameLoc;
-
-  /// Get the name of the async function
-  ///
-  /// The name will come from the AsyncFunctionDecl if available, otherwise will
-  /// fall back on the user-provided name. If that is not defined, this function
-  /// will abort.
-  DeclNameRef getAsyncFunctionName() const;
 
   /// The index of the completion handler
   const size_t CompletionHandlerIndex;
 
   /// Source location of the completion handler index passed to the index
   const SourceLoc CompletionHandlerIndexLoc;
-
-  AbstractFunctionDecl *AsyncFunctionDecl = nullptr;
 
   CompletionHandlerAsyncAttr(DeclNameRef asyncFunctionName,
                              SourceLoc asyncFunctionNameLoc,
@@ -2073,6 +2068,7 @@ public:
                              SourceLoc atLoc, SourceRange range)
       : DeclAttribute(DAK_CompletionHandlerAsync, atLoc, range,
                       /*implicit*/ false),
+        AsyncFunctionDecl(nullptr),
         AsyncFunctionName(asyncFunctionName),
         AsyncFunctionNameLoc(asyncFunctionNameLoc),
         CompletionHandlerIndex(completionHandlerIndex),
@@ -2084,11 +2080,9 @@ public:
                              SourceLoc atLoc, SourceRange range)
       : DeclAttribute(DAK_CompletionHandlerAsync, atLoc, range,
                       /*implicit*/ false),
+        AsyncFunctionDecl(&asyncFunctionDecl) ,
         CompletionHandlerIndex(completionHandlerIndex),
-        CompletionHandlerIndexLoc(completionHandlerIndexLoc),
-        AsyncFunctionDecl(&asyncFunctionDecl) {}
-
-
+        CompletionHandlerIndexLoc(completionHandlerIndexLoc) {}
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_CompletionHandlerAsync;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6097,6 +6097,8 @@ public:
   /// constructor.
   bool hasDynamicSelfResult() const;
 
+  AbstractFunctionDecl *getAsyncAlternative() const;
+
   using DeclContext::operator new;
   using Decl::getASTContext;
 };

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2954,10 +2954,9 @@ public:
   bool isCached() const { return true; }
 };
 
-class TypeCheckCompletionHandlerAsyncAttrRequest
-    : public SimpleRequest<TypeCheckCompletionHandlerAsyncAttrRequest,
-                           bool(AbstractFunctionDecl *,
-                                CompletionHandlerAsyncAttr *),
+class AsyncAlternativeRequest
+    : public SimpleRequest<AsyncAlternativeRequest,
+                           AbstractFunctionDecl *(AbstractFunctionDecl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -2965,12 +2964,10 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator,
-                AbstractFunctionDecl *attachedFucntionDecl,
-                CompletionHandlerAsyncAttr *attr) const;
+  AbstractFunctionDecl *evaluate(
+      Evaluator &evaluator, AbstractFunctionDecl *attachedFunctionDecl) const;
 
 public:
-  // Caching
   bool isCached() const { return true; }
 };
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -325,6 +325,6 @@ SWIFT_REQUEST(TypeChecker, SynthesizeMainFunctionRequest,
 SWIFT_REQUEST(TypeChecker, GetImplicitSendableRequest,
               NormalProtocolConformance *(NominalTypeDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, TypeCheckCompletionHandlerAsyncAttrRequest,
-              bool (AbstractFunctionDecl *, CompletionHandlerAsyncAttr *),
+SWIFT_REQUEST(TypeChecker, AsyncAlternativeRequest,
+              AbstractFunctionDecl *(AbstractFunctionDecl *),
               Cached, NoLocationInfo)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1081,6 +1081,20 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 #include "swift/AST/Attr.def"
     llvm_unreachable("handled above");
 
+  case DAK_CompletionHandlerAsync: {
+    auto *attr = cast<CompletionHandlerAsyncAttr>(this);
+    Printer.printAttrName("@completionHandlerAsync");
+    Printer << "(\"";
+    if (attr->AsyncFunctionDecl) {
+      Printer << attr->AsyncFunctionDecl->getName();
+    } else {
+      Printer << attr->AsyncFunctionName;
+    }
+    Printer << "\", completionHandleIndex: " <<
+        attr->CompletionHandlerIndex << ')';
+    break;
+  }
+
   default:
     assert(DeclAttribute::isDeclModifier(getKind()) &&
            "handled above");
@@ -2002,12 +2016,4 @@ bool CustomAttr::isArgUnsafe() const {
 void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {
   if (attr)
     attr->print(out);
-}
-
-DeclNameRef CompletionHandlerAsyncAttr::getAsyncFunctionName() const {
-  if (AsyncFunctionDecl)
-    return DeclNameRef(AsyncFunctionDecl->getName());
-  if (AsyncFunctionName)
-    return AsyncFunctionName;
-  llvm_unreachable("completionHandlerAsync attr missing async function name");
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6843,6 +6843,12 @@ bool AbstractFunctionDecl::hasDynamicSelfResult() const {
   return isa<ConstructorDecl>(this);
 }
 
+AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
+  auto mutableFunc = const_cast<AbstractFunctionDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           AsyncAlternativeRequest{mutableFunc}, nullptr);
+}
+
 bool AbstractFunctionDecl::argumentNameIsAPIByDefault() const {
   // Initializers have argument labels.
   if (isa<ConstructorDecl>(this))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5653,17 +5653,20 @@ void TypeChecker::checkClosureAttributes(ClosureExpr *closure) {
 
 void AttributeChecker::visitCompletionHandlerAsyncAttr(
     CompletionHandlerAsyncAttr *attr) {
-  AbstractFunctionDecl *AFD = dyn_cast<AbstractFunctionDecl>(D);
-  if (!AFD)
-    return;
-
-  evaluateOrDefault(Ctx.evaluator,
-                    TypeCheckCompletionHandlerAsyncAttrRequest{AFD, attr}, {});
+  if (AbstractFunctionDecl *AFD = dyn_cast<AbstractFunctionDecl>(D))
+    AFD->getAsyncAlternative();
 }
 
-bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
-    Evaluator &evaluator, AbstractFunctionDecl *attachedFunctionDecl,
-    CompletionHandlerAsyncAttr *attr) const {
+AbstractFunctionDecl *AsyncAlternativeRequest::evaluate(
+    Evaluator &evaluator, AbstractFunctionDecl *attachedFunctionDecl) const {
+  auto attr = attachedFunctionDecl->getAttrs()
+    .getAttribute<CompletionHandlerAsyncAttr>();
+  if (!attr)
+    return nullptr;
+
+  if (attr->AsyncFunctionDecl)
+    return attr->AsyncFunctionDecl;
+
   auto &Diags = attachedFunctionDecl->getASTContext().Diags;
   // Check phases:
   //  1. Attached function shouldn't be async and should have enough args
@@ -5681,7 +5684,7 @@ bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
                    diag::attr_completion_handler_async_handler_not_func, attr);
     Diags.diagnose(attachedFunctionDecl->getAsyncLoc(),
                    diag::note_attr_function_declared_async);
-    return false;
+    return nullptr;
   }
 
   const ParameterList *attachedFunctionParams =
@@ -5690,7 +5693,7 @@ bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
   if (attachedFunctionParams->size() == 0) {
     Diags.diagnose(attr->getLocation(),
                    diag::attr_completion_handler_async_handler_not_func, attr);
-    return false;
+    return nullptr;
   }
   size_t completionHandlerIndex = attr->CompletionHandlerIndexLoc.isValid()
                                       ? attr->CompletionHandlerIndex
@@ -5698,7 +5701,7 @@ bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
   if (attachedFunctionParams->size() < completionHandlerIndex) {
     Diags.diagnose(attr->CompletionHandlerIndexLoc,
                    diag::attr_completion_handler_async_handler_out_of_range);
-    return false;
+    return nullptr;
   }
 
   // Phase 2: Typecheck the completion handler
@@ -5718,7 +5721,7 @@ bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
               completionHandlerParamDecl->getType())
           .highlight(
               completionHandlerParamDecl->getTypeRepr()->getSourceRange());
-      return false;
+      return nullptr;
     }
 
     auto handlerTypeRepr =
@@ -5759,7 +5762,7 @@ bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
             handlerTypeAttrs->getLoc(TAK_autoclosure),
             diag::note_attr_completion_handler_async_handler_attr_req, false,
             "autoclosure");
-      return false;
+      return nullptr;
     }
   }
 
@@ -5793,7 +5796,7 @@ bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
     //  should return all of those types in a tuple
 
     SmallVector<ValueDecl *, 2> allCandidates;
-    lookupReplacedDecl(attr->getAsyncFunctionName(), attr, attachedFunctionDecl,
+    lookupReplacedDecl(attr->AsyncFunctionName, attr, attachedFunctionDecl,
                        allCandidates);
     SmallVector<AbstractFunctionDecl *, 2> candidates;
     candidates.reserve(allCandidates.size());
@@ -5810,21 +5813,20 @@ bool TypeCheckCompletionHandlerAsyncAttrRequest::evaluate(
     if (candidates.empty()) {
       Diags.diagnose(attr->AsyncFunctionNameLoc,
                      diag::attr_completion_handler_async_no_suitable_function,
-                     attr->getAsyncFunctionName());
-      return false;
+                     attr->AsyncFunctionName);
+      return nullptr;
     } else if (candidates.size() > 1) {
       Diags.diagnose(attr->AsyncFunctionNameLoc,
                      diag::attr_completion_handler_async_ambiguous_function,
-                     attr, attr->getAsyncFunctionName());
+                     attr, attr->AsyncFunctionName);
 
       for (AbstractFunctionDecl *candidate : candidates) {
         Diags.diagnose(candidate->getLoc(), diag::decl_declared_here,
                        candidate->getName());
       }
-      return false;
+      return nullptr;
     }
-    attr->AsyncFunctionDecl = candidates.front();
-  }
 
-  return true;
+    return candidates.front();
+  }
 }

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -8,26 +8,69 @@
 import _Concurrency
 
 // CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {
-// CHECK-DAG:     func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
-// CHECK-DAG:     func doSomethingSlow(_ operation: String) async -> Int
-// CHECK-DAG:     func doSomethingDangerous(_ operation: String, completionHandler handler: ((String?, Error?) -> Void)? = nil)
-// CHECK-DAG:     func doSomethingDangerous(_ operation: String) async throws -> String
-// CHECK-DAG:     func checkAvailability(completionHandler: @escaping (Bool) -> Void)
-// CHECK-DAG:     func checkAvailability() async -> Bool
-// CHECK-DAG:     func anotherExample() async -> String
-// CHECK-DAG:     func finalExample() async -> String
-// CHECK-DAG:     func replyingOperation(_ operation: String) async -> String
-// CHECK-DAG:     func findAnswer(completionHandler handler: @escaping (String?, Error?) -> Void)
-// CHECK-DAG:     func findAnswer() async throws -> String
-// CHECK-DAG:     func findAnswerFailingly(completionHandler handler: @escaping (String?, Error?) -> Void) throws
-// CHECK-DAG:     func findAnswerFailingly() async throws -> String
-// CHECK-DAG:     func findQAndA() async throws -> (String?, String)
-// CHECK-DAG:     func findQuestionableAnswers() async throws -> (String, String?)
-// CHECK-DAG:     func doSomethingFun(_ operation: String) async
-// CHECK-DAG:     func dance(_ step: String) async -> String
-// CHECK-DAG:     func __leap(_ height: Int) async -> String
-// CHECK-DAG:     func runOnMainThread(completionHandler completion: (@MainActor (String) -> Void)? = nil)
-// CHECK-DAG:     func runOnMainThread() async -> String
+
+// CHECK: @completionHandlerAsync("doSomethingSlow(_:)", completionHandleIndex: 1)
+// CHECK-NEXT: func doSomethingSlow(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK-NEXT: func doSomethingSlow(_ operation: String) async -> Int
+
+// CHECK: @completionHandlerAsync("doSomethingDangerous(_:)", completionHandleIndex: 1)
+// CHECK-NEXT: func doSomethingDangerous(_ operation: String, completionHandler handler: ((String?, Error?) -> Void)? = nil)
+// CHECK-NEXT: func doSomethingDangerous(_ operation: String) async throws -> String
+
+// CHECK: @completionHandlerAsync("checkAvailability()", completionHandleIndex: 0)
+// CHECK-NEXT: func checkAvailability(completionHandler: @escaping (Bool) -> Void)
+// CHECK-NEXT: func checkAvailability() async -> Bool
+
+// CHECK: @completionHandlerAsync("anotherExample()", completionHandleIndex: 0)
+// CHECK-NEXT: func anotherExample(completionBlock block: @escaping (String) -> Void)
+// CHECK-NEXT: func anotherExample() async -> String
+
+// CHECK: @completionHandlerAsync("finalExample()", completionHandleIndex: 0)
+// CHECK-NEXT: func finalExampleWithReply(to block: @escaping (String) -> Void)
+// CHECK-NEXT: func finalExample() async -> String
+
+// CHECK: @completionHandlerAsync("replyingOperation(_:)", completionHandleIndex: 1)
+// CHECK-NEXT: func replyingOperation(_ operation: String, replyTo block: @escaping (String) -> Void)
+// CHECK-NEXT: func replyingOperation(_ operation: String) async -> String
+
+// CHECK: @completionHandlerAsync("findAnswer()", completionHandleIndex: 0)
+// CHECK-NEXT: func findAnswer(completionHandler handler: @escaping (String?, Error?) -> Void)
+// CHECK-NEXT: func findAnswer() async throws -> String
+
+// CHECK: @completionHandlerAsync("findAnswerFailingly()", completionHandleIndex: 0)
+// CHECK-NEXT: func findAnswerFailingly(completionHandler handler: @escaping (String?, Error?) -> Void) throws
+// CHECK-NEXT: func findAnswerFailingly() async throws -> String
+
+// CHECK: @completionHandlerAsync("findQAndA()", completionHandleIndex: 0)
+// CHECK-NEXT: func findQAndA(completionHandler handler: @escaping (String?, String?, Error?) -> Void)
+// CHECK-NEXT: func findQAndA() async throws -> (String?, String)
+
+// CHECK: @completionHandlerAsync("findQuestionableAnswers()", completionHandleIndex: 0)
+// CHECK-NEXT: func findQuestionableAnswers(completionHandler handler: @escaping CompletionHandler)
+// CHECK-NEXT: func findQuestionableAnswers() async throws -> (String, String?)
+
+// CHECK: @completionHandlerAsync("doSomethingFun(_:)", completionHandleIndex: 1)
+// CHECK-NEXT: func doSomethingFun(_ operation: String, then completionHandler: @escaping () -> Void)
+// CHECK-NEXT: func doSomethingFun(_ operation: String) async
+
+// CHECK: @completionHandlerAsync("doSomethingConflicted(_:)", completionHandleIndex: 1)
+// CHECK-NEXT: func doSomethingConflicted(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK-NEXT: func doSomethingConflicted(_ operation: String) async -> Int
+// CHECK-NEXT: func doSomethingConflicted(_ operation: String) -> Int
+
+// CHECK: func dance(_ step: String) async -> String
+// CHECK: func __leap(_ height: Int) async -> String
+
+// CHECK: @completionHandlerAsync("runOnMainThread()", completionHandleIndex: 0)
+// CHECK-NEXT: func runOnMainThread(completionHandler completion: (@MainActor (String) -> Void)? = nil)
+// CHECK-NEXT: func runOnMainThread() async -> String
+
+// CHECK: @completionHandlerAsync("asyncImportSame(_:)", completionHandleIndex: 1)
+// CHECK-NEXT: func asyncImportSame(_ operation: String, completionHandler handler: @escaping (Int) -> Void)
+// CHECK-NEXT: func asyncImportSame(_ operation: String) async -> Int
+// CHECK-NEXT: func asyncImportSame(_ operation: String, replyTo handler: @escaping (Int) -> Void)
+// CHECK-NOT: func asyncImportSame(_ operation: String) async -> Int
+
 // CHECK: {{^[}]$}}
 
 // CHECK-LABEL: protocol RefrigeratorDelegate

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -69,8 +69,11 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 -(void)doSomethingZeroFlaggyWithCompletionHandler:(void (^)(NSString *_Nullable, BOOL, NSError *_Nullable))completionHandler __attribute__((swift_async_error(zero_argument, 2)));
 -(void)doSomethingMultiResultFlaggyWithCompletionHandler:(void (^)(BOOL, NSString *_Nullable, NSError *_Nullable, NSString *_Nullable))completionHandler __attribute__((swift_async_error(zero_argument, 1)));
 
-
 -(void)runOnMainThreadWithCompletionHandler:(MAIN_ACTOR void (^ _Nullable)(NSString *))completion;
+
+// Both would be imported as the same decl - require swift_async(none) on one
+-(void)asyncImportSame:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
+-(void)asyncImportSame:(NSString *)operation replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/attr/Inputs/custom-modules/module.map
+++ b/test/attr/Inputs/custom-modules/module.map
@@ -1,2 +1,3 @@
 module AttrObjc_FooClangModule { header "attr_objc_foo_clang_module.h" }
 module Testable_ClangModule { header "testable_clang.h" }
+module ObjcAsync { header "objc_async.h" }

--- a/test/attr/Inputs/custom-modules/objc_async.h
+++ b/test/attr/Inputs/custom-modules/objc_async.h
@@ -1,0 +1,18 @@
+@import Foundation;
+
+#pragma clang assume_nonnull begin
+
+typedef void (^CompletionHandler)(NSInteger);
+
+@interface HandlerTest : NSObject
+-(void)simpleWithCompletionHandler:(void (^)(NSInteger))handler;
+-(void)simpleArg:(NSInteger)arg completionHandler:(void (^)(NSInteger))handler;
+-(void)aliasWithCompletionHandler:(CompletionHandler)handler;
+-(void)errorWithCompletionHandler:(void (^)(NSString *_Nullable, NSError * _Nullable))handler;
+-(BOOL)removedError:(NSError * _Nullable * _Nullable)error completionHandler:(void (^)(NSString *_Nullable, NSError * _Nullable))handler;
+
+-(void)asyncImportSame:(NSInteger)arg completionHandler:(void (^)(NSInteger))handler;
+-(void)asyncImportSame:(NSInteger)arg replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
+@end
+
+#pragma clang assume_nonnull end


### PR DESCRIPTION
Implicitly add the @completionHandlerAsync attribute for ObjCMethodDecl
that have a completion handler. Adds a link from the non-async to the
async function for use in diagnostics and refactorings.

Resolves rdar://74665226
