### PR TITLE
[Gardening] Remove invalid RUN lines that were accidentally merged

### DIFF
--- a/test/PrintAsObjC/error.swift
+++ b/test/PrintAsObjC/error.swift
@@ -1,7 +1,4 @@
 // RUN: %empty-directory(%t)
-// RdsagUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -emit-objc-header-path %t/error.h
-// RUadsgN: %FileCheck %s < %t/error.h
-
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module-path %t/error.swiftmodule -emit-objc-header-path %t/error.h -experimental-allow-module-with-compiler-errors %s
 // RUN: %FileCheck %s < %t/error.h
 // RUN: %check-in-clang %t/error.h
@@ -48,8 +45,8 @@ import Foundation
   @objc @undefined func invalidAttribute() {}
   // CHECK: - (void)invalidAttribute;
 
-  @objc undefined func invalidModifier() {}
-  // TODO: Not output with invalid modifier
+  @objc someundefinedmodifier func invalidModifier() {}
+  // TODO: someundefinedmodifier treated as a function, so invalidModifier not seen as @objc
 
   @objc @available
   func invalidAvailability() {}


### PR DESCRIPTION
ab5a42160c39509906a1aa5c63072a5de81cdefa added a new test case with
invalid RUN lines - they were a copy paste from a different file, not
intended to be committed.