### PR TITLE
GSB: Fix handling of layout requirements in stripBoundDependentMemberTypes()

### DIFF
--- a/include/swift/AST/RequirementBase.h
+++ b/include/swift/AST/RequirementBase.h
@@ -63,6 +63,7 @@ public:
       : FirstTypeAndKind(first, kind), SecondType(second) {
     assert(first);
     assert(second);
+    assert(kind != RequirementKind::Layout);
   }
 
   /// Create a layout constraint requirement.
@@ -71,6 +72,7 @@ public:
       : FirstTypeAndKind(first, kind), SecondLayout(second) {
     assert(first);
     assert(second);
+    assert(kind == RequirementKind::Layout);
   }
 
   /// Determine the kind of requirement.

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -8414,7 +8414,7 @@ static Requirement stripBoundDependentMemberTypes(Requirement req) {
                        }));
 
   case RequirementKind::Layout:
-    return Requirement(RequirementKind::Conformance, subjectType,
+    return Requirement(RequirementKind::Layout, subjectType,
                        req.getLayoutConstraint());
   }
 

--- a/test/Generics/rdar75691385.swift
+++ b/test/Generics/rdar75691385.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol P {}
+
+struct S : P {}
+
+struct G<T : P> {}
+
+extension G {
+  // CHECK-LABEL: Generic signature: <T, U where T == S, U : AnyObject>
+  func f<U>(_: U) where T == S, U : AnyObject {}
+}


### PR DESCRIPTION
There was a silly typo here. Also add some asserts to the
Requirement constructor to catch this if it happens again.

Fixes rdar://problem/75691385.