### PR TITLE
[Actor isolation] Limit propagation of unsafe global actors to instance members

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2666,8 +2666,16 @@ ActorIsolation ActorIsolationRequest::evaluate(
     // If the declaration is in a nominal type (or extension thereof) that
     // has isolation, use that.
     if (auto selfTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl()) {
-      if (auto selfTypeIsolation = getActorIsolation(selfTypeDecl))
-        return inferredIsolation(selfTypeIsolation);
+      if (auto selfTypeIsolation = getActorIsolation(selfTypeDecl)) {
+        // Don't propagate implicit, unsafe global actor isolation from a type
+        // to non-imported instance members.
+        if (selfTypeIsolation != ActorIsolation::GlobalActorUnsafe ||
+            value->getClangNode() ||
+            (selfTypeDecl->getGlobalActorAttr() &&
+             !selfTypeDecl->getGlobalActorAttr()->first->isImplicit())) {
+          return inferredIsolation(selfTypeIsolation);
+        }
+      }
     }
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -5,7 +5,7 @@
 import Foundation
 import ObjCConcurrency
 
-@MainActor func onlyOnMainActor() { }
+@MainActor func onlyOnMainActor() { } // expected-note{{calls to global function 'onlyOnMainActor()' from outside of its actor context are implicitly asynchronous}}
 
 func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await slowServer.doSomethingSlow("mail")
@@ -130,6 +130,8 @@ struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
+@SomeGlobalActor(unsafe) func unsafelyOnSomeGlobal() { }
+
 class MyButton : NXButton {
   @MainActor func testMain() {
     onButtonPress() // okay
@@ -139,10 +141,28 @@ class MyButton : NXButton {
     onButtonPress() // expected-error{{instance method 'onButtonPress()' isolated to global actor 'MainActor' can not be referenced from different global actor 'SomeGlobalActor'}}
   }
 
-  func test() {
-    onButtonPress() // okay
+  func test() { // expected-note{{add '@MainActor' to make instance method 'test()' part of global actor 'MainActor'}}
+    onButtonPress() // okay, onButtonPress is @MainActor(unsafe)
+    unsafelyOnSomeGlobal() // okay, we haven't opted into anything
+    onlyOnMainActor() // expected-error{{global function 'onlyOnMainActor()' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
   }
 }
+
+class MyOtherButton: NXButton {
+  override func onButtonPress() { // expected-note{{calls to instance method 'onButtonPress()' from outside of its actor context are implicitly asynchronous}}
+    onlyOnMainActor() // yes, we're on the main actor
+    unsafelyOnSomeGlobal() // okay, we haven't opted into any actual checking
+  }
+
+  func test() {
+    onButtonPress() // okay, it's @MainActor(unsafe)
+  }
+
+  @SomeGlobalActor func testOther() {
+    onButtonPress() // expected-error{{instance method 'onButtonPress()' isolated to global actor 'MainActor' can not be referenced from different global actor 'SomeGlobalActor' in a synchronous context}}
+  }
+}
+
 
 func testButtons(mb: MyButton) {
   mb.onButtonPress()


### PR DESCRIPTION
Don't propagate implicit, unsafe global actor annotations from a type
to its instance members. We want the annotation to cover all of a type,
but not implicitly cover (e.g.) all of its subclasses's members except
those it gets through overrides or witnessing protocol requirements.
