### PR TITLE
[stdlib][SR-7556] Re-implement string-to-integer parsing

### DIFF
--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -72,7 +72,6 @@ internal func _parseASCIIDigits<
 // N.B.: This free function is a manually specialized version of the function
 // above. Ensure that any changes are made in sync.
 @_alwaysEmitIntoClient
-@inline(never)
 internal func _parseASCIIDigits<Result: FixedWidthInteger>(
   _ codeUnits: UnsafeBufferPointer<UInt8>, radix: Int, isNegative: Bool
 ) -> Result? {
@@ -144,7 +143,6 @@ internal func _parseASCII<UTF8CodeUnits: Collection, Result: FixedWidthInteger>(
 }
 
 @_alwaysEmitIntoClient
-@inline(never)
 internal func _parseASCII<Result: FixedWidthInteger>(
   _ codeUnits: UnsafeBufferPointer<UInt8>, radix: Int
 ) -> Result? {
@@ -197,7 +195,8 @@ extension FixedWidthInteger {
   ///   - radix: The radix, or base, to use for converting `text` to an integer
   ///     value. `radix` must be in the range `2...36`. The default is 10.
   @inlinable
-  @inline(__always)
+  @_specialize(kind: partial, where S == String)
+  @_specialize(kind: partial, where S == Substring)
   public init?<S: StringProtocol>(_ text: S, radix: Int = 10) {
     _precondition(2...36 ~= radix, "Radix not in range 2...36")
     guard _fastPath(!text.isEmpty) else { return nil }

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -72,6 +72,7 @@ internal func _parseASCIIDigits<
 // N.B.: This free function is a manually specialized version of the function
 // above. Ensure that any changes are made in sync.
 @_alwaysEmitIntoClient
+@inline(never)
 internal func _parseASCIIDigits<Result: FixedWidthInteger>(
   _ codeUnits: UnsafeBufferPointer<UInt8>, radix: Int, isNegative: Bool
 ) -> Result? {
@@ -143,6 +144,7 @@ internal func _parseASCII<UTF8CodeUnits: Collection, Result: FixedWidthInteger>(
 }
 
 @_alwaysEmitIntoClient
+@inline(never)
 internal func _parseASCII<Result: FixedWidthInteger>(
   _ codeUnits: UnsafeBufferPointer<UInt8>, radix: Int
 ) -> Result? {

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -84,10 +84,10 @@ internal func _parseASCII<Result: FixedWidthInteger>(
 
 @_alwaysEmitIntoClient
 internal func _parseASCII<S: StringProtocol, Result: FixedWidthInteger>(
-    _ text: S, radix: Int
+  _ text: S, radix: Int
 ) -> Result? {
-    var str = String(text)
-    return str.withUTF8 { _parseASCII($0, radix: radix) }
+  var str = String(text)
+  return str.withUTF8 { _parseASCII($0, radix: radix) }
 }
 
 extension FixedWidthInteger {

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -15,11 +15,12 @@
 // made in sync.
 @_alwaysEmitIntoClient
 internal func _parseASCIIDigits<
-  UTF8CodeUnits: Sequence, Result: FixedWidthInteger
+  UTF8CodeUnits: Collection, Result: FixedWidthInteger
 >(
   _ codeUnits: UTF8CodeUnits, radix: Int, isNegative: Bool
 ) -> Result? where UTF8CodeUnits.Element == UInt8 {
   _internalInvariant(radix >= 2 && radix <= 36)
+  guard _fastPath(!codeUnits.isEmpty) else { return nil }
   let multiplicand = Result(radix)
   var result = 0 as Result
   if radix <= 10 {
@@ -74,6 +75,7 @@ internal func _parseASCIIDigits<Result: FixedWidthInteger>(
   _ codeUnits: UnsafeBufferPointer<UInt8>, radix: Int, isNegative: Bool
 ) -> Result? {
   _internalInvariant(radix >= 2 && radix <= 36)
+  guard _fastPath(!codeUnits.isEmpty) else { return nil }
   let multiplicand = Result(radix)
   var result = 0 as Result
   if radix <= 10 {
@@ -191,6 +193,7 @@ extension FixedWidthInteger {
   ///   - radix: The radix, or base, to use for converting `text` to an integer
   ///     value. `radix` must be in the range `2...36`. The default is 10.
   @inlinable
+  @inline(__always)
   public init?<S: StringProtocol>(_ text: S, radix: Int = 10) {
     _precondition(2...36 ~= radix, "Radix not in range 2...36")
     guard _fastPath(!text.isEmpty) else { return nil }

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 @_alwaysEmitIntoClient
-internal func _parseDigitsInASCII<Result: FixedWidthInteger>(
-  _ codeUnits: UnsafeBufferPointer<UInt8>, radix: Int, isNegative: Bool
+internal func _parseIntegerDigits<Result: FixedWidthInteger>(
+  ascii codeUnits: UnsafeBufferPointer<UInt8>, radix: Int, isNegative: Bool
 ) -> Result? {
   _internalInvariant(radix >= 2 && radix <= 36)
   guard _fastPath(!codeUnits.isEmpty) else { return nil }
@@ -57,8 +57,8 @@ internal func _parseDigitsInASCII<Result: FixedWidthInteger>(
 }
 
 @_alwaysEmitIntoClient
-internal func _parseASCII<Result: FixedWidthInteger>(
-  _ codeUnits: UnsafeBufferPointer<UInt8>, radix: Int
+internal func _parseInteger<Result: FixedWidthInteger>(
+  ascii codeUnits: UnsafeBufferPointer<UInt8>, radix: Int
 ) -> Result? {
   _internalInvariant(!codeUnits.isEmpty)
   
@@ -67,25 +67,25 @@ internal func _parseASCII<Result: FixedWidthInteger>(
   
   let first = codeUnits[0]
   if first == _minus {
-    return _parseDigitsInASCII(
-      UnsafeBufferPointer(rebasing: codeUnits[1...]),
+    return _parseIntegerDigits(
+      ascii: UnsafeBufferPointer(rebasing: codeUnits[1...]),
       radix: radix, isNegative: true)
   }
   if first == _plus {
-    return _parseDigitsInASCII(
-      UnsafeBufferPointer(rebasing: codeUnits[1...]),
+    return _parseIntegerDigits(
+      ascii: UnsafeBufferPointer(rebasing: codeUnits[1...]),
       radix: radix, isNegative: false)
   }
-  return _parseDigitsInASCII(codeUnits, radix: radix, isNegative: false)
+  return _parseIntegerDigits(ascii: codeUnits, radix: radix, isNegative: false)
 }
 
 @_alwaysEmitIntoClient
 @inline(never)
-internal func _parseASCII<S: StringProtocol, Result: FixedWidthInteger>(
-  _ text: S, radix: Int
+internal func _parseInteger<S: StringProtocol, Result: FixedWidthInteger>(
+  ascii text: S, radix: Int
 ) -> Result? {
   var str = String(text)
-  return str.withUTF8 { _parseASCII($0, radix: radix) }
+  return str.withUTF8 { _parseInteger(ascii: $0, radix: radix) }
 }
 
 extension FixedWidthInteger {
@@ -128,8 +128,8 @@ extension FixedWidthInteger {
     guard _fastPath(!text.isEmpty) else { return nil }
     let result: Self? =
       text.utf8.withContiguousStorageIfAvailable {
-        _parseASCII($0, radix: radix)
-      } ?? _parseASCII(text, radix: radix)
+        _parseInteger(ascii: $0, radix: radix)
+      } ?? _parseInteger(ascii: text, radix: radix)
     guard let result_ = result else { return nil }
     self = result_
   }

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -14,6 +14,7 @@
 // `UTF8CodeUnits == UnsafeBufferPoint<UInt8>`. Ensure that any changes are
 // made in sync.
 @_alwaysEmitIntoClient
+@inline(never)
 internal func _parseASCIIDigits<
   UTF8CodeUnits: Collection, Result: FixedWidthInteger
 >(
@@ -124,6 +125,7 @@ internal func _parseASCIIDigits<Result: FixedWidthInteger>(
 }
 
 @_alwaysEmitIntoClient
+@inline(never)
 internal func _parseASCII<UTF8CodeUnits: Collection, Result: FixedWidthInteger>(
   _ codeUnits: UTF8CodeUnits, radix: Int
 ) -> Result? where UTF8CodeUnits.Element == UInt8 {

--- a/test/stdlib/NSSlowString.swift
+++ b/test/stdlib/NSSlowString.swift
@@ -57,6 +57,23 @@ tests.test("Iterator") {
   expectEqualSequence(opaque.utf8.reversed(), native.utf8.reversed())
 }
 
+tests.test("String-to-integer parsing") {
+  let native = "1234"
+  let opaque = NSSlowString(string: "1234") as String
+  
+  expectEqual(Int(opaque, radix: 16)!, Int(native, radix: 16)!)
+  expectEqual(Int(opaque, radix: 15)!, Int(native, radix: 15)!)
+  expectEqual(Int(opaque, radix: 10)!, Int(native, radix: 10)!)
+  expectEqual(Int(opaque, radix:  8)!, Int(native, radix:  8)!)
+  expectEqual(Int(opaque, radix:  5)!, Int(native, radix:  5)!)
+  
+  expectEqual(UInt16(opaque, radix: 16)!, UInt16(native, radix: 16)!)
+  expectEqual(UInt16(opaque, radix: 15)!, UInt16(native, radix: 15)!)
+  expectEqual(UInt16(opaque, radix: 10)!, UInt16(native, radix: 10)!)
+  expectEqual(UInt16(opaque, radix:  8)!, UInt16(native, radix:  8)!)
+  expectEqual(UInt16(opaque, radix:  5)!, UInt16(native, radix:  5)!)
+}
+
 tests.test("Unicode 9 grapheme breaking")
     .xfail(.osxMinor(10, 9, reason: "Mac OS X 10.9 has an old version of ICU"))
     .xfail(.iOSMajor(7, reason: "iOS 7 has an old version of ICU"))


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR attempts to improve code size and performance for string-to-integer parsing without introducing any additions to the ABI. As noted in the relevant bug:

> Constructing an `Int` from a `String` eventually involves calling `_parseASCII`, which is slow and bloated if not properly specialized.

> A serious of unfortunate events played out over time where this function was overly generic and so was marked `@inline(__always)` to be fast, then it was discovered this function was about 20KB large and the callers were all marked with `@inline(never)` and various `@_semantics` to disable specialization for size (and perhaps compilation time).

> The end result was something bloated, slow, and yet is still emitted into the user module, increasing code size.

To confront this issue, this PR introduces a new `_parseASCII`. Instead of taking an argument of type `T: IteratorProtocol where T.Element == UnsignedInteger`, it expects a buffer of type `UnsafeBufferPointer<UInt8>`. This is made possible by the existence of the `withContiguousStorageIfAvailable` API on `StringProtocol`.

If contiguous storage is not available, then an `@inline(never)` fallback is called, which initializes a mutable `String` value and then makes use of the `withUTF8` API. We consign this function to the fallback path in order to avoid creating a mutable copy if we can.

The extremely pared down implementation shown here is the result of several iterative rounds of benchmarking and simplification described below. It's tempting to consider further specializations for base 8, 10, or 16, but the possible wins would appear to be negligible without a significantly more sophisticated implementation (such as that attempted in #30094, as pointed out in the conversation below). Those are deferred to prioritize addressing some low-hanging fruit.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7556](https://bugs.swift.org/browse/SR-7556).

### Summary of findings

#### Baseline

As a baseline, I used #36625 to demonstrate what would occur if the existing implementation had its `@inline(never)` and `@_semantics` markings removed. This revealed sizable improvements in microbenchmark performance but a significant regression in code size (excerpted results below):

**PERFORMANCE -O<br>Improvement** | **OLD** | **NEW** | **DELTA** | **RATIO**
:---                                    | ---: | ---: | ---:   | ---:     
ParseInt.IntSmall.Decimal               | 437  | 228  | -47.8% | **1.92x**
StrToInt                                | 1600 | 860  | -46.2% | **1.86x**
ParseInt.IntSmall.UncommonRadix         | 481  | 263  | -45.3% | **1.83x**
ParseInt.UInt64.Decimal                 | 204  | 153  | -25.0% | **1.33x**
ParseInt.UInt64.Hex                     | 332  | 272  | -18.1% | **1.22x**
ParseInt.UIntSmall.Binary               | 641  | 542  | -15.4% | **1.18x**
 | | | |
**CODE SIZE -O<br>Regression** | **OLD** | **NEW** | **DELTA** | **RATIO**
IntegerParsing.o ⚠️                        | 56677 | 88581 | +56.3% | **0.64x**
RangeReplaceableCollectionPlusDefault.o | 5442  | 6902  | +26.8% | **0.79x**
 | | | |
**CODE SIZE -O<br>Improvement** | **OLD** | **NEW** | **DELTA** | **RATIO**
StrToInt.o                              | 4615  | 3657  | -20.8% | **1.26x**

#### First attempts

The first attempts to improve upon the status quo yielded similar results to the above.

A manually specialized implementation of `_parseASCII` and a new `_parseASCIIDigits` were added which take an `UnsafeBufferPointer<UInt8>` argument as the source. Additionally, generic versions of the above were maintained; with this setup, I attempted to mark the duplicated implementations with different attributes in the hopes of fine tuning code size and performance.

However, even after marking the fallback generic helper functions using `@inline(never)`, there were improvements in microbenchmarks but significant code size regressions (excerpted results below):

**PERFORMANCE -O<br>Improvement** | **OLD** | **NEW** | **DELTA** | **RATIO**
:---                                               | ---:  | ---:  | ---:   | ---:     
ParseInt.IntSmall.Decimal                          | 437   | 206   | -52.9% | **2.12x**
ParseInt.IntSmall.UncommonRadix                    | 481   | 229   | -52.4% | **2.10x**
ParseInt.UInt64.Decimal                            | 203   | 117   | -42.4% | **1.74x**
StrToInt                                           | 1600  | 990   | -38.1% | **1.62x**
ParseInt.UIntSmall.Binary                          | 641   | 418   | -34.8% | **1.53x**
ParseInt.UInt64.Hex                                | 331   | 272   | -17.8% | **1.22x**
 | | | |
**CODE SIZE -O<br>Regression** | **OLD** | **NEW** | **DELTA** | **RATIO**
IntegerParsing.o ⚠️                        | 56677  | 90807  | +60.2% | **0.62x**
StrToInt.o                              | 4615   | 6065   | +31.4% | **0.76x**
RangeReplaceableCollectionPlusDefault.o | 5442   | 7070   | +29.9% | **0.77x**
LuhnAlgoEager.o                         | 11370  | 13372  | +17.6% | **0.85x**
LuhnAlgoLazy.o                          | 11370  | 13372  | +17.6% | **0.85x**
DictionaryCompactMapValues.o            | 13853  | 15770  | +13.8% | **0.88x**

#### Minimum code size

After removing all manually repeated code and further simplifying the implementation, I attempted to _remove_ the `@inline(__always)` marking from `FixedWidthInteger.init(_:radix:)` and to test the effect of explicitly requiring partial specializations for `S == String` and for `S == Substring` using `@_specialize(kind: partial, ...)`.

This produced a result that decreased the compiled size of the standard library itself by ~1%, as well as improvements in the code size of the `IntegerParsing` microbenchmarks. However, it wiped out most performance improvements at `-O`, except for `StrToInt` (excerpted results below):

**PERFORMANCE -O<br>Regression** | **OLD** | **NEW** | **DELTA** | **RATIO**
:---                                  | ---: | ---: | ---:   | ---:     
ParseInt.UInt64.Hex                   | 332  | 365  | +9.9%  | **0.91x**
 | | | |
**PERFORMANCE -O<br>Improvement** | **OLD** | **NEW** | **DELTA** | **RATIO**
StrToInt                              | 1600 | 950  | -40.6% | **1.68x**
 | | | |
**CODE SIZE -O<br>Regression** | **OLD** | **NEW** | **DELTA** | **RATIO**
RangeReplaceableCollectionPlusDefault.o | 5442  | 6220  | +14.3% | **0.87x**
LuhnAlgoEager.o                         | 11370 | 12298 | +8.2%  | **0.92x**
LuhnAlgoLazy.o                          | 11370 | 12298 | +8.2%  | **0.92x**
DictionaryCompactMapValues.o            | 13853 | 14714 | +6.2%  | **0.94x**
 | | | | 
**CODE SIZE -O<br>Improvement** | **OLD** | **NEW** | **DELTA** | **RATIO**
IntegerParsing.o ✅                        | 56677 | 55733 | -1.7%  | **1.02x**

**CODE SIZE: -swiftlibs**
**Improvement**    | **OLD** | **NEW** | **DELTA** | **RATIO**
:---               | ---:    | ---:    | ---:  | ---:   
libswiftCore.dylib | 3850240 | 3801088 | -1.3% | **1.01x**

#### Inlined performance

The final form of this PR restores the `@inline(__always)` marking to `FixedWidthInteger.init(_:radix:)` (and simplifies the implementation further). Doing so produces a result where a sizable proportion of the performance benefit seen in the baseline benchmarks can be recovered with a very modest code size increase. As before, the compiled size of the standard library itself is _decreased_ by ~1%.

This implementation relies on no `@_semantics` annotations and, perhaps relatedly, exhibits performance improvements at `-O`, `-Osize`, and `-Onone` (excerpted `-O` results below):

**PERFORMANCE -O<br>Improvement** | **OLD** | **NEW** | **DELTA** | **RATIO**
:---                                               | ---:  | ---:  | ---:   | ---:     
StrToInt                                           | 1600  | 1000  | -37.5% | **1.60x**
ParseInt.IntSmall.UncommonRadix                    | 481   | 328   | -31.8% | **1.47x**
ParseInt.IntSmall.Decimal                          | 437   | 302   | -30.9% | **1.45x**
ParseInt.UInt64.Decimal                            | 204   | 166   | -18.6% | **1.23x**
ParseInt.UIntSmall.Binary                          | 641   | 585   | -8.7%  | **1.10x**
 | | | |
**CODE SIZE -O<br>Regression** | **OLD** | **NEW** | **DELTA** | **RATIO**
LuhnAlgoEager.o                         | 11370 | 12178 | +7.1% | **0.93x**
LuhnAlgoLazy.o                          | 11370 | 12178 | +7.1% | **0.93x**
RangeReplaceableCollectionPlusDefault.o | 5442  | 5804  | +6.7% | **0.94x**
StrToInt.o                              | 4615  | 4859  | +5.3% | **0.95x**
DictionaryCompactMapValues.o            | 13853 | 14570 | +5.2% | **0.95x**
IntegerParsing.o 🏁                        | 56677 | 59557 | +5.1% | **0.95x**

**CODE SIZE: -swiftlibs**
**Improvement**    | **OLD** | **NEW** | **DELTA** | **RATIO**
:---               | ---:    | ---:    | ---:  | ---:   
libswiftCore.dylib | 3850240 | 3801088 | -1.3% | **1.01x**

(All versions of this PR show varying degrees of code size regressions in `LuhnAlgoEager`, `LuhnAlgoLazy`, `RangeReplaceableCollectionPlusDefault`, and `DictionaryCompactMapValues`. I have to presume that they are attributable to emitting this new implementation into the client; in the final iteration, these code size increases are the most modest yet.)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
