### PR TITLE
AccessSummaryAnalysis: relax the verification of expected no-escape partial_apply uses

### DIFF
--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -187,32 +187,15 @@ static bool hasExpectedUsesOfNoEscapePartialApply(Operand *partialApplyUse) {
     return partialApplyUse->getOperandNumber() ==
            CopyBlockWithoutEscapingInst::Closure;
 
-  // A copy_value that is only used by the store to a block storage is fine.
-  // It is part of the pattern we emit for verifying that a noescape closure
-  // passed to objc has not escaped.
-  //  %4 = convert_escape_to_noescape [not_guaranteed] %3 :
-  //    $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
-  //  %5 = function_ref @withoutEscapingThunk
-  //  %6 = partial_apply [callee_guaranteed] %5(%4) :
-  //    $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
-  //  %7 = mark_dependence %6 : $@callee_guaranteed () -> () on %4 :
-  //    $@noescape @callee_guaranteed () -> ()
-  //  %8 = copy_value %7 : $@callee_guaranteed () -> ()
-  //  %9 = alloc_stack $@block_storage @callee_guaranteed () -> ()
-  //  %10 = project_block_storage %9 :
-  //    $*@block_storage @callee_guaranteed () -> ()
-  //  store %8 to [init] %10 : $*@callee_guaranteed () -> ()
-  //  %13 = init_block_storage_header %9 :
-  //    $*@block_storage @callee_guaranteed () -> (),
-  //    invoke %12
-  //  %14 = copy_block_without_escaping %13 : $() -> () withoutEscaping %7
   case SILInstructionKind::CopyValueInst:
-    return isa<StoreInst>(getSingleNonDebugUser(cast<CopyValueInst>(user)));
+    return llvm::all_of(cast<CopyValueInst>(user)->getUses(),
+                        hasExpectedUsesOfNoEscapePartialApply);
 
   // End borrow is always ok.
   case SILInstructionKind::EndBorrowInst:
     return true;
 
+  case SILInstructionKind::IsEscapingClosureInst:
   case SILInstructionKind::StoreInst:
   case SILInstructionKind::DestroyValueInst:
     // @block_storage is passed by storing it to the stack. We know this is

--- a/test/SILOptimizer/exclusivity_static_diagnostics.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.swift
@@ -677,3 +677,18 @@ struct TestConflictInCoroutineClosureArg {
     // expected-note@-2 {{conflicting access is here}}
   }
 }
+
+// Check that AccessSummaryAnalysis does not crash with this:
+struct TestStruct {
+  var x = 7
+  mutating func b()  {
+    func c() {}
+    func d() {
+        x // expected-warning {{property is accessed but result is unused}}
+    }
+     withoutActuallyEscaping(c) { e in
+        withoutActuallyEscaping(d) { e in
+        }
+    }
+  }
+}


### PR DESCRIPTION
* add is_escaping_closure as allowed instruction
* don't restrict the uses of copy_value to be a store

Fixes a verification crash (only in assert builds).

https://bugs.swift.org/browse/SR-14394
rdar://75740622
