### PR TITLE
diagnose duplicated @_cdecl and @_silgen_name function names

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -43,6 +43,10 @@ ERROR(bridging_objcbridgeable_broken,none,
       "broken definition of '_ObjectiveCBridgeable' protocol: missing %0",
       (DeclName))
 
+ERROR(sil_function_redefinition,none,
+      "multiple definitions of symbol '%0'",
+      (StringRef))
+
 ERROR(invalid_sil_builtin,none,
       "INTERNAL ERROR: invalid use of builtin: %0",
       (StringRef))

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -756,6 +756,12 @@ void SILGenModule::visitFuncDecl(FuncDecl *fd) { emitFunction(fd); }
 
 void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
 
+  if (!f->empty()) {
+    diagnose(constant.getAsRegularLocation(), diag::sil_function_redefinition,
+             f->getName());
+    return;
+  }
+
   if (constant.isForeignToNativeThunk()) {
     f->setThunk(IsThunk);
     if (constant.asForeign().isClangGenerated())

--- a/test/SILGen/diagnose_duplicate_functions.swift
+++ b/test/SILGen/diagnose_duplicate_functions.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen %s -o /dev/null -verify
+
+@_silgen_name("foo")
+func a(_ x: Int) -> Int {
+  return x
+}
+
+@_silgen_name("foo")
+func b(_ x: Int) -> Int { // expected-error {{multiple definitions of symbol 'foo'}}
+  return x
+}
+
+@_cdecl("bar")
+func c(_ x: Int) -> Int {
+  return x
+}
+
+@_cdecl("bar")
+func d(_ x: Int) -> Int { // expected-error {{multiple definitions of symbol 'bar'}}
+  return x
+}

--- a/validation-test/compiler_crashers_fixed/28806-swift-silmodule-get-or-create-function.swift
+++ b/validation-test/compiler_crashers_fixed/28806-swift-silmodule-get-or-create-function.swift
@@ -6,5 +6,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-@_cdecl("main")func x(){}
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null -verify
+
+@_cdecl("main")func x(){} // expected-error {{multiple definitions of symbol 'main'}}


### PR DESCRIPTION
Prints a regular error instead of crashing.
The check is done in SILGen, because it's simple. We could also do it earlier, but I don't see a strong reason for this.

rdar://75950093
