### PR TITLE
[SemaAnnotator] Fix bug causing custom attributes to be walked out of order

### DIFF
--- a/test/IDE/range_info_basics.swift
+++ b/test/IDE/range_info_basics.swift
@@ -149,6 +149,23 @@ func testDefer() {
   }
 }
 
+func testPropertyWrapper() {
+  @propertyWrapper
+  public struct SR12958 {
+    public var wrappedValue: String
+    init(_ wrappedValue: String) {
+      self.wrappedValue = wrappedValue
+    }
+  }
+
+  public struct MyStruct {
+    @SR12958("something")
+    public static var somevar: String
+    public static var someothervar: Int
+  }
+}
+
+
 // RUN: %target-swift-ide-test -range -pos=8:1 -end-pos 8:32 -source-filename %s | %FileCheck %s -check-prefix=CHECK1
 // RUN: %target-swift-ide-test -range -pos=9:1 -end-pos 9:26 -source-filename %s | %FileCheck %s -check-prefix=CHECK2
 // RUN: %target-swift-ide-test -range -pos=10:1 -end-pos 10:27 -source-filename %s | %FileCheck %s -check-prefix=CHECK3
@@ -187,6 +204,8 @@ func testDefer() {
 // RUN: %target-swift-ide-test -range -pos=133:1 -end-pos=135:65 -source-filename %s | %FileCheck %s -check-prefix=CHECK-NO-PATTERN
 // RUN: %target-swift-ide-test -range -pos=142:12 -end-pos=142:17 -source-filename %s | %FileCheck %s -check-prefix=CHECK-X-Y
 // RUN: %target-swift-ide-test -range -pos=147:1 -end-pos=150:1 -source-filename %s | %FileCheck %s -check-prefix=CHECK-INVALID
+// RUN: %target-swift-ide-test -range -pos=162:5 -end-pos=163:38 -source-filename %s | %FileCheck %s -check-prefix=CHECK-PROPERTY-WRAPPER
+
 
 // CHECK-NO-PATTERN: <Kind>MultiStatement</Kind>
 // CHECK-NO-PATTERN-NEXT: <Content>for key in parameters.keys.sorted(by: <) {
@@ -483,3 +502,11 @@ func testDefer() {
 
 // CHECK-X-Y: <Referenced>x</Referenced><Type>Int</Type>
 // CHECK-X-Y: <Referenced>y</Referenced><Type>Int</Type>
+
+// CHECK-PROPERTY-WRAPPER: <Kind>SingleDecl</Kind>
+// CHECK-PROPERTY-WRAPPER-NEXT: <Content>@SR12958("something")
+// CHECK-PROPERTY-WRAPPER-NEXT:     public static var somevar: String</Content>
+// CHECK-PROPERTY-WRAPPER-NEXT: <Context>swift_ide_test.(file).testPropertyWrapper().MyStruct</Context>
+// CHECK-PROPERTY-WRAPPER-NEXT: <Declared>somevar</Declared><OutscopeReference>false</OutscopeReference>
+// CHECK-PROPERTY-WRAPPER-NEXT: <ASTNodes>1</ASTNodes>
+// CHECK-PROPERTY-WRAPPER-NEXT: <end>

--- a/test/SourceKit/Refactoring/syntactic-rename.swift
+++ b/test/SourceKit/Refactoring/syntactic-rename.swift
@@ -104,6 +104,19 @@ _ = Memberwise1.init(x: 2)
 _ = Memberwise2.init(m: 2, n: Memberwise1(x: 34))
 #endif
 
+@propertyWrapper
+struct Bar<T> {
+  let wrappedValue: T
+  init(wrappedValue: T, other: Int) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+struct Foo {
+  @Bar(other: Foo.test)
+  static var test: Int = 10
+}
+
 // RUN: %empty-directory(%t.result)
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/x.in.json %s >> %t.result/x.expected
 // RUN: %diff -u %S/syntactic-rename/x.expected %t.result/x.expected

--- a/test/SourceKit/Refactoring/syntactic-rename/wrappedProperty.expected
+++ b/test/SourceKit/Refactoring/syntactic-rename/wrappedProperty.expected
@@ -1,0 +1,4 @@
+source.edit.kind.active:
+  116:19-116:34 "renamedProperty"
+source.edit.kind.active:
+  117:14-117:29 "renamedProperty"

--- a/test/SourceKit/Refactoring/syntactic-rename/wrappedProperty.in.json
+++ b/test/SourceKit/Refactoring/syntactic-rename/wrappedProperty.in.json
@@ -1,0 +1,20 @@
+[
+  {
+    "key.name": "wrappedProperty",
+    "key.newname": "renamedProperty",
+    "key.is_function_like": 0,
+    "key.is_non_protocol_type": 0,
+    "key.locations": [
+      {
+        "key.line": 117,
+        "key.column": 14,
+        "key.nametype": source.syntacticrename.definition
+      },
+      {
+        "key.line": 116,
+        "key.column": 19,
+        "key.nametype": source.syntacticrename.reference
+      }
+    ]
+  }
+]


### PR DESCRIPTION
`SemaAnnotator` walks the tree in source order with respect to the source ranges *excluding* attributes, but `RangeResolver` considers attributes part of their declaration. Thus they disagree on what “walking in source order means”. `SemaAnnotator` will visit the attributes *before* the decl they are on, while `RangeResolver` as currently implemented expects them *as part of* the decl they are on.

Thus, for the purpose of `RangeResolver`, we need to assume that nodes are visited in arbitrary order and we might encounter enclosing nodes after their children.

Thus, when we find a new node, remove all nodes that it encloses from `ContainedASTNodes`.

Fixes rdar://64140713 [SR-12958]