### PR TITLE
[Perf][CSSimplify] Transfer conformance requirements of a parameter to an argument

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -190,6 +190,11 @@ enum class ConstraintKind : char {
   /// The first type is a property wrapper with a wrapped-value type
   /// equal to the second type.
   PropertyWrapper,
+  /// The first type (or its optional or pointer version) must conform to a
+  /// second type (protocol type). This is not a direct requirement but one
+  /// inferred from a conversion, so the check is more relax comparing to
+  /// `ConformsTo`.
+  TransitivelyConformsTo,
 };
 
 /// Classification of the different kinds of constraints.
@@ -579,6 +584,7 @@ public:
     case ConstraintKind::OperatorArgumentConversion:
     case ConstraintKind::ConformsTo:
     case ConstraintKind::LiteralConformsTo:
+    case ConstraintKind::TransitivelyConformsTo:
     case ConstraintKind::CheckedCast:
     case ConstraintKind::SelfObjectOfProtocol:
     case ConstraintKind::ApplicableFunction:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4513,6 +4513,12 @@ private:
                                             ConstraintLocatorBuilder locator,
                                             TypeMatchOptions flags);
 
+  /// Similar to \c simplifyConformsToConstraint but also checks for
+  /// optional and pointer derived a given type.
+  SolutionKind simplifyTransitivelyConformsTo(Type type, Type protocol,
+                                              ConstraintLocatorBuilder locator,
+                                              TypeMatchOptions flags);
+
   /// Attempt to simplify a checked-cast constraint.
   SolutionKind simplifyCheckedCastConstraint(Type fromType, Type toType,
                                              TypeMatchOptions flags,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1312,6 +1312,12 @@ void PotentialBindings::infer(Constraint *constraint) {
     // Constraints from which we can't do anything.
     break;
 
+  // For now let's avoid inferring protocol requirements from
+  // this constraint, but in the future we could do that to
+  // to filter bindings.
+  case ConstraintKind::TransitivelyConformsTo:
+    break;
+
   case ConstraintKind::DynamicTypeOf: {
     // Direct binding of the left-hand side could result
     // in `DynamicTypeOf` failure if right-hand side is

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6268,9 +6268,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
 
   SmallVector<Type, 4> typesToCheck;
 
-  // Optional<T>
-  typesToCheck.push_back(
-      OptionalType::get(resolvedTy->getWithoutSpecifierType()));
+  // T -> Optional<T>
+  if (!resolvedTy->getOptionalObjectType())
+    typesToCheck.push_back(OptionalType::get(resolvedTy));
 
   // AnyHashable
   if (auto *anyHashable = ctx.getAnyHashableDecl())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6222,6 +6222,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
     Type type, Type protocolTy, ConstraintLocatorBuilder locator,
     TypeMatchOptions flags) {
+  auto &ctx = getASTContext();
+
   // Since this is a performance optimization, let's ignore it
   // in diagnostic mode.
   if (shouldAttemptFixes())
@@ -6270,10 +6272,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
   typesToCheck.push_back(
       OptionalType::get(resolvedTy->getWithoutSpecifierType()));
 
-  // Unsafe{Mutable}Pointer<T>
-  {
-    auto &ctx = getASTContext();
+  // AnyHashable
+  typesToCheck.push_back(ctx.getAnyHashableDecl()->getDeclaredInterfaceType());
 
+  // Rest of the implicit conversions depend on the resolved type.
+  {
     auto *ptrDecl = ctx.getUnsafePointerDecl();
 
     // String -> UnsafePointer<Void>

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2232,6 +2232,7 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
         case ConstraintKind::Defaultable:
         case ConstraintKind::ConformsTo:
         case ConstraintKind::LiteralConformsTo:
+        case ConstraintKind::TransitivelyConformsTo:
           return false;
 
         default:

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -441,11 +441,16 @@ extension UnsafePointer : Trivial {
   typealias T = Int
 }
 
+extension AnyHashable : Trivial {
+  typealias T = Int
+}
+
 func test_inference_through_implicit_conversion() {
-  class C {}
+  struct C : Hashable {}
 
   func test<T: Trivial>(_: T) -> T {}
 
   let _: C? = test(C()) // Ok -> argument is implicitly promoted into an optional
   let _: UnsafePointer<C> = test([C()]) // Ok - argument is implicitly converted to a pointer
+  let _: AnyHashable = test(C()) // Ok - argument is implicitly converted to `AnyHashable` because it's Hashable
 }

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -445,13 +445,31 @@ extension AnyHashable : Trivial {
   typealias T = Int
 }
 
+extension UnsafeRawPointer : Trivial {
+  typealias T = Int
+}
+
+extension UnsafeMutableRawPointer : Trivial {
+  typealias T = Int
+}
+
 func test_inference_through_implicit_conversion() {
   struct C : Hashable {}
 
   func test<T: Trivial>(_: T) -> T {}
 
+  var arr: [C] = []
+  let ptr: UnsafeMutablePointer<C> = UnsafeMutablePointer(bitPattern: 0)!
+  let rawPtr: UnsafeMutableRawPointer = UnsafeMutableRawPointer(bitPattern: 0)!
+
   let _: C? = test(C()) // Ok -> argument is implicitly promoted into an optional
   let _: UnsafePointer<C> = test([C()]) // Ok - argument is implicitly converted to a pointer
+  let _: UnsafeRawPointer = test([C()]) // Ok - argument is implicitly converted to a raw pointer
+  let _: UnsafeMutableRawPointer = test(&arr) // Ok - inout Array<T> -> UnsafeMutableRawPointer
+  let _: UnsafePointer<C> = test(ptr) // Ok - UnsafeMutablePointer<T> -> UnsafePointer<T>
+  let _: UnsafeRawPointer = test(ptr) // Ok - UnsafeMutablePointer<T> -> UnsafeRawPointer
+  let _: UnsafeRawPointer = test(rawPtr) // Ok - UnsafeMutableRawPointer -> UnsafeRawPointer
+  let _: UnsafeMutableRawPointer = test(ptr) // Ok - UnsafeMutablePointer<T> -> UnsafeMutableRawPointer
   let _: AnyHashable = test(C()) // Ok - argument is implicitly converted to `AnyHashable` because it's Hashable
 }
 

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -454,3 +454,23 @@ func test_inference_through_implicit_conversion() {
   let _: UnsafePointer<C> = test([C()]) // Ok - argument is implicitly converted to a pointer
   let _: AnyHashable = test(C()) // Ok - argument is implicitly converted to `AnyHashable` because it's Hashable
 }
+
+// Make sure that conformances transitively checked through implicit conversions work with conditional requirements
+protocol TestCond {}
+
+extension Optional : TestCond where Wrapped == Int? {}
+
+func simple<T : TestCond>(_ x: T) -> T { x }
+
+func overloaded<T: TestCond>(_ x: T) -> T { x }
+func overloaded<T: TestCond>(_ x: String) -> T { fatalError() }
+
+func overloaded_result() -> Int { 42 }
+func overloaded_result() -> String { "" }
+
+func test_arg_conformance_with_conditional_reqs(i: Int) {
+  let _: Int?? = simple(i)
+  let _: Int?? = overloaded(i)
+  let _: Int?? = simple(overloaded_result())
+  let _: Int?? = overloaded(overloaded_result())
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar26564101.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar26564101.swift
@@ -1,8 +1,7 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
-// REQUIRES: rdar46850561,no_asan
 
 func rdar26564101(a: [Double], m: Double) -> Double {
   return Double(Array(0...a.count - 1).reduce(0) { $0 + $1 - m })
-  // expected-error@-1 {{too complex}}
+  // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 }

--- a/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar31439825.swift
@@ -4,4 +4,3 @@
 let a = 1
 
 _ = -a + -a - -a + -a - -a
-// expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time}}

--- a/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar33688063.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
-// REQUIRES: rdar57050532
 
 let _ = 1 | UInt32(0) << 0 | UInt32(1) << 1 | UInt32(2) << 2 | UInt32(3) << 3 | UInt32(4) << 4

--- a/validation-test/Sema/type_checker_perf/fast/rdar46713933_concrete_args.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar46713933_concrete_args.swift
@@ -7,8 +7,5 @@ func wrap<T: ExpressibleByFloatLiteral>(_ key: String, _ value: T) -> T { return
 func wrap<T: ExpressibleByStringLiteral>(_ key: String, _ value: T) -> T { return value }
 
 func wrapped(i: Int) -> Int {
-  // FIXME: When this stops being "too complex", turn the integer value into
-  // an integer literal.
-  // expected-error@+1{{reasonable time}}
   return wrap("1", i) + wrap("1", i) + wrap("1", i) + wrap("1", i)
 }

--- a/validation-test/Sema/type_checker_perf/slow/fast-operator-typechecking.swift
+++ b/validation-test/Sema/type_checker_perf/slow/fast-operator-typechecking.swift
@@ -19,5 +19,4 @@ func f(tail: UInt64, byteCount: UInt64) {
 func size(count: Int) {
   // Size of the buffer we need to allocate
   let _ = count * MemoryLayout<Float>.size * (4 + 3 + 3 + 2 + 4)
-  // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time}}
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22877285.swift
@@ -3,5 +3,5 @@
 
 let j = 1
 
-_ = "a" + j + "b" + j + "c" + j
+_ = "a" + j + "b" + j + "c" + j + "d" + j
 // expected-error@-1 {{reasonable time}}

--- a/validation-test/Sema/type_checker_perf/slow/rdar74035425.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar74035425.swift
@@ -7,6 +7,6 @@ struct Value {
 
 func test(values: [[Value]]) -> String {
   // expected-error@+1 {{the compiler is unable to type-check this expression in reasonable time}}
-  "[" + "" + values.map({ "[" + $0.map({ $0.debugDescription }).joined(separator: ", ") + "]" }).joined(separator: ", ") + "]"
+  "[" + "" + "" + values.map({ "[" + $0.map({ $0.debugDescription }).joined(separator: ", ") + "" + "]" }).joined(separator: ", ") + "" + "]"
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Performance optimization to help rule out generic overload choices sooner.

This is based on an observation of the constraint solver behavior,
consider following example:

```swift
func test<U: ExpressibleByStringLiteral>(_: U) {}

test(42)
```

Constraint System for call to `test` is going to look like this:

```
$T_test := ($T_U) -> $T_U
$T_U <conforms to> ExpressibleByStringLiteral
$T_42 <argument conversion> $T_U
$T_42 <literal conforms to> ExpressibleByIntegerLiteral
```

Currently to find out that `test` doesn't match, solver would have
to first find a binding for `$T_42`, then find a binding for `$T_U`
(through `<argument conversion>` constraint) and only later fail
while checking conformance of `Int` to `ExpressibleByStringLiteral`.

Instead of waiting for parameter to be bound, let's transfer conformance
requirements through a conversion constraint directly to an argument type,
since it has to conform to the same set of protocols as parameter to
be convertible (restrictions apply i.e. protocol composition types).

With that change it's possible to verify conformances early and reject
`test<U: ExpressibleByStringLiteral>` overload as soon as type of an
argument has been determined. This especially powerful for chained calls
because solver would only have to check as deep as first invalid argument
binding.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
