### PR TITLE
[stdlib][SR-9438] Re-implement integer-to-string conversion

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1661,9 +1661,14 @@ extension BinaryInteger {
       let count = $0.count
       if initializedCount < count {
         let baseAddress = $0.baseAddress!
+        let unusedCapacity = count &- initializedCount
         baseAddress.moveInitialize(
-          from: baseAddress + (count &- initializedCount),
+          from: baseAddress + unusedCapacity,
           count: initializedCount)
+        // Work around a `_SmallString` bug.
+        let ptr = baseAddress + initializedCount
+        ptr.initialize(repeating: 0, count: unusedCapacity)
+        ptr.deinitialize(count: unusedCapacity)
       }
       return initializedCount
     }

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1496,6 +1496,7 @@ extension BinaryInteger {
 //===----------------------------------------------------------------------===//
 
 @_alwaysEmitIntoClient
+@inline(__always)
 internal func _overestimatedBufferCapacity<T: BinaryInteger>(
   _ value: T, radix: Int
 ) -> Int {
@@ -1513,6 +1514,7 @@ internal func _overestimatedBufferCapacity<T: BinaryInteger>(
 }
 
 @_alwaysEmitIntoClient
+@inline(__always)
 internal func _convertSignedInteger<T: BinaryInteger>(
   _ buffer: UnsafeMutableBufferPointer<UInt8>, _ value: T,
   radix: Int, uppercase: Bool
@@ -1527,6 +1529,7 @@ internal func _convertSignedInteger<T: BinaryInteger>(
 }
 
 @_alwaysEmitIntoClient
+@inline(__always)
 internal func _convertUnsignedInteger<T: BinaryInteger>(
   _ buffer: UnsafeMutableBufferPointer<UInt8>, _ value: T,
   radix: Int, uppercase: Bool
@@ -1545,6 +1548,7 @@ internal func _convertUnsignedInteger<T: BinaryInteger>(
 }
 
 @_alwaysEmitIntoClient
+@inline(__always)
 internal func _convertNonzeroUInt64(
   _ buffer: UnsafeMutableBufferPointer<UInt8>, _ value: UInt64,
   radix: Int, uppercase: Bool
@@ -1561,68 +1565,54 @@ internal func _convertNonzeroUInt64(
   }
 }
 
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-@usableFromInline
-internal let _decimalDigitsLookupTable: [(UInt8, UInt8)] = [
-  (0x30, 0x30), (0x31, 0x30), (0x32, 0x30), (0x33, 0x30), (0x34, 0x30),
-  (0x35, 0x30), (0x36, 0x30), (0x37, 0x30), (0x38, 0x30), (0x39, 0x30),
-  (0x30, 0x31), (0x31, 0x31), (0x32, 0x31), (0x33, 0x31), (0x34, 0x31),
-  (0x35, 0x31), (0x36, 0x31), (0x37, 0x31), (0x38, 0x31), (0x39, 0x31),
-  (0x30, 0x32), (0x31, 0x32), (0x32, 0x32), (0x33, 0x32), (0x34, 0x32),
-  (0x35, 0x32), (0x36, 0x32), (0x37, 0x32), (0x38, 0x32), (0x39, 0x32),
-  (0x30, 0x33), (0x31, 0x33), (0x32, 0x33), (0x33, 0x33), (0x34, 0x33),
-  (0x35, 0x33), (0x36, 0x33), (0x37, 0x33), (0x38, 0x33), (0x39, 0x33),
-  (0x30, 0x34), (0x31, 0x34), (0x32, 0x34), (0x33, 0x34), (0x34, 0x34),
-  (0x35, 0x34), (0x36, 0x34), (0x37, 0x34), (0x38, 0x34), (0x39, 0x34),
-  (0x30, 0x35), (0x31, 0x35), (0x32, 0x35), (0x33, 0x35), (0x34, 0x35),
-  (0x35, 0x35), (0x36, 0x35), (0x37, 0x35), (0x38, 0x35), (0x39, 0x35),
-  (0x30, 0x36), (0x31, 0x36), (0x32, 0x36), (0x33, 0x36), (0x34, 0x36),
-  (0x35, 0x36), (0x36, 0x36), (0x37, 0x36), (0x38, 0x36), (0x39, 0x36),
-  (0x30, 0x37), (0x31, 0x37), (0x32, 0x37), (0x33, 0x37), (0x34, 0x37),
-  (0x35, 0x37), (0x36, 0x37), (0x37, 0x37), (0x38, 0x37), (0x39, 0x37),
-  (0x30, 0x38), (0x31, 0x38), (0x32, 0x38), (0x33, 0x38), (0x34, 0x38),
-  (0x35, 0x38), (0x36, 0x38), (0x37, 0x38), (0x38, 0x38), (0x39, 0x38),
-  (0x30, 0x39), (0x31, 0x39), (0x32, 0x39), (0x33, 0x39), (0x34, 0x39),
-  (0x35, 0x39), (0x36, 0x39), (0x37, 0x39), (0x38, 0x39), (0x39, 0x39),
-]
-
 @_alwaysEmitIntoClient
+@inline(__always)
 internal func _convertNonzeroUInt64ToDecimal(
   _ buffer: UnsafeMutableBufferPointer<UInt8>, _ value: UInt64
 ) -> /* initializedCount: */ Int {
-  guard #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) else {
-    return _convertNonzeroUnsignedInteger(
-      buffer, value, radix: 10, uppercase: false)
-  }
   var value = value
   var i = buffer.count
-  while value >= 10 {
-    i -= 2
-    let digits: UInt64
-    (value, digits) = value.quotientAndRemainder(dividingBy: 100)
-    let digits_ = Int(truncatingIfNeeded: digits)
-    (buffer[i &+ 1], buffer[i]) = _decimalDigitsLookupTable[digits_]
-  }
-  if value > 0 {
+  while value > 0 {
     i -= 1
-    buffer[i] = 48 /* "0" */ &+ UInt8(truncatingIfNeeded: value)
+    let digit: UInt64
+    (value, digit) = value.quotientAndRemainder(dividingBy: 10)
+    buffer[i] = 48 /* "0" */ &+ UInt8(truncatingIfNeeded: digit)
   }
   return buffer.count &- i
 }
 
 @_alwaysEmitIntoClient
+@inline(__always)
 internal func _convertNonzeroUInt64ToHexadecimal(
   _ buffer: UnsafeMutableBufferPointer<UInt8>, _ value: UInt64,
   uppercase: Bool
 ) -> /* initializedCount: */ Int {
-  //TODO: Implement fast path.
-  return _convertNonzeroUnsignedInteger(
-    buffer, value, radix: 16, uppercase: uppercase)
+  var value = value
+  var i = buffer.count
+  if uppercase {
+    while value > 0 {
+      i -= 1
+      let digit = value & 15
+      value &>>= 4
+      buffer[i] = digit < 10
+        ? 48 /* "0" */ &+ UInt8(truncatingIfNeeded: digit)
+        : 65 /* "A" */ &+ (UInt8(truncatingIfNeeded: digit) &- 10)
+    }
+  } else {
+    while value > 0 {
+      i -= 1
+      let digit = value & 15
+      value &>>= 4
+      buffer[i] = digit < 10
+        ? 48 /* "0" */ &+ UInt8(truncatingIfNeeded: digit)
+        : 97 /* "a" */ &+ (UInt8(truncatingIfNeeded: digit) &- 10)
+    }
+  }
+  return buffer.count &- i
 }
 
 @_alwaysEmitIntoClient
 @_specialize(where T == UInt64)
-@inline(never)
 internal func _convertNonzeroUnsignedInteger<T: BinaryInteger>(
   _ buffer: UnsafeMutableBufferPointer<UInt8>, _ value: T,
   radix: Int, uppercase: Bool

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -408,7 +408,7 @@ extension UnsafeRawPointer: _CustomPlaygroundQuickLookable {
       bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
     return ptrValue == 0
     ? "UnsafeRawPointer(nil)"
-    : "UnsafeRawPointer(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    : "UnsafeRawPointer(0x\(ptrValue._description(radix: 16, uppercase: true)))"
   }
 
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UnsafeRawPointer.customPlaygroundQuickLook will be removed in a future Swift version")
@@ -423,7 +423,7 @@ extension UnsafeMutableRawPointer: _CustomPlaygroundQuickLookable {
       bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
     return ptrValue == 0
     ? "UnsafeMutableRawPointer(nil)"
-    : "UnsafeMutableRawPointer(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    : "UnsafeMutableRawPointer(0x\(ptrValue._description(radix: 16, uppercase: true)))"
   }
 
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UnsafeMutableRawPointer.customPlaygroundQuickLook will be removed in a future Swift version")
@@ -437,7 +437,7 @@ extension UnsafePointer: _CustomPlaygroundQuickLookable {
     let ptrValue = UInt64(bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
     return ptrValue == 0 
     ? "UnsafePointer(nil)" 
-    : "UnsafePointer(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    : "UnsafePointer(0x\(ptrValue._description(radix: 16, uppercase: true)))"
   }
 
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UnsafePointer.customPlaygroundQuickLook will be removed in a future Swift version")
@@ -451,7 +451,7 @@ extension UnsafeMutablePointer: _CustomPlaygroundQuickLookable {
     let ptrValue = UInt64(bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
     return ptrValue == 0 
     ? "UnsafeMutablePointer(nil)" 
-    : "UnsafeMutablePointer(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    : "UnsafeMutablePointer(0x\(ptrValue._description(radix: 16, uppercase: true)))"
   }
 
   @available(swift, deprecated: 4.2/*, obsoleted: 5.0*/, message: "UnsafeMutablePointer.customPlaygroundQuickLook will be removed in a future Swift version")

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -346,7 +346,7 @@ internal func _uint64ToStringImpl(
   _ uppercase: Bool
 ) -> UInt64
 
-@available(*, unavailable)
+@available(*, deprecated, message: "Use 'String(_:radix:uppercase:)' instead")
 public // @testable
 func _uint64ToString(
   _ value: UInt64,

--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -119,10 +119,10 @@ struct Struct3ConformsToP2 : CustomStringConvertible, Q1 {
     // Don't rely on string interpolation, it uses the casts that we are trying
     // to test.
     var result = ""
-    result += _uint64ToString(a) + " "
-    result += _uint64ToString(b) + " "
-    result += _uint64ToString(c) + " "
-    result += _uint64ToString(d)
+    result += a.description + " "
+    result += b.description + " "
+    result += c.description + " "
+    result += d.description
     return result
   }
 }
@@ -143,10 +143,10 @@ struct Struct4ConformsToP2<T : CustomStringConvertible> : CustomStringConvertibl
     // Don't rely on string interpolation, it uses the casts that we are trying
     // to test.
     var result = value.description + " "
-    result += _uint64ToString(e) + " "
-    result += _uint64ToString(f) + " "
-    result += _uint64ToString(g) + " "
-    result += _uint64ToString(h)
+    result += e.description + " "
+    result += f.description + " "
+    result += g.description + " "
+    result += h.description
     return result
   }
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The referenced bug discusses several drawbacks of the status quo, which this PR attempts to address:

- [x] Fast path most common usage, `Int64` or `UInt64`, base 10 or 16
- [x] Outline cold path
- [x] Write contents directly into pre-allocated `String` buffer, small when appropriate
- [x] Stop relying on C functions `_{u}int64ToString`, implementing purely in Swift

(The diff is kind of garbage this time; the relevant new code is in a contiguous chunk starting [here](https://github.com/apple/swift/blob/8f8eb30fb05d10f64e5b409fc89648a84c387d73/stdlib/public/core/Integers.swift#L1498).) Let's see if this improves performance at all.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-9438](https://bugs.swift.org/browse/SR-9438).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
