### PR TITLE
[windows][test] Mark more concurrency tests as UNSUPPORTED in VS2017

### DIFF
--- a/test/Concurrency/Runtime/async_task_detached.swift
+++ b/test/Concurrency/Runtime/async_task_detached.swift
@@ -3,6 +3,9 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
+// See SR-14333
+// UNSUPPORTED: MSVC_VER=15.0
+
 class X {
   init() {
     print("X: init")

--- a/test/IRGen/async/throwing.swift
+++ b/test/IRGen/async/throwing.swift
@@ -6,7 +6,10 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
+
+// See SR-14333
 // XFAIL: OS=windows-msvc
+// UNSUPPORTED: MSVC_VER=15.0
 
 struct E : Error {}
 


### PR DESCRIPTION
The VS2017 started to succeed while executing
test/IRGen/async/throwing.swift, but it is marked as XFAIL for
OS=windows-msvc. To avoid failing the test in VS2019, only mark it as
unsupported in MSVC_VER=15.0 (VS2017), which will avoid running the
test.

`async_task_detached.swift` seems to fail with an `ACCESS_VIOLATION`
exit status, but seems to pass in VS2019, so also mark it as
`UNSUPPORTED` for VS2017 only.

All these problems are tracked in SR-14333.
