### PR TITLE
[Sanitizer] Disable tests that depend on symbolication on watchOS

### DIFF
--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -5,6 +5,9 @@
 // REQUIRES: asan_runtime
 // REQUIRES: VENDOR=apple
 
+// rdar://75365575 (Failing to start atos external symbolizer)
+// UNSUPPORTED: OS=watchos
+
 // We copy the binary but not the corresponding .dSYM for remote runs (e.g.,
 // on-device testing), and hence online symbolication fails.
 // UNSUPPORTED: remote_run

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -7,6 +7,9 @@
 // REQUIRES: libdispatch
 // REQUIRES: tsan_runtime
 
+// rdar://75365575 (Failing to start atos external symbolizer)
+// UNSUPPORTED: OS=watchos
+
 var globalCounterValue = 0
 
 actor Counter {

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -7,6 +7,9 @@
 // REQUIRES: libdispatch
 // REQUIRES: tsan_runtime
 
+// rdar://75365575 (Failing to start atos external symbolizer)
+// UNSUPPORTED: OS=watchos
+
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)


### PR DESCRIPTION
Some new Sanitizer tests are failing on watchOS because we fail to start
atos to symbolicate the report.  FileCheck then fails when we assert on
the generated report.

Radar-Id: rdar://75766734
