### PR TITLE
Support constant diagnostics on constructors

### DIFF
--- a/test/Sema/diag_constantness_check.swift
+++ b/test/Sema/diag_constantness_check.swift
@@ -344,3 +344,20 @@ func testConstantRange(x: Int) {
   constantClosedRange(x: x...10)
     // expected-error@-1 {{argument must be an integer literal}}
 }
+
+struct ConstructorTest {
+  @_semantics("oslog.requires_constant_arguments")
+  init(x: Int) { }
+
+  @_semantics("oslog.requires_constant_arguments")
+  init(_ x: Int) { }
+}
+
+func testConstructorAnnotation(x: Int) {
+  let _ = ConstructorTest(x: 10)
+  let _ = ConstructorTest(x: x)
+    // expected-error@-1 {{argument must be an integer literal}}
+  let _ = ConstructorTest(10)
+  let _ = ConstructorTest(x)
+    // expected-error@-1 {{argument must be an integer literal}}
+}


### PR DESCRIPTION
This change includes a fix to allow the diagnostics
for constantness in function arguments to work properly
for constructors. This change also includes some minor
code cleanup in the constantness diagnostic pass.
