### PR TITLE
[Actor inference] Extend global actor inference

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2674,16 +2674,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
     // If the declaration is in a nominal type (or extension thereof) that
     // has isolation, use that.
     if (auto selfTypeDecl = value->getDeclContext()->getSelfNominalTypeDecl()) {
-      if (auto selfTypeIsolation = getActorIsolation(selfTypeDecl)) {
-        // Don't propagate implicit, unsafe global actor isolation from a type
-        // to non-imported instance members.
-        if (selfTypeIsolation != ActorIsolation::GlobalActorUnsafe ||
-            value->getClangNode() ||
-            (selfTypeDecl->getGlobalActorAttr() &&
-             !selfTypeDecl->getGlobalActorAttr()->first->isImplicit())) {
-          return inferredIsolation(selfTypeIsolation);
-        }
-      }
+      if (auto selfTypeIsolation = getActorIsolation(selfTypeDecl))
+        return inferredIsolation(selfTypeIsolation);
     }
   }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -5,7 +5,7 @@
 import Foundation
 import ObjCConcurrency
 
-@MainActor func onlyOnMainActor() { } // expected-note{{calls to global function 'onlyOnMainActor()' from outside of its actor context are implicitly asynchronous}}
+@MainActor func onlyOnMainActor() { }
 
 func testSlowServer(slowServer: SlowServer) async throws {
   let _: Int = await slowServer.doSomethingSlow("mail")
@@ -130,8 +130,6 @@ struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
-@SomeGlobalActor(unsafe) func unsafelyOnSomeGlobal() { }
-
 class MyButton : NXButton {
   @MainActor func testMain() {
     onButtonPress() // okay
@@ -141,28 +139,10 @@ class MyButton : NXButton {
     onButtonPress() // expected-error{{instance method 'onButtonPress()' isolated to global actor 'MainActor' can not be referenced from different global actor 'SomeGlobalActor'}}
   }
 
-  func test() { // expected-note{{add '@MainActor' to make instance method 'test()' part of global actor 'MainActor'}}
-    onButtonPress() // okay, onButtonPress is @MainActor(unsafe)
-    unsafelyOnSomeGlobal() // okay, we haven't opted into anything
-    onlyOnMainActor() // expected-error{{global function 'onlyOnMainActor()' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
-  }
-}
-
-class MyOtherButton: NXButton {
-  override func onButtonPress() { // expected-note{{calls to instance method 'onButtonPress()' from outside of its actor context are implicitly asynchronous}}
-    onlyOnMainActor() // yes, we're on the main actor
-    unsafelyOnSomeGlobal() // okay, we haven't opted into any actual checking
-  }
-
   func test() {
-    onButtonPress() // okay, it's @MainActor(unsafe)
-  }
-
-  @SomeGlobalActor func testOther() {
-    onButtonPress() // expected-error{{instance method 'onButtonPress()' isolated to global actor 'MainActor' can not be referenced from different global actor 'SomeGlobalActor' in a synchronous context}}
+    onButtonPress() // okay
   }
 }
-
 
 func testButtons(mb: MyButton) {
   mb.onButtonPress()

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -68,6 +68,30 @@ class C2: P2 {
   }
 }
 
+struct AllInP1: P1 {
+  func method() { } // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+  func other() { } // expected-note {{calls to instance method 'other()' from outside of its actor context are implicitly asynchronous}}
+}
+
+func testAllInP1(ap1: AllInP1) { // expected-note 2 {{add '@SomeGlobalActor' to make global function 'testAllInP1(ap1:)' part of global actor 'SomeGlobalActor'}}
+  ap1.method() // expected-error{{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+  ap1.other() // expected-error{{instance method 'other()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+}
+
+struct NotAllInP1 {
+  func other() { }
+}
+
+extension NotAllInP1: P1 {
+  func method() { } // expected-note{{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
+}
+
+func testNotAllInP1(nap1: NotAllInP1) { // expected-note{{add '@SomeGlobalActor' to make global function 'testNotAllInP1(nap1:)' part of global actor 'SomeGlobalActor'}}
+  nap1.method() // expected-error{{instance method 'method()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+  nap1.other() // okay
+}
+
+
 // ----------------------------------------------------------------------
 // Global actor inference for classes and extensions
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Extend global actor inference in a few ways:
* All value members of a type that has a global actor will infer a global actor, including initializers and static variables
* A type can infer a global actor from conformance to a protocol that is marked with a global actor

Addresses rdar://75992299