### PR TITLE
Filled out platforms for Swift 5.4 availability.

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -393,7 +393,20 @@ AvailabilityContext ASTContext::getSwift53Availability() {
 }
 
 AvailabilityContext ASTContext::getSwift54Availability() {
-  return getSwiftFutureAvailability();
+  auto target = LangOpts.Target;
+
+  if (target.isMacOSX()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(11, 3, 0)));
+  } else if (target.isiOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(14, 5, 0)));
+  } else if (target.isWatchOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(7, 4, 0)));
+  } else {
+    return AvailabilityContext::alwaysAvailable();
+  }
 }
 
 AvailabilityContext ASTContext::getSwiftFutureAvailability() {


### PR DESCRIPTION
Previously, the availability was "Future", meaning that any features that were gated to be available in "Swift 5.4" would only be used if the target were the highest possible version number (like iOS 99).  Here that is fixed by using the OS versions that actually shipped with Swift 5.4.

rdar://75978438