### PR TITLE
[Concurrency] Use correct type for Task.Handle in Task.sleep

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -477,7 +477,7 @@ extension Task {
     // Enqueue the resulting job.
     _enqueueJobGlobalWithDelay(duration, Builtin.convertTaskToJob(task))
 
-    let _ = await Handle<Int, Never>(task).get()
+    await Handle<Void, Never>(task).get()
   }
 }
 


### PR DESCRIPTION
This was probably an oversight after fixing rdar://74957357