### PR TITLE
[concurrency] prevent double @MainActor annotation in ClangImporter

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -83,5 +83,9 @@ WARNING(implicit_bridging_header_imported_from_module,none,
         "is deprecated and will be removed in a later version of Swift",
         (StringRef, Identifier))
 
+WARNING(import_multiple_mainactor_attr,none,
+      "this attribute for global actor '%0' is invalid; the declaration already has attribute for global actor '%1'",
+      (StringRef, StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/test/ClangImporter/Inputs/DoubleMainActor.h
+++ b/test/ClangImporter/Inputs/DoubleMainActor.h
@@ -1,0 +1,17 @@
+@import Foundation;
+
+#pragma clang assume_nonnull begin
+
+#define SWIFT_MAIN_ACTOR __attribute__((swift_attr("@MainActor")))
+#define SWIFT_UI_ACTOR __attribute__((swift_attr("@UIActor")))
+
+// NOTE: If you ever end up removing support for the "@UIActor" alias,
+// just change both to be @MainActor and it won't change the purpose of
+// this test.
+
+SWIFT_UI_ACTOR SWIFT_MAIN_ACTOR @protocol DoubleMainActor
+@required
+- (NSString *)createSeaShanty:(NSInteger)number;
+@end
+
+#pragma clang assume_nonnull end

--- a/test/ClangImporter/duplicate_mainactor.swift
+++ b/test/ClangImporter/duplicate_mainactor.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-concurrency -import-objc-header %S/Inputs/DoubleMainActor.h -emit-module -module-name use %s 2> %t/stderr.txt
+// RUN: %FileCheck -input-file %t/stderr.txt %s
+
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+// CHECK: DoubleMainActor.h:{{[0-9]+}}:{{[0-9]+}}: warning: this attribute for global actor '@MainActor' is invalid; the declaration already has attribute for global actor '@UIActor'
+
+protocol P : DoubleMainActor {}

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -92,3 +92,5 @@ import _Concurrency
 // CHECK: {{^}}var MAGIC_NUMBER: Int32 { get }
 
 // CHECK: func doSomethingConcurrently(_ block: @Sendable () -> Void)
+
+// CHECK: @MainActor protocol TripleMainActor {

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -157,4 +157,8 @@ void doSomethingConcurrently(__attribute__((noescape)) __attribute__((swift_attr
 
 void doSomethingConcurrentlyButUnsafe(__attribute__((noescape)) __attribute__((swift_attr("@_unsafeSendable"))) void (^block)(void));
 
+
+MAIN_ACTOR MAIN_ACTOR __attribute__((__swift_attr__("@MainActor(unsafe)"))) @protocol TripleMainActor
+@end
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
This can lead to latent type errors for API users,
because a swiftmodule would otherwise be emitted,
without any diagnostics, containing imported decl
with two global actor annotations on it. Such
decls will always be an error to the typechecker
when its eventually encountered.

This patch drops all `@MainActor` annotations after
the first one in the ClangImporter, regardless of
whether its the safe or unsafe version, and emits
a warning when doing so.

resolves rdar://75954917
