### PR TITLE
Set `run-test` script to be a python3 script

### DIFF
--- a/utils/run-test
+++ b/utils/run-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/run-test - test runner for Swift -*- python -*-
 #
 # This source file is part of the Swift.org open source project


### PR DESCRIPTION
Otherwise invoking it currently produces the `TypeError: split() takes no keyword arguments` error. 