### PR TITLE
[CSBindings] A couple of adjustments to transitive protocol inference

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1697,6 +1697,7 @@ ConstraintSystem::getTypeOfMemberReference(
         // Concrete type replacing `Self` could be generic, so we need
         // to make sure that it's opened before use.
         baseOpenedTy = openType(concreteSelf, replacements);
+        baseObjTy = baseOpenedTy;
       }
     }
   } else if (baseObjTy->isExistentialType()) {

--- a/test/Constraints/static_member_on_protocol_with_opaque_result.swift
+++ b/test/Constraints/static_member_on_protocol_with_opaque_result.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify %s
+
+// rdar://75978086 - static member lookup doesn't work with opaque types
+
+protocol Intent {}
+
+extension Intent where Self == Intents.List {
+  static func orderedList() -> Self {
+    return Intents.List.orderedList(nestedIn: nil)
+  }
+}
+
+enum Intents {
+  enum List: Intent {
+  case orderedList(nestedIn: Any?)
+  }
+}
+
+let rdar75978086: some Intent = .orderedList() // Ok

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -330,16 +330,7 @@ TEST_F(SemaTest, TestTransitiveProtocolInferenceThroughEquivalenceChains) {
   cs.addConstraint(ConstraintKind::ConformsTo, typeVar2, protocolTy0, nilLocator);
   cs.addConstraint(ConstraintKind::ConformsTo, typeVar3, protocolTy1, nilLocator);
 
-  llvm::SmallDenseMap<TypeVariableType *, BindingSet> cache;
-  for (auto *typeVar : cs.getTypeVariables()) {
-    cache.insert({typeVar, cs.getBindingsFor(typeVar, /*finalize=*/false)});
-  }
-
-  auto bindingSet = cache.find(typeVar0);
-  assert(bindingSet != cache.end());
-
-  auto &bindings = bindingSet->getSecond();
-  bindings.inferTransitiveProtocolRequirements(cache);
+  auto bindings = inferBindings(cs, typeVar0);
 
   ASSERT_TRUE(bool(bindings.TransitiveProtocols));
   verifyProtocolInferenceResults(*bindings.TransitiveProtocols,

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -300,3 +300,48 @@ TEST_F(SemaTest, TestComplexTransitiveProtocolInference) {
       *bindingsForT5.TransitiveProtocols,
       {protocolTy1, protocolTy2, protocolTy3, protocolTy4});
 }
+
+/// Let's try a situation where there protocols are inferred from
+/// multiple sources on different levels of equivalence chain.
+///
+/// T0 = T1
+///         = T2 (P0)
+///              = T3 (P1)
+TEST_F(SemaTest, TestTransitiveProtocolInferenceThroughEquivalenceChains) {
+  ConstraintSystemOptions options;
+  ConstraintSystem cs(DC, options);
+
+  auto *protocolTy0 = createProtocol("P0");
+  auto *protocolTy1 = createProtocol("P1");
+
+  auto *nilLocator = cs.getConstraintLocator({});
+
+  auto typeVar0 = cs.createTypeVariable(nilLocator, /*options=*/0);
+  // Allow this type variable to be bound to l-value type to prevent
+  // it from being merged with the rest of the type variables.
+  auto typeVar1 =
+    cs.createTypeVariable(nilLocator, /*options=*/TVO_CanBindToLValue);
+  auto typeVar2 = cs.createTypeVariable(nilLocator, /*options=*/0);
+  auto typeVar3 = cs.createTypeVariable(nilLocator, TVO_CanBindToLValue);
+
+  cs.addConstraint(ConstraintKind::Conversion, typeVar0, typeVar1, nilLocator);
+  cs.addConstraint(ConstraintKind::Equal, typeVar1, typeVar2, nilLocator);
+  cs.addConstraint(ConstraintKind::Equal, typeVar2, typeVar3, nilLocator);
+  cs.addConstraint(ConstraintKind::ConformsTo, typeVar2, protocolTy0, nilLocator);
+  cs.addConstraint(ConstraintKind::ConformsTo, typeVar3, protocolTy1, nilLocator);
+
+  llvm::SmallDenseMap<TypeVariableType *, BindingSet> cache;
+  for (auto *typeVar : cs.getTypeVariables()) {
+    cache.insert({typeVar, cs.getBindingsFor(typeVar, /*finalize=*/false)});
+  }
+
+  auto bindingSet = cache.find(typeVar0);
+  assert(bindingSet != cache.end());
+
+  auto &bindings = bindingSet->getSecond();
+  bindings.inferTransitiveProtocolRequirements(cache);
+
+  ASSERT_TRUE(bool(bindings.TransitiveProtocols));
+  verifyProtocolInferenceResults(*bindings.TransitiveProtocols,
+                                 {protocolTy0, protocolTy1});
+}

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -136,6 +136,7 @@ BindingSet SemaTest::inferBindings(ConstraintSystem &cs,
       continue;
 
     auto &bindings = cachedBindings->getSecond();
+    bindings.inferTransitiveProtocolRequirements(cache);
     bindings.finalize(cache);
   }
 


### PR DESCRIPTION
-  Use all equivalence chain members while interring transitive protocols
- Infer transitive protocols only for unresolved member base

Resolves: rdar://75978086

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
