### PR TITLE
[IRGen] Disable pre-specialization for 32-bit ARM on Linux

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1641,7 +1641,8 @@ bool IRGenModule::useDllStorage() { return ::useDllStorage(Triple); }
 
 bool IRGenModule::shouldPrespecializeGenericMetadata() {
   auto canPrespecializeTarget =
-      (Triple.isOSDarwin() || Triple.isTvOS() || Triple.isOSLinux());
+      (Triple.isOSDarwin() || Triple.isTvOS() ||
+       (Triple.isOSLinux() && !(Triple.isARM() && Triple.isArch32Bit())));
   if (canPrespecializeTarget && isStandardLibrary()) {
     return true;
   }


### PR DESCRIPTION
This is a temporary workaround for segfaults we observed in TargetMetadata,
caused by invalid pointers.