### PR TITLE
[stdlib][SR-14424] Zero-initialize any unused capacity in '_SmallString.init(initializingUTF8With:)'

### DIFF
--- a/test/stdlib/SmallString.swift
+++ b/test/stdlib/SmallString.swift
@@ -105,4 +105,16 @@ SmallStringTests.test("Append, repeating") {
   }
 }
 
+if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  SmallStringTests.test("Equatable") {
+    let str = String(unsafeUninitializedCapacity: 2) {
+      let last = $0.count &- 1
+      $0[last] = 49 // "1"
+      $0.baseAddress!.moveInitialize(from: $0.baseAddress! + last, count: 1)
+      return 1
+    }
+    expectTrue(str == "1")
+  }
+}
+
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
There's a subtle problem with small strings:

```swift
let str = String(unsafeUninitializedCapacity: 2) {
    let last = $0.count &- 1
    $0[last] = 49 // "1"
    $0.baseAddress!.moveInitialize(from: $0.baseAddress! + last, count: 1)
    return 1
}
print(str) // "1"
print(str == "1") // false (!)
```

Here's why.

The `unsafeUninitializedCapacity` initializer requires users to return the initialized count and to leave the remaining bytes uninitialized. This is what's happening here. To wit:

* Bytes are written from the end of the buffer towards the start as the string representation is being built up.
* Once the final byte sequence for the string has been obtained, it is move-initialized to the start of the buffer (as per discussions on the forums, it is permitted to use `moveInitialize` with overlapping source and destination in this way).
* This leaves the unused bytes uninitialized, as required by the documentation.

All of this works perfectly when the string isn't small. Digging through the sources, I understand that a `_SmallString`'s buffer is backed by a tuple of `(UInt64, UInt64)`. Although unused bytes are deinitialized here, they aren't zero immediately prior to deinitialization.

It has to be the job of `_SmallString` to initialize unused bytes to zero before rebinding the buffer to its original type. The user can't leave the unused capacity zero-initialized themselves after using it because the documentation tells the user that they should leave the unused capacity uninitialized, and therefore leaving it initialized to zero may not be what a non-small string expects.

To fix this bug, we simply zero-initialize the unused capacity before rebinding the memory back to the type of `self._storage`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-14424](https://bugs.swift.org/browse/SR-14424).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
