### PR TITLE
[SwiftShims] Make the void* arguments of memcmp nullable

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -70,7 +70,11 @@ static inline __swift_size_t _swift_stdlib_strlen_unsigned(const unsigned char *
 SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
+#if defined(__APPLE__)
+  extern int memcmp(const void * _Nullable, const void * _Nullable, __swift_size_t);
+#else
   extern int memcmp(const void *, const void *, __swift_size_t);
+#endif
   return memcmp(s1, s2, n);
 }
 

--- a/validation-test/ClangImporter/memcmp-definitions.swift
+++ b/validation-test/ClangImporter/memcmp-definitions.swift
@@ -1,0 +1,11 @@
+/// rdar://69876253
+// RUN: %target-build-swift %s -o %t.out
+
+import SwiftShims
+import Foundation
+
+func foo () {
+  let a = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)
+  let b = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)
+  memcmp(a, b, 4)
+}

--- a/validation-test/ClangImporter/memcmp-definitions.swift
+++ b/validation-test/ClangImporter/memcmp-definitions.swift
@@ -1,4 +1,5 @@
 /// rdar://69876253
+// REQUIRES: VENDOR=apple
 // RUN: %target-build-swift %s -o %t.out
 
 import SwiftShims


### PR DESCRIPTION
This should correspond to the definition of `memcmp` in `usr/include/string.h` and keep it from being a source of confusion for the compiler.

rdar://69876253