### PR TITLE
[stdlib] Fix bug in small string uninitialized init

### DIFF
--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -80,3 +80,27 @@ if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
     expectTrue(empty.isEmpty)
   }
 }
+
+if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  StringCreateTests.test("Small string unsafeUninitializedCapacity") {
+    let str1 = "42"
+    let str2 = String(42)
+    expectEqual(str1, str2)
+
+    let str3 = String(unsafeUninitializedCapacity: 2) {
+      $0[0] = UInt8(ascii: "4")
+      $0[1] = UInt8(ascii: "2")
+      return 2
+    }
+    expectEqual(str1, str3)
+
+    // Write into uninitialized space
+    let str4 = String(unsafeUninitializedCapacity: 3) {
+      $0[0] = UInt8(ascii: "4")
+      $0[1] = UInt8(ascii: "2")
+      $0[2] = UInt8(ascii: "X")
+      return 2
+    }
+    expectEqual(str1, str4)
+  }
+}


### PR DESCRIPTION
Fix a bug and enforce the invariant that all bits between the last code unit
and the descriminator in a small string should be unset.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
