### PR TITLE
[stdlib] Float16/Intel: Add an explicit Sendable conformance to work around a swiftinterface issue

### DIFF
--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1370,6 +1370,17 @@ public struct ${Self} {
   }
 }
 
+%  if bits == 16:
+// This is a workaround for a compiler bug that omits the macOS 11 availability
+// from the implicit conformance emitted into the generated .swiftinterface
+// file. See https://github.com/apple/swift/pull/36669 for details.
+// FIXME: rdar://76092800
+@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+extension ${Self}: Sendable { }
+%  end
+
 #endif
 % end
 % end # for bits in all_floating_point_types

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1019,6 +1019,9 @@ extension ${Self} {
   }
 }
 
+${Availability(bits)}
+extension ${Self}: Sendable { }
+
 //===----------------------------------------------------------------------===//
 // Explicit conversions between types.
 //===----------------------------------------------------------------------===//
@@ -1342,9 +1345,6 @@ internal struct _${Self}AnyHashableBox: _AnyHashableBox {
   }
 }
 % end
-
-${Availability(bits)}
-extension ${Self} : Sendable { }
 
 //===----------------------------------------------------------------------===//
 // Deprecated operators


### PR DESCRIPTION
~~This extension (introduced in https://github.com/apple/swift/pull/35264) was placed in a file location where it wasn’t correctly guarded against mentioning Float16 on macOS/x86_64, so the generated .swiftinterface file included a reference to an unavailable declaration. (The dummy stand-in Float16 type that we currently use on Intel macOS.)~~

~~Moving the declaration out of the “AnyHashable” section and into a file region that’s more suitable for it (i.e., enclosed in `#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))`) resolves the issue.~~

~~**Note:** The reason why the original extension produces an unusable .swiftinterface file without triggering a build error is currently a mystery to me.~~

This is a workaround for a compiler bug that omits the full availability information of an unavailable struct from the implicit Sendable conformance declaration emitted into the generated `.swiftinterface` file. See the discussion below for details.

rdar://76025365