### PR TITLE
[test] Disable some concurrency tests on Windows

### DIFF
--- a/test/Concurrency/Runtime/async_task_detached.swift
+++ b/test/Concurrency/Runtime/async_task_detached.swift
@@ -3,8 +3,8 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
-// See SR-14333
-// UNSUPPORTED: MSVC_VER=15.0
+// https://bugs.swift.org/browse/SR-14333
+// UNSUPPORTED: OS=windows-msvc
 
 class X {
   init() {

--- a/test/IRGen/async/throwing.swift
+++ b/test/IRGen/async/throwing.swift
@@ -7,9 +7,8 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 
-// See SR-14333
-// XFAIL: OS=windows-msvc
-// UNSUPPORTED: MSVC_VER=15.0
+// https://bugs.swift.org/browse/SR-14333
+// UNSUPPORTED: OS=windows-msvc
 
 struct E : Error {}
 


### PR DESCRIPTION
These two have been [previously disabled on VS2017](https://github.com/apple/swift/pull/36637), but they're causing trouble even on VS2019 -- so I'm unconditionally disabling them on all Windows MSVC builds for now.

https://bugs.swift.org/browse/SR-14333

(c.f. https://github.com/apple/swift/pull/36669)