### PR TITLE
[Basic] Update for new fs::createUniqueFile in llvm

### DIFF
--- a/lib/Basic/FileSystem.cpp
+++ b/lib/Basic/FileSystem.cpp
@@ -101,7 +101,8 @@ tryToOpenTemporaryFile(Optional<llvm::raw_fd_ostream> &openedStream,
 
   int fd;
   const unsigned perms = fs::all_read | fs::all_write;
-  std::error_code EC = fs::createUniqueFile(tempPath, fd, tempPath, perms);
+  std::error_code EC = fs::createUniqueFile(tempPath, fd, tempPath,
+                                            fs::OF_None, perms);
 
   if (EC) {
     // Ignore the specific error; the caller has to fall back to not using a


### PR DESCRIPTION
https://reviews.llvm.org/D97785 reintroduced a flags parameter to `fs::createUniqueFile`, this time preceding `params`. (Compare: https://github.com/apple/swift/pull/18472)

rdar://76036856
