### PR TITLE
[test] Skip a @differentiable test during back deployment testing

### DIFF
--- a/test/AutoDiff/validation-test/function_type_metadata.swift
+++ b/test/AutoDiff/validation-test/function_type_metadata.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// rdar://76039256
+// UNSUPPORTED: use_os_stdlib
+
 import StdlibUnittest
 import _Differentiation
 

--- a/test/AutoDiff/validation-test/function_type_metadata.swift
+++ b/test/AutoDiff/validation-test/function_type_metadata.swift
@@ -1,41 +1,40 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// rdar://76039256
-// UNSUPPORTED: use_os_stdlib
-
 import StdlibUnittest
 import _Differentiation
 
 var FunctionTypeMetadataTests = TestSuite("FunctionTypeMetadata")
 
-FunctionTypeMetadataTests.test("Reflect differentiable function type") {
-  expectEqual(
-    "@differentiable(reverse) (Swift.Float) -> Swift.Float",
-    String(reflecting: (@differentiable(reverse) (Float) -> Float).self))
-  expectEqual(
-    "@differentiable(reverse) (inout Swift.Float) -> ()",
-    String(reflecting: (@differentiable(reverse) (inout Float) -> Void).self))
-  expectEqual(
-    """
-    @differentiable(reverse) (Swift.Array<Swift.Float>) -> \
-    Swift.Array<Swift.Float>
-    """,
-    String(reflecting: (@differentiable(reverse) ([Float]) -> [Float]).self))
-  expectEqual(
-    """
-    @differentiable(reverse) (Swift.Optional<Swift.Float>) -> \
-    Swift.Optional<Swift.Float>
-    """,
-    String(reflecting: (@differentiable(reverse) (Float?) -> Float?).self))
-  // FIXME(rdar://75916833): Mangle '@noDerivative' in function types.
-  // expectEqual(
-  //   """
-  //   @differentiable(reverse) (Swift.Optional<Swift.Float>, \
-  //   @noDerivative Swift.Int) -> Swift.Optional<Swift.Float>
-  //   """,
-  //   String(reflecting: (
-  //       @differentiable(reverse) (Float?, @noDerivative Int) -> Float?).self))
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  FunctionTypeMetadataTests.test("Reflect differentiable function type") {
+    expectEqual(
+      "@differentiable(reverse) (Swift.Float) -> Swift.Float",
+      String(reflecting: (@differentiable(reverse) (Float) -> Float).self))
+    expectEqual(
+      "@differentiable(reverse) (inout Swift.Float) -> ()",
+      String(reflecting: (@differentiable(reverse) (inout Float) -> Void).self))
+    expectEqual(
+      """
+      @differentiable(reverse) (Swift.Array<Swift.Float>) -> \
+      Swift.Array<Swift.Float>
+      """,
+      String(reflecting: (@differentiable(reverse) ([Float]) -> [Float]).self))
+    expectEqual(
+      """
+      @differentiable(reverse) (Swift.Optional<Swift.Float>) -> \
+      Swift.Optional<Swift.Float>
+      """,
+      String(reflecting: (@differentiable(reverse) (Float?) -> Float?).self))
+    // FIXME(rdar://75916833): Mangle '@noDerivative' in function types.
+    // expectEqual(
+    //   """
+    //   @differentiable(reverse) (Swift.Optional<Swift.Float>, \
+    //   @noDerivative Swift.Int) -> Swift.Optional<Swift.Float>
+    //   """,
+    //   String(reflecting: (
+    //       @differentiable(reverse) (Float?, @noDerivative Int) -> Float?).self))
+  }
 }
 
 // FIXME(rdar://75916878): Investigate why reflecting differentiable function


### PR DESCRIPTION
This currently fails when run on the macOS 10.14.4 stdlib:

```
[ RUN      ] FunctionTypeMetadata.Reflect differentiable function type
stdout>>> check failed at /Users/buildslave/jenkins/workspace/fs-swift-main-tools_RA-stdlib_RA-macOS-swift-in-OS-10.14.4/swift/test/AutoDiff/validation-test/function_type_metadata.swift, line 10
stdout>>> expected: "@differentiable(reverse) (Swift.Float) -> Swift.Float" (of type Swift.String)
stdout>>> actual: "-3.8442426e-13" (of type Swift.String)
stderr>>> CRASHED: SIGSEGV
the test crashed unexpectedly
[     FAIL ] FunctionTypeMetadata.Reflect differentiable function type
```

rdar://76039256
