### PR TITLE
[Concurrency] Introduce "unsafe" @Sendable and @MainActor parameter attributes

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -637,6 +637,10 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(nonisolated, Nonisolated,
   APIBreakingToAdd | APIStableToRemove,
   112)
 
+CONTEXTUAL_SIMPLE_DECL_ATTR(_unsafeSendable, UnsafeSendable,
+  OnParam | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  113)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -642,6 +642,11 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(_unsafeSendable, UnsafeSendable,
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   113)
 
+CONTEXTUAL_SIMPLE_DECL_ATTR(_unsafeMainActor, UnsafeMainActor,
+  OnParam | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,
+  114)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6097,7 +6097,16 @@ public:
   /// constructor.
   bool hasDynamicSelfResult() const;
 
+
   AbstractFunctionDecl *getAsyncAlternative() const;
+
+  /// Determine whether this function is implicitly known to have its
+  /// parameters of function type be @_unsafeSendable.
+  ///
+  /// This hard-codes knowledge of a number of functions that will
+  /// eventually have @_unsafeSendable and, eventually, @Sendable,
+  /// on their parameters of function type.
+  bool hasKnownUnsafeSendableFunctionParams() const;
 
   using DeclContext::operator new;
   using Decl::getASTContext;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3983,7 +3983,7 @@ public:
         UnsafeConcurrencyBits::MainActor;
   }
 
-  void setContextuallyConcurrent(bool sendable, bool forMainActor) {
+  void setUnsafeConcurrent(bool sendable, bool forMainActor) {
     uint8_t bits = 0;
     if (sendable)
       bits |= UnsafeConcurrencyBits::Sendable;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3811,6 +3811,12 @@ public:
     SeparatelyTypeChecked,
   };
 
+  /// Bits used to indicate contextual information that is concurrency-specific.
+  enum UnsafeConcurrencyBits {
+    Sendable = 1 << 0,
+    MainActor = 1 << 1
+  };
+
 private:
   /// The attributes attached to the closure.
   DeclAttributes Attributes;
@@ -3825,7 +3831,10 @@ private:
   /// the CaptureListExpr which would normally maintain this sort of
   /// information about captured variables), we need to have some way to access
   /// this information directly on the ClosureExpr.
-  VarDecl * CapturedSelfDecl;
+  ///
+  /// The integer indicates how the closure is contextually concurrent.
+  llvm::PointerIntPair<VarDecl *, 2, uint8_t>
+      CapturedSelfDeclAndUnsafeConcurrent;
 
   /// The location of the "async", if present.
   SourceLoc AsyncLoc;
@@ -3855,7 +3864,7 @@ public:
     : AbstractClosureExpr(ExprKind::Closure, Type(), /*Implicit=*/false,
                           discriminator, parent),
       Attributes(attributes), BracketRange(bracketRange),
-      CapturedSelfDecl(capturedSelfDecl),
+      CapturedSelfDeclAndUnsafeConcurrent(capturedSelfDecl, 0),
       AsyncLoc(asyncLoc), ThrowsLoc(throwsLoc), ArrowLoc(arrowLoc),
       InLoc(inLoc),
       ExplicitResultTypeAndBodyState(explicitResultType, BodyState::Parsed),
@@ -3961,7 +3970,27 @@ public:
 
   /// VarDecl captured by this closure under the literal name \c self , if any.
   VarDecl *getCapturedSelfDecl() const {
-    return CapturedSelfDecl;
+    return CapturedSelfDeclAndUnsafeConcurrent.getPointer();
+  }
+
+  bool isUnsafeSendable() const {
+    return CapturedSelfDeclAndUnsafeConcurrent.getInt() &
+        UnsafeConcurrencyBits::Sendable;
+  }
+
+  bool isUnsafeMainActor() const {
+    return CapturedSelfDeclAndUnsafeConcurrent.getInt() &
+        UnsafeConcurrencyBits::MainActor;
+  }
+
+  void setContextuallyConcurrent(bool sendable, bool forMainActor) {
+    uint8_t bits = 0;
+    if (sendable)
+      bits |= UnsafeConcurrencyBits::Sendable;
+    if (forMainActor)
+      bits |= UnsafeConcurrencyBits::MainActor;
+
+    CapturedSelfDeclAndUnsafeConcurrent.setInt(bits);
   }
 
   /// Get the type checking state of this closure's body.

--- a/include/swift/AST/KnownSDKTypes.def
+++ b/include/swift/AST/KnownSDKTypes.def
@@ -38,5 +38,6 @@ KNOWN_SDK_TYPE_DECL(ObjectiveC, ObjCBool, StructDecl, 0)
 // TODO(async): These might move to the stdlib module when concurrency is
 // standardized
 KNOWN_SDK_TYPE_DECL(Concurrency, UnsafeContinuation, NominalTypeDecl, 2)
+KNOWN_SDK_TYPE_DECL(Concurrency, MainActor, NominalTypeDecl, 0)
 
 #undef KNOWN_SDK_TYPE_DECL

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3343,6 +3343,7 @@ struct ParameterListInfo {
   SmallBitVector defaultArguments;
   SmallBitVector acceptsUnlabeledTrailingClosures;
   SmallBitVector propertyWrappers;
+  SmallBitVector unsafeSendable;
 
 public:
   ParameterListInfo() { }
@@ -3360,6 +3361,11 @@ public:
   /// The ParamDecl at the given index if the parameter has an applied
   /// property wrapper.
   bool hasExternalPropertyWrapper(unsigned paramIdx) const;
+
+  /// Whether the given parameter is unsafe Sendable, meaning that
+  /// we will treat it as Sendable in a context that has adopted concurrency
+  /// features.
+  bool isUnsafeSendable(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3344,6 +3344,7 @@ struct ParameterListInfo {
   SmallBitVector acceptsUnlabeledTrailingClosures;
   SmallBitVector propertyWrappers;
   SmallBitVector unsafeSendable;
+  SmallBitVector unsafeMainActor;
 
 public:
   ParameterListInfo() { }
@@ -3366,6 +3367,11 @@ public:
   /// we will treat it as Sendable in a context that has adopted concurrency
   /// features.
   bool isUnsafeSendable(unsigned paramIdx) const;
+
+  /// Whether the given parameter is unsafe MainActor, meaning that
+  /// we will treat it as being part of the main actor but that it is not
+  /// part of the type system.
+  bool isUnsafeMainActor(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7331,6 +7331,27 @@ void AbstractFunctionDecl::addDerivativeFunctionConfiguration(
   DerivativeFunctionConfigs->insert(config);
 }
 
+bool AbstractFunctionDecl::hasKnownUnsafeSendableFunctionParams() const {
+  auto nominal = getDeclContext()->getSelfNominalTypeDecl();
+  if (!nominal)
+    return false;
+
+  // DispatchQueue operations.
+  auto nominalName = nominal->getName().str();
+  if (nominalName == "DispatchQueue") {
+    auto name = getBaseName().userFacingName();
+    return llvm::StringSwitch<bool>(name)
+      .Case("sync", true)
+      .Case("async", true)
+      .Case("asyncAndWait", true)
+      .Case("asyncAfter", true)
+      .Case("concurrentPerform", true)
+      .Default(false);
+  }
+
+  return false;
+}
+
 void FuncDecl::setResultInterfaceType(Type type) {
   getASTContext().evaluator.cacheOutput(ResultTypeRequest{this},
                                         std::move(type));

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -913,12 +913,35 @@ static bool allowsUnlabeledTrailingClosureParameter(const ParamDecl *param) {
   return paramType->is<AnyFunctionType>();
 }
 
+/// Determine whether the parameter is contextually Sendable.
+static bool isParamUnsafeSendable(const ParamDecl *param) {
+  // Check for @_unsafeSendable.
+  if (param->getAttrs().hasAttribute<UnsafeSendableAttr>())
+    return true;
+
+  // Check that the parameter is of function type.
+  Type paramType = param->isVariadic() ? param->getVarargBaseTy()
+                                       : param->getInterfaceType();
+  paramType = paramType->getRValueType()->lookThroughAllOptionalTypes();
+  if (!paramType->is<FunctionType>())
+    return false;
+
+  // Check whether this function is known to have @_unsafeSendable function
+  // parameters.
+  auto func = dyn_cast<AbstractFunctionDecl>(param->getDeclContext());
+  if (!func)
+    return false;
+
+  return func->hasKnownUnsafeSendableFunctionParams();
+}
+
 ParameterListInfo::ParameterListInfo(
     ArrayRef<AnyFunctionType::Param> params,
     const ValueDecl *paramOwner,
     bool skipCurriedSelf) {
   defaultArguments.resize(params.size());
   propertyWrappers.resize(params.size());
+  unsafeSendable.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -970,6 +993,10 @@ ParameterListInfo::ParameterListInfo(
     if (param->hasAttachedPropertyWrapper()) {
       propertyWrappers.set(i);
     }
+
+    if (isParamUnsafeSendable(param)) {
+      unsafeSendable.set(i);
+    }
   }
 }
 
@@ -986,6 +1013,12 @@ bool ParameterListInfo::acceptsUnlabeledTrailingClosureArgument(
 
 bool ParameterListInfo::hasExternalPropertyWrapper(unsigned paramIdx) const {
   return paramIdx < propertyWrappers.size() ? propertyWrappers[paramIdx] : false;
+}
+
+bool ParameterListInfo::isUnsafeSendable(unsigned paramIdx) const {
+  return paramIdx < unsafeSendable.size()
+      ? unsafeSendable[paramIdx]
+      : false;
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -942,6 +942,7 @@ ParameterListInfo::ParameterListInfo(
   defaultArguments.resize(params.size());
   propertyWrappers.resize(params.size());
   unsafeSendable.resize(params.size());
+  unsafeMainActor.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -997,6 +998,10 @@ ParameterListInfo::ParameterListInfo(
     if (isParamUnsafeSendable(param)) {
       unsafeSendable.set(i);
     }
+
+    if (param->getAttrs().hasAttribute<UnsafeMainActorAttr>()) {
+      unsafeMainActor.set(i);
+    }
   }
 }
 
@@ -1018,6 +1023,12 @@ bool ParameterListInfo::hasExternalPropertyWrapper(unsigned paramIdx) const {
 bool ParameterListInfo::isUnsafeSendable(unsigned paramIdx) const {
   return paramIdx < unsafeSendable.size()
       ? unsafeSendable[paramIdx]
+      : false;
+}
+
+bool ParameterListInfo::isUnsafeMainActor(unsigned paramIdx) const {
+  return paramIdx < unsafeMainActor.size()
+      ? unsafeMainActor[paramIdx]
       : false;
 }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1731,7 +1731,7 @@ Type ClangImporter::Implementation::applyParamAttributes(
 
     // Map the main-actor attribute.
     if (isMainActorAttr(SwiftContext, swiftAttr)) {
-      if (Type mainActor = getMainActorType()) {
+      if (Type mainActor = SwiftContext.getMainActorType()) {
         type = applyToFunctionType(type, [&](ASTExtInfo extInfo) {
           return extInfo.withGlobalActor(mainActor);
         });

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -405,9 +405,6 @@ private:
   /// Clang arguments used to create the Clang invocation.
   std::vector<std::string> ClangArgs;
 
-  /// The main actor type, populated the first time we look for it.
-  Optional<Type> MainActorType;
-
   /// Mapping from Clang swift_attr attribute text to the Swift source buffer
   /// IDs that contain that attribute text. These are re-used when parsing the
   /// Swift attributes on import.
@@ -817,9 +814,6 @@ public:
 
   /// Map a Clang identifier name to its imported Swift equivalent.
   StringRef getSwiftNameFromClangName(StringRef name);
-
-  /// Look for the MainActor type in the _Concurrency library.
-  Type getMainActorType();
 
   /// Retrieve the Swift source buffer ID that corresponds to the given
   /// swift_attr attribute text, creating one if necessary.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -683,12 +683,17 @@ public:
     decl->setImplicitlyUnwrappedOptional(true);
   }
 
-  void recordUnsafeSendableForDecl(ValueDecl *decl, bool isUnsafeSendable) {
-    if (!isUnsafeSendable)
-      return;
+  void recordUnsafeConcurrencyForDecl(
+      ValueDecl *decl, bool isUnsafeSendable, bool isUnsafeMainActor) {
+    if (isUnsafeSendable) {
+      decl->getAttrs().add(
+          new (SwiftContext) UnsafeSendableAttr(/*implicit=*/true));
+    }
 
-    decl->getAttrs().add(
-        new (SwiftContext) UnsafeSendableAttr(/*implicit=*/true));
+    if (isUnsafeMainActor) {
+      decl->getAttrs().add(
+          new (SwiftContext) UnsafeMainActorAttr(/*implicit=*/true));
+    }
   }
 
   /// Retrieve the Clang AST context.
@@ -842,7 +847,7 @@ public:
                         const clang::ObjCContainerDecl *NewContext = nullptr);
 
   Type applyParamAttributes(const clang::ParmVarDecl *param, Type type,
-                            bool &isUnsafeSendable);
+                            bool &isUnsafeSendable, bool &isUnsafeMainActor);
 
   /// If we already imported a given decl, return the corresponding Swift decl.
   /// Otherwise, return nullptr.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -683,6 +683,14 @@ public:
     decl->setImplicitlyUnwrappedOptional(true);
   }
 
+  void recordUnsafeSendableForDecl(ValueDecl *decl, bool isUnsafeSendable) {
+    if (!isUnsafeSendable)
+      return;
+
+    decl->getAttrs().add(
+        new (SwiftContext) UnsafeSendableAttr(/*implicit=*/true));
+  }
+
   /// Retrieve the Clang AST context.
   clang::ASTContext &getClangASTContext() const {
     return Instance->getASTContext();
@@ -833,7 +841,8 @@ public:
   void importAttributes(const clang::NamedDecl *ClangDecl, Decl *MappedDecl,
                         const clang::ObjCContainerDecl *NewContext = nullptr);
 
-  Type applyParamAttributes(const clang::ParmVarDecl *param, Type type);
+  Type applyParamAttributes(const clang::ParmVarDecl *param, Type type,
+                            bool &isUnsafeSendable);
 
   /// If we already imported a given decl, return the corresponding Swift decl.
   /// Otherwise, return nullptr.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -19,6 +19,7 @@
 #include "CSDiagnostics.h"
 #include "CodeSynthesis.h"
 #include "MiscDiagnostics.h"
+#include "TypeCheckConcurrency.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
 #include "swift/AST/ASTVisitor.h"
@@ -5707,6 +5708,52 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
   return false;
 }
 
+/// Apply the contextually Sendable flag to the given expression,
+static void applyContextuallyConcurrent(
+      Expr *expr, bool sendable, bool forMainActor) {
+  if (auto closure = dyn_cast<ClosureExpr>(expr)) {
+    closure->setContextuallyConcurrent(sendable, forMainActor);
+    return;
+  }
+
+  if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
+    applyContextuallyConcurrent(
+        captureList->getClosureBody(), sendable, forMainActor);
+  }
+}
+
+/// Whether this is a reference to a method on the main dispatch queue.
+static bool isMainDispatchQueue(Expr *arg) {
+  auto call = dyn_cast<DotSyntaxCallExpr>(arg);
+  if (!call)
+    return false;
+
+  auto memberRef = dyn_cast<MemberRefExpr>(
+      call->getBase()->getValueProvidingExpr());
+  if (!memberRef)
+    return false;
+
+  auto member = memberRef->getMember();
+  if (member.getDecl()->getName().getBaseName().userFacingName() != "main")
+    return false;
+
+  auto typeExpr = dyn_cast<TypeExpr>(
+      memberRef->getBase()->getValueProvidingExpr());
+  if (!typeExpr)
+    return false;
+
+  Type baseType = typeExpr->getInstanceType();
+  if (!baseType)
+    return false;
+
+  auto baseNominal = baseType->getAnyNominal();
+  if (!baseNominal)
+    return false;
+
+  return baseNominal->getName().str() == "DispatchQueue";
+}
+
+
 Expr *ExprRewriter::coerceCallArguments(
     Expr *arg, AnyFunctionType *funcType,
     ConcreteDeclRef callee,
@@ -5924,6 +5971,19 @@ Expr *ExprRewriter::coerceCallArguments(
 
     // Save the original label location.
     newLabelLocs.push_back(getLabelLoc(argIdx));
+
+    // If the parameter is contextually Sendable and we are in a
+    // context that has adopted concurrency, apply contextual Sendable
+    // to the closure (if there is one).
+    if (paramInfo.isUnsafeSendable(paramIdx)) {
+      bool forMainActor = false;
+      if (apply) {
+        forMainActor = isMainDispatchQueue(apply->getFn());
+      }
+
+      applyContextuallyConcurrent(
+          arg, contextUsesConcurrencyFeatures(dc), forMainActor);
+    }
 
     // If the types exactly match, this is easy.
     auto paramType = param.getOldType();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -136,6 +136,7 @@ public:
   IGNORED_ATTR(AtRethrows)
   IGNORED_ATTR(AtReasync)
   IGNORED_ATTR(UnsafeSendable)
+  IGNORED_ATTR(UnsafeMainActor)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -135,6 +135,7 @@ public:
   IGNORED_ATTR(Sendable)
   IGNORED_ATTR(AtRethrows)
   IGNORED_ATTR(AtReasync)
+  IGNORED_ATTR(UnsafeSendable)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1545,6 +1545,7 @@ namespace  {
     UNINTERESTING_ATTR(AtReasync)
     UNINTERESTING_ATTR(Nonisolated)
     UNINTERESTING_ATTR(UnsafeSendable)
+    UNINTERESTING_ATTR(UnsafeMainActor)
 
 #undef UNINTERESTING_ATTR
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1544,6 +1544,7 @@ namespace  {
 
     UNINTERESTING_ATTR(AtReasync)
     UNINTERESTING_ATTR(Nonisolated)
+    UNINTERESTING_ATTR(UnsafeSendable)
 
 #undef UNINTERESTING_ATTR
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -85,6 +85,7 @@ func testSlowServerOldSchool(slowServer: SlowServer) {
 func testSendable(fn: () -> Void) { // expected-note{{parameter 'fn' is implicitly non-concurrent}}
   doSomethingConcurrently(fn)
   // expected-error@-1{{passing non-concurrent parameter 'fn' to function expecting a @Sendable closure}}
+  doSomethingConcurrentlyButUnsafe(fn) // okay, @Sendable not part of the type
 
   var x = 17
   doSomethingConcurrently {
@@ -92,6 +93,14 @@ func testSendable(fn: () -> Void) { // expected-note{{parameter 'fn' is implicit
     x = x + 1 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
     // expected-error@-1{{reference to captured var 'x' in concurrently-executing code}}
   }
+}
+
+func testSendableInAsync() async {
+  var x = 17
+  doSomethingConcurrentlyButUnsafe {
+    x = 42 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+  }
+  print(x)
 }
 
 // Check import of attributes

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -72,6 +72,13 @@ func testSlowServerSynchronous(slowServer: SlowServer) {
     print(s)
     onlyOnMainActor() // okay because runOnMainThread has a @MainActor closure
   }
+
+  slowServer.overridableButRunsOnMainThread { s in
+    print(s)
+    onlyOnMainActor() // okay because parameter has @_unsafeMainActor
+  }
+
+  let _: Int = slowServer.overridableButRunsOnMainThread // expected-error{{cannot convert value of type '(((String) -> Void)?) -> Void' to specified type 'Int'}}
 }
 
 func testSlowServerOldSchool(slowServer: SlowServer) {

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -122,6 +122,24 @@ func testConcurrency() {
   }
 }
 
+func acceptUnsafeSendable(@_unsafeSendable _ fn: () -> Void) { }
+
+func testUnsafeSendableNothing() {
+  var x = 5
+  acceptUnsafeSendable {
+    x = 17
+  }
+  print(x)
+}
+
+func testUnsafeSendableInAsync() async {
+  var x = 5
+  acceptUnsafeSendable {
+    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+  }
+  print(x)
+}
+
 // ----------------------------------------------------------------------
 // Sendable restriction on key paths.
 // ----------------------------------------------------------------------

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency %import-libdispatch -warn-concurrency
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+import Dispatch
+
+// Tests the inference of @_unsafeSendable and @MainActor when working with
+// the Dispatch library, and specifically, DispatchQueue.
+@MainActor func onlyOnMainActor() { }
+
+func testMe() {
+  DispatchQueue.main.async {
+    onlyOnMainActor() // okay, due to inference of @MainActor-ness
+  }
+}
+
+func testUnsafeSendableInAsync() async {
+  var x = 5
+  DispatchQueue.main.async {
+    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+  }
+  print(x)
+}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -461,3 +461,16 @@ func acceptClosure<T>(_: () -> T) { }
   acceptClosure { getGlobal7() } // okay
   acceptClosure { @actorIndependent in getGlobal7() } // expected-error{{global function 'getGlobal7()' isolated to global actor 'SomeGlobalActor' can not be referenced from a non-isolated synchronous context}}
 }
+
+// ----------------------------------------------------------------------
+// Unsafe main actor parameter annotation
+// ----------------------------------------------------------------------
+func takesUnsafeMainActor(@_unsafeMainActor fn: () -> Void) { }
+
+@MainActor func onlyOnMainActor() { }
+
+func useUnsafeMainActor() {
+  takesUnsafeMainActor {
+    onlyOnMainActor() // okay due to parameter attribute
+  }
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -4,6 +4,7 @@
 #pragma clang assume_nonnull begin
 
 #define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
+#define MAIN_ACTOR_UNSAFE __attribute__((__swift_attr__("@_unsafeMainActor")))
 
 @protocol ServiceProvider
 @property(readonly) NSArray<NSString *> *allOperations;
@@ -74,6 +75,8 @@ typedef void (^CompletionHandler)(NSString * _Nullable, NSString * _Nullable_res
 // Both would be imported as the same decl - require swift_async(none) on one
 -(void)asyncImportSame:(NSString *)operation completionHandler:(void (^)(NSInteger))handler;
 -(void)asyncImportSame:(NSString *)operation replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
+
+-(void)overridableButRunsOnMainThreadWithCompletionHandler:(MAIN_ACTOR_UNSAFE void (^ _Nullable)(NSString *))completion;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -150,4 +150,8 @@ __attribute__((__swift_attr__("@MainActor(unsafe)")))
 // Do something concurrently, but without escaping.
 void doSomethingConcurrently(__attribute__((noescape)) __attribute__((swift_attr("@Sendable"))) void (^block)(void));
 
+
+
+void doSomethingConcurrentlyButUnsafe(__attribute__((noescape)) __attribute__((swift_attr("@_unsafeSendable"))) void (^block)(void));
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
Introduce the notion of "unsafe" `@Sendable` parameters, indicated by the
hidden `@_unsafeSendable` parameter attribute. Closure arguments to such
parameters are treated as `@Sendable` within code that has already
adopted concurrency, but are otherwise enert, allowing them to be
applied to existing concurrency-related APIs to smooth the transition
path to concurrency.

Additionally, introduce the notion of an "unsafe" `@MainActor` 
parameters, indicated by the hidden `@_unsafeMainActor` parameter
attribute. This ensures that the given closure will execute on
the main actor but it isn't part of the type system so it doesn't affect
source compatibility.

Pattern-match uses of the Dispatch library's `DispatchQueue` to infer
both kinds of "unsafe" as appropriate, especially (e.g.) matching the pattern

    DispatchQueue.main.async { ... }

to treat the closure as unsafe `@Sendable` and `@MainActor`, allowing
existing code to better integrate with concurrency.

Implements rdar://75988966.