### PR TITLE
[stdlib] Set.intersection iterate over smaller set

### DIFF
--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1223,7 +1223,11 @@ extension Set {
   @inlinable
   public __consuming func intersection(_ other: Set<Element>) -> Set<Element> {
     var newSet = Set<Element>()
-    for member in self {
+    var (iter, other) = (self, other)
+    if iter.count > other.count {
+      swap(&iter, &other)
+    }
+    for member in iter {
       if other.contains(member) {
         newSet.insert(member)
       }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1223,12 +1223,10 @@ extension Set {
   @inlinable
   public __consuming func intersection(_ other: Set<Element>) -> Set<Element> {
     var newSet = Set<Element>()
-    var (iter, other) = (self, other)
-    if iter.count > other.count {
-      swap(&iter, &other)
-    }
-    for member in iter {
-      if other.contains(member) {
+    let (smaller, larger) =
+      count < other.count ? (self, other) : (other, self)
+    for member in smaller {
+      if larger.contains(member) {
         newSet.insert(member)
       }
     }


### PR DESCRIPTION
When intersecting two sets, it is beneficial to iterate over the smaller sized set of the two, and check membership on the other. This speeds up runtime dramatically for cases where the current set is significantly larger than the set being intersected against.


The following is a small comparison of the current intersection vs the proposed version. As input size increases, the current intersection takes significantly longer.

Note that this change only reduces time for cases where the sizes of the inputs differ significantly.

```
name                           time     std        iterations
-------------------------------------------------------------
stdlib intersection [10->10]   0.001 ms ±  51.37 %     947716
fast intersection [10->10]     0.001 ms ± 316.51 %     935652 0.9x faster
stdlib intersection [61->10]   0.001 ms ±  49.55 %     861024
fast intersection [61->10]     0.001 ms ±  75.61 %    1000000 1.1x faster
stdlib intersection [625->10]  0.010 ms ±  21.54 %     132798
fast intersection [625->10]    0.001 ms ±  63.79 %    1000000 7.5x faster
stdlib intersection [6357->10] 0.151 ms ±  12.51 %       8811
fast intersection [6357->10]   0.001 ms ±  49.66 %    1000000 113x faster
```


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
