### PR TITLE
[stdlib] Reduce traps in Slice.wCSIA

### DIFF
--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -221,9 +221,12 @@ extension Slice: Collection {
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     try _base.withContiguousStorageIfAvailable { buffer in
-      let start = _base.distance(from: _base.startIndex, to: _startIndex)
+      guard let baseAddress = buffer.baseAddress else { 
+        return try body(UnsafeBufferPointer(start: nil, count: 0))
+      }
+      let startOffset = _base.distance(from: _base.startIndex, to: _startIndex)
       let count = _base.distance(from: _startIndex, to: _endIndex)
-      let slice = UnsafeBufferPointer(rebasing: buffer[start ..< start + count])
+      let slice = UnsafeBufferPointer(start: baseAddress + startOffset, count: count)
       return try body(slice)
     }
   }

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -226,7 +226,9 @@ extension Slice: Collection {
       }
       let startOffset = _base.distance(from: _base.startIndex, to: _startIndex)
       let count = _base.distance(from: _startIndex, to: _endIndex)
-      let slice = UnsafeBufferPointer(start: baseAddress + startOffset, count: count)
+      let slice = UnsafeBufferPointer(
+        start: baseAddress + startOffset, count: _assumeNonNegative(count)
+      )
       return try body(slice)
     }
   }


### PR DESCRIPTION
The previous implementation used integer addition, a Range, and the rebasing initializer.

I'm currently trying to optimize some code which uses withContiguousStorageIfAvailable. I've found that using a Slice<UBP> rather than a plain UBP introduces _5_ additional traps, which in turn stops the function getting inlined results in very disappointing performance. The generated assembly looks like this:

```
function signature specialization <Arg[0] = Exploded> of function signature specialization <Arg[1] = Dead> of generic specialization <Swift.Slice<Swift.UnsafeBufferPointer<Swift.UInt8>>> of output.WebURL.SchemeKind.init<A where A: Swift.Sequence, A.Element == Swift.UInt8>(parsing: A) -> output.WebURL.SchemeKind:
        sub     rsi, rdi
        jo      .LBB176_18
        add     rsi, rdi
        jo      .LBB176_19
        cmp     rsi, rdi
        jl      .LBB176_20
        lea     rcx, [rdx + rdi]
        test    rdx, rdx
        cmove   rcx, rdx
        sub     rsi, rdi
        jo      .LBB176_21
        test    rsi, rsi
        js      .LBB176_22
        ...
```

Before continuing with the same code as the regular UBP. Looking at the code, I think the calculations and Range initializer could be the culprits.