### PR TITLE
Revert "[TypeChecker] Add a flag to disable Double<->CGFloat implicit…

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -592,9 +592,6 @@ namespace swift {
 
     /// See \ref FrontendOptions.PrintFullConvention
     bool PrintFullConvention = false;
-
-    /// Disallow Double and CGFloat types from being used interchangeably.
-    bool DisableImplicitDoubleCGFloatConversion = false;
   };
 
   /// Options for controlling the behavior of the Clang importer.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -248,9 +248,6 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 // HIDDEN FLAGS
 let Flags = [FrontendOption, NoDriverOption, HelpHidden] in {
 
-def disable_implicit_double_cgfloat_conversion : Flag<["-"], "disable-implicit-double-cgfloat-conversion">,
-  HelpText<"Disable implicit conversion between Double and CGFloat types">;
-
 def debug_constraints : Flag<["-"], "debug-constraints">,
   HelpText<"Debug the constraint-based type checker">;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1405,10 +1405,6 @@ enum class ConstraintSystemFlags {
   /// calling conventions, say due to Clang attributes such as
   /// `__attribute__((ns_consumed))`.
   UseClangFunctionTypes = 0x80,
-
-  /// Disallow using Double and CGFloat interchangeably by means of
-  /// an implicit value conversion.
-  DisableImplicitDoubleCGFloatConversion = 0x100,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -830,9 +830,6 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.DebugConstraintSolver |= Args.hasArg(OPT_debug_constraints);
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);
 
-  Opts.DisableImplicitDoubleCGFloatConversion |=
-      Args.hasArg(OPT_disable_implicit_double_cgfloat_conversion);
-
   for (const Arg *A : Args.filtered(OPT_debug_constraints_on_line)) {
     unsigned line;
     if (StringRef(A->getValue()).getAsInteger(/*radix*/ 10, line)) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5131,10 +5131,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
           nominal1->getDecl() != nominal2->getDecl() &&
           ((nominal1->isCGFloatType() || nominal2->isCGFloatType()) &&
            (nominal1->isDoubleType() || nominal2->isDoubleType()))) {
-        if (Options.contains(
-                ConstraintSystemFlags::DisableImplicitDoubleCGFloatConversion))
-          return getTypeMatchFailure(locator);
-
         // Support implicit Double<->CGFloat conversions only for
         // something which could be directly represented in the AST
         // e.g. argument-to-parameter, contextual conversions etc.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -88,9 +88,6 @@ ConstraintSystem::ConstraintSystem(DeclContext *dc,
   }
   if (Context.LangOpts.UseClangFunctionTypes)
     Options |= ConstraintSystemFlags::UseClangFunctionTypes;
-
-  if (Context.TypeCheckerOpts.DisableImplicitDoubleCGFloatConversion)
-    Options |= ConstraintSystemFlags::DisableImplicitDoubleCGFloatConversion;
 }
 
 ConstraintSystem::~ConstraintSystem() {


### PR DESCRIPTION
… conversion"

This is a leftover from experimentation which is no longer necessary because SE-0307 has been accepted. 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
