### PR TITLE
[TBD] Fixed AsyncFunctionPointer name for @_silgen_name'd funcs.

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -457,7 +457,9 @@ std::string LinkEntity::mangleAsString() const {
 
   case Kind::AsyncFunctionPointerAST: {
     std::string Result;
-    Result = mangler.mangleEntity(getDecl());
+    Result =
+        SILDeclRef(const_cast<ValueDecl *>(getDecl()), SILDeclRef::Kind::Func)
+            .mangle();
     Result.append("Tu");
     return Result;
   }

--- a/test/TBD/async-function-pointer.swift
+++ b/test/TBD/async-function-pointer.swift
@@ -7,6 +7,10 @@
 @asyncHandler
 public func testit() { }
 
+// CHECK: @barTu = global %swift.async_func_pointer
+@_silgen_name("bar")
+public func foo() async {}
+
 // CHECK: @"$s4test1CC1f33_295642D23064661A21CD592AD781409CLLyyYFTu" = global %swift.async_func_pointer 
 
 open class C {


### PR DESCRIPTION
Use SILDeclRef::mangle for AsyncFunctionPointers.

rdar://76026408
