### PR TITLE
[cxx-interop] Implement operator[] for value return types (SR-14351).

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1745,12 +1745,14 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       break;
     case clang::OverloadedOperatorKind::OO_Subscript: {
       auto returnType = functionDecl->getReturnType();
-      if (!returnType->isReferenceType()) {
-        // TODO: support non-reference return types (SR-14351)
-        return ImportedName();
-      }
-      if (returnType->getPointeeType().isConstQualified()) {
+      if ((!returnType->isReferenceType() && !returnType->isAnyPointerType()) ||
+          returnType->getPointeeType().isConstQualified()) {
+        // If we are handling a non-reference return type, treat it as a getter
+        // so that we do not SILGen the value type operator[] as an rvalue.
         baseName = "__operatorSubscriptConst";
+        result.info.accessorKind = ImportedAccessorKind::SubscriptGetter;
+      } else if (returnType->isAnyPointerType()) {
+        baseName = "__operatorSubscript";
         result.info.accessorKind = ImportedAccessorKind::SubscriptGetter;
       } else {
         baseName = "__operatorSubscript";

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -137,14 +137,106 @@ struct TemplatedSubscriptArray {
   }
 };
 
-struct NonReferenceReadIntArray {
+struct IntArrayByVal {
+  // For testing purposes.
+  void setValueAtIndex(int value, unsigned i) { values[i] = value; }
+  int operator[](int x) const { return values[x]; }
 private:
   int values[3] = { 1, 2, 3 };
+};
 
-public:
-  int operator[](int x) const {
-    return values[x];
+struct NonTrivialIntArrayByVal {
+  NonTrivialIntArrayByVal(int first) { values[0] = first; }
+  NonTrivialIntArrayByVal(const NonTrivialIntArrayByVal &other) {}
+  int operator[](int x) const { return values[x]; }
+
+  // For testing purposes.
+  void setValueAtIndex(int value, unsigned i) { values[i] = value; }
+
+private:
+  int values[5] = { 1, 2, 3, 4, 5 };
+};
+
+struct DifferentTypesArrayByVal {
+  int operator[](int x) { return values[x]; }
+  bool operator[](bool x) { return boolValues[x]; }
+  double operator[](double x) const { return doubleValues[x == 0.0]; }
+
+private:
+  int values[3] = { 1, 2, 3 };
+  double doubleValues[2] = { 1.5, 2.5 };
+  bool boolValues[2] = { true, false };
+};
+
+template<class T> struct TemplatedArrayByVal {
+  T ts[];
+  T operator[](int i) { return ts[i]; }
+};
+typedef TemplatedArrayByVal<double> TemplatedDoubleArrayByVal;
+
+struct TemplatedSubscriptArrayByVal {
+  int *ptr;
+  template<class T> T operator[](T i) { return ptr[i]; }
+};
+
+struct NonTrivial {
+  char *Str;
+  long long a;
+  short b;
+  long long c;
+  short d;
+  long long e;
+  int f;
+  NonTrivial() {
+    Str = (char*)"Non-Trivial";
+    a = 1;
+    b = 2;
+    c = 3;
+    d = 4;
+    e = 5;
+    f = 6;
   }
+  ~NonTrivial() { Str = nullptr; }
+};
+
+struct NonTrivialArrayByVal {
+  NonTrivial operator[](int x) { return S; }
+private:
+  NonTrivial S;
+};
+
+struct PtrByVal {
+  int *operator[](int x) { return &a; }
+private:
+  int a = 64;
+};
+
+struct RefToPtr {
+  RefToPtr() { b = &a; }
+  int *&operator[](int x) { return b; }
+private:
+  int a = 64;
+  int *b = nullptr;
+};
+
+struct PtrToPtr {
+  PtrToPtr() { b = &a; }
+  int **operator[](int x) { return &b; }
+private:
+  int a = 64;
+  int *b = nullptr;
+};
+
+struct ConstOpPtrByVal {
+  const int *operator[](int x) const { return &a; }
+private:
+  int a = 64;
+};
+
+struct ConstPtrByVal {
+  const int *operator[](int x) { return &a; }
+private:
+  int a = 64;
 };
 
 #endif

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.cpp
@@ -35,3 +35,7 @@ const int& ReadWriteIntArray::operator[](int x) const {
 int& ReadWriteIntArray::operator[](int x) {
   return values[x];
 }
+
+int NonTrivialIntArrayByVal::operator[](int x) {
+  return values[x];
+}

--- a/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
+++ b/test/Interop/Cxx/operators/Inputs/member-out-of-line.h
@@ -29,4 +29,16 @@ public:
   int &operator[](int x);
 };
 
+struct NonTrivialIntArrayByVal {
+  NonTrivialIntArrayByVal(int first) { values[0] = first; }
+  NonTrivialIntArrayByVal(const NonTrivialIntArrayByVal &other) {}
+  int operator[](int x);
+
+  // For testing purposes.
+  void setValueAtIndex(int value, unsigned i) { values[i] = value; }
+
+private:
+  int values[5] = { 1, 2, 3, 4, 5 };
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -8,12 +8,12 @@ import MemberInline
 public func sub(_ lhs: inout LoadableIntWrapper, _ rhs: LoadableIntWrapper) -> LoadableIntWrapper { lhs - rhs }
 
 // CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN18LoadableIntWrappermiES_|"\?\?GLoadableIntWrapper@@QEAA\?AU0@U0@@Z")]](%struct.LoadableIntWrapper* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\) align 4}} {{%[0-9]+}})
-// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4) {{.*}}, {{i32 %rhs.coerce|\[1 x i32\] %rhs.coerce|i64 %rhs.coerce|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %rhs}})
+// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4) {{.*}}, {{i32 %.*.coerce|\[1 x i32\] %.*.coerce|i64 %.*.coerce|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %.*}})
 
 public func call(_ wrapper: inout LoadableIntWrapper, _ arg: Int32) -> Int32 { wrapper(arg) }
 
 // CHECK: call [[RES:i32|i64]] [[NAME:@(_ZN18LoadableIntWrapperclEi|"\?\?GLoadableIntWrapper@@QEAAHH@Z")]](%struct.LoadableIntWrapper* {{%[0-9]+}}, {{i32|\[1 x i32\]|i64|%struct.LoadableIntWrapper\* byval\(.*\) align 4}} {{%[0-9]+}})
-// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4) {{.*}}, {{i32 %x|\[1 x i32\] %x|i64 %x|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %rhs}})
+// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.LoadableIntWrapper* nonnull dereferenceable(4) {{.*}}, {{i32 %.*|\[1 x i32\] %.*|i64 %.*|%struct.LoadableIntWrapper\* byval\(%struct.LoadableIntWrapper\) align 4 %.*}})
 
 public func call(_ wrapper: inout AddressOnlyIntWrapper) -> Int32 { wrapper() }
 
@@ -23,7 +23,7 @@ public func call(_ wrapper: inout AddressOnlyIntWrapper) -> Int32 { wrapper() }
 public func index(_ arr: inout ReadOnlyIntArray, _ arg: Int32) -> Int32 { arr[arg] }
 
 // CHECK: call [[RES:i32|i64]]* [[NAME:@(_ZNK16ReadOnlyIntArrayixEi|"\?\?AReadOnlyIntArray@@QEBAAEBHH@Z")]](%struct.ReadOnlyIntArray* {{%[0-9]+}}, {{i32|i64}} {{%[0-9]+}})
-// CHECK: define linkonce_odr nonnull align 4 dereferenceable(4) [[RES]]* [[NAME]](%struct.ReadOnlyIntArray* nonnull dereferenceable(20) {{.*}}, {{i32 %x|\[1 x i32\] %x|i64 %x|%struct.ReadOnlyIntArray\* byval\(%struct.ReadOnlyIntArray\) align 2 %rhs}})
+// CHECK: define linkonce_odr nonnull align 4 dereferenceable(4) [[RES]]* [[NAME]](%struct.ReadOnlyIntArray* nonnull dereferenceable(20) {{.*}}, {{i32 %.*|\[1 x i32\] %.*|i64 %.*|%struct.ReadOnlyIntArray\* byval\(%struct.ReadOnlyIntArray\) align 2 %.*}})
 // CHECK:   [[THIS:%.*]] = load %struct.ReadOnlyIntArray*, %struct.ReadOnlyIntArray**
 // CHECK:   [[VALUES:%.*]] = getelementptr inbounds %struct.ReadOnlyIntArray, %struct.ReadOnlyIntArray* [[THIS]]
 // CHECK:   [[VALUE:%.*]] = getelementptr inbounds [5 x {{i32|i64}}], [5 x {{i32|i64}}]* [[VALUES]]
@@ -32,8 +32,18 @@ public func index(_ arr: inout ReadOnlyIntArray, _ arg: Int32) -> Int32 { arr[ar
 public func index(_ arr: inout ReadWriteIntArray, _ arg: Int32, _ val: Int32) { arr[arg] = val }
 
 // CHECK: call [[RES:i32|i64]]* [[NAME:@(_ZN17ReadWriteIntArrayixEi|"\?\?AReadWriteIntArray@@QEAAAEAHH@Z")]](%struct.ReadWriteIntArray* {{%[0-9]+}}, {{i32|i64}} {{%[0-9]+}})
-// CHECK: define linkonce_odr nonnull align 4 dereferenceable(4) [[RES]]* [[NAME]](%struct.ReadWriteIntArray* nonnull dereferenceable(20) {{.*}}, {{i32 %x|\[1 x i32\] %x|i64 %x|%struct.ReadWriteIntArray\* byval\(%struct.ReadWriteIntArray\) align 2 %rhs}})
+// CHECK: define linkonce_odr nonnull align 4 dereferenceable(4) [[RES]]* [[NAME]](%struct.ReadWriteIntArray* nonnull dereferenceable(20) {{.*}}, {{i32 %.*|\[1 x i32\] %.*|i64 %.*|%struct.ReadWriteIntArray\* byval\(%struct.ReadWriteIntArray\) align 2 %.*}})
 // CHECK:   [[THIS:%.*]] = load %struct.ReadWriteIntArray*, %struct.ReadWriteIntArray**
 // CHECK:   [[VALUES:%.*]] = getelementptr inbounds %struct.ReadWriteIntArray, %struct.ReadWriteIntArray* [[THIS]]
 // CHECK:   [[VALUE:%.*]] = getelementptr inbounds [5 x {{i32|i64}}], [5 x {{i32|i64}}]* [[VALUES]]
 // CHECK:   ret {{i32|i64}}* [[VALUE]]
+
+public func index(_ arr: inout NonTrivialIntArrayByVal, _ arg: Int32) -> Int32 { arr[arg] }
+
+// CHECK: call [[RES:i32|i64]] [[NAME:@(_ZNK23NonTrivialIntArrayByValixEi|"\?\?ANonTrivialIntArrayByVal@@QEBAAEBHH@Z")]](%struct.NonTrivialIntArrayByVal* {{%[0-9]+}}, {{i32|i64}} {{%[0-9]+}})
+// CHECK: define linkonce_odr [[RES]] [[NAME]](%struct.NonTrivialIntArrayByVal* nonnull dereferenceable(20) {{.*}}, {{i32 %.*|\[1 x i32\] %.*|i64 %.*|%struct.NonTrivialIntArrayByVal\* byval\(%struct.NonTrivialIntArrayByVal\) align 2 %.*}})
+// CHECK:   [[THIS:%.*]] = load %struct.NonTrivialIntArrayByVal*, %struct.NonTrivialIntArrayByVal**
+// CHECK:   [[VALUES:%.*]] = getelementptr inbounds %struct.NonTrivialIntArrayByVal, %struct.NonTrivialIntArrayByVal* [[THIS]]
+// CHECK:   [[VALUE:%.*]] = getelementptr inbounds [5 x {{i32|i64}}], [5 x {{i32|i64}}]* [[VALUES]]
+// CHECK:   [[VALUE2:%.*]] = load {{i32|i64}}, {{i32|i64}}* [[VALUE]]
+// CHECK:   ret {{i32|i64}} [[VALUE2]]

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -91,7 +91,77 @@
 // CHECK: }
 
 
-// Non-reference subscript operators are not currently imported (SR-14351)
-// so just make sure we don't crash.
-// CHECK: struct NonReferenceReadIntArray {
+// CHECK: struct IntArrayByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> Int32
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK: }
+
+// CHECK: struct NonTrivialIntArrayByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> Int32
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK: }
+
+// CHECK: struct DifferentTypesArrayByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> Int32
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Bool) -> Bool
+
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Double) -> Double
+
+// CHECK:   subscript(x: Int32) -> Int32 { mutating get }
+// CHECK:   subscript(x: Bool) -> Bool { mutating get }
+// CHECK:   subscript(x: Double) -> Double { mutating get }
+// CHECK: }
+
+
+// CHECK: struct TemplatedArrayByVal<T> {
+// CHECK: }
+// CHECK: struct __CxxTemplateInst19TemplatedArrayByValIdE {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ i: Int32) -> Double
+// CHECK:   subscript(i: Int32) -> Double { mutating get }
+// CHECK: }
+// CHECK: typealias TemplatedDoubleArrayByVal = __CxxTemplateInst19TemplatedArrayByValIdE
+
+
+// CHECK: struct TemplatedSubscriptArrayByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst<T>(_ i: T) -> T
+// CHECK:   subscript(i: T) -> T { mutating get }
+// CHECK: }
+
+// CHECK: struct NonTrivialArrayByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> NonTrivial
+// CHECK:   subscript(x: Int32) -> NonTrivial { mutating get }
+// CHECK: }
+// CHECK: struct PtrByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<Int32>!
+// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<Int32>! { mutating get }
+// CHECK: }
+// CHECK: struct RefToPtr {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<UnsafeMutablePointer<Int32>?>
+// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<Int32>? { mutating get set }
+// CHECK: }
+// CHECK: struct PtrToPtr {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscript(_ x: Int32) -> UnsafeMutablePointer<UnsafeMutablePointer<Int32>?>!
+// CHECK:   subscript(x: Int32) -> UnsafeMutablePointer<UnsafeMutablePointer<Int32>?>! { mutating get }
+// CHECK: }
+// CHECK: struct ConstOpPtrByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>!
+// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { mutating get }
+// CHECK: }
+// CHECK: struct ConstPtrByVal {
+// CHECK:   @available(*, unavailable, message: "use subscript")
+// CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> UnsafePointer<Int32>!
+// CHECK:   subscript(x: Int32) -> UnsafePointer<Int32>! { mutating get }
 // CHECK: }

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -73,5 +73,115 @@ public func index(_ arr: inout ReadWriteIntArray, _ arg: Int32, _ val: Int32) { 
 // CHECK:   pointer_to_address [[PTR2]] : $Builtin.RawPointer to [strict] $*Int32
 // CHECK: } // end sil function '$sSo17ReadWriteIntArrayVys5Int32VADcis'
 
+public func index(_ arr: inout NonTrivialIntArrayByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg] }
+
+// CHECK: sil @$s4main5indexys5Int32VSo23NonTrivialIntArrayByValVz_A2DtF : $@convention(thin) (@inout NonTrivialIntArrayByVal, Int32, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $*NonTrivialIntArrayByVal, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*NonTrivialIntArrayByVal
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*NonTrivialIntArrayByVal
+// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAMEBYVAL:@(_ZNK23NonTrivialIntArrayByValixEi|\?\?ANonTrivialIntArrayByVal@@QEBAHH@Z)]] : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo23NonTrivialIntArrayByValVz_A2DtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo23NonTrivialIntArrayByValVys5Int32VADcig : $@convention(method) (Int32, @inout NonTrivialIntArrayByVal) -> Int32 {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*NonTrivialIntArrayByVal):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*NonTrivialIntArrayByVal
+// CHECK:   [[OP:%.*]] = function_ref [[READWRITECLASSNAMEBYVAL]] : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
+// CHECK:   end_access [[SELFACCESS]] : $*NonTrivialIntArrayByVal
+// CHECK: } // end sil function '$sSo23NonTrivialIntArrayByValVys5Int32VADcig
+
+public func index(_ arr: inout PtrByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
+// CHECK: sil @$s4main5indexys5Int32VSo8PtrByValVz_A2DtF : $@convention(thin) (@inout PtrByVal, Int32, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $*PtrByVal, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*PtrByVal
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*PtrByVal
+// CHECK:   [[OP:%.*]] = function_ref [[PTRBYVAL:@(_ZN8PtrByValixEi|\?\?APtrByVal@@QEAAPEAHH@Z)]] : $@convention(c) (@inout PtrByVal, Int32) -> Optional<UnsafeMutablePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout PtrByVal, Int32) -> Optional<UnsafeMutablePointer<Int32>>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo8PtrByValVz_A2DtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo8PtrByValVySpys5Int32VGSgADcig : $@convention(method) (Int32, @inout PtrByVal) -> Optional<UnsafeMutablePointer<Int32>> {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*PtrByVal):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*PtrByVal
+// CHECK:   [[OP:%.*]] = function_ref [[PTRBYVAL]] : $@convention(c) (@inout PtrByVal, Int32) -> Optional<UnsafeMutablePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout PtrByVal, Int32) -> Optional<UnsafeMutablePointer<Int32>>
+// CHECK:   end_access [[SELFACCESS]] : $*PtrByVal
+// CHECK: } // end sil function '$sSo8PtrByValVySpys5Int32VGSgADcig
+
+public func index(_ arr: inout RefToPtr, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
+// CHECK: sil @$s4main5indexys5Int32VSo8RefToPtrVz_A2DtF : $@convention(thin) (@inout RefToPtr, Int32, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $*RefToPtr, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*RefToPtr
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*RefToPtr
+// CHECK:   [[OP:%.*]] = function_ref [[REFTOPTR:@(_ZN8RefToPtrixEi|\?\?ARefToPtr@@QEAAAEAPEAHH@Z)]] : $@convention(c) (@inout RefToPtr, Int32) -> UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout RefToPtr, Int32) -> UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo8RefToPtrVz_A2DtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo8RefToPtrVySpys5Int32VGSgADcig : $@convention(method) (Int32, @inout RefToPtr) -> Optional<UnsafeMutablePointer<Int32>> {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*RefToPtr):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*RefToPtr
+// CHECK:   [[OP:%.*]] = function_ref [[REFTOPTR]] : $@convention(c) (@inout RefToPtr, Int32) -> UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout RefToPtr, Int32) -> UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>
+// CHECK:   end_access [[SELFACCESS]] : $*RefToPtr
+// CHECK: } // end sil function '$sSo8RefToPtrVySpys5Int32VGSgADcig
+
+public func index(_ arr: inout PtrToPtr, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0]![0] }
+// CHECK: sil @$s4main5indexys5Int32VSo05PtrToD0Vz_A2DtF : $@convention(thin) (@inout PtrToPtr, Int32, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $*PtrToPtr, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*PtrToPtr
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*PtrToPtr
+// CHECK:   [[OP:%.*]] = function_ref [[PTRTOPTR:@(_ZN8PtrToPtrixEi|\?\?APtrToPtr@@QEAAPEAPEAHH@Z)]] : $@convention(c) (@inout PtrToPtr, Int32) -> Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout PtrToPtr, Int32) -> Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo05PtrToD0Vz_A2DtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo05PtrToA0VySpySpys5Int32VGSgGSgADcig : $@convention(method) (Int32, @inout PtrToPtr) -> Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>> {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*PtrToPtr):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*PtrToPtr
+// CHECK:   [[OP:%.*]] = function_ref [[PTRTOPTR]] : $@convention(c) (@inout PtrToPtr, Int32) -> Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout PtrToPtr, Int32) -> Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>>
+// CHECK:   end_access [[SELFACCESS]] : $*PtrToPtr
+// CHECK: } // end sil function '$sSo05PtrToA0VySpySpys5Int32VGSgGSgADcig
+
+public func index(_ arr: inout ConstOpPtrByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
+// CHECK: sil @$s4main5indexys5Int32VSo15ConstOpPtrByValVz_A2DtF : $@convention(thin) (@inout ConstOpPtrByVal, Int32, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $*ConstOpPtrByVal, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*ConstOpPtrByVal
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*ConstOpPtrByVal
+// CHECK:   [[OP:%.*]] = function_ref [[CONSTOPPTRBYVAL:@(_ZNK15ConstOpPtrByValixEi|\?\?AConstOpPtrByVal@@QEBAPEBHH@Z)]] : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo15ConstOpPtrByValVz_A2DtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo15ConstOpPtrByValVySPys5Int32VGSgADcig : $@convention(method) (Int32, @inout ConstOpPtrByVal) -> Optional<UnsafePointer<Int32>> {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*ConstOpPtrByVal):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*ConstOpPtrByVal
+// CHECK:   [[OP:%.*]] = function_ref [[CONSTOPPTRBYVAL]] : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   end_access [[SELFACCESS]] : $*ConstOpPtrByVal
+// CHECK: } // end sil function '$sSo15ConstOpPtrByValVySPys5Int32VGSgADcig
+
+public func index(_ arr: inout ConstPtrByVal, _ arg: Int32, _ val: Int32) -> Int32 { arr[arg]![0] }
+// CHECK: sil @$s4main5indexys5Int32VSo13ConstPtrByValVz_A2DtF : $@convention(thin) (@inout ConstPtrByVal, Int32, Int32) -> Int32 {
+// CHECK: bb0([[ARR:%.*]] : $*ConstPtrByVal, [[INDEX:%.*]] : $Int32, [[NEWVALUE:%.*]] : $Int32):
+// CHECK:   [[ARRACCESS:%.*]] = begin_access [modify] [static] [[ARR]] : $*ConstPtrByVal
+// CHECK:   [[ARRACCESS2:%.*]] = begin_access [modify] [static] [[ARRACCESS]] : $*ConstPtrByVal
+// CHECK:   [[OP:%.*]] = function_ref [[CONSTPTRBYVAL:@(_ZN13ConstPtrByValixEi|\?\?AConstPtrByVal@@QEAAPEBHH@Z)]] : $@convention(c) (@inout ConstPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[ARRACCESS2]], [[INDEX]]) : $@convention(c) (@inout ConstPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK: } // end sil function '$s4main5indexys5Int32VSo13ConstPtrByValVz_A2DtF'
+
+// CHECK: sil shared [transparent] [serializable] @$sSo13ConstPtrByValVySPys5Int32VGSgADcig : $@convention(method) (Int32, @inout ConstPtrByVal) -> Optional<UnsafePointer<Int32>> {
+// CHECK: bb0([[NEWVALUE:%.*]] : $Int32, [[INDEX:%.*]] : $*ConstPtrByVal):
+// CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[INDEX]] : $*ConstPtrByVal
+// CHECK:   [[OP:%.*]] = function_ref [[CONSTPTRBYVAL]] : $@convention(c) (@inout ConstPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   [[PTR:%.*]] = apply [[OP]]([[SELFACCESS]], [[NEWVALUE]]) : $@convention(c) (@inout ConstPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK:   end_access [[SELFACCESS]] : $*ConstPtrByVal
+// CHECK: } // end sil function '$sSo13ConstPtrByValVySPys5Int32VGSgADcig
+
 // CHECK: sil [clang ReadOnlyIntArray.__operatorSubscriptConst] [[READCLASSNAME]] : $@convention(c) (@inout ReadOnlyIntArray, Int32) -> UnsafePointer<Int32>
 // CHECK: sil [clang ReadWriteIntArray.__operatorSubscript] [[READWRITECLASSNAME]] : $@convention(c) (@inout ReadWriteIntArray, Int32) -> UnsafeMutablePointer<Int32>
+// CHECK: sil [clang NonTrivialIntArrayByVal.__operatorSubscriptConst] [[READWRITECLASSNAMEBYVAL]] : $@convention(c) (@inout NonTrivialIntArrayByVal, Int32) -> Int32
+
+// CHECK: sil [clang PtrByVal.__operatorSubscript] [[PTRBYVAL]] : $@convention(c) (@inout PtrByVal, Int32) -> Optional<UnsafeMutablePointer<Int32>>
+// CHECK: sil [clang RefToPtr.__operatorSubscript] [[REFTOPTR]] : $@convention(c) (@inout RefToPtr, Int32) -> UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>
+// CHECK: sil [clang PtrToPtr.__operatorSubscript] [[PTRTOPTR]] : $@convention(c) (@inout PtrToPtr, Int32) -> Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int32>>>>
+// CHECK: sil [clang ConstOpPtrByVal.__operatorSubscriptConst] [[CONSTOPPTRBYVAL]] : $@convention(c) (@inout ConstOpPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>
+// CHECK: sil [clang ConstPtrByVal.__operatorSubscriptConst] [[CONSTPTRBYVAL]] : $@convention(c) (@inout ConstPtrByVal, Int32) -> Optional<UnsafePointer<Int32>>

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -30,3 +30,10 @@ let writeOnlyValue = writeOnlyIntArray[2]
 var diffTypesArray = DifferentTypesArray()
 let diffTypesResultInt: Int32 = diffTypesArray[0]
 let diffTypesResultDouble: Double = diffTypesArray[0.5]
+
+var nonTrivialIntArrayByVal = NonTrivialIntArrayByVal(3)
+let nonTrivialValueByVal = nonTrivialIntArrayByVal[1]
+
+var diffTypesArrayByVal = DifferentTypesArrayByVal()
+let diffTypesResultIntByVal: Int32 = diffTypesArrayByVal[0]
+let diffTypesResultDoubleByVal: Double = diffTypesArrayByVal[0.5]

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -90,4 +90,99 @@ OperatorsTestSuite.test("DifferentTypesArray.subscript (inline)") {
   expectEqual(1.5.rounded(.up), resultDouble.rounded(.up))
 }
 
+OperatorsTestSuite.test("IntArrayByVal.subscript (inline)") {
+  var arr = IntArrayByVal()
+  let result0 = arr[0]
+  let result1 = arr[1]
+  let result2 = arr[2]
+
+  expectEqual(1, result0)
+  expectEqual(2, result1)
+  expectEqual(3, result2)
+
+  arr.setValueAtIndex(42, 2)
+  let result3 = arr[2]
+  expectEqual(42, result3)
+}
+
+OperatorsTestSuite.test("NonTrivialIntArrayByVal.subscript (inline)") {
+  var arr = NonTrivialIntArrayByVal(1)
+
+  let result0 = arr[0]
+  let result2 = arr[2]
+  let result4 = arr[4]
+
+  expectEqual(1, result0)
+  expectEqual(3, result2)
+  expectEqual(5, result4)
+
+  arr.setValueAtIndex(42, 2)
+  let result5 = arr[2]
+  expectEqual(42, result5)
+}
+
+OperatorsTestSuite.test("DifferentTypesArrayByVal.subscript (inline)") {
+  var arr = DifferentTypesArrayByVal()
+
+  let resultInt: Int32 = arr[2]
+  let resultDouble: Double = arr[0.1]
+
+  expectEqual(3, resultInt)
+  expectEqual(1.5.rounded(.down), resultDouble.rounded(.down))
+  expectEqual(1.5.rounded(.up), resultDouble.rounded(.up))
+}
+
+OperatorsTestSuite.test("NonTrivialArrayByVal.subscript (inline)") {
+  var arr = NonTrivialArrayByVal()
+  let NonTrivialByVal = arr[0];
+  let cStr = NonTrivialByVal.Str!
+  expectEqual("Non-Trivial", String(cString: cStr))
+
+  expectEqual(1, NonTrivialByVal.a)
+  expectEqual(2, NonTrivialByVal.b)
+  expectEqual(3, NonTrivialByVal.c)
+  expectEqual(4, NonTrivialByVal.d)
+  expectEqual(5, NonTrivialByVal.e)
+  expectEqual(6, NonTrivialByVal.f)
+}
+
+OperatorsTestSuite.test("PtrByVal.subscript (inline)") {
+  var arr = PtrByVal()
+  expectEqual(64, arr[0]![0])
+  arr[0]![0] = 23
+  expectEqual(23, arr[0]![0])
+}
+
+OperatorsTestSuite.test("ConstOpPtrByVal.subscript (inline)") {
+  var arr = ConstOpPtrByVal()
+  expectEqual(64, arr[0]![0])
+}
+
+OperatorsTestSuite.test("ConstPtrByVal.subscript (inline)") {
+  var arr = ConstPtrByVal()
+  expectEqual(64, arr[0]![0])
+}
+
+OperatorsTestSuite.test("RefToPtr.subscript (inline)") {
+  var arr = RefToPtr()
+  let ptr: UnsafeMutablePointer<Int32> =
+    UnsafeMutablePointer<Int32>.allocate(capacity: 64)
+  ptr[0] = 23
+
+  expectEqual(64, arr[0]![0])
+  arr[0] = ptr
+  expectEqual(23, arr[0]![0])
+}
+
+OperatorsTestSuite.test("PtrToPtr.subscript (inline)") {
+  var arr = PtrToPtr()
+  let ptr: UnsafeMutablePointer<Int32> =
+    UnsafeMutablePointer<Int32>.allocate(capacity: 64)
+  ptr[0] = 23
+
+  expectEqual(64, arr[0]![0]![0])
+  arr[0]![0] = ptr
+  expectEqual(23, arr[0]![0]![0])
+}
+
 runAllTests()

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -59,4 +59,20 @@ OperatorsTestSuite.test("ReadWriteIntArray.subscript (out-of-line)") {
   expectEqual(234, resultAfter)
 }
 
+OperatorsTestSuite.test("NonTrivialIntArrayByVal.subscript (out-of-line)") {
+  var arr = NonTrivialIntArrayByVal(1)
+
+  let result0 = arr[0]
+  let result2 = arr[2]
+  let result4 = arr[4]
+
+  expectEqual(1, result0)
+  expectEqual(3, result2)
+  expectEqual(5, result4)
+
+  arr.setValueAtIndex(42, 3)
+  let result5 = arr[3]
+  expectEqual(42, result5)
+}
+
 runAllTests()


### PR DESCRIPTION
This builds on top of the work of Egor Zhdan's PR. It implements
`T operator[]` and does so largely by taking a path very much like the
`const T &operator[]` path.