### PR TITLE
[TypeChecker] NFC: Add a couple of tests for inference with optional/…

### DIFF
--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -432,3 +432,20 @@ func rdar70814576() {
 
   test(S()) // expected-error {{argument type 'S' does not conform to expected type 'Fooable'}}
 }
+
+extension Optional : Trivial {
+  typealias T = Wrapped
+}
+
+extension UnsafePointer : Trivial {
+  typealias T = Int
+}
+
+func test_inference_through_implicit_conversion() {
+  class C {}
+
+  func test<T: Trivial>(_: T) -> T {}
+
+  let _: C? = test(C()) // Ok -> argument is implicitly promoted into an optional
+  let _: UnsafePointer<C> = test([C()]) // Ok - argument is implicitly converted to a pointer
+}


### PR DESCRIPTION
…pointer promotion

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
