### PR TITLE
GYB: Generate Your Boilerplate using Python 3

### DIFF
--- a/utils/gyb
+++ b/utils/gyb
@@ -1,3 +1,3 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 import gyb
 gyb.main()

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # GYB: Generate Your Boilerplate (improved names welcome; at least
 # this one's short).  See -h output for instructions
 

--- a/validation-test/stdlib/Collection/Inputs/LazyMapTemplate.swift.gyb
+++ b/validation-test/stdlib/Collection/Inputs/LazyMapTemplate.swift.gyb
@@ -25,6 +25,13 @@ variations = [
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+%   if kind != 'Sequence': # <https://github.com/apple/swift/pull/29274>
+%
+// With a non-optimized stdlib the test takes very long.
+// REQUIRES: optimized_stdlib
+
+%   end # <https://github.com/apple/swift/pull/29274>
+%
 import StdlibUnittest
 import StdlibCollectionUnittest
 

--- a/validation-test/stdlib/FixedPointConversion/Inputs/FixedPointConversion.swift.gyb
+++ b/validation-test/stdlib/FixedPointConversion/Inputs/FixedPointConversion.swift.gyb
@@ -19,8 +19,7 @@
 %     selfMin = selfType.min
 %     selfMax = selfType.max
 %
-%     testSuite = 'FixedPointConversion_{configuration}{bitWidth}_To{SelfName}'\
-%       .format(**locals()) # TODO(python3): use f-string (PEP 498).
+%     testSuite = f'FixedPointConversion_{configuration}{bitWidth}_To{SelfName}'
 %
 // BEGIN ${testSuite}.swift
 //===----------------------------------------------------------------------===//
@@ -159,7 +158,7 @@ ${testSuite}
 %
 %     # Test conversion behaviors for all floating-point types.
 %     for otherType in all_floating_point_types():
-%       OtherName = 'Float{}'.format(otherType.bits)
+%       OtherName = f'Float{otherType.bits}'
 %       otherMax = int_max(bits=otherType.explicit_significand_bits, signed=False)
 %       otherMin = -otherMax
 %


### PR DESCRIPTION
Follow-up to: apple/swift#32127

Tested locally with the following GYB files:

* [Array/Inputs/ArrayConformanceTests.swift.gyb](https://github.com/apple/swift/blob/main/validation-test/stdlib/Array/Inputs/ArrayConformanceTests.swift.gyb)
* [Collection/Inputs/LazyMapTemplate.swift.gyb](https://github.com/apple/swift/blob/main/validation-test/stdlib/Collection/Inputs/LazyMapTemplate.swift.gyb)
* [Collection/Inputs/Template.swift.gyb](https://github.com/apple/swift/blob/main/validation-test/stdlib/Collection/Inputs/Template.swift.gyb)
* [FixedPointConversion/Inputs/FixedPointConversion.swift.gyb](https://github.com/apple/swift/blob/main/validation-test/stdlib/FixedPointConversion/Inputs/FixedPointConversion.swift.gyb)
* [Slice/Inputs/Template.swift.gyb](https://github.com/apple/swift/blob/main/validation-test/stdlib/Slice/Inputs/Template.swift.gyb)