### PR TITLE
[SourceKit/CursorInfo] Enable passing .swiftsourceinfo test

### DIFF
--- a/test/SourceKit/CursorInfo/use-swift-source-info.swift
+++ b/test/SourceKit/CursorInfo/use-swift-source-info.swift
@@ -3,9 +3,6 @@ func bar() {
   foo()
 }
 
-// FIXME: Rmove REQUIRES rdar://problem/60096971
-// REQUIRES: rdar60096971
-
 // RUN: %empty-directory(%t)
 // RUN: echo "/// Some doc" >> %t/Foo.swift
 // RUN: echo "public func foo() { }" >> %t/Foo.swift
@@ -27,6 +24,7 @@ func bar() {
 // WITHOUT: source.lang.swift.ref.function.free ()
 // BOTH: foo()
 // BOTH-NEXT: s:3Foo3fooyyF
+// BOTH-NEXT: source.lang.swift
 // BOTH-NEXT: () -> ()
 // BOTH-NEXT: $syycD
 // BOTH-NEXT: Foo


### PR DESCRIPTION
use-swift-source-info.swift is checking that the .swiftsourceinfo file
is being used when OptimizedForIDE is false by checking the location
output from a cursor info request.

It also checks that the module name is there, which it should be the
result is in a different file. There was previously a bug where it
*wasn't* added when a location was added (which was valid before
.swiftsourceinfo was used). The test has always worked since it was
modified in the fix to that bug, but some weirdness caused the change
and test to be out of sync (possibly the result of merges between main
and next branches).

The new line is the language, which was added after it was disabled (and
hence missed being updated).