### PR TITLE
[Property Wrappers] Fix accessor synthesis of wrapped parameters that infer the property wrapper attribute.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7983,8 +7983,9 @@ namespace {
 
         // Set the interface type of each property wrapper synthesized var
         auto *backingVar = param->getPropertyWrapperBackingProperty();
-        backingVar->setInterfaceType(
-            solution.simplifyType(solution.getType(backingVar))->mapTypeOutOfContext());
+        auto backingType =
+            solution.simplifyType(solution.getType(backingVar))->mapTypeOutOfContext();
+        backingVar->setInterfaceType(backingType);
 
         if (auto *projectionVar = param->getPropertyWrapperProjectionVar()) {
           projectionVar->setInterfaceType(
@@ -7992,8 +7993,20 @@ namespace {
         }
 
         auto *wrappedValueVar = param->getPropertyWrapperWrappedValueVar();
-        wrappedValueVar->setInterfaceType(
-            solution.simplifyType(solution.getType(wrappedValueVar)));
+        auto wrappedValueType = solution.simplifyType(solution.getType(wrappedValueVar));
+        wrappedValueVar->setInterfaceType(wrappedValueType->getWithoutSpecifierType());
+
+        if (param->hasImplicitPropertyWrapper()) {
+          if (wrappedValueType->is<LValueType>())
+            wrappedValueVar->setImplInfo(StorageImplInfo::getMutableComputed());
+
+          // Add an explicit property wrapper attribute, which is needed for
+          // synthesizing the accessors.
+          auto &context = wrappedValueVar->getASTContext();
+          auto *typeExpr = TypeExpr::createImplicit(backingType, context);
+          auto *attr = CustomAttr::create(context, SourceLoc(), typeExpr, /*implicit=*/true);
+          wrappedValueVar->getAttrs().add(attr);
+        }
       }
 
       TypeChecker::checkParameterList(closure->getParameters(), closure);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8158,7 +8158,12 @@ ConstraintSystem::simplifyPropertyWrapperConstraint(
   }
 
   auto resolvedType = wrapperType->getTypeOfMember(DC->getParentModule(), typeInfo.valueVar);
-  addConstraint(ConstraintKind::Equal, wrappedValueType, resolvedType, locator);
+  if (typeInfo.valueVar->isSettable(nullptr) && typeInfo.valueVar->isSetterAccessibleFrom(DC) &&
+      !typeInfo.valueVar->isSetterMutating()) {
+    resolvedType = LValueType::get(resolvedType);
+  }
+
+  addConstraint(ConstraintKind::Bind, wrappedValueType, resolvedType, locator);
 
   return SolutionKind::Solved;
 }
@@ -8336,7 +8341,8 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
 
       if (paramDecl->hasImplicitPropertyWrapper()) {
         backingType = getContextualParamAt(i)->getPlainType();
-        wrappedValueType = createTypeVariable(getConstraintLocator(locator), TVO_CanBindToHole);
+        wrappedValueType = createTypeVariable(getConstraintLocator(locator),
+                                              TVO_CanBindToHole | TVO_CanBindToLValue);
       } else {
         auto *wrapperAttr = paramDecl->getAttachedPropertyWrappers().front();
         auto wrapperType = paramDecl->getAttachedPropertyWrapperType(0);


### PR DESCRIPTION
* Fix getter synthesis by adding an "explicit" property wrapper attribute to the local wrapped value variable. This is needed for accessor synthesis, which checks `hasAttachedPropertyWrapper()`
* Allow a setter if the inferred property wrapper type has a nonmutating `wrappedValue` setter.