### PR TITLE
AST: Skip requirement checks in IsBindableVisitor::visitBoundGenericType() if substituted type is an interface type

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2095,6 +2095,12 @@ public:
       if (req.getKind() != RequirementKind::Conformance) continue;
 
       auto canTy = req.getFirstType()->getCanonicalType();
+
+      // If the substituted type is an interface type, we can't verify the
+      // generic requirements.
+      if (canTy.subst(substSubMap)->isTypeParameter())
+        continue;
+
       auto *proto = req.getProtocolDecl();
       auto origConf = origSubMap.lookupConformance(canTy, proto);
       auto substConf = substSubMap.lookupConformance(canTy, proto);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1790,9 +1790,6 @@ public:
       if (nom->getDecl() != substNom->getDecl())
         return CanType();
       
-      if (nom->getDecl()->isInvalid())
-        return CanType();
-      
       // Same decl should always either have or not have a parent.
       assert((bool)nom->getParent() == (bool)substNom->getParent());
       
@@ -2034,8 +2031,6 @@ public:
       return CanType();
 
     auto *decl = bgt->getDecl();
-    if (decl->isInvalid())
-      return CanType();
 
     auto *moduleDecl = decl->getParentModule();
     auto origSubMap = bgt->getContextSubstitutionMap(

--- a/validation-test/compiler_crashers_2_fixed/sr13849.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13849.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend -emit-ir %s
+// RUN: %target-swift-frontend -emit-ir %s
 
 public protocol Prot {
     associatedtype T


### PR DESCRIPTION
IsBindableVisitor is part of TypeBase::substituteBindingsTo(), which
is used for two things:

- Checking if one contextual type is a proper substitution of another
  contextual type, used in the solver

- To compute the substituted generic signature when lowering a SIL
  function type

In the first case, we're interested in knowing if the substitution
succeeds or fails. In the second case, we know the substitution is
correct by construction, and we're trying to recover the generic
requirements.

In the second case though, the substituted type might be an
interface type, and if the interface type is constrained to a
concrete type in the original type's generic signature, we would
conclude that the substitution should fail.

This is incorrect, and we should just skip the check if the
substituted type is an interface type -- we do not have enough
information to know if it succeeds, and instead we must assume it
does because otherwise the substituted type passed in to type
lowering must be incorrect.

Fixes https://bugs.swift.org/browse/SR-13849.