### PR TITLE
[Actors] Permit non-sendable, escaping closures to be actor-isolated.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4394,9 +4394,6 @@ ERROR(actor_isolated_from_concurrent_function,none,
 ERROR(actor_isolated_from_async_let,none,
         "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from 'async let' initializer",
         (DescriptiveDeclKind, DeclName, unsigned))
-ERROR(actor_isolated_from_escaping_closure,none,
-        "actor-isolated %0 %1 cannot be %select{referenced|mutated|used 'inout'}2 from an '@escaping' closure",
-        (DescriptiveDeclKind, DeclName, unsigned))
 ERROR(actor_isolated_keypath_component,none,
       "cannot form key path to actor-isolated %0 %1",
       (DescriptiveDeclKind, DeclName))

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -42,7 +42,7 @@ extension MyActor {
 
     // CHECK: acceptEscapingAsyncClosure
     // CHECK: closure_expr
-    // CHEC:actor-isolated
+    // CHECK: actor-isolated
     acceptEscapingAsyncClosure { () async in print(self) }
   }
 }

--- a/test/Concurrency/closure_isolation.swift
+++ b/test/Concurrency/closure_isolation.swift
@@ -2,18 +2,29 @@
 // REQUIRES: concurrency
 
 func acceptClosure<T>(_: () -> T) { }
-func acceptEscapingClosure<T>(_: @escaping () -> T) { }
+func acceptSendableClosure<T>(_: @Sendable () -> T) { }
 
 func acceptAsyncClosure<T>(_: () async -> T) { }
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
 
 actor MyActor {
   func method() async -> String { "" }
+  func syncMethod() -> String { "" }
 }
 
 extension MyActor {
   // CHECK-LABEL: testClosureIsolation
   func testClosureIsolation() async {
+    // CHECK: acceptClosure
+    // CHECK: closure_expr
+    // CHECK: actor-isolated
+    acceptClosure { self.syncMethod() }
+
+    // CHECK: acceptSendableClosure
+    // CHECK: closure_expr
+    // CHECK-NOT: actor-isolated
+    acceptSendableClosure { print(self) }
+
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
     // CHECK-SAME: actor-isolated=closure_isolation.(file).MyActor extension.testClosureIsolation().self
@@ -22,17 +33,17 @@ extension MyActor {
     // CHECK: acceptAsyncClosure
     // CHECK: closure_expr
     // CHECK-NOT: actor-isolated
-    acceptAsyncClosure { () async in print("hello") }
+    acceptAsyncClosure { () async in print() }
 
     // CHECK: acceptEscapingAsyncClosure
     // CHECK: closure_expr
-    // CHECK-NOT: actor-isolated
-    acceptEscapingAsyncClosure { await self.method() }
+    // CHECK: actor-isolated
+    acceptEscapingAsyncClosure { self.syncMethod() }
 
     // CHECK: acceptEscapingAsyncClosure
     // CHECK: closure_expr
-    // CHECK-NOT:actor-isolated
-    acceptEscapingAsyncClosure { () async in print("hello") }
+    // CHEC:actor-isolated
+    acceptEscapingAsyncClosure { () async in print(self) }
   }
 }
 
@@ -61,11 +72,11 @@ func someAsyncFunc() async { }
 
   // CHECK: acceptEscapingAsyncClosure
   // CHECK: closure_expr
-  // CHECK-NOT: actor-isolated
+  // CHECK: actor-isolated
   acceptEscapingAsyncClosure { await someAsyncFunc() }
 
   // CHECK: acceptEscapingAsyncClosure
   // CHECK: closure_expr
-  // CHECK-NOT:actor-isolated
+  // CHECK: actor-isolated
   acceptEscapingAsyncClosure { () async in print("hello") }
 }


### PR DESCRIPTION
Remove the heuristic that escaping closures cannot be actor-isolated.
This is in line with the long term plan for actor isolation, but opens
up some holes in the short term because Sendable closures are not enforced
throughout the Swift ecosystem.

One significant effect of this change is that we will now, statically,
fail to detect many cases where actor isolation can be broken.
