### PR TITLE
Remove unsed local variable from NodePrinter

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -1684,9 +1684,7 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
 
     unsigned lastChildIndex = Node->getNumChildren();
     auto lastChild = Node->getChild(lastChildIndex - 1);
-    bool isSerialized = false;
     if (lastChild->getKind() == Node::Kind::IsSerialized) {
-      isSerialized = true;
       --lastChildIndex;
       lastChild = Node->getChild(lastChildIndex - 1);
     }


### PR DESCRIPTION
local bool variable isSerialized in NodePrinter is unused from source.