### PR TITLE
[Concurrency] Add availability to Concurrency APIs.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -738,6 +738,10 @@ public:
   /// compiler for the target platform.
   AvailabilityContext getSwift54Availability();
 
+  /// Get the runtime availability of features introduced in the Swift 5.5
+  /// compiler for the target platform.
+  AvailabilityContext getSwift55Availability();
+
   /// Get the runtime availability of features that have been introduced in the
   /// Swift compiler for future versions of the target platform.
   AvailabilityContext getSwiftFutureAvailability();

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -324,7 +324,7 @@ ASTContext::getIntermodulePrespecializedGenericMetadataAvailability() {
 }
 
 AvailabilityContext ASTContext::getConcurrencyAvailability() {
-  return getSwiftFutureAvailability();
+  return getSwift55Availability();
 }
 
 AvailabilityContext ASTContext::getDifferentiationAvailability() {
@@ -408,6 +408,11 @@ AvailabilityContext ASTContext::getSwift54Availability() {
     return AvailabilityContext::alwaysAvailable();
   }
 }
+
+AvailabilityContext ASTContext::getSwift55Availability() {
+  return getSwiftFutureAvailability();
+}
+
 
 AvailabilityContext ASTContext::getSwiftFutureAvailability() {
   auto target = LangOpts.Target;

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -17,25 +17,30 @@ import Swift
 ///
 /// The \c Actor protocol generalizes over all actor types. Actor types
 /// implicitly conform to this protocol.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public protocol Actor: AnyObject, Sendable {
 }
 
 /// Called to initialize the default actor instance in an actor.
 /// The implementation will call this within the actor's initializer.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_defaultActor_initialize")
 public func _defaultActorInitialize(_ actor: AnyObject)
 
 /// Called to destroy the default actor instance in an actor.
 /// The implementation will call this within the actor's deinit.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_defaultActor_destroy")
 public func _defaultActorDestroy(_ actor: AnyObject)
 
 /// FIXME: only exists for the quick-and-dirty MainActor implementation.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_MainActor_register")
 fileprivate func _registerMainActor(actor: AnyObject)
 
 /// A singleton actor whose executor is equivalent to 
 /// \c DispatchQueue.main, which is the main dispatch queue.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @globalActor public actor MainActor {
   public static let shared = MainActor()
   
@@ -44,6 +49,7 @@ fileprivate func _registerMainActor(actor: AnyObject)
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension MainActor {
   /// Execute the given body closure on the main actor.
   public static func run<T>(

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncCompactMapSequence: AsyncSequence {
   public typealias Element = ElementOfResult
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func dropFirst(
@@ -23,6 +24,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -37,6 +39,7 @@ public struct AsyncDropFirstSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncDropFirstSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator
@@ -75,6 +78,7 @@ extension AsyncDropFirstSequence: AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncDropFirstSequence {
   @inlinable
   public __consuming func dropFirst(

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func drop(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncDropWhileSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncDropWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func filter(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncFilterSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncFilterSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSe
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncFlatMapSequence: AsyncSequence {
   public typealias Element = SegmentOfResult.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @rethrows
 public protocol AsyncIteratorProtocol {
   associatedtype Element

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func map<Transformed>(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncMapSequence<Base: AsyncSequence, Transformed> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncMapSequence: AsyncSequence {
   public typealias Element = Transformed
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
@@ -23,6 +24,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncPrefixSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -37,6 +39,7 @@ public struct AsyncPrefixSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncPrefixSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncPrefixWhileSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncPrefixWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncSequence.swift
+++ b/stdlib/public/Concurrency/AsyncSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @rethrows
 public protocol AsyncSequence {
   associatedtype AsyncIterator: AsyncIteratorProtocol where AsyncIterator.Element == Element
@@ -19,6 +20,7 @@ public protocol AsyncSequence {
   __consuming func makeAsyncIterator() -> AsyncIterator
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public func reduce<Result>(
@@ -49,6 +51,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @inlinable
 @inline(__always)
 func _contains<Source: AsyncSequence>(
@@ -63,6 +66,7 @@ func _contains<Source: AsyncSequence>(
   return false
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public func contains(
@@ -79,6 +83,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence where Element: Equatable {
   @inlinable
   public func contains(_ search: Element) async rethrows -> Bool {
@@ -91,6 +96,7 @@ extension AsyncSequence where Element: Equatable {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @inlinable
 @inline(__always)
 func _first<Source: AsyncSequence>(
@@ -105,6 +111,7 @@ func _first<Source: AsyncSequence>(
   return nil
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public func first(
@@ -114,6 +121,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   @warn_unqualified_access
@@ -150,6 +158,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence where Element: Comparable {
   @inlinable
   @warn_unqualified_access

--- a/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingCompactMapSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func compactMap<ElementOfResult>(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResult> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncThrowingCompactMapSequence<Base: AsyncSequence, ElementOfResu
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncThrowingCompactMapSequence: AsyncSequence {
   public typealias Element = ElementOfResult
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingDropWhileSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func drop(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncThrowingDropWhileSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncThrowingDropWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFilterSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func filter(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncThrowingFilterSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncThrowingFilterSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingFlatMapSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncThrowingFlatMapSequence<Base: AsyncSequence, SegmentOfResult:
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncThrowingFlatMapSequence: AsyncSequence {
   public typealias Element = SegmentOfResult.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingMapSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func map<Transformed>(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncThrowingMapSequence<Base: AsyncSequence, Transformed> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncThrowingMapSequence: AsyncSequence {
   public typealias Element = Transformed
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -12,6 +12,7 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
@@ -21,6 +22,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -38,6 +40,7 @@ public struct AsyncThrowingPrefixWhileSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncThrowingPrefixWhileSequence: AsyncSequence {
   public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -12,11 +12,13 @@
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_continuation_logFailedCheck")
 internal func logFailedCheck(_ message: UnsafeRawPointer)
 
 /// Implementation class that holds the `UnsafeContinuation` instance for
 /// a `CheckedContinuation`.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 internal final class CheckedContinuationCanary {
   // The instance state is stored in tail-allocated raw memory, so that
   // we can atomically check the continuation state.
@@ -107,6 +109,7 @@ internal final class CheckedContinuationCanary {
 /// of `withCheckedContinuation` or `withCheckedThrowingContinuation` should be
 /// enough to obtain the extra checking without further source modification in
 /// most circumstances.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct CheckedContinuation<T, E: Error> {
   private let canary: CheckedContinuationCanary
   
@@ -172,6 +175,7 @@ public struct CheckedContinuation<T, E: Error> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension CheckedContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given
@@ -237,6 +241,7 @@ extension CheckedContinuation {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func withCheckedContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Never>) -> Void
@@ -246,6 +251,7 @@ public func withCheckedContinuation<T>(
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func withCheckedThrowingContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Error>) -> Void

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -14,6 +14,7 @@ import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
 /// A partial task is a unit of scheduleable work.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @frozen
 public struct PartialAsyncTask {
   private var context: Builtin.Job
@@ -21,6 +22,7 @@ public struct PartialAsyncTask {
   public func run() { }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @frozen
 public struct UnsafeContinuation<T, E: Error> {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
@@ -94,6 +96,7 @@ public struct UnsafeContinuation<T, E: Error> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension UnsafeContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given
@@ -162,6 +165,7 @@ extension UnsafeContinuation {
 #if _runtime(_ObjC)
 
 // Intrinsics used by SILGen to resume or fail continuations.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeContinuation<T>(
   _ continuation: UnsafeContinuation<T, Never>,
@@ -170,6 +174,7 @@ internal func _resumeUnsafeContinuation<T>(
   continuation.resume(returning: value)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeThrowingContinuation<T>(
   _ continuation: UnsafeContinuation<T, Error>,
@@ -178,6 +183,7 @@ internal func _resumeUnsafeThrowingContinuation<T>(
   continuation.resume(returning: value)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_alwaysEmitIntoClient
 internal func _resumeUnsafeThrowingContinuationWithError<T>(
   _ continuation: UnsafeContinuation<T, Error>,
@@ -191,6 +197,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
 /// The operation functions must resume the continuation *exactly once*.
 ///
 /// The continuation will not begin executing until the operation function returns.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_alwaysEmitIntoClient
 public func withUnsafeContinuation<T>(
   _ fn: (UnsafeContinuation<T, Never>) -> Void
@@ -203,6 +210,7 @@ public func withUnsafeContinuation<T>(
 /// The operation functions must resume the continuation *exactly once*.
 ///
 /// The continuation will not begin executing until the operation function returns.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_alwaysEmitIntoClient
 public func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeContinuation<T, Error>) -> Void
@@ -212,5 +220,6 @@ public func withUnsafeThrowingContinuation<T>(
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @available(*, deprecated, message: "please use UnsafeContination<..., Error>")
 public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -31,6 +31,7 @@ import Swift
 /// These partial periods towards the task's completion are `PartialAsyncTask`.
 /// Partial tasks are generally not interacted with by end-users directly,
 /// unless implementing a scheduler.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct Task {
   internal let _task: Builtin.NativeObject
 
@@ -42,6 +43,7 @@ public struct Task {
 
 // ==== Current Task -----------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
 
   /// Returns 'current' `Task` instance, representing the task from within which
@@ -57,6 +59,7 @@ extension Task {
 
 // ==== Task Priority ----------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
 
   /// Returns the `current` task's priority.
@@ -128,6 +131,7 @@ extension Task {
 
 // ==== Task Handle ------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
   /// A task handle refers to an in-flight `Task`,
   /// allowing for potentially awaiting for its result or Cancelling it.
@@ -202,6 +206,7 @@ extension Task {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task.Handle where Failure == Never {
 
   /// Wait for the task to complete, returning its result.
@@ -223,12 +228,14 @@ extension Task.Handle where Failure == Never {
   
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task.Handle: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task.Handle: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -238,12 +245,14 @@ extension Task.Handle: Equatable {
 
 // ==== Conformances -----------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -253,6 +262,7 @@ extension Task: Equatable {
 
 // ==== Job Flags --------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
   /// Flags for schedulable jobs.
   ///
@@ -341,6 +351,7 @@ extension Task {
 
 // ==== Detached Tasks ---------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
   /// Run given throwing `operation` as part of a new top-level task.
   ///
@@ -450,6 +461,7 @@ extension Task {
 
 // ==== Async Handler ----------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func _runAsyncHandler(operation: @escaping () async -> ()) {
   typealias ConcurrentFunctionType = @Sendable () async -> ()
   Task.runDetached(
@@ -459,6 +471,7 @@ public func _runAsyncHandler(operation: @escaping () async -> ()) {
 
 // ==== Async Sleep ------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
   /// Suspends the current task for _at least_ the given duration
   /// in nanoseconds.
@@ -483,6 +496,7 @@ extension Task {
 
 // ==== UnsafeCurrentTask ------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
   /// If available, returns the 'current' task, representing the async context
   /// from which this function was called.
@@ -520,6 +534,7 @@ extension Task {
 /// represented by this handle itself. Doing so may result in undefined behavior,
 /// and most certainly will break invariants in other places of the program
 /// actively running on this task.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct UnsafeCurrentTask {
   internal let _task: Builtin.NativeObject
 
@@ -555,12 +570,14 @@ public struct UnsafeCurrentTask {
 
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension UnsafeCurrentTask: Hashable {
   public func hash(into hasher: inout Hasher) {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(_task)).hash(into: &hasher)
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension UnsafeCurrentTask: Equatable {
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     UnsafeRawPointer(Builtin.bridgeToRawPointer(lhs._task)) ==
@@ -570,16 +587,20 @@ extension UnsafeCurrentTask: Equatable {
 
 // ==== Internal ---------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_getCurrent")
 func _getCurrentAsyncTask() -> Builtin.NativeObject?
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_getJobFlags")
 func getJobFlags(_ task: Builtin.NativeObject) -> Task.JobFlags
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_enqueueGlobal")
 @usableFromInline
 func _enqueueJobGlobal(_ task: Builtin.Job)
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_enqueueGlobalWithDelay")
 @usableFromInline
 func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
@@ -588,9 +609,11 @@ func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: Builtin.Job)
 @_silgen_name("swift_task_runAndBlockThread")
 public func runAsyncAndBlock(_ asyncFun: @escaping () async -> ())
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_asyncMainDrainQueue")
 public func _asyncMainDrainQueue() -> Never
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
 #if os(Windows)
   Task.runDetached {
@@ -622,12 +645,15 @@ public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
 // FIXME: both of these ought to take their arguments _owned so that
 // we can do a move out of the future in the common case where it's
 // unreferenced
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_future_wait")
 public func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_future_wait_throwing")
 public func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public func _runChildTask<T>(
   operation: @Sendable @escaping () async throws -> T
 ) async -> Builtin.NativeObject {
@@ -650,9 +676,11 @@ public func _runChildTask<T>(
   return task
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_cancel")
 func _taskCancel(_ task: Builtin.NativeObject)
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_isCancelled")
 func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
@@ -660,6 +688,7 @@ func _taskIsCancelled(_ task: Builtin.NativeObject) -> Bool
 
 /// Intrinsic used by SILGen to launch a task for bridging a Swift async method
 /// which was called through its ObjC-exported completion-handler-based API.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_alwaysEmitIntoClient
 @usableFromInline
 internal func _runTaskForBridgedAsyncMethod(_ body: @escaping () async -> Void) {

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -15,6 +15,7 @@ import Swift
 
 // ==== Task Cancellation ------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
 
   /// Returns `true` if the task is cancelled, and should stop executing.
@@ -95,9 +96,11 @@ extension Task {
 
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_addCancellationHandler")
 func _taskAddCancellationHandler(handler: @Sendable () -> ()) -> UnsafeRawPointer /*CancellationNotificationStatusRecord*/
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_removeCancellationHandler")
 func _taskRemoveCancellationHandler(
   record: UnsafeRawPointer /*CancellationNotificationStatusRecord*/

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -15,6 +15,7 @@ import Swift
 
 // ==== Task Group -------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
 
   /// Starts a new task group which provides a scope in which a dynamic number of
@@ -265,6 +266,7 @@ extension Task {
 
 /// ==== TaskGroup: AsyncSequence.AsyncIterator --------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task.Group {
 
   public func makeAsyncIterator() -> GroupIterator {
@@ -302,6 +304,7 @@ extension Task.Group {
 
 /// ==== -----------------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task.Group {
   /// Invoked after a withGroup's body exits, and initiates an orderly
   /// teardown of the group.
@@ -341,35 +344,43 @@ func _swiftRelease(
   _ object: Builtin.NativeObject
 )
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_create")
 func _taskGroupCreate() -> Builtin.RawPointer
 
 /// Attach task group child to the group group to the task.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_attachChild")
 func _taskGroupAttachChild(
   group: Builtin.RawPointer,
   child: Builtin.NativeObject
 ) -> UnsafeRawPointer /*ChildTaskStatusRecord*/
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_destroy")
 func _taskGroupDestroy(group: __owned Builtin.RawPointer)
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_addPending")
 func _taskGroupAddPendingTask(
   group: Builtin.RawPointer
 ) -> Bool
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_cancelAll")
 func _taskGroupCancelAll(group: Builtin.RawPointer)
 
 /// Checks ONLY if the group was specifically cancelled.
 /// The task itself being cancelled must be checked separately.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_isCancelled")
 func _taskGroupIsCancelled(group: Builtin.RawPointer) -> Bool
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_wait_next_throwing")
 func _taskGroupWaitNext<T>(group: Builtin.RawPointer) async throws -> T?
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 enum PollStatus: Int {
   case empty   = 0
   case waiting = 1
@@ -377,6 +388,7 @@ enum PollStatus: Int {
   case error   = 3
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_isEmpty")
 func _taskGroupIsEmpty(
   _ group: Builtin.RawPointer

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -14,6 +14,7 @@ import Swift
 @_implementationOnly import _SwiftConcurrencyShims
 
 /// Namespace for declaring `TaskLocalKey`s.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public enum TaskLocalValues {}
 
 /// A `TaskLocalKey` is used to identify, bind and get a task local value from
@@ -21,6 +22,7 @@ public enum TaskLocalValues {}
 ///
 /// - SeeAlso: `Task.withLocal(_:boundTo:operation:)`
 /// - SeeAlso: `Task.local(_:)`
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public protocol TaskLocalKey {
   /// The type of `Value` uniquely identified by this key.
   associatedtype Value
@@ -43,12 +45,14 @@ public protocol TaskLocalKey {
   static var inherit: TaskLocalInheritance { get }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TaskLocalKey {
   public static var inherit: TaskLocalInheritance { .default }
 }
 
 /// Determines task local value behavior in child tasks.
 // TODO: should likely remain extensible
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public enum TaskLocalInheritance: UInt8, Equatable {
   /// The default inheritance strategy.
   ///
@@ -62,6 +66,7 @@ public enum TaskLocalInheritance: UInt8, Equatable {
   case never = 1
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
 
   /// Read a task-local value, bound to the specified key.
@@ -112,6 +117,7 @@ extension Task {
 
 // ==== ------------------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_localValuePush")
 public func _taskLocalValuePush<Value>(
   _ task: Builtin.NativeObject,
@@ -119,11 +125,13 @@ public func _taskLocalValuePush<Value>(
   value: __owned Value
 ) // where Key: TaskLocalKey
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_localValuePop")
 public func _taskLocalValuePop(
   _ task: Builtin.NativeObject
 )
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_localValueGet")
 public func _taskLocalValueGet(
   _ task: Builtin.NativeObject,

--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -7,6 +7,7 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -29,6 +30,7 @@ actor Counter {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -38,6 +40,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -64,6 +67,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Concurrency/Runtime/async_let_fibonacci.swift
+++ b/test/Concurrency/Runtime/async_let_fibonacci.swift
@@ -18,6 +18,7 @@ func fib(_ n: Int) -> Int {
   return first
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -37,6 +38,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -45,6 +47,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/test/Concurrency/Runtime/async_sequence.swift
+++ b/test/Concurrency/Runtime/async_sequence.swift
@@ -14,22 +14,27 @@ import StdlibUnittest
 // TODO: This crashes on linux for some strange reason
 #if os(macOS)
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func throwing<T>(_ value: T) throws -> T {
   return value
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asynchronous<T>(_ value: T) async -> T {
   return value
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asynchronousThrowing<T>(_ value: T) async throws -> T {
   return value
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct Failure: Error, Equatable { 
   var value = 1
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func failable<T, E: Error>(
   _ results: [Result<T, E>]
 ) -> AsyncThrowingMapSequence<AsyncLazySequence<[Result<T, E>]>, T> {
@@ -37,6 +42,7 @@ func failable<T, E: Error>(
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Sequence {
   @inlinable
   public var async: AsyncLazySequence<Self> {
@@ -46,6 +52,7 @@ extension Sequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   public typealias Element = S.Element
   public typealias AsyncIterator = Iterator
@@ -78,6 +85,7 @@ public struct AsyncLazySequence<S: Sequence>: AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence {
   @inlinable
   public func collect() async rethrows -> [Element] {
@@ -90,6 +98,7 @@ extension AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension AsyncSequence where Element: Equatable {
   func `throw`(_ error: Error, on element: Element) -> AsyncThrowingMapSequence<Self, Element> {
     return map { (value: Element) throws -> Element in
@@ -99,6 +108,7 @@ extension AsyncSequence where Element: Equatable {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TestSuite {
   @inline(never)
   public func test(
@@ -111,6 +121,8 @@ extension TestSuite {
     }
   }
 }
+
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 
 var AsyncLazySequenceTests = TestSuite("AsyncLazySequence")
 
@@ -1051,6 +1063,8 @@ AsyncFlatMapSequenceTests.test("flat map throwing inner on throwing outer") {
   } catch {
     expectUnreachable()
   }
+}
+
 }
 
 #endif

--- a/test/Concurrency/Runtime/async_task_cancellation_early.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_early.swift
@@ -9,6 +9,7 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_runDetached_cancel_child_early() async {
   print(#function) // CHECK: test_runDetached_cancel_child_early
   let h: Task.Handle<Bool, Error> = Task.runDetached {
@@ -33,6 +34,7 @@ func test_runDetached_cancel_child_early() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_runDetached_cancel_child_early()

--- a/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
+++ b/test/Concurrency/Runtime/async_task_cancellation_while_running.swift
@@ -9,6 +9,7 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_runDetached_cancel_while_child_running() async {
   let h: Task.Handle<Bool, Error> = Task.runDetached {
     async let childCancelled: Bool = { () -> Bool in
@@ -32,6 +33,7 @@ func test_runDetached_cancel_while_child_running() async {
   print("was cancelled: \(got)") // CHECK: was cancelled: true
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_runDetached_cancel_while_child_running()

--- a/test/Concurrency/Runtime/async_task_detached.swift
+++ b/test/Concurrency/Runtime/async_task_detached.swift
@@ -18,6 +18,7 @@ class X {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_detach() async {
   for _ in 1...3 {
     let x = X()
@@ -32,6 +33,7 @@ func test_detach() async {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_detach()

--- a/test/Concurrency/Runtime/async_task_equals_hashCode.swift
+++ b/test/Concurrency/Runtime/async_task_equals_hashCode.swift
@@ -8,6 +8,7 @@
 
 // UNSUPPORTED: OS=windows-msvc
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func simple() async {
   print("\(#function) -----------------------")
   let one = await Task.current()
@@ -22,6 +23,7 @@ func simple() async {
   print("parent/child hashes equal: \(three.hashValue == two.hashValue)") // CHECK: parent/child hashes equal: false
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func unsafe() async {
   print("\(#function) -----------------------")
   let one = Task.unsafeCurrent!
@@ -39,6 +41,7 @@ func unsafe() async {
   print("unsafe.task parent/child hashes equal: \(three.task.hashValue == two.task.hashValue)") // CHECK: parent/child hashes equal: false
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func unsafeSync() {
   print("\(#function) -----------------------")
   let one = Task.unsafeCurrent!
@@ -47,6 +50,7 @@ func unsafeSync() {
   print("unsafe hashes equal: \(one.hashValue == two.hashValue)") // CHECK: hashes equal: true
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await simple()

--- a/test/Concurrency/Runtime/async_task_handle_cancellation.swift
+++ b/test/Concurrency/Runtime/async_task_handle_cancellation.swift
@@ -9,6 +9,7 @@
 // This test is flaky on VS2017 (unknown reasons)
 // UNSUPPORTED: MSVC_VER=15.0
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     let handle = Task.runDetached {

--- a/test/Concurrency/Runtime/async_task_locals_async_let.swift
+++ b/test/Concurrency/Runtime/async_task_locals_async_let.swift
@@ -16,6 +16,7 @@ class StringLike: CustomStringConvertible {
   var description: String { value }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TaskLocalValues {
   struct NumberKey: TaskLocalKey {
     static var defaultValue: Int { 0 }
@@ -23,6 +24,7 @@ extension TaskLocalValues {
   var number: NumberKey { .init() }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @discardableResult
 func printTaskLocal<Key>(
   _ key: KeyPath<TaskLocalValues, Key>,
@@ -40,6 +42,7 @@ func printTaskLocal<Key>(
 
 // ==== ------------------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func async_let_nested() async {
   _ = printTaskLocal(\.number) // CHECK: NumberKey: 0 {{.*}}
   async let x1: () = Task.withLocal(\.number, boundTo: 2) {
@@ -61,6 +64,7 @@ func async_let_nested() async {
   printTaskLocal(\.number) // CHECK: NumberKey: 0 {{.*}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func async_let_nested_skip_optimization() async {
   async let x1: Int? = Task.withLocal(\.number, boundTo: 2) {
     async let x2: Int? = { () async -> Int? in
@@ -83,6 +87,7 @@ func async_let_nested_skip_optimization() async {
   _ = await x1
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await async_let_nested()

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -17,6 +17,7 @@ class StringLike: CustomStringConvertible {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TaskLocalValues {
 
   struct StringKey: TaskLocalKey {
@@ -41,6 +42,7 @@ extension TaskLocalValues {
 
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 final class ClassTaskLocal {
   init() {
     print("clazz init \(ObjectIdentifier(self))")
@@ -51,6 +53,7 @@ final class ClassTaskLocal {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func printTaskLocal<Key>(
   _ key: KeyPath<TaskLocalValues, Key>,
   _ expected: Key.Value? = nil,
@@ -66,6 +69,7 @@ func printTaskLocal<Key>(
 
 // ==== ------------------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func simple() async {
   printTaskLocal(\.number) // CHECK: NumberKey: 0 {{.*}}
   await Task.withLocal(\.number, boundTo: 1) {
@@ -73,6 +77,7 @@ func simple() async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func simple_deinit() async {
   await Task.withLocal(\.clazz, boundTo: ClassTaskLocal()) {
     // CHECK: clazz init [[C:.*]]
@@ -85,6 +90,7 @@ func simple_deinit() async {
 struct Boom: Error {
   let value: String
 }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func simple_throw() async {
   do {
     try await Task.withLocal(\.clazz, boundTo: ClassTaskLocal()) {
@@ -96,6 +102,7 @@ func simple_throw() async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func nested() async {
   printTaskLocal(\.string) // CHECK: StringKey: <undefined> {{.*}}
   await Task.withLocal(\.string, boundTo: "hello") {
@@ -112,6 +119,7 @@ func nested() async {
   printTaskLocal(\.string) // CHECK-NEXT: StringKey: <undefined> {{.*}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func nested_allContribute() async {
   printTaskLocal(\.string) // CHECK: StringKey: <undefined> {{.*}}
   await Task.withLocal(\.string, boundTo: "one") {
@@ -128,6 +136,7 @@ func nested_allContribute() async {
   printTaskLocal(\.string) // CHECK-NEXT: StringKey: <undefined> {{.*}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func nested_3_onlyTopContributes() async {
   printTaskLocal(\.string) // CHECK: StringKey: <undefined> {{.*}}
   await Task.withLocal(\.string, boundTo: "one") {
@@ -144,6 +153,7 @@ func nested_3_onlyTopContributes() async {
   printTaskLocal(\.string) // CHECK-NEXT: StringKey: <undefined> {{.*}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func withLocal_body_mustNotEscape() async {
   var something = "Nice"
   await Task.withLocal(\.string, boundTo: "xxx") {
@@ -152,6 +162,7 @@ func withLocal_body_mustNotEscape() async {
   _ = something // silence not used warning
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await simple()

--- a/test/Concurrency/Runtime/async_task_locals_groups.swift
+++ b/test/Concurrency/Runtime/async_task_locals_groups.swift
@@ -17,6 +17,7 @@ class StringLike: CustomStringConvertible {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TaskLocalValues {
   struct NumberKey: TaskLocalKey {
     static var defaultValue: Int { 0 }
@@ -24,6 +25,7 @@ extension TaskLocalValues {
   var number: NumberKey { .init() }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func printTaskLocal<Key>(
   _ key: KeyPath<TaskLocalValues, Key>,
   _ expected: Key.Value? = nil,
@@ -40,6 +42,7 @@ func printTaskLocal<Key>(
 // ==== ------------------------------------------------------------------------
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func groups() async {
   // no value
   try! await Task.withGroup(resultType: Int.self) { group in
@@ -85,6 +88,7 @@ func groups() async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await groups()

--- a/test/Concurrency/Runtime/async_task_locals_inherit_never.swift
+++ b/test/Concurrency/Runtime/async_task_locals_inherit_never.swift
@@ -7,6 +7,7 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class StringLike: CustomStringConvertible {
   let value: String
   init(_ value: String) {
@@ -16,6 +17,7 @@ class StringLike: CustomStringConvertible {
   var description: String { value }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func printTaskLocal<Key>(
   _ key: KeyPath<TaskLocalValues, Key>,
   _ expected: Key.Value? = nil,
@@ -29,6 +31,7 @@ func printTaskLocal<Key>(
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TaskLocalValues {
 
   struct StringKey: TaskLocalKey {
@@ -41,6 +44,7 @@ extension TaskLocalValues {
 
 // ==== ------------------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_async_let() async {
   print(#function) // CHECK: test_async_let
 
@@ -55,6 +59,7 @@ func test_async_let() async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_async_group() async {
   // CHECK: test_async_group
   print(#function)
@@ -75,6 +80,7 @@ func test_async_group() async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_async_let()

--- a/test/Concurrency/Runtime/async_task_priority_current.swift
+++ b/test/Concurrency/Runtime/async_task_priority_current.swift
@@ -9,6 +9,7 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_detach() async {
   let a1 = Task.currentPriority
   print("a1: \(a1)") // CHECK: a1: default
@@ -25,6 +26,7 @@ func test_detach() async {
   print("a3: \(a3)") // CHECK: a3: default
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_multiple_lo_indirectly_escalated() async {
   @Sendable
   func loopUntil(priority: Task.Priority) async {
@@ -56,6 +58,7 @@ func test_multiple_lo_indirectly_escalated() async {
   print("default done") // CHECK: default done
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_detach()

--- a/test/Concurrency/Runtime/async_task_sleep.swift
+++ b/test/Concurrency/Runtime/async_task_sleep.swift
@@ -10,6 +10,7 @@ import _Concurrency
 // FIXME: should not depend on Dispatch
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static let pause = 500_000_000 // 500ms
   

--- a/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancelAll_only_specific_group.swift
@@ -9,12 +9,14 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
 /// Tests that only the specific group we cancelAll on is cancelled,
 /// and not accidentally all tasks in all groups within the given parent task.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_cancelAll_onlySpecificGroup() async {
   async let g1: Int = Task.withGroup(resultType: Int.self) { group in
 
@@ -76,6 +78,7 @@ func test_taskGroup_cancelAll_onlySpecificGroup() async {
 
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancelAll_onlySpecificGroup()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_from_inside_child.swift
@@ -9,6 +9,7 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_cancel_from_inside_child() async {
   let result: Int = try! await Task.withGroup(resultType: Int.self) { group in
     let firstAdded = await group.add { [group] in // must explicitly capture, as the task executes concurrently
@@ -34,6 +35,7 @@ func test_taskGroup_cancel_from_inside_child() async {
 
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_from_inside_child()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_parent_affects_group.swift
@@ -9,10 +9,12 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_cancel_parent_affects_group() async {
 
   let x = Task.runDetached {
@@ -44,6 +46,7 @@ func test_taskGroup_cancel_parent_affects_group() async {
 
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_parent_affects_group()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_add.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_add.swift
@@ -9,10 +9,12 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_cancel_then_add() async {
   // CHECK: test_taskGroup_cancel_then_add
   print("\(#function)")
@@ -41,6 +43,7 @@ func test_taskGroup_cancel_then_add() async {
 
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_add()

--- a/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancel_then_completions.swift
@@ -9,10 +9,12 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_cancel_then_completions() async {
   // CHECK: test_taskGroup_cancel_then_completions
   print("before \(#function)")
@@ -57,6 +59,7 @@ func test_taskGroup_cancel_then_completions() async {
   print("result: \(result)") // CHECK: result: 3
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_cancel_then_completions()

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -9,6 +9,7 @@
 // XFAIL: linux
 // XFAIL: windows
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_is_asyncSequence() async {
   let sum: Int = try! await Task.withGroup(resultType: Int.self) { group in
     for n in 1...10 {
@@ -31,6 +32,7 @@ func test_taskGroup_is_asyncSequence() async {
   print("result: \(sum)")
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main()
 

--- a/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_empty.swift
@@ -9,10 +9,12 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncEcho(_ value: Int) async -> Int {
   value
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_isEmpty() async {
   do {
     print("before all")
@@ -46,6 +48,7 @@ func test_taskGroup_isEmpty() async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_isEmpty()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_cancelAll.swift
@@ -9,6 +9,7 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_skipCallingNext_butInvokeCancelAll() async {
   let numbers = [1, 1]
 
@@ -45,6 +46,7 @@ func test_skipCallingNext_butInvokeCancelAll() async {
   assert(result == 0)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext_butInvokeCancelAll()

--- a/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_not_invoked_without_cancelAll.swift
@@ -9,6 +9,7 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_skipCallingNext() async {
   let numbers = [1, 1]
 
@@ -41,6 +42,7 @@ func test_skipCallingNext() async {
   assert(result == 0)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_skipCallingNext()

--- a/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_next_on_completed.swift
@@ -9,6 +9,7 @@
 
 import Dispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_sum_nextOnCompleted() async {
   let numbers = [1, 2, 3, 4, 5]
   let expected = 15 // FIXME: numbers.reduce(0, +) this hangs?
@@ -64,6 +65,7 @@ func test_sum_nextOnCompleted() async {
   print("result: \(sum)")
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_sum_nextOnCompleted()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_recover.swift
@@ -11,12 +11,15 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func one() async -> Int { 1 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func boom() async throws -> Int {
   throw Boom()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_throws() async {
   let got: Int = await Task.withGroup(resultType: Int.self) { group in
     await group.add { try await boom()  }
@@ -59,6 +62,7 @@ func test_taskGroup_throws() async {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws()

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -11,9 +11,12 @@
 struct Boom: Error {}
 struct IgnoredBoom: Error {}
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func echo(_ i: Int) async -> Int { i }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func boom() async throws -> Int { throw Boom() }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_throws_rethrows() async {
   do {
     let got = try await Task.withGroup(resultType: Int.self) { (group) async throws -> Int in
@@ -43,6 +46,7 @@ func test_taskGroup_throws_rethrows() async {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await test_taskGroup_throws_rethrows()

--- a/test/Concurrency/Runtime/basic_future.swift
+++ b/test/Concurrency/Runtime/basic_future.swift
@@ -13,10 +13,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -69,6 +71,7 @@ func testSimple(
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Concurrency/Runtime/cancellation_handler.swift
+++ b/test/Concurrency/Runtime/cancellation_handler.swift
@@ -11,7 +11,7 @@ class Canary {
   }
 }
 
-do {
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
   let task = Task.runDetached {
     let canary = Canary()
     _ = await Task.withCancellationHandler {
@@ -21,6 +21,10 @@ do {
     }
   }
   task.cancel()
+} else {
+  // Fake prints to satisfy FileCheck.
+  print("Canary")
+  print("canary died")
 }
 // CHECK: Canary
 // CHECK-NEXT: canary died

--- a/test/Concurrency/Runtime/checked_continuation.swift
+++ b/test/Concurrency/Runtime/checked_continuation.swift
@@ -10,25 +10,27 @@ struct TestError: Error {}
 
 var tests = TestSuite("CheckedContinuation")
 
-tests.test("trap on double resume non-throwing continuation") {
-  expectCrashLater()
-  runAsyncAndBlock {
-    let _: Int = await withCheckedContinuation { c in
-      c.resume(returning: 17)
-      c.resume(returning: 38)
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  tests.test("trap on double resume non-throwing continuation") {
+    expectCrashLater()
+    runAsyncAndBlock {
+      let _: Int = await withCheckedContinuation { c in
+        c.resume(returning: 17)
+        c.resume(returning: 38)
+      }
     }
   }
-}
 
-tests.test("trap on double resume throwing continuation") {
-  expectCrashLater()
-  runAsyncAndBlock {
-    do {
-      let _: Int = try await withCheckedThrowingContinuation { c in
-        c.resume(returning: 17)
-        c.resume(throwing: TestError())
+  tests.test("trap on double resume throwing continuation") {
+    expectCrashLater()
+    runAsyncAndBlock {
+      do {
+        let _: Int = try await withCheckedThrowingContinuation { c in
+          c.resume(returning: 17)
+          c.resume(throwing: TestError())
+        }
+      } catch {
       }
-    } catch {
     }
   }
 }

--- a/test/Concurrency/Runtime/effectful_properties.swift
+++ b/test/Concurrency/Runtime/effectful_properties.swift
@@ -19,6 +19,7 @@ enum BallKind {
   case KirksandLignature
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class Specs {
   // obtains the number of dimples
   subscript(_ bk : BallKind) -> Int {
@@ -35,6 +36,7 @@ class Specs {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Database {
   var currentData : Specs {
     get async {
@@ -49,18 +51,21 @@ actor Database {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 protocol SphericalObject {
   var name : String { get async throws }
   var dimples : Int { get async throws }
   var description : String { get async throws }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class Ball : SphericalObject {
   var name : String { get async throws { throw GeneralError.Todo } }
   var dimples : Int { get async throws { throw GeneralError.Todo } }
   var description : String { get async throws { throw GeneralError.Todo } }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class GolfBall : Ball {
   private static let db : Database = Database()
 
@@ -104,14 +109,17 @@ class GolfBall : Ball {
 // CHECK: obtaining specs...
 // CHECK: this golf ball has 0 dimples
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func printAsBall(_ b : Ball) async {
   print(try! await b.description)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func printAsAsSphericalObject(_ b : SphericalObject) async {
   print(try! await b.description)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct RunIt {
   static func main() async {
     let balls : [(Bool, Ball)] = [

--- a/test/Concurrency/Runtime/executor_deinit2.swift
+++ b/test/Concurrency/Runtime/executor_deinit2.swift
@@ -10,6 +10,7 @@
 // this needs to match with the check count below.
 let NUM_TASKS : Int = 100
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 final class Capture : Sendable {
     func doSomething() { }
     deinit {
@@ -18,6 +19,7 @@ final class Capture : Sendable {
     }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main
 struct App {
     static func main() async {

--- a/test/Concurrency/Runtime/executor_deinit3.swift
+++ b/test/Concurrency/Runtime/executor_deinit3.swift
@@ -14,6 +14,7 @@
     import Glibc
 #endif
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class Runner {
     func run() async {
         while !Task.isCancelled {
@@ -22,6 +23,7 @@ class Runner {
     }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Container {
     var generation = 0
     var runners = [Int : Task.Handle<Void, Never>]()
@@ -63,6 +65,7 @@ actor Container {
 // FIXME: this doesn't work until we have https://github.com/apple/swift/pull/36298
 // COM: deinit Container with {{[0-9]+}} runners
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct RunIt {
     static func startTest() async {
         let c = Container()
@@ -71,6 +74,7 @@ actor Container {
         await c.cancelAll()
     }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 static func main() async {
         print("starting")
         await RunIt.startTest()

--- a/test/Concurrency/Runtime/future_fibonacci.swift
+++ b/test/Concurrency/Runtime/future_fibonacci.swift
@@ -20,6 +20,7 @@ func fib(_ n: Int) -> Int {
     return first
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -44,6 +45,7 @@ func asyncFib(_ n: Int) async -> Int {
   return result
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func runFibonacci(_ n: Int) async {
   var result = await asyncFib(n)
 
@@ -52,6 +54,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(15)

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -22,6 +22,7 @@ struct Point {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor TestActor {
   // expected-note@+1{{mutation of this property is only permitted within the actor}}
   var position = Point(x: 0, y: 0)
@@ -36,10 +37,15 @@ actor TestActor {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }
-let modifyAsyncValue = modifyAsynchronously
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+enum Container {
+  static let modifyAsyncValue = modifyAsynchronously
+}
 
 // external function call
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TestActor {
 
   // Can't pass actor-isolated primitive into a function
@@ -56,7 +62,7 @@ extension TestActor {
   // Can't pass actor-isolated primitive into first-class function value
   func inoutAsyncValueCall() async {
     // expected-error@+1{{actor-isolated property 'value1' cannot be passed 'inout' to 'async' function call}}
-    await modifyAsyncValue(&value1)
+    await Container.modifyAsyncValue(&value1)
   }
 
   // Can't pass property of actor-isolated state inout to async function
@@ -76,6 +82,7 @@ extension TestActor {
 }
 
 // internal method call
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TestActor {
   func modifyByValue(_ other: inout Int) async {
     other += value1
@@ -88,6 +95,7 @@ extension TestActor {
 }
 
 // external class method call
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class NonAsyncClass {
   func modifyOtherAsync(_ other : inout Int) async {
     // ...
@@ -99,6 +107,7 @@ class NonAsyncClass {
 }
 
 // Calling external class/struct async function
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TestActor {
   // Can't pass state into async method of another class
 
@@ -127,10 +136,12 @@ extension TestActor {
 }
 
 // Check implicit async testing
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor DifferentActor {
   func modify(_ state: inout Int) {}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension TestActor {
   func modify(_ state: inout Int) {}
 
@@ -149,6 +160,7 @@ extension TestActor {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor MyActor {
   var points: [Point] = []
   var int: Int = 0
@@ -185,6 +197,7 @@ actor MyActor {
 
 // Verify global actor protection
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @globalActor
 struct MyGlobalActor {
   static let shared = TestActor()
@@ -195,27 +208,36 @@ struct MyGlobalActor {
 // expected-note@-2{{var declared here}}
 // expected-note@-3{{mutation of this var is only permitted within the actor}}
 
-// expected-error@+2{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-// expected-error@+1{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
-let _ = Task.runDetached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
+// expected-error@+3{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
+// expected-error@+2{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  let _ = Task.runDetached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
+}
 
 // attempt to pass global state owned by the global actor to another async function
-// expected-error@+1{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
+// expected-error@+2{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MyGlobalActor func sneaky() async { await modifyAsynchronously(&number) }
 
 // It's okay to pass actor state inout to synchronous functions!
 
 func globalSyncFunction(_ foo: inout Int) { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MyGlobalActor func globalActorSyncFunction(_ foo: inout Int) { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MyGlobalActor func globalActorAsyncOkay() async { globalActorSyncFunction(&number) }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MyGlobalActor func globalActorAsyncOkay2() async { globalSyncFunction(&number) }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MyGlobalActor func globalActorSyncOkay() { globalSyncFunction(&number) }
 
 // Gently unwrap things that are fine
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct Cat {
   mutating func meow() async { }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct Dog {
   var cat: Cat?
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -4,20 +4,29 @@
 let immutableGlobal: String = "hello"
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func globalFunc() { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func acceptClosure<T>(_: () -> T) { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func acceptConcurrentClosure<T>(_: @Sendable () -> T) { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func acceptEscapingClosure<T>(_: @escaping () -> T) { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func acceptEscapingClosure<T>(_: @escaping (String) -> ()) async -> T? { nil }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @discardableResult func acceptAsyncClosure<T>(_: () async -> T) -> T { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func acceptEscapingAsyncClosure<T>(_: @escaping () async -> T) { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func acceptInout<T>(_: inout T) {}
 
 
 // ----------------------------------------------------------------------
 // Actor state isolation restrictions
 // ----------------------------------------------------------------------
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor MySuperActor {
   var superState: Int = 25 // expected-note {{mutation of this property is only permitted within the actor}}
 
@@ -38,6 +47,7 @@ class Point {
   var y : Int = 0
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor MyActor: MySuperActor {
   let immutable: Int = 17
   // expected-note@+2 3{{property declared here}}
@@ -67,12 +77,14 @@ actor MyActor: MySuperActor {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Camera {
   func accessProp(act : MyActor) async -> String {
     return await act.name
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func checkAsyncPropertyAccess() async {
   let act = MyActor()
   let _ : Int = await act.mutable + act.mutable
@@ -93,6 +105,7 @@ func checkAsyncPropertyAccess() async {
   _ = act.point // expected-warning{{cannot use property 'point' with a non-sendable type 'Point' across actors}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension MyActor {
   nonisolated var actorIndependentVar: Int {
     get { 5 }
@@ -297,27 +310,34 @@ extension MyActor {
 // ----------------------------------------------------------------------
 // Global actor isolation restrictions
 // ----------------------------------------------------------------------
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor SomeActor { }
 
 @globalActor
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct SomeOtherGlobalActor {
   static let shared = SomeActor()
 }
 
 @globalActor
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct GenericGlobalActor<T> {
   static var shared: SomeActor { SomeActor() }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @SomeGlobalActor func onions() {} // expected-note{{calls to global function 'onions()' from outside of its actor context are implicitly asynchronous}}
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MainActor func beets() { onions() } // expected-error{{global function 'onions()' isolated to global actor 'SomeGlobalActor' can not be referenced from different global actor 'MainActor' in a synchronous context}}
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Crystal {
   // expected-note@+2 {{property declared here}}
   // expected-note@+1 2 {{mutation of this property is only permitted within the actor}}
@@ -347,23 +367,30 @@ actor Crystal {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @SomeGlobalActor func syncGlobalActorFunc() { syncGlobalActorFunc() } // expected-note 2{{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @SomeGlobalActor func asyncGlobalActorFunc() async { await asyncGlobalActorFunc() }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @SomeOtherGlobalActor func syncOtherGlobalActorFunc() { }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @SomeOtherGlobalActor func asyncOtherGlobalActorFunc() async {
   await syncGlobalActorFunc()
   await asyncGlobalActorFunc()
 }
 
 // test global actor funcs that are marked asyncHandler
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @SomeGlobalActor func goo1() async {
   let _ = goo2
   goo2()
 }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @asyncHandler @SomeOtherGlobalActor func goo2() { await goo1() }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func testGlobalActorClosures() {
   let _: Int = acceptAsyncClosure { @SomeGlobalActor in
     syncGlobalActorFunc()
@@ -375,6 +402,7 @@ func testGlobalActorClosures() {
   acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-error{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension MyActor {
   @SomeGlobalActor func onGlobalActor(otherActor: MyActor) async {
     // Access to other functions in this actor are okay.
@@ -425,6 +453,7 @@ extension MyActor {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct GenericStruct<T> {
   @GenericGlobalActor<T> func f() { } // expected-note 2{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
@@ -438,6 +467,7 @@ struct GenericStruct<T> {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension GenericStruct where T == String {
   @GenericGlobalActor<T>
   func h2() {
@@ -456,6 +486,7 @@ func badNumberUser() {
   print("The protected number is: \(number)")
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncBadNumberUser() async {
   print("The protected number is: \(await number)")
 }
@@ -463,6 +494,7 @@ func asyncBadNumberUser() async {
 // ----------------------------------------------------------------------
 // Non-actor code isolation restrictions
 // ----------------------------------------------------------------------
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func testGlobalRestrictions(actor: MyActor) async {
   let _ = MyActor()
 
@@ -514,6 +546,7 @@ func testGlobalRestrictions(actor: MyActor) async {
   print("\(number)") //expected-error {{property access is 'async' but is not marked with 'await'}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func f() {
   acceptConcurrentClosure {
     _ = mutableGlobal // expected-warning{{reference to var 'mutableGlobal' is not concurrency-safe because it involves shared mutable state}}
@@ -527,6 +560,7 @@ func f() {
 // ----------------------------------------------------------------------
 // Local function isolation restrictions
 // ----------------------------------------------------------------------
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func checkLocalFunctions() async {
   var i = 0
   var j = 0
@@ -575,6 +609,7 @@ func checkLocalFunctions() async {
 // Lazy properties with initializers referencing 'self'
 // ----------------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor LazyActor {
     var v: Int = 0
     // expected-note@-1 6 {{property declared here}}
@@ -612,6 +647,7 @@ actor LazyActor {
 }
 
 // Infer global actors from context only for instance members.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MainActor
 class SomeClassInActor {
   enum ID: String { case best }
@@ -619,6 +655,7 @@ class SomeClassInActor {
   func inActor() { } // expected-note{{calls to instance method 'inActor()' from outside of its actor context are implicitly asynchronous}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension SomeClassInActor.ID {
   func f(_ object: SomeClassInActor) { // expected-note{{add '@MainActor' to make instance method 'f' part of global actor 'MainActor'}}
     object.inActor() // expected-error{{instance method 'inActor()' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
@@ -628,6 +665,7 @@ extension SomeClassInActor.ID {
 // ----------------------------------------------------------------------
 // Initializers
 // ----------------------------------------------------------------------
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor SomeActorWithInits {
   var mutableState: Int = 17
   var otherMutableState: Int
@@ -642,6 +680,7 @@ actor SomeActorWithInits {
   func isolated() { }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MainActor
 class SomeClassWithInits {
   var mutableState: Int = 17
@@ -678,6 +717,7 @@ class SomeClassWithInits {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make global function 'outsideSomeClassWithInits()' part of global actor 'MainActor'}}
   _ = SomeClassWithInits() // expected-error{{initializer 'init()' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
   _ = SomeClassWithInits.shared // expected-error{{static property 'shared' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
@@ -687,20 +727,24 @@ func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make
 // ----------------------------------------------------------------------
 // Actor protocols.
 // ----------------------------------------------------------------------
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 protocol P: Actor {
   func f()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension P {
   func g() { f() }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor MyActorP: P {
   func f() { }
 
   func h() { g() }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func testCrossActorProtocol<T: P>(t: T) async {
   await t.f()
   await t.g()

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -6,10 +6,12 @@ enum PictureData {
   case failedToLoadImagePlaceholder
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_cancellation_checkCancellation() async throws {
   try Task.checkCancellation()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   guard !Task.isCancelled else {
     return PictureData.failedToLoadImagePlaceholder
@@ -18,10 +20,12 @@ func test_cancellation_guard_isCancelled(_ any: Any) async -> PictureData {
   return PictureData.value("...")
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct SomeFile: Sendable {
   func close() {}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_cancellation_withCancellationHandler(_ anything: Any) async -> PictureData {
   let handle: Task.Handle<PictureData, Error> = Task.runDetached {
     let file = SomeFile()
@@ -36,6 +40,7 @@ func test_cancellation_withCancellationHandler(_ anything: Any) async -> Picture
   handle.cancel()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_cancellation_loop() async -> Int {
   struct SampleTask { func process() async {} }
 

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -1,30 +1,37 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
-// expected-note@+1{{add 'async' to function 'missingAsync' to make it asynchronous}}
+// expected-note@+2{{add 'async' to function 'missingAsync' to make it asynchronous}}
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func missingAsync<T : AsyncSequence>(_ seq: T) throws { 
   for try await _ in seq { } // expected-error{{'async' in a function that does not support concurrency}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func missingThrows<T : AsyncSequence>(_ seq: T) async {
   for try await _ in seq { } // expected-error{{error is not handled because the enclosing function is not declared 'throws'}}
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func executeAsync(_ work: () async -> Void) { }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func execute(_ work: () -> Void) { }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func missingThrowingInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { // expected-error{{invalid conversion from throwing function of type '() async throws -> Void' to non-throwing function type '() async -> Void'}}
     for try await _ in seq { }
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func missingTryInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { 
     for await _ in seq { } // expected-error{{call can throw, but the error is not handled}}
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) { 
   execute { // expected-error{{invalid conversion from 'async' function of type '() async -> Void' to synchronous function type '() -> Void'}}
     do { 
@@ -33,6 +40,7 @@ func missingAsyncInBlock<T : AsyncSequence>(_ seq: T) {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   var it = seq.makeAsyncIterator()
   // expected-note@+2{{call is to 'rethrows' function, but a conformance has a throwing witness}}
@@ -40,6 +48,7 @@ func doubleDiagCheckGeneric<T : AsyncSequence>(_ seq: T) async {
   let _ = await it.next()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   typealias Element = Int
   typealias AsyncIterator = Self
@@ -50,6 +59,7 @@ struct ThrowingAsyncSequence: AsyncSequence, AsyncIteratorProtocol {
   func makeAsyncIterator() -> Self { return self }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
   var it = seq.makeAsyncIterator()
   // expected-error@+1{{call can throw, but it is not marked with 'try' and the error is not handled}}
@@ -57,6 +67,7 @@ func doubleDiagCheckConcrete(_ seq: ThrowingAsyncSequence) async {
 }
 
 // rdar://75274975
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
   do {
     for try await item in source {

--- a/test/Concurrency/async_task_groups.swift
+++ b/test/Concurrency/async_task_groups.swift
@@ -4,8 +4,11 @@
 // REQUIRES: concurrency
 // REQUIRES: libdispatch
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncFunc() async -> Int { 42 }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncThrowsFunc() async throws -> Int { 42 }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncThrowsOnCancel() async throws -> Int {
   // terrible suspend-spin-loop -- do not do this
   // only for purposes of demonstration
@@ -16,6 +19,7 @@ func asyncThrowsOnCancel() async throws -> Int {
   throw Task.CancellationError()
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_add() async throws -> Int {
   try await Task.withGroup(resultType: Int.self) { group in
     await group.add {
@@ -38,9 +42,12 @@ func test_taskGroup_add() async throws -> Int {
 // MARK: Example group Usages
 
 struct Boom: Error {}
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func work() async -> Int { 42 }
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func boom() async throws -> Int { throw Boom() }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func first_allMustSucceed() async throws {
 
   let first: Int = try await Task.withGroup(resultType: Int.self) { group in
@@ -59,6 +66,7 @@ func first_allMustSucceed() async throws {
   // Expected: re-thrown Boom
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func first_ignoreFailures() async throws {
   @Sendable func work() async -> Int { 42 }
   @Sendable func boom() async throws -> Int { throw Boom() }
@@ -92,6 +100,7 @@ func first_ignoreFailures() async throws {
 // ==== ------------------------------------------------------------------------
 // MARK: Advanced Custom Task Group Usage
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_taskGroup_quorum_thenCancel() async {
   // imitates a typical "gather quorum" routine that is typical in distributed systems programming
   enum Vote {
@@ -145,6 +154,7 @@ func test_taskGroup_quorum_thenCancel() async {
   _ = await gatherQuorum(followers: [Follower("A"), Follower("B"), Follower("C")])
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Collection where Self: Sendable, Element: Sendable, Self.Index: Sendable {
 
   /// Just another example of how one might use task groups.

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,9 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
 // REQUIRES: concurrency
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func someAsyncFunc() async -> String { "" }
 
 struct MyError: Error {}
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func someThrowingAsyncFunc() async throws -> String { throw MyError() }
 
 // ==== Unsafe Continuations ---------------------------------------------------
@@ -25,6 +27,7 @@ func buyVegetables(
 ) {}
 
 // returns 1 or more vegetables or throws an error
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
   try await withUnsafeThrowingContinuation { continuation in
     var veggies: [Vegetable] = []
@@ -40,6 +43,7 @@ func buyVegetables(shoppingList: [String]) async throws -> [Vegetable] {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_unsafeContinuations() async {
   // the closure should not allow async operations;
   // after all: if you have async code, just call it directly, without the unsafe continuation
@@ -53,6 +57,7 @@ func test_unsafeContinuations() async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_unsafeThrowingContinuations() async throws {
   let _: String = try await withUnsafeThrowingContinuation { continuation in
     continuation.resume(returning: "")
@@ -77,6 +82,7 @@ func test_unsafeThrowingContinuations() async throws {
 
 // ==== Detached Tasks ---------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_detached() async throws {
   let handle = Task.runDetached() {
     await someAsyncFunc() // able to call async functions
@@ -86,6 +92,7 @@ func test_detached() async throws {
   _ = result
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_detached_throwing() async -> String {
   let handle: Task.Handle<String, Error> = Task.runDetached() {
     try await someThrowingAsyncFunc() // able to call async functions

--- a/test/Concurrency/concurrency_module_shadowing.swift
+++ b/test/Concurrency/concurrency_module_shadowing.swift
@@ -6,8 +6,10 @@
 
 import ShadowsConcur
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func f(_ t : Task) -> Bool {
   return t.someProperty == "123"
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func g(_: _Concurrency.Task) {}

--- a/test/DebugInfo/async-boxed-arg.swift
+++ b/test/DebugInfo/async-boxed-arg.swift
@@ -2,6 +2,7 @@
 // RUN:    -module-name M -enable-experimental-concurrency | %FileCheck %s
 // REQUIRES: concurrency
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Collection {
   public func f() async throws {
     return await try Task.withGroup(resultType: Element.self) { group in

--- a/test/ModuleInterface/Inputs/MeowActor.swift
+++ b/test/ModuleInterface/Inputs/MeowActor.swift
@@ -1,3 +1,4 @@
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @globalActor public final class MeowActor {
   public static let shared = _Impl()
   

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -12,38 +12,46 @@
 // CHECK-EXTENSION-NOT: extension {{.+}} : _Concurrency.Actor
 
 // CHECK: public actor PlainActorClass {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public actor PlainActorClass {
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public actor ExplicitActorClass : Actor {
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // CHECK: public actor EmptyActor {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public actor EmptyActor {}
 
 // CHECK: actor public class EmptyActorClass {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public actor class EmptyActorClass {}
 
 // CHECK: public protocol Cat : _Concurrency.Actor {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public protocol Cat : Actor {
   func mew()
 }
 
 // CHECK: public actor HouseCat : Library.Cat {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public actor HouseCat : Cat {
   @asyncHandler public func mew() {}
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // CHECK: public protocol ToothyMouth {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public protocol ToothyMouth {
   func chew()
 }
 
 // CHECK: public actor Lion : Library.ToothyMouth, _Concurrency.Actor {
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public actor Lion : ToothyMouth, Actor {
   @asyncHandler public func chew() {}
   @actorIndependent public func enqueue(partialTask: PartialAsyncTask) { }

--- a/test/ModuleInterface/global-actor.swift
+++ b/test/ModuleInterface/global-actor.swift
@@ -3,6 +3,7 @@
 
 import MeowActor
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @MeowActor func doMeow() {}
 
 // RUN: %target-swift-frontend -enable-experimental-concurrency -enable-library-evolution -emit-module -o %t/MeowActor.swiftmodule %S/Inputs/MeowActor.swift
@@ -13,6 +14,7 @@ import MeowActor
 // RUN: %target-swift-frontend -enable-experimental-concurrency -emit-silgen %s -I %t | %FileCheck --check-prefix CHECK-FRAGILE %s
 // CHECK-FRAGILE: metatype $@thin MeowActor.Type
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func someFunc() async {
   await doMeow()
 }

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -13,6 +13,7 @@ import Darwin
 import Glibc
 #endif
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Counter {
   private var value = 0
   private let scratchBuffer: UnsafeMutableBufferPointer<Int>
@@ -41,6 +42,7 @@ actor Counter {
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for i in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -50,6 +52,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -76,6 +79,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/Sanitizers/tsan/basic_future.swift
+++ b/test/Sanitizers/tsan/basic_future.swift
@@ -17,10 +17,12 @@ enum HomeworkError: Error, Equatable {
   case dogAteIt(String)
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func formGreeting(name: String) async -> String {
   return "Hello \(name) from async world"
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func testSimple(
   name: String, dogName: String, shouldThrow: Bool, doSuspend: Bool
 ) async {
@@ -73,6 +75,7 @@ func testSimple(
 }
 
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await testSimple(name: "Ted", dogName: "Hazel", shouldThrow: false, doSuspend: false)

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -15,6 +15,7 @@
 
 var globalCounterValue = 0
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor Counter {
   func next() -> Int {
     let current = globalCounterValue
@@ -23,6 +24,7 @@ actor Counter {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   for _ in 0..<numIterations {
     let counterIndex = Int.random(in: 0 ..< counters.count)
@@ -32,6 +34,7 @@ func worker(identity: Int, counters: [Counter], numIterations: Int) async {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   // Create counter actors.
   var counters: [Counter] = []
@@ -57,6 +60,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   print("DONE!")
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     // Useful for debugging: specify counter/worker/iteration counts

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -3,43 +3,53 @@
 
 // Synthesis of for actores.
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A1 {
   var x: Int = 17
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A2: Actor {
   var x: Int = 17
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A3<T>: Actor {
   var x: Int = 17
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A4: A1 {
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A5: A2 {
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
   // expected-note@-1{{'A6' inherits conformance to protocol 'Actor' from superclass here}}
 }
 
 // Explicitly satisfying the requirement.
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A7 {
   // Okay: satisfy the requirement explicitly
   nonisolated func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // A non-actor can conform to the Actor protocol, if it does it properly.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 class C1: Actor { // expected-error{{non-final class 'C1' cannot conform to `Sendable`; use `UnsafeSendable`}}
   func enqueue(partialTask: PartialAsyncTask) { }
 }
 
 // Make sure the conformances actually happen.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func acceptActor<T: Actor>(_: T.Type) { }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func testConformance() {
   acceptActor(A1.self)
   acceptActor(A2.self)

--- a/test/stdlib/Concurrency.swift
+++ b/test/stdlib/Concurrency.swift
@@ -5,5 +5,6 @@
 import _Concurrency
 
 // Make sure the type shows up
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension PartialAsyncTask {
 }

--- a/test/stmt/errors_async.swift
+++ b/test/stmt/errors_async.swift
@@ -6,6 +6,7 @@ enum MyError : Error {
   case bad
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func shouldThrow() async {
   // expected-error@+1 {{errors thrown from here are not handled}}
   let _: Int = try await withUnsafeThrowingContinuation { continuation in


### PR DESCRIPTION
This allows programs to target older OSes while using Concurrency behind an availability check. When targeting older OSes, the symbols are weak-linked and the compiler will require the use of Concurrency features to be guarded by an availability check.

rdar://75850003