### PR TITLE
[Localization] Delay loading localization on startup

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -802,29 +802,11 @@ namespace swift {
 
     bool isPrettyPrintingDecl() const { return IsPrettyPrintingDecl; }
 
-    void setLocalization(std::string locale, std::string path) {
+    void setLocalization(StringRef locale, StringRef path) {
       assert(!locale.empty());
       assert(!path.empty());
-      llvm::SmallString<128> filePath(path);
-      llvm::sys::path::append(filePath, locale);
-      llvm::sys::path::replace_extension(filePath, ".db");
-
-      // If the serialized diagnostics file not available,
-      // fallback to the `YAML` file.
-      if (llvm::sys::fs::exists(filePath)) {
-        if (auto file = llvm::MemoryBuffer::getFile(filePath)) {
-          localization = std::make_unique<diag::SerializedLocalizationProducer>(
-              std::move(file.get()), getPrintDiagnosticNames());
-        }
-      } else {
-        llvm::sys::path::replace_extension(filePath, ".yaml");
-        // In case of missing localization files, we should fallback to messages
-        // from `.def` files.
-        if (llvm::sys::fs::exists(filePath)) {
-          localization = std::make_unique<diag::YAMLLocalizationProducer>(
-              filePath.str(), getPrintDiagnosticNames());
-        }
-      }
+      localization = diag::LocalizationProducer::producerFor(
+          locale, path, getPrintDiagnosticNames());
     }
 
     void ignoreDiagnostic(DiagID id) {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1160,9 +1160,9 @@ DiagnosticEngine::diagnosticStringFor(const DiagID id,
   auto defaultMessage = printDiagnosticNames
                             ? debugDiagnosticStrings[(unsigned)id]
                             : diagnosticStrings[(unsigned)id];
-  if (localization) {
-    auto localizedMessage =
-        localization.get()->getMessageOr(id, defaultMessage);
+
+  if (auto producer = localization.get()) {
+    auto localizedMessage = producer->getMessageOr(id, defaultMessage);
     return localizedMessage;
   }
   return defaultMessage;


### PR DESCRIPTION
We were loading localization files on start-up, but now we need to stop loading them and instead load them when first diagnostic is requested, so there is no startup overhead for the compiler on projects without errors.

cc @xedin 