### PR TITLE
[Concurrency] Added swift_deletedAsyncMethodError.

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -39,6 +39,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   Actor.swift
   CheckedContinuation.swift
   GlobalExecutor.cpp
+  Errors.swift
   Executor.swift
   AsyncCompactMapSequence.swift
   AsyncDropFirstSequence.swift

--- a/stdlib/public/Concurrency/Errors.swift
+++ b/stdlib/public/Concurrency/Errors.swift
@@ -1,0 +1,19 @@
+////===----------------------------------------------------------------------===//
+////
+//// This source file is part of the Swift.org open source project
+////
+//// Copyright (c) 2020 Apple Inc. and the Swift project authors
+//// Licensed under Apache License v2.0 with Runtime Library Exception
+////
+//// See https://swift.org/LICENSE.txt for license information
+//// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+////
+////===----------------------------------------------------------------------===//
+
+import Swift
+@_implementationOnly import _SwiftConcurrencyShims
+
+@_silgen_name("swift_deletedAsyncMethodError")
+public func swift_deletedAsyncMethodError() async {
+    fatalError("Fatal error: Call of deleted method")
+}


### PR DESCRIPTION
The new async function will be used as a placeholder  in VTables and WTables for async functions which have been deleted.

rdar://76061892
