### PR TITLE
[Property Wrappers] Fix availability inference of synthesized property wrapper setters

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -789,6 +789,9 @@ public:
     return Attrs;
   }
 
+  /// Returns the innermost enclosing decl with an availability annotation.
+  const Decl *getInnermostDeclWithAvailability() const;
+
   /// Returns the introduced OS version in the given platform kind specified
   /// by @available attribute.
   /// This function won't consider the parent context to get the information.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -351,6 +351,19 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   llvm_unreachable("bad DescriptiveDeclKind");
 }
 
+const Decl *Decl::getInnermostDeclWithAvailability() const {
+  const Decl *enclosingDecl = this;
+  // Find the innermost enclosing declaration with an @available annotation.
+  while (enclosingDecl != nullptr) {
+    if (enclosingDecl->getAttrs().hasAttribute<AvailableAttr>())
+      return enclosingDecl;
+
+    enclosingDecl = enclosingDecl->getDeclContext()->getAsDecl();
+  }
+
+  return nullptr;
+}
+
 Optional<llvm::VersionTuple>
 Decl::getIntroducedOSVersion(PlatformKind Kind) const {
   for (auto *attr: getAttrs()) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -566,17 +566,15 @@ configureInheritedDesignatedInitAttributes(ClassDecl *classDecl,
   // If the superclass has its own availability, make sure the synthesized
   // constructor is only as available as its superclass's constructor.
   if (superclassCtor->getAttrs().hasAttribute<AvailableAttr>()) {
-    SmallVector<Decl *, 2> asAvailableAs;
+    SmallVector<const Decl *, 2> asAvailableAs;
 
     // We don't have to look at enclosing contexts of the superclass constructor,
     // because designated initializers must always be defined in the superclass
     // body, and we already enforce that a superclass is at least as available as
     // a subclass.
     asAvailableAs.push_back(superclassCtor);
-    Decl *parentDecl = classDecl;
-    while (parentDecl != nullptr) {
+    if (auto *parentDecl = classDecl->getInnermostDeclWithAvailability()) {
       asAvailableAs.push_back(parentDecl);
-      parentDecl = parentDecl->getDeclContext()->getAsDecl();
     }
     AvailabilityInference::applyInferredAvailableAttrs(
         ctor, asAvailableAs, ctx);

--- a/test/Sema/generalized_accessors_availability.swift
+++ b/test/Sema/generalized_accessors_availability.swift
@@ -67,3 +67,46 @@ func butt(x: inout Butt) { // expected-note*{{}}
         x.$wrapped_modify_conditionally_available = 0
     }
 }
+
+@available(macOS 11.0, *)
+struct LessAvailable {
+  @SetterConditionallyAvailable
+  var wrapped_setter_more_available: Int
+
+  @ModifyConditionallyAvailable
+  var wrapped_modify_more_available: Int
+
+  var nested: Nested
+
+  struct Nested {
+    @SetterConditionallyAvailable
+    var wrapped_setter_more_available: Int
+
+    @ModifyConditionallyAvailable
+    var wrapped_modify_more_available: Int
+  }
+}
+
+func testInferredAvailability(x: inout LessAvailable) { // expected-error {{'LessAvailable' is only available in macOS 11.0 or newer}} expected-note*{{}}
+  x.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+  x.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+  x.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+  x.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+
+  x.nested.wrapped_setter_more_available = 0 // expected-error {{setter for 'wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+  x.nested.wrapped_modify_more_available = 0 // expected-error {{setter for 'wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+  x.nested.$wrapped_setter_more_available = 0 // expected-error {{setter for '$wrapped_setter_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+  x.nested.$wrapped_modify_more_available = 0 // expected-error {{setter for '$wrapped_modify_more_available' is only available in macOS 11.0 or newer}} expected-note{{}}
+
+  if #available(macOS 11.0, *) {
+    x.wrapped_setter_more_available = 0
+    x.wrapped_modify_more_available = 0
+    x.$wrapped_setter_more_available = 0
+    x.$wrapped_modify_more_available = 0
+
+    x.nested.wrapped_setter_more_available = 0
+    x.nested.wrapped_modify_more_available = 0
+    x.nested.$wrapped_setter_more_available = 0
+    x.nested.$wrapped_modify_more_available = 0
+  }
+}


### PR DESCRIPTION
Intersect the availability of the wrapped/projected value setter with the availability of the enclosing scope when inferring the availability of the synthesized setter for an applied property wrapper.

Resolves: rdar://71872385