### PR TITLE
GSB: Refactor diagnostics for redundant and conflicting superclass requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2412,16 +2412,17 @@ NOTE(same_type_redundancy_here,none,
      "same-type constraint %1 == %2 %select{written here|implied here|"
      "inferred from type here}0",
      (unsigned, Type, Type))
-ERROR(requires_superclass_conflict,none,
-      "%select{generic parameter %1 cannot|protocol %1 cannot require 'Self' to|" 
-      "%1 cannot}0 be a subclass of both %2 and %3",
-      (unsigned, Type, Type, Type))
+ERROR(conflicting_superclass_constraints,none,
+      "type %0 cannot be a subclass of both %1 and %2",
+      (Type, Type, Type))
+NOTE(conflicting_superclass_constraint,none,
+     "constraint conflicts with %0 : %1",
+     (Type, Type))
 WARNING(redundant_superclass_constraint,none,
         "redundant superclass constraint %0 : %1", (Type, Type))
 NOTE(superclass_redundancy_here,none,
-     "superclass constraint %1 : %2 %select{written here|implied here|"
-     "inferred from type here}0",
-     (unsigned, Type, Type))
+     "superclass constraint %0 : %1 implied here",
+     (Type, Type))
 
 ERROR(conflicting_layout_constraints,none,
       "type %0 has conflicting constraints %1 and %2",

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -653,6 +653,8 @@ private:
 
   void diagnoseRedundantRequirements() const;
 
+  void diagnoseConflictingConcreteTypeRequirements() const;
+
   bool hasExplicitConformancesImpliedByConcrete() const;
 
   /// Describes the relationship between a given constraint and

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -427,6 +427,15 @@ public:
                         Type superclass,
                         FloatingRequirementSource source);
 
+  /// Update the layout constraint for the equivalence class of \c T.
+  ///
+  /// This assumes that the constraint has already been recorded.
+  ///
+  /// \returns true if anything in the equivalence class changed, false
+  /// otherwise.
+  bool updateLayout(ResolvedType type,
+                    LayoutConstraint layout);
+
 private:
   /// Add a new superclass requirement specifying that the given
   /// potential archetype has the given type as an ancestor.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -537,8 +537,7 @@ public:
   LookUpConformanceInBuilder getLookupConformanceFn();
 
   /// Lookup a protocol conformance in a module-agnostic manner.
-  ProtocolConformanceRef lookupConformance(CanType dependentType,
-                                           Type conformingReplacementType,
+  ProtocolConformanceRef lookupConformance(Type conformingReplacementType,
                                            ProtocolDecl *conformedProtocol);
 
   /// Enumerate the requirements that describe the signature of this

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -440,8 +440,7 @@ bool GenericSignatureImpl::isRequirementSatisfied(
     if (canFirstType->isTypeParameter())
       return requiresProtocol(canFirstType, protocol);
     else
-      return (bool)GSB->lookupConformance(/*dependentType=*/CanType(),
-                                          canFirstType, protocol);
+      return (bool)GSB->lookupConformance(canFirstType, protocol);
   }
 
   case RequirementKind::SameType: {

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -5,13 +5,13 @@ class Derived: Base<Int> { }
 
 func foo<T>(_ x: T) -> Derived where T: Base<Int>, T: Derived {
 	// expected-warning@-1{{redundant superclass constraint 'T' : 'Base<Int>'}}
-	// expected-note@-2{{superclass constraint 'T' : 'Derived' written here}}
+	// expected-note@-2{{superclass constraint 'T' : 'Base<Int>' implied here}}
   return x
 }
 
 // FIXME: Should not be an error
-// expected-error@+2{{generic parameter 'U' cannot be a subclass of both 'Derived' and 'Base<T>'}}
-// expected-note@+1{{superclass constraint 'U' : 'Base<T>' written here}}
+// expected-error@+2{{type 'U' cannot be a subclass of both 'Derived' and 'Base<T>'}}
+// expected-note@+1{{constraint conflicts with 'U' : 'Base<T>'}}
 func bar<T, U>(_ x: U, y: T) -> (Derived, Int) where U: Base<T>, U: Derived {
   // FIXME
   // expected-error@+1{{cannot convert return expression}}

--- a/test/Generics/concrete_same_type_versus_anyobject.swift
+++ b/test/Generics/concrete_same_type_versus_anyobject.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+struct S {}
+class C {}
+
+struct G1<T : AnyObject> {}
+
+// CHECK-LABEL: Generic signature: <T where T == S>
+extension G1 where T == S {}
+// expected-error@-1 {{'T' requires that 'S' be a class type}}
+// expected-note@-2 {{same-type constraint 'T' == 'S' implied here}}
+
+// CHECK-LABEL: Generic signature: <T where T == C>
+extension G1 where T == C {}
+
+struct G2<U> {}
+
+// CHECK-LABEL: Generic signature: <U where U == S>
+extension G2 where U == S, U : AnyObject {}
+// expected-error@-1 {{'U' requires that 'S' be a class type}}
+// expected-note@-2 {{same-type constraint 'U' == 'S' implied here}}
+// expected-note@-3 {{constraint 'U' : 'AnyObject' implied here}}
+
+// CHECK-LABEL: Generic signature: <U where U == C>
+extension G2 where U == C, U : AnyObject {}
+// expected-warning@-1 {{redundant constraint 'U' : 'AnyObject'}}
+// expected-note@-2 {{constraint 'U' : 'AnyObject' implied here}}
+
+// CHECK-LABEL: Generic signature: <U where U : C>
+extension G2 where U : C, U : AnyObject {}
+// expected-warning@-1 {{redundant constraint 'U' : 'AnyObject'}}
+// expected-note@-2 {{constraint 'U' : 'AnyObject' implied here}}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -163,7 +163,7 @@ func sameTypeConcrete1<T : P9 & P10>(_: T) where T.A == X3, T.C == T.B, T.C == I
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.B == X3, τ_0_0.C == X3>
 func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
 // expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}
-// expected-note@-2{{same-type constraint 'T.C' == 'X3' written here}}
+// expected-note@-2{{superclass constraint 'T.B' : 'X3' implied here}}
 
 // Note: a standard-library-based stress test to make sure we don't inject
 // any additional requirements.

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -329,9 +329,11 @@ protocol P9 {
 struct X7<T: P9> where T.A : C { }
 
 extension X7 where T.A == Int { } // expected-error {{'T.A' requires that 'Int' inherit from 'C'}}
+// expected-note@-1 {{same-type constraint 'T.A' == 'Int' implied here}}
 struct X8<T: C> { }
 
 extension X8 where T == Int { } // expected-error {{'T' requires that 'Int' inherit from 'C'}}
+// expected-note@-1 {{same-type constraint 'T' == 'Int' implied here}}
 
 protocol P10 {
 	associatedtype A

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -13,12 +13,12 @@ class B : A {
 
 class Other { }
 
-func f1<T : A>(_: T) where T : Other {} // expected-error{{generic parameter 'T' cannot be a subclass of both 'Other' and 'A'}}
-// expected-note@-1{{superclass constraint 'T' : 'A' written here}}
+func f1<T : A>(_: T) where T : Other {} // expected-error{{type 'T' cannot be a subclass of both 'Other' and 'A'}}
+// expected-note@-1{{constraint conflicts with 'T' : 'A'}}
 
 func f2<T : A>(_: T) where T : B {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'A'}}
-// expected-note@-2{{superclass constraint 'T' : 'B' written here}}
+// expected-note@-2{{superclass constraint 'T' : 'A' implied here}}
 
 
 class GA<T> {}
@@ -32,16 +32,16 @@ func f5<T, U : GA<T>>(_: T, _: U) {}
 func f6<U : GA<T>, T : P>(_: T, _: U) {}
 func f7<U, T>(_: T, _: U) where U : GA<T>, T : P {}
 
-func f8<T : GA<A>>(_: T) where T : GA<B> {} // expected-error{{generic parameter 'T' cannot be a subclass of both 'GA<B>' and 'GA<A>'}}
-// expected-note@-1{{superclass constraint 'T' : 'GA<A>' written here}}
+func f8<T : GA<A>>(_: T) where T : GA<B> {} // expected-error{{type 'T' cannot be a subclass of both 'GA<B>' and 'GA<A>'}}
+// expected-note@-1{{constraint conflicts with 'T' : 'GA<A>'}}
 
 func f9<T : GA<A>>(_: T) where T : GB<A> {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'GA<A>'}}
-// expected-note@-2{{superclass constraint 'T' : 'GB<A>' written here}}
+// expected-note@-2{{superclass constraint 'T' : 'GA<A>' implied here}}
 
 func f10<T : GB<A>>(_: T) where T : GA<A> {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'GA<A>'}}
-// expected-note@-2{{superclass constraint 'T' : 'GB<A>' written here}}
+// expected-note@-2{{superclass constraint 'T' : 'GA<A>' implied here}}
 
 func f11<T : GA<T>>(_: T) { } // expected-error{{superclass constraint 'T' : 'GA<T>' is recursive}}
 func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { } // expected-error{{superclass constraint 'U' : 'GB<T>' is recursive}} // expected-error{{superclass constraint 'T' : 'GA<U>' is recursive}}
@@ -88,15 +88,15 @@ class C2 : C, P4 { }
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
 // expected-warning@-1{{redundant superclass constraint 'T' : 'C'}}
-// expected-note@-2{{superclass constraint 'T' : 'C2' written here}}
+// expected-note@-2{{superclass constraint 'T' : 'C' implied here}}
 // expected-warning@-3{{redundant conformance constraint 'T' : 'P4'}}
 // expected-note@-4{{conformance constraint 'T' : 'P4' implied here}}
 
 protocol P5: A { }
 
-protocol P6: A, Other { } // expected-error {{protocol 'P6' cannot require 'Self' to be a subclass of both 'Other' and 'A'}}
+protocol P6: A, Other { } // expected-error {{type 'Self' cannot be a subclass of both 'Other' and 'A'}}
 // expected-error@-1{{multiple inheritance from classes 'A' and 'Other'}}
-// expected-note@-2 {{superclass constraint 'Self' : 'A' written here}}
+// expected-note@-2 {{constraint conflicts with 'Self' : 'A'}}
 
 func takeA(_: A) { }
 func takeP5<T: P5>(_ t: T) {
@@ -105,14 +105,14 @@ func takeP5<T: P5>(_ t: T) {
 
 protocol P7 {
 	associatedtype Assoc: A, Other 
-	// expected-note@-1{{superclass constraint 'Self.Assoc' : 'A' written here}}
+	// expected-note@-1{{constraint conflicts with 'Self.Assoc' : 'A'}}
 	// expected-error@-2{{'Self.Assoc' cannot be a subclass of both 'Other' and 'A'}}
 }
 
 // CHECK: superclassConformance4
 // CHECK: Generic signature: <T, U where T : P3, U : P3, T.T : C, T.T == U.T>
 func superclassConformance4<T: P3, U: P3>(_: T, _: U)
-  where T.T: C, // expected-note{{superclass constraint 'T.T' : 'C' written here}}
+  where T.T: C, // expected-note{{superclass constraint 'U.T' : 'C' implied here}}
         U.T: C, // expected-warning{{redundant superclass constraint 'U.T' : 'C'}}
         T.T == U.T { }
 

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -155,7 +155,7 @@ protocol ProtocolWithInheritance4 : FooClass, FooProtocol {}
 // NO-TYREPR: {{^}}protocol ProtocolWithInheritance4 : FooClass, FooProtocol {{{$}}
 // TYREPR: {{^}}protocol ProtocolWithInheritance4 : FooClass, FooProtocol {{{$}}
 
-protocol ProtocolWithInheritance5 : FooClass, BarClass {} // expected-error{{multiple inheritance from classes 'FooClass' and 'BarClass'}} expected-error{{protocol 'ProtocolWithInheritance5' cannot require 'Self' to be a subclass of both 'BarClass' and 'FooClass'}} // expected-note{{superclass constraint 'Self' : 'FooClass' written here}}
+protocol ProtocolWithInheritance5 : FooClass, BarClass {} // expected-error{{multiple inheritance from classes 'FooClass' and 'BarClass'}} expected-error{{type 'Self' cannot be a subclass of both 'BarClass' and 'FooClass'}} // expected-note{{constraint conflicts with 'Self' : 'FooClass'}}
 // NO-TYREPR: {{^}}protocol ProtocolWithInheritance5 : <<error type>>, <<error type>> {{{$}}
 // TYREPR: {{^}}protocol ProtocolWithInheritance5 : FooClass, BarClass {{{$}}
 

--- a/test/attr/attr_specialize.swift
+++ b/test/attr/attr_specialize.swift
@@ -100,6 +100,7 @@ func sameTypeRequirement<T : HasElt>(_ t: T) where T.Element == Float {}
 
 @_specialize(where T == Sub)
 @_specialize(where T == NonSub) // expected-error{{'T' requires that 'NonSub' inherit from 'Base'}}
+// expected-note@-1 {{same-type constraint 'T' == 'NonSub' implied here}}
 func superTypeRequirement<T : Base>(_ t: T) {}
 
 @_specialize(where X:_Trivial(8), Y == Int) // expected-error{{trailing 'where' clause in '_specialize' attribute of non-generic function 'requirementOnNonGenericFunction(x:y:)'}}

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -323,7 +323,7 @@ class SecondConformer : SecondClass, SecondProtocol {}
 // Duplicate superclass
 // FIXME: Duplicate diagnostics
 protocol DuplicateSuper : Concrete, Concrete {}
-// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' written here}}
+// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' implied here}}
 // expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
 // expected-error@-3 {{duplicate inheritance from 'Concrete'}}
 

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -324,10 +324,10 @@ class SecondConformer : SecondClass, SecondProtocol {}
 // Duplicate superclass
 // FIXME: Should be an error here too
 protocol DuplicateSuper1 : Concrete where Self : Concrete {}
-// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' written here}}
+// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' implied here}}
 // expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
 protocol DuplicateSuper2 where Self : Concrete, Self : Concrete {}
-// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' written here}}
+// expected-note@-1 {{superclass constraint 'Self' : 'Concrete' implied here}}
 // expected-warning@-2 {{redundant superclass constraint 'Self' : 'Concrete'}}
 
 // Ambiguous name lookup situation


### PR DESCRIPTION
Let's use the redundant requirement graph to diagnose these, just like we already do for redundant conformance and layout requirements.

Also, diagnose conflicts:
- Multiple superclass requirements where neither is a superclass of the other
- A superclass requirement and a concrete type requirement that is not a subclass
- A layout requirement and a concrete type requirement that does not satisfy the layout requirement

The first two were already being diagnosed, the third is new. Here is an example:

```
struct G<T : AnyObject> {}

extension G where T == Int {}
```

We now reject this on account of `T` not satisfying `AnyObject`.