### PR TITLE
[SourceKit/CursorInfo] Report the set of decls referenced in the symbol graph's "declarationFragments" field.

### DIFF
--- a/include/swift/SymbolGraphGen/FragmentInfo.h
+++ b/include/swift/SymbolGraphGen/FragmentInfo.h
@@ -1,0 +1,35 @@
+//===--- FragmentInfo.h - Swift SymbolGraph Declaration Fragment Info -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYMBOLGRAPHGEN_FRAGMENTINFO_H
+#define SWIFT_SYMBOLGRAPHGEN_FRAGMENTINFO_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "PathComponent.h"
+
+namespace swift {
+class ValueDecl;
+
+namespace symbolgraphgen {
+
+/// Summary information for a symbol referenced in a symbol graph declaration fragment.
+struct FragmentInfo {
+  /// The swift decl of the referenced symbol.
+  const ValueDecl *VD;
+  /// The path components of the refereced symbol.
+  SmallVector<PathComponent, 4> ParentContexts;
+};
+
+} // end namespace symbolgraphgen
+} // end namespace swift
+
+#endif // SWIFT_SYMBOLGRAPHGEN_FRAGMENTINFO_H

--- a/include/swift/SymbolGraphGen/SymbolGraphGen.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphGen.h
@@ -17,6 +17,7 @@
 #include "swift/AST/Type.h"
 #include "SymbolGraphOptions.h"
 #include "PathComponent.h"
+#include "FragmentInfo.h"
 
 namespace swift {
 class ValueDecl;
@@ -36,7 +37,8 @@ int printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
                             bool InSynthesizedExtension,
                             const SymbolGraphOptions &Options,
                             llvm::raw_ostream &OS,
-                            SmallVectorImpl<PathComponent> &ParentContexts);
+                            SmallVectorImpl<PathComponent> &ParentContexts,
+                            SmallVectorImpl<FragmentInfo> &FragmentInfo);
 
 } // end namespace symbolgraphgen
 } // end namespace swift

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -155,6 +155,8 @@ void DeclarationFragmentPrinter::printTypeRef(Type T, const TypeDecl *RefTo,
   if (ShouldLink) {
     llvm::raw_svector_ostream OS(USR);
     ide::printDeclUSR(RefTo, OS);
+    if (ReferencedDecls)
+      ReferencedDecls->insert(RefTo);
   }
   closeFragment();
 }

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_SYMBOLGRAPHGEN_DECLARATIONFRAGMENTPRINTER_H
 #define SWIFT_SYMBOLGRAPHGEN_DECLARATIONFRAGMENTPRINTER_H
 
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Support/JSON.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/Basic/LLVM.h"
@@ -73,6 +74,9 @@ private:
 
   SmallString<256> USR;
 
+  /// Stores the set of decls referenced in the fragment if non-null.
+  SmallPtrSet<const Decl*, 8> *ReferencedDecls;
+
   StringRef getKindSpelling(FragmentKind Kind) const;
 
   /// Open a new kind of fragment without committing its spelling.
@@ -86,10 +90,12 @@ private:
 public:
   DeclarationFragmentPrinter(const SymbolGraph *SG,
                              llvm::json::OStream &OS,
-                             Optional<StringRef> Key = None)
+                             Optional<StringRef> Key = None,
+                             SmallPtrSet<const Decl*, 8> *ReferencedDecls = nullptr)
     : SG(SG),
       OS(OS),
       Kind(FragmentKind::None),
+      ReferencedDecls(ReferencedDecls),
       NumFragments(0) {
     if (Key) {
       OS.attributeBegin(*Key);

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -19,6 +19,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Markup/Markup.h"
 #include "swift/SymbolGraphGen/PathComponent.h"
+#include "swift/SymbolGraphGen/FragmentInfo.h"
 
 namespace swift {
 namespace symbolgraphgen {
@@ -98,7 +99,13 @@ public:
     return SynthesizedBaseTypeDecl;
   }
 
+  /// Reteive the path components associated with this symbol, from outermost
+  /// to innermost (this symbol).
   void getPathComponents(SmallVectorImpl<PathComponent> &Components) const;
+
+  /// Retrieve information about all symbols referenced in the declaration
+  /// fragment printed for this symbol.
+  void getFragmentInfo(SmallVectorImpl<FragmentInfo> &FragmentInfo) const;
 
   /// Print the symbol path to an output stream.
   void printPath(llvm::raw_ostream &OS) const;

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -100,7 +100,8 @@ printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
                         bool InSynthesizedExtension,
                         const SymbolGraphOptions &Options,
                         llvm::raw_ostream &OS,
-                        SmallVectorImpl<PathComponent> &ParentContexts) {
+                        SmallVectorImpl<PathComponent> &ParentContexts,
+                        SmallVectorImpl<FragmentInfo> &FragmentInfo) {
   if (!Symbol::supportsKind(D->getKind()))
     return EXIT_FAILURE;
 
@@ -116,6 +117,7 @@ printSymbolGraphForDecl(const ValueDecl *D, Type BaseTy,
 
   Symbol MySym(&Graph, D, NTD, BaseTy);
   MySym.getPathComponents(ParentContexts);
+  MySym.getFragmentInfo(FragmentInfo);
   Graph.recordNode(MySym);
   Graph.serialize(JOS);
   return EXIT_SUCCESS;

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
@@ -6,6 +6,7 @@ func callObjC() {
 
 // REQUIRES: objc_interop
 // RUN: %sourcekitd-test -req=cursor -pos=4:3 -req-opts=retrieve_symbol_graph=1 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp -target %target-triple %s | %FileCheck %s
+//
 // CHECK: SYMBOL GRAPH BEGIN
 // CHECK: {
 // CHECK:   "metadata": {

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced.swift
@@ -1,0 +1,352 @@
+import SomeModule
+
+let global = 1
+struct Parent {
+    struct Inner {}
+    func method<T>(x: T) where T: Equatable {}
+}
+
+extension Parent {
+    struct ExtInner {
+        func extInnerMethod(z: Inner, other: Array<ExtInner>, again: FromSomeModule) {}
+        private struct PrivateType {}
+        private func privateFunc(_ x: PrivateType) {}
+
+        @_spi(OtherModule) public struct SPIType {}
+        internal func spiFunc(x: SPIType) {}
+    }
+}
+
+// RUN: %empty-directory(%t)
+// RUN: echo 'public struct FromSomeModule {} ' > %t/SomeModule.swift
+// RUN: %target-build-swift %t/SomeModule.swift -module-name SomeModule -emit-module -emit-module-path %t/
+
+// References should cover symbols from the symbol graph declaration fragments, even if not present in the original source.
+// RUN:  %sourcekitd-test -req=cursor -pos=3:5 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple -I %t | %FileCheck -check-prefixes=GLOBAL %s
+//
+// GLOBAL:      SYMBOL GRAPH BEGIN
+// GLOBAL:        "declarationFragments": [
+// GLOBAL-NEXT:     {
+// GLOBAL-NEXT:       "kind": "keyword",
+// GLOBAL-NEXT:       "spelling": "let"
+// GLOBAL-NEXT:     },
+// GLOBAL-NEXT:     {
+// GLOBAL-NEXT:       "kind": "text",
+// GLOBAL-NEXT:       "spelling": " "
+// GLOBAL-NEXT:     },
+// GLOBAL-NEXT:     {
+// GLOBAL-NEXT:       "kind": "identifier",
+// GLOBAL-NEXT:       "spelling": "global"
+// GLOBAL-NEXT:     },
+// GLOBAL-NEXT:     {
+// GLOBAL-NEXT:       "kind": "text",
+// GLOBAL-NEXT:       "spelling": ": "
+// GLOBAL-NEXT:     },
+// GLOBAL-NEXT:     {
+// GLOBAL-NEXT:       "kind": "typeIdentifier",
+// GLOBAL-NEXT:       "preciseIdentifier": "[[Int_USR:.*]]",
+// GLOBAL-NEXT:       "spelling": "Int"
+// GLOBAL-NEXT:     }
+// GLOBAL-NEXT:   ],
+// GLOBAL:      SYMBOL GRAPH END
+//
+// GLOBAL:      REFERENCED DECLS BEGIN
+// GLOBAL-NEXT: [[Int_USR]] | public | <empty> | Swift | System | NonSPI | source.lang.swift
+// GLOBAL-NEXT:   Int swift.struct [[Int_USR]]
+// GLOBAL-NEXT: REFERENCED DECLS END
+
+
+// References to unsupported types (like generic parameters) should be ignored.
+// RUN:  %sourcekitd-test -req=cursor -pos=6:10 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple -I %t | %FileCheck -check-prefixes=GENERIC %s
+//
+// GENERIC:      SYMBOL GRAPH BEGIN
+// GENERIC:        "declarationFragments": [
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "keyword",
+// GENERIC-NEXT:       "spelling": "func"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "text",
+// GENERIC-NEXT:       "spelling": " "
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "identifier",
+// GENERIC-NEXT:       "spelling": "method"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "text",
+// GENERIC-NEXT:       "spelling": "<"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "genericParameter",
+// GENERIC-NEXT:       "spelling": "T"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "text",
+// GENERIC-NEXT:       "spelling": ">("
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "externalParam",
+// GENERIC-NEXT:       "spelling": "x"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "text",
+// GENERIC-NEXT:       "spelling": ": "
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "typeIdentifier",
+// GENERIC-NEXT:       "preciseIdentifier": "s:30cursor_symbol_graph_referenced6ParentV6method1xyx_tSQRzlF1TL_xmfp",
+// GENERIC-NEXT:       "spelling": "T"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "text",
+// GENERIC-NEXT:       "spelling": ") "
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "keyword",
+// GENERIC-NEXT:       "spelling": "where"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "text",
+// GENERIC-NEXT:       "spelling": " "
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "typeIdentifier",
+// GENERIC-NEXT:       "spelling": "T"
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "text",
+// GENERIC-NEXT:       "spelling": " : "
+// GENERIC-NEXT:     },
+// GENERIC-NEXT:     {
+// GENERIC-NEXT:       "kind": "typeIdentifier",
+// GENERIC-NEXT:       "preciseIdentifier": "[[Equatable_USR:.*]]",
+// GENERIC-NEXT:       "spelling": "Equatable"
+// GENERIC-NEXT:     }
+// GENERIC-NEXT:   ],
+// GENERIC:      SYMBOL GRAPH END
+//
+// GENERIC:      REFERENCED DECLS BEGIN
+// GENERIC-NEXT: [[Equatable_USR]] | public | <empty> | Swift | System | NonSPI | source.lang.swift
+// GENERIC-NEXT:   Equatable swift.protocol [[Equatable_USR]]
+// GENERIC-NEXT: REFERENCED DECLS END
+
+
+// References to unsupported types (like generic parameters) should be ignored.
+// RUN:  %sourcekitd-test -req=cursor -pos=11:14 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple -I %t | %FileCheck -check-prefixes=NESTED %s
+//
+// NESTED:      SYMBOL GRAPH BEGIN
+// NESTED:        "declarationFragments": [
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "keyword",
+// NESTED-NEXT:       "spelling": "func"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": " "
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "identifier",
+// NESTED-NEXT:       "spelling": "extInnerMethod"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": "("
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "externalParam",
+// NESTED-NEXT:       "spelling": "z"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": ": "
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "typeIdentifier",
+// NESTED-NEXT:       "preciseIdentifier": "[[Inner_USR:.*]]",
+// NESTED-NEXT:       "spelling": "Inner"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": ", "
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "externalParam",
+// NESTED-NEXT:       "spelling": "other"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": ": "
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "typeIdentifier",
+// NESTED-NEXT:       "preciseIdentifier": "[[Array_USR:.*]]",
+// NESTED-NEXT:       "spelling": "Array"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": "<"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "typeIdentifier",
+// NESTED-NEXT:       "preciseIdentifier": "[[ExtInner_USR:.*]]",
+// NESTED-NEXT:       "spelling": "ExtInner"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": ">, "
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "externalParam",
+// NESTED-NEXT:       "spelling": "again"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": ": "
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "typeIdentifier",
+// NESTED-NEXT:       "preciseIdentifier": "[[FromSomeModule_USR:.*]]",
+// NESTED-NEXT:       "spelling": "FromSomeModule"
+// NESTED-NEXT:     },
+// NESTED-NEXT:     {
+// NESTED-NEXT:       "kind": "text",
+// NESTED-NEXT:       "spelling": ")"
+// NESTED-NEXT:     }
+// NESTED-NEXT:   ],
+// NESTED:      SYMBOL GRAPH END
+//
+// NESTED:      REFERENCED DECLS BEGIN
+// NESTED-NEXT: [[Inner_USR]] | internal | {{.*}}cursor_symbol_graph_referenced.swift | cursor_symbol_graph_referenced | User | NonSPI | source.lang.swift
+// NESTED-NEXT:   Parent swift.struct s:30cursor_symbol_graph_referenced6ParentV
+// NESTED-NEXT:   Inner swift.struct [[Inner_USR]]
+// NESTED-NEXT: [[Array_USR]] | public | <empty> | Swift | System | NonSPI | source.lang.swift
+// NESTED-NEXT:   Array swift.struct [[Array_USR]]
+// NESTED-NEXT: [[ExtInner_USR]] | internal | {{.*}}cursor_symbol_graph_referenced.swift | cursor_symbol_graph_referenced | User | NonSPI | source.lang.swift
+// NESTED-NEXT:   Parent swift.struct s:30cursor_symbol_graph_referenced6ParentV
+// NESTED-NEXT:   ExtInner swift.struct [[ExtInner_USR]]
+// FIXME: We should get the file path via the swiftsourceinfo file for user modules (rdar://75582627)
+// NESTED-NEXT: [[FromSomeModule_USR]] | public | <empty> | SomeModule | User | NonSPI | source.lang.swift
+// NESTED-NEXT:   FromSomeModule swift.struct [[FromSomeModule_USR]]
+// NESTED-NEXT: REFERENCED DECLS END
+
+
+// Check access level reporting
+// RUN:  %sourcekitd-test -req=cursor -pos=13:22 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple -I %t | %FileCheck -check-prefixes=PRIVATE %s
+//
+// PRIVATE:      SYMBOL GRAPH BEGIN
+// PRIVATE:        "declarationFragments": [
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "keyword",
+// PRIVATE-NEXT:       "spelling": "private"
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "text",
+// PRIVATE-NEXT:       "spelling": " "
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "keyword",
+// PRIVATE-NEXT:       "spelling": "func"
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "text",
+// PRIVATE-NEXT:       "spelling": " "
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "identifier",
+// PRIVATE-NEXT:       "spelling": "privateFunc"
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "text",
+// PRIVATE-NEXT:       "spelling": "("
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "externalParam",
+// PRIVATE-NEXT:       "spelling": "_"
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "text",
+// PRIVATE-NEXT:       "spelling": " "
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "internalParam",
+// PRIVATE-NEXT:       "spelling": "x"
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "text",
+// PRIVATE-NEXT:       "spelling": ": "
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "typeIdentifier",
+// PRIVATE-NEXT:       "preciseIdentifier": "[[PrivateType_USR:.*]]",
+// PRIVATE-NEXT:       "spelling": "PrivateType"
+// PRIVATE-NEXT:     },
+// PRIVATE-NEXT:     {
+// PRIVATE-NEXT:       "kind": "text",
+// PRIVATE-NEXT:       "spelling": ")"
+// PRIVATE-NEXT:     }
+// PRIVATE-NEXT:   ],
+// PRIVATE:      SYMBOL GRAPH END
+//
+// PRIVATE:      REFERENCED DECLS BEGIN
+// PRIVATE-NEXT: [[PrivateType_USR]] | private | {{.*}}cursor_symbol_graph_referenced.swift | cursor_symbol_graph_referenced | User | NonSPI | source.lang.swift
+// PRIVATE-NEXT:   Parent swift.struct s:30cursor_symbol_graph_referenced6ParentV
+// PRIVATE-NEXT:   ExtInner swift.struct s:30cursor_symbol_graph_referenced6ParentV8ExtInnerV
+// PRIVATE-NEXT:   PrivateType swift.struct [[PrivateType_USR]]
+// PRIVATE-NEXT: REFERENCED DECLS END
+
+
+// Check SPI reporting
+// RUN:  %sourcekitd-test -req=cursor -pos=16:23 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple -I %t | %FileCheck -check-prefixes=SPI %s
+//
+// SPI:      SYMBOL GRAPH BEGIN
+// SPI:        "declarationFragments": [
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "keyword",
+// SPI-NEXT:       "spelling": "internal"
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "text",
+// SPI-NEXT:       "spelling": " "
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "keyword",
+// SPI-NEXT:       "spelling": "func"
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "text",
+// SPI-NEXT:       "spelling": " "
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "identifier",
+// SPI-NEXT:       "spelling": "spiFunc"
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "text",
+// SPI-NEXT:       "spelling": "("
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "externalParam",
+// SPI-NEXT:       "spelling": "x"
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "text",
+// SPI-NEXT:       "spelling": ": "
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "typeIdentifier",
+// SPI-NEXT:       "preciseIdentifier": "[[SPIType_USR:.*]]",
+// SPI-NEXT:       "spelling": "SPIType"
+// SPI-NEXT:     },
+// SPI-NEXT:     {
+// SPI-NEXT:       "kind": "text",
+// SPI-NEXT:       "spelling": ")"
+// SPI-NEXT:     }
+// SPI-NEXT:   ],
+// SPI:      SYMBOL GRAPH END
+// SPI:      REFERENCED DECLS BEGIN
+// SPI-NEXT: [[SPIType_USR]] | public | {{.*}}cursor_symbol_graph_referenced.swift | cursor_symbol_graph_referenced | User | SPI | source.lang.swift
+// SPI-NEXT:   Parent swift.struct s:30cursor_symbol_graph_referenced6ParentV
+// SPI-NEXT:   ExtInner swift.struct s:30cursor_symbol_graph_referenced6ParentV8ExtInnerV
+// SPI-NEXT:   SPIType swift.struct [[SPIType_USR]]
+// SPI-NEXT: REFERENCED DECLS END

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced_objc.swift
@@ -1,0 +1,50 @@
+import Foo
+
+struct Parent {
+  func refObjCType(x: FooStruct1) {}
+}
+
+// REQUIRES: objc_interop
+// RUN:  %sourcekitd-test -req=cursor -pos=4:8 -req-opts=retrieve_symbol_graph=1 %s -- %s -target %target-triple -F %S/../Inputs/libIDE-mock-sdk | %FileCheck -check-prefixes=OBJC %s
+
+// OBJC:      SYMBOL GRAPH BEGIN
+// OBJC:      "declarationFragments": [
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "keyword",
+// OBJC-NEXT:       "spelling": "func"
+// OBJC-NEXT:     },
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "text",
+// OBJC-NEXT:       "spelling": " "
+// OBJC-NEXT:     },
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "identifier",
+// OBJC-NEXT:       "spelling": "refObjCType"
+// OBJC-NEXT:     },
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "text",
+// OBJC-NEXT:       "spelling": "("
+// OBJC-NEXT:     },
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "externalParam",
+// OBJC-NEXT:       "spelling": "x"
+// OBJC-NEXT:     },
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "text",
+// OBJC-NEXT:       "spelling": ": "
+// OBJC-NEXT:     },
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "typeIdentifier",
+// OBJC-NEXT:       "preciseIdentifier": "[[FooStruct1_USR:.*]]",
+// OBJC-NEXT:       "spelling": "FooStruct1"
+// OBJC-NEXT:     },
+// OBJC-NEXT:     {
+// OBJC-NEXT:       "kind": "text",
+// OBJC-NEXT:       "spelling": ")"
+// OBJC-NEXT:     }
+// OBJC-NEXT:   ],
+// OBJC:      SYMBOL GRAPH END
+// OBJC:      REFERENCED DECLS BEGIN
+// OBJC-NEXT: [[FooStruct1_USR]] | public | {{.*}}Foo.h | Foo | User | NonSPI | source.lang.objc
+// OBJC-NEXT:   FooStruct1 swift.struct [[FooStruct1_USR]]
+// OBJC-NEXT: REFERENCED DECLS END

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -390,6 +390,24 @@ struct ParentInfo {
       : Title(Title), KindName(KindName), USR(USR) {}
 };
 
+struct ReferencedDeclInfo {
+  StringRef USR;
+  UIdent DeclarationLang;
+  StringRef AccessLevel;
+  StringRef FilePath;
+  StringRef ModuleName;
+  bool IsSystem;
+  bool IsSPI;
+  ArrayRef<ParentInfo> ParentContexts;
+
+  ReferencedDeclInfo(StringRef USR, UIdent DeclLang, StringRef AccessLevel,
+                     StringRef FilePath, StringRef ModuleName, bool System,
+                     bool SPI, ArrayRef<ParentInfo> Parents)
+      : USR(USR), DeclarationLang(DeclLang), AccessLevel(AccessLevel),
+        FilePath(FilePath), ModuleName(ModuleName), IsSystem(System),
+        IsSPI(SPI), ParentContexts(Parents) {}
+};
+
 struct CursorSymbolInfo {
   UIdent Kind;
   UIdent DeclarationLang;
@@ -429,6 +447,8 @@ struct CursorSymbolInfo {
   /// Stores the Symbol Graph title, kind, and USR of the parent contexts of the
   /// symbol under the cursor.
   ArrayRef<ParentInfo> ParentContexts;
+  /// The set of decls referenced in the symbol graph delcaration fragments.
+  ArrayRef<ReferencedDeclInfo> ReferencedSymbols;
   /// For calls this lists the USRs of the receiver types (multiple only in the
   /// case that the base is a protocol composition).
   ArrayRef<StringRef> ReceiverUSRs;

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1807,6 +1807,28 @@ static void addCursorSymbolInfo(const CursorSymbolInfo &Symbol,
     }
   }
 
+  if (!Symbol.ReferencedSymbols.empty()) {
+    auto Refs = Elem.setArray(KeyReferencedSymbols);
+    for (const auto &Ref: Symbol.ReferencedSymbols) {
+      auto Symbol = Refs.appendDictionary();
+      Symbol.set(KeyUSR, Ref.USR);
+      Symbol.set(KeyAccessLevel, Ref.AccessLevel);
+      Symbol.set(KeyFilePath, Ref.FilePath);
+      Symbol.set(KeyModuleName, Ref.ModuleName);
+      Symbol.set(KeyDeclarationLang, Ref.DeclarationLang);
+      Symbol.setBool(KeyIsSystem, Ref.IsSystem);
+      Symbol.setBool(KeyIsSPI, Ref.IsSPI);
+
+      auto Parents = Symbol.setArray(KeyParentContexts);
+      for (const auto &ParentTy : Ref.ParentContexts) {
+        auto Parent = Parents.appendDictionary();
+        Parent.set(KeyName, ParentTy.Title);
+        Parent.set(KeyKind, ParentTy.KindName);
+        Parent.set(KeyUSR, ParentTy.USR);
+      }
+    }
+  }
+
   if (!Symbol.ReceiverUSRs.empty()) {
     auto Receivers = Elem.setArray(KeyReceivers);
     for (auto USR : Symbol.ReceiverUSRs) {

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -161,6 +161,8 @@ UID_KEYS = [
     KEY('SymbolGraph', 'key.symbol_graph'),
     KEY('RetrieveSymbolGraph', 'key.retrieve_symbol_graph'),
     KEY('ParentContexts', 'key.parent_contexts'),
+    KEY('ReferencedSymbols', 'key.referenced_symbols'),
+    KEY('IsSPI', 'key.is_spi'),
     KEY('ActionUID', 'key.actionuid'),
     KEY('ActionUnavailableReason', 'key.actionunavailablereason'),
     KEY('CompileID', 'key.compileid'),


### PR DESCRIPTION
For each referenced decl, also report whether it is a system symbol and/or SPI, its access level, source language, file path, module name, and parent contexts.
 
Resolves rdar://75809521
