### PR TITLE
StringOptimization: don't constant fold dynamic Self type names.

### DIFF
--- a/lib/SILOptimizer/Transforms/StringOptimization.cpp
+++ b/lib/SILOptimizer/Transforms/StringOptimization.cpp
@@ -300,7 +300,7 @@ bool StringOptimization::optimizeTypeName(ApplyInst *typeNameCall) {
 
   auto metatype = metatypeInst->getType().getAs<MetatypeType>();
   Type ty = metatype->getInstanceType();
-  if (ty->hasArchetype())
+  if (ty->hasArchetype() || ty->hasDynamicSelfType())
     return false;
   
   // Usually the "qualified" parameter of _typeName() is a constant boolean.

--- a/test/SILOptimizer/string_optimization.swift
+++ b/test/SILOptimizer/string_optimization.swift
@@ -22,6 +22,13 @@ struct Outer {
   static let staticString = "static"
 }
 
+class C {
+  @inline(never)
+  func f() -> String {
+    return "\(Self.self)"
+  }
+}
+
 // More types are tested in test/stdlib/TypeName.swift and
 // test/stdlib/TypeNameInterpolation.swift
 
@@ -148,6 +155,9 @@ printEmbeeded(testQualifiedLocalType())
 
 // CHECK-OUTPUT: <test.Outer.InnerClass>
 printEmbeeded(testInnerClass())
+
+// CHECK-OUTPUT: <C>
+printEmbeeded(C().f())
 
 #if _runtime(_ObjC)
 


### PR DESCRIPTION
This wrongly results in "Self" instead of the real type name.

rdar://76113269
