### PR TITLE
Only diagnose references to globals under -warn-concurrency.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1460,7 +1460,7 @@ namespace {
     ///
     /// \returns true if we diagnosed the entity, \c false otherwise.
     bool diagnoseReferenceToUnsafeGlobal(ValueDecl *value, SourceLoc loc) {
-      if (!shouldDiagnoseExistingDataRaces(getDeclContext()))
+      if (!ctx.LangOpts.WarnConcurrency)
         return false;
 
       // Only diagnose direct references to mutable global state.

--- a/test/decl/var/effectful_properties_global.swift
+++ b/test/decl/var/effectful_properties_global.swift
@@ -5,17 +5,15 @@ var intAsyncProp : Int {
   get async { 0 }
 }
 
-var intThrowsProp : Int { // expected-note 2 {{var declared here}}
+var intThrowsProp : Int {
   get throws { 0 }
 }
 
 var asyncThrowsProp : Int {
-  // expected-warning@+1 {{reference to var 'intThrowsProp' is not concurrency-safe because it involves shared mutable state}}
   get async throws { try await intAsyncProp + intThrowsProp }
 }
 
 func hello() async {
-  // expected-warning@+1 {{reference to var 'intThrowsProp' is not concurrency-safe because it involves shared mutable state}}
   _ = intThrowsProp // expected-error{{property access can throw, but it is not marked with 'try' and the error is not handled}}
 
   _ = intAsyncProp // expected-error{{property access is 'async' but is not marked with 'await'}}
@@ -25,7 +23,7 @@ class C {
   var counter : Int = 0
 }
 
-var refTypeThrowsProp : C { // expected-note {{var declared here}}
+var refTypeThrowsProp : C {
   get throws { return C() }
 }
 
@@ -34,7 +32,6 @@ var refTypeAsyncProp : C {
 }
 
 func salam() async {
-  // expected-warning@+1 {{reference to var 'refTypeThrowsProp' is not concurrency-safe because it involves shared mutable state}}
   _ = refTypeThrowsProp // expected-error{{property access can throw, but it is not marked with 'try' and the error is not handled}}
 
 


### PR DESCRIPTION
Fixes rdar://75996222.
