### PR TITLE
[NFC] Move Some Type Resolution Methods from TypeChecker to TypeResolution

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -702,11 +702,9 @@ Type ConstraintSystem::openUnboundGenericType(
   // pointing at a generic TypeAliasDecl here. If we find a way to
   // handle generic TypeAliases elsewhere, this can just become a
   // call to BoundGenericType::get().
-  return TypeChecker::applyUnboundGenericArguments(
-      decl, parentTy, SourceLoc(),
-      TypeResolution::forContextual(DC, None, /*unboundTyOpener*/ nullptr,
-                                    /*placeholderHandler*/ nullptr),
-      arguments);
+  return TypeResolution::forContextual(DC, None, /*unboundTyOpener*/ nullptr,
+                                       /*placeholderHandler*/ nullptr)
+      .applyUnboundGenericArguments(decl, parentTy, SourceLoc(), arguments);
 }
 
 static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1291,12 +1291,12 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
   // Unqualified reference to a type.
   if (auto typeDecl = dyn_cast<TypeDecl>(value)) {
     // Resolve the reference to this type declaration in our current context.
-    auto type = TypeChecker::resolveTypeInContext(
-        typeDecl, nullptr,
+    auto type =
         TypeResolution::forContextual(useDC, TypeResolverContext::InExpression,
                                       /*unboundTyOpener*/ nullptr,
-                                      /*placeholderHandler*/ nullptr),
-        /*isSpecialized=*/false);
+                                      /*placeholderHandler*/ nullptr)
+            .resolveTypeInContext(typeDecl, /*foundDC*/ nullptr,
+                                  /*isSpecialized=*/false);
 
     checkNestedTypeConstraints(*this, type, locator);
 

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -407,6 +407,21 @@ public:
   /// Determine whether the given two types are equivalent within this
   /// type resolution context.
   bool areSameType(Type type1, Type type2) const;
+
+  /// Resolve a reference to the given type declaration within a particular
+  /// context.
+  ///
+  /// This routine aids unqualified name lookup for types by performing the
+  /// resolution necessary to rectify the declaration found by name lookup with
+  /// the declaration context from which name lookup started.
+  ///
+  /// \param typeDecl The type declaration found by name lookup.
+  /// \param foundDC The declaration context this type reference was found in.
+  /// \param isSpecialized Whether the type will have generic arguments applied.
+  ///
+  /// \returns the resolved type.
+  Type resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
+                            bool isSpecialized);
 };
 
 } // end namespace swift

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -421,7 +421,27 @@ public:
   ///
   /// \returns the resolved type.
   Type resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
-                            bool isSpecialized);
+                            bool isSpecialized) const;
+
+  /// Apply generic arguments to the unbound generic type represented by the
+  /// given declaration and parent type.
+  ///
+  /// This function requires the correct number of generic arguments,
+  /// whereas applyGenericArguments emits diagnostics in those cases.
+  ///
+  /// \param decl The declaration that the resulting bound generic type
+  /// shall reference.
+  /// \param parentTy The parent type.
+  /// \param loc The source location for diagnostic reporting.
+  /// \param genericArgs The list of generic arguments to apply.
+  ///
+  /// \returns A BoundGenericType bound to the given arguments, or null on
+  /// error.
+  ///
+  /// \see applyGenericArguments
+  Type applyUnboundGenericArguments(GenericTypeDecl *decl, Type parentTy,
+                                    SourceLoc loc,
+                                    ArrayRef<Type> genericArgs) const;
 };
 
 } // end namespace swift

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -43,7 +43,6 @@ class GenericSignatureBuilder;
 class NominalTypeDecl;
 class NormalProtocolConformance;
 class RootProtocolConformance;
-class TypeResolution;
 class TypeResolutionOptions;
 class TypoCorrectionResults;
 class ExprPattern;
@@ -263,27 +262,6 @@ void checkUnsupportedProtocolType(ASTContext &ctx,
 /// list.
 void checkUnsupportedProtocolType(ASTContext &ctx,
                                   GenericParamList *genericParams);
-
-/// Apply generic arguments to the unbound generic type represented by the
-/// given declaration and parent type.
-///
-/// This function requires the correct number of generic arguments,
-/// whereas applyGenericArguments emits diagnostics in those cases.
-///
-/// \param decl The declaration that the resulting bound generic type
-/// shall reference.
-/// \param parentTy The parent type.
-/// \param loc The source location for diagnostic reporting.
-/// \param resolution The type resolution.
-/// \param genericArgs The list of generic arguments to apply.
-///
-/// \returns A BoundGenericType bound to the given arguments, or null on
-/// error.
-///
-/// \see applyGenericArguments
-Type applyUnboundGenericArguments(GenericTypeDecl *decl, Type parentTy,
-                                  SourceLoc loc, TypeResolution resolution,
-                                  ArrayRef<Type> genericArgs);
 
 /// Substitute the given base type into the type of the given nested type,
 /// producing the effective type that the nested type will have.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -264,21 +264,6 @@ void checkUnsupportedProtocolType(ASTContext &ctx,
 void checkUnsupportedProtocolType(ASTContext &ctx,
                                   GenericParamList *genericParams);
 
-/// Resolve a reference to the given type declaration within a particular
-/// context.
-///
-/// This routine aids unqualified name lookup for types by performing the
-/// resolution necessary to rectify the declaration found by name lookup with
-/// the declaration context from which name lookup started.
-///
-/// \param typeDecl The type declaration found by name lookup.
-/// \param isSpecialized Whether the type will have generic arguments applied.
-/// \param resolution The resolution to perform.
-///
-/// \returns the resolved type.
-Type resolveTypeInContext(TypeDecl *typeDecl, DeclContext *foundDC,
-                          TypeResolution resolution, bool isSpecialized);
-
 /// Apply generic arguments to the unbound generic type represented by the
 /// given declaration and parent type.
 ///


### PR DESCRIPTION
Just a mechanical change to keep stripping the TypeChecker namespace of utilities it doesn't need.