### PR TITLE
Add a Null Check for Missing Generic Signatures

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1188,7 +1188,9 @@ bool DeclContext::hasValueSemantics() const {
 bool DeclContext::isClassConstrainedProtocolExtension() const {
   if (getExtendedProtocolDecl()) {
     auto ED = cast<ExtensionDecl>(this);
-    return ED->getGenericSignature()->requiresClass(ED->getSelfInterfaceType());
+    if (auto sig = ED->getGenericSignature()) {
+      return sig->requiresClass(ED->getSelfInterfaceType());
+    }
   }
   return false;
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar76049852.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar76049852.swift
@@ -1,0 +1,14 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+struct MyStruct {}
+protocol MyProtocol {}
+
+func foo(bytes: [MyStruct]) {
+  bytes.withUnsafeBufferPointer { a in
+    extension MyProtocol {
+      var bytes: MyStruct {
+        fatalError()
+      }
+    }
+  }
+}


### PR DESCRIPTION
When an extension is nested inside of an invalid decl context, it is
going to pull the signature of its nearest enclosing context instead of
its extended type. This leads to a null signature since the nearest
enclosing context for an extension should always be its parent source
file.

rdar://76049852