### PR TITLE
[Concurrency] YieldingContinuation

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -68,6 +68,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   TaskLocal.swift
   ThreadSanitizer.cpp
   Mutex.cpp
+  YieldingContinuation.swift
   ${swift_concurrency_objc_sources}
 
   SWIFT_MODULE_DEPENDS_LINUX Glibc

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -16,7 +16,7 @@ import Swift
 public struct YieldingContinuation<Element, Failure: Error>: Sendable {
   @_fixed_layout
   @usableFromInline
-  internal final class Storage: UnsafeConcurrentValue {
+  internal final class Storage {
     @usableFromInline
     var continuation: UnsafeContinuation<Element, Error>?
   }

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -1,0 +1,196 @@
+import Swift
+import _Concurrency
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+
+public struct YieldingContinuation<Element, Failure: Error>: Sendable {
+  @_fixed_layout
+  @usableFromInline
+  internal final class Storage: UnsafeConcurrentValue {
+    @usableFromInline
+    var continuation: UnsafeContinuation<Element, Error>?
+  }
+  
+  @usableFromInline
+  let storage = Storage()
+
+  /// Construct a YieldingContinuation.
+  ///
+  /// This continuation type can be called more than once, unlike the unsafe and
+  /// checked counterparts. Each call to the yielding functions will resume any
+  /// awaiter on the next function. This type is inherently sendable and can
+  /// safely be used and stored in multiple task contexts.
+  public init() { }
+
+  /// Construct a YieldingContinuation with specific types including a failure.
+  ///
+  /// This continuation type can be called more than once, unlike the unsafe and
+  /// checked counterparts. Each call to the yielding functions will resume any
+  /// awaiter on the next function. This type is inherently sendable and can
+  /// safely be used and stored in multiple task contexts.
+  public init(yielding: Element.Type, throwing: Failure.Type) { }
+
+  @inlinable
+  @inline(__always)
+  internal func _extract() -> UnsafeContinuation<Element, Error>? {
+    let raw = Builtin.atomicrmw_xchg_seqcst_Word(
+      Builtin.addressof(&storage.continuation),
+      UInt(bitPattern: 0)._builtinWordValue)
+    return unsafeBitCast(raw, to: UnsafeContinuation<Element, Error>?.self)
+  }
+  
+  @inlinable
+  @inline(__always)
+  internal func _inject(
+    _ continuation: UnsafeContinuation<Element, Error>
+  ) -> UnsafeContinuation<Element, Error>? {
+    let rawContinuation = unsafeBitCast(continuation, to: Builtin.Word.self)
+    let raw = Builtin.atomicrmw_xchg_seqcst_Word(
+      Builtin.addressof(&storage.continuation), rawContinuation)
+    return unsafeBitCast(raw, to: UnsafeContinuation<Element, Error>?.self)
+  }
+  
+  /// Resume the task awaiting next by having it return normally from its 
+  /// suspension point.
+  ///
+  /// - Parameter value: The value to return from an awaiting call to next.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  public func yield(_ value: __owned Element) -> Bool {
+    if let continuation = _extract() {
+      continuation.resume(returning: value)
+      return true
+    }
+    return false
+  }
+  
+  /// Resume the task awaiting the continuation by having it throw an error
+  /// from its suspension point.
+  ///
+  /// - Parameter error: The error to throw from an awaiting call to next.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  public func yield(throwing error: __owned Failure) -> Bool {
+    if let continuation = _extract() {
+      continuation.resume(throwing: error)
+      _fixLifetime(storage)
+      return true
+    }
+    return false
+  }
+
+  /// Await a resume from a call to a yielding function.
+  ///
+  /// - Return: The element that was yielded or a error that was thrown.
+  public func next() async throws -> Element {
+    var existing: UnsafeContinuation<Element, Error>?
+    do {
+      let result = try await withUnsafeThrowingContinuation {
+        (continuation: UnsafeContinuation<Element, Error>) in
+        existing = _inject(continuation)
+      }
+      existing?.resume(returning: result)
+      return result
+    } catch {
+      existing?.resume(throwing: error)
+      throw error
+    }
+  }
+}
+
+extension YieldingContinuation where Failure == Never {
+  /// Construct a YieldingContinuation with a specific Element type.
+  ///
+  /// This continuation type can be called more than once, unlike the unsafe and
+  /// checked counterparts. Each call to the yielding functions will resume any
+  /// awaiter on the next function. This type is inherently sendable and can
+  /// safely be used and stored in multiple task contexts.
+  public init(yielding: Element.Type) { }
+
+  /// Await a resume from a call to a yielding function.
+  ///
+  /// - Return: The element that was yielded.
+  public func next() async -> Element {
+    var existing: UnsafeContinuation<Element, Error>?
+    let result = try! await withUnsafeThrowingContinuation {
+      (continuation: UnsafeContinuation<Element, Error>) in
+      existing = _inject(continuation)
+    }
+    existing?.resume(returning: result)
+    return result
+  }
+}
+
+extension YieldingContinuation {
+  /// Resume the task awaiting the continuation by having it either
+  /// return normally or throw an error based on the state of the given
+  /// `Result` value.
+  ///
+  /// - Parameter result: A value to either return or throw from the
+  ///   continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  public func yield<Er: Error>(
+    with result: Result<Element, Er>
+  ) -> Bool where Failure == Error {
+    switch result {
+      case .success(let val):
+        return self.yield(val)
+      case .failure(let err):
+        return self.yield(throwing: err)
+    }
+  }
+  
+  /// Resume the task awaiting the continuation by having it either
+  /// return normally or throw an error based on the state of the given
+  /// `Result` value.
+  ///
+  /// - Parameter result: A value to either return or throw from the
+  ///   continuation.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  public func yield(with result: Result<Element, Failure>) -> Bool {
+    switch result {
+      case .success(let val):
+        return self.yield(val)
+      case .failure(let err):
+        return self.yield(throwing: err)
+    }
+  }
+  
+  /// Resume the task awaiting the continuation by having it return normally
+  /// from its suspension point.
+  ///
+  /// Unlike other continuations `YieldingContinuation` may resume more than
+  /// once. However if there are no potential awaiting calls to `next` this
+  /// function will return false, indicating that the caller needs to decide how
+  /// the behavior should be handled.
+  public func yield() -> Bool where Element == Void {
+    return self.yield(())
+  }
+}
+

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -12,16 +12,12 @@
 
 import Swift
 
-@_fixed_layout
-@usableFromInline
 internal final class _YieldingContinuationStorage: UnsafeSendable {
-  @usableFromInline
   var continuation: Builtin.RawUnsafeContinuation?
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct YieldingContinuation<Element, Failure: Error>: Sendable {
-  @usableFromInline
   let storage = _YieldingContinuationStorage()
 
   /// Construct a YieldingContinuation.
@@ -40,17 +36,13 @@ public struct YieldingContinuation<Element, Failure: Error>: Sendable {
   /// safely be used and stored in multiple task contexts.
   public init(yielding: Element.Type, throwing: Failure.Type) { }
 
-  @inlinable
-  @inline(__always)
   internal func _extract() -> UnsafeContinuation<Element, Error>? {
     let raw = Builtin.atomicrmw_xchg_acqrel_Word(
       Builtin.addressof(&storage.continuation),
       UInt(bitPattern: 0)._builtinWordValue)
     return unsafeBitCast(raw, to: UnsafeContinuation<Element, Error>?.self)
   }
-  
-  @inlinable
-  @inline(__always)
+
   internal func _inject(
     _ continuation: UnsafeContinuation<Element, Error>
   ) -> UnsafeContinuation<Element, Error>? {

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -1,6 +1,3 @@
-import Swift
-import _Concurrency
-
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -15,6 +12,7 @@ import _Concurrency
 
 import Swift
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 public struct YieldingContinuation<Element, Failure: Error>: Sendable {
   @_fixed_layout
   @usableFromInline
@@ -116,6 +114,7 @@ public struct YieldingContinuation<Element, Failure: Error>: Sendable {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension YieldingContinuation where Failure == Never {
   /// Construct a YieldingContinuation with a specific Element type.
   ///
@@ -139,6 +138,7 @@ extension YieldingContinuation where Failure == Never {
   }
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension YieldingContinuation {
   /// Resume the task awaiting the continuation by having it either
   /// return normally or throw an error based on the state of the given

--- a/stdlib/public/Concurrency/YieldingContinuation.swift
+++ b/stdlib/public/Concurrency/YieldingContinuation.swift
@@ -16,7 +16,7 @@ import Swift
 public struct YieldingContinuation<Element, Failure: Error>: Sendable {
   @_fixed_layout
   @usableFromInline
-  internal final class Storage {
+  internal final class Storage: UnsafeSendable {
     @usableFromInline
     var continuation: UnsafeContinuation<Element, Error>?
   }

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -15,10 +15,13 @@ let sleepInterval: UInt64 = 125_000_000
 var tests = TestSuite("YieldingContinuation")
 
 if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+	func forceBeingAsync() async -> Void { }
+
 	tests.test("yield with no awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
 	    expectFalse(continuation.yield("hello"))
+	    await forceBeingAsync()
 	  }
 	}
 
@@ -26,6 +29,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    expectFalse(continuation.yield(throwing: SomeError()))
+	    await forceBeingAsync()
 	  }
 	}
 
@@ -33,6 +37,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
 	    expectFalse(continuation.yield(with: .success("hello")))
+	    await forceBeingAsync()
 	  }
 	}
 
@@ -40,6 +45,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    expectFalse(continuation.yield(with: .failure(SomeError())))
+	    await forceBeingAsync()
 	  }
 	}
 

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -1,0 +1,241 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+import _Concurrency
+import StdlibUnittest
+
+
+struct SomeError: Error, Equatable {
+  var value = Int.random(in: 0..<100)
+}
+
+let sleepInterval: UInt64 = 125_000_000
+var tests = TestSuite("YieldingContinuation")
+
+tests.test("yield with no awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self)
+    expectFalse(continuation.yield("hello"))
+  }
+}
+
+tests.test("yield throwing with no awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+    expectFalse(continuation.yield(throwing: SomeError()))
+  }
+}
+
+tests.test("yield success result no awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self)
+    expectFalse(continuation.yield(with: .success("hello")))
+  }
+}
+
+tests.test("yield failure result no awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+    expectFalse(continuation.yield(with: .failure(SomeError())))
+  }
+}
+
+tests.test("yield with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self)
+    let t = Task.runDetached {
+      let value = await continuation.next()
+      expectEqual(value, "hello")
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield("hello"))
+    await t.get()
+  }
+}
+
+tests.test("yield result with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self)
+    let t = Task.runDetached {
+      let value = await continuation.next()
+      expectEqual(value, "hello")
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(with: .success("hello")))
+    await t.get()
+  }
+}
+
+tests.test("yield throwing with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+    let failure = SomeError()
+    let t = Task.runDetached {
+      do {
+        let value = try await continuation.next()
+        expectUnreachable()
+      } catch {
+        if let error = error as? SomeError {
+          expectEqual(error, failure)
+        } else {
+          expectUnreachable()
+        }
+      }
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(throwing: failure))
+    await t.get()
+  }
+}
+
+tests.test("yield failure with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+    let failure = SomeError()
+    let t = Task.runDetached {
+      do {
+        let value = try await continuation.next()
+        expectUnreachable()
+      } catch {
+        if let error = error as? SomeError {
+          expectEqual(error, failure)
+        } else {
+          expectUnreachable()
+        }
+      }
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(with: .failure(failure)))
+    await t.get()
+  }
+}
+
+tests.test("yield multiple times with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self)
+    let t = Task.runDetached {
+      let value1 = await continuation.next()
+      expectEqual(value1, "hello")
+      let value2 = await continuation.next()
+      expectEqual(value2, "world")
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield("hello"))
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield("world"))
+    await t.get()
+  }
+}
+
+tests.test("yield result multiple times with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self)
+    let t = Task.runDetached {
+      let value1 = await continuation.next()
+      expectEqual(value1, "hello")
+      let value2 = await continuation.next()
+      expectEqual(value2, "world")
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(with: .success("hello")))
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(with: .success("world")))
+    await t.get()
+  }
+}
+
+tests.test("yield throwing multiple times with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+    let failure1 = SomeError()
+    let failure2 = SomeError()
+    let t = Task.runDetached {
+      do {
+        let value1 = try await continuation.next()
+      } catch {
+        if let error = error as? SomeError {
+          expectEqual(error, failure1)
+        } else {
+          expectUnreachable()
+        }
+      }
+      do {
+        let value2 = try await continuation.next()
+      } catch {
+        if let error = error as? SomeError {
+          expectEqual(error, failure2)
+        } else {
+          expectUnreachable()
+        }
+      }
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(throwing: failure1))
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(throwing: failure2))
+    await t.get()
+  }
+}
+
+tests.test("yield failure multiple times with awaiting next") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+    let failure1 = SomeError()
+    let failure2 = SomeError()
+    let t = Task.runDetached {
+      do {
+        let value1 = try await continuation.next()
+      } catch {
+        if let error = error as? SomeError {
+          expectEqual(error, failure1)
+        } else {
+          expectUnreachable()
+        }
+      }
+      do {
+        let value2 = try await continuation.next()
+      } catch {
+        if let error = error as? SomeError {
+          expectEqual(error, failure2)
+        } else {
+          expectUnreachable()
+        }
+      }
+    }
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(with: .failure(failure1)))
+    await Task.sleep(sleepInterval)
+    expectTrue(continuation.yield(with: .failure(failure2)))
+    await t.get()
+  }
+}
+
+tests.test("concurrent value production") {
+  runAsyncAndBlock {
+    let continuation = YieldingContinuation(yielding: String.self)
+    let t1 = Task.runDetached {
+      var result = await continuation.next()
+      expectEqual(result, "hello")
+      result = await continuation.next()
+      expectEqual(result, "world")
+    }
+    
+    let t2 = Task.runDetached {
+      var result = await continuation.next()
+      expectEqual(result, "hello")
+      result = await continuation.next()
+      expectEqual(result, "world")
+    }
+    
+    await Task.sleep(sleepInterval)
+    continuation.yield("hello")
+    await Task.sleep(sleepInterval)
+    continuation.yield("world")
+    await t1.get()
+    await t2.get()
+  }
+}
+
+runAllTests()

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -52,7 +52,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.detach {
+	    let t = detach {
 	      let value = await continuation.next()
 	      expectEqual(value, "hello")
 	    }
@@ -65,7 +65,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield result with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.detach {
+	    let t = detach {
 	      let value = await continuation.next()
 	      expectEqual(value, "hello")
 	    }
@@ -79,7 +79,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure = SomeError()
-	    let t = Task.detach {
+	    let t = detach {
 	      do {
 	        let value = try await continuation.next()
 	        expectUnreachable()
@@ -101,7 +101,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure = SomeError()
-	    let t = Task.detach {
+	    let t = detach {
 	      do {
 	        let value = try await continuation.next()
 	        expectUnreachable()
@@ -122,7 +122,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield multiple times with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.detach {
+	    let t = detach {
 	      let value1 = await continuation.next()
 	      expectEqual(value1, "hello")
 	      let value2 = await continuation.next()
@@ -139,7 +139,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield result multiple times with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.detach {
+	    let t = detach {
 	      let value1 = await continuation.next()
 	      expectEqual(value1, "hello")
 	      let value2 = await continuation.next()
@@ -158,7 +158,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure1 = SomeError()
 	    let failure2 = SomeError()
-	    let t = Task.detach {
+	    let t = detach {
 	      do {
 	        let value1 = try await continuation.next()
 	      } catch {
@@ -191,7 +191,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure1 = SomeError()
 	    let failure2 = SomeError()
-	    let t = Task.detach {
+	    let t = detach {
 	      do {
 	        let value1 = try await continuation.next()
 	      } catch {
@@ -222,14 +222,14 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("concurrent value production") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t1 = Task.detach {
+	    let t1 = detach {
 	      var result = await continuation.next()
 	      expectEqual(result, "hello")
 	      result = await continuation.next()
 	      expectEqual(result, "world")
 	    }
 	    
-	    let t2 = Task.detach {
+	    let t2 = detach {
 	      var result = await continuation.next()
 	      expectEqual(result, "hello")
 	      result = await continuation.next()

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -52,7 +52,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      let value = await continuation.next()
 	      expectEqual(value, "hello")
 	    }
@@ -65,7 +65,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield result with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      let value = await continuation.next()
 	      expectEqual(value, "hello")
 	    }
@@ -79,7 +79,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure = SomeError()
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      do {
 	        let value = try await continuation.next()
 	        expectUnreachable()
@@ -101,7 +101,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure = SomeError()
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      do {
 	        let value = try await continuation.next()
 	        expectUnreachable()
@@ -122,7 +122,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield multiple times with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      let value1 = await continuation.next()
 	      expectEqual(value1, "hello")
 	      let value2 = await continuation.next()
@@ -139,7 +139,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("yield result multiple times with awaiting next") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      let value1 = await continuation.next()
 	      expectEqual(value1, "hello")
 	      let value2 = await continuation.next()
@@ -158,7 +158,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure1 = SomeError()
 	    let failure2 = SomeError()
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      do {
 	        let value1 = try await continuation.next()
 	      } catch {
@@ -191,7 +191,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
 	    let failure1 = SomeError()
 	    let failure2 = SomeError()
-	    let t = Task.runDetached {
+	    let t = Task.detach {
 	      do {
 	        let value1 = try await continuation.next()
 	      } catch {
@@ -222,14 +222,14 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	tests.test("concurrent value production") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
-	    let t1 = Task.runDetached {
+	    let t1 = Task.detach {
 	      var result = await continuation.next()
 	      expectEqual(result, "hello")
 	      result = await continuation.next()
 	      expectEqual(result, "world")
 	    }
 	    
-	    let t2 = Task.runDetached {
+	    let t2 = Task.detach {
 	      var result = await continuation.next()
 	      expectEqual(result, "hello")
 	      result = await continuation.next()

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -27,7 +27,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 
 	tests.test("yield throwing with no awaiting next") {
 	  runAsyncAndBlock {
-	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: Error.self)
 	    expectFalse(continuation.yield(throwing: SomeError()))
 	    await forceBeingAsync()
 	  }
@@ -43,7 +43,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 
 	tests.test("yield failure result no awaiting next") {
 	  runAsyncAndBlock {
-	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: Error.self)
 	    expectFalse(continuation.yield(with: .failure(SomeError())))
 	    await forceBeingAsync()
 	  }
@@ -77,7 +77,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 
 	tests.test("yield throwing with awaiting next") {
 	  runAsyncAndBlock {
-	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: Error.self)
 	    let failure = SomeError()
 	    let t = detach {
 	      do {
@@ -99,7 +99,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 
 	tests.test("yield failure with awaiting next") {
 	  runAsyncAndBlock {
-	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: Error.self)
 	    let failure = SomeError()
 	    let t = detach {
 	      do {
@@ -155,7 +155,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 
 	tests.test("yield throwing multiple times with awaiting next") {
 	  runAsyncAndBlock {
-	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: Error.self)
 	    let failure1 = SomeError()
 	    let failure2 = SomeError()
 	    let t = detach {
@@ -188,7 +188,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 
 	tests.test("yield failure multiple times with awaiting next") {
 	  runAsyncAndBlock {
-	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: Error.self)
 	    let failure1 = SomeError()
 	    let failure2 = SomeError()
 	    let t = detach {

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -219,7 +219,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	  }
 	}
 
-	tests.test("concurrent value production") {
+	tests.test("concurrent value consumption") {
 	  runAsyncAndBlock {
 	    let continuation = YieldingContinuation(yielding: String.self)
 	    let t1 = detach {

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -14,228 +14,229 @@ struct SomeError: Error, Equatable {
 let sleepInterval: UInt64 = 125_000_000
 var tests = TestSuite("YieldingContinuation")
 
-tests.test("yield with no awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self)
-    expectFalse(continuation.yield("hello"))
-  }
-}
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+	tests.test("yield with no awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self)
+	    expectFalse(continuation.yield("hello"))
+	  }
+	}
 
-tests.test("yield throwing with no awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
-    expectFalse(continuation.yield(throwing: SomeError()))
-  }
-}
+	tests.test("yield throwing with no awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    expectFalse(continuation.yield(throwing: SomeError()))
+	  }
+	}
 
-tests.test("yield success result no awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self)
-    expectFalse(continuation.yield(with: .success("hello")))
-  }
-}
+	tests.test("yield success result no awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self)
+	    expectFalse(continuation.yield(with: .success("hello")))
+	  }
+	}
 
-tests.test("yield failure result no awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
-    expectFalse(continuation.yield(with: .failure(SomeError())))
-  }
-}
+	tests.test("yield failure result no awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    expectFalse(continuation.yield(with: .failure(SomeError())))
+	  }
+	}
 
-tests.test("yield with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self)
-    let t = Task.runDetached {
-      let value = await continuation.next()
-      expectEqual(value, "hello")
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield("hello"))
-    await t.get()
-  }
-}
+	tests.test("yield with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self)
+	    let t = Task.runDetached {
+	      let value = await continuation.next()
+	      expectEqual(value, "hello")
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield("hello"))
+	    await t.get()
+	  }
+	}
 
-tests.test("yield result with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self)
-    let t = Task.runDetached {
-      let value = await continuation.next()
-      expectEqual(value, "hello")
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(with: .success("hello")))
-    await t.get()
-  }
-}
+	tests.test("yield result with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self)
+	    let t = Task.runDetached {
+	      let value = await continuation.next()
+	      expectEqual(value, "hello")
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(with: .success("hello")))
+	    await t.get()
+	  }
+	}
 
-tests.test("yield throwing with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
-    let failure = SomeError()
-    let t = Task.runDetached {
-      do {
-        let value = try await continuation.next()
-        expectUnreachable()
-      } catch {
-        if let error = error as? SomeError {
-          expectEqual(error, failure)
-        } else {
-          expectUnreachable()
-        }
-      }
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(throwing: failure))
-    await t.get()
-  }
-}
+	tests.test("yield throwing with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let failure = SomeError()
+	    let t = Task.runDetached {
+	      do {
+	        let value = try await continuation.next()
+	        expectUnreachable()
+	      } catch {
+	        if let error = error as? SomeError {
+	          expectEqual(error, failure)
+	        } else {
+	          expectUnreachable()
+	        }
+	      }
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(throwing: failure))
+	    await t.get()
+	  }
+	}
 
-tests.test("yield failure with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
-    let failure = SomeError()
-    let t = Task.runDetached {
-      do {
-        let value = try await continuation.next()
-        expectUnreachable()
-      } catch {
-        if let error = error as? SomeError {
-          expectEqual(error, failure)
-        } else {
-          expectUnreachable()
-        }
-      }
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(with: .failure(failure)))
-    await t.get()
-  }
-}
+	tests.test("yield failure with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let failure = SomeError()
+	    let t = Task.runDetached {
+	      do {
+	        let value = try await continuation.next()
+	        expectUnreachable()
+	      } catch {
+	        if let error = error as? SomeError {
+	          expectEqual(error, failure)
+	        } else {
+	          expectUnreachable()
+	        }
+	      }
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(with: .failure(failure)))
+	    await t.get()
+	  }
+	}
 
-tests.test("yield multiple times with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self)
-    let t = Task.runDetached {
-      let value1 = await continuation.next()
-      expectEqual(value1, "hello")
-      let value2 = await continuation.next()
-      expectEqual(value2, "world")
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield("hello"))
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield("world"))
-    await t.get()
-  }
-}
+	tests.test("yield multiple times with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self)
+	    let t = Task.runDetached {
+	      let value1 = await continuation.next()
+	      expectEqual(value1, "hello")
+	      let value2 = await continuation.next()
+	      expectEqual(value2, "world")
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield("hello"))
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield("world"))
+	    await t.get()
+	  }
+	}
 
-tests.test("yield result multiple times with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self)
-    let t = Task.runDetached {
-      let value1 = await continuation.next()
-      expectEqual(value1, "hello")
-      let value2 = await continuation.next()
-      expectEqual(value2, "world")
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(with: .success("hello")))
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(with: .success("world")))
-    await t.get()
-  }
-}
+	tests.test("yield result multiple times with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self)
+	    let t = Task.runDetached {
+	      let value1 = await continuation.next()
+	      expectEqual(value1, "hello")
+	      let value2 = await continuation.next()
+	      expectEqual(value2, "world")
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(with: .success("hello")))
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(with: .success("world")))
+	    await t.get()
+	  }
+	}
 
-tests.test("yield throwing multiple times with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
-    let failure1 = SomeError()
-    let failure2 = SomeError()
-    let t = Task.runDetached {
-      do {
-        let value1 = try await continuation.next()
-      } catch {
-        if let error = error as? SomeError {
-          expectEqual(error, failure1)
-        } else {
-          expectUnreachable()
-        }
-      }
-      do {
-        let value2 = try await continuation.next()
-      } catch {
-        if let error = error as? SomeError {
-          expectEqual(error, failure2)
-        } else {
-          expectUnreachable()
-        }
-      }
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(throwing: failure1))
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(throwing: failure2))
-    await t.get()
-  }
-}
+	tests.test("yield throwing multiple times with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let failure1 = SomeError()
+	    let failure2 = SomeError()
+	    let t = Task.runDetached {
+	      do {
+	        let value1 = try await continuation.next()
+	      } catch {
+	        if let error = error as? SomeError {
+	          expectEqual(error, failure1)
+	        } else {
+	          expectUnreachable()
+	        }
+	      }
+	      do {
+	        let value2 = try await continuation.next()
+	      } catch {
+	        if let error = error as? SomeError {
+	          expectEqual(error, failure2)
+	        } else {
+	          expectUnreachable()
+	        }
+	      }
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(throwing: failure1))
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(throwing: failure2))
+	    await t.get()
+	  }
+	}
 
-tests.test("yield failure multiple times with awaiting next") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
-    let failure1 = SomeError()
-    let failure2 = SomeError()
-    let t = Task.runDetached {
-      do {
-        let value1 = try await continuation.next()
-      } catch {
-        if let error = error as? SomeError {
-          expectEqual(error, failure1)
-        } else {
-          expectUnreachable()
-        }
-      }
-      do {
-        let value2 = try await continuation.next()
-      } catch {
-        if let error = error as? SomeError {
-          expectEqual(error, failure2)
-        } else {
-          expectUnreachable()
-        }
-      }
-    }
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(with: .failure(failure1)))
-    await Task.sleep(sleepInterval)
-    expectTrue(continuation.yield(with: .failure(failure2)))
-    await t.get()
-  }
-}
+	tests.test("yield failure multiple times with awaiting next") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self, throwing: SomeError.self)
+	    let failure1 = SomeError()
+	    let failure2 = SomeError()
+	    let t = Task.runDetached {
+	      do {
+	        let value1 = try await continuation.next()
+	      } catch {
+	        if let error = error as? SomeError {
+	          expectEqual(error, failure1)
+	        } else {
+	          expectUnreachable()
+	        }
+	      }
+	      do {
+	        let value2 = try await continuation.next()
+	      } catch {
+	        if let error = error as? SomeError {
+	          expectEqual(error, failure2)
+	        } else {
+	          expectUnreachable()
+	        }
+	      }
+	    }
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(with: .failure(failure1)))
+	    await Task.sleep(sleepInterval)
+	    expectTrue(continuation.yield(with: .failure(failure2)))
+	    await t.get()
+	  }
+	}
 
-tests.test("concurrent value production") {
-  runAsyncAndBlock {
-    let continuation = YieldingContinuation(yielding: String.self)
-    let t1 = Task.runDetached {
-      var result = await continuation.next()
-      expectEqual(result, "hello")
-      result = await continuation.next()
-      expectEqual(result, "world")
-    }
-    
-    let t2 = Task.runDetached {
-      var result = await continuation.next()
-      expectEqual(result, "hello")
-      result = await continuation.next()
-      expectEqual(result, "world")
-    }
-    
-    await Task.sleep(sleepInterval)
-    continuation.yield("hello")
-    await Task.sleep(sleepInterval)
-    continuation.yield("world")
-    await t1.get()
-    await t2.get()
-  }
+	tests.test("concurrent value production") {
+	  runAsyncAndBlock {
+	    let continuation = YieldingContinuation(yielding: String.self)
+	    let t1 = Task.runDetached {
+	      var result = await continuation.next()
+	      expectEqual(result, "hello")
+	      result = await continuation.next()
+	      expectEqual(result, "world")
+	    }
+	    
+	    let t2 = Task.runDetached {
+	      var result = await continuation.next()
+	      expectEqual(result, "hello")
+	      result = await continuation.next()
+	      expectEqual(result, "world")
+	    }
+	    
+	    await Task.sleep(sleepInterval)
+	    continuation.yield("hello")
+	    await Task.sleep(sleepInterval)
+	    continuation.yield("world")
+	    await t1.get()
+	    await t2.get()
+	  }
+	}
 }
-
 runAllTests()

--- a/test/Concurrency/Runtime/yielding_continuation.swift
+++ b/test/Concurrency/Runtime/yielding_continuation.swift
@@ -161,6 +161,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	    let t = detach {
 	      do {
 	        let value1 = try await continuation.next()
+	        expectUnreachable()
 	      } catch {
 	        if let error = error as? SomeError {
 	          expectEqual(error, failure1)
@@ -194,6 +195,7 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
 	    let t = detach {
 	      do {
 	        let value1 = try await continuation.next()
+	        expectUnreachable()
 	      } catch {
 	        if let error = error as? SomeError {
 	          expectEqual(error, failure1)


### PR DESCRIPTION
This implements a YieldingContinuation type suitable for emitting values more than once via a yielding family of functions and awaiting production via next

This is a type suitable for usage points that need to resume an awaiting function more than once. This can be used to implement AsyncIteratorProtocol adopters for AsyncSequence that are sourced from state that is external from the control of the iterator. Callbacks or delegation can be passed this continuation type (unlike the Unsafe and Checked variants usable for singular callbacks) as an escaping/sendable concept. This means that the continuation can escape into closures that get called more than once. Yielding will return a boolean state identifying that the continuation was resumed or not. Ignoring this will result in a dropping style behavior (e.g. if no one is awaiting a value the value will be dropped). Implementors of async iterators need to choose if the values are distinct and need to be buffered for use before the next awaiting call is invoked. 

