### PR TITLE
Improved error handling for composed property wrapper mismatches

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5678,8 +5678,8 @@ ERROR(wrapped_value_mismatch, none,
       "property type %0 does not match 'wrappedValue' type %1",
       (Type, Type))
 ERROR(composed_property_wrapper_mismatch, none,
-      "composed wrapper type %0 does not match the type of %1.wrappedValue, which is %2",
-      (Type, Type, Type))
+      "composed wrapper type %0 does not match type of '%1.wrappedValue', which is %2",
+      (Type, StringRef, Type))
 
 ERROR(property_wrapper_type_access,none,
       "%select{%select{variable|constant}0|property}1 "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5678,8 +5678,8 @@ ERROR(wrapped_value_mismatch, none,
       "property type %0 does not match 'wrappedValue' type %1",
       (Type, Type))
 ERROR(composed_property_wrapper_mismatch, none,
-      "composed wrapper type %0 does not match former 'wrappedValue' type %1",
-      (Type, Type))
+      "composed wrapper type %0 does not match the type of %1.wrappedValue, which is %2",
+      (Type, Type, Type))
 
 ERROR(property_wrapper_type_access,none,
       "%select{%select{variable|constant}0|property}1 "

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -322,10 +322,11 @@ enum class FixKind : uint8_t {
   /// even though result type of the reference doesn't conform
   /// to an expected protocol.
   AllowInvalidStaticMemberRefOnProtocolMetatype,
-    
-  /// Allow the wrappedValue type of the outermost property
-  /// wrapper of a composed property wrapper to mismatch
-  /// the type of its innermost property wrapper.
+
+  /// Allow the wrappedValue type of any property wrapper that is a
+  /// part of a composed property wrapper to mismatch the type of
+  /// another property wrapper that is a part of the same composed
+  /// property wrapper.
   AllowWrappedValueMismatch,
 };
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -322,6 +322,11 @@ enum class FixKind : uint8_t {
   /// even though result type of the reference doesn't conform
   /// to an expected protocol.
   AllowInvalidStaticMemberRefOnProtocolMetatype,
+    
+  /// Allow the wrappedValue type of the outermost property
+  /// wrapper of a composed property wrapper to mismatch
+  /// the type of its innermost property wrapper.
+  AllowWrappedValueMismatch,
 };
 
 class ConstraintFix {
@@ -613,6 +618,20 @@ public:
   static TreatArrayLiteralAsDictionary *create(ConstraintSystem &cs,
                                                Type dictionaryTy, Type arrayTy,
                                                ConstraintLocator *loc);
+};
+
+class AllowWrappedValueMismatch : public ContextualMismatch {
+  AllowWrappedValueMismatch(ConstraintSystem &cs, Type lhs, Type rhs,
+                            ConstraintLocator *locator)
+      : ContextualMismatch(cs, FixKind::AllowWrappedValueMismatch, lhs, rhs, locator) {}
+
+public:
+  std::string getName() const override { return "fix wrapped value type mismatch"; }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowWrappedValueMismatch *create(ConstraintSystem &cs, Type lhs, Type rhs,
+                                           ConstraintLocator *locator);
 };
 
 /// Mark function type as explicitly '@escaping'.

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -212,9 +212,10 @@ public:
   /// Determine whether this locator points to the generic parameter.
   bool isForGenericParameter() const;
 
-  /// Determine whether this locator points to the outer
-  /// property wrapper's type for a given composed property
-  /// wrapper.
+  /// Determine whether this locator points to any of the
+  /// property wrappers' types for a given composed property
+  /// wrapper, with the exception of the innermost property wrapper's
+  /// type.
   bool isForWrappedValue() const;
 
   /// Determine whether this locator points to the element type of a
@@ -360,10 +361,11 @@ public:
 
   /// If this locator points to generic parameter return its type.
   GenericTypeParamType *getGenericParameter() const;
-    
-  /// If this locator points to the outer property wrapper's
-  /// type for a given composed property wrapper.
-  TypeBase *getWrappedValue() const;
+
+  /// If this locator points to any of the property wrappers' types
+  /// for a given composed property wrapper, with the exception
+  /// of the innermost property wrapper's type.
+  Type getWrappedValue() const;
 
   /// Produce a profile of this locator, for use in a folding set.
   static void Profile(llvm::FoldingSetNodeID &id, ASTNode anchor,
@@ -703,13 +705,12 @@ public:
 
 class LocatorPathElt::WrappedValue final : public StoredPointerElement<TypeBase> {
 public:
-  WrappedValue(TypeBase *type)
-      : StoredPointerElement(PathElementKind::WrappedValue, type) {
+  WrappedValue(Type type)
+      : StoredPointerElement(PathElementKind::WrappedValue, type.getPointer()) {
+    assert(type.getPointer() != nullptr);
   }
 
-  TypeBase *getType() const {
-    return getStoredPointer();
-  }
+  Type getType() const { return getStoredPointer(); }
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == PathElementKind::WrappedValue;

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -212,6 +212,11 @@ public:
   /// Determine whether this locator points to the generic parameter.
   bool isForGenericParameter() const;
 
+  /// Determine whether this locator points to the outer
+  /// property wrapper's type for a given composed property
+  /// wrapper.
+  bool isForWrappedValue() const;
+
   /// Determine whether this locator points to the element type of a
   /// sequence in a for ... in ... loop.
   bool isForSequenceElementType() const;
@@ -355,6 +360,10 @@ public:
 
   /// If this locator points to generic parameter return its type.
   GenericTypeParamType *getGenericParameter() const;
+    
+  /// If this locator points to the outer property wrapper's
+  /// type for a given composed property wrapper.
+  TypeBase *getWrappedValue() const;
 
   /// Produce a profile of this locator, for use in a folding set.
   static void Profile(llvm::FoldingSetNodeID &id, ASTNode anchor,
@@ -689,6 +698,21 @@ public:
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == PathElementKind::GenericParameter;
+  }
+};
+
+class LocatorPathElt::WrappedValue final : public StoredPointerElement<TypeBase> {
+public:
+  WrappedValue(TypeBase *type)
+      : StoredPointerElement(PathElementKind::WrappedValue, type) {
+  }
+
+  TypeBase *getType() const {
+    return getStoredPointer();
+  }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == PathElementKind::WrappedValue;
   }
 };
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -96,7 +96,7 @@ SIMPLE_LOCATOR_PATH_ELT(InstanceType)
 /// Also contains the generic parameter type itself.
 CUSTOM_LOCATOR_PATH_ELT(GenericParameter)
 
-/// The former wrappedValue type for a property wrapper.
+/// The wrappedValue type for a property wrapper.
 ///
 /// Must equal the property declaration's property wrapper type.
 CUSTOM_LOCATOR_PATH_ELT(WrappedValue)

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -96,6 +96,11 @@ SIMPLE_LOCATOR_PATH_ELT(InstanceType)
 /// Also contains the generic parameter type itself.
 CUSTOM_LOCATOR_PATH_ELT(GenericParameter)
 
+/// The former wrappedValue type for a property wrapper.
+///
+/// Must equal the property declaration's property wrapper type.
+CUSTOM_LOCATOR_PATH_ELT(WrappedValue)
+
 /// A component of a key path.
 CUSTOM_LOCATOR_PATH_ELT(KeyPathComponent)
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -350,9 +350,10 @@ bool RequirementFailure::isStaticOrInstanceMember(const ValueDecl *decl) {
 
 bool WrappedValueMismatch::diagnoseAsError() {
   auto *locator = getLocator();
-  auto elt = locator->getLastElementAs<LocatorPathElt::WrappedValue>();
+  auto elt = locator->castLastElementTo<LocatorPathElt::WrappedValue>();
 
-  emitDiagnostic(diag::composed_property_wrapper_mismatch, resolveType(getFromType()), elt->getType(), getToType());
+  emitDiagnostic(diag::composed_property_wrapper_mismatch, getFromType(),
+                 resolveType(elt.getType())->getString(), getToType());
 
   return true;
 }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -348,6 +348,15 @@ bool RequirementFailure::isStaticOrInstanceMember(const ValueDecl *decl) {
   return decl->isStatic();
 }
 
+bool WrappedValueMismatch::diagnoseAsError() {
+  auto *locator = getLocator();
+  auto elt = locator->getLastElementAs<LocatorPathElt::WrappedValue>();
+
+  emitDiagnostic(diag::composed_property_wrapper_mismatch, resolveType(getFromType()), elt->getType(), getToType());
+
+  return true;
+}
+
 bool RequirementFailure::diagnoseAsError() {
   const auto *reqDC = getRequirementDC();
   auto *genericCtx = getGenericContext();
@@ -639,11 +648,10 @@ Optional<Diag<Type, Type>> GenericArgumentsMismatchFailure::getDiagnosticFor(
     return diag::cannot_convert_condition_value;
   case CTP_WrappedProperty:
     return diag::wrapped_value_mismatch;
-  case CTP_ComposedPropertyWrapper:
-    return diag::composed_property_wrapper_mismatch;
 
   case CTP_ThrowStmt:
   case CTP_ForEachStmt:
+  case CTP_ComposedPropertyWrapper:
   case CTP_Unused:
   case CTP_CannotFail:
   case CTP_YieldByReference:
@@ -3132,11 +3140,10 @@ ContextualFailure::getDiagnosticFor(ContextualTypePurpose context,
 
   case CTP_WrappedProperty:
     return diag::wrapped_value_mismatch;
-  case CTP_ComposedPropertyWrapper:
-    return diag::composed_property_wrapper_mismatch;
 
   case CTP_ThrowStmt:
   case CTP_ForEachStmt:
+  case CTP_ComposedPropertyWrapper:
   case CTP_Unused:
   case CTP_CannotFail:
   case CTP_YieldByReference:

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -769,6 +769,16 @@ private:
   void offerForceUnwrapFixIt(const Expr *expr) const;
 };
 
+class WrappedValueMismatch final : public ContextualFailure {
+public:
+  WrappedValueMismatch(const Solution &solution, Type fromType,
+                       Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {
+  }
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnostics for mismatched generic arguments e.g
 /// ```swift
 /// struct F<G> {}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -374,7 +374,7 @@ ContextualMismatch *ContextualMismatch::create(ConstraintSystem &cs, Type lhs,
 
 bool AllowWrappedValueMismatch::diagnose(const Solution &solution, bool asError) const {
   WrappedValueMismatch failure(solution, getFromType(), getToType(), getLocator());
-  return(failure.diagnoseAsError());
+  return failure.diagnoseAsError();
 }
 
 AllowWrappedValueMismatch *AllowWrappedValueMismatch::create(ConstraintSystem &cs,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -372,6 +372,18 @@ ContextualMismatch *ContextualMismatch::create(ConstraintSystem &cs, Type lhs,
   return new (cs.getAllocator()) ContextualMismatch(cs, lhs, rhs, locator);
 }
 
+bool AllowWrappedValueMismatch::diagnose(const Solution &solution, bool asError) const {
+  WrappedValueMismatch failure(solution, getFromType(), getToType(), getLocator());
+  return(failure.diagnoseAsError());
+}
+
+AllowWrappedValueMismatch *AllowWrappedValueMismatch::create(ConstraintSystem &cs,
+                                                             Type lhs,
+                                                             Type rhs,
+                                                             ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowWrappedValueMismatch(cs, lhs, rhs, locator);
+}
+
 /// Computes the contextual type information for a type mismatch of a
 /// component in a structural type (tuple or function type).
 ///

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3613,7 +3613,7 @@ static bool generateWrappedPropertyTypeConstraints(
     } else {
       // The former wrappedValue type must be equal to the current wrapper type
       auto *locator = cs.getConstraintLocator(
-          typeExpr, LocatorPathElt::WrappedValue(wrapperType.getPointer()));
+          typeExpr, LocatorPathElt::WrappedValue(wrapperType));
       wrapperType =
           cs.replaceInferableTypesWithTypeVars(rawWrapperType, locator);
       cs.addConstraint(ConstraintKind::Equal, wrapperType, wrappedValueType, locator);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3590,7 +3590,7 @@ static bool generateWrappedPropertyTypeConstraints(
   auto dc = wrappedVar->getInnermostDeclContext();
 
   Type wrappedValueType;
-  Type wrapperType = initializerType;
+  Type wrapperType;
   auto wrapperAttributes = wrappedVar->getAttachedPropertyWrappers();
   for (unsigned i : indices(wrapperAttributes)) {
     // FIXME: We should somehow pass an OpenUnboundGenericTypeFn to
@@ -3602,18 +3602,24 @@ static bool generateWrappedPropertyTypeConstraints(
       return true;
 
     auto *typeExpr = wrapperAttributes[i]->getTypeExpr();
-    auto *locator = cs.getConstraintLocator(typeExpr, LocatorPathElt::WrappedValue(wrapperType.getPointer()));
-    wrapperType = cs.replaceInferableTypesWithTypeVars(rawWrapperType, locator);
-    cs.setType(typeExpr, wrapperType);
 
     if (!wrappedValueType) {
       // Equate the outermost wrapper type to the initializer type.
+      auto *locator = cs.getConstraintLocator(typeExpr);
+      wrapperType =
+          cs.replaceInferableTypesWithTypeVars(rawWrapperType, locator);
       if (initializerType)
         cs.addConstraint(ConstraintKind::Equal, wrapperType, initializerType, locator);
     } else {
       // The former wrappedValue type must be equal to the current wrapper type
+      auto *locator = cs.getConstraintLocator(
+          typeExpr, LocatorPathElt::WrappedValue(wrapperType.getPointer()));
+      wrapperType =
+          cs.replaceInferableTypesWithTypeVars(rawWrapperType, locator);
       cs.addConstraint(ConstraintKind::Equal, wrapperType, wrappedValueType, locator);
     }
+
+    cs.setType(typeExpr, wrapperType);
 
     wrappedValueType = wrapperType->getTypeOfMember(
         dc->getParentModule(), wrapperInfo.valueVar);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11260,6 +11260,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowUnsupportedRuntimeCheckedCast:
   case FixKind::AllowAlwaysSucceedCheckedCast:
   case FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype:
+  case FixKind::AllowWrappedValueMismatch:
   case FixKind::RemoveExtraneousArguments: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
@@ -11396,11 +11397,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     }
 
     return SolutionKind::Solved;
-  }
-          
-  case FixKind::AllowWrappedValueMismatch: {
-    if (recordFix(fix)) return SolutionKind::Error;
-      return SolutionKind::Solved;
   }
 
   case FixKind::UseSubscriptOperator:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4312,6 +4312,12 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::WrappedValue: {
+    conversionsOrFixes.push_back(AllowWrappedValueMismatch::create(
+            *this, lhs, rhs, getConstraintLocator(locator)));
+    break;
+  }
+
   case ConstraintLocator::FunctionArgument: {
     auto *argLoc = getConstraintLocator(
         locator.withPathElement(LocatorPathElt::SynthesizedArgument(0)));
@@ -11390,6 +11396,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     }
 
     return SolutionKind::Solved;
+  }
+          
+  case FixKind::AllowWrappedValueMismatch: {
+    if (recordFix(fix)) return SolutionKind::Error;
+      return SolutionKind::Solved;
   }
 
   case FixKind::UseSubscriptOperator:

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -223,9 +223,10 @@ GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
       castLastElementTo<LocatorPathElt::GenericParameter>().getType() : nullptr;
 }
 
-TypeBase *ConstraintLocator::getWrappedValue() const {
-  return isForWrappedValue() ?
-      castLastElementTo<LocatorPathElt::WrappedValue>().getType() : nullptr;
+Type ConstraintLocator::getWrappedValue() const {
+  return isForWrappedValue()
+             ? castLastElementTo<LocatorPathElt::WrappedValue>().getType()
+             : Type();
 }
 
 void ConstraintLocator::dump(SourceManager *sm) const {
@@ -283,7 +284,7 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
     case WrappedValue: {
       auto wrappedValueElt = elt.castTo<LocatorPathElt::WrappedValue>();
       out << "composed property wrapper type '"
-      << wrappedValueElt.getType()->getString(PO) << "'";
+          << wrappedValueElt.getType()->getString(PO) << "'";
       break;
     }
     case ApplyArgument:

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -60,6 +60,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::DynamicType:
   case ConstraintLocator::SubscriptMember:
   case ConstraintLocator::OpenedGeneric:
+  case ConstraintLocator::WrappedValue:
   case ConstraintLocator::GenericParameter:
   case ConstraintLocator::GenericArgument:
   case ConstraintLocator::NamedTupleElement:
@@ -188,6 +189,10 @@ bool ConstraintLocator::isForGenericParameter() const {
   return isLastElement<LocatorPathElt::GenericParameter>();
 }
 
+bool ConstraintLocator::isForWrappedValue() const {
+  return isLastElement<LocatorPathElt::WrappedValue>();
+}
+
 bool ConstraintLocator::isForSequenceElementType() const {
   return isLastElement<LocatorPathElt::SequenceElementType>();
 }
@@ -216,6 +221,11 @@ GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter.
   return isForGenericParameter() ?
       castLastElementTo<LocatorPathElt::GenericParameter>().getType() : nullptr;
+}
+
+TypeBase *ConstraintLocator::getWrappedValue() const {
+  return isForWrappedValue() ?
+      castLastElementTo<LocatorPathElt::WrappedValue>().getType() : nullptr;
 }
 
 void ConstraintLocator::dump(SourceManager *sm) const {
@@ -268,6 +278,12 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
     case GenericParameter: {
       auto gpElt = elt.castTo<LocatorPathElt::GenericParameter>();
       out << "generic parameter '" << gpElt.getType()->getString(PO) << "'";
+      break;
+    }
+    case WrappedValue: {
+      auto wrappedValueElt = elt.castTo<LocatorPathElt::WrappedValue>();
+      out << "composed property wrapper type '"
+      << wrappedValueElt.getType()->getString(PO) << "'";
       break;
     }
     case ApplyArgument:

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1097,9 +1097,9 @@ struct TestComposition {
   @WrapperD<WrapperC, Int, String> @WrapperC var p4: Int?
   @WrapperD<WrapperC, Int, String> @WrapperE var p5: Int // expected-error{{generic parameter 'Value' could not be inferred}}
     // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
-    // expected-error@-2 {{composed wrapper type 'WrapperE<Int>' does not match the type of 'WrapperD<WrapperC<_>, Int, String>'.wrappedValue, which is 'WrapperC<Value>'}}
+    // expected-error@-2 {{composed wrapper type 'WrapperE<Int>' does not match type of 'WrapperD<WrapperC<Value>, Int, String>.wrappedValue', which is 'WrapperC<Value>'}}
 
-  @Wrapper<String> @Wrapper var value: Int // expected-error{{composed wrapper type 'Wrapper<Int>' does not match the type of 'Wrapper<String>'.wrappedValue, which is 'String'}}
+  @Wrapper<String> @Wrapper var value: Int // expected-error{{composed wrapper type 'Wrapper<Int>' does not match type of 'Wrapper<String>.wrappedValue', which is 'String'}}
 
 	func triggerErrors(d: Double) { // expected-note 6 {{mark method 'mutating' to make 'self' mutable}} {{2-2=mutating }}
 		p1 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}} {{8-8=Int(}} {{9-9=)}}

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1096,8 +1096,10 @@ struct TestComposition {
   @WrapperD<WrapperE, Int, String> @WrapperE var p3: Int?
   @WrapperD<WrapperC, Int, String> @WrapperC var p4: Int?
   @WrapperD<WrapperC, Int, String> @WrapperE var p5: Int // expected-error{{generic parameter 'Value' could not be inferred}}
-  // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
-  // expected-error@-2 {{composed wrapper type 'WrapperE<Int>' does not match former 'wrappedValue' type 'WrapperC<Value>'}}
+    // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+    // expected-error@-2 {{composed wrapper type 'WrapperE<Int>' does not match the type of 'WrapperD<WrapperC<_>, Int, String>'.wrappedValue, which is 'WrapperC<Value>'}}
+
+  @Wrapper<String> @Wrapper var value: Int // expected-error{{composed wrapper type 'Wrapper<Int>' does not match the type of 'Wrapper<String>'.wrappedValue, which is 'String'}}
 
 	func triggerErrors(d: Double) { // expected-note 6 {{mark method 'mutating' to make 'self' mutable}} {{2-2=mutating }}
 		p1 = d // expected-error{{cannot assign value of type 'Double' to type 'Int?'}} {{8-8=Int(}} {{9-9=)}}

--- a/validation-test/compiler_crashers_2_fixed/sr11599.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11599.swift
@@ -11,5 +11,5 @@ struct B {
 }
 
 struct C {
-  @A @B var foo: Int // expected-error{{composed wrapper type 'B' does not match former 'wrappedValue' type 'Int'}}
+  @A @B var foo: Int // expected-error{{composed wrapper type 'B' does not match type of 'A.wrappedValue', which is 'Int'}}
 }


### PR DESCRIPTION
The purpose of this pull request is to remedy a confusing error associated with wrapped value type mismatches to give more context for the wrapped value type in the error message. So that when running this block of code:

```swift
@propertyWrapper struct Wrapper<Value> {
    var wrappedValue: Value
}


struct User {
    @Wrapper<String> @Wrapper var value: Int
}
```

the new error message for the above example would be 

```
composed wrapper type 'Wrapper<Int>' does not match the type of 'Wrapper<String>'.wrappedValue, which is 'String'
```

Should this change not have been made, the error would have looked like the following:

```
composed wrapper type 'Wrapper<Int>' does not match former 'wrappedValue' type 'String'
```

which is rather confusing. 

NOTE: There is an existing diagnostic, called wrapped_value_mismatch that should be combine with this diagnostic, called composed_property_wrapper_mismatch. There are too many separate modifications to include in this PR in order to combine these two diagnostics, so that will be done in a separate PR.  

Resolves:
https://bugs.swift.org/browse/SR-14130

Thank you @hborla for all of your help with this!