### PR TITLE
[CodeCompletion][Parse] Don't drop the contained expression when completing within an InOutExpr

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -533,7 +533,7 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
 
     ParserResult<Expr> SubExpr = parseExprUnary(Message, isExprBasic);
     if (SubExpr.hasCodeCompletion())
-      return makeParserCodeCompletionResult<Expr>();
+      return makeParserCodeCompletionResult<Expr>(SubExpr.getPtrOrNull());
     if (SubExpr.isNull())
       return nullptr;
     return makeParserResult(

--- a/validation-test/IDE/crashers_2_fixed/rdar75366814.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar75366814.swift
@@ -1,0 +1,3 @@
+// RUN: %swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename %s
+
+if undefined(&self.#^COMPLETE^#


### PR DESCRIPTION
When completing within an `InOutExpr` like `&foo.<complete>`, we were forming a `CodeCompletionExpr` with a base when parsing the content of the `InOutExpr` and storing it in `CodeCompletionCallbacksImpl::CodeCompleteTokenExpr`. Whenever the result of that parse contained a code completion though, we were dropping it completely and returning an empty code completion `ParseResult` in place of the inout expression, which resulted in later code inserting a different `CodeCompletionExpr` into the AST that had no base expression. The solver-based completion implementation would later ask for the type of the `CodeCompletionExpr` and its base using the expression stored in `CodeCompletionCallbacksImpl::CodeCompleteTokenExpr`, but that never actually ended up in the AST, resulting in an assertion hit about the expression not having a type in the formed solution(s).

Resolves rdar://75366814