### PR TITLE
Disable mandatory-copy-propagation (-Onone only)

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -847,7 +847,7 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   P.startPipeline("non-Diagnostic Enabling Mandatory Optimizations");
   P.addForEachLoopUnroll();
   P.addMandatoryCombine();
-  if (!P.getOptions().DisableCopyPropagation) {
+  if (P.getOptions().EnableCopyPropagation) {
     // MandatoryCopyPropagation should only be run at -Onone, not -O.
     P.addMandatoryCopyPropagation();
   }

--- a/test/IRGen/unmanaged_objc_throw_func.swift
+++ b/test/IRGen/unmanaged_objc_throw_func.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -enable-copy-propagation %s | %FileCheck %s
 // REQUIRES: objc_interop
 // REQUIRES: optimized_stdlib
 

--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Onone -parse-stdlib) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
+// RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
 // RUN: %target-run-simple-swift(-O -parse-stdlib) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
 
 // REQUIRES: executable_test

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -2,8 +2,7 @@
 
 // CHECK: ---
 // CHECK: name:            non-Diagnostic Enabling Mandatory Optimizations
-// CHECK: passes:          [ "for-each-loop-unroll", "mandatory-combine", "mandatory-copy-propagation",
-// CHECK:                    "mandatory-arc-opts" ]
+// CHECK: passes:          [ "for-each-loop-unroll", "mandatory-combine", "mandatory-arc-opts" ]
 // CHECK: ---
 // CHECK: name:            Serialization
 // CHECK: passes:          [ "serialize-sil", "ownership-model-eliminator" ]


### PR DESCRIPTION
This feature degrades the debugging experience and causes a large
number of unit test failures.

These were both known issues, but our planned debugger improvements
won't be ready for a while. Until then, we'll leave the feature under
a compiler option, and developers can adopt it at there own speed for
now when they are ready to fix lifetime issues in their code.

rdar://76177280 (Disable mandatory-copy-propagation (-Onone only))

