### PR TITLE
XFAIL  IDE/complete_where_clause.swift

### DIFF
--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
+// REQUIRES: rdar76184601
+
 class A1<T1, T2, T3> {}
 
 class A2<T4, T5> {}


### PR DESCRIPTION
The failure blocks PR testing.

/branch-main/swift/test/IDE/complete_where_clause.swift:69:19: error: GEN_T_DOT-DAG: expected string not found in input
// GEN_T_DOT-DAG: Keyword/None: Type[#T.Type#];
                  ^
/branch-main/buildbot_incremental/swift-macosx-x86_64/test-watchsimulator-i386/IDE/Output/complete_where_clause.swift.tmp/complete-FUNC_4.result:2:18: note: scanning from here
Begin completions, 1 items
                 ^
/branch-main/buildbot_incremental/swift-macosx-x86_64/test-watchsimulator-i386/IDE/Output/complete_where_clause.swift.tmp/complete-FUNC_4.result:3:1: note: possible intended match here
Keyword/None: Type[#<<error type>>.Type#]; name=Type
^

Input file: /branch-main/buildbot_incremental/swift-macosx-x86_64/test-watchsimulator-i386/IDE/Output/complete_where_clause.swift.tmp/complete-FUNC_4.result
Check file: /branch-main/swift/test/IDE/complete_where_clause.swift

-dump-input=help explains the following input dump.

Input was:
<<<<<<
          1: // Token: FUNC_4
          2: Begin completions, 1 items
dag:69'0                      X~~~~~~~~ error: no match found
          3: Keyword/None: Type[#<<error type>>.Type#]; name=Type
dag:69'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
dag:69'1     ?                                                    possible intended match
          4: End completions
dag:69'0     ~~~~~~~~~~~~~~~
>>>>>>
