### PR TITLE
[SR-14424] Add 'moveInitialize' test case for small string 'init(unsafeUninitializedCapacity:initializingUTF8With:)'

### DIFF
--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -94,22 +94,34 @@ if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
     }
     expectEqual(str1, str3)
 
-    // Write into uninitialized space
+    // Write into uninitialized space.
     let str4 = String(unsafeUninitializedCapacity: 3) {
       $0[0] = UInt8(ascii: "4")
       $0[1] = UInt8(ascii: "2")
       $0[2] = UInt8(ascii: "X")
+      // Deinitialize memory used for scratch space before returning.
       ($0.baseAddress! + 2).deinitialize(count: 1)
       return 2
     }
     expectEqual(str1, str4)
-    
+
     let str5 = String(unsafeUninitializedCapacity: 3) {
       $0[1] = UInt8(ascii: "4")
       $0[2] = UInt8(ascii: "2")
+      // Move the initialized UTF-8 code units to the start of the buffer,
+      // leaving the non-overlapping source memory uninitialized.
       $0.baseAddress!.moveInitialize(from: $0.baseAddress! + 1, count: 2)
       return 2
     }
     expectEqual(str1, str5)
   }
+
+  // Ensure reasonable behavior despite a deliberate API contract violation.
+  let str6 = String(unsafeUninitializedCapacity: 3) {
+      $0[0] = UInt8(ascii: "4")
+      $0[1] = UInt8(ascii: "2")
+      $0[2] = UInt8(ascii: "X")
+      return 2
+    }
+    expectEqual(str1, str6)
 }

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -114,14 +114,14 @@ if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
       return 2
     }
     expectEqual(str1, str5)
-  }
 
-  // Ensure reasonable behavior despite a deliberate API contract violation.
-  let str6 = String(unsafeUninitializedCapacity: 3) {
+    // Ensure reasonable behavior despite a deliberate API contract violation.
+    let str6 = String(unsafeUninitializedCapacity: 3) {
       $0[0] = UInt8(ascii: "4")
       $0[1] = UInt8(ascii: "2")
       $0[2] = UInt8(ascii: "X")
       return 2
     }
     expectEqual(str1, str6)
+  }
 }

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -99,8 +99,17 @@ if #available(macOS 10.16, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
       $0[0] = UInt8(ascii: "4")
       $0[1] = UInt8(ascii: "2")
       $0[2] = UInt8(ascii: "X")
+      ($0.baseAddress! + 2).deinitialize(count: 1)
       return 2
     }
     expectEqual(str1, str4)
+    
+    let str5 = String(unsafeUninitializedCapacity: 3) {
+      $0[1] = UInt8(ascii: "4")
+      $0[2] = UInt8(ascii: "2")
+      $0.baseAddress!.moveInitialize(from: $0.baseAddress! + 1, count: 2)
+      return 2
+    }
+    expectEqual(str1, str5)
   }
 }


### PR DESCRIPTION
...and make an adjustment to an existing test case.

<!-- What's in this pull request? -->
This PR adds a `moveInitialize` test case, and it adjusts the prior test case for writing into uninitialized memory to fulfill the requirement that unused capacity be uninitialized.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
