### PR TITLE
[test] Also disable test on OpenBSD.

### DIFF
--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -8,6 +8,7 @@
 
 // XFAIL: linux
 // XFAIL: windows
+// XFAIL: openbsd
 
 func test_taskGroup_is_asyncSequence() async {
   let sum: Int = try! await Task.withGroup(resultType: Int.self) { group in


### PR DESCRIPTION
This test fails with a linker error; it looks like this test is disabled
on other platforms, so please disable on OpenBSD also until resolved.