### PR TITLE
[test] Use target_arch for module dir on OpenBSD.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1764,6 +1764,8 @@ if swift_execution_tests_extra_flags:
 relative_platform_module_dir_prefix = ''
 if platform.system() != 'Darwin':
     relative_platform_module_dir_prefix = os.path.join(config.target_sdk_name, run_cpu)
+    if platform.system() == 'OpenBSD':
+      relative_platform_module_dir_prefix = os.path.join(config.target_sdk_name, target_arch)
 platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
 
 platform_dylib_dir = platform_module_dir


### PR DESCRIPTION
On OpenBSD, x86_64 is spelled as amd64, and Swift already uses amd64 for
the module path on this platform. We save the target architecture name as
`target_arch` elsewhere in the lit config file, so on this platform, we
need to use this for the module path.