### PR TITLE
[C++ Interop] Cache failed imports.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3342,7 +3342,8 @@ std::string ClangImporter::getClangModuleHash() const {
 }
 
 Decl *ClangImporter::importDeclCached(const clang::NamedDecl *ClangDecl) {
-  return Impl.importDeclCached(ClangDecl, Impl.CurrentVersion);
+  return Impl.importDeclCached(ClangDecl, Impl.CurrentVersion)
+      .getValueOr(nullptr);
 }
 
 void ClangImporter::printStatistics() const {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2494,7 +2494,7 @@ namespace {
         // case we need to bail here.
         auto cachedResult =
             Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
-        if (cachedResult != Impl.ImportedDecls.end())
+        if (cachedResult != Impl.ImportedDecls.end() && cachedResult->second != nullptr)
           return cachedResult->second;
         dc = cast<ExtensionDecl>(parent)
                  ->getExtendedType()
@@ -3444,7 +3444,7 @@ namespace {
       // this will cause an infinite loop.
       auto alreadyImportedResult =
           Impl.ImportedDecls.find({decl->getCanonicalDecl(), getVersion()});
-      if (alreadyImportedResult != Impl.ImportedDecls.end())
+      if (alreadyImportedResult != Impl.ImportedDecls.end() && alreadyImportedResult->second != nullptr)
         return alreadyImportedResult->second;
       result = Impl.createDeclWithClangNode<StructDecl>(
           decl, AccessLevel::Public, Impl.importSourceLoc(decl->getBeginLoc()),
@@ -4784,7 +4784,7 @@ namespace {
         // methods.
         auto known = Impl.ImportedDecls.find({decl->getCanonicalDecl(),
                                               getVersion()});
-        if (known != Impl.ImportedDecls.end()) {
+        if (known != Impl.ImportedDecls.end() && known->second != nullptr) {
           auto decl = known->second;
           if (isAcceptableResult(decl, accessorInfo))
             return decl;
@@ -4930,7 +4930,7 @@ namespace {
         // methods.
         auto known = Impl.ImportedDecls.find({decl->getCanonicalDecl(),
                                               getVersion()});
-        if (known != Impl.ImportedDecls.end()) {
+        if (known != Impl.ImportedDecls.end() && known->second != nullptr) {
           auto decl = known->second;
           if (isAcceptableResult(decl, accessorInfo))
             return decl;
@@ -5737,7 +5737,7 @@ namespace {
       if (dc == Impl.importDeclContextOf(decl, decl->getDeclContext())) {
         auto known = Impl.ImportedDecls.find({decl->getCanonicalDecl(),
                                               getVersion()});
-        if (known != Impl.ImportedDecls.end())
+        if (known != Impl.ImportedDecls.end() && known->second != nullptr)
           return known->second;
       }
 
@@ -8279,7 +8279,7 @@ Optional<Decl *> ClangImporter::Implementation::importDeclCached(
   std::pair<const clang::Decl *, Version> Key = {
       UseCanonical ? ClangDecl->getCanonicalDecl() : ClangDecl, version};
   auto Known = ImportedDecls.find(Key);
-  if (Known != ImportedDecls.end())
+  if (Known != ImportedDecls.end() && Known->second != nullptr)
     return Known->second;
 
   return None;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -415,7 +415,8 @@ private:
   llvm::SmallDenseMap<ModuleDecl *, SourceFile *> ClangSwiftAttrSourceFiles;
 
 public:
-  /// Mapping of already-imported declarations.
+  /// Mapping of already-imported declarations. If the import failed then it
+  /// maps to nullptr.
   llvm::DenseMap<std::pair<const clang::Decl *, Version>, Decl *> ImportedDecls;
 
   /// The set of "special" typedef-name declarations, which are
@@ -851,8 +852,9 @@ public:
 
   /// If we already imported a given decl, return the corresponding Swift decl.
   /// Otherwise, return nullptr.
-  Decl *importDeclCached(const clang::NamedDecl *ClangDecl, Version version,
-                         bool UseCanonicalDecl = true);
+  Optional<Decl *> importDeclCached(const clang::NamedDecl *ClangDecl,
+                                    Version version,
+                                    bool UseCanonicalDecl = true);
 
   Decl *importDeclImpl(const clang::NamedDecl *ClangDecl, Version version,
                        bool &TypedefIsSuperfluous, bool &HadForwardDeclaration);

--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -66,7 +66,8 @@ private:
 
   StableSerializationPath findImportedPath(const clang::NamedDecl *decl) {
     // We've almost certainly imported this declaration, look for it.
-    if (auto swiftDecl = Impl.importDeclCached(decl, Impl.CurrentVersion)) {
+    if (auto swiftDecl = Impl.importDeclCached(decl, Impl.CurrentVersion)
+                             .getValueOr(nullptr)) {
       // The serialization code doesn't allow us to cross-reference
       // typealias declarations directly.  We could fix that, but it's
       // easier to just avoid doing so and fall into the external-path code.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Cached failed import Decl's and modify importDeclCached api to return an optional.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-14137. https://bugs.swift.org/browse/SR-14137

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
