### PR TITLE
Change ExecutorRef and fix the actor runtime

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -516,7 +516,7 @@ Types
   type ::= 'BB'                              // Builtin.UnsafeValueBuffer
   type ::= 'Bc'                              // Builtin.RawUnsafeContinuation
   type ::= 'BD'                              // Builtin.DefaultActorStorage
-  type ::= 'Be'                              // Builtin.ExecutorRef
+  type ::= 'Be'                              // Builtin.Executor
   type ::= 'Bf' NATURAL '_'                  // Builtin.Float<n>
   type ::= 'Bi' NATURAL '_'                  // Builtin.Int<n>
   type ::= 'BI'                              // Builtin.IntLiteral

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -4288,6 +4288,10 @@ public:
     return FieldOffsetVectorOffset;
   }
 
+  bool isDefaultActor() const {
+    return this->getTypeContextDescriptorFlags().class_isDefaultActor();
+  }
+
   bool hasVTable() const {
     return this->getTypeContextDescriptorFlags().class_hasVTable();
   }

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2166,6 +2166,20 @@ enum class ContinuationStatus : size_t {
   Resumed = 2
 };
 
+/// Flags describing the executor implementation that are stored
+/// in the ExecutorRef.
+enum class ExecutorRefFlags : size_t {
+  // The number of bits available here is very limited because it's
+  // potentially just the alignment bits of a protocol witness table
+  // pointer
+
+  /// The executor is a default actor.
+  DefaultActor = 0x1,
+
+  /// TODO: remove this
+  MainActorIdentity = 0x2,
+};
+
 } // end namespace swift
 
 #endif // SWIFT_ABI_METADATAVALUES_H

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1385,6 +1385,14 @@ class TypeContextDescriptorFlags : public FlagSet<uint16_t> {
 
     // Type-specific flags:
 
+    /// Set if the class is a default actor class.  Note that this is
+    /// based on the best knowledge available to the class; actor
+    /// classes with resilient superclassess might be default actors
+    /// without knowing it.
+    ///
+    /// Only meaningful for class descriptors.
+    Class_IsDefaultActor = 8,
+
     /// The kind of reference that this class makes to its resilient superclass
     /// descriptor.  A TypeReferenceKind.
     ///
@@ -1464,6 +1472,9 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(Class_AreImmediateMembersNegative,
                                 class_areImmediateMembersNegative,
                                 class_setAreImmediateMembersNegative)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Class_IsDefaultActor,
+                                class_isDefaultActor,
+                                class_setIsDefaultActor)
 
   FLAGSET_DEFINE_FIELD_ACCESSORS(Class_ResilientSuperclassReferenceKind,
                                  Class_ResilientSuperclassReferenceKind_width,

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -758,12 +758,15 @@ BUILTIN_MISC_OPERATION(BuildSerialExecutorRef,
 // Retrieve the ExecutorRef on which the current asynchronous
 // function is executing.
 // Does not retain an actor executor.
-BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentExecutor, "getCurrentExecutor", "n", Special)
+BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentExecutor, "getCurrentExecutor", "", Special)
 
 // getCurrentAsyncTask: () -> Builtin.NativeObject
 //
 // Retrieve the pointer to the task in which the current asynchronous
 // function is executing.
+//
+// This is readnone because, within the world modeled by SIL, the
+// current async task of a thread never changes.
 BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentAsyncTask, "getCurrentAsyncTask", "n", Special)
 
 /// cancelAsyncTask(): (Builtin.NativeObject) -> Void

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3766,13 +3766,18 @@ public:
 
   /// Whether the class is (known to be) a default actor.
   bool isDefaultActor() const;
+  bool isDefaultActor(ModuleDecl *M, ResilienceExpansion expansion) const;
 
   /// Whether the class is known to be a *root* default actor,
   /// i.e. the first class in its hierarchy that is a default actor.
   bool isRootDefaultActor() const;
+  bool isRootDefaultActor(ModuleDecl *M, ResilienceExpansion expansion) const;
 
   /// Whether the class was explicitly declared with the `actor` keyword.
   bool isExplicitActor() const { return Bits.ClassDecl.IsActor; }
+
+  /// Get the closest-to-root superclass that's an actor class.
+  const ClassDecl *getRootActorClass() const;
 
   /// Does this class explicitly declare any of the methods that
   /// would prevent it from being a default actor?

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -938,7 +938,7 @@ public:
 /// Determine whether the given class is a default actor.
 class IsDefaultActorRequest :
     public SimpleRequest<IsDefaultActorRequest,
-                         bool(ClassDecl *),
+                         bool(ClassDecl *, ModuleDecl *, ResilienceExpansion),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -946,7 +946,8 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, ClassDecl *classDecl) const;
+  bool evaluate(Evaluator &evaluator, ClassDecl *classDecl,
+                ModuleDecl *M, ResilienceExpansion expansion) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -99,7 +99,8 @@ SWIFT_REQUEST(TypeChecker, CanBeAsyncHandlerRequest, bool(FuncDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, IsActorRequest, bool(NominalTypeDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest, bool(ClassDecl *),
+SWIFT_REQUEST(TypeChecker, IsDefaultActorRequest,
+              bool(ClassDecl *, ModuleDecl *, ResilienceExpansion),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GlobalActorInstanceRequest,
               VarDecl *(NominalTypeDecl *),

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -512,6 +512,14 @@ void swift_defaultActor_initialize(DefaultActor *actor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_defaultActor_destroy(DefaultActor *actor);
 
+/// Deallocate an instance of a default actor.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_defaultActor_deallocate(DefaultActor *actor);
+
+/// Deallocate an instance of what might be a default actor.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_defaultActor_deallocateResilient(HeapObject *actor);
+
 /// Enqueue a job on the default actor implementation.
 ///
 /// The job must be ready to run.  Notably, if it's a task, that

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1595,7 +1595,7 @@ FUNCTION(TaskSwitchFunc,
          swift_task_switch, SwiftAsyncCC,
          ConcurrencyAvailability,
          RETURNS(VoidTy),
-         ARGS(SwiftContextPtrTy, Int8PtrTy, SwiftExecutorPtrTy),
+         ARGS(SwiftContextPtrTy, Int8PtrTy, ExecutorFirstTy, ExecutorSecondTy),
          ATTRS(NoUnwind))
 
 // AsyncTask *swift_continuation_init(AsyncContext *continuationContext,
@@ -1636,7 +1636,7 @@ FUNCTION(ContinuationThrowingResumeWithError,
 FUNCTION(TaskGetCurrentExecutor,
          swift_task_getCurrentExecutor, SwiftCC,
          ConcurrencyAvailability,
-         RETURNS(IntPtrTy),
+         RETURNS(SwiftExecutorTy),
          ARGS(),
          ATTRS(NoUnwind, ArgMemOnly))
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1656,6 +1656,22 @@ FUNCTION(DefaultActorDestroy,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
+// void swift_defaultActor_deallocate(DefaultActor *actor);
+FUNCTION(DefaultActorDeallocate,
+         swift_defaultActor_deallocate, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind))
+
+// void swift_defaultActor_deallocateResilient(HeapObject *actor);
+FUNCTION(DefaultActorDeallocateResilient,
+         swift_defaultActor_deallocateResilient, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind))
+
 //// void swift_taskGroup_initialize(AsyncTask *task, TaskGroup *group);
 //FUNCTION(TaskGroupInitialize,
 //         swift_taskGroup_initialize, SwiftCC,

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -16,6 +16,7 @@ add_swift_host_library(swiftIRGen STATIC
   GenConstant.cpp
   GenControl.cpp
   GenCoverage.cpp
+  GenConcurrency.cpp
   GenDecl.cpp
   GenDiffFunc.cpp
   GenDiffWitness.cpp

--- a/lib/IRGen/ExtraInhabitants.h
+++ b/lib/IRGen/ExtraInhabitants.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_IRGEN_EXTRAINHABITANTS_H
 #define SWIFT_IRGEN_EXTRAINHABITANTS_H
 
+#include "IRGen.h"
+
 namespace llvm {
 class APInt;
 class ConstantInt;
@@ -30,6 +32,60 @@ class Address;
 class Alignment;
 class IRGenFunction;
 class IRGenModule;
+
+/// Whether the zero pointer is a valid value (i.e. not a valid
+/// extra inhabitant) of a particular pointer type.
+enum IsNullable_t: bool {
+  IsNotNullable = false,
+  IsNullable = true
+};
+
+/// Information about a particular pointer type.
+struct PointerInfo {
+  Alignment PointeeAlign;
+  uint8_t NumReservedLowBits;
+  IsNullable_t Nullable;
+
+  static PointerInfo forHeapObject(const IRGenModule &IGM);
+  static PointerInfo forFunction(const IRGenModule &IGM);
+  static PointerInfo forAligned(Alignment pointeeAlign) {
+    return {pointeeAlign, 0, IsNotNullable};
+  }
+
+  PointerInfo withNullable(IsNullable_t nullable) const {
+    return {PointeeAlign, NumReservedLowBits, nullable};
+  }
+
+  /// Return the number of extra inhabitant representations for
+  /// pointers with these properties: i.e. the number of values
+  /// that do not collide with any valid pointers.
+  unsigned getExtraInhabitantCount(const IRGenModule &IGM) const;
+
+
+  /// Return an indexed extra inhabitant constant for a pointer
+  /// with these properties.
+  ///
+  /// If the pointer appears within a larger aggregate, the
+  /// 'bits' and 'offset' arguments can be used to position
+  /// the inhabitant within the larger integer constant.
+  llvm::APInt getFixedExtraInhabitantValue(const IRGenModule &IGM,
+                                           unsigned bits,
+                                           unsigned index,
+                                           unsigned offset) const;
+
+  /// Given the address of storage for a pointer with these
+  /// properties, return the extra inhabitant index of the
+  /// value, or -1 if the value is a valid pointer.  Always
+  /// produces an i32. 
+  llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
+                                       Address src) const;
+
+  /// Store an extra inhabitant representation for the given
+  /// dynamic extra inhabitant index into the given storage.
+  void storeExtraInhabitant(IRGenFunction &IGF,
+                            llvm::Value *index,
+                            Address dest) const;
+};
 
 /*****************************************************************************/
 
@@ -60,69 +116,6 @@ llvm::Value *getHeapObjectExtraInhabitantIndex(IRGenFunction &IGF,
 void storeHeapObjectExtraInhabitant(IRGenFunction &IGF,
                                     llvm::Value *index,
                                     Address dest);
-
-/*****************************************************************************/
-
-/// \group Extra inhabitants of aligned object pointers.
-
-/// Return the number of extra inhabitant representations for aligned
-/// object pointers.
-unsigned getAlignedPointerExtraInhabitantCount(IRGenModule &IGM,
-                                               Alignment pointeeAlign);
-
-/// Return an indexed extra inhabitant constant for an aligned pointer.
-///
-/// If the pointer appears within a larger aggregate, the 'bits' and 'offset'
-/// arguments can be used to position the inhabitant within the larger integer
-/// constant.
-llvm::APInt getAlignedPointerExtraInhabitantValue(IRGenModule &IGM,
-                                                  Alignment pointeeAlign,
-                                                  unsigned bits,
-                                                  unsigned index,
-                                                  unsigned offset);
-
-/// Calculate the index of an aligned pointer extra inhabitant
-/// representation stored in memory.
-llvm::Value *getAlignedPointerExtraInhabitantIndex(IRGenFunction &IGF,
-                                                   Alignment pointeeAlign,
-                                                   Address src);
-
-/// Calculate an extra inhabitant representation from an index and store it to
-/// memory.
-void storeAlignedPointerExtraInhabitant(IRGenFunction &IGF,
-                                        Alignment pointeeAlign,
-                                        llvm::Value *index,
-                                        Address dest);
-
-/*****************************************************************************/
-
-/// \group Extra inhabitants of function pointers.
-
-/// Return the number of extra inhabitant representations for function pointers,
-/// that is, the number of invalid function pointer values that can be used
-/// to represent enum tags for enums involving a reference type as a payload.
-unsigned getFunctionPointerExtraInhabitantCount(IRGenModule &IGM);
-  
-/// Return an indexed extra inhabitant constant for a function pointer.
-///
-/// If the pointer appears within a larger aggregate, the 'bits' and 'offset'
-/// arguments can be used to position the inhabitant within the larger integer
-/// constant.
-llvm::APInt getFunctionPointerFixedExtraInhabitantValue(IRGenModule &IGM,
-                                                        unsigned bits,
-                                                        unsigned index,
-                                                        unsigned offset);
-  
-/// Calculate the index of a function pointer extra inhabitant
-/// representation stored in memory.
-llvm::Value *getFunctionPointerExtraInhabitantIndex(IRGenFunction &IGF,
-                                                    Address src);
-
-/// Calculate an extra inhabitant representation from an index and
-/// store it to memory.
-void storeFunctionPointerExtraInhabitant(IRGenFunction &IGF,
-                                         llvm::Value *index,
-                                         Address dest);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -28,6 +28,7 @@
 #include "Explosion.h"
 #include "GenCall.h"
 #include "GenCast.h"
+#include "GenConcurrency.h"
 #include "GenPointerAuth.h"
 #include "GenIntegerLiteral.h"
 #include "IRGenFunction.h"
@@ -221,11 +222,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
 
   // getCurrentActor has no arguments.
   if (Builtin.ID == BuiltinValueKind::GetCurrentExecutor) {
-    auto *call = IGF.Builder.CreateCall(IGF.IGM.getTaskGetCurrentExecutorFn(),
-                                        {});
-    call->setDoesNotThrow();
-    call->setCallingConv(IGF.IGM.SwiftCC);
-    out.add(call);
+    emitGetCurrentExecutor(IGF, out);
     return;
   }
 
@@ -307,10 +304,8 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   }
 
   if (Builtin.ID == BuiltinValueKind::BuildSerialExecutorRef) {
-    auto executor = args.claimNext();
-    executor = IGF.Builder.CreateBitCast(executor,
-                                         IGF.IGM.SwiftExecutorPtrTy);
-    out.add(executor);
+    auto actor = args.claimNext();
+    emitBuildSerialExecutorRef(IGF, actor, argTypes[0], out);
     return;
   }
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1971,10 +1971,17 @@ void irgen::extractScalarResults(IRGenFunction &IGF, llvm::Type *bodyType,
     returned = IGF.coerceValue(returned, bodyType, IGF.IGM.DataLayout);
 
   if (auto *structType = dyn_cast<llvm::StructType>(bodyType))
-    for (unsigned i = 0, e = structType->getNumElements(); i != e; ++i)
-      out.add(IGF.Builder.CreateExtractValue(returned, i));
+    IGF.emitAllExtractValues(returned, structType, out);
   else
     out.add(returned);
+}
+
+void IRGenFunction::emitAllExtractValues(llvm::Value *value,
+                                         llvm::StructType *structType,
+                                         Explosion &out) {
+  assert(value->getType() == structType);
+  for (unsigned i = 0, e = structType->getNumElements(); i != e; ++i)
+    out.add(Builder.CreateExtractValue(value, i));
 }
 
 std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -1,0 +1,172 @@
+//===--- GenConcurrency.cpp - IRGen for concurrency features --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements IR generation for concurrency features (other than
+//  basic async function lowering, which is more spread out).
+//
+//===----------------------------------------------------------------------===//
+
+#include "GenConcurrency.h"
+
+#include "BitPatternBuilder.h"
+#include "ExtraInhabitants.h"
+#include "GenType.h"
+#include "IRGenFunction.h"
+#include "IRGenModule.h"
+#include "LoadableTypeInfo.h"
+#include "ScalarPairTypeInfo.h"
+#include "swift/ABI/MetadataValues.h"
+
+using namespace swift;
+using namespace irgen;
+
+namespace {
+
+/// A TypeInfo implementation for Builtin.Executor.
+class ExecutorTypeInfo :
+  public TrivialScalarPairTypeInfo<ExecutorTypeInfo, LoadableTypeInfo> {
+
+public:
+  ExecutorTypeInfo(llvm::StructType *storageType,
+                   Size size, Alignment align, SpareBitVector &&spareBits)
+      : TrivialScalarPairTypeInfo(storageType, size, std::move(spareBits),
+                                  align, IsPOD, IsFixedSize) {}
+
+  static Size getFirstElementSize(IRGenModule &IGM) {
+    return IGM.getPointerSize();
+  }
+  static StringRef getFirstElementLabel() {
+    return ".identity";
+  }
+
+  TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
+                                        SILType T) const override {
+    return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+  }
+
+  static Size getSecondElementOffset(IRGenModule &IGM) {
+    return IGM.getPointerSize();
+  }
+  static Size getSecondElementSize(IRGenModule &IGM) {
+    return IGM.getPointerSize();
+  }
+  static StringRef getSecondElementLabel() {
+    return ".impl";
+  }
+
+  // The identity pointer is a heap object reference, but it's
+  // nullable because of the generic executor.
+  bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
+    return true;
+  }
+
+  PointerInfo getPointerInfo(IRGenModule &IGM) const {
+    return PointerInfo::forHeapObject(IGM).withNullable(IsNullable);
+  }
+  unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
+    return getPointerInfo(IGM).getExtraInhabitantCount(IGM);
+  }
+  APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
+                                     unsigned bits,
+                                     unsigned index) const override {
+    return getPointerInfo(IGM)
+          .getFixedExtraInhabitantValue(IGM, bits, index, 0);
+  }
+  llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
+                                       SILType T,
+                                       bool isOutlined) const override {
+    src = projectFirstElement(IGF, src);
+    return getPointerInfo(IGF.IGM).getExtraInhabitantIndex(IGF, src);
+  }
+  APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
+    auto pointerSize = IGM.getPointerSize();
+    auto mask = BitPatternBuilder(IGM.Triple.isLittleEndian());
+    mask.appendSetBits(pointerSize.getValueInBits());
+    mask.appendClearBits(pointerSize.getValueInBits());
+    return mask.build().getValue();
+  }
+  void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
+                            Address dest, SILType T,
+                            bool isOutlined) const override {
+    dest = projectFirstElement(IGF, dest);
+    getPointerInfo(IGF.IGM).storeExtraInhabitant(IGF, index, dest);
+  }
+};
+
+} // end anonymous namespace
+
+const LoadableTypeInfo &IRGenModule::getExecutorTypeInfo() {
+  return Types.getExecutorTypeInfo();
+}
+
+const LoadableTypeInfo &TypeConverter::getExecutorTypeInfo() {
+  if (ExecutorTI) return *ExecutorTI;
+
+  auto ty = IGM.SwiftExecutorTy;
+
+  SpareBitVector spareBits;
+  spareBits.append(IGM.getHeapObjectSpareBits());
+  spareBits.appendClearBits(IGM.getPointerSize().getValueInBits());
+
+  ExecutorTI =
+    new ExecutorTypeInfo(ty, IGM.getPointerSize() * 2,
+                         IGM.getPointerAlignment(),
+                         std::move(spareBits));
+  ExecutorTI->NextConverted = FirstType;
+  FirstType = ExecutorTI;
+  return *ExecutorTI;
+}
+
+void irgen::emitBuildSerialExecutorRef(IRGenFunction &IGF,
+                                       llvm::Value *actor,
+                                       SILType actorType,
+                                       Explosion &out) {
+  auto cls = actorType.getClassOrBoundGenericClass();
+
+  // HACK: if the actor type is Swift.MainActor, treat it specially.
+  if (cls && cls->getNameStr() == "MainActor" &&
+      cls->getDeclContext()->isModuleScopeContext() &&
+      cls->getModuleContext()->getName().str() == SWIFT_CONCURRENCY_NAME) {
+    llvm::Value *identity = llvm::ConstantInt::get(IGF.IGM.SizeTy,
+                              unsigned(ExecutorRefFlags::MainActorIdentity));
+    identity = IGF.Builder.CreateIntToPtr(identity, IGF.IGM.ExecutorFirstTy);
+    out.add(identity);
+
+    llvm::Value *impl = IGF.IGM.getSize(Size(0));
+    out.add(impl);
+    return;
+  }
+
+  llvm::Value *identity =
+    IGF.Builder.CreateBitCast(actor, IGF.IGM.ExecutorFirstTy);
+  llvm::Value *impl = IGF.IGM.getSize(Size(0));
+
+  unsigned flags = 0;
+
+  // FIXME: this isn't how we should be doing any of this
+  flags |= unsigned(ExecutorRefFlags::DefaultActor);
+
+  if (flags) {
+    impl = IGF.Builder.CreateOr(impl, IGF.IGM.getSize(Size(flags)));
+  }
+  out.add(identity);
+  out.add(impl);
+}
+
+void irgen::emitGetCurrentExecutor(IRGenFunction &IGF, Explosion &out) {
+  auto *call = IGF.Builder.CreateCall(IGF.IGM.getTaskGetCurrentExecutorFn(),
+                                      {});
+  call->setDoesNotThrow();
+  call->setCallingConv(IGF.IGM.SwiftCC);
+
+  IGF.emitAllExtractValues(call, IGF.IGM.SwiftExecutorTy, out);
+}

--- a/lib/IRGen/GenConcurrency.h
+++ b/lib/IRGen/GenConcurrency.h
@@ -1,0 +1,42 @@
+//===--- GenConcurrency.h - IRGen for concurrency features ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines interfaces for emitting code for various concurrency
+// features.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_GENCONCURRENCY_H
+#define SWIFT_IRGEN_GENCONCURRENCY_H
+
+namespace llvm {
+class Value;
+}
+
+namespace swift {
+class SILType;
+
+namespace irgen {
+class Explosion;
+class IRGenFunction;
+
+/// Emit the buildSerialExecutorRef builtin.
+void emitBuildSerialExecutorRef(IRGenFunction &IGF, llvm::Value *actor,
+                                SILType actorType, Explosion &out);
+
+/// Emit the getCurrentExecutor builtin.
+void emitGetCurrentExecutor(IRGenFunction &IGF, Explosion &out);
+
+} // end namespace irgen
+} // end namespace swift
+
+#endif

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -164,25 +164,28 @@ namespace {
     }
 
     unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
-      return getFunctionPointerExtraInhabitantCount(IGM);
+      return PointerInfo::forFunction(IGM).getExtraInhabitantCount(IGM);
     }
 
     APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
                                        unsigned bits,
                                        unsigned index) const override {
-      return getFunctionPointerFixedExtraInhabitantValue(IGM, bits, index, 0);
+      return PointerInfo::forFunction(IGM)
+               .getFixedExtraInhabitantValue(IGM, bits, index, 0);
     }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
                                          SILType T, bool isOutlined)
     const override {
-      return getFunctionPointerExtraInhabitantIndex(IGF, src);
+      return PointerInfo::forFunction(IGF.IGM)
+               .getExtraInhabitantIndex(IGF, src);
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
                               Address dest, SILType T, bool isOutlined)
     const override {
-      return storeFunctionPointerExtraInhabitant(IGF, index, dest);
+      return PointerInfo::forFunction(IGF.IGM)
+               .storeExtraInhabitant(IGF, index, dest);
     }
   };
 
@@ -341,20 +344,29 @@ namespace {
     }
 
     unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
-      return getFunctionPointerExtraInhabitantCount(IGM);
+      return PointerInfo::forFunction(IGM)
+               .getExtraInhabitantCount(IGM);
     }
 
     APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
                                        unsigned bits,
                                        unsigned index) const override {
-      return getFunctionPointerFixedExtraInhabitantValue(IGM, bits, index, 0);
+      return PointerInfo::forFunction(IGM)
+               .getFixedExtraInhabitantValue(IGM, bits, index, 0);
     }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,
                                          SILType T, bool isOutlined)
     const override {
-      src = projectFunction(IGF, src);
-      return getFunctionPointerExtraInhabitantIndex(IGF, src);
+      return PointerInfo::forFunction(IGF.IGM)
+               .getExtraInhabitantIndex(IGF, projectFunction(IGF, src));
+    }
+
+    void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
+                              Address dest, SILType T, bool isOutlined)
+    const override {
+      return PointerInfo::forFunction(IGF.IGM)
+               .storeExtraInhabitant(IGF, index, projectFunction(IGF, dest));
     }
 
     APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {
@@ -364,13 +376,6 @@ namespace {
       mask.appendSetBits(pointerSize.getValueInBits());
       mask.appendClearBits(pointerSize.getValueInBits());
       return mask.build().getValue();
-    }
-
-    void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
-                              Address dest, SILType T, bool isOutlined)
-    const override {
-      dest = projectFunction(IGF, dest);
-      return storeFunctionPointerExtraInhabitant(IGF, index, dest);
     }
   };
 

--- a/lib/IRGen/GenIntegerLiteral.cpp
+++ b/lib/IRGen/GenIntegerLiteral.cpp
@@ -36,13 +36,13 @@ namespace {
 
 /// A TypeInfo implementation for Builtin.IntegerLiteral.
 class IntegerLiteralTypeInfo :
-  public ScalarPairTypeInfo<IntegerLiteralTypeInfo, LoadableTypeInfo> {
+  public TrivialScalarPairTypeInfo<IntegerLiteralTypeInfo, LoadableTypeInfo> {
 
 public:
   IntegerLiteralTypeInfo(llvm::StructType *storageType,
                          Size size, Alignment align, SpareBitVector &&spareBits)
-      : ScalarPairTypeInfo(storageType, size, std::move(spareBits), align,
-                           IsPOD, IsFixedSize) {}
+      : TrivialScalarPairTypeInfo(storageType, size, std::move(spareBits), align,
+                                  IsPOD, IsFixedSize) {}
 
   static Size getFirstElementSize(IRGenModule &IGM) {
     return IGM.getPointerSize();
@@ -50,22 +50,10 @@ public:
   static StringRef getFirstElementLabel() {
     return ".data";
   }
-  static bool isFirstElementTrivial() {
-    return true;
-  }
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                         SILType T) const override {
     return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
-  }
-
-  void emitRetainFirstElement(IRGenFunction &IGF, llvm::Value *fn,
-                              Optional<Atomicity> atomicity = None) const {}
-  void emitReleaseFirstElement(IRGenFunction &IGF, llvm::Value *fn,
-                               Optional<Atomicity> atomicity = None) const {}
-  void emitAssignFirstElement(IRGenFunction &IGF, llvm::Value *fn,
-                              Address fnAddr) const {
-    IGF.Builder.CreateStore(fn, fnAddr);
   }
 
   static Size getSecondElementOffset(IRGenModule &IGM) {
@@ -76,17 +64,6 @@ public:
   }
   static StringRef getSecondElementLabel() {
     return ".flags";
-  }
-  bool isSecondElementTrivial() const {
-    return true;
-  }
-  void emitRetainSecondElement(IRGenFunction &IGF, llvm::Value *data,
-                               Optional<Atomicity> atomicity = None) const {}
-  void emitReleaseSecondElement(IRGenFunction &IGF, llvm::Value *data,
-                                Optional<Atomicity> atomicity = None) const {}
-  void emitAssignSecondElement(IRGenFunction &IGF, llvm::Value *context,
-                               Address dataAddr) const {
-    IGF.Builder.CreateStore(context, dataAddr);
   }
 
   // The data pointer isn't a heap object, but it is an aligned pointer.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1619,6 +1619,10 @@ namespace {
 
         if (MetadataLayout->hasResilientSuperclass())
           flags.class_setHasResilientSuperclass(true);
+
+        if (getType()->isDefaultActor(IGM.getSwiftModule(),
+                                      ResilienceExpansion::Maximal))
+          flags.class_setIsDefaultActor(true);
       }
 
       if (ResilientSuperClassRef) {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1552,20 +1552,6 @@ const TypeInfo &TypeConverter::getTaskContinuationFunctionPtrTypeInfo() {
   return *TaskContinuationFunctionPtrTI;
 }
 
-const TypeInfo &IRGenModule::getSwiftExecutorPtrTypeInfo() {
-  return Types.getExecutorTypeInfo();
-}
-
-const LoadableTypeInfo &TypeConverter::getExecutorTypeInfo() {
-  if (ExecutorTI) return *ExecutorTI;
-  ExecutorTI = createPrimitive(IGM.SwiftExecutorPtrTy,
-                               IGM.getPointerSize(),
-                               IGM.getPointerAlignment());
-  ExecutorTI->NextConverted = FirstType;
-  FirstType = ExecutorTI;
-  return *ExecutorTI;
-}
-
 const LoadableTypeInfo &
 IRGenModule::getReferenceObjectTypeInfo(ReferenceCounting refcounting) {
   switch (refcounting) {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1027,27 +1027,31 @@ namespace {
       return true;
     }
 
+    PointerInfo getPointerInfo() const {
+      return PointerInfo::forAligned(PointeeAlign);
+    }
+
     unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {
-      return getAlignedPointerExtraInhabitantCount(IGM, PointeeAlign);
+      return getPointerInfo().getExtraInhabitantCount(IGM);
     }
 
     APInt getFixedExtraInhabitantValue(IRGenModule &IGM, unsigned bits,
                                        unsigned index) const override {
-      return getAlignedPointerExtraInhabitantValue(IGM, PointeeAlign,
-                                                   bits, index, 0);
+      return getPointerInfo()
+               .getFixedExtraInhabitantValue(IGM, bits, index, 0);
     }
 
     llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF,
                                          Address src,
                                          SILType T,
                                          bool isOutlined) const override {
-      return getAlignedPointerExtraInhabitantIndex(IGF, PointeeAlign, src);
+      return getPointerInfo().getExtraInhabitantIndex(IGF, src);
     }
 
     void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,
                               Address dest, SILType T,
                               bool isOutlined) const override {
-      storeAlignedPointerExtraInhabitant(IGF, PointeeAlign, index, dest);
+      getPointerInfo().storeExtraInhabitant(IGF, index, dest);
     }
   };
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -103,6 +103,9 @@ public:
   void emitBBForReturn();
   bool emitBranchToReturnBB();
 
+  void emitAllExtractValues(llvm::Value *aggValue, llvm::StructType *type,
+                            Explosion &out);
+
   /// Return the error result slot to be passed to the callee, given an error
   /// type.  There's always only one error type.
   ///
@@ -168,7 +171,7 @@ public:
   FunctionPointer
   getFunctionPointerForResumeIntrinsic(llvm::Value *resumeIntrinsic);
 
-  void emitSuspensionPoint(llvm::Value *toExecutor, llvm::Value *asyncResume);
+  void emitSuspensionPoint(Explosion &executor, llvm::Value *asyncResume);
   llvm::Function *getOrCreateResumeFromSuspensionFn();
   llvm::Function *createAsyncSuspendFn();
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -616,11 +616,15 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
     IntPtrTy              // Task.Status
   });
 
-  SwiftExecutorTy = createStructType(*this, "swift.executor", {});
   AsyncFunctionPointerPtrTy = AsyncFunctionPointerTy->getPointerTo(DefaultAS);
   SwiftTaskPtrTy = SwiftTaskTy->getPointerTo(DefaultAS);
   SwiftTaskGroupPtrTy = Int8PtrTy; // we pass it opaquely (TaskGroup*)
-  SwiftExecutorPtrTy = SwiftExecutorTy->getPointerTo(DefaultAS);
+  ExecutorFirstTy = RefCountedPtrTy;
+  ExecutorSecondTy = SizeTy;
+  SwiftExecutorTy = createStructType(*this, "swift.executor", {
+    ExecutorFirstTy,      // identity
+    ExecutorSecondTy,     // implementation
+  });
   SwiftJobTy = createStructType(*this, "swift.job", {
     RefCountedStructTy,   // object header
     Int8PtrTy, Int8PtrTy, // SchedulerPrivate
@@ -651,7 +655,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
        SizeTy,               // await synchronization
        ErrorPtrTy,           // error result pointer
        OpaquePtrTy,          // normal result address
-       SwiftExecutorPtrTy}); // resume to executor
+       SwiftExecutorTy});    // resume to executor
   ContinuationAsyncContextPtrTy =
     ContinuationAsyncContextTy->getPointerTo(DefaultAS);
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -734,7 +734,8 @@ public:
   llvm::PointerType *SwiftTaskPtrTy;
   llvm::PointerType *SwiftTaskGroupPtrTy;
   llvm::PointerType *SwiftJobPtrTy;
-  llvm::PointerType *SwiftExecutorPtrTy;
+  llvm::PointerType *ExecutorFirstTy;
+  llvm::IntegerType *ExecutorSecondTy;
   llvm::FunctionType *TaskContinuationFunctionTy;
   llvm::PointerType *TaskContinuationFunctionPtrTy;
   llvm::StructType *AsyncTaskAndContextTy;
@@ -908,7 +909,7 @@ public:
   const TypeInfo &getTypeMetadataPtrTypeInfo();
   const TypeInfo &getSwiftContextPtrTypeInfo();
   const TypeInfo &getTaskContinuationFunctionPtrTypeInfo();
-  const TypeInfo &getSwiftExecutorPtrTypeInfo();
+  const LoadableTypeInfo &getExecutorTypeInfo();
   const TypeInfo &getObjCClassPtrTypeInfo();
   const LoadableTypeInfo &getOpaqueStorageTypeInfo(Size size, Alignment align);
   const LoadableTypeInfo &

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6141,8 +6141,11 @@ void IRGenSILFunction::visitHopToExecutorInst(HopToExecutorInst *i) {
   assert(i->getTargetExecutor()->getType().is<BuiltinExecutorType>());
   llvm::Value *resumeFn = Builder.CreateIntrinsicCall(
           llvm::Intrinsic::coro_async_resume, {});
-          
-  emitSuspensionPoint(getLoweredSingletonExplosion(i->getOperand()), resumeFn);
+
+  Explosion executor;
+  getLoweredExplosion(i->getOperand(), executor);
+
+  emitSuspensionPoint(executor, resumeFn);
 }
 
 void IRGenSILFunction::visitKeyPathInst(swift::KeyPathInst *I) {

--- a/lib/IRGen/ScalarPairTypeInfo.h
+++ b/lib/IRGen/ScalarPairTypeInfo.h
@@ -179,6 +179,43 @@ public:
   }
 };
 
+template <class Derived, class Base>
+class TrivialScalarPairTypeInfo : public ScalarPairTypeInfo<Derived, Base> {
+  using super = ScalarPairTypeInfo<Derived, Base>;
+protected:
+  template <class... T> TrivialScalarPairTypeInfo(T &&...args)
+    : super(::std::forward<T>(args)...) {}
+
+  const Derived &asDerived() const {
+    return static_cast<const Derived &>(*this);
+  }
+
+public:
+  static bool isFirstElementTrivial() {
+    return true;
+  }
+  void emitRetainFirstElement(IRGenFunction &IGF, llvm::Value *value,
+                              Optional<Atomicity> atomicity = None) const {}
+  void emitReleaseFirstElement(IRGenFunction &IGF, llvm::Value *value,
+                               Optional<Atomicity> atomicity = None) const {}
+  void emitAssignFirstElement(IRGenFunction &IGF, llvm::Value *value,
+                              Address valueAddr) const {
+    IGF.Builder.CreateStore(value, valueAddr);
+  }
+
+  static bool isSecondElementTrivial() {
+    return true;
+  }
+  void emitRetainSecondElement(IRGenFunction &IGF, llvm::Value *value,
+                               Optional<Atomicity> atomicity = None) const {}
+  void emitReleaseSecondElement(IRGenFunction &IGF, llvm::Value *value,
+                                Optional<Atomicity> atomicity = None) const {}
+  void emitAssignSecondElement(IRGenFunction &IGF, llvm::Value *value,
+                              Address valueAddr) const {
+    IGF.Builder.CreateStore(value, valueAddr);
+  }
+};
+
 }
 }
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1857,6 +1857,7 @@ static void visitBuiltinAddress(BuiltinInst *builtin,
     case BuiltinValueKind::AutoDiffAllocateSubcontext:
     case BuiltinValueKind::InitializeDefaultActor:
     case BuiltinValueKind::DestroyDefaultActor:
+    case BuiltinValueKind::GetCurrentExecutor:
       return;
 
     // General memory access to a pointer in first operand position.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -299,7 +299,8 @@ bool IsActorRequest::evaluate(
 }
 
 bool IsDefaultActorRequest::evaluate(
-    Evaluator &evaluator, ClassDecl *classDecl) const {
+    Evaluator &evaluator, ClassDecl *classDecl, ModuleDecl *M,
+    ResilienceExpansion expansion) const {
   // If the class isn't an actor, it's not a default actor.
   if (!classDecl->isActor())
     return false;
@@ -318,6 +319,11 @@ bool IsDefaultActorRequest::evaluate(
     if (!superclassDecl->isNSObject())
       return false;
   }
+
+  // If the class is resilient from the perspective of the module
+  // module, it's not a default actor.
+  if (classDecl->isForeign() || classDecl->isResilient(M, expansion))
+    return false;
 
   // If the class has explicit custom-actor methods, it's not
   // a default actor.

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -27,9 +27,6 @@
 #include "llvm/ADT/PointerIntPair.h"
 #include "TaskPrivate.h"
 
-// Uncomment to enable helpful debug spew to stderr
-//#define SWIFT_TASK_PRINTF_DEBUG 1
-
 using namespace swift;
 
 /// Should we yield the thread?
@@ -74,6 +71,11 @@ class ExecutorTrackingInfo {
   /// The active executor.
   ExecutorRef ActiveExecutor = ExecutorRef::generic();
 
+  /// Whether this context allows switching.  Some contexts do not;
+  /// for example, we do not allow switching from swift_job_run
+  /// unless the passed-in executor is generic.
+  bool AllowsSwitching = true;
+
   /// The tracking info that was active when this one was entered.
   ExecutorTrackingInfo *SavedInfo;
 
@@ -114,21 +116,27 @@ public:
     return ActiveExecutor;
   }
 
-  static ExecutorRef getActiveExecutorInThread() {
-    if (auto activeInfo = ActiveInfoInThread.get())
-      return activeInfo->getActiveExecutor();
-    return ExecutorRef::generic();
+  void setActiveExecutor(ExecutorRef newExecutor) {
+    ActiveExecutor = newExecutor;
+  }
+
+
+  bool allowsSwitching() const {
+    return AllowsSwitching;
+  }
+
+  /// Disallow switching in this tracking context.  This should only
+  /// be set on a new tracking info, before any jobs are run in it.
+  void disallowSwitching() {
+    AllowsSwitching = false;
+  }
+
+  static ExecutorTrackingInfo *current() {
+    return ActiveInfoInThread.get();
   }
 
   void leave() {
     ActiveInfoInThread.set(SavedInfo);
-  }
-  
-  static ExecutorRef getActiveExecutorOnThread() {
-    if (auto active = ActiveInfoInThread.get())
-      return active->getActiveExecutor();
-
-    swift_unreachable("no active executor?!");
   }
 };
 
@@ -151,16 +159,6 @@ SWIFT_RUNTIME_DECLARE_THREAD_LOCAL(
   ActiveTask::Value);
 
 } // end anonymous namespace
-
-SWIFT_CC(swift)
-static void swift_job_runImpl(Job *job, ExecutorRef executor) {
-  ExecutorTrackingInfo trackingInfo;
-  trackingInfo.enterAndShadow(executor);
-
-  runJobInEstablishedExecutorContext(job);
-
-  trackingInfo.leave();
-}
 
 void swift::runJobInEstablishedExecutorContext(Job *job) {
   _swift_tsan_acquire(job);
@@ -199,9 +197,11 @@ AsyncTask *swift::_swift_task_clearCurrent() {
 
 SWIFT_CC(swift)
 static ExecutorRef swift_task_getCurrentExecutorImpl() {
-  auto result = ExecutorTrackingInfo::getActiveExecutorOnThread();
+  auto currentTracking = ExecutorTrackingInfo::current();
+  auto result = (currentTracking ? currentTracking->getActiveExecutor()
+                                 : ExecutorRef::generic());
 #if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "%p getting current executor %p\n", pthread_self(), (void*)result.getRawValue());
+  fprintf(stderr, "[%p] getting current executor %p\n", pthread_self(), result.getIdentity());
 #endif
   return result;
 }
@@ -885,7 +885,7 @@ static Job *preprocessQueue(JobRef first,
 
 void DefaultActorImpl::giveUpThread(RunningJobInfo runner) {
 #if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "%p %p.giveUpThread\n", pthread_self(), this);
+  fprintf(stderr, "[%p] giving up thread for actor %p\n", pthread_self(), this);
 #endif
   auto oldState = CurrentState.load(std::memory_order_acquire);
   assert(oldState.Flags.getStatus() == Status::Running);
@@ -936,8 +936,8 @@ void DefaultActorImpl::giveUpThread(RunningJobInfo runner) {
     }
     
 #if SWIFT_TASK_PRINTF_DEBUG
-#  define LOG_STATE_TRANSITION fprintf(stderr, "%p transition from %zx to %zx in %p.%s\n", \
-  pthread_self(), oldState.Flags.getOpaqueValue(), newState.Flags.getOpaqueValue(), this, __FUNCTION__)
+#  define LOG_STATE_TRANSITION fprintf(stderr, "[%p] actor %p transitioned from %zx to %zx (%s)\n", \
+  pthread_self(), this, oldState.Flags.getOpaqueValue(), newState.Flags.getOpaqueValue(), __FUNCTION__)
 #else
 #  define LOG_STATE_TRANSITION ((void)0)
 #endif
@@ -1141,6 +1141,34 @@ Job *DefaultActorImpl::claimNextJobOrGiveUp(bool actorIsOwned,
   }
 }
 
+SWIFT_CC(swift)
+static void swift_job_runImpl(Job *job, ExecutorRef executor) {
+  ExecutorTrackingInfo trackingInfo;
+
+  // swift_job_run is a primary entrypoint for executors telling us to
+  // run jobs.  Actor executors won't expect us to switch off them
+  // during this operation.  But do allow switching if the executor
+  // is generic.
+  if (!executor.isGeneric()) trackingInfo.disallowSwitching();
+
+  trackingInfo.enterAndShadow(executor);
+
+  runJobInEstablishedExecutorContext(job);
+
+  trackingInfo.leave();
+
+  // Give up the current executor if this is a switching context
+  // (which, remember, only happens if we started out on a generic
+  // executor) and we've switched to a default actor.
+  auto currentExecutor = trackingInfo.getActiveExecutor();
+  if (trackingInfo.allowsSwitching() && currentExecutor.isDefaultActor()) {
+    // Use an underestimated priority; if this means we create an
+    // extra processing job in some cases, that's probably okay.
+    auto runner = RunningJobInfo::forOther(JobPriority(0));
+    asImpl(currentExecutor.getDefaultActor())->giveUpThread(runner);
+  }
+}
+
 /// The primary function for processing an actor on a thread.  Start
 /// processing the given default actor as the active default actor on
 /// the current thread, and keep processing whatever actor we're
@@ -1154,15 +1182,18 @@ Job *DefaultActorImpl::claimNextJobOrGiveUp(bool actorIsOwned,
 static void processDefaultActor(DefaultActorImpl *currentActor,
                                 RunningJobInfo runner) {
 #if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "%p processDefaultActor %p\n", pthread_self(), currentActor);
+  fprintf(stderr, "[%p] processDefaultActor %p\n", pthread_self(), currentActor);
 #endif
   DefaultActorImpl *actor = currentActor;
 
-  // Register that we're processing a default actor in this frame.
+  // If we actually have work to do, we'll need to set up tracking info.
+  // Optimistically assume that we will; the alternative (an override job
+  // took over the actor first) is rare.
   ExecutorTrackingInfo trackingInfo;
-  auto activeTrackingInfo = trackingInfo.enterOrUpdate(
+  trackingInfo.enterAndShadow(
     ExecutorRef::forDefaultActor(asAbstract(currentActor)));
 
+  // Remember whether we've already taken over the actor.
   bool threadIsRunningActor = false;
   while (true) {
     assert(currentActor);
@@ -1171,12 +1202,13 @@ static void processDefaultActor(DefaultActorImpl *currentActor,
     if (shouldYieldThread())
       break;
 
-    // Claim another job from the current actor.
+    // Try to claim another job from the current actor, taking it over
+    // if we haven't already.
     auto job = currentActor->claimNextJobOrGiveUp(threadIsRunningActor,
                                                   runner);
 
 #if SWIFT_TASK_PRINTF_DEBUG
-    fprintf(stderr, "%p processDefaultActor %p claimed job %p\n", pthread_self(), currentActor, job);
+    fprintf(stderr, "[%p] processDefaultActor %p claimed job %p\n", pthread_self(), currentActor, job);
 #endif
 
     // If we failed to claim a job, we have nothing to do.
@@ -1187,15 +1219,18 @@ static void processDefaultActor(DefaultActorImpl *currentActor,
       break;
     }
 
+    // This thread now owns the current actor.
+    threadIsRunningActor = true;
+
     // Run the job.
     runJobInEstablishedExecutorContext(job);
 
     // The current actor may have changed after the job.
     // If it's become nil, or not a default actor, we have nothing to do.
-    auto currentExecutor = activeTrackingInfo->getActiveExecutor();
+    auto currentExecutor = trackingInfo.getActiveExecutor();
 
 #if SWIFT_TASK_PRINTF_DEBUG
-    fprintf(stderr, "%p processDefaultActor %p current executor now %p\n", pthread_self(), currentActor, (void*)currentExecutor.getRawValue());
+    fprintf(stderr, "[%p] processDefaultActor %p current executor now %p\n", pthread_self(), currentActor, currentExecutor.getIdentity());
 #endif
 
     if (!currentExecutor.isDefaultActor()) {
@@ -1205,17 +1240,15 @@ static void processDefaultActor(DefaultActorImpl *currentActor,
       break;
     }
     currentActor = asImpl(currentExecutor.getDefaultActor());
-
-    // Otherwise, we know that we're running the actor on this thread.
-    threadIsRunningActor = true;
   }
 
-  if (activeTrackingInfo == &trackingInfo)
-    trackingInfo.leave();
+  // Leave the tracking info.
+  trackingInfo.leave();
 
   // If we still have an active actor, we should give it up.
-  if (currentActor)
+  if (threadIsRunningActor && currentActor) {
     currentActor->giveUpThread(runner);
+  }
 
   swift_release(actor);
 }
@@ -1386,7 +1419,14 @@ void swift::swift_MainActor_register(HeapObject *actor) {
 /*****************************************************************************/
 
 /// Can the current executor give up its thread?
-static bool canGiveUpThreadForSwitch(ExecutorRef currentExecutor) {
+static bool canGiveUpThreadForSwitch(ExecutorTrackingInfo *trackingInfo,
+                                     ExecutorRef currentExecutor) {
+  assert(trackingInfo || currentExecutor.isGeneric());
+
+  // Some contexts don't allow switching at all.
+  if (trackingInfo && !trackingInfo->allowsSwitching())
+    return false;
+
   // We can certainly "give up" a generic executor to try to run
   // a task for an actor.
   if (currentExecutor.isGeneric())
@@ -1439,30 +1479,37 @@ static bool tryAssumeThreadForSwitch(ExecutorRef newExecutor,
 /// continue to run the given task on it.
 SWIFT_CC(swiftasync)
 static void runOnAssumedThread(AsyncTask *task, ExecutorRef executor,
+                               ExecutorTrackingInfo *oldTracking,
                                RunningJobInfo runner) {
-  // Set that this actor is now the active default actor on this thread,
-  // and set up tracking info if there isn't any already.
-  ExecutorTrackingInfo trackingInfo;
-  auto activeTrackingInfo = trackingInfo.enterOrUpdate(executor);
+  // If there's alreaady tracking info set up, just change the executor
+  // there and tail-call the task.  We don't want these frames to
+  // potentially accumulate linearly.
+  if (oldTracking) {
+    oldTracking->setActiveExecutor(executor);
 
-  // If one already existed, we should just tail-call the task; we don't
-  // want these frames to potentially accumulate linearly.
-  if (activeTrackingInfo != &trackingInfo) {
     // FIXME: force tail call
     return task->runInFullyEstablishedContext();
   }
 
-  // Otherwise, run the new task.
+  // Otherwise, set up tracking info.
+  ExecutorTrackingInfo trackingInfo;
+  trackingInfo.enterAndShadow(executor);
+
+  // Run the new task.
   task->runInFullyEstablishedContext();
 
   // Leave the tracking frame, and give up the current actor if
   // we have one.
   //
-  // In principle, we could execute more tasks here, but that's probably
-  // not a reasonable thing to do in an assumed context rather than a
-  // dedicated actor-processing job.
+  // In principle, we could execute more tasks from the actor here, but
+  // that's probably not a reasonable thing to do in an assumed context
+  // rather than a dedicated actor-processing job.
   executor = trackingInfo.getActiveExecutor();
   trackingInfo.leave();
+
+#if SWIFT_TASK_PRINTF_DEBUG
+  fprintf(stderr, "[%p] leaving assumed thread, current executor is %p\n", pthread_self(), executor.getIdentity());
+#endif
 
   if (executor.isDefaultActor())
     asImpl(executor.getDefaultActor())->giveUpThread(runner);
@@ -1472,9 +1519,12 @@ SWIFT_CC(swiftasync)
 static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContext,
                                   TaskContinuationFunction *resumeFunction,
                                   ExecutorRef newExecutor) {
-  auto currentExecutor = ExecutorTrackingInfo::getActiveExecutorInThread();
+  auto trackingInfo = ExecutorTrackingInfo::current();
+  auto currentExecutor =
+    (trackingInfo ? trackingInfo->getActiveExecutor()
+                  : ExecutorRef::generic());
 #if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "%p switch %p -> %p\n", pthread_self(), (void*)currentExecutor.getRawValue(), (void*)newExecutor.getRawValue());
+  fprintf(stderr, "[%p] trying to switch from executor %p to %p\n", pthread_self(), currentExecutor.getIdentity(), newExecutor.getIdentity());
 #endif
 
   // If the current executor is compatible with running the new executor,
@@ -1499,16 +1549,22 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
   // If the current executor can give up its thread, and the new executor
   // can take over a thread, try to do so; but don't do this if we've
   // been asked to yield the thread.
-  if (canGiveUpThreadForSwitch(currentExecutor) &&
+  if (canGiveUpThreadForSwitch(trackingInfo, currentExecutor) &&
       !shouldYieldThread() &&
       tryAssumeThreadForSwitch(newExecutor, runner)) {
+#if SWIFT_TASK_PRINTF_DEBUG
+    fprintf(stderr, "[%p] switch succeeded, task %p assumed thread for executor %p\n", pthread_self(), task, newExecutor.getIdentity());
+#endif
     giveUpThreadForSwitch(currentExecutor, runner);
     // FIXME: force tail call
-    return runOnAssumedThread(task, newExecutor, runner);
+    return runOnAssumedThread(task, newExecutor, trackingInfo, runner);
   }
 
   // Otherwise, just asynchronously enqueue the task on the given
   // executor.
+#if SWIFT_TASK_PRINTF_DEBUG
+  fprintf(stderr, "[%p] switch failed, task %p enqueued on executor %p\n", pthread_self(), task, newExecutor.getIdentity());
+#endif
   swift_task_enqueue(task, newExecutor);
 }
 
@@ -1519,7 +1575,7 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
 SWIFT_CC(swift)
 static void swift_task_enqueueImpl(Job *job, ExecutorRef executor) {
 #if SWIFT_TASK_PRINTF_DEBUG
-  fprintf(stderr, "%p enqueue %p\n", pthread_self(), (void*)executor.getRawValue());
+  fprintf(stderr, "[%p] enqueue job %p on executor %p\n", pthread_self(), job, executor.getIdentity());
 #endif
 
   assert(job && "no job provided");

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1538,9 +1538,7 @@ static void swift_task_enqueueImpl(Job *job, ExecutorRef executor) {
 
   // Just assume it's actually a default actor that we haven't tagged
   // properly.
-  // FIXME: call the general method.
-  return asImpl(reinterpret_cast<DefaultActor*>(executor.getRawValue()))
-    ->enqueue(job);
+  swift_unreachable("unexpected or corrupt executor reference");
 }
 
 #define OVERRIDE_ACTOR COMPATIBILITY_OVERRIDE

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -25,6 +25,9 @@
 
 namespace swift {
 
+// Uncomment to enable helpful debug spew to stderr
+//#define SWIFT_TASK_PRINTF_DEBUG 1
+
 class AsyncTask;
 class TaskGroup;
 

--- a/test/IRGen/async/Inputs/resilient_actor.swift
+++ b/test/IRGen/async/Inputs/resilient_actor.swift
@@ -1,0 +1,13 @@
+open actor ResilientBaseActor {
+  public init() {}
+}
+
+@_fixed_layout
+open actor FixedSubclassOfResilientBaseActor : ResilientBaseActor {
+  public override init() {}
+}
+
+@_fixed_layout
+open actor FixedBaseActor {
+  public init() {}
+}

--- a/test/IRGen/async/default_actor.swift
+++ b/test/IRGen/async/default_actor.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-experimental-concurrency -enable-library-evolution -emit-module-path=%t/resilient_actor.swiftmodule -module-name=resilient_actor %S/Inputs/resilient_actor.swift
+// RUN: %target-swift-frontend -I %t -emit-ir -enable-experimental-concurrency -enable-library-evolution %s | %IRGenFileCheck %s
+// REQUIRES: concurrency
+
+// CHECK: @"$s13default_actor1ACMn" = hidden constant
+//   0x81000050: 0x01000000 IsDefaultActor
+// CHECK-SAME: i32 -2130706352,
+
+// CHECK: @"$s13default_actor1BCMn" = hidden constant
+//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
+// CHECK-SAME: i32 1644232784,
+
+// CHECK: @"$s13default_actor1CCMn" = hidden constant
+//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
+// CHECK-SAME: i32 1644232784,
+
+// CHECK: @"$s13default_actor1DCMn" = hidden constant
+//   0x63010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
+// CHECK-SAME: i32 1661010000,
+
+import resilient_actor
+
+// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1ACfD"(%T13default_actor1AC* swiftself %0)
+// CHECK-NOT: ret void
+// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     ret void
+actor A {}
+
+// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1BCfD"(%T13default_actor1BC* swiftself %0)
+// CHECK-NOT: ret void
+// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     ret void
+actor B : ResilientBaseActor {}
+
+// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1CCfD"(%T13default_actor1CC* swiftself %0)
+// CHECK-NOT: ret void
+// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     ret void
+actor C : FixedSubclassOfResilientBaseActor {}
+
+// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1DCfD"(%T13default_actor1DC* swiftself %0)
+// CHECK-NOT: ret void
+// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     ret void
+actor D : FixedBaseActor {}

--- a/test/IRGen/async/default_actor.swift
+++ b/test/IRGen/async/default_actor.swift
@@ -23,24 +23,24 @@ import resilient_actor
 
 // CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1ACfD"(%T13default_actor1AC* swiftself %0)
 // CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     call swiftcc void @swift_defaultActor_deallocate(
 // CHECK:     ret void
 actor A {}
 
 // CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1BCfD"(%T13default_actor1BC* swiftself %0)
 // CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
 // CHECK:     ret void
 actor B : ResilientBaseActor {}
 
 // CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1CCfD"(%T13default_actor1CC* swiftself %0)
 // CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
 // CHECK:     ret void
 actor C : FixedSubclassOfResilientBaseActor {}
 
 // CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1DCfD"(%T13default_actor1DC* swiftself %0)
 // CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_deallocObject(
+// CHECK:     call swiftcc void @swift_defaultActor_deallocate(
 // CHECK:     ret void
 actor D : FixedBaseActor {}

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-concurrency -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -enable-experimental-concurrency -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s
 
 // REQUIRES: concurrency
 
@@ -8,11 +8,12 @@ import Builtin
 import Swift
 import _Concurrency
 
-// CHECK-LABEL: define{{.*}} void @test_simple(%swift.context* swiftasync %0, %swift.executor* %1)
+// CHECK-LABEL: define{{.*}} void @test_simple(
+// CHECK-SAME: %swift.context* swiftasync %0, %swift.refcounted* %1, [[INT]] %2)
 // CHECK: [[CTX:%[0-9]+]] = bitcast %swift.context* %0
 // CHECK: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
-// CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* %1, %swift.context* {{%[0-9]+}})
-// CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.executor*, %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.executor* %1, %swift.context* {{%[0-9]+}})
+// CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.refcounted*, [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.refcounted* %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
+// CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, %swift.refcounted*, [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], %swift.refcounted* %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
 // CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.context*)* {{.*}} to i8*
 // CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
 // CHECK: unreachable
@@ -25,11 +26,11 @@ bb0(%0 : $Builtin.Executor):
 }
 
 // CHECK-LABEL: define internal swift{{(tail)?}}cc void @__swift_suspend_point
-// CHECK-SAME:  (i8* [[RESUME_FN:%0]], %swift.executor* %1, %swift.context* [[CTXT:%[^,]+]])
+// CHECK-SAME:  (i8* [[RESUME_FN:%0]], %swift.refcounted* %1, [[INT]] %2, %swift.context* [[CTXT:%[^,]+]])
 // CHECK-arm64e: [[RESUME_FN_INT:%[^,]+]] = ptrtoint i8* [[RESUME_FN]] to i64
 // CHECK-arm64e: [[PTRAUTH_SIGN:%[^,]+]] = call i64 @llvm.ptrauth.sign.i64(i64 [[RESUME_FN_INT]], i32 0, i64 0)
 // CHECK-arm64e: [[RESUME_FN:%[^,]+]] = inttoptr i64 [[PTRAUTH_SIGN]] to i8*
-// CHECK:    {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_switch(%swift.context* swiftasync [[CTXT]], i8* [[RESUME_FN]], %swift.executor* %1)
+// CHECK:    {{(must)?}}tail call swift{{(tail)?}}cc void @swift_task_switch(%swift.context* swiftasync [[CTXT]], i8* [[RESUME_FN]], %swift.refcounted* %1, [[INT]] %2)
 // CHECK:    ret void
 
 // CHECK: define{{.*}} void @[[TAIL_CALL_FUNC]](i8* %0, %swift.context* %1)

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -208,3 +208,34 @@ bb2:
   return %r : $()
 }
 
+//   This pattern is definitely optimizable, but it's *not* supposed to
+//   be optimized by simply removing the hop before the builtin.
+// CHECK-LABEL: sil [ossa] @handleGetCurrentExecutor : $@convention(method) @async (@guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK:       bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    function_ref
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    hop_to_executor
+// CHECK-NEXT:    builtin
+// CHECK-NEXT:    hop_to_executor
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    function_ref
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function 'handleGetCurrentExecutor'
+sil [ossa] @handleGetCurrentExecutor : $@convention(method) @async (@guaranteed MyActor, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  hop_to_executor %0 : $MyActor
+  %async_f = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+  apply %async_f() : $@convention(thin) @async () -> ()
+  hop_to_executor %0 : $MyActor  
+  %curExec = builtin "getCurrentExecutor"() : $Builtin.Executor
+  hop_to_executor %1 : $MyActor
+  %f = function_ref @requiredToRunOnActor : $@convention(method) (@guaranteed MyActor) -> ()
+  apply %f(%1) : $@convention(method) (@guaranteed MyActor) -> ()
+  hop_to_executor %0 : $MyActor
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
This PR started as an ABI change to the layout of `ExecutorRef` to make it two words.  This is in preparation for custom executors, as the second word will be used to stored the protocol witness table for custom serial executors.

In order to successfully land that patch, I've needed to fix several serious defects in the actor runtime and optimizer, most of them my fault.  The biggest original sin here came from my efforts to avoid retaining default actors when switching to them.  I did consider just giving up on that optimization, but eventually I figured out a way to preserve it by introducing the concept of a "zombie" actor state in which the actor's deallocation is delayed until it is no longer running.  This is supported mechanically by changing the behavior of the SIL `dealloc_ref` operation on instances of default actor classes.  This is implemented correctly across resilience domains, which required adding a dynamic representation for default-actor-ness, as well as fixing the type-checker's predicate for default-actor-ness.

I have also fully restored the original vision for the default actor retaining optimization in the runtime, which had previously been valiantly worked around by retaining during processing jobs.  Unfortunately, in addition to the performance costs, this also didn't quite fix the problem, as it didn't cover the case where we simply switched to the actor from a different context.  Anyway, it should no longer be necessary.