### PR TITLE
[SR-9425][Sema] Use derived conformance as witness when possible for == operator of raw representable enums

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3833,6 +3833,25 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
   }
 }
 
+// If the given witness matches a generic RawRepresentable function conforming
+// with a given protocol e.g. `func == <T : RawRepresentable>(lhs: T, rhs: T) ->
+// Bool where T.RawValue : Equatable`
+static bool isRawRepresentableGenericFunction(
+    ASTContext &ctx, const ValueDecl *witness,
+    const NormalProtocolConformance *conformance) {
+  auto *fnDecl = dyn_cast<AbstractFunctionDecl>(witness);
+  return fnDecl && fnDecl->isGeneric() &&
+         llvm::all_of(
+             fnDecl->getGenericRequirements(), [&](Requirement genericReq) {
+               return genericReq.getKind() == RequirementKind::Conformance &&
+                      (genericReq.getProtocolDecl() ==
+                           ctx.getProtocol(
+                               KnownProtocolKind::RawRepresentable) ||
+                       genericReq.getProtocolDecl() ==
+                           conformance->getProtocol());
+             });
+}
+
 ResolveWitnessResult
 ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   assert(!isa<AssociatedTypeDecl>(requirement) && "Use resolveTypeWitnessVia*");
@@ -3881,6 +3900,16 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
   bool considerRenames =
       !canDerive && !requirement->getAttrs().hasAttribute<OptionalAttr>() &&
       !requirement->getAttrs().isUnavailable(getASTContext());
+
+  auto &ctx = getASTContext();
+  bool isEquatableConformance = Conformance->getProtocol() ==
+                                ctx.getProtocol(KnownProtocolKind::Equatable);
+
+  auto decl = Conformance->getDeclContext()->getSelfNominalTypeDecl();
+  auto *enumDecl = dyn_cast_or_null<EnumDecl>(decl);
+  bool isSwiftRawRepresentableEnum =
+      enumDecl && enumDecl->hasRawType() && !enumDecl->isObjC();
+
   if (findBestWitness(requirement,
                       considerRenames ? &ignoringNames : nullptr,
                       Conformance,
@@ -3888,6 +3917,17 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                       matches, numViable, bestIdx, doNotDiagnoseMatches)) {
     const auto &best = matches[bestIdx];
     auto witness = best.Witness;
+
+    if (canDerive && isSwiftRawRepresentableEnum && isEquatableConformance) {
+      // For swift enum types that can derive equatable conformance,
+      // if the best witness is default generic conditional conforming
+      // `func == <T : RawRepresentable>(lhs: T, rhs: T) -> Bool where
+      // T.RawValue : Equatable` let's return as missing and derive
+      // the conformance since it is possible.
+      if (isRawRepresentableGenericFunction(ctx, witness, Conformance)) {
+        return ResolveWitnessResult::Missing;
+      }
+    }
 
     // If the name didn't actually line up, complain.
     if (ignoringNames &&

--- a/test/SILGen/enum_equatable_witness.swift
+++ b/test/SILGen/enum_equatable_witness.swift
@@ -1,0 +1,58 @@
+// RUN: %target-swift-emit-silgen -module-name main %s -verify | %FileCheck %s
+// SR-9425
+enum MyState : String {
+    case closed = "closed"
+    case opened = "opened"
+}
+
+@inline(never)
+func check_state(_ state : MyState) -> Int {
+  // CHECK: function_ref @$s4main7MyStateO21__derived_enum_equalsySbAC_ACtFZ
+  return state == .opened ? 1 : 0
+}
+
+// regular-enum.swift
+enum Regular {
+  case closed
+  case opened
+}
+
+@inline(never)
+func check_regular(_ state : Regular) -> Int {
+  // CHECK: function_ref @$s4main7RegularO21__derived_enum_equalsySbAC_ACtFZ
+  return state == .closed ? 1 : 0
+}
+
+// string-enum.swift
+enum Alphabet : String {
+  case A = "A", B = "B", C = "C", D = "D", E = "E", F = "F", G = "G", H = "H", I = "I", J = "J"
+}
+
+@inline(never)
+func check_alphabet(_ state : Alphabet) -> Int {
+  // CHECK: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+  return state == .E ? 1 : 0
+}
+
+@inline(never)
+func compareIt(_ state : Alphabet, _ rhs: Alphabet) -> Bool {
+  // CHECK: function_ref @$s4main8AlphabetO21__derived_enum_equalsySbAC_ACtFZ
+  return state == rhs
+}
+
+// int-enum.swift
+enum AlphabetInt : Int {
+  case A = 10, B = 100, C = 12, D = 456, E = 1, F = 3, G = 77, H = 2, I = 27, J = 42
+}
+
+@inline(never)
+func check_alphabet_int(_ state : AlphabetInt) -> Int {
+  // CHECK: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+  return state == .E ? 1 : 0
+}
+
+@inline(never)
+func compareIt(_ state : AlphabetInt, _ rhs: AlphabetInt) -> Bool {
+  // CHECK: function_ref @$s4main11AlphabetIntO21__derived_enum_equalsySbAC_ACtFZ
+  return state == rhs
+}

--- a/test/SILGen/enum_equatable_witness.swift
+++ b/test/SILGen/enum_equatable_witness.swift
@@ -11,6 +11,18 @@ func check_state(_ state : MyState) -> Int {
   return state == .opened ? 1 : 0
 }
 
+// generic-enum.swift
+enum GenericMyState<T> : String {
+  case closed
+  case opened
+}
+
+@inline(never)
+func check_generic_state(_ state : GenericMyState<Int>) -> Int {
+  // CHECK: function_ref @$s4main14GenericMyStateO21__derived_enum_equalsySbACyxG_AEtFZ
+  return state == .opened ? 1 : 0
+}
+
 // regular-enum.swift
 enum Regular {
   case closed

--- a/test/SILGen/opaque_ownership.swift
+++ b/test/SILGen/opaque_ownership.swift
@@ -150,13 +150,33 @@ public struct Int64 : ExpressibleByIntegerLiteral, _ExpressibleByBuiltinIntegerL
   }
 }
 
+public struct Int : _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLiteral, Equatable {
+  var _value: Builtin.Int64
+  public init() {
+    self = 0
+  }
+  public typealias IntegerLiteralType = Int
+  public init(_builtinIntegerLiteral x: _MaxBuiltinIntegerType) {
+    _value = Builtin.s_to_s_checked_trunc_IntLiteral_Int64(x).0
+  }
+
+  public init(integerLiteral value: Int) {
+    self = value
+  }
+
+  public static func ==(_ lhs: Int, rhs: Int) -> Bool {
+    return Bool(Builtin.cmp_eq_Int64(lhs._value, rhs._value))
+  }
+}
+
 // Test ownership of multi-case Enum values in the context of to @in thunks.
 // ---
 // CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [ossa] @$ss17FloatingPointSignOSQsSQ2eeoiySbx_xtFZTW :
 // CHECK: bb0(%0 : $FloatingPointSign, %1 : $FloatingPointSign, %2 : $@thick FloatingPointSign.Type):
-// CHECK:   %3 = function_ref @$ss2eeoiySbx_xtSYRzSQ8RawValueRpzlF : $@convention(thin) <τ_0_0 where τ_0_0 : RawRepresentable, τ_0_0.RawValue : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
-// CHECK:   %4 = apply %3<FloatingPointSign>(%0, %1) : $@convention(thin) <τ_0_0 where τ_0_0 : RawRepresentable, τ_0_0.RawValue : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
-// CHECK:   return %4 : $Bool
+// CHECK:   %3 = metatype $@thin FloatingPointSign.Type // user: %5
+// CHECK:   %4 = function_ref @$ss17FloatingPointSignO21__derived_enum_equalsySbAB_ABtFZ : $@convention(method) (FloatingPointSign, FloatingPointSign, @thin FloatingPointSign.Type) -> Bool // user: %5
+// CHECK:   %5 = apply %4(%0, %1, %3) : $@convention(method) (FloatingPointSign, FloatingPointSign, @thin FloatingPointSign.Type) -> Bool // user: %6
+// CHECK:   return %5 : $Bool
 // CHECK-LABEL: } // end sil function '$ss17FloatingPointSignOSQsSQ2eeoiySbx_xtFZTW'
 public enum FloatingPointSign: Int64 {
   /// The sign for a positive value.

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -542,6 +542,37 @@
           "fixedbinaryorder": 0
         },
         {
+          "kind": "Function",
+          "name": "__derived_enum_equals",
+          "printedName": "__derived_enum_equals(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Number",
+              "printedName": "cake.Number",
+              "usr": "s:4cake6NumberO"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Number",
+              "printedName": "cake.Number",
+              "usr": "s:4cake6NumberO"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:4cake6NumberO21__derived_enum_equalsySbAC_ACtFZ",
+          "moduleName": "cake",
+          "static": true,
+          "implicit": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
           "kind": "Constructor",
           "name": "init",
           "printedName": "init(rawValue:)",

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -545,6 +545,37 @@
           "moduleName": "cake"
         },
         {
+          "kind": "Function",
+          "name": "__derived_enum_equals",
+          "printedName": "__derived_enum_equals(_:_:)",
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Bool",
+              "printedName": "Swift.Bool",
+              "usr": "s:Sb"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Number",
+              "printedName": "cake.Number",
+              "usr": "s:4cake6NumberO"
+            },
+            {
+              "kind": "TypeNominal",
+              "name": "Number",
+              "printedName": "cake.Number",
+              "usr": "s:4cake6NumberO"
+            }
+          ],
+          "declKind": "Func",
+          "usr": "s:4cake6NumberO21__derived_enum_equalsySbAC_ACtFZ",
+          "moduleName": "cake",
+          "static": true,
+          "implicit": true,
+          "funcSelfKind": "NonMutating"
+        },
+        {
           "kind": "Constructor",
           "name": "init",
           "printedName": "init(rawValue:)",


### PR DESCRIPTION
<!-- What's in this pull request? -->
There are two overloads involved in this case 
* `<Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool`
* `<T where T : RawRepresentable, T.RawValue : Equatable> (T, T) -> Bool`

Solver is finding the first one as best because the ranking rule of non-generic is better than generic.
However in CSApply https://github.com/apple/swift/blob/22506f9bdb009c0c82410406d825c87c08af7f29/lib/Sema/CSApply.cpp#L621
currently it is finding the `<T where T : RawRepresentable, T.RawValue : Equatable> (T, T) -> Bool` as the `Equatable` (`WitnessChecker::findBestWitness` find only this one)witness which ends up applied. What given the implementation of it:
```swift
@inlinable // trivial-implementation
public func == <T: RawRepresentable>(lhs: T, rhs: T) -> Bool
  where T.RawValue: Equatable {
  return lhs.rawValue == rhs.rawValue
}
```
When raw value is a `String` the codegen ends up with a string compare. 

This PR adjusts `ConformanceChecker::resolveWitnessViaLookup` to not consider this witness as best match for swift raw representable enums when derive `Equatable` is possible(favor derived). Therefore avoiding a str compare for those cases. 

**Note**
More details on the JIRA issue
Also, this PR although fixes the issue and makes sense to me, I'm not familiar enough with this to know if it is really the best fix. 

cc @eeckstein @xedin 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-9425, rdar://46555205

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
