### PR TITLE
unittests: add a more verbose error message

### DIFF
--- a/unittests/DependencyScan/Features.cpp
+++ b/unittests/DependencyScan/Features.cpp
@@ -30,7 +30,7 @@ testHasOption(llvm::opt::OptTable &table, options::ID id,
     if (strlen(name) > 0) {
       auto nameStr = std::string(name);
       bool setContainsOption = optionSet.find(nameStr) != optionSet.end();
-      EXPECT_EQ(setContainsOption, true);
+      EXPECT_EQ(setContainsOption, true) << "Missing Option: " << nameStr;
     }
   }
 }


### PR DESCRIPTION
This test was failing for me locally due to a path configuration issue.
Add an indication which option is missing.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
