### PR TITLE
[Parse] Understand arch(arm64_32)

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -58,6 +58,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationOSs[] = {
 static const SupportedConditionalValue SupportedConditionalCompilationArches[] = {
   "arm",
   "arm64",
+  "arm64_32",
   "i386",
   "x86_64",
   "powerpc64",
@@ -305,6 +306,9 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::ArchType::aarch64:
     addPlatformConditionValue(PlatformConditionKind::Arch, "arm64");
     break;
+  case llvm::Triple::ArchType::aarch64_32:
+    addPlatformConditionValue(PlatformConditionKind::Arch, "arm64_32");
+    break;
   case llvm::Triple::ArchType::ppc64:
     addPlatformConditionValue(PlatformConditionKind::Arch, "powerpc64");
     break;
@@ -336,6 +340,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   case llvm::Triple::ArchType::arm:
   case llvm::Triple::ArchType::thumb:
   case llvm::Triple::ArchType::aarch64:
+  case llvm::Triple::ArchType::aarch64_32:
   case llvm::Triple::ArchType::ppc64le:
   case llvm::Triple::ArchType::wasm32:
   case llvm::Triple::ArchType::x86:

--- a/test/Parse/ConditionalCompilation/arm64_32WatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64_32WatchOSTarget.swift
@@ -1,0 +1,14 @@
+// RUN: %swift -typecheck %s -verify -target arm64_32-apple-watchos7.0 -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64_32-apple-watchos7.0
+
+#if os(iOS)
+// This block should not parse.
+// os(tvOS) or os(watchOS) does not imply os(iOS).
+let i: Int = "Hello"
+#endif
+
+#if arch(arm64_32) && os(watchOS) && _runtime(_ObjC) && _endian(little)
+class C {}
+var x = C()
+#endif
+var y = x


### PR DESCRIPTION
Currently the open source Swift compiler does not understand
`arch(arm64_32)` while Xcode's Swift compiler does. Implement the
minimum to be able to parse and conditionally compile parts of the code
marked with `arch(arm64_32)`. This way open source code that includes
these conditional compilation directives will not fail to get parsed.

Includes a test checking that the new directive is correctly supported.