### PR TITLE
Disabling failing driver tests

### DIFF
--- a/test/Driver/Dependencies/dependencies-preservation-fine.swift
+++ b/test/Driver/Dependencies/dependencies-preservation-fine.swift
@@ -2,6 +2,8 @@
 // Verify that the top-level build record file from the last incremental
 // compilation is preserved with the same name, suffixed by a '~'.
 
+// REQUIRES: rdar76238077
+
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -1,5 +1,7 @@
 /// other ==> main
 
+// REQUIRES: rdar76238077
+
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: touch -t 201401240005 %t/*


### PR DESCRIPTION
It looks like an issue crept in with https://github.com/apple/swift-driver/pull/580.
This should get things moving until that can be resolved.