### PR TITLE
Sema: Fix effects checking of 'for await' with a concrete conformance

### DIFF
--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -75,3 +75,10 @@ func forAwaitInsideDoCatch<Source: AsyncSequence>(_ source: Source) async {
     }
   } catch {} // no-warning
 }
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func forAwaitWithConcreteType(_ seq: ThrowingAsyncSequence) throws { // expected-note {{add 'async' to function 'forAwaitWithConcreteType' to make it asynchronous}}
+  for try await elt in seq { // expected-error {{'async' in a function that does not support concurrency}}
+    _ = elt
+  }
+}


### PR DESCRIPTION
AsyncSequence is only polymorphic over 'throws' effects, not 'async',
because it is @rethrows and not @reasync. So the logic here was wrong,
and it would incorrectly conclude that a 'for await' with a concrete
conformance did not require the outer function to be 'async'.

Fixes rdar://problem/75436909.