### PR TITLE
Revert "stdlib: Add reasync variants of '&&', '||' and '??'"

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -276,10 +276,10 @@ extension Bool {
   ///   - lhs: The left-hand side of the operation.
   ///   - rhs: The right-hand side of the operation.
   @_transparent
-  @_alwaysEmitIntoClient
-  public static func && (lhs: Bool, rhs: @autoclosure () async throws -> Bool) reasync rethrows
+  @inline(__always)
+  public static func && (lhs: Bool, rhs: @autoclosure () throws -> Bool) rethrows
       -> Bool {
-    return lhs ? try await rhs() : false
+    return lhs ? try rhs() : false
   }
 
   /// Performs a logical OR operation on two Boolean values.
@@ -316,24 +316,8 @@ extension Bool {
   ///   - lhs: The left-hand side of the operation.
   ///   - rhs: The right-hand side of the operation.
   @_transparent
-  @_alwaysEmitIntoClient
-  public static func || (lhs: Bool, rhs: @autoclosure () async throws -> Bool) reasync rethrows
-      -> Bool {
-    return lhs ? true : try await rhs()
-  }
-
-  // We keep the old entry points around but mark them unavailable for
-  // ABI compatibility.
-  @usableFromInline
-  @available(*, unavailable)
-  internal static func && (lhs: Bool, rhs: @autoclosure () throws -> Bool) rethrows
-      -> Bool {
-    return lhs ? try rhs() : false
-  }
-
-  @usableFromInline
-  @available(*, unavailable)
-  internal static func || (lhs: Bool, rhs: @autoclosure () throws -> Bool) rethrows
+  @inline(__always)
+  public static func || (lhs: Bool, rhs: @autoclosure () throws -> Bool) rethrows
       -> Bool {
     return lhs ? true : try rhs()
   }

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -289,8 +289,6 @@ endif()
 list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-experimental-concise-pound-file")
 list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-ossa-modules")
 
-list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-experimental-concurrency")
-
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_target_library(swift_stdlib_essential ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
       INSTALL_IN_COMPONENT never_install

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -607,14 +607,13 @@ extension Optional {
 ///   - defaultValue: A value to use as a default. `defaultValue` is the same
 ///     type as the `Wrapped` type of `optional`.
 @_transparent
-@_alwaysEmitIntoClient
-public func ?? <T>(optional: T?, defaultValue: @autoclosure () async throws -> T)
-    reasync rethrows -> T {
+public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T)
+    rethrows -> T {
   switch optional {
   case .some(let value):
     return value
   case .none:
-    return try await defaultValue()
+    return try defaultValue()
   }
 }
 
@@ -661,34 +660,7 @@ public func ?? <T>(optional: T?, defaultValue: @autoclosure () async throws -> T
 ///   - defaultValue: A value to use as a default. `defaultValue` and
 ///     `optional` have the same type.
 @_transparent
-@_alwaysEmitIntoClient
-public func ?? <T>(optional: T?, defaultValue: @autoclosure () async throws -> T?)
-    reasync rethrows -> T? {
-  switch optional {
-  case .some(let value):
-    return value
-  case .none:
-    return try await defaultValue()
-  }
-}
-
-// We keep the old entry points around but mark them unavailable for
-// ABI compatibility.
-@usableFromInline
-@available(*, unavailable)
-internal func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T)
-    rethrows -> T {
-  switch optional {
-  case .some(let value):
-    return value
-  case .none:
-    return try defaultValue()
-  }
-}
-
-@usableFromInline
-@available(*, unavailable)
-internal func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T?)
+public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T?)
     rethrows -> T? {
   switch optional {
   case .some(let value):

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -103,7 +103,7 @@ func test_various_situations_converting_to_double() {
 }
 
 func test_conversions_with_optionals(v: CGFloat?) {
-  // CHECK: function_ref @$s34implicit_double_cgfloat_conversion31test_conversions_with_optionals1vy12CoreGraphics7CGFloatVSg_tFAFyYKXEfu_ : $@convention(thin) @async () -> (CGFloat, @error Error)
+  // CHECK: function_ref @$s34implicit_double_cgfloat_conversion31test_conversions_with_optionals1vy12CoreGraphics7CGFloatVSg_tFAFyKXEfu_ : $@convention(thin) () -> (CGFloat, @error Error)
   // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC : $@convention(method) (CGFloat, @thin Double.Type) -> Double
   let _: Double = (v ?? 0)
 }

--- a/test/Profiler/coverage_closures.swift
+++ b/test/Profiler/coverage_closures.swift
@@ -17,7 +17,7 @@ func foo() {
 // CHECK-LABEL: sil_coverage_map {{.*}}// f1 #1 ((Swift.Int32, Swift.Int32) -> Swift.Bool) -> Swift.Bool in coverage_closures.foo()
 // CHECK-NEXT: [[@LINE+1]]:55 -> {{.*}}:4 : 0
   func f1(_ closure : (Int32, Int32) -> Bool) -> Bool {
-// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 () async throws -> Swift.Bool in f1
+// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 () throws -> Swift.Bool in f1
 // CHECK-NEXT: [[@LINE+1]]:29 -> [[@LINE+1]]:42 : 0
     return closure(0, 1) && closure(1, 0)
   }
@@ -30,7 +30,7 @@ func foo() {
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// closure #3 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
 // CHECK-NEXT: [[@LINE+3]]:6 -> [[@LINE+3]]:48 : 0
-// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 () async throws -> {{.*}} in coverage_closures.foo
+// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 () throws -> {{.*}} in coverage_closures.foo
 // CHECK-NEXT: [[@LINE+1]]:36 -> [[@LINE+1]]:46 : 0
   f1 { left, right in left == 0 || right == 1 }
 }

--- a/test/Profiler/instrprof_operators.swift
+++ b/test/Profiler/instrprof_operators.swift
@@ -21,7 +21,7 @@ func operators(a : Bool, b : Bool) {
 }
 
 // CHECK: implicit closure
-// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$s19instrprof_operators0B01a1bySb_SbtFSbyYKXEfu_"
+// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$s19instrprof_operators0B01a1bySb_SbtFSbyKXEfu_"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
 // CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 1
 // CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0
@@ -29,7 +29,7 @@ func operators(a : Bool, b : Bool) {
 // CHECK-NOT: builtin "int_instrprof_increment"
 
 // CHECK: implicit closure
-// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$s19instrprof_operators0B01a1bySb_SbtFSbyYKXEfu0_"
+// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$s19instrprof_operators0B01a1bySb_SbtFSbyKXEfu0_"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
 // CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 1
 // CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0

--- a/test/SILGen/capture-transitive.swift
+++ b/test/SILGen/capture-transitive.swift
@@ -7,7 +7,7 @@ func fibonacci(_ n: Int) -> Int {
     return cache[m] ?? {
       // Make sure cache is only captured once in the closure
       // CHECK: implicit closure #1 in recursive #1
-      // CHECK-LABEL: sil private [transparent] [ossa] @{{.*}}9fibonacci{{.*}}9recursive{{.*}} : $@convention(thin) @async (Int, @guaranteed { var Dictionary<Int, Int> }) -> (Int, @error Error)
+      // CHECK-LABEL: sil private [transparent] [ossa] @{{.*}}9fibonacci{{.*}}9recursive{{.*}} : $@convention(thin) (Int, @guaranteed { var Dictionary<Int, Int> }) -> (Int, @error Error)
       // CHECK: closure #1 in implicit closure #1 in recursive #1
       // CHECK-LABEL: sil private [ossa] @{{.*}}9fibonacci{{.*}}9recursive{{.*}} : $@convention(thin) (Int, @guaranteed { var Dictionary<Int, Int> }) -> Int
       let output = m < 2 ? m : recursive(m - 1) + recursive(m - 2)

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -604,15 +604,15 @@ class SuperSub : SuperBase {
   func f() {
     // CHECK: sil private [ossa] @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> () {
     // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
-    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:\$s8closures8SuperSubC1fyyFyycfU_yyYKXEfu_]] : $@convention(thin) @async (@guaranteed SuperSub) -> @error Error
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:\$s8closures8SuperSubC1fyyFyycfU_yyKXEfu_]] : $@convention(thin) (@guaranteed SuperSub) -> @error Error
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[ARG_COPY]])
     // CHECK:   [[CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PA]]
     // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply [callee_guaranteed] {{.*}}([[CVT]])
     // CHECK:   [[REABSTRACT_CVF:%.*]] = convert_function [[REABSTRACT_PA]]
     // CHECK:   [[REABSTRACT_CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[REABSTRACT_CVF]]
-    // CHECK:   [[TRY_APPLY_AUTOCLOSURE:%.*]] = function_ref @$ss2qqoiyxxSg_xyYKXKtYKlF :
-    // CHECK:   try_apply [noasync] [[TRY_APPLY_AUTOCLOSURE]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}}, normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
+    // CHECK:   [[TRY_APPLY_AUTOCLOSURE:%.*]] = function_ref @$ss2qqoiyxxSg_xyKXKtKlF :
+    // CHECK:   try_apply [[TRY_APPLY_AUTOCLOSURE]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}}, normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
     // CHECK: [[NORMAL_BB]]{{.*}}
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     let f1 = {
@@ -636,19 +636,19 @@ class SuperSub : SuperBase {
   func g() {
     // CHECK: sil private [ossa] @[[INNER_FUNC_1]] : $@convention(thin) (@guaranteed SuperSub) -> ()
     // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
-    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:\$s8closures8SuperSubC1g.*]] : $@convention(thin) @async (@guaranteed SuperSub) -> @error Error
+    // CHECK:   [[INNER:%.*]] = function_ref @[[INNER_FUNC_2:\$s8closures8SuperSubC1g.*]] : $@convention(thin) (@guaranteed SuperSub) -> @error Error
     // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
     // CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[INNER]]([[ARG_COPY]])
-    // CHECK:   [[CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PA]] : $@async @callee_guaranteed () -> @error Error to $@noescape @async @callee_guaranteed () -> @error Error
-    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[CVT]]) : $@convention(thin) @async (@noescape @async @callee_guaranteed () -> @error Error) -> (@out (), @error Error)
+    // CHECK:   [[CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PA]] : $@callee_guaranteed () -> @error Error to $@noescape @callee_guaranteed () -> @error Error
+    // CHECK:   [[REABSTRACT_PA:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[CVT]]) : $@convention(thin) (@noescape @callee_guaranteed () -> @error Error) -> (@out (), @error Error)
     // CHECK:   [[REABSTRACT_CVF:%.*]] = convert_function [[REABSTRACT_PA]]
     // CHECK:   [[REABSTRACT_CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[REABSTRACT_CVF]]
-    // CHECK:   [[TRY_APPLY_FUNC:%.*]] = function_ref @$ss2qqoiyxxSg_xyYKXKtYKlF :
-    // CHECK:   try_apply [noasync] [[TRY_APPLY_FUNC]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}}, normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
+    // CHECK:   [[TRY_APPLY_FUNC:%.*]] = function_ref @$ss2qqoiyxxSg_xyKXKtKlF :
+    // CHECK:   try_apply [[TRY_APPLY_FUNC]]<()>({{.*}}, {{.*}}, [[REABSTRACT_CVT]]) : {{.*}}, normal [[NORMAL_BB:bb1]], error [[ERROR_BB:bb2]]
     // CHECK: [[NORMAL_BB]]{{.*}}
     // CHECK: } // end sil function '[[INNER_FUNC_1]]'
     func g1() {
-      // CHECK: sil private [transparent] [ossa] @[[INNER_FUNC_2]] : $@convention(thin) @async (@guaranteed SuperSub) -> @error Error {
+      // CHECK: sil private [transparent] [ossa] @[[INNER_FUNC_2]] : $@convention(thin) (@guaranteed SuperSub) -> @error Error {
       // CHECK: bb0([[ARG:%.*]] : @guaranteed $SuperSub):
       // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
       // CHECK:   [[ARG_COPY_SUPER:%.*]] = upcast [[ARG_COPY]] : $SuperSub to $SuperBase

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -466,13 +466,13 @@ public class Base {
 public class Sub : Base {
   // CHECK-LABEL: sil hidden [ossa] @$s7dynamic3SubC1xSbvg : $@convention(method) (@guaranteed Sub) -> Bool {
   // CHECK: bb0([[SELF:%.*]] : @guaranteed $Sub):
-  // CHECK:     [[AUTOCLOSURE:%.*]] = function_ref @$s7dynamic3SubC1xSbvgSbyYKXEfu_ : $@convention(thin) @async (@guaranteed Sub) -> (Bool, @error Error)
+  // CHECK:     [[AUTOCLOSURE:%.*]] = function_ref @$s7dynamic3SubC1xSbvgSbyKXEfu_ : $@convention(thin) (@guaranteed Sub) -> (Bool, @error Error)
   // CHECK:     [[SELF_COPY:%.*]] = copy_value [[SELF]]
   // CHECK:     = partial_apply [callee_guaranteed] [[AUTOCLOSURE]]([[SELF_COPY]])
   // CHECK:     return {{%.*}} : $Bool
   // CHECK: } // end sil function '$s7dynamic3SubC1xSbvg'
 
-  // CHECK-LABEL: sil private [transparent] [ossa] @$s7dynamic3SubC1xSbvgSbyYKXEfu_ : $@convention(thin) @async (@guaranteed Sub) -> (Bool, @error Error) {
+  // CHECK-LABEL: sil private [transparent] [ossa] @$s7dynamic3SubC1xSbvgSbyKXEfu_ : $@convention(thin) (@guaranteed Sub) -> (Bool, @error Error) {
   // CHECK: bb0([[VALUE:%.*]] : @guaranteed $Sub):
   // CHECK:     [[VALUE_COPY:%.*]] = copy_value [[VALUE]]
   // CHECK:     [[CAST_VALUE_COPY:%.*]] = upcast [[VALUE_COPY]]
@@ -482,7 +482,7 @@ public class Sub : Base {
   // CHECK:     = apply [[SUPER]]([[BORROWED_CAST_VALUE_COPY]])
   // CHECK:     end_borrow [[BORROWED_CAST_VALUE_COPY]]
   // CHECK:     destroy_value [[CAST_VALUE_COPY]]
-  // CHECK: } // end sil function '$s7dynamic3SubC1xSbvgSbyYKXEfu_'
+  // CHECK: } // end sil function '$s7dynamic3SubC1xSbvgSbyKXEfu_'
   override var x: Bool { return false || super.x }
 }
 

--- a/test/SILGen/mangling.swift
+++ b/test/SILGen/mangling.swift
@@ -88,8 +88,8 @@ func uses_optionals(x: Int?) -> UnicodeScalar? { return nil }
 struct HasVarInit {
   static var state = true && false
 }
-// CHECK-LABEL: // function_ref implicit closure #1 () async throws -> Swift.Bool in variable initialization expression of static mangling.HasVarInit.state : Swift.Bool
-// CHECK-NEXT:  function_ref @$s8mangling10HasVarInitV5stateSbvpZfiSbyYKXEfu_
+// CHECK-LABEL: // function_ref implicit closure #1 () throws -> Swift.Bool in variable initialization expression of static mangling.HasVarInit.state : Swift.Bool
+// CHECK-NEXT:  function_ref @$s8mangling10HasVarInitV5stateSbvpZfiSbyKXEfu_
 
 // auto_closures should not collide with the equivalent non-auto_closure
 // function type.

--- a/test/api-digester/Outputs/stability-stdlib-source-arm64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-arm64.swift.expected
@@ -25,7 +25,3 @@ Constructor UInt8.init(_:) has parameter 0 type change from Swift.Float80 to Swi
 Constructor UInt8.init(exactly:) has parameter 0 type change from Swift.Float80 to Swift.Float16
 Struct Float80 has been removed
 TypeAlias CLongDouble has underlying type change from Swift.Float80 to Swift.Double
-
-Func Bool.&&(_:_:) is now with @reasync
-Func Bool.||(_:_:) is now with @reasync
-Func ??(_:_:) is now with @reasync

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -2,7 +2,3 @@ Protocol CodingKey has added inherited protocol Sendable
 Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible, Self : Swift.Sendable>
 Protocol Error has added inherited protocol Sendable
 Protocol Error has generic signature change from to <Self : Swift.Sendable>
-
-Func Bool.&&(_:_:) is now with @reasync
-Func Bool.||(_:_:) is now with @reasync
-Func ??(_:_:) is now with @reasync

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -57,7 +57,3 @@ Protocol CodingKey has added inherited protocol Sendable
 Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible> to <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomStringConvertible, Self : Swift.Sendable>
 Protocol Error has added inherited protocol Sendable
 Protocol Error has generic signature change from to <Self : Swift.Sendable>
-
-Func ??(_:_:) has been removed
-Func Bool.&&(_:_:) has been removed
-Func Bool.||(_:_:) has been removed


### PR DESCRIPTION
Reverts apple/swift#36614. It broke the build of the standard library in Debug configurations.