### PR TITLE
[Concurrency] Fix try-await fix-it

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1719,6 +1719,10 @@ public:
     if (!suggestTryFixIt)
       return;
 
+    // 'try' should go before 'await'
+    if (awaitLoc.isValid())
+      insertLoc = awaitLoc;
+
     Diags.diagnose(loc, diag::note_forgot_try)
         .fixItInsert(insertLoc, "try ");
     Diags.diagnose(loc, diag::note_error_to_optional)

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -99,9 +99,9 @@ func testThrowingAndAsync() async throws {
 
   // Errors
   _ = await throwingAndAsync() // expected-error{{call can throw but is not marked with 'try'}}
-  // expected-note@-1{{did you mean to use 'try'?}}
-  // expected-note@-2{{did you mean to handle error as optional value?}}
-  // expected-note@-3{{did you mean to disable error propagation?}}
+  // expected-note@-1{{did you mean to use 'try'?}}{{7-7=try }}
+  // expected-note@-2{{did you mean to handle error as optional value?}}{{7-7=try? }}
+  // expected-note@-3{{did you mean to disable error propagation?}}{{7-7=try! }}
   _ = try throwingAndAsync() // expected-error{{call is 'async' but is not marked with 'await'}}{{11-11=await }}
 }
 


### PR DESCRIPTION
This patch fixes the order that the fix-it for `try` is emitted. It was prepending it to the call, but if an await is present, it should go before that instead. e.g `try await foo()` instead of `await try foo()`.

Resolves: rdar://71058133