### PR TITLE
[IRGen] Added function pointer to direct async FunctionPointer instances.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1985,18 +1985,33 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
   assert(functionPointer.getKind() != FunctionPointer::Kind::Function);
   bool emitFunction = values.first;
   bool emitSize = values.second;
-  auto *ptr = functionPointer.getRawPointer();
-  if (auto authInfo = functionPointer.getAuthInfo()) {
-    ptr = emitPointerAuthAuth(IGF, ptr, authInfo);
-  }
-  auto *afpPtr =
-      IGF.Builder.CreateBitCast(ptr, IGF.IGM.AsyncFunctionPointerPtrTy);
+  // Ensure that the AsyncFunctionPointer is not auth'd if it is not used and
+  // that it is not auth'd more than once if it is needed.
+  //
+  // The AsyncFunctionPointer is not needed in the case where only the function
+  // is being loaded and the FunctionPointer was created from a function_ref
+  // instruction.
+  llvm::Optional<llvm::Value *> afpPtrValue = llvm::None;
+  auto getAFPPtr = [&]() {
+    if (!afpPtrValue) {
+      auto *ptr = functionPointer.getRawPointer();
+      if (auto authInfo = functionPointer.getAuthInfo()) {
+        ptr = emitPointerAuthAuth(IGF, ptr, authInfo);
+      }
+      auto *afpPtr =
+          IGF.Builder.CreateBitCast(ptr, IGF.IGM.AsyncFunctionPointerPtrTy);
+      afpPtrValue = afpPtr;
+    }
+    return *afpPtrValue;
+  };
   llvm::Value *fn = nullptr;
   if (emitFunction) {
     if (functionPointer.useStaticContextSize()) {
       fn = functionPointer.getRawPointer();
+    } else if (auto *function = functionPointer.getRawAsyncFunction()) {
+      fn = function;
     } else {
-      llvm::Value *addrPtr = IGF.Builder.CreateStructGEP(afpPtr, 0);
+      llvm::Value *addrPtr = IGF.Builder.CreateStructGEP(getAFPPtr(), 0);
       fn = IGF.emitLoadOfRelativePointer(
           Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
           /*expectedType*/ functionPointer.getFunctionType()->getPointerTo());
@@ -2014,7 +2029,7 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
                                     initialContextSize.getValue());
     } else {
       assert(!functionPointer.useStaticContextSize());
-      auto *sizePtr = IGF.Builder.CreateStructGEP(afpPtr, 1);
+      auto *sizePtr = IGF.Builder.CreateStructGEP(getAFPPtr(), 1);
       size = IGF.Builder.CreateLoad(sizePtr, IGF.IGM.getPointerAlignment());
     }
   }
@@ -4667,8 +4682,9 @@ Callee irgen::getCFunctionPointerCallee(IRGenFunction &IGF,
 
 FunctionPointer FunctionPointer::forDirect(IRGenModule &IGM,
                                            llvm::Constant *fnPtr,
+                                           llvm::Constant *secondaryValue,
                                            CanSILFunctionType fnType) {
-  return forDirect(fnType, fnPtr, IGM.getSignature(fnType));
+  return forDirect(fnType, fnPtr, secondaryValue, IGM.getSignature(fnType));
 }
 
 StringRef FunctionPointer::getName(IRGenModule &IGM) const {
@@ -4690,6 +4706,14 @@ llvm::Value *FunctionPointer::getPointer(IRGenFunction &IGF) const {
   case BasicKind::Function:
     return Value;
   case BasicKind::AsyncFunctionPointer: {
+    if (auto *rawFunction = getRawAsyncFunction()) {
+      // If the pointer to the underlying function is available, it means that
+      // this FunctionPointer instance was created via 
+      // FunctionPointer::forDirect and as such has no AuthInfo.
+      assert(!AuthInfo && "have PointerAuthInfo for an async FunctionPointer "
+                          "for which the raw function is known");
+      return rawFunction;
+    }
     auto *fnPtr = Value;
     if (auto authInfo = AuthInfo) {
       fnPtr = emitPointerAuthAuth(IGF, fnPtr, authInfo);

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -2653,7 +2653,15 @@ FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
   case ClassMetadataLayout::MethodInfo::Kind::DirectImpl: {
     auto fnPtr = llvm::ConstantExpr::getBitCast(methodInfo.getDirectImpl(),
                                            signature.getType()->getPointerTo());
-    return FunctionPointer::forDirect(methodType, fnPtr, signature);
+    llvm::Constant *secondaryValue = nullptr;
+    if (cast<AbstractFunctionDecl>(method.getDecl())->hasAsync()) {
+      auto *silFn = IGF.IGM.getSILFunctionForAsyncFunctionPointer(
+          methodInfo.getDirectImpl());
+      secondaryValue = cast<llvm::Constant>(
+          IGF.IGM.getAddrOfSILFunction(silFn, NotForDefinition));
+    }
+    return FunctionPointer::forDirect(methodType, fnPtr, secondaryValue,
+                                      signature);
   }
   }
   

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -252,8 +252,9 @@ getAccessorForComputedComponent(IRGenModule &IGM,
                                &ignoreWitnessMetadata,
                                forwardedArgs);
     }
-    auto fnPtr = FunctionPointer::forDirect(IGM, accessorFn,
-                                            accessor->getLoweredFunctionType());
+    auto fnPtr =
+        FunctionPointer::forDirect(IGM, accessorFn, /*secondaryValue*/ nullptr,
+                                   accessor->getLoweredFunctionType());
     auto call = IGF.Builder.CreateCall(fnPtr, forwardedArgs.claimAll());
     
     if (call->getType()->isVoidTy())

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -658,8 +658,9 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
   Selector selector(method);
   llvm::Value *selectorValue = IGF.emitObjCSelectorRefLoad(selector.str());
 
-  auto fn = FunctionPointer::forDirect(FunctionPointer::Kind::Function,
-                                       messenger, sig);
+  auto fn =
+      FunctionPointer::forDirect(FunctionPointer::Kind::Function, messenger,
+                                 /*secondaryValue*/ nullptr, sig);
   return Callee(std::move(info), fn, receiverValue, selectorValue);
 }
 

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency -parse-as-library) | %FileCheck %s --dump-input=always
 // REQUIRES: executable_test
 // REQUIRES: concurrency
-// XFAIL: linux
+// UNSUPPORTED: linux
 // XFAIL: windows
 
 struct Boom: Error {}

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -6,7 +6,7 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
-// XFAIL: linux
+// UNSUPPORTED: linux
 // XFAIL: windows
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)


### PR DESCRIPTION
The address of the function to be called when generating code to invoke the function associated with FunctionPointer which is produced via direct reference is by definition statically known; it is neither necessary nor desireable to load this address out of the AsyncFunctionPointer corresponding to the function.

Here, that spurious additional work is skipped.  The approach is to add a second value to the FunctionPointer struct.  For FunctionPointers whose kind is AsyncFunctionPointer, this value is either null or else the address of the corresponding function.

rdar://71376092
