### PR TITLE
Add 'deprecated' shims for removed "old" Task APIs to ease migration

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -368,8 +368,8 @@ extension Task {
   @available(*, deprecated, message: "`Task.runDetached` was replaced by `detach` and will be removed shortly.")
   public func runDetached<T>(
     priority: Task.Priority = .unspecified,
-    operation: __owned @Sendable @escaping () async -> T
-  ) -> Task.Handle<T, Never> {
+    operation: __owned @Sendable @escaping () async throws -> T
+  ) -> Task.Handle<T, Error> {
     detach(priority: priority, operation: operation)
   }
 
@@ -518,6 +518,22 @@ extension Task {
 }
 
 // ==== UnsafeCurrentTask ------------------------------------------------------
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension Task {
+
+  @available(*, deprecated, message: "`Task.unsafeCurrent` was replaced by `withUnsafeCurrentTask { task in ... }`, and will be removed soon.")
+  public static var unsafeCurrent: UnsafeCurrentTask? {
+    guard let _task = _getCurrentAsyncTask() else {
+      return nil
+    }
+    // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
+    //        with "destroying a task that never completed" in the task's destroy.
+    //        How do we solve this properly?
+    _swiftRetain(_task)
+    return UnsafeCurrentTask(_task)
+  }
+}
 
 /// Calls the given closure with the with the "current" task in which this
 /// function was invoked.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -361,6 +361,20 @@ extension Task {
 
 // ==== Detached Tasks ---------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension Task {
+
+  @discardableResult
+  @available(*, deprecated, message: "`Task.runDetached` was replaced by `detach` and will be removed shortly.")
+  public func runDetached<T>(
+    priority: Task.Priority = .unspecified,
+    operation: __owned @Sendable @escaping () async -> T
+  ) -> Task.Handle<T, Never> {
+    detach(priority: priority, operation: operation)
+  }
+
+}
+
 /// Run given throwing `operation` as part of a new top-level task.
 ///
 /// Creating detached tasks should, generally, be avoided in favor of using

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -15,6 +15,37 @@ import Swift
 
 // ==== Task Cancellation ------------------------------------------------------
 
+/// Execute an operation with cancellation handler which will immediately be
+/// invoked if the current task is cancelled.
+///
+/// This differs from the operation cooperatively checking for cancellation
+/// and reacting to it in that the cancellation handler is _always_ and
+/// _immediately_ invoked when the task is cancelled. For example, even if the
+/// operation is running code which never checks for cancellation, a cancellation
+/// handler still would run and give us a chance to run some cleanup code.
+///
+/// Does not check for cancellation, and always executes the passed `operation`.
+///
+/// This function returns instantly and will never suspend.
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public func withTaskCancellationHandler<T>(
+  handler: @Sendable () -> (),
+  operation: () async throws -> T
+) async rethrows -> T {
+  let task = Builtin.getCurrentAsyncTask()
+
+  guard !_taskIsCancelled(task) else {
+    // If the current task is already cancelled, run the handler immediately.
+    handler()
+    return try await operation()
+  }
+
+  let record = _taskAddCancellationHandler(handler: handler)
+  defer { _taskRemoveCancellationHandler(record: record) }
+
+  return try await operation()
+}
+
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 extension Task {
 
@@ -57,34 +88,12 @@ extension Task {
     }
   }
 
-  /// Execute an operation with cancellation handler which will immediately be
-  /// invoked if the current task is cancelled.
-  ///
-  /// This differs from the operation cooperatively checking for cancellation
-  /// and reacting to it in that the cancellation handler is _always_ and
-  /// _immediately_ invoked when the task is cancelled. For example, even if the
-  /// operation is running code which never checks for cancellation, a cancellation
-  /// handler still would run and give us a chance to run some cleanup code.
-  ///
-  /// Does not check for cancellation, and always executes the passed `operation`.
-  ///
-  /// This function returns instantly and will never suspend.
+  @available(*, deprecated, message: "`Task.withCancellationHandler` has been replaced by `withTaskCancellationHandler` and will be removed shortly.")
   public static func withCancellationHandler<T>(
     handler: @Sendable () -> (),
     operation: () async throws -> T
   ) async rethrows -> T {
-    let task = Builtin.getCurrentAsyncTask()
-
-    guard !_taskIsCancelled(task) else {
-      // If the current task is already cancelled, run the handler immediately.
-      handler()
-      return try await operation()
-    }
-
-    let record = _taskAddCancellationHandler(handler: handler)
-    defer { _taskRemoveCancellationHandler(record: record) }
-
-    return try await operation()
+    try await withTaskCancellationHandler(handler: handler, operation: operation)
   }
 
   /// The default cancellation thrown when a task is cancelled.
@@ -95,7 +104,6 @@ extension Task {
     // no extra information, cancellation is intended to be light-weight
     public init() {}
   }
-
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -15,6 +15,24 @@ import Swift
 
 // ==== TaskGroup --------------------------------------------------------------
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+extension Task {
+  @available(*, deprecated, message: "`Task.Group` was replaced by `ThrowingTaskGroup` and `TaskGroup` and will be removed shortly.")
+  public typealias Group<TaskResult: Sendable> = ThrowingTaskGroup<TaskResult, Error>
+
+  @available(*, deprecated, message: "`Task.withGroup` was replaced by `withThrowingTaskGroup` and `withTaskGroup` and will be removed shortly.")
+  public static func withGroup<TaskResult, BodyResult>(
+      resultType: TaskResult.Type,
+      returning returnType: BodyResult.Type = BodyResult.self,
+      body: (inout Task.Group<TaskResult>) async throws -> BodyResult
+  ) async rethrows -> BodyResult {
+    try await withThrowingTaskGroup(of: resultType) { group in
+      try await body(&group)
+    }
+  }
+}
+
+
 /// Starts a new task group which provides a scope in which a dynamic number of
 /// tasks may be spawned.
 ///
@@ -206,8 +224,19 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     self._task = task
     self._group = group
   }
-  
-  /// Add a child task to the group.
+
+  @available(*, deprecated, message: "`Task.Group.add` has been replaced by `TaskGroup.spawn` or `TaskGroup.spawnUnlessCancelled` and will be removed shortly.")
+  public mutating func add(
+      priority: Task.Priority = .unspecified,
+      operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) async -> Bool {
+    return try await self.spawnUnlessCancelled(priority: priority) {
+      try! await operation()
+    }
+  }
+
+
+/// Add a child task to the group.
   ///
   /// ### Error handling
   /// Operations are allowed to `throw`, in which case the `try await next()`
@@ -444,6 +473,16 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
 
     self._task = task
     self._group = group
+  }
+
+  @available(*, deprecated, message: "`Task.Group.add` has been replaced by `(Throwing)TaskGroup.spawn` or `(Throwing)TaskGroup.spawnUnlessCancelled` and will be removed shortly.")
+  public mutating func add(
+    priority: Task.Priority = .unspecified,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) async -> Bool {
+    return try await self.spawnUnlessCancelled(priority: priority) {
+      try await operation()
+    }
   }
 
   /// Spawn, unconditionally, a child task in the group.

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -26,15 +26,14 @@ struct SomeFile: Sendable {
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-func test_cancellation_withCancellationHandler(_ anything: Any) async -> PictureData {
+func test_cancellation_withTaskCancellationHandler(_ anything: Any) async -> PictureData {
   let handle: Task.Handle<PictureData, Error> = detach {
     let file = SomeFile()
 
-    return await Task.withCancellationHandler(
-      handler: { file.close() },
-      operation: {
+    return await withTaskCancellationHandler(
+      handler: { file.close() }) {
       await test_cancellation_guard_isCancelled(file)
-    })
+    }
   }
 
   handle.cancel()


### PR DESCRIPTION
APIs that have been renamed or moved re-gained their old APIs but as deprecated:

- Task.runDetached -> detached
- group.add -> group.spawn
- Task.withCancellationHandler -> withTaskCancellationHandler 
- Task.withGroup -> withTaskGroup / withThrowingTaskGroup