### PR TITLE
[Incremental] Revise lit tests that were broken in https://github.com/apple/swift-driver/pull/580 

### DIFF
--- a/test/Driver/Dependencies/dependencies-preservation-fine.swift
+++ b/test/Driver/Dependencies/dependencies-preservation-fine.swift
@@ -2,8 +2,6 @@
 // Verify that the top-level build record file from the last incremental
 // compilation is preserved with the same name, suffixed by a '~'.
 
-// REQUIRES: rdar76238077
-
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: %{python} %S/Inputs/touch.py 443865900 %t/*
@@ -16,7 +14,7 @@
 // RUN: %FileCheck -check-prefix CHECK-OVERWRITTEN %s < main~buildrecord.swiftdeps
 // CHECK-OVERWRITTEN: version: "{{.*}}"
 // CHECK-OVERWRITTEN: options: "{{.*}}"
-// CHECK-OVERWRITTEN: build_time: [{{[0-9]*}}, {{[0-9]*}}]
+// CHECK-OVERWRITTEN: build_{{(start_)?}}time: [{{[0-9]*}}, {{[0-9]*}}]
 // CHECK-OVERWRITTEN: inputs:
 // CHECK-OVERWRITTEN: "{{(./)?}}main.swift": [443865900, 0]
 // CHECK-OVERWRITTEN: "{{(./)?}}other.swift": [443865900, 0]

--- a/test/Driver/Dependencies/one-way-merge-module-fine.swift
+++ b/test/Driver/Dependencies/one-way-merge-module-fine.swift
@@ -1,7 +1,5 @@
 /// other ==> main
 
-// REQUIRES: rdar76238077
-
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: touch -t 201401240005 %t/*
@@ -14,7 +12,7 @@
 // CHECK-FIRST: Produced master.swiftmodule
 
 // swift-driver checks existence of all outputs
-// RUN: touch -t 201401240006 %t/{main,other}.swift{module,doc,sourceinfo}
+// RUN: touch -t 201401240006 %t/{main,other,master}.swift{module,doc,sourceinfo}
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path "%{python.unquoted};%S/Inputs/update-dependencies.py;%swift-dependency-tool" -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 


### PR DESCRIPTION
https://github.com/apple/swift-driver/pull/580 added a field to the build record and was more careful about skipping the post-compile jobs. But it broke two lit tests. Fix them here by: Accepting "build_start_time"  as well as "build_time" in the build record and by touching all post-compile outputs when expecting the driver to skip those jobs. 
Fixes rdar://76238077 (XFailed Driver Tests).
