### PR TITLE
Make Builtin.getCurrentExecutor conservatively not readnone

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -758,12 +758,15 @@ BUILTIN_MISC_OPERATION(BuildSerialExecutorRef,
 // Retrieve the ExecutorRef on which the current asynchronous
 // function is executing.
 // Does not retain an actor executor.
-BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentExecutor, "getCurrentExecutor", "n", Special)
+BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentExecutor, "getCurrentExecutor", "", Special)
 
 // getCurrentAsyncTask: () -> Builtin.NativeObject
 //
 // Retrieve the pointer to the task in which the current asynchronous
 // function is executing.
+//
+// This is readnone because, within the world modeled by SIL, the
+// current async task of a thread never changes.
 BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentAsyncTask, "getCurrentAsyncTask", "n", Special)
 
 /// cancelAsyncTask(): (Builtin.NativeObject) -> Void

--- a/test/SILOptimizer/optimize_hop_to_executor.sil
+++ b/test/SILOptimizer/optimize_hop_to_executor.sil
@@ -208,3 +208,34 @@ bb2:
   return %r : $()
 }
 
+//   This pattern is definitely optimizable, but it's *not* supposed to
+//   be optimized by simply removing the hop before the builtin.
+// CHECK-LABEL: sil [ossa] @handleGetCurrentExecutor : $@convention(method) @async (@guaranteed MyActor, @guaranteed MyActor) -> () {
+// CHECK:       bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    function_ref
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    hop_to_executor
+// CHECK-NEXT:    builtin
+// CHECK-NEXT:    hop_to_executor
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    function_ref
+// CHECK-NEXT:    apply
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK:       } // end sil function 'handleGetCurrentExecutor'
+sil [ossa] @handleGetCurrentExecutor : $@convention(method) @async (@guaranteed MyActor, @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
+  hop_to_executor %0 : $MyActor
+  %async_f = function_ref @anotherAsyncFunction : $@convention(thin) @async () -> ()
+  apply %async_f() : $@convention(thin) @async () -> ()
+  hop_to_executor %0 : $MyActor  
+  %curExec = builtin "getCurrentExecutor"() : $Builtin.Executor
+  hop_to_executor %1 : $MyActor
+  %f = function_ref @requiredToRunOnActor : $@convention(method) (@guaranteed MyActor) -> ()
+  apply %f(%1) : $@convention(method) (@guaranteed MyActor) -> ()
+  hop_to_executor %0 : $MyActor
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
Fixes a miscompile where the `hop_to_executor` optimizer would remove `hop_to_executor` before a `getCurrentExecutor`.