### PR TITLE
Infer a type's actor isolation from the property wrappers it uses.

### DIFF
--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -370,6 +370,34 @@ actor ActorWithWrapper {
   }
 }
 
+@propertyWrapper
+struct WrapperOnSomeGlobalActor<Wrapped> {
+  @actorIndependent(unsafe) private var stored: Wrapped
+
+  nonisolated init(wrappedValue: Wrapped) {
+    stored = wrappedValue
+  }
+
+  @SomeGlobalActor var wrappedValue: Wrapped {
+    get { stored }
+    set { stored = newValue }
+  }
+}
+
+struct InferredFromPropertyWrapper {
+  @WrapperOnSomeGlobalActor var value = 17
+
+  func test() -> Int { // expected-note{{calls to instance method 'test()' from outside of its actor context are implicitly asynchronous}}
+    value
+  }
+}
+
+func testInferredFromWrapper(x: InferredFromPropertyWrapper) { // expected-note{{add '@SomeGlobalActor' to make global function 'testInferredFromWrapper(x:)' part of global actor 'SomeGlobalActor'}}
+  _ = x.test() // expected-error{{instance method 'test()' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+}
+
+
+
 // ----------------------------------------------------------------------
 // Unsafe global actors
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes rdar://76252310.
