### PR TITLE
[Concurrency] tune back the yield test it isn't really testing much

### DIFF
--- a/test/Concurrency/Runtime/async_task_yield.swift
+++ b/test/Concurrency/Runtime/async_task_yield.swift
@@ -43,7 +43,5 @@ func yielding() async {
   static func main() async {
     await yielding()
     // TODO: No idea for a good test for this... Open to ideas?
-    // CHECK:      One
-    // CHECK-NEXT: Two
   }
 }


### PR DESCRIPTION
The way we used FileCheck in this test was pretty useless and prone to racyness causing a flaky failure.

It is very hard to test a "yield" so let's just test it does not crash for now.