### PR TITLE
[Serialization] Revert the change to path printing on failures

### DIFF
--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -222,11 +222,12 @@ public:
   }
 
   void print(raw_ostream &os, StringRef leading = "") const {
-    os << "Cross-reference to '";
-    interleave(path,
-               [&](auto &piece) { piece.print(os); },
-               [&] { os << '.'; });
-    os << "' in module '" << baseM.getName() << "'\n";
+    os << "Cross-reference to module '" << baseM.getName() << "'\n";
+    for (auto &piece : path) {
+      os << leading << "... ";
+      piece.print(os);
+      os << "\n";
+    }
   }
 };
 

--- a/test/Serialization/Recovery/crash-xref.swift
+++ b/test/Serialization/Recovery/crash-xref.swift
@@ -30,6 +30,7 @@ public func foo() -> A.SomeType { fatalError() }
 // CHECK: *** DESERIALIZATION FAILURE (please include this section in any bug report) ***
 // CHECK-NEXT: Could not deserialize type for 'foo()'
 // CHECK-NEXT: Caused by: top-level value not found
-// CHECK-NEXT: Cross-reference to 'SomeType' in module 'A'
+// CHECK-NEXT: Cross-reference to module 'A'
+// CHECK-NEXT: ... SomeType
 // CHECK-NEXT: Notes:
 // CHECK-NEXT: * 'SomeType' was not found in module 'B', but there is one in module 'B'. If this is imported from clang, please make sure the header is part of a single clang module.


### PR DESCRIPTION
Some paths have more information and the dotted format isn't appropriate for them. Let's bring back the `...` format.

This is a partial revert  of commit c5c850c14d84d386ae66731fe60d765bc85523c2.