### PR TITLE
Skip adding alias targets when they don't exist

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -196,13 +196,23 @@ function(swift_create_stdlib_targets name variant define_all_alias)
   if(NOT define_all_alias)
     set(ALL_keyword ALL)
   endif()
-  add_custom_target(${name}${variant}
-    ${ALL_keyword}
-    DEPENDS
-    ${name}${SWIFT_PRIMARY_VARIANT_SUFFIX}${variant})
-  set_target_properties(${name}${variant}
-    PROPERTIES
-    FOLDER "Swift libraries/Aggregate")
+
+  # When cross-compiling host tools for multiple architectures, targeting a
+  # different SDK, the primary variant is not one of the variants being built,
+  # so it can't be added as a target here. build-script will invoke the
+  # more-specific target, so just skip creating this target and warn in case
+  # someone is using the CMake more directly.
+  if(TARGET ${name}${SWIFT_PRIMARY_VARIANT_SUFFIX}${variant})
+    add_custom_target(${name}${variant}
+      ${ALL_keyword}
+      DEPENDS
+      ${name}${SWIFT_PRIMARY_VARIANT_SUFFIX}${variant})
+    set_target_properties(${name}${variant}
+      PROPERTIES
+      FOLDER "Swift libraries/Aggregate")
+  else()
+    message(WARNING "Primary variant is not being built, target ${name}${SWIFT_PRIMARY_VARIANT_SUFFIX}${variant} does not exist, not creating ${name}${variant} alias target.")
+  endif()
 endfunction()
 
 swift_create_stdlib_targets("swift-stdlib" "" TRUE)

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -202,7 +202,7 @@ function(swift_create_stdlib_targets name variant define_all_alias)
   # so it can't be added as a target here. build-script will invoke the
   # more-specific target, so just skip creating this target and warn in case
   # someone is using the CMake more directly.
-  if(TARGET ${name}${SWIFT_PRIMARY_VARIANT_SUFFIX}${variant})
+  if(SWIFT_PRIMARY_VARIANT_SDK IN_LIST SWIFT_SDKS)
     add_custom_target(${name}${variant}
       ${ALL_keyword}
       DEPENDS
@@ -211,7 +211,7 @@ function(swift_create_stdlib_targets name variant define_all_alias)
       PROPERTIES
       FOLDER "Swift libraries/Aggregate")
   else()
-    message(WARNING "Primary variant is not being built, target ${name}${SWIFT_PRIMARY_VARIANT_SUFFIX}${variant} does not exist, not creating ${name}${variant} alias target.")
+    message(WARNING "Primary variant ${SWIFT_PRIMARY_VARIANT_SDK} is not being built, not creating ${name}${variant} alias target for it.")
   endif()
 endfunction()
 


### PR DESCRIPTION
The CMake uses the concept of a "primary variant" which isn't necessarily aligned with either the host or target. In some cases, like cross-compiling an iOS compiler toolchain for `macosx-arm64`, the expected "primary variant" target will be missing and so CMake will fail. We can skip adding the alias since `build-script` will call the more specific target anyway.