### PR TITLE
[SymbolGraphGen] silence symbolgraph-extract output without -v flag

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -184,7 +184,8 @@ def help_hidden : Flag<["-", "--"], "help-hidden">,
   Flags<[HelpHidden, FrontendOption]>,
   HelpText<"Display available options, including hidden options">;
 
-def v : Flag<["-"], "v">, Flags<[DoesNotAffectIncrementalBuild]>,
+def v : Flag<["-"], "v">,
+  Flags<[DoesNotAffectIncrementalBuild, SwiftSymbolGraphExtractOption]>,
   HelpText<"Show commands to run and use verbose output">;
 def version : Flag<["-", "--"], "version">, Flags<[FrontendOption]>,
   HelpText<"Print version information and exit">;

--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -36,9 +36,9 @@ struct SymbolGraphOptions {
   /// implementations with compound, "SYNTHESIZED" USRs.
   bool EmitSynthesizedMembers;
   
-  /// Whether to silence the "Found N symbols" messages when rendering
+  /// Whether to print informational messages when rendering
   /// a symbol graph.
-  bool QuietMessages;
+  bool PrintMessages;
 };
 
 } // end namespace symbolgraphgen

--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -35,6 +35,10 @@ struct SymbolGraphOptions {
   /// Emit members gotten through class inheritance or protocol default
   /// implementations with compound, "SYNTHESIZED" USRs.
   bool EmitSynthesizedMembers;
+  
+  /// Whether to silence the "Found N symbols" messages when rendering
+  /// a symbol graph.
+  bool QuietMessages;
 };
 
 } // end namespace symbolgraphgen

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5633,6 +5633,7 @@ void swift::serialize(ModuleOrSourceFile DC,
         /* PrettyPrint */false,
         AccessLevel::Public,
         /*EmitSynthesizedMembers*/true,
+        /*QuietMessages*/true,
       };
       symbolgraphgen::emitSymbolGraphForModule(M, SGOpts);
     }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5633,7 +5633,7 @@ void swift::serialize(ModuleOrSourceFile DC,
         /* PrettyPrint */false,
         AccessLevel::Public,
         /*EmitSynthesizedMembers*/true,
-        /*QuietMessages*/true,
+        /*PrintMessages*/false,
       };
       symbolgraphgen::emitSymbolGraphForModule(M, SGOpts);
     }

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -70,7 +70,7 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
   SmallVector<Decl *, 64> ModuleDecls;
   M->getDisplayDecls(ModuleDecls);
 
-  if (!Options.QuietMessages)
+  if (Options.PrintMessages)
     llvm::errs() << ModuleDecls.size()
         << " top-level declarations in this module.\n";
 
@@ -78,7 +78,7 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
     Walker.walk(Decl);
   }
 
-  if (!Options.QuietMessages)
+  if (Options.PrintMessages)
     llvm::errs()
       << "Found " << Walker.MainGraph.Nodes.size() << " symbols and "
       << Walker.MainGraph.Edges.size() << " relationships.\n";

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -70,16 +70,18 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
   SmallVector<Decl *, 64> ModuleDecls;
   M->getDisplayDecls(ModuleDecls);
 
-  llvm::errs() << ModuleDecls.size()
-      << " top-level declarations in this module.\n";
+  if (!Options.QuietMessages)
+    llvm::errs() << ModuleDecls.size()
+        << " top-level declarations in this module.\n";
 
   for (auto *Decl : ModuleDecls) {
     Walker.walk(Decl);
   }
 
-  llvm::errs()
-    << "Found " << Walker.MainGraph.Nodes.size() << " symbols and "
-    << Walker.MainGraph.Edges.size() << " relationships.\n";
+  if (!Options.QuietMessages)
+    llvm::errs()
+      << "Found " << Walker.MainGraph.Nodes.size() << " symbols and "
+      << Walker.MainGraph.Edges.size() << " relationships.\n";
 
   int Success = EXIT_SUCCESS;
 

--- a/test/SymbolGraph/verbose.swift
+++ b/test/SymbolGraph/verbose.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name verbose -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name verbose -I %t -pretty-print -output-dir %t | %FileCheck %s -check-prefix=QUIET --allow-empty
+// RUN: %target-swift-symbolgraph-extract -module-name verbose -I %t -pretty-print -output-dir %t -v 2>&1 | %FileCheck %s -check-prefix=VERBOSE
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name verbose -emit-module -emit-module-path %t/verbose.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t | %FileCheck %s -check-prefix=DRIVER --allow-empty
+
+// QUIET-NOT: Emitting symbol graph for module file
+// QUIET-NOT: 2 top-level declarations in this module.
+// QUIET-NOT: Found 1 symbols and 0 relationships.
+
+// VERBOSE: Emitting symbol graph for module file
+// VERBOSE: 2 top-level declarations in this module.
+// VERBOSE: Found 1 symbols and 0 relationships.
+
+// DRIVER-NOT: Emitting symbol graph for module file
+// DRIVER-NOT: 2 top-level declarations in this module.
+// DRIVER-NOT: Found 1 symbols and 0 relationships.
+
+public func someFunc() {}

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -869,6 +869,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
         /*PrettyPrint=*/false,
         AccessLevel::Private,
         /*EmitSynthesizedMembers*/ false,
+        /*QuietMessages*/ true,
     };
 
     symbolgraphgen::printSymbolGraphForDecl(DInfo.VD, DInfo.BaseType,

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -869,7 +869,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
         /*PrettyPrint=*/false,
         AccessLevel::Private,
         /*EmitSynthesizedMembers*/ false,
-        /*QuietMessages*/ true,
+        /*PrintMessages*/ false,
     };
 
     symbolgraphgen::printSymbolGraphForDecl(DInfo.VD, DInfo.BaseType,

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -166,6 +166,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
       ParsedArgs.hasArg(OPT_pretty_print),
       AccessLevel::Public,
       !ParsedArgs.hasArg(OPT_skip_synthesized_members),
+      !ParsedArgs.hasArg(OPT_v),
   };
 
   if (auto *A = ParsedArgs.getLastArg(OPT_minimum_access_level)) {
@@ -218,7 +219,9 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   }
 
   const auto &MainFile = M->getMainFile(FileUnitKind::SerializedAST);
-  llvm::errs() << "Emitting symbol graph for module file: " << MainFile.getModuleDefiningPath() << '\n';
+  
+  if (!Options.QuietMessages)
+    llvm::errs() << "Emitting symbol graph for module file: " << MainFile.getModuleDefiningPath() << '\n';
   
   int Success = symbolgraphgen::emitSymbolGraphForModule(M, Options);
   
@@ -236,8 +239,10 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
     auto CIM = CI.getASTContext().getModuleByName(OM->getNameStr());
     if (CIM) {
       const auto &CIMainFile = CIM->getMainFile(FileUnitKind::SerializedAST);
-      llvm::errs() << "Emitting symbol graph for cross-import overlay module file: "
-        << CIMainFile.getModuleDefiningPath() << '\n';
+      
+      if (!Options.QuietMessages)
+        llvm::errs() << "Emitting symbol graph for cross-import overlay module file: "
+          << CIMainFile.getModuleDefiningPath() << '\n';
       
       Success |= symbolgraphgen::emitSymbolGraphForModule(CIM, Options);
     }

--- a/tools/driver/swift_symbolgraph_extract_main.cpp
+++ b/tools/driver/swift_symbolgraph_extract_main.cpp
@@ -166,7 +166,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
       ParsedArgs.hasArg(OPT_pretty_print),
       AccessLevel::Public,
       !ParsedArgs.hasArg(OPT_skip_synthesized_members),
-      !ParsedArgs.hasArg(OPT_v),
+      ParsedArgs.hasArg(OPT_v),
   };
 
   if (auto *A = ParsedArgs.getLastArg(OPT_minimum_access_level)) {
@@ -220,7 +220,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
 
   const auto &MainFile = M->getMainFile(FileUnitKind::SerializedAST);
   
-  if (!Options.QuietMessages)
+  if (Options.PrintMessages)
     llvm::errs() << "Emitting symbol graph for module file: " << MainFile.getModuleDefiningPath() << '\n';
   
   int Success = symbolgraphgen::emitSymbolGraphForModule(M, Options);
@@ -240,7 +240,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
     if (CIM) {
       const auto &CIMainFile = CIM->getMainFile(FileUnitKind::SerializedAST);
       
-      if (!Options.QuietMessages)
+      if (Options.PrintMessages)
         llvm::errs() << "Emitting symbol graph for cross-import overlay module file: "
           << CIMainFile.getModuleDefiningPath() << '\n';
       


### PR DESCRIPTION
Resolves rdar://72630103

This PR changes how SymbolGraphGen emits its output. By default, the SymbolGraphGen code will not output anything other than errors without a `-v` flag given to `swift-symbolgraph-extract`. This also means that the symbol-graph code called from the driver or from SourceKit will now also be silenced.