### PR TITLE
[Diagnostics] Fix crash while trying to print candidates for a option…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3706,7 +3706,11 @@ static bool diagnoseAmbiguity(
                  })) {
         // All fixes have to do with arguments, so let's show the parameter
         // lists.
-        auto *fn = type->getAs<AnyFunctionType>();
+        //
+        // It's possible that function type is wrapped in an optional
+        // if it's from `@objc optional` method, so we need to ignore that.
+        auto *fn =
+            type->lookThroughAllOptionalTypes()->getAs<AnyFunctionType>();
         assert(fn);
 
         if (fn->getNumParams() == 1) {

--- a/test/Constraints/objc_optional_methods_diagnostics.swift
+++ b/test/Constraints/objc_optional_methods_diagnostics.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol P {
+  @objc optional static func test(a: UnsafePointer<Int>, _: Int)
+  // expected-note@-1 {{candidate has partially matching parameter list (a: UnsafePointer<Int>, Int)}}
+  @objc optional static func test(b: [Int], _: Int)
+  // expected-note@-1 {{candidate has partially matching parameter list (b: [Int], Int)}}
+}
+
+@objc class S : NSObject, P {
+  static func test(a: UnsafePointer<Int>, _: Int) {}
+  static func test(b: [Int], _: Int) {}
+}
+
+func test(s: P.Type, v: Int) {
+  _ = s.test!(c: v, 0) // expected-error {{no exact matches in call to static method 'test'}}
+}


### PR DESCRIPTION
…al @objc method reference

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
