### PR TITLE
[Concurrency] unlock the yield test

### DIFF
--- a/test/Concurrency/Runtime/async_task_yield.swift
+++ b/test/Concurrency/Runtime/async_task_yield.swift
@@ -3,8 +3,6 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 
-// REQUIRES: rdar76274257
-
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 protocol Go: Actor {
   func go(times: Int) async -> Int
@@ -45,5 +43,6 @@ func yielding() async {
   static func main() async {
     await yielding()
     // TODO: No idea for a good test for this... Open to ideas?
+    // CHECK: Two @ 100
   }
 }


### PR DESCRIPTION
rdar://76274257

Undoes https://github.com/apple/swift/commit/4de232ec5733d858cdf8372c80a6bcb6cb55a495 and fixes test broken in https://github.com/apple/swift/pull/36776