### PR TITLE
[ASTScope] Always skip implicit attributes.

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -506,10 +506,11 @@ void ScopeCreator::addChildrenForKnownAttributes(ValueDecl *decl,
   SmallVector<DeclAttribute *, 2> relevantAttrs;
 
   for (auto *attr : decl->getAttrs()) {
-    if (isa<DifferentiableAttr>(attr)) {
-      if (!attr->isImplicit())
-        relevantAttrs.push_back(attr);
-    }
+    if (attr->isImplicit())
+      continue;
+
+    if (isa<DifferentiableAttr>(attr))
+      relevantAttrs.push_back(attr);
 
     if (isa<SpecializeAttr>(attr))
       relevantAttrs.push_back(attr);

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -282,6 +282,17 @@ struct WrapperOnActor<Wrapped> {
   }
 }
 
+@MainActor
+@propertyWrapper
+public struct WrapperOnMainActor<Wrapped> {
+  // Make sure inference of @MainActor on wrappedValue doesn't crash.
+  public var wrappedValue: Wrapped
+
+  public init(wrappedValue: Wrapped) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
 @propertyWrapper
 actor WrapperActor<Wrapped> {
   @actorIndependent(unsafe) var storage: Wrapped


### PR DESCRIPTION
ASTScope only cares about attributes when lookup can be done inside of the attribute, which isn't the case for implicit attributes because they're typically built fully type-checked. This also avoids a crash when an implicit attribute does not have a source range.

Resolves: rdar://75371211