### PR TITLE
Make the function to compute the prebuilt module cache path public 

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -204,6 +204,12 @@ public:
 
   void setRuntimeResourcePath(StringRef Path);
 
+  /// Compute the default prebuilt module cache path for a given resource path
+  /// and SDK version. This function is also used by LLDB.
+  static std::string
+  computePrebuiltCachePath(StringRef RuntimeResourcePath, llvm::Triple target,
+                           Optional<llvm::VersionTuple> sdkVer);
+
   /// If we haven't explicitly passed -prebuilt-module-cache-path, set it to
   /// the default value of <resource-dir>/<platform>/prebuilt-modules.
   /// @note This should be called once, after search path options and frontend


### PR DESCRIPTION
so it can be called by LLDB. (NFC).

rdar://76112632

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
