### PR TITLE
[SourceKit] Verify the stdlib is loaded before creating an AST

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -848,6 +848,11 @@ ASTUnitRef ASTProducer::createASTUnit(
     Error = "compilation setup failed";
     return nullptr;
   }
+  if (CompIns.loadStdlibIfNeeded()) {
+    LOG_WARN_FUNC("Loading the stdlib failed");
+    Error = "Loading the stdlib failed";
+    return nullptr;
+  }
   registerIDERequestFunctions(CompIns.getASTContext().evaluator);
   if (TracedOp.enabled()) {
     TracedOp.start(TraceInfo);


### PR DESCRIPTION
We have seen a couple of crashes that look like they are being caused by `sourcekitd` being unable to load the Swift stdlib. Emit a proper error message explaining the issue instead of crashing.

This change assumes that all sourcekitd requests that create an AST require the stdlib. IMHO this is a reasonable assumption.

Fixes rdar://75740572 by catching the crash in the new check.