### PR TITLE
IRGen: repair the IRGen on Windows

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -899,9 +899,8 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
 }
 
 llvm::Constant *IRGenModule::getDeletedAsyncMethodErrorAsyncFunctionPointer() {
-  return getAddrOfLLVMVariable(
-      LinkEntity::forKnownAsyncFunctionPointer("swift_deletedAsyncMethodError"),
-      ConstantInit(), DebugTypeInfo());
+  return getAddrOfLLVMVariableOrGOTEquivalent(
+      LinkEntity::forKnownAsyncFunctionPointer("swift_deletedAsyncMethodError")).getValue();
 }
 
 #define QUOTE(...) __VA_ARGS__


### PR DESCRIPTION
The cross-module reference must be indirected through the moral
equivalent of the GOT - the IAT.  This indirects through the import
address table, permitting the pointer to be resolved.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
