### PR TITLE
[CSSimplify] Add a null check to guard against broken/missing `Expres…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6216,8 +6216,11 @@ static CheckedCastKind getCheckedCastKind(ConstraintSystem *cs,
 static bool isCastToExpressibleByNilLiteral(ConstraintSystem &cs, Type fromType,
                                             Type toType) {
   auto &ctx = cs.getASTContext();
-  auto *nilLiteral =
-      ctx.getProtocol(KnownProtocolKind::ExpressibleByNilLiteral);
+  auto *nilLiteral = TypeChecker::getProtocol(
+      ctx, SourceLoc(), KnownProtocolKind::ExpressibleByNilLiteral);
+  if (!nilLiteral)
+    return false;
+
   return toType->isEqual(nilLiteral->getDeclaredType()) &&
          fromType->getOptionalObjectType();
 }


### PR DESCRIPTION
…sibleByNilLiteral`

I couldn't come up with an isolated test-case to add to the suite,
but it's possible that `getProtocol` returns `nullptr` for invalid
or missing protocol so there has to be a check for that otherwise
compiler is going to crash trying to access `getDeclaredType()`.

Resolves: rdar://76187450


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
