### PR TITLE
Turn on additional musttail checks for swiftc and runtime.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1193,6 +1193,12 @@ def user_module_version : Separate<["-"], "user-module-version">,
   HelpText<"Module version specified from Swift module authors">,
   MetaVarName<"<vers>">;
 
+// LLVM verification
+def skip_swifttailcc_musttail_check : Flag<["-"], "skip-swifttailcc-musttail-check">,
+  Flags<[HelpHidden, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Skip additional LLVM verification that all tail calls from "
+           "swifttailcc->swifttailcc are marked musttail.">;
+
 // VFS
 
 def vfsoverlay : JoinedOrSeparate<["-"], "vfsoverlay">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -323,6 +323,11 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
       arguments.push_back("-enable-anonymous-context-mangled-names");
   }
 
+  if (!inputArgs.hasArg(options::OPT_skip_swifttailcc_musttail_check)) {
+    arguments.push_back("-Xllvm");
+    arguments.push_back("-enable-swifttailcc-musttail-check");
+  }
+
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -79,6 +79,13 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include/llvm/Support -I${SWIFT_SOURCE_DIR}/include)
 
+# Check that the runtime is using the async calling convention
+# correctly, and that musttail isn't missed by Clang/LLVM.
+if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+  list(APPEND swift_runtime_library_compile_flags
+        "-mllvm" "-enable-swifttailcc-musttail-check")
+endif()
+
 set(sdk "${SWIFT_HOST_VARIANT_SDK}")
 if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   set(static_binary_lnk_file_list)

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -129,4 +129,12 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
     )
+
+  # Check that the tests are using the async calling convention
+  # correctly, and that musttail isn't missed by Clang/LLVM.
+  if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+    target_compile_options(SwiftRuntimeTests
+      PUBLIC "-mllvm;-enable-swifttailcc-musttail-check")
+  endif()
+
 endif()


### PR DESCRIPTION
Fixes rdar://76024810.