### PR TITLE
Make the function to compute the prebuilt module cache path public

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -204,6 +204,12 @@ public:
 
   void setRuntimeResourcePath(StringRef Path);
 
+  /// Compute the default prebuilt module cache path for a given resource path
+  /// and SDK version. This function is also used by LLDB.
+  static std::string
+  computePrebuiltCachePath(StringRef RuntimeResourcePath, llvm::Triple target,
+                           Optional<llvm::VersionTuple> sdkVer);
+
   /// If we haven't explicitly passed -prebuilt-module-cache-path, set it to
   /// the default value of <resource-dir>/<platform>/prebuilt-modules.
   /// @note This should be called once, after search path options and frontend


### PR DESCRIPTION
so it can be called by LLDB. (NFC).

rdar://76112632
(cherry picked from commit ab3da1625ec65cd19b6dcfb8f6ebf5f31e9c4952)
