### PR TITLE
GSB: Start purging the notion of "derived via concrete" requirements

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -654,7 +654,7 @@ public:
 
   class ExplicitRequirement;
 
-  bool isRedundantExplicitRequirement(ExplicitRequirement req) const;
+  bool isRedundantExplicitRequirement(const ExplicitRequirement &req) const;
 
 private:
   void computeRedundantRequirements();

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1096,12 +1096,14 @@ const RequirementSource *RequirementSource::getMinimalConformanceSource(
                                           ArchetypeResolutionKind::WellFormed);
       assert(parentEquivClass && "Not a well-formed type?");
 
-      if (parentEquivClass->concreteType)
-        derivedViaConcrete = true;
-      else if (parentEquivClass->superclass &&
-               builder.lookupConformance(parentEquivClass->superclass,
-                                         source->getProtocolDecl()))
-        derivedViaConcrete = true;
+      if (requirementSignatureSelfProto) {
+        if (parentEquivClass->concreteType)
+          derivedViaConcrete = true;
+        else if (parentEquivClass->superclass &&
+                 builder.lookupConformance(parentEquivClass->superclass,
+                                           source->getProtocolDecl()))
+          derivedViaConcrete = true;
+      }
 
       // The parent potential archetype must conform to the protocol in which
       // this requirement resides. Add this constraint.
@@ -7200,6 +7202,9 @@ void GenericSignatureBuilder::diagnoseRedundantRequirements() const {
 
       for (auto otherReq : found->second) {
         auto *otherSource = otherReq.getSource();
+        if (otherSource->isInferredRequirement())
+          continue;
+
         auto otherLoc = otherSource->getLoc();
         if (otherLoc.isInvalid())
           continue;
@@ -7237,6 +7242,9 @@ void GenericSignatureBuilder::diagnoseRedundantRequirements() const {
 
         for (auto otherReq : found->second) {
           auto *otherSource = otherReq.getSource();
+          if (otherSource->isInferredRequirement())
+            continue;
+
           auto otherLoc = otherSource->getLoc();
           if (otherLoc.isInvalid())
             continue;
@@ -7276,6 +7284,9 @@ void GenericSignatureBuilder::diagnoseRedundantRequirements() const {
 
         for (auto otherReq : found->second) {
           auto *otherSource = otherReq.getSource();
+          if (otherSource->isInferredRequirement())
+            continue;
+
           auto otherLoc = otherSource->getLoc();
           if (otherLoc.isInvalid())
             continue;

--- a/test/Generics/protocol_superclass_cycle.swift
+++ b/test/Generics/protocol_superclass_cycle.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+protocol P : C {}
+final class C : P {}
+
+// CHECK: Generic signature: <T where T : P>
+func foo<T : P>(_: T) {}

--- a/test/Generics/rdar75656022.swift
+++ b/test/Generics/rdar75656022.swift
@@ -49,7 +49,8 @@ struct OriginalExampleWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
     where C : P1,
           D : P1, // expected-warning {{redundant conformance constraint 'D' : 'P1'}}
           C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
-          A == S1<C, C.T.T, S2<C.T>>,
+          A == S1<C, C.T.T, S2<C.T>>, // expected-note {{conformance constraint 'D' : 'P1' implied here}}
+          // expected-note@-1 {{conformance constraint 'C.T' : 'P1' implied here}}
           C.T == D,
           E == D.T { }
 }
@@ -71,6 +72,7 @@ struct WithoutBogusGenericParametersWithWarning<A, B> where A : P2, B : P2, A.T 
     where C : P1,
           C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
           A == S1<C, C.T.T, S2<C.T>> {}
+          // expected-note@-1 {{conformance constraint 'C.T' : 'P1' implied here}}
 }
 
 // Same as above but without unnecessary generic parameters


### PR DESCRIPTION
The notion of a 'derived via concrete' requirement was meant to handle the following scenario:

    protocol P { associatedtype T : P }
    class C<T : P> : P
    func foo<X, Y>(_: X, _: Y) where X : P, Y : P, X : C<Y> {}

The requirement `Y : P` is implied by `X : P`, since `X : C<Y>` introduces `Y == X.T`, we have `X : P`, and `T : P` in protocol `P`. Since `X : P` is in turn implied by `X : C<Y>`, we would normally consider _both_ `X : P` and `Y : P` redundant -- but as soon as we drop `X : P`, we must keep `Y : P`, since `X : C<Y>` by itself does not imply that `Y : P`. This was captured by saying that `Y : P` was "derived via (the) concrete" requirement `X : C<Y>`.

However, the recently-introduced mechanism for rebuilding signatures after dropping redundant conformance requirements subsumes this notion. In the above example, once we drop `X : P`, we build the signature `X : C<Y>, Y : P`. The only thing we have to change is that when rebuilding a signature, instead of dropping _all_ redundant requirements (which would also drop `Y : P`) we only drop those that are directly implied by a superclass or concrete type requirement. `X : P` is directly implied by `X : C<Y>`, but `Y : P` is derived from `X : P`.

Since rebuilding doesn't yet work for requirement signatures, we can't remove it outright, but we can narrow it down to only occur with a requirement signature. Once we can rebuild requirement signatures, we can remove this logic entirely.