### PR TITLE
[CodeComplete] Complete argument labels after vararg

### DIFF
--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -860,3 +860,31 @@ func testClosurePlaceholderPrintsTypesOnlyIfNoInternalParameterNamesExist() {
 // COMPLETE_CLOSURE_PARAM_WITHOUT_INTERNAL_NAMES-DAG: Decl[FreeFunction]/Local:           ['(']{#callback: (Int, Int) -> Bool##(Int, Int) -> Bool#}[')'][#Void#];
 // COMPLETE_CLOSURE_PARAM_WITHOUT_INTERNAL_NAMES: End completions
 }
+
+func testCompleteLabelAfterVararg() {
+  enum Foo {
+    case bar
+  }
+
+  struct Rdar76355192 {
+    func test(_: String, xArg: Foo..., yArg: Foo..., zArg: Foo...) {}
+  }
+
+  private func test(value: Rdar76355192) {
+    value.test("test", xArg: #^COMPLETE_AFTER_VARARG^#)
+    // COMPLETE_AFTER_VARARG: Begin completions
+    // COMPLETE_AFTER_VARARG-NOT: Pattern/ExprSpecific:               {#yArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG-NOT: Pattern/ExprSpecific:               {#zArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG: End completions
+    value.test("test", xArg: .bar, #^COMPLETE_AFTER_VARARG_WITH_PREV_PARAM^#)
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM: Begin completions
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/ExprSpecific:               {#yArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM-DAG: Pattern/ExprSpecific:               {#zArg: Foo...#}[#Foo#];
+    // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM: End completions
+    value.test("test", xArg: .bar, .#^COMPLETE_MEMBER_IN_VARARG^#)
+    // COMPLETE_MEMBER_IN_VARARG: Begin completions, 2 items
+    // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#Foo#];
+    // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
+    // COMPLETE_MEMBER_IN_VARARG: End completions
+  }
+}


### PR DESCRIPTION
Currently, if the code completion token is after a label that refers to a vararg, it is part of that `VarargExpansionExpr`, so we don’t suggest the subsequent parameter’s label.

Add special handling to detect this situation and suggest the parameter label.

Fixes rdar://76355192