### PR TITLE
test: re-enable test on Windows (SR-14457)

### DIFF
--- a/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
+++ b/test/IRGen/async/run-partialapply-capture-generic_conformer-and-generic-to-void.sil
@@ -11,9 +11,6 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 
-// This test is failing on Windows.
-// UNSUPPORTED: OS=windows-msvc
-
 import Builtin
 import Swift
 import _Concurrency


### PR DESCRIPTION
The underlying IRGen issue has been fixed (#36803), re-enable the test.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
