### PR TITLE
Re-enable test run-call-dynamic-void_to_void.swift

### DIFF
--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -16,10 +16,9 @@ import _Concurrency
 
 
 // CHECK: running
+// CHECK-LL: @"$s4main3runyyY{.*}FTu" = hidden global %swift.async_func_pointer
 
-// CHECK-LL: @"$s4main3runyyYFTu" = hidden global %swift.async_func_pointer
-
-// CHECK-LL: define hidden swift{{(tail)?}}cc void @"$s4main3runyyYF"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
+// CHECK-LL: define {{.*}}hidden swift{{(tail)?}}cc void @"$s4main3runyyY{{.*}}F"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 // CHECK-LL: musttail call swifttailcc void
 dynamic func run() async {
   print("running")

--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -16,7 +16,7 @@ import _Concurrency
 
 
 // CHECK: running
-// CHECK-LL: @"$s4main3runyyY{.*}FTu" = hidden global %swift.async_func_pointer
+// CHECK-LL: @"$s4main3runyyY{{.*}}FTu" = hidden global %swift.async_func_pointer
 
 // CHECK-LL: define {{.*}}hidden swift{{(tail)?}}cc void @"$s4main3runyyY{{.*}}F"(%swift.context* swiftasync {{%[0-9]+}}) {{#[0-9]*}}
 // CHECK-LL: musttail call swifttailcc void

--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -9,6 +9,9 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 
+// Windows does not do swiftailcc
+// XFAIL: OS=windows-msvc
+
 import _Concurrency
 
 

--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -8,7 +8,6 @@
 // REQUIRES: swift_test_mode_optimize_none
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
-// REQUIRES: waiting_on_automerger
 
 import _Concurrency
 


### PR DESCRIPTION
This should work after i386 swiftailcc is enabled per
https://github.com/apple/llvm-project/pull/2797.