### PR TITLE
Add location to the `sema_no_import_target` diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -704,7 +704,7 @@ ERROR(sema_no_import,Fatal,
       "no such module '%0'", (StringRef))
 ERROR(sema_no_import_target,Fatal,
       "could not find module '%0' for target '%1'; "
-      "found: %2", (StringRef, StringRef, StringRef))
+      "found: %2, at: %3", (StringRef, StringRef, StringRef, StringRef))
 ERROR(sema_no_import_repl,none,
       "no such module '%0'", (StringRef))
 NOTE(sema_no_import_no_sdk,none,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -496,7 +496,7 @@ bool ImplicitSerializedModuleLoader::maybeDiagnoseTargetMismatch(
   }
 
   Ctx.Diags.diagnose(sourceLocation, diag::sema_no_import_target, moduleName,
-                     target, foundArchs);
+                     target, foundArchs, dir);
   return true;
 }
 

--- a/test/Serialization/load-invalid-arch.swift
+++ b/test/Serialization/load-invalid-arch.swift
@@ -18,7 +18,7 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -check-prefix CHECK-ALL -DTARGET_ARCHITECTURE=%target
 
 // CHECK-ALL-NOT: error:
-// CHECK: {{.*}} error: could not find module 'new_module' for target '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}
+// CHECK: {{.*}} error: could not find module 'new_module' for target '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}, at: {{.*}}new_module.swiftmodule
 // CHECK-NEXT: import new_module
 // CHECK-NEXT: 		^
 // CHECK-ALL: error: no such module 'new_module'

--- a/test/Serialization/runtime-import-from-sdk.swift
+++ b/test/Serialization/runtime-import-from-sdk.swift
@@ -53,7 +53,7 @@
 // RUN: %empty-directory(%t/mcp)
 // RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-sdk) -resource-dir %t/empty-toolchain/usr/lib/swift -module-cache-path %t/mcp -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck --check-prefix CHECK-EMPTY %s
 // CHECK-EMPTY-NOT: '-isystem' '{{.*}}/bad-sdk/usr/lib/swift/shims'
-// CHECK-EMPTY: error: could not find module 'Swift' for target '{{.*}}'; found: garbage-garbage-garbage
+// CHECK-EMPTY: error: could not find module 'Swift' for target '{{.*}}'; found: garbage-garbage-garbage, at: {{.*}}/Swift.swiftmodule
 
 // Check that, when the toolchain *doesn't* have SwiftShims in it, ClagImporter
 // *does* add a -I flag to look in the SDK.
@@ -61,6 +61,6 @@
 // RUN: %empty-directory(%t/mcp)
 // RUN: not %target-swift-frontend(mock-sdk: -sdk %t/bad-sdk) -resource-dir %t/really-empty-toolchain/usr/lib/swift -module-cache-path %t/mcp -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck --check-prefix CHECK-REALLY-EMPTY %s
 // CHECK-REALLY-EMPTY: '-isystem' '{{.*}}/bad-sdk/usr/lib/swift/shims'
-// CHECK-REALLY-EMPTY: error: could not find module 'Swift' for target '{{.*}}'; found: garbage-garbage-garbage
+// CHECK-REALLY-EMPTY: error: could not find module 'Swift' for target '{{.*}}'; found: garbage-garbage-garbage, at: {{.*}}/Swift.swiftmodule
 
 let x: Int = 1


### PR DESCRIPTION
This diagnostic currently emits, for example:
```
could not find module Foo for target arm64; found: x86_64
```
It is sometimes very useful to know where exactly the `found` module is located, so this PR changes this diagnostic to emit:
```
could not find module Foo for target arm64; found: x86_64, at:
<Path where Foo.swiftmodule/x86_64.swiftmodule is located>
```