### PR TITLE
[stdlib] Prevent Slice.wCSIA trapping

### DIFF
--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -223,10 +223,10 @@ extension Slice: Collection {
     try _base.withContiguousStorageIfAvailable { buffer in
       let start = _base.distance(from: _base.startIndex, to: _startIndex)
       let count = _base.distance(from: _startIndex, to: _endIndex)
-      let endAndOF = start.addingReportingOverflow(count)
-      _debugPrecondition(!endAndOF.overflow)
+      let (end, overflow) = start.addingReportingOverflow(count)
+      _debugPrecondition(!overflow)
       let slice = UnsafeBufferPointer(
-        rebasing: buffer[Range(uncheckedBounds: (start, endAndOF.partialValue))]
+        rebasing: buffer[Range(uncheckedBounds: (start, end))]
       )
       return try body(slice)
     }

--- a/stdlib/public/core/Slice.swift
+++ b/stdlib/public/core/Slice.swift
@@ -223,7 +223,11 @@ extension Slice: Collection {
     try _base.withContiguousStorageIfAvailable { buffer in
       let start = _base.distance(from: _base.startIndex, to: _startIndex)
       let count = _base.distance(from: _startIndex, to: _endIndex)
-      let slice = UnsafeBufferPointer(rebasing: buffer[start ..< start + count])
+      let endAndOF = start.addingReportingOverflow(count)
+      _debugPrecondition(!endAndOF.overflow)
+      let slice = UnsafeBufferPointer(
+        rebasing: buffer[Range(uncheckedBounds: (start, endAndOF.partialValue))]
+      )
       return try body(slice)
     }
   }


### PR DESCRIPTION
The integer addition and range operator introduce 2 traps which should be safe to avoid in release mode.

https://godbolt.org/z/qKaEr4s4b - compare `doIt` vs. `doIt2`

UnsafeBufferPointer does its own bounds-checking and overflow reporting is maintained for debug builds, so they should not see a functional change. In release mode, we will be assuming that `_base.distance(from:to:)` is accurate - which is a critical dependency of the current implementation anyway, because if you returned a negative start offset or too-large count, nothing would warn you in release mode.

A better version of #36680 which should maintain the debug-mode safety rails.