### PR TITLE
[Concurrency] Emit async methods in ObjC protocols once.

### DIFF
--- a/test/Concurrency/Inputs/Delegate.h
+++ b/test/Concurrency/Inputs/Delegate.h
@@ -17,5 +17,8 @@
 
 @end
 
+@protocol MyAsyncProtocol
+-(void)myAsyncMethod:(void (^ _Nullable)(NSError * _Nullable, NSString * _Nullable))completionHandler;
+@end
 
 #endif

--- a/test/Concurrency/objc_async_protocol_irgen.swift
+++ b/test/Concurrency/objc_async_protocol_irgen.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-experimental-concurrency -import-objc-header %S/Inputs/Delegate.h %s -emit-ir -o - | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+
+let anyObject: AnyObject = (MyAsyncProtocol.self as AnyObject) // or something like this
+
+// rdar://76192003
+// Make sure we don't emit 2 copies of methods, due to a completion-handler
+// version and another due to an async based version.
+
+// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS_MyAsyncProtocol = internal constant
+// CHECK-SAME: selector_data(myAsyncMethod:)
+// CHECK-NOT: selector_data(myAsyncMethod:)
+// CHECK-SAME: align 8


### PR DESCRIPTION
Previously, the method table would contain duplicate copies due to the
ProtocolDecl carrying a completionHandler-based version of the method,
as well as the async version of the method.

Fixes rdar://76192003.