### PR TITLE
[DiagnosticsQoI] Inform the User When Unavailable Inits Are Called

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5291,6 +5291,10 @@ ERROR(availabilty_string_subscript_migration, none,
       "subscripts returning String were obsoleted in Swift 4; explicitly "
       "construct a String from subscripted result", ())
 
+NOTE(availability_unavailable_implicit_init, none,
+     "call to unavailable %0 %1 from superclass %2 occurs implicitly at the "
+     "end of this initializer", (DescriptiveDeclKind, DeclName, DeclName))
+
 // Conformance availability checking diagnostics
 
 ERROR(conformance_availability_unavailable, none,

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1662,7 +1662,7 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
 
     for (auto decl : lookupResults) {
       auto superclassCtor = dyn_cast<ConstructorDecl>(decl);
-    if (!superclassCtor || !superclassCtor->isDesignatedInit() ||
+      if (!superclassCtor || !superclassCtor->isDesignatedInit() ||
           superclassCtor == ctor)
         continue;
 
@@ -1673,9 +1673,14 @@ static bool checkSuperInit(ConstructorDecl *fromCtor,
 
     // Make sure we can reference the designated initializer correctly.
     auto loc = fromCtor->getLoc();
-    diagnoseDeclAvailability(
+    const bool didDiagnose = diagnoseDeclAvailability(
         ctor, loc, nullptr,
         ExportContext::forFunctionBody(fromCtor, loc));
+    if (didDiagnose) {
+      fromCtor->diagnose(diag::availability_unavailable_implicit_init,
+                         ctor->getDescriptiveKind(), ctor->getName(),
+                         superclassDecl->getName());
+    }
   }
 
 

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -1117,3 +1117,14 @@ func testBadRename() {
 
 struct AvailableGenericParam<@available(*, deprecated) T> {}
 // expected-error@-1 {{'@available' attribute cannot be applied to this declaration}}
+
+class UnavailableNoArgsSuperclassInit {
+  @available(*, unavailable)
+  init() {} // expected-note {{'init()' has been explicitly marked unavailable here}}
+}
+
+class UnavailableNoArgsSubclassInit: UnavailableNoArgsSuperclassInit {
+  init(marker: ()) {}
+  // expected-error@-1 {{'init()' is unavailable}}
+  // expected-note@-2 {{call to unavailable initializer 'init()' from superclass 'UnavailableNoArgsSuperclassInit' occurs implicitly at the end of this initializer}}
+}

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -229,6 +229,7 @@ public class Derived3 : Base3 {
   @inlinable
   public init(_: Int) {}
   // expected-error@-1 {{initializer 'init()' is internal and cannot be referenced from an '@inlinable' function}}
+  // expected-note@-2 {{call to unavailable initializer 'init()' from superclass 'Base3' occurs implicitly at the end of this initializer}}
 }
 
 @_fixed_layout
@@ -245,6 +246,7 @@ class Derived4 : Middle4 {
   @inlinable
   public init(_: Int) {}
   // expected-error@-1 {{initializer 'init()' is internal and cannot be referenced from an '@inlinable' function}}
+  // expected-note@-2 {{call to unavailable initializer 'init()' from superclass 'Middle4' occurs implicitly at the end of this initializer}}
 }
 
 


### PR DESCRIPTION
When a no-args init is the only designated init in the superclass, Swift will automatically
call it from the subclass. Unfortunately, if this initializer is
unavailable, an error is issued that points at the subclass' init but
makes no mention of the implicit call. Fix that by providing a note that
explains what's going on here.