### PR TITLE
[IRGen] Don't use extended encoding for async @objc protocol methods.

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1185,10 +1185,11 @@ irgen::emitObjCMethodDescriptorParts(IRGenModule &IGM,
   /// with numbers that used to represent stack offsets for each of these
   /// elements.
   CanSILFunctionType methodType = getObjCMethodType(IGM, method);
-  descriptor.typeEncoding =
-      getObjCEncodingForMethod(IGM, methodType, /*extended*/ method->hasAsync(),
-                               method);
   
+  bool useExtendedEncoding =
+    method->hasAsync() && !isa<ProtocolDecl>(method->getDeclContext());
+  descriptor.typeEncoding = getObjCEncodingForMethod(
+      IGM, methodType, /*extended*/ useExtendedEncoding, method);
   /// The third element is the method implementation pointer.
   if (!concrete) {
     descriptor.impl = nullptr;

--- a/test/IRGen/objc_async_metadata.swift
+++ b/test/IRGen/objc_async_metadata.swift
@@ -21,3 +21,16 @@ class MyClass: NSObject {
   @objc func method() async -> String { "" }
   @objc func throwingMethod() async throws -> String { "" }
 }
+
+// CHECK: [[ENCODE_ASYNC_STRING_PROTO:@.*]] = private unnamed_addr constant [15 x i8] c"v32@0:8@16@?24\00"
+// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS__TtP19objc_async_metadata7MyProto_ = internal constant
+// CHECK-SAME: _selector_data(myProtoRequirement:completionHandler:)
+// CHECK-SAME: [15 x i8]* [[ENCODE_ASYNC_STRING_PROTO]]
+
+// CHECK: [[ENCODE_ASYNC_STRING_PROTO_TYPE:@.*]] = private unnamed_addr constant [41 x i8] c"v32@0:8@\22NSString\2216@?<v@?@\22NSString\22>24\00"
+// CHECK-LABEL: @_PROTOCOL_METHOD_TYPES__TtP19objc_async_metadata7MyProto_ = internal constant
+// CHECK-SAME: [41 x i8]* [[ENCODE_ASYNC_STRING_PROTO_TYPE]]
+
+@objc protocol MyProto {
+  @objc func myProtoRequirement(_ x: String) async -> String
+}


### PR DESCRIPTION
It should only be used for `@objc` classes.