### PR TITLE
Sema: Don't score a solution higher if there's a sync-vs-async mismatch with a 'reasync' function

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -627,8 +627,8 @@ bool CompareDeclSpecializationRequest::evaluate(
     // If they both have trailing closures, compare those separately.
     bool compareTrailingClosureParamsSeparately = false;
     if (numParams1 > 0 && numParams2 > 0 &&
-        params1.back().getOldType()->is<AnyFunctionType>() &&
-        params2.back().getOldType()->is<AnyFunctionType>()) {
+        params1.back().getParameterType()->is<AnyFunctionType>() &&
+        params2.back().getParameterType()->is<AnyFunctionType>()) {
       compareTrailingClosureParamsSeparately = true;
     }
 
@@ -1132,8 +1132,8 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
         auto params = fnTy->getParams();
         assert(params.size() == 2);
 
-        auto param1 = params[0].getOldType();
-        auto param2 = params[1].getOldType()->castTo<AnyFunctionType>();
+        auto param1 = params[0].getParameterType();
+        auto param2 = params[1].getParameterType()->castTo<AnyFunctionType>();
 
         assert(param1->getOptionalObjectType());
         assert(params[1].isAutoClosure());

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2890,7 +2890,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // If we're choosing an asynchronous declaration within a synchronous
     // context, or vice-versa, increase the async/async mismatch score.
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      if (func->isAsyncContext() != isAsynchronousContext(useDC)) {
+      if (!func->hasPolymorphicEffect(EffectKind::Async) &&
+          func->isAsyncContext() != isAsynchronousContext(useDC)) {
         increaseScore(
             func->isAsyncContext() ? SK_AsyncInSyncMismatch : SK_SyncInAsync);
       }

--- a/test/Concurrency/reasync_ranking.swift
+++ b/test/Concurrency/reasync_ranking.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-concurrency
+
+// We don't want 'reasync' overloads to have a higher score in the
+// case of a sync vs reasync mismatch the way 'async' overloads do,
+// since this would change solver performance characteristics when
+// using the reasync '&&', '||' and '??' operators.
+
+func asyncOverload(_: () async -> (), _: Int) async {}
+func asyncOverload(_: () -> (), _: String) {}
+
+func referencesAsyncOverload() {
+  _ = asyncOverload // we prefer the sync overload
+}
+
+func referencesAsyncOverloadAsync() async {
+  _ = asyncOverload // we prefer the async overload
+}
+
+func reasyncOverload(_: () async -> (), _: Int) reasync {} // expected-note {{found this candidate}}
+func reasyncOverload(_: () -> (), _: String) {} // expected-note {{found this candidate}}
+
+func referencesReasyncOverload() {
+  _ = reasyncOverload // expected-error {{ambiguous use of 'reasyncOverload'}}
+}
+
+func referencesReasyncOverloadAsync() async {
+  // we prefer the async overload because the sync overload scores higher
+  // due to a sync-vs-async mismatch.
+  _ = reasyncOverload
+}


### PR DESCRIPTION
This fixes a performance regression with the reasync '&&', '||' and '??'
operators.

Also arguably it makes sense anyway since 'reasync' functions can in
fact be called from synchronous functions, so the solution should not
be considered worse.

We don't actually want to be able to overload a synchronous function
with a 'reasync' function anyway; the whole point of 'reasync' is to
avoid the need for such overloading.

Fixes rdar://problem/76254445.