### PR TITLE
[AST] make ASTContext RawComment cache aware of serialization

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1170,8 +1170,8 @@ public:
 
 private:
   friend Decl;
-  Optional<RawComment> getRawComment(const Decl *D);
-  void setRawComment(const Decl *D, RawComment RC);
+  Optional<std::pair<RawComment, bool>> getRawComment(const Decl *D);
+  void setRawComment(const Decl *D, RawComment RC, bool FromSerialized);
 
   Optional<StringRef> getBriefComment(const Decl *D);
   void setBriefComment(const Decl *D, StringRef Comment);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -285,7 +285,7 @@ struct ASTContext::Implementation {
   ClangModuleLoader *TheDWARFModuleLoader = nullptr;
 
   /// Map from Swift declarations to raw comments.
-  llvm::DenseMap<const Decl *, RawComment> RawComments;
+  llvm::DenseMap<const Decl *, std::pair<RawComment, bool>> RawComments;
 
   /// Map from Swift declarations to brief comments.
   llvm::DenseMap<const Decl *, StringRef> BriefComments;
@@ -2020,7 +2020,7 @@ ModuleDecl *ASTContext::getStdlibModule(bool loadIfAbsent) {
   return TheStdlibModule;
 }
 
-Optional<RawComment> ASTContext::getRawComment(const Decl *D) {
+Optional<std::pair<RawComment, bool>> ASTContext::getRawComment(const Decl *D) {
   auto Known = getImpl().RawComments.find(D);
   if (Known == getImpl().RawComments.end())
     return None;
@@ -2028,8 +2028,8 @@ Optional<RawComment> ASTContext::getRawComment(const Decl *D) {
   return Known->second;
 }
 
-void ASTContext::setRawComment(const Decl *D, RawComment RC) {
-  getImpl().RawComments[D] = RC;
+void ASTContext::setRawComment(const Decl *D, RawComment RC, bool FromSerialized) {
+  getImpl().RawComments[D] = std::make_pair(RC, FromSerialized);
 }
 
 Optional<StringRef> ASTContext::getBriefComment(const Decl *D) {

--- a/test/SymbolGraph/Symbols/DocComment/BatchMode.swift
+++ b/test/SymbolGraph/Symbols/DocComment/BatchMode.swift
@@ -1,8 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -module-name BatchMode -emit-module-path %t/BatchMode.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t -O -enable-batch-mode -incremental
+// RUN: %target-build-swift %s -module-name BatchMode -emit-module-path %t/BatchMode.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t -O -enable-batch-mode
 // RUN: %FileCheck %s --input-file %t/BatchMode.symbols.json
 
+// changes to the doc comment cache created situations where building in batch mode caused symbol
+// graphs to lose source range information for individual doc comment lines.
+
+// CHECK: "range":{"start":{"line":[[# @LINE]],"character":4},"end":{"line":[[# @LINE]],"character":22}}
 /// This is some func.
 public func someFunc() {}
-
-// CHECK: range

--- a/test/SymbolGraph/Symbols/DocComment/BatchMode.swift
+++ b/test/SymbolGraph/Symbols/DocComment/BatchMode.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name BatchMode -emit-module-path %t/BatchMode.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t -O -enable-batch-mode -incremental
+// RUN: %FileCheck %s --input-file %t/BatchMode.symbols.json
+
+/// This is some func.
+public func someFunc() {}
+
+// CHECK: range

--- a/test/SymbolGraph/verbose.swift
+++ b/test/SymbolGraph/verbose.swift
@@ -10,15 +10,15 @@
 // REQUIRES: rdar76461340
 
 // QUIET-NOT: Emitting symbol graph for module file
-// QUIET-NOT: 2 top-level declarations in this module.
-// QUIET-NOT: Found 1 symbols and 0 relationships.
+// QUIET-NOT: {{[[:digit:]]}} top-level declarations in this module.
+// QUIET-NOT: Found {{[[:digit:]]}} symbols and {{[[:digit:]]}} relationships.
 
 // VERBOSE: Emitting symbol graph for module file
-// VERBOSE: 2 top-level declarations in this module.
-// VERBOSE: Found 1 symbols and 0 relationships.
+// VERBOSE: {{[[:digit:]]}} top-level declarations in this module.
+// VERBOSE: Found {{[[:digit:]]}} symbols and {{[[:digit:]]}} relationships.
 
 // DRIVER-NOT: Emitting symbol graph for module file
-// DRIVER-NOT: 2 top-level declarations in this module.
-// DRIVER-NOT: Found 1 symbols and 0 relationships.
+// DRIVER-NOT: {{[[:digit:]]}} top-level declarations in this module.
+// DRIVER-NOT: Found {{[[:digit:]]}} symbols and {{[[:digit:]]}} relationships.
 
 public func someFunc() {}

--- a/test/SymbolGraph/verbose.swift
+++ b/test/SymbolGraph/verbose.swift
@@ -6,9 +6,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name verbose -emit-module -emit-module-path %t/verbose.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t | %FileCheck %s -check-prefix=DRIVER --allow-empty
 
-// rdar://76461340
-// REQUIRES: rdar76461340
-
 // QUIET-NOT: Emitting symbol graph for module file
 // QUIET-NOT: {{[[:digit:]]}} top-level declarations in this module.
 // QUIET-NOT: Found {{[[:digit:]]}} symbols and {{[[:digit:]]}} relationships.


### PR DESCRIPTION
Resolves rdar://76162972

In situations where different parts of the codebase want to load raw comments, there's an ordering constraint between sections that don't want to load `.swiftsourceinfo` files (for performance reasons) and those that do (for completeness reasons). If a code with the former constraint loads the raw comment first, code with the latter constraint won't know to reload the comment to get all the information available. This caused a situation where emitting symbol graphs while compiling in batch mode (after #36270) would cause doc comments to lose their source-range information.

This PR adds a boolean to the RawComment cache in the ASTContext. This indicates whether the RawComment in question came from a `RawDocCommentAttr` or `.swiftsourceinfo` file. The existing `SerializedOK` flag then compares against the boolean from the cache to determine whether to discard the cached comment information and attempt to load the comment anyway. If `SerializedOK` is false, then the cached comment is used every time. If `SerializedOK` is true, then the cached comment will be used only if it came from the above situations.