### PR TITLE
Clean up the TaskGroup ABI

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -740,6 +740,14 @@ BUILTIN_MISC_OPERATION(ResumeThrowingContinuationThrowing,
 BUILTIN_MISC_OPERATION(BuildSerialExecutorRef,
                        "buildSerialExecutorRef", "", Special)
 
+/// Create a task group.
+BUILTIN_MISC_OPERATION(CreateTaskGroup,
+                       "createTaskGroup", "", Special)
+
+/// Destroy a task group.
+BUILTIN_MISC_OPERATION(DestroyTaskGroup,
+                       "destroyTaskGroup", "", Special)
+
 // BUILTIN_MISC_OPERATION_WITH_SILGEN - Miscellaneous operations that are
 // specially emitted during SIL generation.
 //

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -44,5 +44,6 @@ LANGUAGE_FEATURE(GlobalActors, 0, "Global actors", langOpts.EnableExperimentalCo
 LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type", true)
 LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable", true)
 LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins", true)
+LANGUAGE_FEATURE(BuiltinTaskGroup, 0, "TaskGroup builtins", true)
 
 #undef LANGUAGE_FEATURE

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -178,17 +178,6 @@ void swift_taskGroup_wait_next_throwing(
     OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *rawContext,
     TaskGroup *group, const Metadata *successType);
 
-/// Create a new `TaskGroup`.
-/// The caller is responsible for retaining and managing the group's lifecycle.
-///
-/// Its Swift signature is
-///
-/// \code
-/// func swift_taskGroup_create() -> Builtin.RawPointer
-/// \endcode
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-TaskGroup* swift_taskGroup_create(); // TODO: probably remove this call, and just use the initialize always
-
 /// Initialize a `TaskGroup` in the passed `group` memory location.
 /// The caller is responsible for retaining and managing the group's lifecycle.
 ///

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1672,21 +1672,21 @@ FUNCTION(DefaultActorDeallocateResilient,
          ARGS(RefCountedPtrTy),
          ATTRS(NoUnwind))
 
-//// void swift_taskGroup_initialize(AsyncTask *task, TaskGroup *group);
-//FUNCTION(TaskGroupInitialize,
-//         swift_taskGroup_initialize, SwiftCC,
-//         ConcurrencyAvailability,
-//         RETURNS(VoidTy),
-//         ARGS(RefCountedPtrTy, RefCountedPtrTy),
-//         ATTRS(NoUnwind))
-//
-//// void swift_taskGroup_destroy(AsyncTask *task, TaskGroup *group);
-//FUNCTION(TaskGroupDestroy,
-//         swift_taskGroup_destroy, SwiftCC,
-//         ConcurrencyAvailability,
-//         RETURNS(VoidTy),
-//         ARGS(RefCountedPtrTy, RefCountedPtrTy),
-//         ATTRS(NoUnwind))
+// void swift_taskGroup_initialize(TaskGroup *group);
+FUNCTION(TaskGroupInitialize,
+         swift_taskGroup_initialize, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy),
+         ATTRS(NoUnwind))
+
+// void swift_taskGroup_destroy(TaskGroup *group);
+FUNCTION(TaskGroupDestroy,
+         swift_taskGroup_destroy, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(Int8PtrTy),
+         ATTRS(NoUnwind))
 
 // AutoDiffLinearMapContext *swift_autoDiffCreateLinearMapContext(size_t);
 FUNCTION(AutoDiffCreateLinearMapContext,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2724,6 +2724,10 @@ static bool usesFeatureBuiltinContinuation(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinTaskGroup(Decl *decl) {
+  return false;
+}
+
 /// Determine the set of "new" features used on a given declaration.
 ///
 /// Note: right now, all features we check for are "new". At some point, we'll

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1481,6 +1481,18 @@ static ValueDecl *getResumeContinuationThrowing(ASTContext &ctx,
                             _void);
 }
 
+static ValueDecl *getCreateTaskGroup(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin,
+                            _parameters(),
+                            _rawPointer);
+}
+
+static ValueDecl *getDestroyTaskGroup(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin,
+                            _parameters(_rawPointer),
+                            _void);
+}
+
 static ValueDecl *getBuildSerialExecutorRef(ASTContext &ctx, Identifier id) {
   // TODO: restrict the generic parameter to the SerialExecutor protocol
   return getBuiltinFunction(ctx, id, _thin,
@@ -2727,6 +2739,12 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
   case BuiltinValueKind::InitializeDefaultActor:
   case BuiltinValueKind::DestroyDefaultActor:
     return getDefaultActorInitDestroy(Context, Id);
+
+  case BuiltinValueKind::CreateTaskGroup:
+    return getCreateTaskGroup(Context, Id);
+
+  case BuiltinValueKind::DestroyTaskGroup:
+    return getDestroyTaskGroup(Context, Id);
 
   case BuiltinValueKind::ResumeNonThrowingContinuationReturning:
   case BuiltinValueKind::ResumeThrowingContinuationReturning:

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -223,6 +223,17 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   // getCurrentActor has no arguments.
   if (Builtin.ID == BuiltinValueKind::GetCurrentExecutor) {
     emitGetCurrentExecutor(IGF, out);
+
+    return;
+  }
+
+  if (Builtin.ID == BuiltinValueKind::CreateTaskGroup) {
+    out.add(emitCreateTaskGroup(IGF));
+    return;
+  }
+
+  if (Builtin.ID == BuiltinValueKind::DestroyTaskGroup) {
+    emitDestroyTaskGroup(IGF, args.claimNext());
     return;
   }
 

--- a/lib/IRGen/GenConcurrency.h
+++ b/lib/IRGen/GenConcurrency.h
@@ -36,6 +36,12 @@ void emitBuildSerialExecutorRef(IRGenFunction &IGF, llvm::Value *actor,
 /// Emit the getCurrentExecutor builtin.
 void emitGetCurrentExecutor(IRGenFunction &IGF, Explosion &out);
 
+/// Emit the createTaskGroup builtin.
+llvm::Value *emitCreateTaskGroup(IRGenFunction &IGF);
+
+/// Emit the destroyTaskGroup builtin.
+void emitDestroyTaskGroup(IRGenFunction &IGF, llvm::Value *group);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -744,6 +744,8 @@ BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, PoundAssert)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GlobalStringTablePointer)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TypePtrAuthDiscriminator)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IntInstrprofIncrement)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, CreateTaskGroup)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, DestroyTaskGroup)
 
 BUILTIN_OPERAND_OWNERSHIP(ForwardingConsume, COWBufferForReading)
 BUILTIN_OPERAND_OWNERSHIP(ForwardingConsume, UnsafeGuaranteed)

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -553,6 +553,8 @@ CONSTANT_OWNERSHIP_BUILTIN(None, ResumeNonThrowingContinuationReturning)
 CONSTANT_OWNERSHIP_BUILTIN(None, ResumeThrowingContinuationReturning)
 CONSTANT_OWNERSHIP_BUILTIN(None, ResumeThrowingContinuationThrowing)
 CONSTANT_OWNERSHIP_BUILTIN(None, BuildSerialExecutorRef)
+CONSTANT_OWNERSHIP_BUILTIN(None, CreateTaskGroup)
+CONSTANT_OWNERSHIP_BUILTIN(None, DestroyTaskGroup)
 
 #undef CONSTANT_OWNERSHIP_BUILTIN
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1858,6 +1858,8 @@ static void visitBuiltinAddress(BuiltinInst *builtin,
     case BuiltinValueKind::InitializeDefaultActor:
     case BuiltinValueKind::DestroyDefaultActor:
     case BuiltinValueKind::GetCurrentExecutor:
+    case BuiltinValueKind::CreateTaskGroup:
+    case BuiltinValueKind::DestroyTaskGroup:
       return;
 
     // General memory access to a pointer in first operand position.

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -144,6 +144,8 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::GetCurrentAsyncTask:
     case BuiltinValueKind::GetCurrentExecutor:
     case BuiltinValueKind::AutoDiffCreateLinearMapContext:
+    case BuiltinValueKind::CreateTaskGroup:
+    case BuiltinValueKind::DestroyTaskGroup:
       return false;
 
     // Handle some rare builtins that may be sensitive to object lifetime

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -145,10 +145,6 @@ OVERRIDE_TASK_GROUP(taskGroup_initialize, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group), (group))
 
-OVERRIDE_TASK_GROUP(taskGroup_create, TaskGroup *,
-                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-                    swift::, , )
-
 OVERRIDE_TASK_GROUP(taskGroup_attachChild, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group, AsyncTask *child),

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -346,6 +346,10 @@ static AsyncTaskAndContext swift_task_create_group_future_commonImpl(
   if (flags.task_isChildTask()) {
     parent = swift_task_getCurrent();
     assert(parent != nullptr && "creating a child task with no active task");
+
+    // Inherit the priority of the parent task if unspecified.
+    if (flags.getPriority() == JobPriority::Unspecified)
+      flags.setPriority(parent->getPriority());
   }
 
   // Figure out the size of the header.

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -58,7 +58,7 @@ extension Task {
     // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
     //        with "destroying a task that never completed" in the task's destroy.
     //        How do we solve this properly?
-    _swiftRetain(_task)
+    Builtin.retain(_task)
 
     return Task(_task)
   }
@@ -561,7 +561,7 @@ extension Task {
     // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
     //        with "destroying a task that never completed" in the task's destroy.
     //        How do we solve this properly?
-    _swiftRetain(_task)
+    Builtin.retain(_task)
     return UnsafeCurrentTask(_task)
   }
 }
@@ -591,7 +591,7 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
   // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
   //        with "destroying a task that never completed" in the task's destroy.
   //        How do we solve this properly?
-  _swiftRetain(_task)
+  Builtin.retain(_task)
 
   return try body(UnsafeCurrentTask(_task))
 }

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -80,30 +80,28 @@ extension Task {
 ///   - the group will await any not yet complete tasks,
 ///   - once the `withTaskGroup` returns the group is guaranteed to be empty.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@inlinable
 public func withTaskGroup<ChildTaskResult: Sendable, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
   returning returnType: GroupResult.Type = GroupResult.self,
   body: (inout TaskGroup<ChildTaskResult>) async -> GroupResult
 ) async -> GroupResult {
-  let task = Builtin.getCurrentAsyncTask()
-  let _group = _taskGroupCreate()
-  var group: TaskGroup<ChildTaskResult>! = TaskGroup(task: task, group: _group)
+  #if compiler(>=5.5) && $BuiltinTaskGroup
+
+  let _group = Builtin.createTaskGroup()
+  var group = TaskGroup<ChildTaskResult>(group: _group)
 
   // Run the withTaskGroup body.
   let result = await body(&group)
 
-  // Drain any not next() awaited tasks if the group wasn't cancelled
-  // If any of these tasks were to throw
-  //
-  // Failures of tasks are ignored.
-  while !group.isEmpty {
-    _ = await group.next()
-    continue // keep awaiting on all pending tasks
-  }
+  await group.awaitAllRemainingTasks()
 
-  group = nil
-  _taskGroupDestroy(group: _group)
+  Builtin.destroyTaskGroup(_group)
   return result
+
+  #else
+  fatalError("Swift compiler is incompatible with this SDK version")
+  #endif
 }
 
 /// Starts a new throwing task group which provides a scope in which a dynamic 
@@ -161,67 +159,54 @@ public func withTaskGroup<ChildTaskResult: Sendable, GroupResult>(
 /// - if the body throws:
 ///   - all tasks remaining in the group will be automatically cancelled.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@inlinable
 public func withThrowingTaskGroup<ChildTaskResult: Sendable, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
   returning returnType: GroupResult.Type = GroupResult.self,
   body: (inout ThrowingTaskGroup<ChildTaskResult, Error>) async throws -> GroupResult
 ) async rethrows -> GroupResult {
-  let task = Builtin.getCurrentAsyncTask()
-  let _group = _taskGroupCreate()
-  var group: ThrowingTaskGroup<ChildTaskResult, Error>! =
-    ThrowingTaskGroup(task: task, group: _group)
+  #if compiler(>=5.5) && $BuiltinTaskGroup
+
+  let _group = Builtin.createTaskGroup()
+  var group = ThrowingTaskGroup<ChildTaskResult, Error>(group: _group)
 
   do {
     // Run the withTaskGroup body.
     let result = try await body(&group)
 
-    // TODO: For whatever reason extracting the common teardown code into a local async function here causes it to hang forever?!
-    // Drain any not next() awaited tasks if the group wasn't cancelled
-    // If any of these tasks were to throw
-    //
-    // Failures of tasks are ignored.
-    while !group.isEmpty {
-      _ = try? await group.next()
-      continue // keep awaiting on all pending tasks
-    }
-    group = nil
-    _taskGroupDestroy(group: _group)
+    await group.awaitAllRemainingTasks()
+    Builtin.destroyTaskGroup(_group)
 
     return result
   } catch {
     group.cancelAll()
-    // Drain any not next() awaited tasks if the group wasn't cancelled
-    // If any of these tasks were to throw
-    //
-    // Failures of tasks are ignored.
-    while !group.isEmpty {
-      _ = try? await group.next()
-      continue // keep awaiting on all pending tasks
-    }
-    group = nil
-    _taskGroupDestroy(group: _group)
+
+    await group.awaitAllRemainingTasks()
+    Builtin.destroyTaskGroup(_group)
 
     throw error
   }
+
+  #else
+  fatalError("Swift compiler is incompatible with this SDK version")
+  #endif
 }
 
 /// A task group serves as storage for dynamically spawned tasks.
 ///
 /// It is created by the `withTaskGroup` function.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@frozen
 public struct TaskGroup<ChildTaskResult: Sendable> {
 
-  private let _task: Builtin.NativeObject
   /// Group task into which child tasks offer their results,
   /// and the `next()` function polls those results from.
-  private let _group: Builtin.RawPointer
+  @usableFromInline
+  internal let _group: Builtin.RawPointer
 
   /// No public initializers
-  init(task: Builtin.NativeObject, group: Builtin.RawPointer) {
-    // TODO: this feels slightly off, any other way to avoid the task being too eagerly released?
-    _swiftRetain(task) // to avoid the task being destroyed when the group is destroyed
-
-    self._task = task
+  @inlinable
+  init(group: Builtin.RawPointer) {
     self._group = group
   }
 
@@ -231,12 +216,11 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
       operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) async -> Bool {
     return try await self.spawnUnlessCancelled(priority: priority) {
-      try! await operation()
+      await operation()
     }
   }
 
-
-/// Add a child task to the group.
+  /// Add a child task to the group.
   ///
   /// ### Error handling
   /// Operations are allowed to `throw`, in which case the `try await next()`
@@ -256,12 +240,11 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
     _ = _taskGroupAddPendingTask(group: _group, unconditionally: true)
-    
+
     // Set up the job flags for a new task.
     var flags = Task.JobFlags()
     flags.kind = .task
-    flags.priority = priority != Task.Priority.unspecified ?
-        priority : getJobFlags(_task).priority
+    flags.priority = priority
     flags.isFuture = true
     flags.isChildTask = true
     flags.isGroupChildTask = true
@@ -306,8 +289,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
     // Set up the job flags for a new task.
     var flags = Task.JobFlags()
     flags.kind = .task
-    flags.priority = priority != Task.Priority.unspecified ?
-        priority : getJobFlags(_task).priority
+    flags.priority = priority
     flags.isFuture = true
     flags.isChildTask = true
     flags.isGroupChildTask = true
@@ -379,19 +361,15 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// It is possible to directly rethrow such error out of a `withTaskGroup` body
   /// function's body, causing all remaining tasks to be implicitly cancelled.
   public mutating func next() async -> ChildTaskResult? {
-    #if NDEBUG
-    let callingTask = Builtin.getCurrentAsyncTask() // can't inline into the assert sadly
-    assert(unsafeBitCast(callingTask, to: size_t.self) ==
-      unsafeBitCast(_task, to: size_t.self),
-      """
-      group.next() invoked from task other than the task which created the group! \
-      This means the group must have illegally escaped the withTaskGroup{} scope.
-      """)
-    #endif
-  
     // try!-safe because this function only exists for Failure == Never,
     // and as such, it is impossible to spawn a throwing child task.
     return try! await _taskGroupWaitNext(group: _group)
+  }
+
+  /// Await all the remaining tasks on this group.
+  @usableFromInline
+  internal mutating func awaitAllRemainingTasks() async {
+    while let _ = await next() {}
   }
   
   /// Query whether the group has any remaining tasks.
@@ -430,8 +408,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// - Returns: `true` if the group (or its parent task) was cancelled,
   ///            `false` otherwise.
   public var isCancelled: Bool {
-    return _taskIsCancelled(_task) ||
-      _taskGroupIsCancelled(group: _group)
+    return _taskGroupIsCancelled(group: _group)
   }
 }
 
@@ -459,20 +436,30 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
 ///
 /// It is created by the `withTaskGroup` function.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@frozen
 public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
 
-  private let _task: Builtin.NativeObject
   /// Group task into which child tasks offer their results,
   /// and the `next()` function polls those results from.
-  private let _group: Builtin.RawPointer
+  @usableFromInline
+  internal let _group: Builtin.RawPointer
 
   /// No public initializers
-  init(task: Builtin.NativeObject, group: Builtin.RawPointer) {
-    // FIXME: this feels slightly off, any other way to avoid the task being too eagerly released?
-    _swiftRetain(task) // to avoid the task being destroyed when the group is destroyed
-
-    self._task = task
+  @inlinable
+  init(group: Builtin.RawPointer) {
     self._group = group
+  }
+
+  /// Await all the remaining tasks on this group.
+  @usableFromInline
+  internal mutating func awaitAllRemainingTasks() async {
+    while true {
+      do {
+        guard let _ = try await next() else {
+          return
+        }
+      } catch {}
+    }
   }
 
   @available(*, deprecated, message: "`Task.Group.add` has been replaced by `(Throwing)TaskGroup.spawn` or `(Throwing)TaskGroup.spawnUnlessCancelled` and will be removed shortly.")
@@ -510,8 +497,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     // Set up the job flags for a new task.
     var flags = Task.JobFlags()
     flags.kind = .task
-    flags.priority = priority != Task.Priority.unspecified ?
-        priority : getJobFlags(_task).priority
+    flags.priority = priority
     flags.isFuture = true
     flags.isChildTask = true
     flags.isGroupChildTask = true
@@ -556,8 +542,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     // Set up the job flags for a new task.
     var flags = Task.JobFlags()
     flags.kind = .task
-    flags.priority = priority != Task.Priority.unspecified ?
-        priority : getJobFlags(_task).priority
+    flags.priority = priority
     flags.isFuture = true
     flags.isChildTask = true
     flags.isGroupChildTask = true
@@ -629,31 +614,11 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// It is possible to directly rethrow such error out of a `withTaskGroup` body
   /// function's body, causing all remaining tasks to be implicitly cancelled.
   public mutating func next() async throws -> ChildTaskResult? {
-    #if NDEBUG
-    let callingTask = Builtin.getCurrentAsyncTask() // can't inline into the assert sadly
-    assert(unsafeBitCast(callingTask, to: size_t.self) ==
-      unsafeBitCast(_task, to: size_t.self),
-      """
-      group.next() invoked from task other than the task which created the group! \
-      This means the group must have illegally escaped the withTaskGroup{} scope.
-      """)
-    #endif
-
     return try await _taskGroupWaitNext(group: _group)
   }
 
   /// - SeeAlso: `next()`
   public mutating func nextResult() async throws -> Result<ChildTaskResult, Failure>? {
-    #if NDEBUG
-    let callingTask = Builtin.getCurrentAsyncTask() // can't inline into the assert sadly
-    assert(unsafeBitCast(callingTask, to: size_t.self) ==
-      unsafeBitCast(_task, to: size_t.self),
-      """
-      group.next() invoked from task other than the task which created the group! \
-      This means the group must have illegally escaped the withTaskGroup{} scope.
-      """)
-    #endif
-
     do {
       guard let success: ChildTaskResult = try await _taskGroupWaitNext(group: _group) else {
         return nil
@@ -701,8 +666,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// - Returns: `true` if the group (or its parent task) was cancelled,
   ///            `false` otherwise.
   public var isCancelled: Bool {
-    return _taskIsCancelled(_task) ||
-      _taskGroupIsCancelled(group: _group)
+    return _taskGroupIsCancelled(group: _group)
   }
 }
 
@@ -819,22 +783,6 @@ extension ThrowingTaskGroup: AsyncSequence {
 }
 
 /// ==== -----------------------------------------------------------------------
-
-// FIXME: remove this
-@_silgen_name("swift_retain")
-func _swiftRetain(
-  _ object: Builtin.NativeObject
-)
-
-// FIXME: remove this
-@_silgen_name("swift_release")
-func _swiftRelease(
-  _ object: Builtin.NativeObject
-)
-
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-@_silgen_name("swift_taskGroup_create")
-func _taskGroupCreate() -> Builtin.RawPointer
 
 /// Attach task group child to the group group to the task.
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -107,3 +107,20 @@ bb0(%0 : @owned $Error, %1 : $Builtin.RawUnsafeContinuation):
   %21 = tuple ()
   return %21 : $()
 }
+
+// CHECK-LABEL: define hidden swift{{(tail)?}}cc  void @task_group_create_destroy
+sil hidden [ossa] @task_group_create_destroy : $@async () -> () {
+bb0:
+  // CHECK:      [[TASKGROUP:%.*]] = alloca [32 x i8*], align 16
+  // CHECK:      [[T0:%.*]] = bitcast [32 x i8*]* [[TASKGROUP]] to i8*
+  // CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 -1, i8* [[T0]])
+  // CHECK-NEXT: call swiftcc void @swift_taskGroup_initialize(i8* [[T0]])
+  %0 = builtin "createTaskGroup"() : $Builtin.RawPointer
+
+  // CHECK-NEXT: call swiftcc void @swift_taskGroup_destroy(i8* [[T0]])
+  // CHECK-NEXT: call void @llvm.lifetime.end.p0i8(i64 -1, i8* [[T0]])
+  builtin "destroyTaskGroup"(%0 : $Builtin.RawPointer) : $()
+
+  %21 = tuple ()
+  return %21 : $()
+}

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -179,10 +179,6 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_initialize) {
   swift_taskGroup_initialize(nullptr);
 }
 
-TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_create) {
-  swift_taskGroup_create();
-}
-
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_attachChild) {
   swift_taskGroup_attachChild(nullptr, nullptr);
 }


### PR DESCRIPTION
- stop storing the parent task in the `TaskGroup` at the .swift level
- make sure that `swift_taskGroup_isCancelled` is implied by the parent task being cancelled
- make the `TaskGroup` structs `@frozen`
- make the `withTaskGroup` functions `@inlinable`
- remove `swift_taskGroup_create`
- teach IRGen to allocate memory for the task group
- don't deallocate the task group in `swift_taskGroup_destroy`

To achieve the allocation change, introduce paired create/destroy builtins.

Furthermore, remove the `_swiftRetain` and `_swiftRelease` functions and several calls to them.  Replace them with uses of the appropriate builtins. I should probably change the builtins to return retained, since they're working with a managed type, but I'll do that in a separate commit.