### PR TITLE
[ptrauth] Adapted authinfo for async PAF callees.

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1164,9 +1164,14 @@ public:
     return fnPtr;
   }
   llvm::CallInst *createCall(FunctionPointer &fnPtr) override {
+    PointerAuthInfo newAuthInfo;
+    if (auto authInfo = fnPtr.getAuthInfo()) {
+      newAuthInfo = PointerAuthInfo(authInfo.getCorrespondingCodeKey(),
+                                    authInfo.getDiscriminator());
+    }
     auto newFnPtr = FunctionPointer(
-        FunctionPointer::Kind::Function, fnPtr.getPointer(subIGF),
-        fnPtr.getAuthInfo(), Signature::forAsyncAwait(subIGF.IGM, origType));
+        FunctionPointer::Kind::Function, fnPtr.getPointer(subIGF), newAuthInfo,
+        Signature::forAsyncAwait(subIGF.IGM, origType));
     auto &Builder = subIGF.Builder;
 
     auto argValues = args.claimAll();


### PR DESCRIPTION
Fixes arm64e non-executable test failures of IRGen/async/partial_apply.sil and IRGen/async/partial_apply_forwarder.sil.
