### PR TITLE
[TypeChecker] Allow Double<->CGFloat conversion with optional promotions

### DIFF
--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -192,3 +192,20 @@ func test_no_ambiguity_with_unary_operators(width: CGFloat, height: CGFloat) {
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion38test_no_ambiguity_with_unary_operators5width6heighty12CoreGraphics7CGFloatV_AGtF1RL_V1x1yAcdiG_A3GtcfC
   _ = R(x: width / 4, y: -height / 2, width: width, height: height)
 }
+
+func test_conversions_with_optional_promotion(d: Double, cgf: CGFloat) {
+  func test_double(_: Double??) {}
+  func test_cgfloat(_: CGFloat??) {}
+
+  // CHECK: function_ref @$sSd12CoreGraphicsEySdAA7CGFloatVcfC
+  // CHECK-NEXT: apply
+  // CHECK-NEXT: enum $Optional<Double>, #Optional.some!enumelt
+  // CHECK-NEXT: enum $Optional<Optional<Double>>, #Optional.some!enumelt
+  test_double(cgf)
+
+  // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcfC
+  // CHECK-NEXT: apply
+  // CHECK-NEXT: enum $Optional<CGFloat>, #Optional.some!enumelt
+  // CHECK-NEXT: enum $Optional<Optional<CGFloat>>, #Optional.some!enumelt
+  test_cgfloat(d)
+}

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -228,4 +228,10 @@ func test_implicit_cgfloat_conversion() {
     }
     _ = S(x: 0.0, y: values.0) // Ok
   }
+
+  func allow_optional_promotion_double(_: Double??) {}
+  func allow_optional_promotion_cgfloat(_: CGFloat??) {}
+
+  allow_optional_promotion_double(cgf) // Ok -> CGFloat -> Double -> Double??
+  allow_optional_promotion_cgfloat(d) // Ok -> Double -> CGFloat -> CFloat??
 }


### PR DESCRIPTION
There are APIs that expect a `Double?` or `CGFloat?` argument
and it should be possible to pass `CGFloat` and `Double` respectively.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
