### PR TITLE
[mem2reg] Before adding support for promoting allocations with load_borrow, modernize/standardize style

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -18,8 +18,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #define DEBUG_TYPE "sil-mem2reg"
+
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/Projection.h"
@@ -50,56 +50,61 @@ STATISTIC(NumPhiPlaced,          "Number of Phi blocks placed");
 
 namespace {
 
-typedef llvm::DomTreeNodeBase<SILBasicBlock> DomTreeNode;
-typedef llvm::DenseMap<DomTreeNode *, unsigned> DomTreeLevelMap;
+using DomTreeNode = llvm::DomTreeNodeBase<SILBasicBlock>;
+using DomTreeLevelMap = llvm::DenseMap<DomTreeNode *, unsigned>;
 
 /// Promotes a single AllocStackInst into registers..
 class StackAllocationPromoter {
-  typedef BasicBlockSetVector<16> BlockSet;
-  typedef llvm::DenseMap<SILBasicBlock *, SILInstruction *> BlockToInstMap;
+  using BlockSet = BasicBlockSetVector<16>;
+  using BlockToInstMap = llvm::DenseMap<SILBasicBlock *, SILInstruction *>;
 
   // Use a priority queue keyed on dominator tree level so that inserted nodes
   // are handled from the bottom of the dom tree upwards.
-  typedef std::pair<DomTreeNode *, unsigned> DomTreeNodePair;
-  typedef std::priority_queue<DomTreeNodePair, SmallVector<DomTreeNodePair, 32>,
-                                 llvm::less_second> NodePriorityQueue;
+  using DomTreeNodePair = std::pair<DomTreeNode *, unsigned>;
+  using NodePriorityQueue =
+      std::priority_queue<DomTreeNodePair, SmallVector<DomTreeNodePair, 32>,
+                          llvm::less_second>;
 
   /// The AllocStackInst that we are handling.
-  AllocStackInst *ASI;
+  AllocStackInst *asi;
 
   /// The deallocation Instruction. This value could be NULL if there are
   /// multiple deallocations.
-  DeallocStackInst *DSI;
+  DeallocStackInst *dsi;
 
   /// Dominator info.
-  DominanceInfo *DT;
+  DominanceInfo *domInfo;
 
   /// Map from dominator tree node to tree level.
-  DomTreeLevelMap &DomTreeLevels;
+  DomTreeLevelMap &domTreeLevels;
 
   /// The builder used to create new instructions during register promotion.
-  SILBuilder &B;
+  SILBuilder &b;
 
   /// Records the last store instruction in each block for a specific
   /// AllocStackInst.
-  BlockToInstMap LastStoreInBlock;
+  BlockToInstMap lastStoreInBlock;
+
 public:
   /// C'tor.
-  StackAllocationPromoter(AllocStackInst *Asi, DominanceInfo *Di,
-                          DomTreeLevelMap &DomTreeLevels, SILBuilder &B)
-      : ASI(Asi), DSI(nullptr), DT(Di), DomTreeLevels(DomTreeLevels), B(B) {
+  StackAllocationPromoter(AllocStackInst *inputASI, DominanceInfo *inputDomInfo,
+                          DomTreeLevelMap &inputDomTreeLevels,
+                          SILBuilder &inputB)
+      : asi(inputASI), dsi(nullptr), domInfo(inputDomInfo),
+        domTreeLevels(inputDomTreeLevels), b(inputB) {
     // Scan the users in search of a deallocation instruction.
-    for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E; ++UI)
-      if (auto *D = dyn_cast<DeallocStackInst>(UI->getUser())) {
+    for (auto *use : asi->getUses()) {
+      if (auto *foundDealloc = dyn_cast<DeallocStackInst>(use->getUser())) {
         // Don't record multiple dealloc instructions.
-        if (DSI) {
-          DSI = nullptr;
+        if (dsi) {
+          dsi = nullptr;
           break;
         }
         // Record the deallocation instruction.
-        DSI = D;
+        dsi = foundDealloc;
       }
-      }
+    }
+  }
 
   /// Promote the Allocation.
   void run();
@@ -109,26 +114,26 @@ private:
   void promoteAllocationToPhi();
 
   /// Replace the dummy nodes with new block arguments.
-  void addBlockArguments(BlockSet &PhiBlocks);
+  void addBlockArguments(BlockSet &phiBlocks);
 
   /// Fix all of the branch instructions and the uses to use
   /// the AllocStack definitions (which include stores and Phis).
-  void fixBranchesAndUses(BlockSet &Blocks);
+  void fixBranchesAndUses(BlockSet &blocks);
 
   /// update the branch instructions with the new Phi argument.
   /// The blocks in \p PhiBlocks are blocks that define a value, \p Dest is
   /// the branch destination, and \p Pred is the predecessors who's branch we
   /// modify.
-  void fixPhiPredBlock(BlockSet &PhiBlocks, SILBasicBlock *Dest,
-                       SILBasicBlock *Pred);
+  void fixPhiPredBlock(BlockSet &phiBlocks, SILBasicBlock *dest,
+                       SILBasicBlock *pred);
 
   /// Get the value for this AllocStack variable that is
   /// flowing out of StartBB.
-  SILValue getLiveOutValue(BlockSet &PhiBlocks, SILBasicBlock *StartBB);
+  SILValue getLiveOutValue(BlockSet &phiBlocks, SILBasicBlock *startBlock);
 
   /// Get the value for this AllocStack variable that is
   /// flowing into BB.
-  SILValue getLiveInValue(BlockSet &PhiBlocks, SILBasicBlock *BB);
+  SILValue getLiveInValue(BlockSet &phiBlocks, SILBasicBlock *block);
 
   /// Prune AllocStacks usage in the function. Scan the function
   /// and remove in-block usage of the AllocStack. Leave only the first
@@ -139,41 +144,43 @@ private:
   /// linear scan. This function deletes all of the loads and stores except
   /// for the first load and the last store.
   /// \returns the last StoreInst found or zero if none found.
-  StoreInst *promoteAllocationInBlock(SILBasicBlock *BB);
+  StoreInst *promoteAllocationInBlock(SILBasicBlock *block);
 };
 
 } // end of namespace
 
 namespace {
+
 /// Promote memory to registers
 class MemoryToRegisters {
   /// The function that we are optimizing.
-  SILFunction &F;
+  SILFunction &f;
 
   /// Dominators.
-  DominanceInfo *DT;
+  DominanceInfo *domInfo;
 
   /// The builder used to create new instructions during register promotion.
-  SILBuilder B;
+  SILBuilder b;
 
   /// Check if the AllocStackInst \p ASI is only written into.
-  bool isWriteOnlyAllocation(AllocStackInst *ASI);
+  bool isWriteOnlyAllocation(AllocStackInst *asi);
 
   /// Promote all of the AllocStacks in a single basic block in one
   /// linear scan. Note: This function deletes all of the users of the
   /// AllocStackInst, including the DeallocStackInst but it does not remove the
   /// AllocStackInst itself!
-  void removeSingleBlockAllocation(AllocStackInst *ASI);
+  void removeSingleBlockAllocation(AllocStackInst *asi);
 
   /// Attempt to promote the specified stack allocation, returning true if so
   /// or false if not.  On success, all uses of the AllocStackInst have been
   /// removed, but the ASI itself is still in the program.
-  bool promoteSingleAllocation(AllocStackInst *ASI,
-                               DomTreeLevelMap &DomTreeLevels);
+  bool promoteSingleAllocation(AllocStackInst *asi,
+                               DomTreeLevelMap &domTreeLevels);
+
 public:
   /// C'tor
-  MemoryToRegisters(SILFunction &Func, DominanceInfo *Dt) : F(Func), DT(Dt),
-                                                            B(Func) {}
+  MemoryToRegisters(SILFunction &inputFunc, DominanceInfo *inputDomInfo)
+      : f(inputFunc), domInfo(inputDomInfo), b(inputFunc) {}
 
   /// Promote memory to registers. Return True on change.
   bool run();
@@ -187,10 +194,10 @@ public:
 /// This function looks for these patterns:
 /// 1. (load %ASI)
 /// 2. (load (struct_element_addr/tuple_element_addr/unchecked_addr_cast %ASI))
-static bool isAddressForLoad(SILInstruction *I, SILBasicBlock *&singleBlock,
+static bool isAddressForLoad(SILInstruction *load, SILBasicBlock *&singleBlock,
                              bool &hasGuaranteedOwnership) {
 
-  if (isa<LoadInst>(I)) {
+  if (isa<LoadInst>(load)) {
     // SILMem2Reg is disabled when we find:
     // (load [take] (struct_element_addr/tuple_element_addr %ASI))
     // struct_element_addr and tuple_element_addr are lowered into
@@ -198,41 +205,42 @@ static bool isAddressForLoad(SILInstruction *I, SILBasicBlock *&singleBlock,
     // guaranteed ownership. For replacing load's users, we need an owned value.
     // We will need a new copy and destroy of the running val placed after the
     // last use. This is not implemented currently.
-    if (hasGuaranteedOwnership && cast<LoadInst>(I)->getOwnershipQualifier() ==
-                                      LoadOwnershipQualifier::Take) {
+    if (hasGuaranteedOwnership &&
+        cast<LoadInst>(load)->getOwnershipQualifier() ==
+            LoadOwnershipQualifier::Take) {
       return false;
     }
     return true;
   }
 
-  if (!isa<UncheckedAddrCastInst>(I) && !isa<StructElementAddrInst>(I) &&
-      !isa<TupleElementAddrInst>(I))
+  if (!isa<UncheckedAddrCastInst>(load) && !isa<StructElementAddrInst>(load) &&
+      !isa<TupleElementAddrInst>(load))
     return false;
 
-  if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I)) {
+  if (isa<StructElementAddrInst>(load) || isa<TupleElementAddrInst>(load)) {
     hasGuaranteedOwnership = true;
   }
 
   // Recursively search for other (non-)loads in the instruction's uses.
-  for (auto UI : cast<SingleValueInstruction>(I)->getUses()) {
-    SILInstruction *II = UI->getUser();
-    if (II->getParent() != singleBlock)
+  for (auto *use : cast<SingleValueInstruction>(load)->getUses()) {
+    SILInstruction *user = use->getUser();
+    if (user->getParent() != singleBlock)
       singleBlock = nullptr;
 
-    if (!isAddressForLoad(II, singleBlock, hasGuaranteedOwnership))
+    if (!isAddressForLoad(user, singleBlock, hasGuaranteedOwnership))
       return false;
   }
   return true;
 }
 
 /// Returns true if \p I is a dead struct_element_addr or tuple_element_addr.
-static bool isDeadAddrProjection(SILInstruction *I) {
-  if (!isa<UncheckedAddrCastInst>(I) && !isa<StructElementAddrInst>(I) &&
-      !isa<TupleElementAddrInst>(I))
+static bool isDeadAddrProjection(SILInstruction *inst) {
+  if (!isa<UncheckedAddrCastInst>(inst) && !isa<StructElementAddrInst>(inst) &&
+      !isa<TupleElementAddrInst>(inst))
     return false;
 
   // Recursively search for uses which are dead themselves.
-  for (auto UI : cast<SingleValueInstruction>(I)->getUses()) {
+  for (auto UI : cast<SingleValueInstruction>(inst)->getUses()) {
     SILInstruction *II = UI->getUser();
     if (!isDeadAddrProjection(II))
       return false;
@@ -242,40 +250,39 @@ static bool isDeadAddrProjection(SILInstruction *I) {
 
 /// Returns true if this AllocStacks is captured.
 /// Sets \p inSingleBlock to true if all uses of \p ASI are in a single block.
-static bool isCaptured(AllocStackInst *ASI, bool &inSingleBlock) {
-  
-  SILBasicBlock *singleBlock = ASI->getParent();
-  
-  // For all users of the AllocStack instruction.
-  for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E; ++UI) {
-    SILInstruction *II = UI->getUser();
+static bool isCaptured(AllocStackInst *asi, bool &inSingleBlock) {
+  SILBasicBlock *singleBlock = asi->getParent();
 
-    if (II->getParent() != singleBlock)
+  // For all users of the AllocStack instruction.
+  for (auto *use : asi->getUses()) {
+    SILInstruction *user = use->getUser();
+
+    if (user->getParent() != singleBlock)
       singleBlock = nullptr;
     
     // Loads are okay.
     bool hasGuaranteedOwnership = false;
-    if (isAddressForLoad(II, singleBlock, hasGuaranteedOwnership))
+    if (isAddressForLoad(user, singleBlock, hasGuaranteedOwnership))
       continue;
 
     // We can store into an AllocStack (but not the pointer).
-    if (auto *SI = dyn_cast<StoreInst>(II))
-      if (SI->getDest() == ASI)
+    if (auto *si = dyn_cast<StoreInst>(user))
+      if (si->getDest() == asi)
         continue;
 
     // Deallocation is also okay, as are DebugValueAddr. We will turn
     // the latter into DebugValue.
-    if (isa<DeallocStackInst>(II) || isa<DebugValueAddrInst>(II))
+    if (isa<DeallocStackInst>(user) || isa<DebugValueAddrInst>(user))
       continue;
 
     // Destroys of loadable types can be rewritten as releases, so
     // they are fine.
-    if (auto *DAI = dyn_cast<DestroyAddrInst>(II))
-      if (DAI->getOperand()->getType().isLoadable(*DAI->getFunction()))
+    if (auto *dai = dyn_cast<DestroyAddrInst>(user))
+      if (dai->getOperand()->getType().isLoadable(*dai->getFunction()))
         continue;
 
     // Other instructions are assumed to capture the AllocStack.
-    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack is captured by: " << *II);
+    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack is captured by: " << *user);
     return true;
   }
 
@@ -285,30 +292,30 @@ static bool isCaptured(AllocStackInst *ASI, bool &inSingleBlock) {
 }
 
 /// Returns true if the AllocStack is only stored into.
-bool MemoryToRegisters::isWriteOnlyAllocation(AllocStackInst *ASI) {
+bool MemoryToRegisters::isWriteOnlyAllocation(AllocStackInst *asi) {
   // For all users of the AllocStack:
-  for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E; ++UI) {
-    SILInstruction *II = UI->getUser();
+  for (auto *use : asi->getUses()) {
+    SILInstruction *user = use->getUser();
 
     // It is okay to store into this AllocStack.
-    if (auto *SI = dyn_cast<StoreInst>(II))
-      if (!isa<AllocStackInst>(SI->getSrc()))
+    if (auto *si = dyn_cast<StoreInst>(user))
+      if (!isa<AllocStackInst>(si->getSrc()))
         continue;
 
     // Deallocation is also okay.
-    if (isa<DeallocStackInst>(II))
+    if (isa<DeallocStackInst>(user))
       continue;
 
     // If we haven't already promoted the AllocStack, we may see
     // DebugValueAddr uses.
-    if (isa<DebugValueAddrInst>(II))
+    if (isa<DebugValueAddrInst>(user))
       continue;
 
-    if (isDeadAddrProjection(II))
+    if (isDeadAddrProjection(user))
       continue;
 
     // Can't do anything else with it.
-    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack has non-write use: " << *II);
+    LLVM_DEBUG(llvm::dbgs() << "*** AllocStack has non-write use: " << *user);
     return false;
   }
 
@@ -316,70 +323,69 @@ bool MemoryToRegisters::isWriteOnlyAllocation(AllocStackInst *ASI) {
 }
 
 /// Promote a DebugValueAddr to a DebugValue of the given value.
-static void
-promoteDebugValueAddr(DebugValueAddrInst *DVAI, SILValue Value, SILBuilder &B) {
-  assert(DVAI->getOperand()->getType().isLoadable(*DVAI->getFunction()) &&
+static void promoteDebugValueAddr(DebugValueAddrInst *dvai, SILValue value,
+                                  SILBuilder &b) {
+  assert(dvai->getOperand()->getType().isLoadable(*dvai->getFunction()) &&
          "Unexpected promotion of address-only type!");
-  assert(Value && "Expected valid value");
+  assert(value && "Expected valid value");
   // Avoid inserting the same debug_value twice.
-  for (Operand *Use : Value->getUses())
-    if (auto *DVI = dyn_cast<DebugValueInst>(Use->getUser()))
-      if (*DVI->getVarInfo() == *DVAI->getVarInfo()) {
-        DVAI->eraseFromParent();
+  for (auto *use : value->getUses())
+    if (auto *dvi = dyn_cast<DebugValueInst>(use->getUser()))
+      if (*dvi->getVarInfo() == *dvai->getVarInfo()) {
+        dvai->eraseFromParent();
         return;
       }
-  B.setInsertionPoint(DVAI);
-  B.setCurrentDebugScope(DVAI->getDebugScope());
-  B.createDebugValue(DVAI->getLoc(), Value, *DVAI->getVarInfo());
+  b.setInsertionPoint(dvai);
+  b.setCurrentDebugScope(dvai->getDebugScope());
+  b.createDebugValue(dvai->getLoc(), value, *dvai->getVarInfo());
 
-  DVAI->eraseFromParent();
+  dvai->eraseFromParent();
 }
 
 /// Returns true if \p I is a load which loads from \p ASI.
-static bool isLoadFromStack(SILInstruction *I, AllocStackInst *ASI) {
-  if (!isa<LoadInst>(I))
+static bool isLoadFromStack(SILInstruction *i, AllocStackInst *asi) {
+  if (!isa<LoadInst>(i))
     return false;
   
   // Skip struct and tuple address projections.
-  ValueBase *op = I->getOperand(0);
-  while (op != ASI) {
+  ValueBase *op = i->getOperand(0);
+  while (op != asi) {
     if (!isa<UncheckedAddrCastInst>(op) && !isa<StructElementAddrInst>(op) &&
         !isa<TupleElementAddrInst>(op))
       return false;
-    
     op = cast<SingleValueInstruction>(op)->getOperand(0);
   }
   return true;
 }
 
 /// Collects all load instructions which (transitively) use \p I as address.
-static void collectLoads(SILInstruction *I, SmallVectorImpl<LoadInst *> &Loads) {
-  if (auto *load = dyn_cast<LoadInst>(I)) {
-    Loads.push_back(load);
+static void collectLoads(SILInstruction *i,
+                         SmallVectorImpl<LoadInst *> &foundLoads) {
+  if (auto *load = dyn_cast<LoadInst>(i)) {
+    foundLoads.push_back(load);
     return;
   }
-  if (!isa<UncheckedAddrCastInst>(I) && !isa<StructElementAddrInst>(I) &&
-      !isa<TupleElementAddrInst>(I))
+  if (!isa<UncheckedAddrCastInst>(i) && !isa<StructElementAddrInst>(i) &&
+      !isa<TupleElementAddrInst>(i))
     return;
   
   // Recursively search for other loads in the instruction's uses.
-  for (auto UI : cast<SingleValueInstruction>(I)->getUses()) {
-    collectLoads(UI->getUser(), Loads);
+  for (auto *use : cast<SingleValueInstruction>(i)->getUses()) {
+    collectLoads(use->getUser(), foundLoads);
   }
 }
 
+static void replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi) {
+  ProjectionPath projections(newValue->getType());
+  SILValue op = li->getOperand();
+  SILBuilderWithScope builder(li);
 
-static void replaceLoad(LoadInst *LI, SILValue val, AllocStackInst *ASI) {
-  ProjectionPath projections(val->getType());
-  SILValue op = LI->getOperand();
-  SILBuilderWithScope builder(LI);
-
-  while (op != ASI) {
+  while (op != asi) {
     assert(isa<UncheckedAddrCastInst>(op) || isa<StructElementAddrInst>(op) ||
            isa<TupleElementAddrInst>(op));
-    auto *Inst = cast<SingleValueInstruction>(op);
-    projections.push_back(Projection(Inst));
-    op = Inst->getOperand(0);
+    auto *inst = cast<SingleValueInstruction>(op);
+    projections.push_back(Projection(inst));
+    op = inst->getOperand(0);
   }
 
   SmallVector<SILValue, 4> borrowedVals;
@@ -393,270 +399,272 @@ static void replaceLoad(LoadInst *LI, SILValue val, AllocStackInst *ASI) {
     // non-trivial RunningVal is owned. Insert borrow operation to convert
     if (projection.getKind() == ProjectionKind::Struct ||
         projection.getKind() == ProjectionKind::Tuple) {
-      SILValue opVal = builder.emitBeginBorrowOperation(LI->getLoc(), val);
-      if (opVal != val) {
+      SILValue opVal = builder.emitBeginBorrowOperation(li->getLoc(), newValue);
+      if (opVal != newValue) {
         borrowedVals.push_back(opVal);
-        val = opVal;
+        newValue = opVal;
       }
     }
-    val = projection.createObjectProjection(builder, LI->getLoc(), val).get();
+    newValue =
+        projection.createObjectProjection(builder, li->getLoc(), newValue)
+            .get();
   }
 
-  op = LI->getOperand();
+  op = li->getOperand();
   // Replace users of the loaded value with `val`
   // If we have a load [copy], replace the users with copy_value of `val`
-  if (LI->getOwnershipQualifier() == LoadOwnershipQualifier::Copy) {
-    LI->replaceAllUsesWith(builder.createCopyValue(LI->getLoc(), val));
+  if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Copy) {
+    li->replaceAllUsesWith(builder.createCopyValue(li->getLoc(), newValue));
   } else {
-    assert(!ASI->getFunction()->hasOwnership() ||
-           val.getOwnershipKind() != OwnershipKind::Guaranteed);
-    LI->replaceAllUsesWith(val);
+    assert(!asi->getFunction()->hasOwnership() ||
+           newValue.getOwnershipKind() != OwnershipKind::Guaranteed);
+    li->replaceAllUsesWith(newValue);
   }
 
   for (auto borrowedVal : borrowedVals) {
-    builder.emitEndBorrowOperation(LI->getLoc(), borrowedVal);
+    builder.emitEndBorrowOperation(li->getLoc(), borrowedVal);
   }
 
   // Delete the load
-  LI->eraseFromParent();
+  li->eraseFromParent();
 
-  while (op != ASI && op->use_empty()) {
+  while (op != asi && op->use_empty()) {
     assert(isa<UncheckedAddrCastInst>(op) || isa<StructElementAddrInst>(op) ||
            isa<TupleElementAddrInst>(op));
-    auto *Inst = cast<SingleValueInstruction>(op);
-    SILValue next = Inst->getOperand(0);
-    Inst->eraseFromParent();
+    auto *inst = cast<SingleValueInstruction>(op);
+    SILValue next = inst->getOperand(0);
+    inst->eraseFromParent();
     op = next;
   }
 }
 
-static void replaceDestroy(DestroyAddrInst *DAI, SILValue NewValue) {
-  SILFunction *F = DAI->getFunction();
-  auto Ty = DAI->getOperand()->getType();
+static void replaceDestroy(DestroyAddrInst *dai, SILValue newValue) {
+  SILFunction *f = dai->getFunction();
+  auto ty = dai->getOperand()->getType();
 
-  assert(Ty.isLoadable(*F) &&
-         "Unexpected promotion of address-only type!");
+  assert(ty.isLoadable(*f) && "Unexpected promotion of address-only type!");
 
-  assert(NewValue || (Ty.is<TupleType>() && Ty.getAs<TupleType>()->getNumElements() == 0));
+  assert(newValue ||
+         (ty.is<TupleType>() && ty.getAs<TupleType>()->getNumElements() == 0));
 
-  SILBuilderWithScope Builder(DAI);
+  SILBuilderWithScope builder(dai);
 
-  auto &TL = F->getTypeLowering(Ty);
+  auto &typeLowering = f->getTypeLowering(ty);
 
-  bool expand = shouldExpand(DAI->getModule(),
-                             DAI->getOperand()->getType().getObjectType());
+  bool expand = shouldExpand(dai->getModule(),
+                             dai->getOperand()->getType().getObjectType());
   using TypeExpansionKind = Lowering::TypeLowering::TypeExpansionKind;
   auto expansionKind = expand ? TypeExpansionKind::MostDerivedDescendents
                               : TypeExpansionKind::None;
-  TL.emitLoweredDestroyValue(Builder, DAI->getLoc(), NewValue, expansionKind);
-  DAI->eraseFromParent();
+  typeLowering.emitLoweredDestroyValue(builder, dai->getLoc(), newValue,
+                                       expansionKind);
+  dai->eraseFromParent();
 }
 
-StoreInst *
-StackAllocationPromoter::promoteAllocationInBlock(SILBasicBlock *BB) {
-  LLVM_DEBUG(llvm::dbgs() << "*** Promoting ASI in block: " << *ASI);
+StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
+    SILBasicBlock *blockPromotingWithin) {
+  LLVM_DEBUG(llvm::dbgs() << "*** Promoting ASI in block: " << *asi);
 
   // RunningVal is the current value in the stack location.
   // We don't know the value of the alloca until we find the first store.
-  SILValue RunningVal = SILValue();
+  SILValue runningVal = SILValue();
   // Keep track of the last StoreInst that we found.
-  StoreInst *LastStore = nullptr;
+  StoreInst *lastStore = nullptr;
 
   // For all instructions in the block.
-  for (auto BBI = BB->begin(), E = BB->end(); BBI != E;) {
-    SILInstruction *Inst = &*BBI;
-    ++BBI;
+  for (auto bbi = blockPromotingWithin->begin(),
+            bbe = blockPromotingWithin->end();
+       bbi != bbe;) {
+    SILInstruction *inst = &*bbi;
+    ++bbi;
 
-    if (isLoadFromStack(Inst, ASI)) {
-      auto Load = cast<LoadInst>(Inst);
-      if (RunningVal) {
+    if (isLoadFromStack(inst, asi)) {
+      auto *li = cast<LoadInst>(inst);
+      if (runningVal) {
         // If we are loading from the AllocStackInst and we already know the
         // content of the Alloca then use it.
-        LLVM_DEBUG(llvm::dbgs() << "*** Promoting load: " << *Load);
-        replaceLoad(Load, RunningVal, ASI);
+        LLVM_DEBUG(llvm::dbgs() << "*** Promoting load: " << *li);
+        replaceLoad(li, runningVal, asi);
         ++NumInstRemoved;
-      } else if (Load->getOperand() == ASI &&
-                 Load->getOwnershipQualifier() !=
-                     LoadOwnershipQualifier::Copy) {
+      } else if (li->getOperand() == asi &&
+                 li->getOwnershipQualifier() != LoadOwnershipQualifier::Copy) {
         // If we don't know the content of the AllocStack then the loaded
         // value *is* the new value;
         // Don't use result of load [copy] as a RunningVal, it necessitates
         // additional logic for cleanup of consuming instructions of the result.
         // StackAllocationPromoter::fixBranchesAndUses will later handle it.
-        LLVM_DEBUG(llvm::dbgs() << "*** First load: " << *Load);
-        RunningVal = Load;
+        LLVM_DEBUG(llvm::dbgs() << "*** First load: " << *li);
+        runningVal = li;
       }
       continue;
     }
 
     // Remove stores and record the value that we are saving as the running
     // value.
-    if (auto *SI = dyn_cast<StoreInst>(Inst)) {
-      if (SI->getDest() != ASI)
+    if (auto *si = dyn_cast<StoreInst>(inst)) {
+      if (si->getDest() != asi)
         continue;
 
       // If we see a store [assign], always convert it to a store [init]. This
       // simplifies further processing.
-      if (SI->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
-        if (RunningVal) {
-          SILBuilderWithScope(SI).createDestroyValue(SI->getLoc(), RunningVal);
+      if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
+        if (runningVal) {
+          SILBuilderWithScope(si).createDestroyValue(si->getLoc(), runningVal);
         } else {
-          SILBuilderWithScope localBuilder(SI);
-          auto *newLoad = localBuilder.createLoad(SI->getLoc(), ASI,
+          SILBuilderWithScope localBuilder(si);
+          auto *newLoad = localBuilder.createLoad(si->getLoc(), asi,
                                                   LoadOwnershipQualifier::Take);
-          localBuilder.createDestroyValue(SI->getLoc(), newLoad);
+          localBuilder.createDestroyValue(si->getLoc(), newLoad);
         }
-        SI->setOwnershipQualifier(StoreOwnershipQualifier::Init);
+        si->setOwnershipQualifier(StoreOwnershipQualifier::Init);
       }
 
       // If we met a store before this one, delete it.
-      if (LastStore) {
-        assert(LastStore->getOwnershipQualifier() !=
+      if (lastStore) {
+        assert(lastStore->getOwnershipQualifier() !=
                    StoreOwnershipQualifier::Assign &&
                "store [assign] to the stack location should have been "
                "transformed to a store [init]");
         LLVM_DEBUG(llvm::dbgs()
-                   << "*** Removing redundant store: " << *LastStore);
+                   << "*** Removing redundant store: " << *lastStore);
         ++NumInstRemoved;
-        LastStore->eraseFromParent();
+        lastStore->eraseFromParent();
       }
 
       // The stored value is the new running value.
-      RunningVal = SI->getSrc();
+      runningVal = si->getSrc();
       // The current store is now the LastStore
-      LastStore = SI;
+      lastStore = si;
       continue;
     }
 
     // Replace debug_value_addr with debug_value of the promoted value
     // if we have a valid value to use at this point. Otherwise we'll
     // promote this when we deal with hooking up phis.
-    if (auto *DVAI = dyn_cast<DebugValueAddrInst>(Inst)) {
-      if (DVAI->getOperand() == ASI &&
-          RunningVal)
-        promoteDebugValueAddr(DVAI, RunningVal, B);
+    if (auto *dvai = dyn_cast<DebugValueAddrInst>(inst)) {
+      if (dvai->getOperand() == asi && runningVal)
+        promoteDebugValueAddr(dvai, runningVal, b);
       continue;
     }
 
     // Replace destroys with a release of the value.
-    if (auto *DAI = dyn_cast<DestroyAddrInst>(Inst)) {
-      if (DAI->getOperand() == ASI &&
-          RunningVal) {
-        replaceDestroy(DAI, RunningVal);
+    if (auto *DAI = dyn_cast<DestroyAddrInst>(inst)) {
+      if (DAI->getOperand() == asi && runningVal) {
+        replaceDestroy(DAI, runningVal);
       }
       continue;
     }
 
-    if (auto *DVI = dyn_cast<DestroyValueInst>(Inst)) {
-      if (DVI->getOperand() == RunningVal) {
+    if (auto *dvi = dyn_cast<DestroyValueInst>(inst)) {
+      if (dvi->getOperand() == runningVal) {
         // Reset LastStore.
         // So that we don't end up passing dead values as phi args in
         // StackAllocationPromoter::fixBranchesAndUses
-        LastStore = nullptr;
+        lastStore = nullptr;
       }
     }
 
     // Stop on deallocation.
-    if (auto *DSI = dyn_cast<DeallocStackInst>(Inst)) {
-      if (DSI->getOperand() == ASI)
+    if (auto *dsi = dyn_cast<DeallocStackInst>(inst)) {
+      if (dsi->getOperand() == asi)
         break;
     }
   }
 
-  if (LastStore) {
-    assert(LastStore->getOwnershipQualifier() !=
+  if (lastStore) {
+    assert(lastStore->getOwnershipQualifier() !=
                StoreOwnershipQualifier::Assign &&
            "store [assign] to the stack location should have been "
            "transformed to a store [init]");
-    LLVM_DEBUG(llvm::dbgs() << "*** Finished promotion. Last store: "
-                            << *LastStore);
+    LLVM_DEBUG(llvm::dbgs()
+               << "*** Finished promotion. Last store: " << *lastStore);
   } else {
     LLVM_DEBUG(llvm::dbgs() << "*** Finished promotion with no stores.\n");
   }
-  return LastStore;
+  return lastStore;
 }
 
 /// Create a tuple value for an empty tuple or a tuple of empty tuples.
 SILValue createValueForEmptyTuple(SILType ty, SILInstruction *insertionPoint) {
   auto tupleTy = ty.castTo<TupleType>();
   SmallVector<SILValue, 4> elements;
-  for (unsigned idx = 0, end = tupleTy->getNumElements(); idx < end; ++ idx) {
+  for (unsigned idx : range(tupleTy->getNumElements())) {
     SILType elementTy = ty.getTupleElementType(idx);
     elements.push_back(createValueForEmptyTuple(elementTy, insertionPoint));
   }
-  SILBuilder builder(insertionPoint);
+  SILBuilderWithScope builder(insertionPoint);
   return builder.createTuple(insertionPoint->getLoc(), ty, elements);
 }
 
-void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
-  LLVM_DEBUG(llvm::dbgs() << "*** Promoting in-block: " << *ASI);
+void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
+  LLVM_DEBUG(llvm::dbgs() << "*** Promoting in-block: " << *asi);
 
-  SILBasicBlock *BB = ASI->getParent();
+  SILBasicBlock *parentBlock = asi->getParent();
 
   // The default value of the AllocStack is NULL because we don't have
   // uninitialized variables in Swift.
-  SILValue RunningVal = SILValue();
+  SILValue runningVal = SILValue();
 
   // For all instructions in the block.
-  for (auto BBI = BB->begin(), E = BB->end(); BBI != E;) {
-    SILInstruction *Inst = &*BBI;
-    ++BBI;
+  for (auto bbi = parentBlock->begin(), bbe = parentBlock->end(); bbi != bbe;) {
+    SILInstruction *inst = &*bbi;
+    ++bbi;
 
     // Remove instructions that we are loading from. Replace the loaded value
     // with our running value.
-    if (isLoadFromStack(Inst, ASI)) {
-      if (!RunningVal) {
+    if (isLoadFromStack(inst, asi)) {
+      if (!runningVal) {
         // Loading without a previous store is only acceptable if the type is
         // Void (= empty tuple) or a tuple of Voids.
-        RunningVal = createValueForEmptyTuple(ASI->getElementType(), Inst);
+        runningVal = createValueForEmptyTuple(asi->getElementType(), inst);
       }
-      replaceLoad(cast<LoadInst>(Inst), RunningVal, ASI);
+      replaceLoad(cast<LoadInst>(inst), runningVal, asi);
       ++NumInstRemoved;
       continue;
     }
 
     // Remove stores and record the value that we are saving as the running
     // value.
-    if (auto *SI = dyn_cast<StoreInst>(Inst)) {
-      if (SI->getDest() == ASI) {
-        if (SI->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
-          assert(RunningVal);
-          SILBuilderWithScope(SI).createDestroyValue(SI->getLoc(), RunningVal);
+    if (auto *si = dyn_cast<StoreInst>(inst)) {
+      if (si->getDest() == asi) {
+        if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
+          assert(runningVal);
+          SILBuilderWithScope(si).createDestroyValue(si->getLoc(), runningVal);
         }
-        RunningVal = SI->getSrc();
-        Inst->eraseFromParent();
+        runningVal = si->getSrc();
+        inst->eraseFromParent();
         ++NumInstRemoved;
         continue;
       }
     }
 
     // Replace debug_value_addr with debug_value of the promoted value.
-    if (auto *DVAI = dyn_cast<DebugValueAddrInst>(Inst)) {
-      if (DVAI->getOperand() == ASI) {
-        if (RunningVal) {
-          promoteDebugValueAddr(DVAI, RunningVal, B);
+    if (auto *dvai = dyn_cast<DebugValueAddrInst>(inst)) {
+      if (dvai->getOperand() == asi) {
+        if (runningVal) {
+          promoteDebugValueAddr(dvai, runningVal, b);
         } else {
           // Drop debug_value_addr of uninitialized void values.
-          assert(ASI->getElementType().isVoid() &&
+          assert(asi->getElementType().isVoid() &&
                  "Expected initialization of non-void type!");
-          DVAI->eraseFromParent();
+          dvai->eraseFromParent();
         }
       }
       continue;
     }
 
     // Replace destroys with a release of the value.
-    if (auto *DAI = dyn_cast<DestroyAddrInst>(Inst)) {
-      if (DAI->getOperand() == ASI) {
-        replaceDestroy(DAI, RunningVal);
+    if (auto *DAI = dyn_cast<DestroyAddrInst>(inst)) {
+      if (DAI->getOperand() == asi) {
+        replaceDestroy(DAI, runningVal);
       }
       continue;
     }
 
     // Remove deallocation.
-    if (auto *DSI = dyn_cast<DeallocStackInst>(Inst)) {
-      if (DSI->getOperand() == ASI) {
-        Inst->eraseFromParent();
+    if (auto *dsi = dyn_cast<DeallocStackInst>(inst)) {
+      if (dsi->getOperand() == asi) {
+        inst->eraseFromParent();
         NumInstRemoved++;
         // No need to continue scanning after deallocation.
         break;
@@ -664,7 +672,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
     }
 
     // Remove dead address instructions that may be uses of the allocation.
-    auto *addrInst = dyn_cast<SingleValueInstruction>(Inst);
+    auto *addrInst = dyn_cast<SingleValueInstruction>(inst);
     while (addrInst && addrInst->use_empty() &&
            (isa<StructElementAddrInst>(addrInst) ||
             isa<TupleElementAddrInst>(addrInst) ||
@@ -677,108 +685,107 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *ASI) {
   }
 }
 
-void StackAllocationPromoter::addBlockArguments(BlockSet &PhiBlocks) {
+void StackAllocationPromoter::addBlockArguments(BlockSet &phiBlocks) {
   LLVM_DEBUG(llvm::dbgs() << "*** Adding new block arguments.\n");
 
-  for (auto *Block : PhiBlocks)
-    Block->createPhiArgument(ASI->getElementType(), OwnershipKind::Owned);
+  for (auto *block : phiBlocks)
+    block->createPhiArgument(asi->getElementType(), OwnershipKind::Owned);
 }
 
-SILValue
-StackAllocationPromoter::getLiveOutValue(BlockSet &PhiBlocks,
-                                         SILBasicBlock *StartBB) {
+SILValue StackAllocationPromoter::getLiveOutValue(BlockSet &phiBlocks,
+                                                  SILBasicBlock *startBlock) {
   LLVM_DEBUG(llvm::dbgs() << "*** Searching for a value definition.\n");
   // Walk the Dom tree in search of a defining value:
-  for (DomTreeNode *Node = DT->getNode(StartBB); Node; Node = Node->getIDom()) {
-    SILBasicBlock *BB = Node->getBlock();
+  for (DomTreeNode *domNode = domInfo->getNode(startBlock); domNode;
+       domNode = domNode->getIDom()) {
+    SILBasicBlock *domBlock = domNode->getBlock();
 
     // If there is a store (that must come after the phi), use its value.
-    BlockToInstMap::iterator it = LastStoreInBlock.find(BB);
-    if (it != LastStoreInBlock.end())
-      if (auto *St = dyn_cast_or_null<StoreInst>(it->second)) {
-        LLVM_DEBUG(llvm::dbgs() << "*** Found Store def " << *St->getSrc());
-        return St->getSrc();
+    BlockToInstMap::iterator it = lastStoreInBlock.find(domBlock);
+    if (it != lastStoreInBlock.end())
+      if (auto *si = dyn_cast_or_null<StoreInst>(it->second)) {
+        LLVM_DEBUG(llvm::dbgs() << "*** Found Store def " << *si->getSrc());
+        return si->getSrc();
       }
 
     // If there is a Phi definition in this block:
-    if (PhiBlocks.contains(BB)) {
+    if (phiBlocks.contains(domBlock)) {
       // Return the dummy instruction that represents the new value that we will
       // add to the basic block.
-      SILValue Phi = BB->getArgument(BB->getNumArguments() - 1);
-      LLVM_DEBUG(llvm::dbgs() << "*** Found a dummy Phi def " << *Phi);
-      return Phi;
+      SILValue phi = domBlock->getArgument(domBlock->getNumArguments() - 1);
+      LLVM_DEBUG(llvm::dbgs() << "*** Found a dummy Phi def " << *phi);
+      return phi;
     }
 
     // Move to the next dominating block.
     LLVM_DEBUG(llvm::dbgs() << "*** Walking up the iDOM.\n");
   }
   LLVM_DEBUG(llvm::dbgs() << "*** Could not find a Def. Using Undef.\n");
-  return SILUndef::get(ASI->getElementType(), *ASI->getFunction());
+  return SILUndef::get(asi->getElementType(), *asi->getFunction());
 }
 
-SILValue
-StackAllocationPromoter::getLiveInValue(BlockSet &PhiBlocks,
-                                        SILBasicBlock *BB) {
+SILValue StackAllocationPromoter::getLiveInValue(BlockSet &phiBlocks,
+                                                 SILBasicBlock *block) {
   // First, check if there is a Phi value in the current block. We know that
   // our loads happen before stores, so we need to first check for Phi nodes
   // in the first block, but stores first in all other stores in the idom
   // chain.
-  if (PhiBlocks.contains(BB)) {
+  if (phiBlocks.contains(block)) {
     LLVM_DEBUG(llvm::dbgs() << "*** Found a local Phi definition.\n");
-    return BB->getArgument(BB->getNumArguments() - 1);
+    return block->getArgument(block->getNumArguments() - 1);
   }
 
-  if (BB->pred_empty() || !DT->getNode(BB))
-    return SILUndef::get(ASI->getElementType(), *ASI->getFunction());
+  if (block->pred_empty() || !domInfo->getNode(block))
+    return SILUndef::get(asi->getElementType(), *asi->getFunction());
 
   // No phi for this value in this block means that the value flowing
   // out of the immediate dominator reaches here.
-  DomTreeNode *IDom = DT->getNode(BB)->getIDom();
-  assert(IDom &&
+  DomTreeNode *iDom = domInfo->getNode(block)->getIDom();
+  assert(iDom &&
          "Attempt to get live-in value for alloc_stack in entry block!");
 
-  return getLiveOutValue(PhiBlocks, IDom->getBlock());
+  return getLiveOutValue(phiBlocks, iDom->getBlock());
 }
 
-void StackAllocationPromoter::fixPhiPredBlock(BlockSet &PhiBlocks,
-                                              SILBasicBlock *Dest,
-                                              SILBasicBlock *Pred) {
-  TermInst *TI = Pred->getTerminator();
-  LLVM_DEBUG(llvm::dbgs() << "*** Fixing the terminator " << TI << ".\n");
+void StackAllocationPromoter::fixPhiPredBlock(BlockSet &phiBlocks,
+                                              SILBasicBlock *destBlock,
+                                              SILBasicBlock *predBlock) {
+  TermInst *ti = predBlock->getTerminator();
+  LLVM_DEBUG(llvm::dbgs() << "*** Fixing the terminator " << ti << ".\n");
 
-  SILValue Def = getLiveOutValue(PhiBlocks, Pred);
+  SILValue def = getLiveOutValue(phiBlocks, predBlock);
 
-  LLVM_DEBUG(llvm::dbgs() << "*** Found the definition: " << *Def);
+  LLVM_DEBUG(llvm::dbgs() << "*** Found the definition: " << *def);
 
-  addArgumentToBranch(Def, Dest, TI);
-  TI->eraseFromParent();
+  addArgumentToBranch(def, destBlock, ti);
+  ti->eraseFromParent();
 }
 
-void StackAllocationPromoter::fixBranchesAndUses(BlockSet &PhiBlocks) {
+void StackAllocationPromoter::fixBranchesAndUses(BlockSet &phiBlocks) {
   // First update uses of the value.
   SmallVector<LoadInst *, 4> collectedLoads;
 
-  for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E;) {
-    auto *Inst = UI->getUser();
-    ++UI;
+  for (auto ui = asi->use_begin(), ue = asi->use_end(); ui != ue;) {
+    auto *user = ui->getUser();
+    ++ui;
     bool removedUser = false;
 
     collectedLoads.clear();
-    collectLoads(Inst, collectedLoads);
-    for (LoadInst *LI : collectedLoads) {
-      SILValue Def;
+    collectLoads(user, collectedLoads);
+    for (auto *li : collectedLoads) {
+      SILValue def;
       // If this block has no predecessors then nothing dominates it and
       // the instruction is unreachable. If the instruction we're
       // examining is a value, replace it with undef. Either way, delete
       // the instruction and move on.
-      SILBasicBlock *BB = LI->getParent();
-      Def = getLiveInValue(PhiBlocks, BB);
+      SILBasicBlock *loadBlock = li->getParent();
+      def = getLiveInValue(phiBlocks, loadBlock);
 
-      LLVM_DEBUG(llvm::dbgs() << "*** Replacing " << *LI
-                              << " with Def " << *Def);
+      LLVM_DEBUG(llvm::dbgs()
+                 << "*** Replacing " << *li << " with Def " << *def);
 
       // Replace the load with the definition that we found.
-      replaceLoad(LI, Def, ASI);
+      replaceLoad(li, def, asi);
       removedUser = true;
       ++NumInstRemoved;
     }
@@ -789,19 +796,19 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSet &PhiBlocks) {
     // If this block has no predecessors then nothing dominates it and
     // the instruction is unreachable. Delete the instruction and move
     // on.
-    SILBasicBlock *BB = Inst->getParent();
+    SILBasicBlock *userBlock = user->getParent();
 
-    if (auto *DVAI = dyn_cast<DebugValueAddrInst>(Inst)) {
+    if (auto *dvai = dyn_cast<DebugValueAddrInst>(user)) {
       // Replace DebugValueAddr with DebugValue.
-      SILValue Def = getLiveInValue(PhiBlocks, BB);
-      promoteDebugValueAddr(DVAI, Def, B);
+      SILValue def = getLiveInValue(phiBlocks, userBlock);
+      promoteDebugValueAddr(dvai, def, b);
       ++NumInstRemoved;
       continue;
     }
 
     // Replace destroys with a release of the value.
-    if (auto *DAI = dyn_cast<DestroyAddrInst>(Inst)) {
-      SILValue Def = getLiveInValue(PhiBlocks, BB);
+    if (auto *DAI = dyn_cast<DestroyAddrInst>(user)) {
+      SILValue Def = getLiveInValue(phiBlocks, userBlock);
       replaceDestroy(DAI, Def);
       continue;
     }
@@ -811,167 +818,169 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSet &PhiBlocks) {
   // to the blocks with the added arguments.
 
   // For each Block with a new Phi argument:
-  for (auto Block : PhiBlocks) {
+  for (auto *block : phiBlocks) {
     // Fix all predecessors.
-    for (auto PBBI = Block->getPredecessorBlocks().begin(),
-              E = Block->getPredecessorBlocks().end();
-         PBBI != E;) {
-      auto *PBB = *PBBI;
-      ++PBBI;
-      assert(PBB && "Invalid block!");
-      fixPhiPredBlock(PhiBlocks, Block, PBB);
+    for (auto pbbi = block->getPredecessorBlocks().begin(),
+              pbbe = block->getPredecessorBlocks().end();
+         pbbi != pbbe;) {
+      auto *predBlock = *pbbi;
+      ++pbbi;
+      assert(predBlock && "Invalid block!");
+      fixPhiPredBlock(phiBlocks, block, predBlock);
     }
   }
 
   // If the owned phi arg we added did not have any uses, create end_lifetime to
   // end its lifetime. In asserts mode, make sure we have only undef incoming
   // values for such phi args.
-    for (auto Block : PhiBlocks) {
-      auto *phiArg = cast<SILPhiArgument>(
-          Block->getArgument(Block->getNumArguments() - 1));
-      if (phiArg->use_empty()) {
-        erasePhiArgument(Block, Block->getNumArguments() - 1);
-      }
+  for (auto *block : phiBlocks) {
+    auto *phiArg =
+        cast<SILPhiArgument>(block->getArgument(block->getNumArguments() - 1));
+    if (phiArg->use_empty()) {
+      erasePhiArgument(block, block->getNumArguments() - 1);
     }
+  }
 }
 
 void StackAllocationPromoter::pruneAllocStackUsage() {
-  LLVM_DEBUG(llvm::dbgs() << "*** Pruning : " << *ASI);
-  BlockSet Blocks(ASI->getFunction());
+  LLVM_DEBUG(llvm::dbgs() << "*** Pruning : " << *asi);
+  BlockSet functionBlocks(asi->getFunction());
 
-  // Insert all of the blocks that ASI is live in.
-  for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E; ++UI)
-    Blocks.insert(UI->getUser()->getParent());
+  // Insert all of the blocks that asi is live in.
+  for (auto *use : asi->getUses())
+    functionBlocks.insert(use->getUser()->getParent());
 
   // Clear AllocStack state.
-  LastStoreInBlock.clear();
+  lastStoreInBlock.clear();
 
-  for (auto Block : Blocks) {
-    StoreInst *SI = promoteAllocationInBlock(Block);
-    LastStoreInBlock[Block] = SI;
+  for (auto block : functionBlocks) {
+    StoreInst *si = promoteAllocationInBlock(block);
+    lastStoreInBlock[block] = si;
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "*** Finished pruning : " << *ASI);
+  LLVM_DEBUG(llvm::dbgs() << "*** Finished pruning : " << *asi);
 }
 
-/// Compute the dominator tree levels for DT.
-static void computeDomTreeLevels(DominanceInfo *DT,
-                                 DomTreeLevelMap &DomTreeLevels) {
+/// Compute the dominator tree levels for domInfo.
+static void computeDomTreeLevels(DominanceInfo *domInfo,
+                                 DomTreeLevelMap &domTreeLevels) {
   // TODO: This should happen once per function.
-  SmallVector<DomTreeNode *, 32> Worklist;
-  DomTreeNode *Root = DT->getRootNode();
-  DomTreeLevels[Root] = 0;
-  Worklist.push_back(Root);
-  while (!Worklist.empty()) {
-    DomTreeNode *Node = Worklist.pop_back_val();
-    unsigned ChildLevel = DomTreeLevels[Node] + 1;
-    for (auto CI = Node->begin(), CE = Node->end(); CI != CE; ++CI) {
-      DomTreeLevels[*CI] = ChildLevel;
-      Worklist.push_back(*CI);
+  SmallVector<DomTreeNode *, 32> worklist;
+  DomTreeNode *rootNode = domInfo->getRootNode();
+  domTreeLevels[rootNode] = 0;
+  worklist.push_back(rootNode);
+  while (!worklist.empty()) {
+    DomTreeNode *domNode = worklist.pop_back_val();
+    unsigned childLevel = domTreeLevels[domNode] + 1;
+    for (auto *childNode : domNode->children()) {
+      domTreeLevels[childNode] = childLevel;
+      worklist.push_back(childNode);
     }
   }
 }
 
 void StackAllocationPromoter::promoteAllocationToPhi() {
-  LLVM_DEBUG(llvm::dbgs() << "*** Placing Phis for : " << *ASI);
+  LLVM_DEBUG(llvm::dbgs() << "*** Placing Phis for : " << *asi);
 
   // A list of blocks that will require new Phi values.
-  BlockSet PhiBlocks(ASI->getFunction());
+  BlockSet phiBlocks(asi->getFunction());
 
   // The "piggy-bank" data-structure that we use for processing the dom-tree
   // bottom-up.
-  NodePriorityQueue PQ;
+  NodePriorityQueue priorityQueue;
 
   // Collect all of the stores into the AllocStack. We know that at this point
   // we have at most one store per block.
-  for (auto UI = ASI->use_begin(), E = ASI->use_end(); UI != E; ++UI) {
-    SILInstruction *II = UI->getUser();
+  for (auto *use : asi->getUses()) {
+    SILInstruction *user = use->getUser();
     // We need to place Phis for this block.
-    if (isa<StoreInst>(II)) {
+    if (isa<StoreInst>(user)) {
       // If the block is in the dom tree (dominated by the entry block).
-      if (DomTreeNode *Node = DT->getNode(II->getParent()))
-        PQ.push(std::make_pair(Node, DomTreeLevels[Node]));
+      if (auto *node = domInfo->getNode(user->getParent()))
+        priorityQueue.push(std::make_pair(node, domTreeLevels[node]));
     }
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "*** Found: " << PQ.size() << " Defs\n");
+  LLVM_DEBUG(llvm::dbgs() << "*** Found: " << priorityQueue.size()
+                          << " Defs\n");
 
   // A list of nodes for which we already calculated the dominator frontier.
-  llvm::SmallPtrSet<DomTreeNode *, 32> Visited;
+  llvm::SmallPtrSet<DomTreeNode *, 32> visited;
 
-  SmallVector<DomTreeNode *, 32> Worklist;
+  SmallVector<DomTreeNode *, 32> worklist;
 
   // Scan all of the definitions in the function bottom-up using the priority
   // queue.
-  while (!PQ.empty()) {
-    DomTreeNodePair RootPair = PQ.top();
-    PQ.pop();
-    DomTreeNode *Root = RootPair.first;
-    unsigned RootLevel = RootPair.second;
+  while (!priorityQueue.empty()) {
+    DomTreeNodePair rootPair = priorityQueue.top();
+    priorityQueue.pop();
+    DomTreeNode *root = rootPair.first;
+    unsigned rootLevel = rootPair.second;
 
     // Walk all dom tree children of Root, inspecting their successors. Only
     // J-edges, whose target level is at most Root's level are added to the
     // dominance frontier.
-    Worklist.clear();
-    Worklist.push_back(Root);
+    worklist.clear();
+    worklist.push_back(root);
 
-    while (!Worklist.empty()) {
-      DomTreeNode *Node = Worklist.pop_back_val();
-      SILBasicBlock *BB = Node->getBlock();
+    while (!worklist.empty()) {
+      DomTreeNode *node = worklist.pop_back_val();
+      SILBasicBlock *nodeBlock = node->getBlock();
 
       // For all successors of the node:
-      for (auto &Succ : BB->getSuccessors()) {
-        DomTreeNode *SuccNode = DT->getNode(Succ);
+      for (auto &nodeBlockSuccs : nodeBlock->getSuccessors()) {
+        auto *successorNode = domInfo->getNode(nodeBlockSuccs);
 
         // Skip D-edges (edges that are dom-tree edges).
-        if (SuccNode->getIDom() == Node)
+        if (successorNode->getIDom() == node)
           continue;
 
         // Ignore J-edges that point to nodes that are not smaller or equal
         // to the root level.
-        unsigned SuccLevel = DomTreeLevels[SuccNode];
-        if (SuccLevel > RootLevel)
+        unsigned succLevel = domTreeLevels[successorNode];
+        if (succLevel > rootLevel)
           continue;
 
         // Ignore visited nodes.
-        if (!Visited.insert(SuccNode).second)
+        if (!visited.insert(successorNode).second)
           continue;
 
         // If the new PHInode is not dominated by the allocation then it's dead.
-        if (!DT->dominates(ASI->getParent(), SuccNode->getBlock()))
-            continue;
+        if (!domInfo->dominates(asi->getParent(), successorNode->getBlock()))
+          continue;
 
         // If the new PHInode is properly dominated by the deallocation then it
         // is obviously a dead PHInode, so we don't need to insert it.
-        if (DSI && DT->properlyDominates(DSI->getParent(),
-                                         SuccNode->getBlock()))
+        if (dsi && domInfo->properlyDominates(dsi->getParent(),
+                                              successorNode->getBlock()))
           continue;
 
         // The successor node is a new PHINode. If this is a new PHI node
         // then it may require additional definitions, so add it to the PQ.
-        if (PhiBlocks.insert(Succ))
-          PQ.push(std::make_pair(SuccNode, SuccLevel));
+        if (phiBlocks.insert(nodeBlockSuccs))
+          priorityQueue.push(std::make_pair(successorNode, succLevel));
       }
 
       // Add the children in the dom-tree to the worklist.
-      for (auto CI = Node->begin(), CE = Node->end(); CI != CE; ++CI)
-        if (!Visited.count(*CI))
-          Worklist.push_back(*CI);
+      for (auto *child : node->children())
+        if (!visited.count(child))
+          worklist.push_back(child);
     }
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "*** Found: " << PhiBlocks.size() <<" new PHIs\n");
-  NumPhiPlaced += PhiBlocks.size();
+  LLVM_DEBUG(llvm::dbgs() << "*** Found: " << phiBlocks.size()
+                          << " new PHIs\n");
+  NumPhiPlaced += phiBlocks.size();
 
   // At this point we calculated the locations of all of the new Phi values.
   // Next, add the Phi values and promote all of the loads and stores into the
   // new locations.
 
   // Replace the dummy values with new block arguments.
-  addBlockArguments(PhiBlocks);
+  addBlockArguments(phiBlocks);
 
   // Hook up the Phi nodes, loads, and debug_value_addr with incoming values.
-  fixBranchesAndUses(PhiBlocks);
+  fixBranchesAndUses(phiBlocks);
 
   LLVM_DEBUG(llvm::dbgs() << "*** Finished placing Phis ***\n");
 }
@@ -990,8 +999,8 @@ void StackAllocationPromoter::run() {
 /// or false if not.  On success, this returns true and usually drops all of the
 /// uses of the AllocStackInst, but never deletes the ASI itself.  Callers
 /// should check to see if the ASI is dead after this and remove it if so.
-bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc,
-                                                DomTreeLevelMap &DomTreeLevels){
+bool MemoryToRegisters::promoteSingleAllocation(
+    AllocStackInst *alloc, DomTreeLevelMap &domTreeLevels) {
   LLVM_DEBUG(llvm::dbgs() << "*** Memory to register looking at: " << *alloc);
   ++NumAllocStackFound;
 
@@ -1022,8 +1031,8 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc,
       // This can come up if the source contains a withUnsafePointer where
       // the pointer escapes. It's illegal code but we should not crash.
       // Re-insert a dealloc_stack so that the verifier is happy.
-      B.setInsertionPoint(std::next(alloc->getIterator()));
-      B.createDeallocStack(alloc->getLoc(), alloc);
+      b.setInsertionPoint(std::next(alloc->getIterator()));
+      b.createDeallocStack(alloc->getLoc(), alloc);
     }
     return true;
   }
@@ -1031,7 +1040,7 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc,
   LLVM_DEBUG(llvm::dbgs() << "*** Need to insert BB arguments for " << *alloc);
 
   // Promote this allocation.
-  StackAllocationPromoter(alloc, DT, DomTreeLevels, B).run();
+  StackAllocationPromoter(alloc, domInfo, domTreeLevels, b).run();
 
   // Make sure that all of the allocations were promoted into registers.
   assert(isWriteOnlyAllocation(alloc) && "Non-write uses left behind");
@@ -1040,58 +1049,61 @@ bool MemoryToRegisters::promoteSingleAllocation(AllocStackInst *alloc,
   return true;
 }
 
-
 bool MemoryToRegisters::run() {
-  bool Changed = false;
+  bool madeChange = false;
 
-  if (F.getModule().getOptions().VerifyAll)
-    F.verifyCriticalEdges();
+  if (f.getModule().getOptions().VerifyAll)
+    f.verifyCriticalEdges();
 
   // Compute dominator tree node levels for the function.
-  DomTreeLevelMap DomTreeLevels;
-  computeDomTreeLevels(DT, DomTreeLevels);
+  DomTreeLevelMap domTreeLevels;
+  computeDomTreeLevels(domInfo, domTreeLevels);
 
-  for (auto &BB : F) {
-    auto I = BB.begin(), E = BB.end();
-    while (I != E) {
-      SILInstruction *Inst = &*I;
-      auto *ASI = dyn_cast<AllocStackInst>(Inst);
-      if (!ASI) {
-        ++I;
+  for (auto &block : f) {
+    auto ii = block.begin(), ie = block.end();
+    while (ii != ie) {
+      SILInstruction *inst = &*ii;
+      auto *asi = dyn_cast<AllocStackInst>(inst);
+      if (!asi) {
+        ++ii;
         continue;
       }
 
-      bool promoted = promoteSingleAllocation(ASI, DomTreeLevels);
-      ++I;
+      bool promoted = promoteSingleAllocation(asi, domTreeLevels);
+      ++ii;
       if (promoted) {
-        if (ASI->use_empty())
-          ASI->eraseFromParent();
+        if (asi->use_empty())
+          asi->eraseFromParent();
         ++NumInstRemoved;
-        Changed = true;
+        madeChange = true;
       }
     }
   }
-  return Changed;
+  return madeChange;
 }
 
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
 namespace {
+
 class SILMem2Reg : public SILFunctionTransform {
 
   void run() override {
-    SILFunction *F = getFunction();
+    SILFunction *f = getFunction();
 
-    LLVM_DEBUG(llvm::dbgs() << "** Mem2Reg on function: " << F->getName()
-                            << " **\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "** Mem2Reg on function: " << f->getName() << " **\n");
 
-    DominanceAnalysis* DA = PM->getAnalysis<DominanceAnalysis>();
+    auto *da = PM->getAnalysis<DominanceAnalysis>();
 
-    bool Changed = MemoryToRegisters(*F, DA->get(F)).run();
-
-    if (Changed)
+    bool madeChange = MemoryToRegisters(*f, da->get(f)).run();
+    if (madeChange)
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
   }
-
 };
+
 } // end anonymous namespace
 
 SILTransform *swift::createMem2Reg() {


### PR DESCRIPTION
This pass is one of the earliest passes that was written for Swift and its style has diverged from the rest of the code base. I am updating this as a separate thing before I touch it for borrows since most likely no one will touch it again for a long time and the code has some old style some new style. So I am standardizing on new style.

I also re-organized the code into logical sections.