### PR TITLE
[Diagnostics] Allow result build to detect `ErrorExpr`s in the body

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1872,6 +1872,13 @@ public:
           E, DC, /*replaceInvalidRefsWithErrors=*/false);
       HasError |= transaction.hasErrors();
 
+      if (!HasError) {
+        E->forEachChildExpr([&](Expr *expr) {
+          HasError |= isa<ErrorExpr>(expr);
+          return HasError ? nullptr : expr;
+        });
+      }
+
       if (SuppressDiagnostics)
         transaction.abort();
 

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -712,4 +712,13 @@ struct TuplifiedStructWithInvalidClosure {
       0
     }
   }
+
+  @TupleBuilder var errorsDiagnosedByParser: some Any {
+    if let cond = condition {
+      tuplify { _ in
+        self. // expected-error {{expected member name following '.'}}
+      }
+      42
+    }
+  }
 }


### PR DESCRIPTION
We assume that presence of `ErrorExpr` means that the problem has
been diagnosed early (i.e. by parser), so the fix is going to return
`true` if diagnostic engine has emitted an error.

Resolves: rdar://76246526

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
