### PR TITLE
[sil-mem2reg] Rather than pass around a shared builder, pass around a shared SILBuilderContext.

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -59,7 +59,8 @@ using DomTreeLevelMap = llvm::DenseMap<DomTreeNode *, unsigned>;
 //                                 Utilities
 //===----------------------------------------------------------------------===//
 
-static void replaceDestroy(DestroyAddrInst *dai, SILValue newValue) {
+static void replaceDestroy(DestroyAddrInst *dai, SILValue newValue,
+                           SILBuilderContext &ctx) {
   SILFunction *f = dai->getFunction();
   auto ty = dai->getOperand()->getType();
 
@@ -68,7 +69,7 @@ static void replaceDestroy(DestroyAddrInst *dai, SILValue newValue) {
   assert(newValue ||
          (ty.is<TupleType>() && ty.getAs<TupleType>()->getNumElements() == 0));
 
-  SILBuilderWithScope builder(dai);
+  SILBuilderWithScope builder(dai, ctx);
 
   auto &typeLowering = f->getTypeLowering(ty);
 
@@ -84,21 +85,22 @@ static void replaceDestroy(DestroyAddrInst *dai, SILValue newValue) {
 
 /// Promote a DebugValueAddr to a DebugValue of the given value.
 static void promoteDebugValueAddr(DebugValueAddrInst *dvai, SILValue value,
-                                  SILBuilder &b) {
+                                  SILBuilderContext &ctx) {
   assert(dvai->getOperand()->getType().isLoadable(*dvai->getFunction()) &&
          "Unexpected promotion of address-only type!");
   assert(value && "Expected valid value");
   // Avoid inserting the same debug_value twice.
-  for (auto *use : value->getUses())
-    if (auto *dvi = dyn_cast<DebugValueInst>(use->getUser()))
+  for (auto *use : value->getUses()) {
+    if (auto *dvi = dyn_cast<DebugValueInst>(use->getUser())) {
       if (*dvi->getVarInfo() == *dvai->getVarInfo()) {
         dvai->eraseFromParent();
         return;
       }
-  b.setInsertionPoint(dvai);
-  b.setCurrentDebugScope(dvai->getDebugScope());
-  b.createDebugValue(dvai->getLoc(), value, *dvai->getVarInfo());
+    }
+  }
 
+  SILBuilderWithScope b(dvai, ctx);
+  b.createDebugValue(dvai->getLoc(), value, *dvai->getVarInfo());
   dvai->eraseFromParent();
 }
 
@@ -135,10 +137,11 @@ static void collectLoads(SILInstruction *i,
   }
 }
 
-static void replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi) {
+static void replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi,
+                        SILBuilderContext &ctx) {
   ProjectionPath projections(newValue->getType());
   SILValue op = li->getOperand();
-  SILBuilderWithScope builder(li);
+  SILBuilderWithScope builder(li, ctx);
 
   while (op != asi) {
     assert(isa<UncheckedAddrCastInst>(op) || isa<StructElementAddrInst>(op) ||
@@ -200,14 +203,16 @@ static void replaceLoad(LoadInst *li, SILValue newValue, AllocStackInst *asi) {
 
 /// Create a tuple value for an empty tuple or a tuple of empty tuples.
 static SILValue createValueForEmptyTuple(SILType ty,
-                                         SILInstruction *insertionPoint) {
+                                         SILInstruction *insertionPoint,
+                                         SILBuilderContext &ctx) {
   auto tupleTy = ty.castTo<TupleType>();
   SmallVector<SILValue, 4> elements;
   for (unsigned idx : range(tupleTy->getNumElements())) {
     SILType elementTy = ty.getTupleElementType(idx);
-    elements.push_back(createValueForEmptyTuple(elementTy, insertionPoint));
+    elements.push_back(
+        createValueForEmptyTuple(elementTy, insertionPoint, ctx));
   }
-  SILBuilderWithScope builder(insertionPoint);
+  SILBuilderWithScope builder(insertionPoint, ctx);
   return builder.createTuple(insertionPoint->getLoc(), ty, elements);
 }
 
@@ -242,8 +247,9 @@ class StackAllocationPromoter {
   /// Map from dominator tree node to tree level.
   DomTreeLevelMap &domTreeLevels;
 
-  /// The builder used to create new instructions during register promotion.
-  SILBuilder &b;
+  /// The SIL builder used when creating new instructions during register
+  /// promotion.
+  SILBuilderContext &ctx;
 
   /// Records the last store instruction in each block for a specific
   /// AllocStackInst.
@@ -253,9 +259,9 @@ public:
   /// C'tor.
   StackAllocationPromoter(AllocStackInst *inputASI, DominanceInfo *inputDomInfo,
                           DomTreeLevelMap &inputDomTreeLevels,
-                          SILBuilder &inputB)
+                          SILBuilderContext &inputCtx)
       : asi(inputASI), dsi(nullptr), domInfo(inputDomInfo),
-        domTreeLevels(inputDomTreeLevels), b(inputB) {
+        domTreeLevels(inputDomTreeLevels), ctx(inputCtx) {
     // Scan the users in search of a deallocation instruction.
     for (auto *use : asi->getUses()) {
       if (auto *foundDealloc = dyn_cast<DeallocStackInst>(use->getUser())) {
@@ -336,7 +342,7 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
         // If we are loading from the AllocStackInst and we already know the
         // content of the Alloca then use it.
         LLVM_DEBUG(llvm::dbgs() << "*** Promoting load: " << *li);
-        replaceLoad(li, runningVal, asi);
+        replaceLoad(li, runningVal, asi, ctx);
         ++NumInstRemoved;
       } else if (li->getOperand() == asi &&
                  li->getOwnershipQualifier() != LoadOwnershipQualifier::Copy) {
@@ -361,9 +367,10 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
       // simplifies further processing.
       if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
         if (runningVal) {
-          SILBuilderWithScope(si).createDestroyValue(si->getLoc(), runningVal);
+          SILBuilderWithScope(si, ctx).createDestroyValue(si->getLoc(),
+                                                          runningVal);
         } else {
-          SILBuilderWithScope localBuilder(si);
+          SILBuilderWithScope localBuilder(si, ctx);
           auto *newLoad = localBuilder.createLoad(si->getLoc(), asi,
                                                   LoadOwnershipQualifier::Take);
           localBuilder.createDestroyValue(si->getLoc(), newLoad);
@@ -395,14 +402,14 @@ StoreInst *StackAllocationPromoter::promoteAllocationInBlock(
     // promote this when we deal with hooking up phis.
     if (auto *dvai = dyn_cast<DebugValueAddrInst>(inst)) {
       if (dvai->getOperand() == asi && runningVal)
-        promoteDebugValueAddr(dvai, runningVal, b);
+        promoteDebugValueAddr(dvai, runningVal, ctx);
       continue;
     }
 
     // Replace destroys with a release of the value.
-    if (auto *DAI = dyn_cast<DestroyAddrInst>(inst)) {
-      if (DAI->getOperand() == asi && runningVal) {
-        replaceDestroy(DAI, runningVal);
+    if (auto *dai = dyn_cast<DestroyAddrInst>(inst)) {
+      if (dai->getOperand() == asi && runningVal) {
+        replaceDestroy(dai, runningVal, ctx);
       }
       continue;
     }
@@ -536,7 +543,7 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSet &phiBlocks) {
                  << "*** Replacing " << *li << " with Def " << *def);
 
       // Replace the load with the definition that we found.
-      replaceLoad(li, def, asi);
+      replaceLoad(li, def, asi, ctx);
       removedUser = true;
       ++NumInstRemoved;
     }
@@ -552,15 +559,15 @@ void StackAllocationPromoter::fixBranchesAndUses(BlockSet &phiBlocks) {
     if (auto *dvai = dyn_cast<DebugValueAddrInst>(user)) {
       // Replace DebugValueAddr with DebugValue.
       SILValue def = getLiveInValue(phiBlocks, userBlock);
-      promoteDebugValueAddr(dvai, def, b);
+      promoteDebugValueAddr(dvai, def, ctx);
       ++NumInstRemoved;
       continue;
     }
 
     // Replace destroys with a release of the value.
-    if (auto *DAI = dyn_cast<DestroyAddrInst>(user)) {
-      SILValue Def = getLiveInValue(phiBlocks, userBlock);
-      replaceDestroy(DAI, Def);
+    if (auto *dai = dyn_cast<DestroyAddrInst>(user)) {
+      SILValue def = getLiveInValue(phiBlocks, userBlock);
+      replaceDestroy(dai, def, ctx);
       continue;
     }
   }
@@ -742,8 +749,9 @@ class MemoryToRegisters {
   /// Dominators.
   DominanceInfo *domInfo;
 
-  /// The builder used to create new instructions during register promotion.
-  SILBuilder b;
+  /// The builder context used when creating new instructions during register
+  /// promotion.
+  SILBuilderContext ctx;
 
   /// Check if the AllocStackInst \p ASI is only written into.
   bool isWriteOnlyAllocation(AllocStackInst *asi);
@@ -763,7 +771,7 @@ class MemoryToRegisters {
 public:
   /// C'tor
   MemoryToRegisters(SILFunction &inputFunc, DominanceInfo *inputDomInfo)
-      : f(inputFunc), domInfo(inputDomInfo), b(inputFunc) {}
+      : f(inputFunc), domInfo(inputDomInfo), ctx(inputFunc.getModule()) {}
 
   /// Promote memory to registers. Return True on change.
   bool run();
@@ -925,9 +933,9 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
       if (!runningVal) {
         // Loading without a previous store is only acceptable if the type is
         // Void (= empty tuple) or a tuple of Voids.
-        runningVal = createValueForEmptyTuple(asi->getElementType(), inst);
+        runningVal = createValueForEmptyTuple(asi->getElementType(), inst, ctx);
       }
-      replaceLoad(cast<LoadInst>(inst), runningVal, asi);
+      replaceLoad(cast<LoadInst>(inst), runningVal, asi, ctx);
       ++NumInstRemoved;
       continue;
     }
@@ -938,7 +946,8 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
       if (si->getDest() == asi) {
         if (si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign) {
           assert(runningVal);
-          SILBuilderWithScope(si).createDestroyValue(si->getLoc(), runningVal);
+          SILBuilderWithScope(si, ctx).createDestroyValue(si->getLoc(),
+                                                          runningVal);
         }
         runningVal = si->getSrc();
         inst->eraseFromParent();
@@ -951,7 +960,7 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     if (auto *dvai = dyn_cast<DebugValueAddrInst>(inst)) {
       if (dvai->getOperand() == asi) {
         if (runningVal) {
-          promoteDebugValueAddr(dvai, runningVal, b);
+          promoteDebugValueAddr(dvai, runningVal, ctx);
         } else {
           // Drop debug_value_addr of uninitialized void values.
           assert(asi->getElementType().isVoid() &&
@@ -963,9 +972,9 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
     }
 
     // Replace destroys with a release of the value.
-    if (auto *DAI = dyn_cast<DestroyAddrInst>(inst)) {
-      if (DAI->getOperand() == asi) {
-        replaceDestroy(DAI, runningVal);
+    if (auto *dai = dyn_cast<DestroyAddrInst>(inst)) {
+      if (dai->getOperand() == asi) {
+        replaceDestroy(dai, runningVal, ctx);
       }
       continue;
     }
@@ -1048,8 +1057,9 @@ bool MemoryToRegisters::promoteSingleAllocation(
       // This can come up if the source contains a withUnsafePointer where
       // the pointer escapes. It's illegal code but we should not crash.
       // Re-insert a dealloc_stack so that the verifier is happy.
-      b.setInsertionPoint(std::next(alloc->getIterator()));
-      b.createDeallocStack(alloc->getLoc(), alloc);
+      auto *next = alloc->getNextInstruction();
+      SILBuilderWithScope b(next, ctx);
+      b.createDeallocStack(next->getLoc(), alloc);
     }
     return true;
   }
@@ -1057,7 +1067,7 @@ bool MemoryToRegisters::promoteSingleAllocation(
   LLVM_DEBUG(llvm::dbgs() << "*** Need to insert BB arguments for " << *alloc);
 
   // Promote this allocation.
-  StackAllocationPromoter(alloc, domInfo, domTreeLevels, b).run();
+  StackAllocationPromoter(alloc, domInfo, domTreeLevels, ctx).run();
 
   // Make sure that all of the allocations were promoted into registers.
   assert(isWriteOnlyAllocation(alloc) && "Non-write uses left behind");
@@ -1106,7 +1116,6 @@ bool MemoryToRegisters::run() {
 namespace {
 
 class SILMem2Reg : public SILFunctionTransform {
-
   void run() override {
     SILFunction *f = getFunction();
 


### PR DESCRIPTION
This is another NFC-ish sort of update for SILMem2Reg that eliminates global SILBuilder patterns in favor of threading down a SILBuilderContext.

This is a pretty old style of code that we are trying to move away from.
Specifically, we use to always store a global SILBuilder and manually manipulate
its insertion point/other state when we moved places. This was very bugprone so
we instead now create new SILBuilders when we want to create instructions at a
new insertion point and pass down a SILBuilderContext for global state (like the
list of inserted instructions/etc) to each SILBuilder.

I went through and updated all of the code to now follow this pattern.