### PR TITLE
Add CHANGELOG SE-0293 link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8429,6 +8429,7 @@ Swift 1.0
 [SE-0284]: <https://github.com/apple/swift-evolution/blob/main/proposals/0284-multiple-variadic-parameters.md>
 [SE-0286]: <https://github.com/apple/swift-evolution/blob/main/proposals/0286-forward-scan-trailing-closures.md>
 [SE-0287]: <https://github.com/apple/swift-evolution/blob/main/proposals/0287-implicit-member-chains.md>
+[SE-0293]: <https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md>
 [SE-0296]: <https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md>
 [SE-0297]: <https://github.com/apple/swift-evolution/blob/main/proposals/0297-concurrency-objc.md>
 [SE-0298]: <https://github.com/apple/swift-evolution/blob/main/proposals/0298-asyncsequence.md>


### PR DESCRIPTION
Currently this SE link is missing:
<img width="871" alt="Screen Shot 2021-04-11 at 08 02 58" src="https://user-images.githubusercontent.com/5277837/114288795-68472200-9a9c-11eb-8c35-51ca0af25b5e.png">

This PR fixes that.