### PR TITLE
SIL: remove the sub-classes of MultipleValueInstructionResult

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1372,7 +1372,7 @@ public:
   Result visitGlobalAccess(SILValue global) {
     return asImpl().visitBase(global, AccessedStorage::Global);
   }
-  Result visitYieldAccess(BeginApplyResult *yield) {
+  Result visitYieldAccess(MultipleValueInstructionResult *yield) {
     return asImpl().visitBase(yield, AccessedStorage::Yield);
   }
   Result visitStackAccess(AllocStackInst *stack) {
@@ -1448,8 +1448,10 @@ Result AccessUseDefChainVisitor<Impl, Result>::visit(SILValue sourceAddr) {
 
   // A yield is effectively a nested access, enforced independently in
   // the caller and callee.
-  case ValueKind::BeginApplyResult:
-    return asImpl().visitYieldAccess(cast<BeginApplyResult>(sourceAddr));
+  case ValueKind::MultipleValueInstructionResult:
+    if (auto *baResult = isaResultOf<BeginApplyInst>(sourceAddr))
+      return asImpl().visitYieldAccess(baResult);
+    break;
 
   // A function argument is effectively a nested access, enforced
   // independently in the caller and callee.

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -894,8 +894,10 @@ public:
       ;
     case ValueKind::ApplyInst:
       return Kind::Apply;
-    case ValueKind::BeginApplyResult:
-      return Kind::BeginApply;
+    case ValueKind::MultipleValueInstructionResult:
+      if (isaResultOf<BeginApplyInst>(value))
+        return Kind::BeginApply;
+      return Kind::Invalid;
     case ValueKind::StructInst:
       return Kind::Struct;
     case ValueKind::TupleInst:

--- a/include/swift/SIL/PatternMatch.h
+++ b/include/swift/SIL/PatternMatch.h
@@ -411,9 +411,11 @@ template <typename LTy> struct tupleextractoperation_ty {
              L.match((ValueBase *)TEI->getOperand());
     }
 
-    if (auto *DTR = dyn_cast<DestructureTupleResult>(V)) {
-      return DTR->getIndex() == index &&
-             L.match((ValueBase *)DTR->getParent()->getOperand());
+    if (auto *DTR = dyn_cast<MultipleValueInstructionResult>(V)) {
+      if (auto *DT = dyn_cast<DestructureTupleInst>(DTR->getParent())) {
+        return DTR->getIndex() == index &&
+          L.match((ValueBase *)DT->getOperand());
+      }
     }
 
     return false;

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -411,12 +411,7 @@ ABSTRACT_VALUE(SILArgument, ValueBase)
   ARGUMENT(SILFunctionArgument, SILArgument)
   ARGUMENT_RANGE(SILArgument, SILPhiArgument, SILFunctionArgument)
 
-ABSTRACT_VALUE(MultipleValueInstructionResult, ValueBase)
-  MULTIPLE_VALUE_INST_RESULT(BeginApplyResult, MultipleValueInstructionResult)
-  MULTIPLE_VALUE_INST_RESULT(BeginCOWMutationResult, MultipleValueInstructionResult)
-  MULTIPLE_VALUE_INST_RESULT(DestructureStructResult, MultipleValueInstructionResult)
-  MULTIPLE_VALUE_INST_RESULT(DestructureTupleResult, MultipleValueInstructionResult)
-  VALUE_RANGE(MultipleValueInstructionResult, BeginApplyResult, DestructureTupleResult)
+VALUE(MultipleValueInstructionResult, ValueBase)
 
 VALUE(SILUndef, ValueBase)
 

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1539,9 +1539,8 @@ MultipleValueInstruction::getIndexOfResult(SILValue Target) const {
 }
 
 MultipleValueInstructionResult::MultipleValueInstructionResult(
-    ValueKind valueKind, unsigned index, SILType type,
-    ValueOwnershipKind ownershipKind)
-    : ValueBase(valueKind, type) {
+    unsigned index, SILType type, ValueOwnershipKind ownershipKind)
+    : ValueBase(ValueKind::MultipleValueInstructionResult, type) {
   setOwnershipKind(ownershipKind);
   setIndex(index);
 }
@@ -1561,7 +1560,7 @@ ValueOwnershipKind MultipleValueInstructionResult::getOwnershipKind() const {
   return ValueOwnershipKind(Bits.MultipleValueInstructionResult.VOKind);
 }
 
-MultipleValueInstruction *MultipleValueInstructionResult::getParent() {
+MultipleValueInstruction *MultipleValueInstructionResult::getParentImpl() const {
   char *Ptr = reinterpret_cast<char *>(
       const_cast<MultipleValueInstructionResult *>(this));
 

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -495,8 +495,8 @@ BeginApplyInst::create(SILDebugLocation loc, SILValue callee,
   collectTypeDependentOperands(typeDependentOperands, openedArchetypes, F,
                                substCalleeType, subs);
   void *buffer =
-    allocateTrailingInst<BeginApplyInst, Operand,
-                         MultipleValueInstruction*, BeginApplyResult>(
+    allocateTrailingInst<BeginApplyInst, Operand, MultipleValueInstruction*,
+                         MultipleValueInstructionResult>(
       F, getNumAllOperands(args, typeDependentOperands),
       1, resultTypes.size());
   return ::new(buffer) BeginApplyInst(loc, callee, substCalleeSILType,
@@ -2125,8 +2125,8 @@ BeginCOWMutationInst::create(SILDebugLocation loc, SILValue operand,
                                       OwnershipKind::Owned};
 
   void *buffer =
-    allocateTrailingInst<BeginCOWMutationInst,
-                         MultipleValueInstruction*, BeginCOWMutationResult>(
+    allocateTrailingInst<BeginCOWMutationInst, MultipleValueInstruction*,
+                         MultipleValueInstructionResult>(
       F, 1, 2);
   return ::new(buffer) BeginCOWMutationInst(loc, operand,
                                   ArrayRef<SILType>(resultTypes, 2),
@@ -2807,7 +2807,7 @@ DestructureStructInst::create(const SILFunction &F, SILDebugLocation Loc,
 
   unsigned NumElts = Types.size();
   unsigned Size =
-      totalSizeToAlloc<MultipleValueInstruction *, DestructureStructResult>(
+    totalSizeToAlloc<MultipleValueInstruction *, MultipleValueInstructionResult>(
           1, NumElts);
 
   void *Buffer = M.allocateInst(Size, alignof(DestructureStructInst));
@@ -2834,7 +2834,7 @@ DestructureTupleInst::create(const SILFunction &F, SILDebugLocation Loc,
   // We add 1 since we store an offset to our
   unsigned NumElts = Types.size();
   unsigned Size =
-      totalSizeToAlloc<MultipleValueInstruction *, DestructureTupleResult>(
+    totalSizeToAlloc<MultipleValueInstruction *, MultipleValueInstructionResult>(
           1, NumElts);
 
   void *Buffer = M.allocateInst(Size, alignof(DestructureTupleInst));

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1042,9 +1042,7 @@ public:
       printSILUndef(cast<SILUndef>(node));
       return;
 
-#define MULTIPLE_VALUE_INST_RESULT(ID, PARENT) \
-    case SILNodeKind::ID:
-#include "swift/SIL/SILNodes.def"
+    case SILNodeKind::MultipleValueInstructionResult:
       printSILMultipleValueInstructionResult(
           cast<MultipleValueInstructionResult>(node));
       return;

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -285,29 +285,14 @@ ValueOwnershipKind ValueOwnershipKindClassifier::visitSILUndef(SILUndef *arg) {
   return arg->getOwnershipKind();
 }
 
+ValueOwnershipKind ValueOwnershipKindClassifier::
+visitMultipleValueInstructionResult(MultipleValueInstructionResult *Result) {
+  return Result->getOwnershipKind();
+}
+
 ValueOwnershipKind
 ValueOwnershipKindClassifier::visitSILPhiArgument(SILPhiArgument *Arg) {
   return Arg->getOwnershipKind();
-}
-
-ValueOwnershipKind ValueOwnershipKindClassifier::visitDestructureStructResult(
-    DestructureStructResult *Result) {
-  return Result->getOwnershipKind();
-}
-
-ValueOwnershipKind ValueOwnershipKindClassifier::visitDestructureTupleResult(
-    DestructureTupleResult *Result) {
-  return Result->getOwnershipKind();
-}
-
-ValueOwnershipKind ValueOwnershipKindClassifier::visitBeginApplyResult(
-    BeginApplyResult *Result) {
-  return Result->getOwnershipKind();
-}
-
-ValueOwnershipKind ValueOwnershipKindClassifier::visitBeginCOWMutationResult(
-    BeginCOWMutationResult *Result) {
-  return Result->getOwnershipKind();
 }
 
 ValueOwnershipKind ValueOwnershipKindClassifier::visitSILFunctionArgument(

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -486,7 +486,8 @@ AccessedStorage::AccessedStorage(SILValue base, Kind kind) {
     value = base;
     break;
   case Yield:
-    assert(isa<BeginApplyResult>(base));
+    assert(isa<BeginApplyInst>(
+             cast<MultipleValueInstructionResult>(base)->getParent()));
     value = base;
     break;
   case Unidentified:

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4569,7 +4569,7 @@ SILValue SILGenFunction::emitApplyWithRethrow(SILLocation loc, SILValue fn,
   return normalBB->createPhiArgument(resultType, OwnershipKind::Owned);
 }
 
-std::pair<SILValue, CleanupHandle>
+std::pair<MultipleValueInstructionResult *, CleanupHandle>
 SILGenFunction::emitBeginApplyWithRethrow(SILLocation loc, SILValue fn,
                                           SILType substFnType,
                                           SubstitutionMap subs,
@@ -4583,7 +4583,7 @@ SILGenFunction::emitBeginApplyWithRethrow(SILLocation loc, SILValue fn,
   auto yieldResults = beginApply->getYieldedValues();
   yields.append(yieldResults.begin(), yieldResults.end());
 
-  auto token = beginApply->getTokenResult();
+  auto *token = beginApply->getTokenResult();
 
   Cleanups.pushCleanup<EndCoroutineApply>(token);
   auto abortCleanup = Cleanups.getTopCleanup();
@@ -4591,10 +4591,10 @@ SILGenFunction::emitBeginApplyWithRethrow(SILLocation loc, SILValue fn,
   return { token, abortCleanup };
 }
 
-void SILGenFunction::emitEndApplyWithRethrow(SILLocation loc, SILValue token) {
-  // TODO: adjust this to handle TryBeginApplyResult.
-  assert(isa<BeginApplyResult>(token));
-  assert(cast<BeginApplyResult>(token)->isTokenResult());
+void SILGenFunction::emitEndApplyWithRethrow(SILLocation loc,
+                                        MultipleValueInstructionResult *token) {
+  // TODO: adjust this to handle results of TryBeginApplyInst.
+  assert(token->isBeginApplyToken());
 
   B.createEndApply(loc, token);
 }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1626,11 +1626,12 @@ public:
                                 SubstitutionMap subs,
                                 ArrayRef<SILValue> args);
 
-  std::pair<SILValue, CleanupHandle>
+  std::pair<MultipleValueInstructionResult *, CleanupHandle>
   emitBeginApplyWithRethrow(SILLocation loc, SILValue fn, SILType substFnType,
                             SubstitutionMap subs, ArrayRef<SILValue> args,
                             SmallVectorImpl<SILValue> &yields);
-  void emitEndApplyWithRethrow(SILLocation loc, SILValue token);
+  void emitEndApplyWithRethrow(SILLocation loc,
+                               MultipleValueInstructionResult *token);
 
   /// Emit a literal that applies the various initializers.
   RValue emitLiteral(LiteralExpr *literal, SGFContext C);

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -332,8 +332,8 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
   // If this is a destructure_result, then we can return the element being
   // extracted.
-  if (isa<DestructureStructResult>(value) ||
-      isa<DestructureTupleResult>(value)) {
+  if (isaResultOf<DestructureStructInst>(value) ||
+      isaResultOf<DestructureTupleInst>(value)) {
     auto *result = cast<MultipleValueInstructionResult>(value);
     SILValue aggValue = result->getParent()->getOperand(0);
     auto val = getConstantValue(aggValue);


### PR DESCRIPTION
They are not really needed, because they don't contain any stored properties and for isa-checks we can check the parent instruction.
