### PR TITLE
[stdlib] Remove force-unwrap from UnsafeMutableBufferPointer.swapAt

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -384,8 +384,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     guard i != j else { return }
     _debugPrecondition(i >= 0 && j >= 0)
     _debugPrecondition(i < endIndex && j < endIndex)
-    let pi = (_position! + i)
-    let pj = (_position! + j)
+    let pi = _position._unsafelyUnwrappedUnchecked + i
+    let pj = _position._unsafelyUnwrappedUnchecked + j
     let tmp = pi.move()
     pi.moveInitialize(from: pj, count: 1)
     pj.initialize(to: tmp)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -238,8 +238,8 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
     guard i != j else { return }
     _debugPrecondition(i >= 0 && j >= 0)
     _debugPrecondition(i < endIndex && j < endIndex)
-    let pi = (_position! + i)
-    let pj = (_position! + j)
+    let pi = _position._unsafelyUnwrappedUnchecked + i
+    let pj = _position._unsafelyUnwrappedUnchecked + j
     let tmp = pi.load(fromByteOffset: 0, as: UInt8.self)
     pi.copyMemory(from: pj, byteCount: MemoryLayout<UInt8>.size)
     pj.storeBytes(of: tmp, toByteOffset: 0, as: UInt8.self)


### PR DESCRIPTION
Lots of algorithms are based on an efficient `swap`. Unfortunately, `UMBP`'s implementation includes a superfluous trap which can lead to very poor code generation and missed optimisations. For trivial element types, it's significantly better to load in to a temporary rather than use `swapAt`.

Here's an example of an IPv6 address parser written in Swift: https://godbolt.org/z/rrqdYecEe

At source line 379, we shuffle a bunch of UInt16s down to the end of the buffer (IPv6 addressed can contain compressed sections, such as in `1234::5678`, where the `::` means to expand to fill with 0s - in this case, 1234 should be piece[0], and 5678 should be piece[7], with 0s in-between).

This is implemented using `swapAt`. The generated code for this section after specialization can be seen at asm line 1461 (`.LBB47_41`). Here's what the compiler does with this, as of the latest nightly:

<details>
  <summary>Generated code</summary>

```
.LBB47_41:
        mov     rax, r13
        sub     rax, r12
        test    rax, rax
        jle     .LBB47_79
        cmp     r13, 8
        je      .LBB47_45
        mov     rcx, qword ptr [r14]
        test    rcx, rcx
        je      .LBB47_88
        movzx   edx, word ptr [rcx + 14]
        movzx   esi, word ptr [rcx + 2*r13 - 2]
        mov     word ptr [rcx + 14], si
        mov     word ptr [rcx + 2*r13 - 2], dx
.LBB47_45:
        cmp     rax, 1
        jle     .LBB47_79
        cmp     r13, 8
        je      .LBB47_49
        mov     rcx, qword ptr [r14]
        test    rcx, rcx
        je      .LBB47_88
        movzx   edx, word ptr [rcx + 12]
        movzx   esi, word ptr [rcx + 2*r13 - 4]
        mov     word ptr [rcx + 12], si
        mov     word ptr [rcx + 2*r13 - 4], dx
.LBB47_49:
        cmp     rax, 3
        jl      .LBB47_79
        cmp     r13, 8
        je      .LBB47_53
        mov     rcx, qword ptr [r14]
        test    rcx, rcx
        je      .LBB47_88
        movzx   edx, word ptr [rcx + 10]
        movzx   esi, word ptr [rcx + 2*r13 - 6]
        mov     word ptr [rcx + 10], si
        mov     word ptr [rcx + 2*r13 - 6], dx
.LBB47_53:
        cmp     rax, 4
        jl      .LBB47_79
        cmp     r13, 8
        je      .LBB47_57
        mov     rcx, qword ptr [r14]
        test    rcx, rcx
        je      .LBB47_88
        movzx   edx, word ptr [rcx + 8]
        movzx   esi, word ptr [rcx + 2*r13 - 8]
        mov     word ptr [rcx + 8], si
        mov     word ptr [rcx + 2*r13 - 8], dx
.LBB47_57:
        cmp     rax, 5
        jl      .LBB47_79
        cmp     r13, 8
        je      .LBB47_61
        mov     rcx, qword ptr [r14]
        test    rcx, rcx
        je      .LBB47_88
        movzx   edx, word ptr [rcx + 6]
        movzx   esi, word ptr [rcx + 2*r13 - 10]
        mov     word ptr [rcx + 6], si
        mov     word ptr [rcx + 2*r13 - 10], dx
.LBB47_61:
        cmp     rax, 6
        jl      .LBB47_79
        cmp     r13, 8
        je      .LBB47_65
        mov     rcx, qword ptr [r14]
        test    rcx, rcx
        je      .LBB47_88
        movzx   edx, word ptr [rcx + 4]
        movzx   esi, word ptr [rcx + 2*r13 - 12]
        mov     word ptr [rcx + 4], si
        mov     word ptr [rcx + 2*r13 - 12], dx
.LBB47_65:
        cmp     rax, 7
        jl      .LBB47_79
        cmp     r13, 8
        je      .LBB47_79
        mov     rax, qword ptr [r14]
        test    rax, rax
        je      .LBB47_88
        movzx   ecx, word ptr [rax + 2]
        movzx   edx, word ptr [rax + 2*r13 - 14]
        mov     word ptr [rax + 2], dx
        mov     word ptr [rax + 2*r13 - 14], cx
        jmp     .LBB47_79
```
</details>

That's a lot of code! Still, it's hard to say whether or not it's the best the compiler can do. Let's try making one simple change: instead of `swapAt`, we'll do a naive swap, copying in to a temporary:

```
let tmp = parsedPieces[pieceIndex]
parsedPieces[pieceIndex] = parsedPieces[destinationPiece]
parsedPieces[destinationPiece] = tmp
```

And what does the compiler do now? https://godbolt.org/z/haGM7hP9f

<details>
  <summary>Code using naive swap</summary>

```
.LBB47_42:
        mov     rcx, rbp
        sub     rcx, r12
        test    rcx, rcx
        jle     .LBB47_60
        mov     rax, qword ptr [r14]
        movzx   edx, word ptr [rax + 14]
        movzx   esi, word ptr [rax + 2*rbp - 2]
        mov     word ptr [rax + 14], si
        mov     word ptr [rax + 2*rbp - 2], dx
        cmp     rcx, 1
        jle     .LBB47_60
        lea     rdx, [rcx - 1]
        movzx   esi, word ptr [rax + 12]
        movzx   edi, word ptr [rax + 2*rbp - 4]
        mov     word ptr [rax + 12], di
        mov     word ptr [rax + 2*rbp - 4], si
        cmp     rdx, 2
        jl      .LBB47_60
        lea     rdx, [rcx - 2]
        movzx   esi, word ptr [rax + 10]
        movzx   edi, word ptr [rax + 2*rbp - 6]
        mov     word ptr [rax + 10], di
        mov     word ptr [rax + 2*rbp - 6], si
        cmp     rdx, 2
        jl      .LBB47_60
        lea     rdx, [rcx - 3]
        movzx   esi, word ptr [rax + 8]
        movzx   edi, word ptr [rax + 2*rbp - 8]
        mov     word ptr [rax + 8], di
        mov     word ptr [rax + 2*rbp - 8], si
        cmp     rdx, 2
        jl      .LBB47_60
        lea     rdx, [rcx - 4]
        movzx   esi, word ptr [rax + 6]
        movzx   edi, word ptr [rax + 2*rbp - 10]
        mov     word ptr [rax + 6], di
        mov     word ptr [rax + 2*rbp - 10], si
        cmp     rdx, 2
        jl      .LBB47_60
        add     rcx, -5
        movzx   edx, word ptr [rax + 4]
        movzx   esi, word ptr [rax + 2*rbp - 12]
        mov     word ptr [rax + 4], si
        mov     word ptr [rax + 2*rbp - 12], dx
        cmp     rcx, 2
        jl      .LBB47_60
        movzx   ecx, word ptr [rax + 2]
        movzx   edx, word ptr [rax + 2*rbp - 14]
        mov     word ptr [rax + 2], dx
        mov     word ptr [rax + 2*rbp - 14], cx
        jmp     .LBB47_60
```
</details>

What a difference! We've eliminated 2/3 branches, and the ones that remain all go to the same place. This is what I would _expect_ to see from loop unrolling. It is also a not-insignificant reduction in code size against the previous implementation.