### PR TITLE
Refine access note descriptions in diagnostics

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -854,6 +854,7 @@ public:
   /// Determine whether the name associated with this attribute was
   /// implicit.
   bool isNameImplicit() const { return Bits.ObjCAttr.ImplicitName; }
+  void setNameImplicit(bool newValue) { Bits.ObjCAttr.ImplicitName = newValue; }
 
   /// Set the name of this entity.
   void setName(ObjCSelector name, bool implicit) {
@@ -880,11 +881,6 @@ public:
   /// @objc inference rules.
   void setSwift3Inferred(bool inferred = true) {
     Bits.ObjCAttr.Swift3Inferred = inferred;
-  }
-
-  /// Clear the name of this entity.
-  void clearName() {
-    NameData = nullptr;
   }
 
   /// Retrieve the source locations for the names in a non-implicit

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -115,6 +115,7 @@ namespace swift {
     VersionTuple,
     LayoutConstraint,
     ActorIsolation,
+    Diagnostic
   };
 
   namespace diag {
@@ -146,6 +147,7 @@ namespace swift {
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
       ActorIsolation ActorIsolationVal;
+      DiagnosticInfo *DiagnosticVal;
     };
     
   public:
@@ -241,6 +243,11 @@ namespace swift {
     DiagnosticArgument(ActorIsolation AI)
       : Kind(DiagnosticArgumentKind::ActorIsolation),
         ActorIsolationVal(AI) {
+    }
+
+    DiagnosticArgument(DiagnosticInfo *D)
+      : Kind(DiagnosticArgumentKind::Diagnostic),
+        DiagnosticVal(D) {
     }
 
     /// Initializes a diagnostic argument using the underlying type of the
@@ -343,6 +350,11 @@ namespace swift {
       assert(Kind == DiagnosticArgumentKind::ActorIsolation);
       return ActorIsolationVal;
     }
+
+    DiagnosticInfo *getAsDiagnostic() const {
+      assert(Kind == DiagnosticArgumentKind::Diagnostic);
+      return DiagnosticVal;
+    }
   };
 
   /// Describes the current behavior to take with a diagnostic.
@@ -410,6 +422,7 @@ namespace swift {
     DiagnosticBehavior BehaviorLimit = DiagnosticBehavior::Unspecified;
 
     friend DiagnosticEngine;
+    friend class InFlightDiagnostic;
 
   public:
     // All constructors are intentionally implicit.
@@ -514,6 +527,42 @@ namespace swift {
     /// instance, if \c DiagnosticBehavior::Warning is passed, an error will be
     /// emitted as a warning, but a note will still be emitted as a note.
     InFlightDiagnostic &limitBehavior(DiagnosticBehavior limit);
+
+    /// Wraps this diagnostic in another diagnostic. That is, \p wrapper will be
+    /// emitted in place of the diagnostic that otherwise would have been
+    /// emitted.
+    ///
+    /// The first argument of \p wrapper must be of type 'Diagnostic *'.
+    ///
+    /// The emitted diagnostic will have:
+    ///
+    /// \li The ID, message, and behavior of \c wrapper.
+    /// \li The arguments of \c wrapper, with the last argument replaced by the
+    ///     diagnostic currently in \c *this.
+    /// \li The location, ranges, decl, fix-its, and behavior limit of the
+    ///     diagnostic currently in \c *this.
+    InFlightDiagnostic &wrapIn(const Diagnostic &wrapper);
+
+    /// Wraps this diagnostic in another diagnostic. That is, \p ID and
+    /// \p VArgs will be emitted in place of the diagnostic that otherwise would
+    /// have been emitted.
+    ///
+    /// The first argument of \p ID must be of type 'Diagnostic *'.
+    ///
+    /// The emitted diagnostic will have:
+    ///
+    /// \li The ID, message, and behavior of \c ID.
+    /// \li The arguments of \c VArgs, with an argument appended for the
+    ///     diagnostic currently in \c *this.
+    /// \li The location, ranges, decl, fix-its, and behavior limit of the
+    ///     diagnostic currently in \c *this.
+    template<typename ...ArgTypes>
+    InFlightDiagnostic &
+    wrapIn(Diag<DiagnosticInfo *, ArgTypes...> ID,
+           typename detail::PassArgument<ArgTypes>::type... VArgs) {
+      Diagnostic wrapper{ID, nullptr, std::move(VArgs)...};
+      return wrapIn(wrapper);
+    }
 
     /// Add a token-based range to the currently-active diagnostic.
     InFlightDiagnostic &highlight(SourceRange R);
@@ -678,6 +727,16 @@ namespace swift {
       ignoredDiagnostics[(unsigned)id] = ignored;
     }
 
+    void swap(DiagnosticState &other) {
+      std::swap(showDiagnosticsAfterFatalError, other.showDiagnosticsAfterFatalError);
+      std::swap(suppressWarnings, other.suppressWarnings);
+      std::swap(warningsAsErrors, other.warningsAsErrors);
+      std::swap(fatalErrorOccurred, other.fatalErrorOccurred);
+      std::swap(anyErrorOccurred, other.anyErrorOccurred);
+      std::swap(previousBehavior, other.previousBehavior);
+      std::swap(ignoredDiagnostics, other.ignoredDiagnostics);
+    }
+
   private:
     // Make the state movable only
     DiagnosticState(const DiagnosticState &) = delete;
@@ -705,6 +764,10 @@ namespace swift {
 
     /// The currently active diagnostic, if there is one.
     Optional<Diagnostic> ActiveDiagnostic;
+
+    /// Diagnostics wrapped by ActiveDiagnostic, if any.
+    SmallVector<DiagnosticInfo, 2> WrappedDiagnostics;
+    SmallVector<std::vector<DiagnosticArgument>, 4> WrappedDiagnosticArgs;
 
     /// All diagnostics that have are no longer active but have not yet
     /// been emitted due to an open transaction.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5878,5 +5878,10 @@ REMARK(attr_objc_name_conflicts_with_access_note, none,
        "source code specifies %3; the access note will be ignored",
        (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
 
+// Used on invalid @objc diagnostics
+NOTE(note_invalid_attr_added_by_access_note, none,
+     "%select{attribute|modifier}0 '%1' was added by access note for %2",
+     (bool, StringRef, StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5018,10 +5018,11 @@ NOTE(objc_declared_here,none,
      OBJC_DIAG_SELECT " declared here",
      (unsigned, DeclName))
 
+// %2 and %3 are unused to make signature match with diag::objc_redecl.
 ERROR(objc_redecl_same,none,
-      OBJC_DIAG_SELECT " with Objective-C selector %2 conflicts with "
+      OBJC_DIAG_SELECT " with Objective-C selector %4 conflicts with "
       "previous declaration with the same Objective-C selector",
-      (unsigned, DeclName, ObjCSelector))
+      (unsigned, DeclName, unsigned, DeclName, ObjCSelector))
 
 ERROR(objc_override_other,none,
       OBJC_DIAG_SELECT " with Objective-C selector %4 conflicts with "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5852,39 +5852,43 @@ ERROR(atomics_ordering_must_be_constant, none,
 // MARK: access notes
 //------------------------------------------------------------------------------
 
+#define WHICH_ACCESS_NOTE(reason) "specified by access note for %" #reason
+
 REMARK(attr_added_by_access_note, none,
-       "access note for %0 adds %select{attribute|modifier}1 '%2' to this %3",
-       (StringRef, bool, StringRef, DescriptiveDeclKind))
+       "implicitly added '%1' to this %2, as " WHICH_ACCESS_NOTE(0),
+       (StringRef, StringRef, DescriptiveDeclKind))
 NOTE(fixit_attr_added_by_access_note, none,
-     "add %select{attribute|modifier}0 explicitly to silence this warning",
-     (bool))
+     "add '%0' explicitly to silence this warning",
+     (StringRef))
 
 REMARK(attr_removed_by_access_note, none,
-       "access note for %0 removes %select{attribute|modifier}1 '%2' from "
-       "this %3",
-       (StringRef, bool, StringRef, DescriptiveDeclKind))
+       "implicitly removed '%1' from this %3, as " WHICH_ACCESS_NOTE(0),
+       (StringRef, StringRef, DescriptiveDeclKind))
 NOTE(fixit_attr_removed_by_access_note, none,
-     "remove %select{attribute|modifier}0 explicitly to silence this warning",
-     (bool))
+     "remove '%0' explicitly to silence this warning",
+     (StringRef))
 
 REMARK(attr_objc_name_changed_by_access_note, none,
-        "access note for %0 changes the '@objc' name of this %1 to %2",
-        (StringRef, DescriptiveDeclKind, ObjCSelector))
+       "implicitly changed Objective-C name of this %1 to %2, as "
+       WHICH_ACCESS_NOTE(0),
+       (StringRef, DescriptiveDeclKind, ObjCSelector))
 NOTE(fixit_attr_objc_name_changed_by_access_note, none,
-     "change '@objc' name in source code explicitly to silence this warning",
+     "change Objective-C name explicitly to silence this warning",
      ())
 
 // Bad access note diagnostics. These are usually emitted as remarks, but
 // '-Raccess-note=all-validate' emits them as errors.
 
 ERROR(attr_objc_name_conflicts_with_access_note, none,
-      "access note for %0 changes the '@objc' name of this %1 to %2, but "
-      "source code specifies %3; the access note will be ignored",
+      "ignored access note: did not change Objective-C name of this %1 from %2 "
+      "to %3, even though it was " WHICH_ACCESS_NOTE(0),
       (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
 ERROR(wrap_invalid_attr_added_by_access_note, none,
-      "access note for %1 failed to add invalid "
-      "%select{attribute|modifier}2 '%3': %0",
-      (DiagnosticInfo *, StringRef, bool, StringRef))
+      "ignored access note: %0; did not implicitly add '%2' to this %3, even "
+      "though it was " WHICH_ACCESS_NOTE(1),
+      (DiagnosticInfo *, StringRef, StringRef, DescriptiveDeclKind))
+
+#undef WHICH_ACCESS_NOTE
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5879,9 +5879,10 @@ REMARK(attr_objc_name_conflicts_with_access_note, none,
        (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
 
 // Used on invalid @objc diagnostics
-NOTE(note_invalid_attr_added_by_access_note, none,
-     "%select{attribute|modifier}0 '%1' was added by access note for %2",
-     (bool, StringRef, StringRef))
+REMARK(wrap_invalid_attr_added_by_access_note, none,
+       "access note for %1 failed to add invalid "
+       "%select{attribute|modifier}2 '%3': %0",
+       (DiagnosticInfo *, StringRef, bool, StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5873,16 +5873,18 @@ REMARK(attr_objc_name_changed_by_access_note, none,
 NOTE(fixit_attr_objc_name_changed_by_access_note, none,
      "change '@objc' name in source code explicitly to silence this warning",
      ())
-REMARK(attr_objc_name_conflicts_with_access_note, none,
-       "access note for %0 changes the '@objc' name of this %1 to %2, but "
-       "source code specifies %3; the access note will be ignored",
-       (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
 
-// Used on invalid @objc diagnostics
-REMARK(wrap_invalid_attr_added_by_access_note, none,
-       "access note for %1 failed to add invalid "
-       "%select{attribute|modifier}2 '%3': %0",
-       (DiagnosticInfo *, StringRef, bool, StringRef))
+// Bad access note diagnostics. These are usually emitted as remarks, but
+// '-Raccess-note=all-validate' emits them as errors.
+
+ERROR(attr_objc_name_conflicts_with_access_note, none,
+      "access note for %0 changes the '@objc' name of this %1 to %2, but "
+      "source code specifies %3; the access note will be ignored",
+      (StringRef, DescriptiveDeclKind, ObjCSelector, ObjCSelector))
+ERROR(wrap_invalid_attr_added_by_access_note, none,
+      "access note for %1 failed to add invalid "
+      "%select{attribute|modifier}2 '%3': %0",
+      (DiagnosticInfo *, StringRef, bool, StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -246,11 +246,10 @@ public:
   /// List of Objective-C member conflicts we have found during type checking.
   std::vector<ObjCMethodConflict> ObjCMethodConflicts;
 
-  using DeclAndAttr = std::tuple<ValueDecl *, DeclAttribute *>;
-
   /// List of attributes added by access notes, used to emit remarks for valid
   /// ones.
-  std::vector<DeclAndAttr> AttrsAddedByAccessNotes;
+  llvm::DenseMap<ValueDecl *, std::vector<DeclAttribute *>>
+      AttrsAddedByAccessNotes;
 
   /// Describes what kind of file this is, which can affect some type checking
   /// and other behavior.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -246,6 +246,12 @@ public:
   /// List of Objective-C member conflicts we have found during type checking.
   std::vector<ObjCMethodConflict> ObjCMethodConflicts;
 
+  using DeclAndAttr = std::tuple<ValueDecl *, DeclAttribute *>;
+
+  /// List of attributes added by access notes, used to emit remarks for valid
+  /// ones.
+  std::vector<DeclAndAttr> AttrsAddedByAccessNotes;
+
   /// Describes what kind of file this is, which can affect some type checking
   /// and other behavior.
   const SourceFileKind Kind;

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -241,6 +241,8 @@ public:
   /// unsatisfied, which might conflict with other Objective-C methods.
   std::vector<ObjCUnsatisfiedOptReq> ObjCUnsatisfiedOptReqs;
 
+  /// A selector that is used by two different declarations in the same class.
+  /// Fields: classDecl, selector, isInstanceMethod.
   using ObjCMethodConflict = std::tuple<ClassDecl *, ObjCSelector, bool>;
 
   /// List of Objective-C member conflicts we have found during type checking.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -36,6 +36,8 @@
 
 namespace swift {
 
+  enum class DiagnosticBehavior : uint8_t;
+
   /// Kind of implicit platform conditions.
   enum class PlatformConditionKind {
 #define PLATFORM_CONDITION(LABEL, IDENTIFIER) LABEL,
@@ -67,6 +69,13 @@ namespace swift {
 
     /// The library has some other undefined distribution.
     Other
+  };
+
+  enum class AccessNoteDiagnosticBehavior : uint8_t {
+    Ignore,
+    RemarkOnFailure,
+    RemarkOnFailureOrSuccess,
+    ErrorOnFailureRemarkOnSuccess
   };
 
   /// A collection of options that affect the language dialect and
@@ -338,6 +347,17 @@ namespace swift {
     /// These are shared_ptrs so that this class remains copyable.
     std::shared_ptr<llvm::Regex> OptimizationRemarkPassedPattern;
     std::shared_ptr<llvm::Regex> OptimizationRemarkMissedPattern;
+
+    /// How should we emit diagnostics about access notes?
+    AccessNoteDiagnosticBehavior AccessNoteBehavior =
+        AccessNoteDiagnosticBehavior::RemarkOnFailureOrSuccess;
+
+    DiagnosticBehavior getAccessNoteFailureLimit() const;
+
+    bool shouldRemarkOnAccessNoteSuccess() const {
+      return AccessNoteBehavior >=
+          AccessNoteDiagnosticBehavior::RemarkOnFailureOrSuccess;
+    }
 
     /// Whether collect tokens during parsing for syntax coloring.
     bool CollectParsedToken = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -196,6 +196,12 @@ def enable_infer_public_concurrent_value : Flag<["-"], "enable-infer-public-send
 def disable_infer_public_concurrent_value : Flag<["-"], "disable-infer-public-sendable">,
     HelpText<"Disable inference of Sendable conformances for public structs and enums">;
 
+def Raccess_note : Separate<["-"], "Raccess-note">,
+    MetaVarName<"none|failures|all|all-validate">,
+    HelpText<"Control access note remarks (default: all)">;
+def Raccess_note_EQ : Joined<["-"], "Raccess-note=">,
+    Alias<Raccess_note>;
+
 } // end let Flags = [FrontendOption, NoDriverOption]
 
 def debug_crash_Group : OptionGroup<"<automatic crashing options>">;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/LangOptions.h"
+#include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/Feature.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/Range.h"
@@ -389,5 +390,19 @@ llvm::StringRef swift::getFeatureName(Feature feature) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
   case Feature::FeatureName: return #FeatureName;
 #include "swift/Basic/Features.def"
+  }
+}
+
+DiagnosticBehavior LangOptions::getAccessNoteFailureLimit() const {
+  switch (AccessNoteBehavior) {
+  case AccessNoteDiagnosticBehavior::Ignore:
+    return DiagnosticBehavior::Ignore;
+
+  case AccessNoteDiagnosticBehavior::RemarkOnFailure:
+  case AccessNoteDiagnosticBehavior::RemarkOnFailureOrSuccess:
+    return DiagnosticBehavior::Remark;
+
+  case AccessNoteDiagnosticBehavior::ErrorOnFailureRemarkOnSuccess:
+    return DiagnosticBehavior::Error;
   }
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -609,6 +609,21 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.OptimizationRemarkMissedPattern =
         generateOptimizationRemarkRegex(Diags, Args, A);
 
+  if (Arg *A = Args.getLastArg(OPT_Raccess_note)) {
+    auto value = llvm::StringSwitch<Optional<AccessNoteDiagnosticBehavior>>(A->getValue())
+      .Case("none", AccessNoteDiagnosticBehavior::Ignore)
+      .Case("failures", AccessNoteDiagnosticBehavior::RemarkOnFailure)
+      .Case("all", AccessNoteDiagnosticBehavior::RemarkOnFailureOrSuccess)
+      .Case("all-validate", AccessNoteDiagnosticBehavior::ErrorOnFailureRemarkOnSuccess)
+      .Default(None);
+
+    if (value)
+      Opts.AccessNoteBehavior = *value;
+    else
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+  }
+
   Opts.EnableConcisePoundFile =
       Args.hasArg(OPT_enable_experimental_concise_pound_file);
   Opts.EnableFuzzyForwardScanTrailingClosureMatching =

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1587,10 +1587,7 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
     }
 
     if (attr) {
-      ctx.Diags.diagnose(
-          attr->getLocation(), diag::result_builder_remove_attr)
-        .fixItRemove(attr->getRangeWithAt());
-      attr->setInvalid();
+      diagnoseAndRemoveAttr(func, attr, diag::result_builder_remove_attr);
     }
 
     // Note that one can remove all of the return statements.

--- a/lib/Sema/TypeCheckDecl.h
+++ b/lib/Sema/TypeCheckDecl.h
@@ -59,6 +59,8 @@ void validatePrecedenceGroup(PrecedenceGroupDecl *PGD);
 bool checkDesignatedTypes(OperatorDecl *OD,
                           ArrayRef<Located<Identifier>> identifiers);
 
+void diagnoseAttrsAddedByAccessNote(SourceFile &SF);
+
 }
 
 #endif

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -55,7 +55,7 @@ swift::behaviorLimitForObjCReason(ObjCReason reason, ASTContext &ctx) {
     return DiagnosticBehavior::Ignore;
 
   case ObjCReason::ExplicitlyObjCByAccessNote:
-    return DiagnosticBehavior::Remark;
+    return ctx.LangOpts.getAccessNoteFailureLimit();
 
   case ObjCReason::MemberOfObjCSubclass:
   case ObjCReason::MemberOfObjCMembersClass:

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -1049,7 +1049,9 @@ bool swift::isRepresentableInObjC(const VarDecl *VD, ObjCReason Reason) {
   // to mark them as @objc
   if (VD->getEffectfulGetAccessor()) {
     VD->diagnose(diag::effectful_not_representable_objc,
-                 VD->getDescriptiveKind());
+                 VD->getDescriptiveKind())
+        .limitBehavior(behavior);
+    Reason.describe(VD);
     return false;
   }
 
@@ -1088,7 +1090,9 @@ bool swift::isRepresentableInObjC(const SubscriptDecl *SD, ObjCReason Reason) {
   // to mark them as @objc
   if (SD->getEffectfulGetAccessor()) {
     SD->diagnose(diag::effectful_not_representable_objc,
-                 SD->getDescriptiveKind());
+                 SD->getDescriptiveKind())
+        .limitBehavior(behavior);
+    Reason.describe(SD);
     return false;
   }
 

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -21,6 +21,7 @@
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/PointerUnion.h"
 
 namespace swift {
 
@@ -90,14 +91,49 @@ private:
   Kind kind;
 
   /// When the kind is \c WitnessToObjC, the requirement being witnessed.
-  ValueDecl * decl = nullptr;
+  llvm::PointerUnion<ValueDecl *, DeclAttribute *> declOrAttr =
+      static_cast<DeclAttribute *>(nullptr);
 
-  ObjCReason(Kind kind, ValueDecl *decl) : kind(kind), decl(decl) { }
+  ObjCReason(Kind kind, ValueDecl *decl) : kind(kind), declOrAttr(decl) { }
+
+  static bool requiresAttr(Kind kind) {
+    switch (kind) {
+    case ExplicitlyCDecl:
+    case ExplicitlyDynamic:
+    case ExplicitlyObjC:
+    case ExplicitlyIBOutlet:
+    case ExplicitlyIBAction:
+    case ExplicitlyIBSegueAction:
+    case ExplicitlyNSManaged:
+    case ExplicitlyIBInspectable:
+    case ExplicitlyGKInspectable:
+    case ExplicitlyObjCByAccessNote:
+      return true;
+
+    case MemberOfObjCProtocol:
+    case ImplicitlyObjC:
+    case OverridesObjC:
+    case WitnessToObjC:
+    case MemberOfObjCExtension:
+    case MemberOfObjCMembersClass:
+    case MemberOfObjCSubclass:
+    case ElementOfObjCEnum:
+    case Accessor:
+      return false;
+    }
+  }
 
 public:
   /// Implicit conversion from the trivial reason kinds.
   ObjCReason(Kind kind) : kind(kind) {
     assert(kind != WitnessToObjC && "Use ObjCReason::witnessToObjC()");
+    assert(!requiresAttr(kind) && "Use ObjCReason(Kind, DeclAttribute*)");
+  }
+
+  ObjCReason(Kind kind, const DeclAttribute *attr)
+      : kind(kind), declOrAttr(const_cast<DeclAttribute *>(attr)) {
+    // const_cast above because it's difficult to get a non-const DeclAttribute.
+    assert(requiresAttr(kind) && "Use ObjCReason(Kind)");
   }
 
   /// Retrieve the kind of requirement.
@@ -113,8 +149,16 @@ public:
   /// requirement, retrieve the requirement.
   ValueDecl *getObjCRequirement() const {
     assert(kind == WitnessToObjC);
-    return decl;
+    return declOrAttr.get<ValueDecl *>();
   }
+
+  DeclAttribute *getAttr() const {
+    if (!requiresAttr(kind))
+      return nullptr;
+    return declOrAttr.get<DeclAttribute *>();
+  }
+
+  void setAttrInvalid() const;
 };
 
 /// Determine how to diagnose conflicts due to inferring @objc with this

--- a/lib/Sema/TypeCheckObjC.h
+++ b/lib/Sema/TypeCheckObjC.h
@@ -159,6 +159,10 @@ public:
   }
 
   void setAttrInvalid() const;
+
+  /// Emit an additional diagnostic describing why we are applying @objc to the
+  /// decl, if this is not obvious from the decl itself.
+  void describe(const Decl *VD) const;
 };
 
 /// Determine how to diagnose conflicts due to inferring @objc with this

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/Subsystems.h"
 #include "TypeChecker.h"
+#include "TypeCheckDecl.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
 #include "CodeSynthesis.h"
@@ -335,6 +336,7 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
     diagnoseObjCMethodConflicts(SF);
     diagnoseObjCUnsatisfiedOptReqConflicts(SF);
     diagnoseUnintendedObjCMethodOverrides(SF);
+    diagnoseAttrsAddedByAccessNote(SF);
     return;
   case SourceFileKind::SIL:
   case SourceFileKind::Interface:

--- a/test/Index/kinds_objc.swift
+++ b/test/Index/kinds_objc.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
 // REQUIRES: objc_interop
 
+import Foundation
+
 @objc class TargetForIBAction {}
 // CHECK: [[@LINE-1]]:13 | class/Swift | TargetForIBAction | [[TargetForIBAction_USR:.*]] | Def |
 @objc class TargetForIBSegueAction {}

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -10,8 +10,8 @@ import gizmo
 import ansible
 
 class Hoozit : Gizmo {
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this instance method, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   func typical(_ x: Int, y: Gizmo) -> Gizmo { return y }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7typical_1ySo5GizmoCSi_AGtFTo : $@convention(objc_method) (Int, Gizmo, Hoozit) -> @autoreleased Gizmo {
   // CHECK: bb0([[X:%.*]] : $Int, [[Y:%.*]] : @unowned $Gizmo, [[THIS:%.*]] : @unowned $Hoozit):
@@ -56,8 +56,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this instance method, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   func copyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7copyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -72,8 +72,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-mutableCopy)
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this instance method, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   func mutableCopyFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC14mutableCopyFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -90,8 +90,8 @@ class Hoozit : Gizmo {
   // NS_RETURNS_RETAINED by family (-copy). This is different from Swift's
   // normal notion of CamelCase, but it's what Clang does, so we should match
   // it.
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this instance method, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   func copy8() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC5copy8So5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -106,8 +106,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT: }
 
   // NS_RETURNS_RETAINED by family (-copy)
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc(copyDuplicate) }}
+  // expected-remark@+2 {{implicitly added '@objc(copyDuplicate)' to this instance method, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc(copyDuplicate)' explicitly to silence this warning}} {{3-3=@objc(copyDuplicate) }}
   func makeDuplicate() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC13makeDuplicateSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -123,8 +123,8 @@ class Hoozit : Gizmo {
 
   // Override the normal family conventions to make this non-consuming and
   // returning at +0.
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this instance method, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   func initFoo() -> Gizmo { return self }
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC7initFooSo5GizmoCyFTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo
   // CHECK: bb0([[THIS:%.*]] : @unowned $Hoozit):
@@ -138,8 +138,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return [[RES]]
   // CHECK-NEXT: }
 
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this property, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   var typicalProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
@@ -190,8 +190,8 @@ class Hoozit : Gizmo {
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs'
 
   // NS_RETURNS_RETAINED getter by family (-copy)
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this property, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   var copyProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @owned Gizmo {
@@ -239,8 +239,8 @@ class Hoozit : Gizmo {
   // CHECK:   destroy_value [[ARG1]]
   // CHECK: } // end sil function '$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs'
 
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this property, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   var roProperty: Gizmo { return self }
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
@@ -258,8 +258,8 @@ class Hoozit : Gizmo {
   // -- no setter
   // CHECK-NOT: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC10roPropertySo5GizmoCvsTo
 
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this property, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   var rwProperty: Gizmo {
     get {
       return self
@@ -283,8 +283,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this property, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   var copyRWProperty: Gizmo {
     get {
       return self
@@ -319,8 +319,8 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this property, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   var initProperty: Gizmo
   // -- getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC12initPropertySo5GizmoCvgTo : $@convention(objc_method) (Hoozit) -> @autoreleased Gizmo {
@@ -349,14 +349,14 @@ class Hoozit : Gizmo {
   // CHECK-NEXT:   return
   // CHECK-NEXT: }
 
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this property}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this property, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   var propComputed: Gizmo {
-    // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this getter}}
-    // expected-note@+1 {{add attribute explicitly to silence this warning}} {{5-5=@objc(initPropComputedGetter) }}
+    // expected-remark@+2 {{implicitly added '@objc(initPropComputedGetter)' to this getter, as specified by access note for fancy test suite}}
+    // expected-note@+1 {{add '@objc(initPropComputedGetter)' explicitly to silence this warning}} {{5-5=@objc(initPropComputedGetter) }}
     get { return self }
-    // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this setter}}
-    // expected-note@+1 {{add attribute explicitly to silence this warning}} {{5-5=@objc(initPropComputedSetter:) }}
+    // expected-remark@+2 {{implicitly added '@objc(initPropComputedSetter:)' to this setter, as specified by access note for fancy test suite}}
+    // expected-note@+1 {{add '@objc(initPropComputedSetter:)' explicitly to silence this warning}} {{5-5=@objc(initPropComputedSetter:) }}
     set {}
   }
   // -- getter
@@ -410,8 +410,8 @@ class Hoozit : Gizmo {
   }
 
   // Subscript
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this subscript}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this subscript, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   subscript (i: Int) -> Hoozit {
   // Getter
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitCyACSicigTo : $@convention(objc_method) (Int, Hoozit) -> @autoreleased Hoozit
@@ -458,7 +458,7 @@ class Wotsit<T> : Gizmo {
   // CHECK-NEXT: }
   @objc(plain)
   func plain() { }
-  // expected-remark@-2 {{access note for fancy test suite changes the '@objc' name of this instance method to 'fancy', but source code specifies 'plain'; the access note will be ignored}}
+  // expected-remark@-1 {{ignored access note: did not change Objective-C name of this instance method from 'plain' to 'fancy', even though it was specified by access note for fancy test suite}}
 
   func generic<U>(_ x: U) {}
 
@@ -505,10 +505,8 @@ class Wotsit<T> : Gizmo {
 extension Hoozit {
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC3intACSi_tcfcTo : $@convention(objc_method) (Int, @owned Hoozit) -> @owned Hoozit
   convenience init(int i: Int) { self.init(bellsOn: i) }
-  // expected-remark@-1 {{access note for fancy test suite adds attribute 'objc' to this initializer}}
-  // expected-note@-2 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
-  // expected-remark@-3 {{access note for fancy test suite adds modifier 'dynamic' to this initializer}}
-  // expected-note@-4 {{add modifier explicitly to silence this warning}} {{3-3=dynamic }}
+  // expected-remark@-1 {{implicitly added '@objc dynamic' to this initializer, as specified by access note for fancy test suite}}
+  // expected-note@-2 {{add '@objc dynamic' explicitly to silence this warning}} {{3-3=@objc dynamic }}
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC6doubleACSd_tcfC : $@convention(method) (Double, @thick Hoozit.Type) -> @owned Hoozit
   convenience init(double d: Double) {
@@ -517,8 +515,8 @@ extension Hoozit {
     other()
   }
 
-  // expected-remark@+2 {{access note for fancy test suite adds attribute 'objc' to this instance method}}
-  // expected-note@+1 {{add attribute explicitly to silence this warning}} {{3-3=@objc }}
+  // expected-remark@+2 {{implicitly added '@objc' to this instance method, as specified by access note for fancy test suite}}
+  // expected-note@+1 {{add '@objc' explicitly to silence this warning}} {{3-3=@objc }}
   func foof() {}
   // CHECK-LABEL: sil hidden [thunk] [ossa] @$s11objc_thunks6HoozitC4foofyyFTo : $@convention(objc_method) (Hoozit) -> () {
 

--- a/test/Sema/Inputs/extra.accessnotes
+++ b/test/Sema/Inputs/extra.accessnotes
@@ -5,3 +5,9 @@ Notes:
 - Name: 'fn()'
   CorinthianLeather: 'rich'
   # expected-remark@-1 {{ignored invalid content in access notes file: unknown key 'CorinthianLeather'}}
+  
+# These notes should apply, or attempt to apply, despite the other problems.
+- Name: 'Extant.good(_:)'
+  ObjC: true
+- Name: 'Extant.bad(_:)'
+  ObjC: true

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -15,16 +15,16 @@
 
 class Extant {
   func good(_: Int) {} // expected-remark * {{}} expected-note * {{}}
-  // GOOD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-1]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax adds attribute 'objc' to this instance method
-  // GOOD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-2]]:{{[0-9]+}}: note: add attribute explicitly to silence this warning
-  // GOOD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-3]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax adds attribute 'objc' to this instance method
-  // GOOD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-4]]:{{[0-9]+}}: note: add attribute explicitly to silence this warning
+  // GOOD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-1]]:{{[0-9]+}}: remark: implicitly added '@objc' to this instance method, as specified by access note for Access notes containing future, unknown syntax
+  // GOOD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-2]]:{{[0-9]+}}: note: add '@objc' explicitly to silence this warning
+  // GOOD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-3]]:{{[0-9]+}}: remark: implicitly added '@objc' to this instance method, as specified by access note for Access notes containing future, unknown syntax
+  // GOOD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-4]]:{{[0-9]+}}: note: add '@objc' explicitly to silence this warning
 
   func bad(_: Int?) {} // expected-remark * {{}}
-  // BAD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-1]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
-  // BAD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-2]]:{{[0-9]+}}: error: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
-  // BAD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-3]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
-  // BAD-ERROR-DAG: access-notes-invalid.swift:[[@LINE-4]]:{{[0-9]+}}: error: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
+  // BAD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-1]]:{{[0-9]+}}: remark: ignored access note: method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C; did not implicitly add '@objc' to this instance method, even though it was specified by access note for Access notes containing future, unknown syntax
+  // BAD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-2]]:{{[0-9]+}}: error: ignored access note: method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C; did not implicitly add '@objc' to this instance method, even though it was specified by access note for Access notes containing future, unknown syntax
+  // BAD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-3]]:{{[0-9]+}}: remark: ignored access note: method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C; did not implicitly add '@objc' to this instance method, even though it was specified by access note for Access notes containing future, unknown syntax
+  // BAD-ERROR-DAG: access-notes-invalid.swift:[[@LINE-4]]:{{[0-9]+}}: error: ignored access note: method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C; did not implicitly add '@objc' to this instance method, even though it was specified by access note for Access notes containing future, unknown syntax
 }
 
 // FIXME: Should diagnose multiple access notes for the same decl

--- a/test/Sema/access-notes-invalid.swift
+++ b/test/Sema/access-notes-invalid.swift
@@ -5,6 +5,31 @@
 
 // RUN: %target-typecheck-verify-swift -access-notes-path %S/Inputs/extra.accessnotes -verify-additional-file %S/Inputs/extra.accessnotes
 
+// RUN: %target-swift-frontend -typecheck -primary-file %/s -access-notes-path %/S/Inputs/extra.accessnotes -Raccess-note=none 2>&1 | %FileCheck --check-prefixes=GOOD-IGNORE,BAD-IGNORE %s
+// RUN: %target-swift-frontend -typecheck -primary-file %/s -access-notes-path %/S/Inputs/extra.accessnotes -Raccess-note=failures 2>&1 | %FileCheck --check-prefixes=GOOD-IGNORE,BAD-REMARK %s
+// RUN: %target-swift-frontend -typecheck -primary-file %/s -access-notes-path %/S/Inputs/extra.accessnotes -Raccess-note=all 2>&1 | %FileCheck --check-prefixes=GOOD-REMARK,BAD-REMARK %s
+// RUN: not %target-swift-frontend -typecheck -primary-file %/s -access-notes-path %/S/Inputs/extra.accessnotes -Raccess-note=all-validate 2>&1 | %FileCheck --check-prefixes=GOOD-REMARK,BAD-ERROR %s
+
+// Default should be 'all'.
+// RUN: %target-swift-frontend -typecheck -primary-file %/s -access-notes-path %/S/Inputs/extra.accessnotes 2>&1 | %FileCheck --check-prefixes=GOOD-REMARK,BAD-REMARK %s
+
+class Extant {
+  func good(_: Int) {} // expected-remark * {{}} expected-note * {{}}
+  // GOOD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-1]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax adds attribute 'objc' to this instance method
+  // GOOD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-2]]:{{[0-9]+}}: note: add attribute explicitly to silence this warning
+  // GOOD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-3]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax adds attribute 'objc' to this instance method
+  // GOOD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-4]]:{{[0-9]+}}: note: add attribute explicitly to silence this warning
+
+  func bad(_: Int?) {} // expected-remark * {{}}
+  // BAD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-1]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
+  // BAD-IGNORE-NOT: access-notes-invalid.swift:[[@LINE-2]]:{{[0-9]+}}: error: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
+  // BAD-REMARK-DAG: access-notes-invalid.swift:[[@LINE-3]]:{{[0-9]+}}: remark: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
+  // BAD-ERROR-DAG: access-notes-invalid.swift:[[@LINE-4]]:{{[0-9]+}}: error: access note for Access notes containing future, unknown syntax failed to add invalid attribute 'objc': method cannot be marked @objc by an access note because the type of the parameter cannot be represented in Objective-C
+}
+
 // FIXME: Should diagnose multiple access notes for the same decl
 
 // FIXME: Should diagnose access notes that don't match a decl in the source code
+
+// Only valid on platforms where @objc is valid.
+// REQUIRES: objc_interop

--- a/test/SourceKit/NameTranslation/swiftnames.swift
+++ b/test/SourceKit/NameTranslation/swiftnames.swift
@@ -56,40 +56,40 @@ class C3: NSObject {
 }
 
 // REQUIRES: objc_interop
-// RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: %sourcekitd-test -req=translate -swift-name '`foo`(`a`:b:c:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: %sourcekitd-test -req=translate -swift-name '`foo(`a:b:c:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK_RAW1 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "bar(x:y:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKFEWER1 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "bar(::)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING1 %s
-// RUN: %sourcekitd-test -req=translate -swift-name 'bar(`:`:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING1 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "(x:y:z:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING2 %s
-// RUN: %sourcekitd-test -req=translate -swift-name '`(x:y:z:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING2 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo(a1:b1:c1:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK2 %s
-// RUN: %sourcekitd-test -req=translate -swift-name '`foo`(a1:`b1`:c1:)' -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK2 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo(_:b1:c1:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK3 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo1(_:_:c2:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK4 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo1(_:_:_:)" -pos=11:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK5 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo2(a:b:c:)" -pos=12:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK6 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo2(_:_:_:)" -pos=12:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK7 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK8 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK_RAW8 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo1(a:b:c:)" -pos=14:11 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK-DIAG %s
-// RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=1:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK9 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`foo`(`a`:b:c:)' -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`foo(`a:b:c:)' -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo(a:b:c:)" -pos=11:11 %s -print-raw-response -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK_RAW1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "bar(x:y:)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKFEWER1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "bar(::)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name 'bar(`:`:)' -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING1 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "(x:y:z:)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING2 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`(x:y:z:)' -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECKMISSING2 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo(a1:b1:c1:)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -swift-name '`foo`(a1:`b1`:c1:)' -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo(_:b1:c1:)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK3 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo1(_:_:c2:)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK4 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo1(_:_:_:)" -pos=11:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK5 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo2(a:b:c:)" -pos=12:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK6 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo2(_:_:_:)" -pos=12:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK7 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK8 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo1()" -pos=14:11 %s -print-raw-response -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK_RAW8 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo1(a:b:c:)" -pos=14:11 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK-DIAG %s
+// RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=1:8 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK9 %s
 
-// RUN: %sourcekitd-test -req=translate -swift-name "init(a1:b2:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK10 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "init(_:_:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK11 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK9 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "foo(a1:_:)" -pos=10:16 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK12 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "init(a1:b2:)" -pos=10:16 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK10 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "init(_:_:)" -pos=10:16 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK11 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "C11" -pos=10:16 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK9 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "foo(a1:_:)" -pos=10:16 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK12 %s
 
-// RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=27:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK13 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "a2" -pos=27:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK13 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "a2" -pos=41:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK14 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=41:10 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK14 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "C3" -pos=48:8 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK15 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "bar(_:other:)" -pos=51:36 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK16 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK17 %s
-// RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -print-raw-response -- -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK_RAW17 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=27:10 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK13 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "a2" -pos=27:10 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK13 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "a2" -pos=41:10 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK14 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "A2" -pos=41:10 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK14 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "C3" -pos=48:8 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK15 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "bar(_:other:)" -pos=51:36 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK16 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK17 %s
+// RUN: %sourcekitd-test -req=translate -swift-name "zoo(m:)" -pos=55:14 %s -print-raw-response -- -Xfrontend -disable-objc-attr-requires-foundation-module -F %S/Inputs/mock-sdk -I %t.tmp %s | %FileCheck -check-prefix=CHECK_RAW17 %s
 
 // CHECK-DIAG: <empty name translation info; internal diagnostic: "Unable to resolve Swift declaration name.">
 // CHECK1: fooWithA:b:c:

--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -115,7 +115,8 @@ def adjust_comments(offset, inserted_attr, comment_str):
 # Writing attrs to access notes
 #
 
-def move_at_objc_to_access_note(access_notes_file, arg, maybe_bad, offset, access_note_name):
+def move_at_objc_to_access_note(access_notes_file, arg, maybe_bad, offset,
+                                access_note_name):
     """Write an @objc attribute into an access notes file, then return the
        string that will replace the attribute and trailing comment."""
 
@@ -134,7 +135,7 @@ def move_at_objc_to_access_note(access_notes_file, arg, maybe_bad, offset, acces
 
     inserted_attr = u"@objc"
     if arg:
-      inserted_attr += u"(" + arg + u")"
+        inserted_attr += u"(" + arg + u")"
 
     replacement = u"// access-note-adjust" + offsetify(offset) + \
                   u"{{" + inserted_attr + "}} [attr moved] "
@@ -145,6 +146,7 @@ def move_at_objc_to_access_note(access_notes_file, arg, maybe_bad, offset, acces
                        u"' explicitly to silence this warning}}"
 
     return replacement
+
 
 #
 # Matching lines

--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -126,7 +126,10 @@ def move_at_objc_to_access_note(access_notes_file, arg, maybe_bad, offset, acces
 
     replacement = u"// access-note-adjust" + offsetify(offset) + u" [attr moved] "
 
-    if not is_bad:
+    if is_bad:
+        replacement += u"expected-note{{attribute 'objc' was added by access note " + \
+                       u"for fancy tests}}"
+    else:
         replacement += u"expected-remark{{access note for fancy tests adds attribute " + \
                        u"'objc' to this }} expected-note{{add attribute explicitly to " + \
                        u"silence this warning}}"

--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -78,7 +78,8 @@ expected_other_diag_re = re.compile(r'expected-(warning|note|remark)' +
                                     offset_re_fragment)
 
 """Matches expected-error and its offset."""
-expected_error_re = re.compile(r'expected-error' + offset_re_fragment)
+expected_error_re = re.compile(r'expected-error' + offset_re_fragment +
+                               r'\s*(\d*\s*)\{\{')
 
 """Matches the string 'marked @objc'."""
 marked_objc_re = re.compile(r'marked @objc')
@@ -91,11 +92,15 @@ def adjust_comments(offset, comment_str):
     """Replace expected-errors with expected-remarks, and make other adjustments
        to diagnostics so that they reflect access notes."""
 
+    bad_prefix = u"access note for fancy tests failed to add invalid " + \
+                 u"attribute 'objc': "
+
     adjusted = expected_other_diag_re.sub(lambda m: u"expected-" + m.group(1) +
                                                     offsetify(offset, m.group(2)),
                                           comment_str)
     adjusted = expected_error_re.sub(lambda m: u"expected-remark" +
-                                               offsetify(offset, m.group(1)),
+                                               offsetify(offset, m.group(1)) + " " +
+                                               m.group(2) + "{{" + bad_prefix,
                                      adjusted)
     adjusted = marked_objc_re.sub(u"marked @objc by an access note", adjusted)
     adjusted = fixit_re.sub(u"{{none}}", adjusted)
@@ -127,8 +132,9 @@ def move_at_objc_to_access_note(access_notes_file, arg, maybe_bad, offset, acces
     replacement = u"// access-note-adjust" + offsetify(offset) + u" [attr moved] "
 
     if is_bad:
-        replacement += u"expected-note{{attribute 'objc' was added by access note " + \
-                       u"for fancy tests}}"
+        pass
+#        replacement += u"expected-note{{attribute 'objc' was added by access note " + \
+#                       u"for fancy tests}}"
     else:
         replacement += u"expected-remark{{access note for fancy tests adds attribute " + \
                        u"'objc' to this }} expected-note{{add attribute explicitly to " + \

--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -107,9 +107,11 @@ def adjust_comments(offset, comment_str):
 # Writing attrs to access notes
 #
 
-def move_at_objc_to_access_note(access_notes_file, arg, offset, access_note_name):
+def move_at_objc_to_access_note(access_notes_file, arg, maybe_bad, offset, access_note_name):
     """Write an @objc attribute into an access notes file, then return the
        string that will replace the attribute and trailing comment."""
+
+    is_bad = (maybe_bad == "bad-")
 
     access_notes_file.write(u"""
 - Name: '{}'
@@ -122,19 +124,23 @@ def move_at_objc_to_access_note(access_notes_file, arg, offset, access_note_name
     if offset is None:
         offset = 1
 
-    return u"// access-note-adjust" + offsetify(offset) + u" [attr moved] " + \
-           u"expected-remark{{access note for fancy tests adds attribute 'objc' to " + \
-           u"this }} expected-note{{add attribute explicitly to silence this warning}}"
+    replacement = u"// access-note-adjust" + offsetify(offset) + u" [attr moved] "
 
+    if not is_bad:
+        replacement += u"expected-remark{{access note for fancy tests adds attribute " + \
+                       u"'objc' to this }} expected-note{{add attribute explicitly to " + \
+                       u"silence this warning}}"
+
+    return replacement
 
 #
 # Matching lines
 #
 
 """Matches '@objc(foo) // access-note-move{{access-note-name}}'
-   or '@objc // access-note-move{{access-note-name}}'"""
+   or '@objc // bad-access-note-move{{access-note-name}}'"""
 access_note_move_re = re.compile(r'@objc(?:\(([\w:]+)\))?[ \t]*' +
-                                 r'//[ \t]*access-note-move' +
+                                 r'//[ \t]*(bad-)?access-note-move' +
                                  offset_re_fragment +
                                  r'\{\{([^}]*)\}\}')
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2003,18 +2003,18 @@ extension PlainClass {
   func badlyNamed(_: Int, y: Int) {}
 }
 
-@objc(Class:) // access-note-move{{BadClass1}} expected-error{{'@objc' class must have a simple name}}{{12-13=}}
+@objc(Class:) // bad-access-note-move{{BadClass1}} expected-error{{'@objc' class must have a simple name}}{{12-13=}}
 class BadClass1 { }
 
-@objc(Protocol:) // access-note-move{{BadProto1}} expected-error{{'@objc' protocol must have a simple name}}{{15-16=}}
+@objc(Protocol:) // bad-access-note-move{{BadProto1}} expected-error{{'@objc' protocol must have a simple name}}{{15-16=}}
 protocol BadProto1 { }
 
-@objc(Enum:) // access-note-move{{BadEnum1}} expected-error{{'@objc' enum must have a simple name}}{{11-12=}}
+@objc(Enum:) // bad-access-note-move{{BadEnum1}} expected-error{{'@objc' enum must have a simple name}}{{11-12=}}
 enum BadEnum1: Int { case X }
 
 @objc // access-note-move{{BadEnum2}}
 enum BadEnum2: Int {
-  @objc(X:) // access-note-move{{BadEnum2.X}} expected-error{{'@objc' enum case must have a simple name}}{{10-11=}}
+  @objc(X:) // bad-access-note-move{{BadEnum2.X}} expected-error{{'@objc' enum case must have a simple name}}{{10-11=}}
   case X
 }
 
@@ -2022,32 +2022,32 @@ class BadClass2 {
   @objc(realDealloc) // expected-error{{'@objc' deinitializer cannot have a name}}
   deinit { }
 
-  @objc(badprop:foo:wibble:) // access-note-move{{BadClass2.badprop}} expected-error{{'@objc' property must have a simple name}}{{16-28=}}
+  @objc(badprop:foo:wibble:) // bad-access-note-move{{BadClass2.badprop}} expected-error{{'@objc' property must have a simple name}}{{16-28=}}
   var badprop: Int = 5
 
-  @objc(foo) // access-note-move{{BadClass2.subscript(_:)}} expected-error{{'@objc' subscript cannot have a name; did you mean to put the name on the getter or setter?}}
+  @objc(foo) // bad-access-note-move{{BadClass2.subscript(_:)}} expected-error{{'@objc' subscript cannot have a name; did you mean to put the name on the getter or setter?}}
   subscript (i: Int) -> Int {
     get {
       return i
     }
   }
 
-  @objc(foo) // access-note-move{{BadClass2.noArgNamesOneParam(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
+  @objc(foo) // bad-access-note-move{{BadClass2.noArgNamesOneParam(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
   func noArgNamesOneParam(x: Int) { }
   
-  @objc(foo) // access-note-move{{BadClass2.noArgNamesOneParam2(_:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
+  @objc(foo) // bad-access-note-move{{BadClass2.noArgNamesOneParam2(_:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter}}
   func noArgNamesOneParam2(_: Int) { }
 
-  @objc(foo) // access-note-move{{BadClass2.noArgNamesTwoParams(_:y:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters}}
+  @objc(foo) // bad-access-note-move{{BadClass2.noArgNamesTwoParams(_:y:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters}}
   func noArgNamesTwoParams(_: Int, y: Int) { }
 
-  @objc(foo:) // access-note-move{{BadClass2.oneArgNameTwoParams(_:y:)}} expected-error{{'@objc' method name provides one argument name, but method has 2 parameters}}
+  @objc(foo:) // bad-access-note-move{{BadClass2.oneArgNameTwoParams(_:y:)}} expected-error{{'@objc' method name provides one argument name, but method has 2 parameters}}
   func oneArgNameTwoParams(_: Int, y: Int) { }
 
-  @objc(foo:) // access-note-move{{BadClass2.oneArgNameNoParams()}} expected-error{{'@objc' method name provides one argument name, but method has 0 parameters}}
+  @objc(foo:) // bad-access-note-move{{BadClass2.oneArgNameNoParams()}} expected-error{{'@objc' method name provides one argument name, but method has 0 parameters}}
   func oneArgNameNoParams() { }
 
-  @objc(foo:) // access-note-move{{BadClass2.init()}} expected-error{{'@objc' initializer name provides one argument name, but initializer has 0 parameters}}
+  @objc(foo:) // bad-access-note-move{{BadClass2.init()}} expected-error{{'@objc' initializer name provides one argument name, but initializer has 0 parameters}}
   init() { }
 
   var _prop = 5
@@ -2098,14 +2098,14 @@ class Super {
 }
 
 class Sub1 : Super {
-  @objc(foo) // access-note-move{{Sub1.foo}} expected-error{{Objective-C property has a different name from the property it overrides ('foo' vs. 'renamedFoo')}}{{9-12=renamedFoo}}
+  @objc(foo) // bad-access-note-move{{Sub1.foo}} expected-error{{Objective-C property has a different name from the property it overrides ('foo' vs. 'renamedFoo')}}{{9-12=renamedFoo}}
   override var foo: Int { get { return 5 } }
 
   override func process(i: Int?) -> Int { } // expected-error{{method cannot be an @objc override because the type of the parameter cannot be represented in Objective-C}}
 }
 
 class Sub2 : Super {
-  @objc // access-note-move{{Sub2.foo}}
+  @objc // bad-access-note-move{{Sub2.foo}} -- @objc is already implied by overriding an @objc attribute, so access notes shouldn't emit a remark
   override var foo: Int { get { return 5 } }
 }
 
@@ -2119,7 +2119,7 @@ class Sub4 : Super {
 }
 
 class Sub5 : Super {
-  @objc(wrongFoo) // access-note-move{{Sub5.foo}} expected-error{{Objective-C property has a different name from the property it overrides ('wrongFoo' vs. 'renamedFoo')}} {{9-17=renamedFoo}}
+  @objc(wrongFoo) // bad-access-note-move{{Sub5.foo}} expected-error{{Objective-C property has a different name from the property it overrides ('wrongFoo' vs. 'renamedFoo')}} {{9-17=renamedFoo}}
   override var foo: Int { get { return 5 } }
 }
 
@@ -2402,10 +2402,10 @@ class ThrowsObjCName {
   @objc(method5AndReturnError:x:closure:) // access-note-move{{ThrowsObjCName.method5(x:closure:)}}
   func method5(x: Int, closure: @escaping (Int) -> Int) throws { }
 
-  @objc(method6) // access-note-move{{ThrowsObjCName.method6()}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
+  @objc(method6) // bad-access-note-move{{ThrowsObjCName.method6()}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
   func method6() throws { }
 
-  @objc(method7) // access-note-move{{ThrowsObjCName.method7(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
+  @objc(method7) // bad-access-note-move{{ThrowsObjCName.method7(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
   func method7(x: Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
@@ -2432,7 +2432,7 @@ protocol ProtocolThrowsObjCName {
 }
 
 class ConformsToProtocolThrowsObjCName1 : ProtocolThrowsObjCName {
-  @objc // access-note-move{{ConformsToProtocolThrowsObjCName1.doThing(_:)}}
+  @objc // bad-access-note-move{{ConformsToProtocolThrowsObjCName1.doThing(_:)}} -- @objc inherited, so no remarks
   func doThing(_ x: String) throws -> String { return x } // okay
 }
 

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -274,13 +274,13 @@ enum subject_enum: Int {
   @objc(subject_enumElement3) // bad-access-note-move{{subject_enum.subject_enumElement3}} expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-31=}}
   case subject_enumElement3, subject_enumElement4
   // Becuase of the fake access-note-move above, we expect to see extra diagnostics when we run this test with both explicit @objc attributes *and* access notes:
-  // expected-remark@-2 * {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}
+  // expected-remark@-2 * {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}} expected-note@-2 *{{attribute 'objc' was added by access note for fancy tests}}
 
   // Fake for access notes: @objc // bad-access-note-move@+2{{subject_enum.subject_enumElement6}}
   @objc // bad-access-note-move{{subject_enum.subject_enumElement5}} expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement5, subject_enumElement6
   // Becuase of the fake access-note-move above, we expect to see extra diagnostics when we run this test with both explicit @objc attributes *and* access notes:
-  // expected-remark@-2 * {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}}
+  // expected-remark@-2 * {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} expected-note@-2 *{{attribute 'objc' was added by access note for fancy tests}}
 
   @nonobjc // expected-error {{'@nonobjc' attribute cannot be applied to this declaration}}
   case subject_enumElement7
@@ -596,7 +596,7 @@ class subject_subscriptGeneric<T> {
 }
 
 class subject_subscriptInvalid1 {
-  @objc // access-note-move{{subject_subscriptInvalid1.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid1.subscript(_:)}}
   class subscript(_ i: Int) -> AnyObject? { // access-note-adjust expected-error {{class subscript cannot be marked @objc}}
     return nil
   }
@@ -869,6 +869,7 @@ class infer_instanceFunc1 {
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
   // access-note-adjust expected-error@-3 {{method cannot be marked @objc because the type of the parameter 2 cannot be represented in Objective-C}}
   // expected-note@-4 {{non-'@objc' enums cannot be represented in Objective-C}}
+  // Produces an extra: expected-note@-5 * {{attribute 'objc' was added by access note for fancy tests}}
 
   @objc // access-note-move{{infer_instanceFunc1.func_UnnamedParam1(_:)}}
   func func_UnnamedParam1(_: Int) {} // no-error
@@ -1835,8 +1836,7 @@ protocol infer_protocol5 : Protocol_ObjC1, Protocol_Class1 {
 
 class C {
   // Don't crash.
-  @objc // bad-access-note-move{{C.foo(x:)}}
-  func foo(x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
+  @objc func foo(x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBAction func myAction(sender: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBSegueAction func myAction(coder: Undeclared, sender: Undeclared) -> Undeclared {fatalError()} // expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}}
 }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -405,7 +405,7 @@ class ConcreteContext3 {
   func dynamicSelf1_() -> Self { return self }
 
   @objc // bad-access-note-move{{ConcreteContext3.genericParams()}}
-  func genericParams<T: NSObject>() -> [T] { return [] } // access-note-adjust expected-error{{method cannot be marked @objc because it has generic parameters}}
+  func genericParams<T: NSObject>() -> [T] { return [] } // access-note-adjust expected-error{{instance method cannot be marked @objc because it has generic parameters}}
 
   @objc // bad-access-note-move{{ConcreteContext3.returnObjCProtocolMetatype()}}
   func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
@@ -2402,10 +2402,10 @@ class ThrowsObjCName {
   @objc(method5AndReturnError:x:closure:) // access-note-move{{ThrowsObjCName.method5(x:closure:)}}
   func method5(x: Int, closure: @escaping (Int) -> Int) throws { }
 
-  @objc(method6) // access-note-move{{ThrowsObjCName.method6()}} expected-error{{@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
+  @objc(method6) // access-note-move{{ThrowsObjCName.method6()}} expected-error{{'@objc' method name provides names for 0 arguments, but method has one parameter (the error parameter)}}
   func method6() throws { }
 
-  @objc(method7) // access-note-move{{ThrowsObjCName.method7(x:)}} expected-error{{@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
+  @objc(method7) // access-note-move{{ThrowsObjCName.method7(x:)}} expected-error{{'@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
   func method7(x: Int) throws { }
 
   // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2366,33 +2366,33 @@ class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
 class ThrowsRedecl1 {
   @objc // access-note-move{{ThrowsRedecl1.method1(_:error:)}}
   func method1(_ x: Int, error: Class_ObjC1) { } // expected-note{{declared here}}
-  @objc // access-note-move{{ThrowsRedecl1.method1(_:)}}
-  func method1(_ x: Int) throws { } // expected-error {{with Objective-C selector 'method1:error:'}}
+  @objc // bad-access-note-move{{ThrowsRedecl1.method1(_:)}}
+  func method1(_ x: Int) throws { } // access-note-adjust{{@objc}} expected-error {{method 'method1' with Objective-C selector 'method1:error:' conflicts with method 'method1(_:error:)' with the same Objective-C selector}}
 
   @objc // access-note-move{{ThrowsRedecl1.method2AndReturnError(_:)}}
   func method2AndReturnError(_ x: Int) { } // expected-note{{declared here}}
-  @objc // access-note-move{{ThrowsRedecl1.method2()}}
-  func method2() throws { } // expected-error {{with Objective-C selector 'method2AndReturnError:'}}
+  @objc // bad-access-note-move{{ThrowsRedecl1.method2()}}
+  func method2() throws { } // access-note-adjust{{@objc}} expected-error {{method 'method2()' with Objective-C selector 'method2AndReturnError:' conflicts with method 'method2AndReturnError' with the same Objective-C selector}}
 
   @objc // access-note-move{{ThrowsRedecl1.method3(_:error:closure:)}}
   func method3(_ x: Int, error: Int, closure: @escaping (Int) -> Int) { }  // expected-note{{declared here}}
-  @objc // access-note-move{{ThrowsRedecl1.method3(_:closure:)}}
-  func method3(_ x: Int, closure: (Int) -> Int) throws { } // expected-error {{with Objective-C selector 'method3:error:closure:'}}
+  @objc // bad-access-note-move{{ThrowsRedecl1.method3(_:closure:)}}
+  func method3(_ x: Int, closure: (Int) -> Int) throws { } // access-note-adjust{{@objc}} expected-error {{method 'method3(_:closure:)' with Objective-C selector 'method3:error:closure:' conflicts with method 'method3(_:error:closure:)' with the same Objective-C selector}}
 
   @objc(initAndReturnError:) // access-note-move{{ThrowsRedecl1.initMethod1(error:)}}
   func initMethod1(error: Int) { } // expected-note{{declared here}}
-  @objc // access-note-move{{ThrowsRedecl1.init()}}
-  init() throws { } // expected-error {{with Objective-C selector 'initAndReturnError:'}}
+  @objc // bad-access-note-move{{ThrowsRedecl1.init()}}
+  init() throws { } // access-note-adjust{{@objc}} expected-error {{initializer 'init()' with Objective-C selector 'initAndReturnError:' conflicts with method 'initMethod1(error:)' with the same Objective-C selector}}
 
   @objc(initWithString:error:) // access-note-move{{ThrowsRedecl1.initMethod2(string:error:)}}
   func initMethod2(string: String, error: Int) { } // expected-note{{declared here}}
-  @objc // access-note-move{{ThrowsRedecl1.init(string:)}}
-  init(string: String) throws { } // expected-error {{with Objective-C selector 'initWithString:error:'}}
+  @objc // bad-access-note-move{{ThrowsRedecl1.init(string:)}}
+  init(string: String) throws { } // access-note-adjust{{@objc}} expected-error {{initializer 'init(string:)' with Objective-C selector 'initWithString:error:' conflicts with method 'initMethod2(string:error:)' with the same Objective-C selector}}
 
   @objc(initAndReturnError:fn:) // access-note-move{{ThrowsRedecl1.initMethod3(error:fn:)}}
   func initMethod3(error: Int, fn: @escaping (Int) -> Int) { } // expected-note{{declared here}}
-  @objc // access-note-move{{ThrowsRedecl1.init(fn:)}}
-  init(fn: (Int) -> Int) throws { } // expected-error {{with Objective-C selector 'initAndReturnError:fn:'}}
+  @objc // bad-access-note-move{{ThrowsRedecl1.init(fn:)}}
+  init(fn: (Int) -> Int) throws { } // access-note-adjust{{@objc}} expected-error {{initializer 'init(fn:)' with Objective-C selector 'initAndReturnError:fn:' conflicts with method 'initMethod3(error:fn:)' with the same Objective-C selector}}
 }
 
 class ThrowsObjCName {

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -237,7 +237,7 @@ class subject_genericClass<T> {
   func subject_instanceFunc() {} // no_error
 }
 
-@objc // bad-access-note-move{{subject_genericClass2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
+@objc // bad-access-note-move{{subject_genericClass2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class subject_genericClass2<T> : Class_ObjC1 {
   @objc // access-note-move{{subject_genericClass2.subject_instanceVar}}
   var subject_instanceVar: Int // no-error
@@ -251,15 +251,15 @@ class subject_genericClass2<T> : Class_ObjC1 {
 
 extension subject_genericClass where T : Hashable {
   @objc // bad-access-note-move{{subject_genericClass.prop}}
-  var prop: Int { return 0 } // access-note-adjust expected-error{{members of constrained extensions cannot be declared @objc}}
+  var prop: Int { return 0 } // access-note-adjust{{@objc}} expected-error{{members of constrained extensions cannot be declared @objc}}
 }
 
 extension subject_genericClass {
   @objc // bad-access-note-move{{subject_genericClass.extProp}}
-  var extProp: Int { return 0 } // access-note-adjust expected-error{{extensions of generic classes cannot contain '@objc' members}}
+  var extProp: Int { return 0 } // access-note-adjust{{@objc}} expected-error{{extensions of generic classes cannot contain '@objc' members}}
   
   @objc // bad-access-note-move{{subject_genericClass.extFoo()}}
-  func extFoo() {} // access-note-adjust expected-error{{extensions of generic classes cannot contain '@objc' members}}
+  func extFoo() {} // access-note-adjust{{@objc}} expected-error{{extensions of generic classes cannot contain '@objc' members}}
 }
 
 @objc // access-note-move{{subject_enum}}
@@ -405,42 +405,42 @@ class ConcreteContext3 {
   func dynamicSelf1_() -> Self { return self }
 
   @objc // bad-access-note-move{{ConcreteContext3.genericParams()}}
-  func genericParams<T: NSObject>() -> [T] { return [] } // access-note-adjust expected-error{{instance method cannot be marked @objc because it has generic parameters}}
+  func genericParams<T: NSObject>() -> [T] { return [] } // access-note-adjust{{@objc}} expected-error{{instance method cannot be marked @objc because it has generic parameters}}
 
   @objc // bad-access-note-move{{ConcreteContext3.returnObjCProtocolMetatype()}}
-  func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self } // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias AnotherNSCoding = NSCoding
   typealias MetaNSCoding1 = NSCoding.Protocol
   typealias MetaNSCoding2 = AnotherNSCoding.Protocol
 
   @objc // bad-access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype1()}}
-  func returnObjCAliasProtocolMetatype1() -> AnotherNSCoding.Protocol { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  func returnObjCAliasProtocolMetatype1() -> AnotherNSCoding.Protocol { return NSCoding.self } // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype2()}}
-  func returnObjCAliasProtocolMetatype2() -> MetaNSCoding1 { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  func returnObjCAliasProtocolMetatype2() -> MetaNSCoding1 { return NSCoding.self } // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype3()}}
-  func returnObjCAliasProtocolMetatype3() -> MetaNSCoding2 { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  func returnObjCAliasProtocolMetatype3() -> MetaNSCoding2 { return NSCoding.self } // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias Composition = NSCopying & NSCoding
 
   @objc // bad-access-note-move{{ConcreteContext3.returnCompositionMetatype1()}}
-  func returnCompositionMetatype1() -> Composition.Protocol { return Composition.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  func returnCompositionMetatype1() -> Composition.Protocol { return Composition.self } // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{ConcreteContext3.returnCompositionMetatype2()}}
-  func returnCompositionMetatype2() -> (NSCopying & NSCoding).Protocol { return (NSCopying & NSCoding).self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  func returnCompositionMetatype2() -> (NSCopying & NSCoding).Protocol { return (NSCopying & NSCoding).self } // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias NSCodingExistential = NSCoding.Type
 
   @objc // bad-access-note-move{{ConcreteContext3.inoutFunc(a:)}}
-  func inoutFunc(a: inout Int) {} // access-note-adjust expected-error{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
+  func inoutFunc(a: inout Int) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram1(a:)}}
-  func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram2(a:)}}
-  func metatypeOfExistentialMetatypePram2(a: NSCoding.Type.Protocol) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  func metatypeOfExistentialMetatypePram2(a: NSCoding.Type.Protocol) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
 func genericContext1<T>(_: T) {
@@ -470,7 +470,7 @@ class GenericContext2<T> {
   @objc // bad-access-note-move{{GenericContext2.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
   class subject_inGenericContext {}
 
-  @objc // bad-access-note-move{{GenericContext2.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
+  @objc // bad-access-note-move{{GenericContext2.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
   class subject_inGenericContext2 : Class_ObjC1 {}
 
   @objc // access-note-move{{GenericContext2.f()}}
@@ -482,7 +482,7 @@ class GenericContext3<T> {
     @objc // bad-access-note-move{{GenericContext3.MoreNested.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{5-11=}}
     class subject_inGenericContext {}
 
-    @objc // bad-access-note-move{{GenericContext3.MoreNested.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{5-11=}}
+    @objc // bad-access-note-move{{GenericContext3.MoreNested.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{5-11=}}
     class subject_inGenericContext2 : Class_ObjC1 {}
 
     @objc // access-note-move{{GenericContext3.MoreNested.f()}}
@@ -492,7 +492,7 @@ class GenericContext3<T> {
 
 class GenericContext4<T> {
   @objc // bad-access-note-move{{GenericContext4.foo()}}
-  func foo() where T: Hashable { } // access-note-adjust expected-error {{instance method cannot be marked @objc because it has a 'where' clause}}
+  func foo() where T: Hashable { } // access-note-adjust{{@objc}} expected-error {{instance method cannot be marked @objc because it has a 'where' clause}}
 }
 
 @objc // bad-access-note-move{{ConcreteSubclassOfGeneric}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
@@ -503,7 +503,7 @@ extension ConcreteSubclassOfGeneric {
   func foo() {} // okay
 }
 
-@objc // bad-access-note-move{{ConcreteSubclassOfGeneric2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
+@objc // bad-access-note-move{{ConcreteSubclassOfGeneric2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class ConcreteSubclassOfGeneric2 : subject_genericClass2<Int> {}
 
 extension ConcreteSubclassOfGeneric2 {
@@ -597,7 +597,7 @@ class subject_subscriptGeneric<T> {
 
 class subject_subscriptInvalid1 {
   @objc // bad-access-note-move{{subject_subscriptInvalid1.subscript(_:)}}
-  class subscript(_ i: Int) -> AnyObject? { // access-note-adjust expected-error {{class subscript cannot be marked @objc}}
+  class subscript(_ i: Int) -> AnyObject? { // access-note-adjust{{@objc}} expected-error {{class subscript cannot be marked @objc}}
     return nil
   }
 }
@@ -605,48 +605,48 @@ class subject_subscriptInvalid1 {
 class subject_subscriptInvalid2 {
   @objc // bad-access-note-move{{subject_subscriptInvalid2.subscript(_:)}}
   subscript(a: PlainClass) -> Int {
-  // access-note-adjust expected-error@-1 {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid3 {
   @objc // bad-access-note-move{{subject_subscriptInvalid3.subscript(_:)}}
-  subscript(a: PlainClass.Type) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  subscript(a: PlainClass.Type) -> Int { // access-note-adjust{{@objc}} expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid4 {
   @objc // bad-access-note-move{{subject_subscriptInvalid4.subscript(_:)}}
-  subscript(a: PlainStruct) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  subscript(a: PlainStruct) -> Int { // access-note-adjust{{@objc}} expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{Swift structs cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid5 {
   @objc // bad-access-note-move{{subject_subscriptInvalid5.subscript(_:)}}
-  subscript(a: PlainEnum) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  subscript(a: PlainEnum) -> Int { // access-note-adjust{{@objc}} expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{enums cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid6 {
   @objc // bad-access-note-move{{subject_subscriptInvalid6.subscript(_:)}}
-  subscript(a: PlainProtocol) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  subscript(a: PlainProtocol) -> Int { // access-note-adjust{{@objc}} expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid7 {
   @objc // bad-access-note-move{{subject_subscriptInvalid7.subscript(_:)}}
-  subscript(a: Protocol_Class1) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  subscript(a: Protocol_Class1) -> Int { // access-note-adjust{{@objc}} expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid8 {
   @objc // bad-access-note-move{{subject_subscriptInvalid8.subscript(_:)}}
-  subscript(a: Protocol_Class1 & Protocol_Class2) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
+  subscript(a: Protocol_Class1 & Protocol_Class2) -> Int { // access-note-adjust{{@objc}} expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
     get { return 0 }
   }
@@ -654,7 +654,7 @@ class subject_subscriptInvalid8 {
 
 class subject_propertyInvalid1 {
   @objc // bad-access-note-move{{subject_propertyInvalid1.plainStruct}}
-  let plainStruct = PlainStruct() // access-note-adjust expected-error {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  let plainStruct = PlainStruct() // access-note-adjust{{@objc}} expected-error {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-1{{Swift structs cannot be represented in Objective-C}}
 }
 
@@ -705,7 +705,7 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func7_(a:)}}
   func func7_(a: PlainClass) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   func func7m(a: PlainClass.Type) {}
@@ -713,14 +713,14 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func7m_(a:)}}
   func func7m_(a: PlainClass.Type) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 
   func func8() -> PlainClass {}
 // CHECK-LABEL: {{^}} func func8() -> PlainClass {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func8_()}}
   func func8_() -> PlainClass {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   func func8m() -> PlainClass.Type {}
@@ -728,14 +728,14 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func8m_()}}
   func func8m_() -> PlainClass.Type {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   func func9(a: PlainStruct) {}
 // CHECK-LABEL: {{^}} func func9(a: PlainStruct) {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func9_(a:)}}
   func func9_(a: PlainStruct) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   func func10() -> PlainStruct {}
@@ -743,7 +743,7 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func10_()}}
   func func10_() -> PlainStruct {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   func func11(a: PlainEnum) {}
@@ -751,7 +751,7 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func11_(a:)}}
   func func11_(a: PlainEnum) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
 
   func func12(a: PlainProtocol) {}
@@ -759,7 +759,7 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func12_(a:)}}
   func func12_(a: PlainProtocol) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   func func13(a: Class_ObjC1) {}
@@ -773,7 +773,7 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func14_(a:)}}
   func func14_(a: Protocol_Class1) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   func func15(a: Protocol_ObjC1) {}
@@ -865,9 +865,9 @@ class infer_instanceFunc1 {
   // Check that we produce diagnostics for every parameter and return type.
   @objc // bad-access-note-move{{infer_instanceFunc1.func_MultipleDiags(a:b:)}}
   func func_MultipleDiags(a: PlainStruct, b: PlainEnum) -> Any {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter 1 cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter 1 cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
-  // access-note-adjust expected-error@-3 {{method cannot be marked @objc because the type of the parameter 2 cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-3 {{method cannot be marked @objc because the type of the parameter 2 cannot be represented in Objective-C}}
   // expected-note@-4 {{non-'@objc' enums cannot be represented in Objective-C}}
   // Produces an extra: expected-note@-5 * {{attribute 'objc' was added by access note for fancy tests}}
 
@@ -876,7 +876,7 @@ class infer_instanceFunc1 {
 
   @objc // bad-access-note-move{{infer_instanceFunc1.func_UnnamedParam2(_:)}}
   func func_UnnamedParam2(_: PlainStruct) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   @objc // access-note-move{{infer_instanceFunc1.func_varParam1(a:)}}
@@ -942,7 +942,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.instanceVar1_}}
   var (instanceVar1_, instanceVar2_): (Int, PlainProtocol)
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
   // Fake for access notes: @objc // access-note-move@-3{{infer_instanceVar1.instanceVar2_}}
 
@@ -1018,7 +1018,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_tuple1_}}
   var var_tuple1_: ()
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
 
   var var_tuple2: Void
@@ -1026,7 +1026,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_tuple2_}}
   var var_tuple2_: Void
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
 
   var var_tuple3: (Int)
@@ -1040,7 +1040,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_tuple4_}}
   var var_tuple4_: (Int, Int)
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{tuples cannot be represented in Objective-C}}
 
   //===--- Stdlib integer types.
@@ -1071,7 +1071,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainClass_}}
   var var_PlainClass_: PlainClass
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
 
   var var_PlainStruct: PlainStruct
@@ -1079,7 +1079,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainStruct_}}
   var var_PlainStruct_: PlainStruct
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_PlainEnum: PlainEnum
@@ -1087,7 +1087,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainEnum_}}
   var var_PlainEnum_: PlainEnum
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
 
   var var_PlainProtocol: PlainProtocol
@@ -1095,7 +1095,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainProtocol_}}
   var var_PlainProtocol_: PlainProtocol
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_ClassObjC: Class_ObjC1
@@ -1109,7 +1109,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ProtocolClass_}}
   var var_ProtocolClass_: Protocol_Class1
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_ProtocolObjC: Protocol_ObjC1
@@ -1124,28 +1124,28 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainClassMetatype_}}
   var var_PlainClassMetatype_: PlainClass.Type
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainStructMetatype: PlainStruct.Type
 // CHECK-LABEL: {{^}}  var var_PlainStructMetatype: PlainStruct.Type
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainStructMetatype_}}
   var var_PlainStructMetatype_: PlainStruct.Type
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainEnumMetatype: PlainEnum.Type
 // CHECK-LABEL: {{^}}  var var_PlainEnumMetatype: PlainEnum.Type
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainEnumMetatype_}}
   var var_PlainEnumMetatype_: PlainEnum.Type
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainExistentialMetatype: PlainProtocol.Type
 // CHECK-LABEL: {{^}}  var var_PlainExistentialMetatype: PlainProtocol.Type
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_PlainExistentialMetatype_}}
   var var_PlainExistentialMetatype_: PlainProtocol.Type
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ClassObjCMetatype: Class_ObjC1.Type
 // CHECK-LABEL: @objc var var_ClassObjCMetatype: Class_ObjC1.Type
@@ -1158,7 +1158,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ProtocolClassMetatype_}}
   var var_ProtocolClassMetatype_: Protocol_Class1.Type
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ProtocolObjCMetatype1: Protocol_ObjC1.Type
 // CHECK-LABEL: @objc var var_ProtocolObjCMetatype1: Protocol_ObjC1.Type
@@ -1188,7 +1188,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_Existential1_}}
   var var_Existential1_: PlainProtocol
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential2: PlainProtocol & PlainProtocol
@@ -1196,7 +1196,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_Existential2_}}
   var var_Existential2_: PlainProtocol & PlainProtocol
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential3: PlainProtocol & Protocol_Class1
@@ -1204,7 +1204,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_Existential3_}}
   var var_Existential3_: PlainProtocol & Protocol_Class1
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential4: PlainProtocol & Protocol_ObjC1
@@ -1212,7 +1212,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_Existential4_}}
   var var_Existential4_: PlainProtocol & Protocol_ObjC1
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
 
   var var_Existential5: Protocol_Class1
@@ -1220,7 +1220,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_Existential5_}}
   var var_Existential5_: Protocol_Class1
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential6: Protocol_Class1 & Protocol_Class2
@@ -1228,7 +1228,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_Existential6_}}
   var var_Existential6_: Protocol_Class1 & Protocol_Class2
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential7: Protocol_Class1 & Protocol_ObjC1
@@ -1236,7 +1236,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_Existential7_}}
   var var_Existential7_: Protocol_Class1 & Protocol_ObjC1
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
 
   var var_Existential8: Protocol_ObjC1
@@ -1553,14 +1553,14 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType3_}}
   var var_ArrayType3_: [PlainStruct]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType4: [(AnyObject) -> AnyObject] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType4: [(AnyObject) -> AnyObject]
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType4_}}
   var var_ArrayType4_: [(AnyObject) -> AnyObject]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType5: [Protocol_ObjC1]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType5: [Protocol_ObjC1]
@@ -1579,21 +1579,21 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType7_}}
   var var_ArrayType7_: [PlainClass]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType8: [PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType8: [PlainProtocol]
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType8_}}
   var var_ArrayType8_: [PlainProtocol]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType9: [Protocol_ObjC1 & PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType9: [PlainProtocol & Protocol_ObjC1]
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType9_}}
   var var_ArrayType9_: [Protocol_ObjC1 & PlainProtocol]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
@@ -1613,14 +1613,14 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType13_}}
   var var_ArrayType13_: [Any?]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType15: [AnyObject?]
   // CHECK-LABEL: {{^}}  var var_ArrayType15: [AnyObject?]
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType15_}}
   var var_ArrayType15_: [AnyObject?]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType16: [[@convention(block) (AnyObject) -> AnyObject]] // no-error
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType16: {{\[}}[@convention(block) (AnyObject) -> AnyObject]]
@@ -1633,7 +1633,7 @@ class infer_instanceVar1 {
 
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType17_}}
   var var_ArrayType17_: [[(AnyObject) -> AnyObject]]
-  // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 }
 
 @objc // access-note-move{{ObjCBase}}
@@ -1654,7 +1654,7 @@ class infer_instanceVar2<
 
   @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Unconstrained_}}
   var var_GP_Unconstrained_: GP_Unconstrained
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_PlainClass: GP_PlainClass
@@ -1662,7 +1662,7 @@ class infer_instanceVar2<
 
   @objc // bad-access-note-move{{infer_instanceVar2.var_GP_PlainClass_}}
   var var_GP_PlainClass_: GP_PlainClass
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_PlainProtocol: GP_PlainProtocol
@@ -1670,7 +1670,7 @@ class infer_instanceVar2<
 
   @objc // bad-access-note-move{{infer_instanceVar2.var_GP_PlainProtocol_}}
   var var_GP_PlainProtocol_: GP_PlainProtocol
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Class_ObjC: GP_Class_ObjC
@@ -1678,7 +1678,7 @@ class infer_instanceVar2<
 
   @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Class_ObjC_}}
   var var_GP_Class_ObjC_: GP_Class_ObjC
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Protocol_Class: GP_Protocol_Class
@@ -1686,7 +1686,7 @@ class infer_instanceVar2<
 
   @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Protocol_Class_}}
   var var_GP_Protocol_Class_: GP_Protocol_Class
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   var var_GP_Protocol_ObjC: GP_Protocol_ObjC
@@ -1694,7 +1694,7 @@ class infer_instanceVar2<
 
   @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Protocol_ObjCa}}
   var var_GP_Protocol_ObjCa: GP_Protocol_ObjC
-  // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   func func_GP_Unconstrained(a: GP_Unconstrained) {}
@@ -1702,17 +1702,17 @@ class infer_instanceVar2<
 
   @objc // bad-access-note-move{{infer_instanceVar2.func_GP_Unconstrained_(a:)}}
   func func_GP_Unconstrained_(a: GP_Unconstrained) {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{infer_instanceVar2.func_GP_Unconstrained_()}}
   func func_GP_Unconstrained_() -> GP_Unconstrained {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{infer_instanceVar2.func_GP_Class_ObjC__()}}
   func func_GP_Class_ObjC__() -> GP_Class_ObjC {}
-  // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 }
 
@@ -2135,18 +2135,18 @@ class ClosureArguments {
   func foo(f: (Int) -> ()) {}
   // CHECK: @objc func bar
   @objc // bad-access-note-move{{ClosureArguments.bar(f:)}}
-  func bar(f: (NotObjCEnum) -> NotObjCStruct) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  func bar(f: (NotObjCEnum) -> NotObjCStruct) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func bas
   @objc // bad-access-note-move{{ClosureArguments.bas(f:)}}
-  func bas(f: (NotObjCEnum) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  func bas(f: (NotObjCEnum) -> ()) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zim
   @objc // bad-access-note-move{{ClosureArguments.zim(f:)}}
-  func zim(f: () -> NotObjCStruct) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  func zim(f: () -> NotObjCStruct) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zang
   @objc // bad-access-note-move{{ClosureArguments.zang(f:)}}
-  func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   @objc // bad-access-note-move{{ClosureArguments.zangZang(f:)}}
-  func zangZang(f: (Int...) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
+  func zangZang(f: (Int...) -> ()) {} // access-note-adjust{{@objc}} expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func fooImplicit
   func fooImplicit(f: (Int) -> ()) {}
   // CHECK: {{^}}  func barImplicit
@@ -2268,28 +2268,28 @@ class ClassThrows1 {
   // Errors
 
   @objc // bad-access-note-move{{ClassThrows1.methodReturnsOptionalObjCClass()}}
-  func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of optional type 'Class_ObjC1?'; 'nil' indicates failure to Objective-C}}
+  func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil } // access-note-adjust{{@objc}} expected-error{{throwing method cannot be marked @objc because it returns a value of optional type 'Class_ObjC1?'; 'nil' indicates failure to Objective-C}}
 
   @objc // bad-access-note-move{{ClassThrows1.methodReturnsOptionalArray()}}
-  func methodReturnsOptionalArray() throws -> [String]? { return nil } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of optional type '[String]?'; 'nil' indicates failure to Objective-C}}
+  func methodReturnsOptionalArray() throws -> [String]? { return nil } // access-note-adjust{{@objc}} expected-error{{throwing method cannot be marked @objc because it returns a value of optional type '[String]?'; 'nil' indicates failure to Objective-C}}
 
   @objc // bad-access-note-move{{ClassThrows1.methodReturnsInt()}}
-  func methodReturnsInt() throws -> Int { return 0 } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of type 'Int'; return 'Void' or a type that bridges to an Objective-C class}}
+  func methodReturnsInt() throws -> Int { return 0 } // access-note-adjust{{@objc}} expected-error{{throwing method cannot be marked @objc because it returns a value of type 'Int'; return 'Void' or a type that bridges to an Objective-C class}}
 
   @objc // bad-access-note-move{{ClassThrows1.methodAcceptsThrowingFunc(fn:)}}
   func methodAcceptsThrowingFunc(fn: (String) throws -> Int) { }
-  // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{throwing function types cannot be represented in Objective-C}}
 
   @objc // bad-access-note-move{{ClassThrows1.init(radians:)}}
-  init?(radians: Double) throws { } // access-note-adjust expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
+  init?(radians: Double) throws { } // access-note-adjust{{@objc}} expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
   @objc // bad-access-note-move{{ClassThrows1.init(string:)}}
-  init!(string: String) throws { } // access-note-adjust expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
+  init!(string: String) throws { } // access-note-adjust{{@objc}} expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
   @objc // bad-access-note-move{{ClassThrows1.fooWithErrorEnum1(x:)}}
   func fooWithErrorEnum1(x: ErrorEnum) {}
-  // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{non-'@objc' enums cannot be represented in Objective-C}}
 
   // CHECK: {{^}} func fooWithErrorEnum2(x: ErrorEnum)
@@ -2297,7 +2297,7 @@ class ClassThrows1 {
 
   @objc // bad-access-note-move{{ClassThrows1.fooWithErrorProtocolComposition1(x:)}}
   func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
-  // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // access-note-adjust{{@objc}} expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{protocol-constrained type containing 'Error' cannot be represented in Objective-C}}
 
   // CHECK: {{^}} func fooWithErrorProtocolComposition2(x: Error & Protocol_ObjC1)
@@ -2342,7 +2342,7 @@ class ImplicitClassThrows1 {
   func methodReturnsBridgedValueType2() throws -> NSRange {
     return NSRange()
   }
-  // access-note-adjust expected-error@-3{{throwing method cannot be marked @objc because it returns a value of type 'NSRange' (aka '_NSRange'); return 'Void' or a type that bridges to an Objective-C class}}
+  // access-note-adjust{{@objc}} expected-error@-3{{throwing method cannot be marked @objc because it returns a value of type 'NSRange' (aka '_NSRange'); return 'Void' or a type that bridges to an Objective-C class}}
 
   // CHECK: {{^}} @objc func methodReturnsError() throws -> Error
   func methodReturnsError() throws -> Error { return ErrorEnum.failed }
@@ -2653,5 +2653,5 @@ protocol SR_9035_P {
 class SR12801 {
   @objc // bad-access-note-move{{SR12801.subscript(_:)}}
   subscript<T>(foo : [T]) -> Int { return 0 }
-  // access-note-adjust expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
+  // access-note-adjust{{@objc}} expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
 }

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -92,15 +92,15 @@ class FáncyName {}
 @objc(FancyName)
 extension FáncyName {}
 
-@objc // access-note-move{{subject_globalVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+@objc // bad-access-note-move{{subject_globalVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
 var subject_globalVar: Int
 
 var subject_getterSetter: Int {
-  @objc // access-note-move{{getter:subject_getterSetter()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{getter:subject_getterSetter()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   get {
     return 0
   }
-  @objc // access-note-move{{setter:subject_getterSetter()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{setter:subject_getterSetter()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   set {
   }
 }
@@ -116,8 +116,8 @@ var subject_global_observingAccessorsVar1: Int = 0 {
 
 class subject_getterSetter1 {
   var instanceVar1: Int {
-    @objc // access-note-move{{getter:subject_getterSetter1.instanceVar1()}}
-    get { // access-note-adjust expected-error {{'@objc' getter for non-'@objc' property}}
+    @objc // bad-access-note-move{{getter:subject_getterSetter1.instanceVar1()}} expected-error {{'@objc' getter for non-'@objc' property}} {{5-11=}}
+    get {
       return 0
     }
   }
@@ -126,18 +126,18 @@ class subject_getterSetter1 {
     get {
       return 0
     }
-    @objc // access-note-move{{setter:subject_getterSetter1.instanceVar2()}}
-    set { // access-note-adjust expected-error {{'@objc' setter for non-'@objc' property}}
+    @objc // bad-access-note-move{{setter:subject_getterSetter1.instanceVar2()}} expected-error {{'@objc' setter for non-'@objc' property}} {{5-11=}}
+    set {
     }
   }
 
   var instanceVar3: Int {
-    @objc // access-note-move{{getter:subject_getterSetter1.instanceVar3()}}
-    get { // access-note-adjust expected-error {{'@objc' getter for non-'@objc' property}}
+    @objc // bad-access-note-move{{getter:subject_getterSetter1.instanceVar3()}} expected-error {{'@objc' getter for non-'@objc' property}} {{5-11=}}
+    get {
       return 0
     }
-    @objc // access-note-move{{setter:subject_getterSetter1.instanceVar3()}}
-    set { // access-note-adjust expected-error {{'@objc' setter for non-'@objc' property}}
+    @objc // bad-access-note-move{{setter:subject_getterSetter1.instanceVar3()}} expected-error {{'@objc' setter for non-'@objc' property}} {{5-11=}}
+    set {
     }
   }
 
@@ -159,7 +159,7 @@ class subject_staticVar1 {
   class var staticVar2: Int { return 42 }
 }
 
-@objc // access-note-move{{subject_freeFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
+@objc // bad-access-note-move{{subject_freeFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
 func subject_freeFunc() {
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
@@ -170,7 +170,7 @@ func subject_freeFunc() {
   }
 }
 
-@objc // access-note-move{{subject_genericFunc(t:)}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
+@objc // bad-access-note-move{{subject_genericFunc(t:)}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{1-7=}}
 func subject_genericFunc<T>(t: T) {
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
@@ -183,27 +183,27 @@ func subject_genericFunc<T>(t: T) {
 func subject_funcParam(a: @objc Int) { // expected-error {{attribute can only be applied to declarations, not types}} {{1-1=@objc }} {{27-33=}}
 }
 
-@objc // access-note-move{{subject_struct}} expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
+@objc // bad-access-note-move{{subject_struct}} expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
 struct subject_struct {
-  @objc // access-note-move{{subject_struct.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_struct.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_instanceVar: Int
 
-  @objc // access-note-move{{subject_struct.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_struct.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   init() {}
 
-  @objc // access-note-move{{subject_struct.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_struct.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_instanceFunc() {}
 }
 
-@objc // access-note-move{{subject_genericStruct}} expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
+@objc // bad-access-note-move{{subject_genericStruct}} expected-error {{'@objc' attribute cannot be applied to this declaration}} {{1-7=}}
 struct subject_genericStruct<T> {
-  @objc // access-note-move{{subject_genericStruct.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_genericStruct.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_instanceVar: Int
 
-  @objc // access-note-move{{subject_genericStruct.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_genericStruct.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   init() {}
 
-  @objc // access-note-move{{subject_genericStruct.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_genericStruct.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_instanceFunc() {}
 }
 
@@ -225,7 +225,7 @@ class subject_class1 { // no-error
 class subject_class2 : Protocol_Class1, PlainProtocol { // no-error
 }
 
-@objc // access-note-move{{subject_genericClass}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
+@objc // bad-access-note-move{{subject_genericClass}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class subject_genericClass<T> {
   @objc // access-note-move{{subject_genericClass.subject_instanceVar}}
   var subject_instanceVar: Int // no-error
@@ -237,7 +237,7 @@ class subject_genericClass<T> {
   func subject_instanceFunc() {} // no_error
 }
 
-@objc // access-note-move{{subject_genericClass2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
+@objc // bad-access-note-move{{subject_genericClass2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
 class subject_genericClass2<T> : Class_ObjC1 {
   @objc // access-note-move{{subject_genericClass2.subject_instanceVar}}
   var subject_instanceVar: Int // no-error
@@ -250,50 +250,50 @@ class subject_genericClass2<T> : Class_ObjC1 {
 }
 
 extension subject_genericClass where T : Hashable {
-  @objc // access-note-move{{subject_genericClass.prop}}
+  @objc // bad-access-note-move{{subject_genericClass.prop}}
   var prop: Int { return 0 } // access-note-adjust expected-error{{members of constrained extensions cannot be declared @objc}}
 }
 
 extension subject_genericClass {
-  @objc // access-note-move{{subject_genericClass.extProp}}
+  @objc // bad-access-note-move{{subject_genericClass.extProp}}
   var extProp: Int { return 0 } // access-note-adjust expected-error{{extensions of generic classes cannot contain '@objc' members}}
   
-  @objc // access-note-move{{subject_genericClass.extFoo()}}
+  @objc // bad-access-note-move{{subject_genericClass.extFoo()}}
   func extFoo() {} // access-note-adjust expected-error{{extensions of generic classes cannot contain '@objc' members}}
 }
 
 @objc // access-note-move{{subject_enum}}
 enum subject_enum: Int {
-  @objc // access-note-move{{subject_enum.subject_enumElement1}} expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_enum.subject_enumElement1}} expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement1
 
   @objc(subject_enumElement2) // access-note-move{{subject_enum.subject_enumElement2}}
   case subject_enumElement2
 
-  // Fake for access notes: @objc(subject_enumElement3) // access-note-move@+2{{subject_enum.subject_enumElement4}}
-  @objc(subject_enumElement3) // access-note-move{{subject_enum.subject_enumElement3}} expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-31=}}
+  // Fake for access notes: @objc(subject_enumElement3) // bad-access-note-move@+2{{subject_enum.subject_enumElement4}}
+  @objc(subject_enumElement3) // bad-access-note-move{{subject_enum.subject_enumElement3}} expected-error {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}{{3-31=}}
   case subject_enumElement3, subject_enumElement4
   // Becuase of the fake access-note-move above, we expect to see extra diagnostics when we run this test with both explicit @objc attributes *and* access notes:
-  // expected-remark@-2 * {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}} expected-remark@-2 * {{access note for fancy tests adds attribute 'objc' to this enum case}} expected-note@-2 * {{add attribute explicitly to silence this warning}}
+  // expected-remark@-2 * {{'@objc' enum case declaration defines multiple enum cases with the same Objective-C name}}
 
-  // Fake for access notes: @objc // access-note-move@+2{{subject_enum.subject_enumElement6}}
-  @objc // access-note-move{{subject_enum.subject_enumElement5}} expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
+  // Fake for access notes: @objc // bad-access-note-move@+2{{subject_enum.subject_enumElement6}}
+  @objc // bad-access-note-move{{subject_enum.subject_enumElement5}} expected-error {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} {{3-9=}}
   case subject_enumElement5, subject_enumElement6
   // Becuase of the fake access-note-move above, we expect to see extra diagnostics when we run this test with both explicit @objc attributes *and* access notes:
-  // expected-remark@-2 * {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}} expected-remark@-2 * {{access note for fancy tests adds attribute 'objc' to this enum case}} expected-note@-2 * {{add attribute explicitly to silence this warning}}
+  // expected-remark@-2 * {{attribute has no effect; cases within an '@objc' enum are already exposed to Objective-C}}
 
   @nonobjc // expected-error {{'@nonobjc' attribute cannot be applied to this declaration}}
   case subject_enumElement7
 
-  @objc // access-note-move{{subject_enum.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_enum.init()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   init() {}
 
-  @objc // access-note-move{{subject_enum.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
+  @objc // bad-access-note-move{{subject_enum.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_instanceFunc() {}
 }
 
 enum subject_enum2 {
-  @objc(subject_enum2Element1) // access-note-move{{subject_enum2.subject_enumElement1}} expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-32=}}
+  @objc(subject_enum2Element1) // bad-access-note-move{{subject_enum2.subject_enumElement1}} expected-error{{'@objc' enum case is not allowed outside of an '@objc' enum}}{{3-32=}}
   case subject_enumElement1
 }
 
@@ -324,13 +324,13 @@ protocol subject_protocol5 : Protocol_Class1 {} // expected-error {{@objc protoc
 protocol subject_protocol6 : Protocol_ObjC1 {}
 
 protocol subject_containerProtocol1 {
-  @objc // access-note-move{{subject_containerProtocol1.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{subject_containerProtocol1.subject_instanceVar}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   var subject_instanceVar: Int { get }
 
-  @objc // access-note-move{{subject_containerProtocol1.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{subject_containerProtocol1.subject_instanceFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func subject_instanceFunc()
 
-  @objc // access-note-move{{subject_containerProtocol1.subject_staticFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{subject_containerProtocol1.subject_staticFunc()}} expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   static func subject_staticFunc()
 }
 
@@ -383,7 +383,7 @@ protocol subject_containerObjCProtocol2 {
 }
 
 protocol nonObjCProtocol {
-  @objc // access-note-move{{nonObjCProtocol.objcRequirement()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{nonObjCProtocol.objcRequirement()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func objcRequirement()
 }
 
@@ -404,42 +404,42 @@ class ConcreteContext3 {
   @objc // access-note-move{{ConcreteContext3.dynamicSelf1_()}}
   func dynamicSelf1_() -> Self { return self }
 
-  @objc // access-note-move{{ConcreteContext3.genericParams()}}
+  @objc // bad-access-note-move{{ConcreteContext3.genericParams()}}
   func genericParams<T: NSObject>() -> [T] { return [] } // access-note-adjust expected-error{{method cannot be marked @objc because it has generic parameters}}
 
-  @objc // access-note-move{{ConcreteContext3.returnObjCProtocolMetatype()}}
+  @objc // bad-access-note-move{{ConcreteContext3.returnObjCProtocolMetatype()}}
   func returnObjCProtocolMetatype() -> NSCoding.Protocol { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias AnotherNSCoding = NSCoding
   typealias MetaNSCoding1 = NSCoding.Protocol
   typealias MetaNSCoding2 = AnotherNSCoding.Protocol
 
-  @objc // access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype1()}}
+  @objc // bad-access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype1()}}
   func returnObjCAliasProtocolMetatype1() -> AnotherNSCoding.Protocol { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype2()}}
+  @objc // bad-access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype2()}}
   func returnObjCAliasProtocolMetatype2() -> MetaNSCoding1 { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype3()}}
+  @objc // bad-access-note-move{{ConcreteContext3.returnObjCAliasProtocolMetatype3()}}
   func returnObjCAliasProtocolMetatype3() -> MetaNSCoding2 { return NSCoding.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias Composition = NSCopying & NSCoding
 
-  @objc // access-note-move{{ConcreteContext3.returnCompositionMetatype1()}}
+  @objc // bad-access-note-move{{ConcreteContext3.returnCompositionMetatype1()}}
   func returnCompositionMetatype1() -> Composition.Protocol { return Composition.self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{ConcreteContext3.returnCompositionMetatype2()}}
+  @objc // bad-access-note-move{{ConcreteContext3.returnCompositionMetatype2()}}
   func returnCompositionMetatype2() -> (NSCopying & NSCoding).Protocol { return (NSCopying & NSCoding).self } // access-note-adjust expected-error{{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   typealias NSCodingExistential = NSCoding.Type
 
-  @objc // access-note-move{{ConcreteContext3.inoutFunc(a:)}}
+  @objc // bad-access-note-move{{ConcreteContext3.inoutFunc(a:)}}
   func inoutFunc(a: inout Int) {} // access-note-adjust expected-error{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram1(a:)}}
+  @objc // bad-access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram1(a:)}}
   func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram2(a:)}}
+  @objc // bad-access-note-move{{ConcreteContext3.metatypeOfExistentialMetatypePram2(a:)}}
   func metatypeOfExistentialMetatypePram2(a: NSCoding.Type.Protocol) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
@@ -467,10 +467,10 @@ func genericContext1<T>(_: T) {
 }
 
 class GenericContext2<T> {
-  @objc // access-note-move{{GenericContext2.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
+  @objc // bad-access-note-move{{GenericContext2.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{3-9=}}
   class subject_inGenericContext {}
 
-  @objc // access-note-move{{GenericContext2.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
+  @objc // bad-access-note-move{{GenericContext2.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{3-9=}}
   class subject_inGenericContext2 : Class_ObjC1 {}
 
   @objc // access-note-move{{GenericContext2.f()}}
@@ -479,10 +479,10 @@ class GenericContext2<T> {
 
 class GenericContext3<T> {
   class MoreNested {
-    @objc // access-note-move{{GenericContext3.MoreNested.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{5-11=}}
+    @objc // bad-access-note-move{{GenericContext3.MoreNested.subject_inGenericContext}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{5-11=}}
     class subject_inGenericContext {}
 
-    @objc // access-note-move{{GenericContext3.MoreNested.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{5-11=}}
+    @objc // bad-access-note-move{{GenericContext3.MoreNested.subject_inGenericContext2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{5-11=}}
     class subject_inGenericContext2 : Class_ObjC1 {}
 
     @objc // access-note-move{{GenericContext3.MoreNested.f()}}
@@ -491,11 +491,11 @@ class GenericContext3<T> {
 }
 
 class GenericContext4<T> {
-  @objc // access-note-move{{GenericContext4.foo()}}
+  @objc // bad-access-note-move{{GenericContext4.foo()}}
   func foo() where T: Hashable { } // access-note-adjust expected-error {{instance method cannot be marked @objc because it has a 'where' clause}}
 }
 
-@objc // access-note-move{{ConcreteSubclassOfGeneric}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
+@objc // bad-access-note-move{{ConcreteSubclassOfGeneric}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}} {{1-7=}}
 class ConcreteSubclassOfGeneric : GenericContext3<Int> {}
 
 extension ConcreteSubclassOfGeneric {
@@ -503,7 +503,7 @@ extension ConcreteSubclassOfGeneric {
   func foo() {} // okay
 }
 
-@objc // access-note-move{{ConcreteSubclassOfGeneric2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
+@objc // bad-access-note-move{{ConcreteSubclassOfGeneric2}} expected-error{{generic subclasses of '@objc' classes cannot have an explicit '@objc'}} {{1-7=}}
 class ConcreteSubclassOfGeneric2 : subject_genericClass2<Int> {}
 
 extension ConcreteSubclassOfGeneric2 {
@@ -603,7 +603,7 @@ class subject_subscriptInvalid1 {
 }
 
 class subject_subscriptInvalid2 {
-  @objc // access-note-move{{subject_subscriptInvalid2.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid2.subscript(_:)}}
   subscript(a: PlainClass) -> Int {
   // access-note-adjust expected-error@-1 {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
@@ -611,41 +611,41 @@ class subject_subscriptInvalid2 {
   }
 }
 class subject_subscriptInvalid3 {
-  @objc // access-note-move{{subject_subscriptInvalid3.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid3.subscript(_:)}}
   subscript(a: PlainClass.Type) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid4 {
-  @objc // access-note-move{{subject_subscriptInvalid4.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid4.subscript(_:)}}
   subscript(a: PlainStruct) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{Swift structs cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid5 {
-  @objc // access-note-move{{subject_subscriptInvalid5.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid5.subscript(_:)}}
   subscript(a: PlainEnum) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{enums cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid6 {
-  @objc // access-note-move{{subject_subscriptInvalid6.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid6.subscript(_:)}}
   subscript(a: PlainProtocol) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid7 {
-  @objc // access-note-move{{subject_subscriptInvalid7.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid7.subscript(_:)}}
   subscript(a: Protocol_Class1) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
     get { return 0 }
   }
 }
 class subject_subscriptInvalid8 {
-  @objc // access-note-move{{subject_subscriptInvalid8.subscript(_:)}}
+  @objc // bad-access-note-move{{subject_subscriptInvalid8.subscript(_:)}}
   subscript(a: Protocol_Class1 & Protocol_Class2) -> Int { // access-note-adjust expected-error {{subscript cannot be marked @objc because its type cannot be represented in Objective-C}}
     // expected-note@-1{{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
     get { return 0 }
@@ -653,7 +653,7 @@ class subject_subscriptInvalid8 {
 }
 
 class subject_propertyInvalid1 {
-  @objc // access-note-move{{subject_propertyInvalid1.plainStruct}}
+  @objc // bad-access-note-move{{subject_propertyInvalid1.plainStruct}}
   let plainStruct = PlainStruct() // access-note-adjust expected-error {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-1{{Swift structs cannot be represented in Objective-C}}
 }
@@ -703,7 +703,7 @@ class infer_instanceFunc1 {
   func func7(a: PlainClass) {}
 // CHECK-LABEL: {{^}} func func7(a: PlainClass) {
 
-  @objc // access-note-move{{infer_instanceFunc1.func7_(a:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func7_(a:)}}
   func func7_(a: PlainClass) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
@@ -711,14 +711,14 @@ class infer_instanceFunc1 {
   func func7m(a: PlainClass.Type) {}
 // CHECK-LABEL: {{^}} func func7m(a: PlainClass.Type) {
 
-  @objc // access-note-move{{infer_instanceFunc1.func7m_(a:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func7m_(a:)}}
   func func7m_(a: PlainClass.Type) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 
   func func8() -> PlainClass {}
 // CHECK-LABEL: {{^}} func func8() -> PlainClass {
 
-  @objc // access-note-move{{infer_instanceFunc1.func8_()}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func8_()}}
   func func8_() -> PlainClass {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
@@ -726,14 +726,14 @@ class infer_instanceFunc1 {
   func func8m() -> PlainClass.Type {}
 // CHECK-LABEL: {{^}} func func8m() -> PlainClass.Type {
 
-  @objc // access-note-move{{infer_instanceFunc1.func8m_()}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func8m_()}}
   func func8m_() -> PlainClass.Type {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
 
   func func9(a: PlainStruct) {}
 // CHECK-LABEL: {{^}} func func9(a: PlainStruct) {
 
-  @objc // access-note-move{{infer_instanceFunc1.func9_(a:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func9_(a:)}}
   func func9_(a: PlainStruct) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
@@ -741,7 +741,7 @@ class infer_instanceFunc1 {
   func func10() -> PlainStruct {}
 // CHECK-LABEL: {{^}} func func10() -> PlainStruct {
 
-  @objc // access-note-move{{infer_instanceFunc1.func10_()}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func10_()}}
   func func10_() -> PlainStruct {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
@@ -749,7 +749,7 @@ class infer_instanceFunc1 {
   func func11(a: PlainEnum) {}
 // CHECK-LABEL: {{^}} func func11(a: PlainEnum) {
 
-  @objc // access-note-move{{infer_instanceFunc1.func11_(a:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func11_(a:)}}
   func func11_(a: PlainEnum) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
@@ -757,7 +757,7 @@ class infer_instanceFunc1 {
   func func12(a: PlainProtocol) {}
 // CHECK-LABEL: {{^}} func func12(a: PlainProtocol) {
 
-  @objc // access-note-move{{infer_instanceFunc1.func12_(a:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func12_(a:)}}
   func func12_(a: PlainProtocol) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
@@ -771,7 +771,7 @@ class infer_instanceFunc1 {
   func func14(a: Protocol_Class1) {}
 // CHECK-LABEL: {{^}} func func14(a: Protocol_Class1) {
 
-  @objc // access-note-move{{infer_instanceFunc1.func14_(a:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func14_(a:)}}
   func func14_(a: Protocol_Class1) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
@@ -863,7 +863,7 @@ class infer_instanceFunc1 {
   func func_TupleStyle2a(a: Int, b: Int, c: Int) {}
 
   // Check that we produce diagnostics for every parameter and return type.
-  @objc // access-note-move{{infer_instanceFunc1.func_MultipleDiags(a:b:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func_MultipleDiags(a:b:)}}
   func func_MultipleDiags(a: PlainStruct, b: PlainEnum) -> Any {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter 1 cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
@@ -873,7 +873,7 @@ class infer_instanceFunc1 {
   @objc // access-note-move{{infer_instanceFunc1.func_UnnamedParam1(_:)}}
   func func_UnnamedParam1(_: Int) {} // no-error
 
-  @objc // access-note-move{{infer_instanceFunc1.func_UnnamedParam2(_:)}}
+  @objc // bad-access-note-move{{infer_instanceFunc1.func_UnnamedParam2(_:)}}
   func func_UnnamedParam2(_: PlainStruct) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
@@ -939,7 +939,7 @@ class infer_instanceVar1 {
   // CHECK: @objc var instanceVar2: Int
   // CHECK: {{^}}  var instanceVar3: PlainProtocol
 
-  @objc // access-note-move{{infer_instanceVar1.instanceVar1_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.instanceVar1_}}
   var (instanceVar1_, instanceVar2_): (Int, PlainProtocol)
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
@@ -1015,7 +1015,7 @@ class infer_instanceVar1 {
   var var_tuple1: ()
 // CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple1: ()
 
-  @objc // access-note-move{{infer_instanceVar1.var_tuple1_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_tuple1_}}
   var var_tuple1_: ()
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
@@ -1023,7 +1023,7 @@ class infer_instanceVar1 {
   var var_tuple2: Void
 // CHECK-LABEL: {{^}} @_hasInitialValue var var_tuple2: Void
 
-  @objc // access-note-move{{infer_instanceVar1.var_tuple2_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_tuple2_}}
   var var_tuple2_: Void
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{empty tuple type cannot be represented in Objective-C}}
@@ -1037,7 +1037,7 @@ class infer_instanceVar1 {
   var var_tuple4: (Int, Int)
 // CHECK-LABEL: {{^}} var var_tuple4: (Int, Int)
 
-  @objc // access-note-move{{infer_instanceVar1.var_tuple4_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_tuple4_}}
   var var_tuple4_: (Int, Int)
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{tuples cannot be represented in Objective-C}}
@@ -1068,7 +1068,7 @@ class infer_instanceVar1 {
   var var_PlainClass: PlainClass
 // CHECK-LABEL: {{^}}  var var_PlainClass: PlainClass
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainClass_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainClass_}}
   var var_PlainClass_: PlainClass
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{classes not annotated with @objc cannot be represented in Objective-C}}
@@ -1076,7 +1076,7 @@ class infer_instanceVar1 {
   var var_PlainStruct: PlainStruct
 // CHECK-LABEL: {{^}}  var var_PlainStruct: PlainStruct
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainStruct_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainStruct_}}
   var var_PlainStruct_: PlainStruct
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
@@ -1084,7 +1084,7 @@ class infer_instanceVar1 {
   var var_PlainEnum: PlainEnum
 // CHECK-LABEL: {{^}} var var_PlainEnum: PlainEnum
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainEnum_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainEnum_}}
   var var_PlainEnum_: PlainEnum
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{non-'@objc' enums cannot be represented in Objective-C}}
@@ -1092,7 +1092,7 @@ class infer_instanceVar1 {
   var var_PlainProtocol: PlainProtocol
 // CHECK-LABEL: {{^}}  var var_PlainProtocol: PlainProtocol
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainProtocol_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainProtocol_}}
   var var_PlainProtocol_: PlainProtocol
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
@@ -1106,7 +1106,7 @@ class infer_instanceVar1 {
   var var_ProtocolClass: Protocol_Class1
 // CHECK-LABEL: {{^}}  var var_ProtocolClass: Protocol_Class1
 
-  @objc // access-note-move{{infer_instanceVar1.var_ProtocolClass_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ProtocolClass_}}
   var var_ProtocolClass_: Protocol_Class1
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
@@ -1121,28 +1121,28 @@ class infer_instanceVar1 {
   var var_PlainClassMetatype: PlainClass.Type
 // CHECK-LABEL: {{^}}  var var_PlainClassMetatype: PlainClass.Type
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainClassMetatype_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainClassMetatype_}}
   var var_PlainClassMetatype_: PlainClass.Type
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainStructMetatype: PlainStruct.Type
 // CHECK-LABEL: {{^}}  var var_PlainStructMetatype: PlainStruct.Type
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainStructMetatype_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainStructMetatype_}}
   var var_PlainStructMetatype_: PlainStruct.Type
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainEnumMetatype: PlainEnum.Type
 // CHECK-LABEL: {{^}}  var var_PlainEnumMetatype: PlainEnum.Type
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainEnumMetatype_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainEnumMetatype_}}
   var var_PlainEnumMetatype_: PlainEnum.Type
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_PlainExistentialMetatype: PlainProtocol.Type
 // CHECK-LABEL: {{^}}  var var_PlainExistentialMetatype: PlainProtocol.Type
 
-  @objc // access-note-move{{infer_instanceVar1.var_PlainExistentialMetatype_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_PlainExistentialMetatype_}}
   var var_PlainExistentialMetatype_: PlainProtocol.Type
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
@@ -1155,7 +1155,7 @@ class infer_instanceVar1 {
   var var_ProtocolClassMetatype: Protocol_Class1.Type
 // CHECK-LABEL: {{^}}  var var_ProtocolClassMetatype: Protocol_Class1.Type
 
-  @objc // access-note-move{{infer_instanceVar1.var_ProtocolClassMetatype_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ProtocolClassMetatype_}}
   var var_ProtocolClassMetatype_: Protocol_Class1.Type
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
@@ -1185,7 +1185,7 @@ class infer_instanceVar1 {
   var var_Existential1: PlainProtocol
   // CHECK-LABEL: {{^}}  var var_Existential1: PlainProtocol
 
-  @objc // access-note-move{{infer_instanceVar1.var_Existential1_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_Existential1_}}
   var var_Existential1_: PlainProtocol
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
@@ -1193,7 +1193,7 @@ class infer_instanceVar1 {
   var var_Existential2: PlainProtocol & PlainProtocol
 // CHECK-LABEL: {{^}}  var var_Existential2: PlainProtocol
 
-  @objc // access-note-move{{infer_instanceVar1.var_Existential2_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_Existential2_}}
   var var_Existential2_: PlainProtocol & PlainProtocol
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
@@ -1201,7 +1201,7 @@ class infer_instanceVar1 {
   var var_Existential3: PlainProtocol & Protocol_Class1
 // CHECK-LABEL: {{^}}  var var_Existential3: PlainProtocol & Protocol_Class1
 
-  @objc // access-note-move{{infer_instanceVar1.var_Existential3_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_Existential3_}}
   var var_Existential3_: PlainProtocol & Protocol_Class1
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
@@ -1209,7 +1209,7 @@ class infer_instanceVar1 {
   var var_Existential4: PlainProtocol & Protocol_ObjC1
 // CHECK-LABEL: {{^}}  var var_Existential4: PlainProtocol & Protocol_ObjC1
 
-  @objc // access-note-move{{infer_instanceVar1.var_Existential4_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_Existential4_}}
   var var_Existential4_: PlainProtocol & Protocol_ObjC1
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'PlainProtocol' cannot be represented in Objective-C}}
@@ -1217,7 +1217,7 @@ class infer_instanceVar1 {
   var var_Existential5: Protocol_Class1
   // CHECK-LABEL: {{^}}  var var_Existential5: Protocol_Class1
 
-  @objc // access-note-move{{infer_instanceVar1.var_Existential5_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_Existential5_}}
   var var_Existential5_: Protocol_Class1
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
@@ -1225,7 +1225,7 @@ class infer_instanceVar1 {
   var var_Existential6: Protocol_Class1 & Protocol_Class2
 // CHECK-LABEL: {{^}}  var var_Existential6: Protocol_Class1 & Protocol_Class2
 
-  @objc // access-note-move{{infer_instanceVar1.var_Existential6_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_Existential6_}}
   var var_Existential6_: Protocol_Class1 & Protocol_Class2
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
@@ -1233,7 +1233,7 @@ class infer_instanceVar1 {
   var var_Existential7: Protocol_Class1 & Protocol_ObjC1
 // CHECK-LABEL: {{^}}  var var_Existential7: Protocol_Class1 & Protocol_ObjC1
 
-  @objc // access-note-move{{infer_instanceVar1.var_Existential7_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_Existential7_}}
   var var_Existential7_: Protocol_Class1 & Protocol_ObjC1
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{protocol-constrained type containing protocol 'Protocol_Class1' cannot be represented in Objective-C}}
@@ -1550,14 +1550,14 @@ class infer_instanceVar1 {
   var var_ArrayType3: [PlainStruct]
   // CHECK-LABEL: {{^}}  var var_ArrayType3: [PlainStruct]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType3_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType3_}}
   var var_ArrayType3_: [PlainStruct]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType4: [(AnyObject) -> AnyObject] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType4: [(AnyObject) -> AnyObject]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType4_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType4_}}
   var var_ArrayType4_: [(AnyObject) -> AnyObject]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
@@ -1576,21 +1576,21 @@ class infer_instanceVar1 {
   var var_ArrayType7: [PlainClass]
   // CHECK-LABEL: {{^}}  var var_ArrayType7: [PlainClass]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType7_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType7_}}
   var var_ArrayType7_: [PlainClass]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType8: [PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType8: [PlainProtocol]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType8_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType8_}}
   var var_ArrayType8_: [PlainProtocol]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType9: [Protocol_ObjC1 & PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType9: [PlainProtocol & Protocol_ObjC1]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType9_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType9_}}
   var var_ArrayType9_: [Protocol_ObjC1 & PlainProtocol]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
@@ -1610,14 +1610,14 @@ class infer_instanceVar1 {
   var var_ArrayType13: [Any?]
   // CHECK-LABEL: {{^}}  var var_ArrayType13: [Any?]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType13_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType13_}}
   var var_ArrayType13_: [Any?]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
   var var_ArrayType15: [AnyObject?]
   // CHECK-LABEL: {{^}}  var var_ArrayType15: [AnyObject?]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType15_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType15_}}
   var var_ArrayType15_: [AnyObject?]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 
@@ -1630,7 +1630,7 @@ class infer_instanceVar1 {
   var var_ArrayType17: [[(AnyObject) -> AnyObject]] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType17: {{\[}}[(AnyObject) -> AnyObject]]
 
-  @objc // access-note-move{{infer_instanceVar1.var_ArrayType17_}}
+  @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType17_}}
   var var_ArrayType17_: [[(AnyObject) -> AnyObject]]
   // access-note-adjust expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
 }
@@ -1651,7 +1651,7 @@ class infer_instanceVar2<
   var var_GP_Unconstrained: GP_Unconstrained
 // CHECK-LABEL: {{^}}  var var_GP_Unconstrained: GP_Unconstrained
 
-  @objc // access-note-move{{infer_instanceVar2.var_GP_Unconstrained_}}
+  @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Unconstrained_}}
   var var_GP_Unconstrained_: GP_Unconstrained
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
@@ -1659,7 +1659,7 @@ class infer_instanceVar2<
   var var_GP_PlainClass: GP_PlainClass
 // CHECK-LABEL: {{^}}  var var_GP_PlainClass: GP_PlainClass
 
-  @objc // access-note-move{{infer_instanceVar2.var_GP_PlainClass_}}
+  @objc // bad-access-note-move{{infer_instanceVar2.var_GP_PlainClass_}}
   var var_GP_PlainClass_: GP_PlainClass
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
@@ -1667,7 +1667,7 @@ class infer_instanceVar2<
   var var_GP_PlainProtocol: GP_PlainProtocol
 // CHECK-LABEL: {{^}}  var var_GP_PlainProtocol: GP_PlainProtocol
 
-  @objc // access-note-move{{infer_instanceVar2.var_GP_PlainProtocol_}}
+  @objc // bad-access-note-move{{infer_instanceVar2.var_GP_PlainProtocol_}}
   var var_GP_PlainProtocol_: GP_PlainProtocol
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
@@ -1675,7 +1675,7 @@ class infer_instanceVar2<
   var var_GP_Class_ObjC: GP_Class_ObjC
 // CHECK-LABEL: {{^}}  var var_GP_Class_ObjC: GP_Class_ObjC
 
-  @objc // access-note-move{{infer_instanceVar2.var_GP_Class_ObjC_}}
+  @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Class_ObjC_}}
   var var_GP_Class_ObjC_: GP_Class_ObjC
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
@@ -1683,7 +1683,7 @@ class infer_instanceVar2<
   var var_GP_Protocol_Class: GP_Protocol_Class
 // CHECK-LABEL: {{^}}  var var_GP_Protocol_Class: GP_Protocol_Class
 
-  @objc // access-note-move{{infer_instanceVar2.var_GP_Protocol_Class_}}
+  @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Protocol_Class_}}
   var var_GP_Protocol_Class_: GP_Protocol_Class
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
@@ -1691,7 +1691,7 @@ class infer_instanceVar2<
   var var_GP_Protocol_ObjC: GP_Protocol_ObjC
 // CHECK-LABEL: {{^}}  var var_GP_Protocol_ObjC: GP_Protocol_ObjC
 
-  @objc // access-note-move{{infer_instanceVar2.var_GP_Protocol_ObjCa}}
+  @objc // bad-access-note-move{{infer_instanceVar2.var_GP_Protocol_ObjCa}}
   var var_GP_Protocol_ObjCa: GP_Protocol_ObjC
   // access-note-adjust expected-error@-1 {{property cannot be marked @objc because its type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
@@ -1699,17 +1699,17 @@ class infer_instanceVar2<
   func func_GP_Unconstrained(a: GP_Unconstrained) {}
 // CHECK-LABEL: {{^}} func func_GP_Unconstrained(a: GP_Unconstrained) {
 
-  @objc // access-note-move{{infer_instanceVar2.func_GP_Unconstrained_(a:)}}
+  @objc // bad-access-note-move{{infer_instanceVar2.func_GP_Unconstrained_(a:)}}
   func func_GP_Unconstrained_(a: GP_Unconstrained) {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{infer_instanceVar2.func_GP_Unconstrained_()}}
+  @objc // bad-access-note-move{{infer_instanceVar2.func_GP_Unconstrained_()}}
   func func_GP_Unconstrained_() -> GP_Unconstrained {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{infer_instanceVar2.func_GP_Class_ObjC__()}}
+  @objc // bad-access-note-move{{infer_instanceVar2.func_GP_Class_ObjC__()}}
   func func_GP_Class_ObjC__() -> GP_Class_ObjC {}
   // access-note-adjust expected-error@-1 {{method cannot be marked @objc because its result type cannot be represented in Objective-C}}
   // expected-note@-2 {{generic type parameters cannot be represented in Objective-C}}
@@ -1835,7 +1835,7 @@ protocol infer_protocol5 : Protocol_ObjC1, Protocol_Class1 {
 
 class C {
   // Don't crash.
-  @objc // access-note-move{{C.foo(x:)}}
+  @objc // bad-access-note-move{{C.foo(x:)}}
   func foo(x: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBAction func myAction(sender: Undeclared) {} // expected-error {{cannot find type 'Undeclared' in scope}}
   @IBSegueAction func myAction(coder: Undeclared, sender: Undeclared) -> Undeclared {fatalError()} // expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{cannot find type 'Undeclared' in scope}}
@@ -2060,10 +2060,10 @@ class BadClass2 {
   }
 
   var prop2: Int {
-    @objc(property) // access-note-move{{getter:BadClass2.prop2()}}
-    get { return _prop } // access-note-adjust expected-error{{'@objc' getter for non-'@objc' property}}
-    @objc(setProperty:) // access-note-move{{setter:BadClass2.prop2()}}
-    set { _prop = newValue } // access-note-adjust expected-error{{'@objc' setter for non-'@objc' property}}
+    @objc(property) // bad-access-note-move{{getter:BadClass2.prop2()}} expected-error{{'@objc' getter for non-'@objc' property}} {{5-21=}}
+    get { return _prop }
+    @objc(setProperty:) // bad-access-note-move{{setter:BadClass2.prop2()}} expected-error{{'@objc' setter for non-'@objc' property}} {{5-25=}}
+    set { _prop = newValue }
   }
 
   var prop3: Int {
@@ -2134,18 +2134,18 @@ class ClosureArguments {
   @objc // access-note-move{{ClosureArguments.foo(f:)}}
   func foo(f: (Int) -> ()) {}
   // CHECK: @objc func bar
-  @objc // access-note-move{{ClosureArguments.bar(f:)}}
+  @objc // bad-access-note-move{{ClosureArguments.bar(f:)}}
   func bar(f: (NotObjCEnum) -> NotObjCStruct) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func bas
-  @objc // access-note-move{{ClosureArguments.bas(f:)}}
+  @objc // bad-access-note-move{{ClosureArguments.bas(f:)}}
   func bas(f: (NotObjCEnum) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zim
-  @objc // access-note-move{{ClosureArguments.zim(f:)}}
+  @objc // bad-access-note-move{{ClosureArguments.zim(f:)}}
   func zim(f: () -> NotObjCStruct) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func zang
-  @objc // access-note-move{{ClosureArguments.zang(f:)}}
+  @objc // bad-access-note-move{{ClosureArguments.zang(f:)}}
   func zang(f: (NotObjCEnum, NotObjCStruct) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
-  @objc // access-note-move{{ClosureArguments.zangZang(f:)}}
+  @objc // bad-access-note-move{{ClosureArguments.zangZang(f:)}}
   func zangZang(f: (Int...) -> ()) {} // access-note-adjust expected-error{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}} expected-note{{function types cannot be represented in Objective-C unless their parameters and returns can be}}
   // CHECK: @objc func fooImplicit
   func fooImplicit(f: (Int) -> ()) {}
@@ -2211,24 +2211,24 @@ class Load3 {
 // Members of protocol extensions cannot be @objc
 
 extension PlainProtocol {
-  @objc // access-note-move{{PlainProtocol.property}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{PlainProtocol.property}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   var property: Int { return 5 }
 
-  @objc // access-note-move{{PlainProtocol.subscript(_:)}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{PlainProtocol.subscript(_:)}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() }
 
-  @objc // access-note-move{{PlainProtocol.fun()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{PlainProtocol.fun()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func fun() { }
 }
 
 extension Protocol_ObjC1 {
-  @objc // access-note-move{{Protocol_ObjC1.property}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{Protocol_ObjC1.property}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   var property: Int { return 5 }
 
-  @objc // access-note-move{{Protocol_ObjC1.subscript(_:)}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{Protocol_ObjC1.subscript(_:)}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   subscript(x: Int) -> Class_ObjC1 { return Class_ObjC1() }
 
-  @objc // access-note-move{{Protocol_ObjC1.fun()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
+  @objc // bad-access-note-move{{Protocol_ObjC1.fun()}} expected-error{{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}}
   func fun() { }
 }
 
@@ -2267,27 +2267,27 @@ class ClassThrows1 {
 
   // Errors
 
-  @objc // access-note-move{{ClassThrows1.methodReturnsOptionalObjCClass()}}
+  @objc // bad-access-note-move{{ClassThrows1.methodReturnsOptionalObjCClass()}}
   func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of optional type 'Class_ObjC1?'; 'nil' indicates failure to Objective-C}}
 
-  @objc // access-note-move{{ClassThrows1.methodReturnsOptionalArray()}}
+  @objc // bad-access-note-move{{ClassThrows1.methodReturnsOptionalArray()}}
   func methodReturnsOptionalArray() throws -> [String]? { return nil } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of optional type '[String]?'; 'nil' indicates failure to Objective-C}}
 
-  @objc // access-note-move{{ClassThrows1.methodReturnsInt()}}
+  @objc // bad-access-note-move{{ClassThrows1.methodReturnsInt()}}
   func methodReturnsInt() throws -> Int { return 0 } // access-note-adjust expected-error{{throwing method cannot be marked @objc because it returns a value of type 'Int'; return 'Void' or a type that bridges to an Objective-C class}}
 
-  @objc // access-note-move{{ClassThrows1.methodAcceptsThrowingFunc(fn:)}}
+  @objc // bad-access-note-move{{ClassThrows1.methodAcceptsThrowingFunc(fn:)}}
   func methodAcceptsThrowingFunc(fn: (String) throws -> Int) { }
   // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{throwing function types cannot be represented in Objective-C}}
 
-  @objc // access-note-move{{ClassThrows1.init(radians:)}}
+  @objc // bad-access-note-move{{ClassThrows1.init(radians:)}}
   init?(radians: Double) throws { } // access-note-adjust expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
-  @objc // access-note-move{{ClassThrows1.init(string:)}}
+  @objc // bad-access-note-move{{ClassThrows1.init(string:)}}
   init!(string: String) throws { } // access-note-adjust expected-error{{a failable and throwing initializer cannot be marked @objc because 'nil' indicates failure to Objective-C}}
 
-  @objc // access-note-move{{ClassThrows1.fooWithErrorEnum1(x:)}}
+  @objc // bad-access-note-move{{ClassThrows1.fooWithErrorEnum1(x:)}}
   func fooWithErrorEnum1(x: ErrorEnum) {}
   // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{non-'@objc' enums cannot be represented in Objective-C}}
@@ -2295,7 +2295,7 @@ class ClassThrows1 {
   // CHECK: {{^}} func fooWithErrorEnum2(x: ErrorEnum)
   func fooWithErrorEnum2(x: ErrorEnum) {}
 
-  @objc // access-note-move{{ClassThrows1.fooWithErrorProtocolComposition1(x:)}}
+  @objc // bad-access-note-move{{ClassThrows1.fooWithErrorProtocolComposition1(x:)}}
   func fooWithErrorProtocolComposition1(x: Error & Protocol_ObjC1) { }
   // access-note-adjust expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   // expected-note@-2{{protocol-constrained type containing 'Error' cannot be represented in Objective-C}}
@@ -2338,7 +2338,7 @@ class ImplicitClassThrows1 {
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
   func methodReturnsBridgedValueType() throws -> NSRange { return NSRange() }
 
-  @objc // access-note-move{{ImplicitClassThrows1.methodReturnsBridgedValueType2()}}
+  @objc // bad-access-note-move{{ImplicitClassThrows1.methodReturnsBridgedValueType2()}}
   func methodReturnsBridgedValueType2() throws -> NSRange {
     return NSRange()
   }
@@ -2651,7 +2651,7 @@ protocol SR_9035_P {
 
 // SR-12801: Make sure we reject an @objc generic subscript.
 class SR12801 {
-  @objc // access-note-move{{SR12801.subscript(_:)}}
+  @objc // bad-access-note-move{{SR12801.subscript(_:)}}
   subscript<T>(foo : [T]) -> Int { return 0 }
   // access-note-adjust expected-error@-1 {{subscript cannot be marked @objc because it has generic parameters}}
 }

--- a/test/decl/protocol/effectful_properties_objc.swift
+++ b/test/decl/protocol/effectful_properties_objc.swift
@@ -5,10 +5,10 @@
 /////////
 // check for disallowed attributes in protocols
 @objc protocol Tea {
- var temperature : Double { get throws } // expected-error{{property with 'throws' or 'async' is not representable in Objective-C}}
- subscript(_ d : Double) -> Bool { get async throws } // expected-error{{subscript with 'throws' or 'async' is not representable in Objective-C}}
+ var temperature : Double { get throws } // expected-error{{property with 'throws' or 'async' is not representable in Objective-C}} expected-note{{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
+ subscript(_ d : Double) -> Bool { get async throws } // expected-error{{subscript with 'throws' or 'async' is not representable in Objective-C}} expected-note{{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
 
  // NOTE: this seems counter-intuitive, but TSPL says @nonobjc applies to
  // members that are representable in ObjC, and this is not representable.
- @nonobjc var sugar : Bool { get async } // expected-error{{property with 'throws' or 'async' is not representable in Objective-C}}
+ @nonobjc var sugar : Bool { get async } // expected-error{{property with 'throws' or 'async' is not representable in Objective-C}} expected-note{{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
 }


### PR DESCRIPTION
This PR will finalize the way diagnostics describe when they're caused by access notes.

Specifically, the pre-existing access note remarks are now only emitted for valid attributes; for invalid attributes, the diagnostic is augmented with text explaining that it was added for an access note and has been disabled:

```
class MyClass: NSObject {
    // Both of these methods have ObjC: true in access notes

    func good(_: Int) {}
    // remark: implicitly added '@objc' to this method, as specified by access note for <reason string>
    // note: add '@objc' explicitly to silence this warning

    func bad(_: Int?) {}
    // remark: ignored access note: the type of the parameter cannot be represented in Objective-C;
    //         did not implicitly add '@objc' to this method, even though it was specified by access
    //         note for <reason string>
}
```

To accomplish this behavior, this PR makes it possible for a diagnostic to take a `DiagnosticInfo *` as a parameter; it then adds an `InFlightDiagnostic::wrapIn()` method which uses this capability. Thus, an error like `diag::objc_invalid_on_func_single_param_type` can be wrapped in `diag::wrap_invalid_attr_added_by_access_note` to add verbiage relating to access notes.

This PR also:

* Emits one access note success remark covering all attributes added to each declaration, instead of separate ones for each attribute.
* Softens selector conflicts caused by access notes into remarks.
* Adds a command-line option which controls whether and how access note remarks are emitted; in particular, you can use it to strengthen ignored access notes back to errors.

~~I will probably be tweaking this further before I'm finished with this PR.~~

Fixes rdar://71872575.