### PR TITLE
[Serialization] Serialize internal closure labels

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -510,6 +510,7 @@ struct PrintOptions {
     result.PrintDocumentationComments = true;
     result.PrintRegularClangComments = true;
     result.PrintLongAttrsOnSeparateLines = true;
+    result.AlwaysTryPrintParameterLabels = true;
     return result;
   }
 
@@ -655,6 +656,7 @@ struct PrintOptions {
     PO.ShouldQualifyNestedDeclarations = QualifyNestedDeclarations::TypesOnly;
     PO.PrintParameterSpecifiers = true;
     PO.SkipImplicit = true;
+    PO.AlwaysTryPrintParameterLabels = true;
     return PO;
   }
 };

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -135,6 +135,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
   if (printFullConvention)
     result.PrintFunctionRepresentationAttrs =
       PrintOptions::FunctionRepresentationMode::Full;
+  result.AlwaysTryPrintParameterLabels = true;
   result.PrintSPIs = printSPIs;
 
   // We should print __consuming, __owned, etc for the module interface file.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5250,12 +5250,13 @@ public:
         break;
 
       IdentifierID labelID;
+      IdentifierID internalLabelID;
       TypeID typeID;
       bool isVariadic, isAutoClosure, isNonEphemeral, isNoDerivative;
       unsigned rawOwnership;
       decls_block::FunctionParamLayout::readRecord(
-          scratch, labelID, typeID, isVariadic, isAutoClosure, isNonEphemeral,
-          rawOwnership, isNoDerivative);
+          scratch, labelID, internalLabelID, typeID, isVariadic, isAutoClosure,
+          isNonEphemeral, rawOwnership, isNoDerivative);
 
       auto ownership =
           getActualValueOwnership((serialization::ValueOwnership)rawOwnership);
@@ -5269,7 +5270,8 @@ public:
       params.emplace_back(paramTy.get(), MF.getIdentifier(labelID),
                           ParameterTypeFlags(isVariadic, isAutoClosure,
                                              isNonEphemeral, *ownership,
-                                             isNoDerivative));
+                                             isNoDerivative),
+                          MF.getIdentifier(internalLabelID));
     }
 
     if (!isGeneric) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 607; // async / throws property decls
+const uint16_t SWIFTMODULE_VERSION_MINOR = 608; // internal parameter labels
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1007,6 +1007,7 @@ namespace decls_block {
   using FunctionParamLayout = BCRecordLayout<
     FUNCTION_PARAM,
     IdentifierIDField,   // name
+    IdentifierIDField,   // internal label
     TypeIDField,         // type
     BCFixed<1>,          // vararg?
     BCFixed<1>,          // autoclosure?

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4345,6 +4345,7 @@ public:
       FunctionParamLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode,
           S.addDeclBaseNameRef(param.getLabel()),
+          S.addDeclBaseNameRef(param.getInternalLabel()),
           S.addTypeRef(param.getPlainType()), paramFlags.isVariadic(),
           paramFlags.isAutoClosure(), paramFlags.isNonEphemeral(), rawOwnership,
           paramFlags.isNoDerivative());

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -89,7 +89,7 @@ func testArchetypeReplacement2<BAR : Equatable>(_ a: [BAR]) {
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         min({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         max({#by: (Equatable, Equatable) throws -> Bool##(Equatable, Equatable) throws -> Bool#})[' rethrows'][#Equatable?#]{{; name=.+}}
 // FIXME: The following should include 'partialResult' as local parameter name: "(nextPartialResult): (_ partialResult: Result, Equatable)"
-// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         reduce({#(initialResult): Result#}, {#(nextPartialResult): (Result, Equatable) throws -> Result##(Result, Equatable) throws -> Result#})[' rethrows'][#Result#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         reduce({#(initialResult): Result#}, {#(nextPartialResult): (Result, Equatable) throws -> Result##(_ partialResult: Result, Equatable) throws -> Result#})[' rethrows'][#Result#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_6-DAG: Decl[InstanceMethod]/Super/IsSystem:         dropFirst({#(k): Int#})[#ArraySlice<Equatable>#]{{; name=.+}}
 // FIXME: restore Decl[InstanceMethod]/Super:         flatMap({#(transform): (Equatable) throws -> Sequence##(Equatable) throws -> Sequence#})[' rethrows'][#[IteratorProtocol.Element]#]{{; name=.+}}
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -12,7 +12,7 @@
 //
 // RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=false -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
-// RUN: %FileCheck %s -check-prefix=PASS_PRINT_AST -strict-whitespace < %t.printed.txt
+// RUN: %FileCheck %s -check-prefixes=PASS_PRINT_AST,PASS_PRINT_AST_TYPE -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_GET_SET -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_2200 -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_2500 -strict-whitespace < %t.printed.txt
@@ -23,7 +23,7 @@
 //
 // RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -swift-version 4 -skip-deinit=false -print-ast-typechecked -source-filename %s -F %S/Inputs/mock-sdk -function-definitions=false -prefer-type-repr=true -print-implicit-attrs=true -enable-objc-interop -disable-objc-attr-requires-foundation-module > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_COMMON -strict-whitespace < %t.printed.txt
-// RUN: %FileCheck %s -check-prefix=PASS_PRINT_AST -strict-whitespace < %t.printed.txt
+// RUN: %FileCheck %s -check-prefixes=PASS_PRINT_AST,PASS_PRINT_AST_TYPEREPR -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_RW_PROP_GET_SET -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_2200 -strict-whitespace < %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=PASS_2500 -strict-whitespace < %t.printed.txt
@@ -1343,8 +1343,15 @@ public func ParamAttrs5(a : (@escaping () -> ()) -> ()) {
 // PASS_PRINT_AST: public typealias ParamAttrs6 = (@autoclosure () -> ()) -> ()
 public typealias ParamAttrs6 = (@autoclosure () -> ()) -> ()
 
-// PASS_PRINT_AST: public var ParamAttrs7: (@escaping () -> ()) -> ()
+// The following type only has the internal paramter name inferred from the
+// closure on the right-hand side of `=`. Thus, it is only part of the `Type`
+// and not part of the `TypeRepr`.
+// PASS_PRINT_AST_TYPE: public var ParamAttrs7: (_ f: @escaping () -> ()) -> ()
+// PASS_PRINT_AST_TYPEREPR: public var ParamAttrs7: (@escaping () -> ()) -> ()
 public var ParamAttrs7: (@escaping () -> ()) -> () = { f in f() }
+
+// PASS_PRINT_AST: public var ParamAttrs8: (_ f: @escaping () -> ()) -> ()
+public var ParamAttrs8: (_ f: @escaping () -> ()) -> () = { f in f() }
 
 // Setter
 // PASS_PRINT_AST: class FooClassComputed {

--- a/test/IDE/print_types.swift
+++ b/test/IDE/print_types.swift
@@ -9,8 +9,8 @@ typealias MyInt = Int
 // FULL:  TypeAliasDecl '''MyInt''' swift_ide_test.MyInt.Type{{$}}
 
 func testVariableTypes(_ param: Int, param2: inout Double) {
-// CHECK: FuncDecl '''testVariableTypes''' (Int, inout Double) -> (){{$}}
-// FULL:  FuncDecl '''testVariableTypes''' (Swift.Int, inout Swift.Double) -> (){{$}}
+// CHECK: FuncDecl '''testVariableTypes''' (_ param: Int, param2: inout Double) -> (){{$}}
+// FULL:  FuncDecl '''testVariableTypes''' (_ param: Swift.Int, param2: inout Swift.Double) -> (){{$}}
 
   var a1 = 42
 // CHECK: VarDecl '''a1''' Int{{$}}
@@ -92,16 +92,16 @@ func testFuncType6() -> (Int, Int) {}
 // FULL:  FuncDecl '''testFuncType6''' () -> (Swift.Int, Swift.Int){{$}}
 
 func testFuncType7(_ a: Int, withFloat b: Float) {}
-// CHECK: FuncDecl '''testFuncType7''' (Int, Float) -> (){{$}}
-// FULL:  FuncDecl '''testFuncType7''' (Swift.Int, Swift.Float) -> (){{$}}
+// CHECK: FuncDecl '''testFuncType7''' (_ a: Int, withFloat: Float) -> (){{$}}
+// FULL:  FuncDecl '''testFuncType7''' (_ a: Swift.Int, withFloat: Swift.Float) -> (){{$}}
 
 func testVariadicFuncType(_ a: Int, b: Float...) {}
-// CHECK: FuncDecl '''testVariadicFuncType''' (Int, Float...) -> (){{$}}
-// FULL:  FuncDecl '''testVariadicFuncType''' (Swift.Int, Swift.Float...) -> (){{$}}
+// CHECK: FuncDecl '''testVariadicFuncType''' (_ a: Int, b: Float...) -> (){{$}}
+// FULL:  FuncDecl '''testVariadicFuncType''' (_ a: Swift.Int, b: Swift.Float...) -> (){{$}}
 
 func testCurriedFuncType1(_ a: Int) -> (_ b: Float) -> () {}
-// CHECK: FuncDecl '''testCurriedFuncType1''' (Int) -> (Float) -> (){{$}}
-// FULL:  FuncDecl '''testCurriedFuncType1''' (Swift.Int) -> (Swift.Float) -> (){{$}}
+// CHECK: FuncDecl '''testCurriedFuncType1''' (_ a: Int) -> (_ b: Float) -> (){{$}}
+// FULL:  FuncDecl '''testCurriedFuncType1''' (_ a: Swift.Int) -> (_ b: Swift.Float) -> (){{$}}
 
 protocol FooProtocol {}
 protocol BarProtocol {}
@@ -110,8 +110,8 @@ protocol QuxProtocol { associatedtype Qux }
 struct GenericStruct<A, B : FooProtocol> {}
 
 func testInGenericFunc1<A, B : FooProtocol, C : FooProtocol & BarProtocol>(_ a: A, b: B, c: C) {
-// CHECK: FuncDecl '''testInGenericFunc1''' <A, B, C where B : FooProtocol, C : BarProtocol, C : FooProtocol> (A, b: B, c: C) -> (){{$}}
-// FULL:  FuncDecl '''testInGenericFunc1''' <A, B, C where B : swift_ide_test.FooProtocol, C : swift_ide_test.BarProtocol, C : swift_ide_test.FooProtocol> (A, b: B, c: C) -> (){{$}}
+// CHECK: FuncDecl '''testInGenericFunc1''' <A, B, C where B : FooProtocol, C : BarProtocol, C : FooProtocol> (_ a: A, b: B, c: C) -> (){{$}}
+// FULL:  FuncDecl '''testInGenericFunc1''' <A, B, C where B : swift_ide_test.FooProtocol, C : swift_ide_test.BarProtocol, C : swift_ide_test.FooProtocol> (_ a: A, b: B, c: C) -> (){{$}}
 
   var a1 = a
   _ = a1; a1 = a

--- a/test/SourceKit/DocSupport/doc_internal_closure_label.swift
+++ b/test/SourceKit/DocSupport/doc_internal_closure_label.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t.module-cache)
+//
+// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/label.swiftinterface -enable-library-evolution -module-cache-path %t.module-cache %s
+// RUN: %FileCheck --check-prefix=SWIFT_INTERFACE %s < %t/label.swiftinterface
+// RUN: %sourcekitd-test -req=doc-info -module label -- -I %t -target %target-triple -module-cache-path %t.module-cache > %t.response
+// RUN: %diff -u %s.response %t.response
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t.module-cache)
+// RUN: %target-swift-frontend -emit-module %s -module-name label -emit-module-path %t/label.swiftmodule -module-cache-path %t.module-cache
+// RUN: %sourcekitd-test -req=doc-info -module label -- -I %t -target %target-triple -module-cache-path %t.module-cache> %t.response
+// RUN: %diff -u %s.response %t.response
+
+public func foo(_ callback: (_ myInternalParam: Int) -> Void) {}
+
+// SWIFT_INTERFACE: import Swift
+// SWIFT_INTERFACE: public func foo(_ callback: (_ myInternalParam: Swift.Int) -> Swift.Void)

--- a/test/SourceKit/DocSupport/doc_internal_closure_label.swift.response
+++ b/test/SourceKit/DocSupport/doc_internal_closure_label.swift.response
@@ -1,0 +1,80 @@
+import SwiftOnoneSupport
+
+func foo(_ callback: (_ myInternalParam: Int) -> Void)
+
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 26,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 31,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 35,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 37,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 48,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 50,
+    key.length: 15
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
+    key.offset: 67,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.name: "Void",
+    key.usr: "s:s4Voida",
+    key.offset: 75,
+    key.length: 4
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.name: "foo(_:)",
+    key.usr: "s:5label3fooyyySiXEF",
+    key.offset: 26,
+    key.length: 54,
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>callback</decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter>_ <decl.var.parameter.name>myInternalParam</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.typealias usr=\"s:s4Voida\">Void</ref.typealias></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.var.local,
+        key.keyword: "_",
+        key.name: "callback",
+        key.offset: 47,
+        key.length: 32
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Since https://github.com/apple/swift/pull/36551 we are keeping track of internal closure labels in the closure’s type. With this change, wer are also serializing them to the swiftmodules.

Furthermore, this change adjusts the printing behaviour to print the parameter labels in the swift interfaces.

I’m not sure if printing the parameter labels in all cases (especially `print_types.swift`) is actually beneficial because I don’t have a detailed understanding of what they are used for.

Resolves rdar://63633158