### PR TITLE
[CodeComplete] Fix issue with completion in string literal as last token in case stmt

### DIFF
--- a/test/IDE/complete_sr14455.swift
+++ b/test/IDE/complete_sr14455.swift
@@ -1,0 +1,17 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token=COMPLETE | %FileCheck %s
+
+public enum Endpoint {
+  case movieDetail
+
+
+  func path() -> String {
+    switch self {
+    case .movieDetail:
+      let myInt: Int = 2
+      return "\(#^COMPLETE^#)"
+    }
+  }
+}
+// CHECK: Begin completions
+// CHECK: Decl[LocalVar]/Local/TypeRelation[Convertible]: myInt[#Int#];
+// CHECK: End completions


### PR DESCRIPTION
The last token in a case stmt can be a string literal token, which can *contain* its interpolation segments. If one of these interpolation segments is the reference point, we'd return false from `isReferencePointInRange` because the string literal token's start location is before the interpolation token. To fix this, adjust the range we are checking to range until the end of the string interpolation token.

I chose to adjust the range for the brace statements only if the statement is implicit to avoid setting up the lexer to retrieve the token’s end location unless necessary. 

Fixes rdar://76330416 [SR-14455]