### PR TITLE
[CodeComplete] Fix issue completing type in generic signature

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1582,7 +1582,7 @@ public:
   DeclNameRef parseDeclNameRef(DeclNameLoc &loc, const Diagnostic &diag,
                                DeclNameOptions flags);
 
-  Expr *parseExprIdentifier();
+  ParserResult<Expr> parseExprIdentifier();
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,
                                    Identifier PlaceholderId);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1545,7 +1545,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
 
     LLVM_FALLTHROUGH;
   case tok::kw_Self:     // Self
-    return makeParserResult(parseExprIdentifier());
+    return parseExprIdentifier();
 
   case tok::kw_Any: { // Any
     ExprContext.setCreateSyntax(SyntaxKind::TypeExpr);
@@ -2192,7 +2192,8 @@ DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
 
 ///   expr-identifier:
 ///     unqualified-decl-name generic-args?
-Expr *Parser::parseExprIdentifier() {
+ParserResult<Expr> Parser::parseExprIdentifier() {
+  ParserStatus status;
   assert(Tok.isAny(tok::identifier, tok::kw_self, tok::kw_Self));
   SyntaxParsingContext IDSyntaxContext(SyntaxContext,
                                        SyntaxKind::IdentifierExpr);
@@ -2217,8 +2218,9 @@ Expr *Parser::parseExprIdentifier() {
   if (canParseAsGenericArgumentList()) {
     SyntaxContext->createNodeInPlace(SyntaxKind::IdentifierExpr);
     SyntaxContext->setCreateSyntax(SyntaxKind::SpecializeExpr);
-    auto argStat = parseGenericArguments(args, LAngleLoc, RAngleLoc);
-    if (argStat.isErrorOrHasCompletion())
+    auto argStatus = parseGenericArguments(args, LAngleLoc, RAngleLoc);
+    status |= argStatus;
+    if (argStatus.isErrorOrHasCompletion())
       diagnose(LAngleLoc, diag::while_parsing_as_left_angle_bracket);
     
     // The result can be empty in error cases.
@@ -2227,7 +2229,8 @@ Expr *Parser::parseExprIdentifier() {
   
   if (name.getBaseName().isEditorPlaceholder()) {
     IDSyntaxContext.setCreateSyntax(SyntaxKind::EditorPlaceholderExpr);
-    return parseExprEditorPlaceholder(IdentTok, name.getBaseIdentifier());
+    return makeParserResult(
+        status, parseExprEditorPlaceholder(IdentTok, name.getBaseIdentifier()));
   }
 
   auto refKind = DeclRefKind::Ordinary;
@@ -2237,7 +2240,7 @@ Expr *Parser::parseExprIdentifier() {
     E = UnresolvedSpecializeExpr::create(Context, E, LAngleLoc, args,
                                          RAngleLoc);
   }
-  return E;
+  return makeParserResult(status, E);
 }
 
 Expr *Parser::parseExprEditorPlaceholder(Token PlaceholderTok,
@@ -2508,7 +2511,9 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
         // If this is the simple case, then the identifier is both the name and
         // the expression to capture.
         name = Context.getIdentifier(Tok.getText());
-        initializer = parseExprIdentifier();
+        auto initializerResult = parseExprIdentifier();
+        status |= initializerResult;
+        initializer = initializerResult.get();
 
         // It is a common error to try to capture a nested field instead of just
         // a local name, reject it with a specific error message.

--- a/test/IDE/complete_generic_param.swift
+++ b/test/IDE/complete_generic_param.swift
@@ -4,6 +4,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT4 | %FileCheck %s -check-prefix=INHERIT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT5 | %FileCheck %s -check-prefix=INHERIT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INHERIT6 | %FileCheck %s -check-prefix=INHERIT
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TYPE_PARAM
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=SECOND_GENERIC_TYPE_PARAM | %FileCheck %s -check-prefix=GENERIC_TYPE_PARAM
 
 class C1{}
 protocol P1{}
@@ -34,3 +36,12 @@ class C3 {
 // INHERIT-NOT: ValueInt1
 // INHERIT-NOT: ValueString2
 // INHERIT-NOT: TopLevelFunc
+
+
+class Sr14432<T, U> {}
+
+_ = Sr14432<#^GENERIC_TYPE_PARAM^# >()
+_ = Sr14432<SomeType, #^SECOND_GENERIC_TYPE_PARAM^# >()
+// GENERIC_TYPE_PARAM: Begin completions
+// GENERIC_TYPE_PARAM-DAG: Decl[Class]/CurrModule:             C1[#C1#];
+// GENERIC_TYPE_PARAM: End completions


### PR DESCRIPTION
Due to https://github.com/apple/swift/pull/36552, parsing the code completion token as a type inside a generic parameter list no longer fails. Instead, it consumes the code completion token as a type identifier. However, since `parseExprIdentifer` does not return a `ParserStatus`, the information whether a code completion token was consumed gets lost, causing `setCodeCompletionDelayedDeclState` to not be called and thus no code completion results show up.

To resolve this, make `parseExprIdentifier` return its `ParserStatus` through a `ParserResult`.

Fixes rdar://76335452 [SR-14432]
