### PR TITLE
IRGen: ObjC rodata can only go in __objc_const if layout is fixed.

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1494,7 +1494,12 @@ namespace {
       emitRODataFields(fields, forMeta, hasUpdater);
       
       auto dataSuffix = forMeta ? "_METACLASS_DATA_" : "_DATA_";
-      return buildGlobalVariable(fields, dataSuffix, /*const*/ true);
+      
+      // The rodata is constant if the object layout is known entirely
+      // statically. Otherwise, the ObjC runtime may slide the InstanceSize
+      // based on changing base class layout.
+      return buildGlobalVariable(fields, dataSuffix,
+                               /*const*/ forMeta || FieldLayout->isFixedSize());
     }
 
   private:

--- a/test/IRGen/Inputs/ObjCBaseClasses.h
+++ b/test/IRGen/Inputs/ObjCBaseClasses.h
@@ -1,0 +1,4 @@
+#import <Foundation.h>
+
+@interface ObjCBase: NSObject
+@end

--- a/test/IRGen/Inputs/ResilientBaseClasses.swift
+++ b/test/IRGen/Inputs/ResilientBaseClasses.swift
@@ -1,0 +1,1 @@
+open class ResilientBase {}

--- a/test/IRGen/objc_class_rodata_const.swift
+++ b/test/IRGen/objc_class_rodata_const.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module-path %t/ResilientBaseClasses.swiftmodule %S/Inputs/ResilientBaseClasses.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -import-objc-header %S/Inputs/ObjCBaseClasses.h -emit-ir %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+
+import ResilientBaseClasses
+
+// CHECK: @_METACLASS_DATA_{{.*}}9PureSwift = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+// CHECK: @_DATA_{{.*}}9PureSwift = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+class PureSwift {
+    var x: Int = 0
+}
+
+// CHECK: @_METACLASS_DATA_{{.*}}12PureSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+// CHECK: @_DATA_{{.*}}12PureSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+class PureSwiftSub: PureSwift {
+    var y: Int = 0
+}
+
+// CHECK: @_METACLASS_DATA_{{.*}}12ObjCSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+// CHECK: @_DATA_{{.*}}12ObjCSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_data"
+class ObjCSwiftSub: ObjCBase {
+    var z: Int = 0
+}
+
+// CHECK: @_METACLASS_DATA_{{.*}}17ResilientSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_const"
+// CHECK: @_DATA_{{.*}}17ResilientSwiftSub = {{.*}} constant {{.*}} section "__DATA, __objc_data"
+class ResilientSwiftSub: ResilientBase {
+    var z: Int = 0
+}


### PR DESCRIPTION
Otherwise, the runtime needs to be able to adjust the instance size when nonfragile ObjC bases
and/or resilient Swift bases are accounted for. rdar://54089488