### PR TITLE
Add support for cross compiling from Apple Silicon to Intel

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1019,7 +1019,7 @@ function false_true() {
 CROSS_COMPILE_HOSTS=($CROSS_COMPILE_HOSTS)
 for t in "${CROSS_COMPILE_HOSTS[@]}"; do
     case ${t} in
-        macosx-arm64* | iphone* | appletv* | watch* | linux-armv6 | linux-armv7 | android-* )
+        macosx* | iphone* | appletv* | watch* | linux-armv6 | linux-armv7 | android-* )
             ;;
         *)
             echo "Unknown host to cross-compile for: ${t}"


### PR DESCRIPTION
If you have an Apple Silicon machine but want to produce an Intel
binary, using `--cross-compile-hosts macosx-x86_64` can be useful.