### PR TITLE
[ConstraintSystem] Allow fixing r-value -> l-value mismatch without a…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3667,6 +3667,12 @@ bool ConstraintSystem::repairFailures(
                                TMF_ApplyingFix, locator);
 
       if (result.isSuccess()) {
+        // If left side is a hole, let's not record a fix since hole can
+        // assume any type and already represents a problem elsewhere in
+        // the expression.
+        if (lhs->isPlaceholder())
+          return true;
+
         conversionsOrFixes.push_back(
             TreatRValueAsLValue::create(*this, getConstraintLocator(locator)));
         return true;

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1084,3 +1084,16 @@ var emptyBodyMismatch: () -> Int {
     return
   }
 }
+
+// rdar://76250381 - crash when passing an argument to a closure that takes no arguments
+struct R_76250381<Result, Failure: Error> {
+  func test(operation: @escaping () -> Result) -> Bool {
+    return try self.crash { group in // expected-error {{contextual closure type '() -> Result' expects 0 arguments, but 1 was used in closure body}}
+      operation(&group) // expected-error {{argument passed to call that takes no arguments}}
+    }
+  }
+
+  func crash(_: @escaping () -> Result) -> Bool {
+    return false
+  }
+}


### PR DESCRIPTION
… fix for placeholders

If left-hand side of a conversion that requires l-value is a placeholder type,
let's fix that by propagating placeholder to the order side (to allow it to
infer a placeholder if needed) without recording a fix since placeholder can
be converted to `inout` and/or l-value and already indicates existence of a
problem at some other spot in the expression.

Resolves: rdar://76250381

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
