### PR TITLE
[ASTPrinter] Don't transform type if current type can't have members

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_info_existential_var.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_existential_var.swift
@@ -1,0 +1,13 @@
+protocol MyError {
+    var myVar: String { get }
+}
+
+func foo(error: MyError) {
+    _ = error.myVar
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=6:15 %s -- %s | %FileCheck %s
+// CHECK: myVar
+// CHECK-NEXT: s:27cursor_info_existential_var7MyErrorP5myVarSSvp
+// CHECK-NEXT: source.lang.swift
+// CHECK-NEXT: String


### PR DESCRIPTION
Since https://github.com/apple/swift/pull/36784 we always transform `CurrentType` in `ASTPrinter` to be an interface type.

This causes issues for variables that whose type is a protocol. Previously, when printing the type, we had `CurrentType` set to an `OpenedArchetypeType`. Now we replace the archetype by a `GenericTypeParamType`, which may not have members, so we are hitting an assertion in [`ASTPrinter.cpp:270`](https://github.com/apple/swift/blob/main/lib/AST/ASTPrinter.cpp#L270). The simplest solution to solve this, seems to be to not perform any type substitutions in `printTransformedTypeWithOptions` if `CurrentType` may not have members. AFAICT no substitutions were happening previously as well because protocols can’t be nested in other declarations.

Resolves rdar://76580851 [SR-14479]