### PR TITLE
C++ Interop: fix crash for Swift extensions of C++ classes declared in namespaces

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2303,9 +2303,9 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl) {
                isa<clang::ObjCCompatibleAliasDecl>(namedDecl)) {
       appendOperator("a");
     } else if (isa<clang::NamespaceDecl>(namedDecl)) {
-      // Note: Namespaces are not really structs, but since namespaces are
+      // Note: Namespaces are not really enums, but since namespaces are
       // imported as enums, be consistent.
-      appendOperator("V");
+      appendOperator("O");
     } else {
       llvm_unreachable("unknown imported Clang type");
     }

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -9,17 +9,17 @@ func indirectUsage() {
   useT(makeT())
 }
 
-// CHECK-LABEL: define hidden swiftcc %swift.type* @"$s6cxx_ir14reflectionInfo3argypXpSo2nsV10CXXInteropE1TV_tF"
-// CHECK: %0 = call swiftcc %swift.metadata_response @"$sSo2nsV10CXXInteropE1TVMa"({{i64|i32}} 0)
+// CHECK-LABEL: define hidden swiftcc %swift.type* @"$s6cxx_ir14reflectionInfo3argypXpSo2nsO10CXXInteropE1TV_tF"
+// CHECK: %0 = call swiftcc %swift.metadata_response @"$sSo2nsO10CXXInteropE1TVMa"({{i64|i32}} 0)
 func reflectionInfo(arg: namespacedT) -> Any.Type {
   return type(of: arg)
 }
 
-// CHECK: define hidden swiftcc void @"$s6cxx_ir24namespaceManglesIntoName3argySo2nsV10CXXInteropE1TV_tF"
+// CHECK: define hidden swiftcc void @"$s6cxx_ir24namespaceManglesIntoName3argySo2nsO10CXXInteropE1TV_tF"
 func namespaceManglesIntoName(arg: namespacedT) {
 }
 
-// CHECK: define hidden swiftcc void @"$s6cxx_ir42namespaceManglesIntoNameForUsingShadowDecl3argySo2nsV10CXXInteropE14NamespacedTypeV_tF"
+// CHECK: define hidden swiftcc void @"$s6cxx_ir42namespaceManglesIntoNameForUsingShadowDecl3argySo2nsO10CXXInteropE14NamespacedTypeV_tF"
 func namespaceManglesIntoNameForUsingShadowDecl(arg: NamespacedType) {
 }
 

--- a/test/Interop/Cxx/class/Inputs/extensions.h
+++ b/test/Interop/Cxx/class/Inputs/extensions.h
@@ -1,0 +1,14 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_EXTENSIONS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_EXTENSIONS_H
+
+namespace Outer {
+namespace Space {
+
+struct Foo {
+  int a;
+};
+
+}
+}
+
+#endif //TEST_INTEROP_CXX_CLASS_INPUTS_EXTENSIONS_H

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -23,6 +23,11 @@ module Destructors {
   requires cplusplus
 }
 
+module Extensions {
+  header "extensions.h"
+  requires cplusplus
+}
+
 module LoadableTypes {
   header "loadable-types.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/extensions-executable.swift
+++ b/test/Interop/Cxx/class/extensions-executable.swift
@@ -1,0 +1,18 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import Extensions
+
+var CxxClassExtensionsTestSuite = TestSuite("CxxClassExtensions")
+
+extension Outer.Space.Foo {
+  func bar() -> Int32 { return a + 1 }
+}
+
+CxxClassExtensionsTestSuite.test("calling extension method") {
+  var foo = Outer.Space.Foo(a: 123)
+  expectEqual(124, foo.bar())
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/extensions-irgen.swift
+++ b/test/Interop/Cxx/class/extensions-irgen.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+//
+// We can't yet call member functions correctly on Windows (SR-13129).
+// XFAIL: OS=windows-msvc
+
+import Extensions
+
+extension Outer.Space.Foo {
+  func foo() {}
+}
+
+Outer.Space.Foo().foo()
+
+// CHECK: call swiftcc void @"$sSo5OuterO5SpaceO10ExtensionsE3FooV4mainE3fooyyF"
+
+// CHECK: define hidden swiftcc void @"$sSo5OuterO5SpaceO10ExtensionsE3FooV4mainE3fooyyF"

--- a/test/Interop/Cxx/class/extensions-typechecker.swift
+++ b/test/Interop/Cxx/class/extensions-typechecker.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+
+import Extensions
+
+extension Outer.Space.Foo {
+  func bar() -> Int32 { return a }
+}
+
+extension Outer.Space.Foo: ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: IntegerLiteralType) {
+    self.init(a: Int32(value))
+  }
+}
+
+var it: Outer.Space.Foo = 123
+let res = it.bar()


### PR DESCRIPTION
This change makes this code compile & run correctly:

```swift
import std

extension std.__1.string: ExpressibleByStringLiteral {
  public init(stringLiteral value: String) {
    self.init()
    for char in value.utf8CString.dropLast() {
      push_back(char)
    }
  }

  public mutating func asString() -> String? {
    return String(validatingUTF8: data())
  }
}

var a: std.__1.string = "abcde"
print(a.asString()!)
```

Previously it caused a compiler crash in `IRGenDebugInfoImpl::getMangledName`:
~~~
Failed to reconstruct type for $sSo3stdV3__1V0A7_configE056__CxxTemplateInstNSt3__112basic_stringIcNS_11char_traitsi15EENS_9allocatorI4EEEEVXMtD
Original type:
(metatype_type thin
  (struct_type decl=std_config.(file).__1 extension.__CxxTemplateInstNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE
    (parent=enum_type decl=__ObjC.(file).std.__1
      (parent=enum_type decl=__ObjC.(file).std))))
~~~