### PR TITLE
Reinstate "SIL: add a StackList data structure with zero cost operations."

### DIFF
--- a/include/swift/SIL/BasicBlockBits.h
+++ b/include/swift/SIL/BasicBlockBits.h
@@ -14,8 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SIL_SILBITFIELD_H
-#define SWIFT_SIL_SILBITFIELD_H
+#ifndef SWIFT_SIL_BASICBLOCKBITS_H
+#define SWIFT_SIL_BASICBLOCKBITS_H
 
 #include "swift/SIL/SILFunction.h"
 #include "llvm/ADT/SmallVector.h"
@@ -171,101 +171,6 @@ public:
   bool insert(SILBasicBlock *block) { return !flag.testAndSet(block); }
 
   void erase(SILBasicBlock *block) { flag.reset(block); }
-};
-
-/// An implementation of `llvm::SetVector<SILBasicBlock *,
-///                                       SmallVector<SILBasicBlock *, N>,
-///                                       BasicBlockSet>`.
-///
-/// Unfortunately it's not possible to use `llvm::SetVector` directly because
-/// the BasicBlockSet constructor needs a `SILFunction` argument.
-///
-/// Note: This class does not provide a `remove` method intentinally, because
-/// it would have a O(n) complexity.
-template <unsigned N> class BasicBlockSetVector {
-  using Vector = llvm::SmallVector<SILBasicBlock *, N>;
-
-  Vector vector;
-  BasicBlockSet set;
-  
-public:
-  using iterator = typename Vector::const_iterator;
-
-  BasicBlockSetVector(SILFunction *function) : set(function) {}
-
-  iterator begin() const { return vector.begin(); }
-  iterator end() const { return vector.end(); }
-
-  unsigned size() const { return vector.size(); }
-  bool empty() const { return vector.empty(); }
-
-  bool contains(SILBasicBlock *block) const { return set.contains(block); }
-
-  /// Returns true if \p block was not contained in the set before inserting.
-  bool insert(SILBasicBlock *block) {
-    if (set.insert(block)) {
-      vector.push_back(block);
-      return true;
-    }
-    return false;
-  }
-};
-
-/// A utility for processing basic blocks in a worklist.
-///
-/// It is basically a combination of a block vector and a block set. It can be
-/// used for typical worklist-processing algorithms.
-template <unsigned N> class BasicBlockWorklist {
-  llvm::SmallVector<SILBasicBlock *, N> worklist;
-  BasicBlockSet visited;
-  
-public:
-  /// Construct an empty worklist.
-  BasicBlockWorklist(SILFunction *function) : visited(function) {}
-
-  /// Initialize the worklist with \p initialBlock.
-  BasicBlockWorklist(SILBasicBlock *initialBlock)
-      : visited(initialBlock->getParent()) {
-    push(initialBlock);
-  }
-
-  /// Pops the last added element from the worklist or returns null, if the
-  /// worklist is empty.
-  SILBasicBlock *pop() {
-    if (worklist.empty())
-      return nullptr;
-    return worklist.pop_back_val();
-  }
-
-  /// Pushes \p block onto the worklist if \p block has never been push before.
-  bool pushIfNotVisited(SILBasicBlock *block) {
-    if (visited.insert(block)) {
-      worklist.push_back(block);
-      return true;
-    }
-    return false;
-  }
-
-  /// Like `pushIfNotVisited`, but requires that \p block has never been on the
-  /// worklist before.
-  void push(SILBasicBlock *block) {
-    assert(!visited.contains(block));
-    visited.insert(block);
-    worklist.push_back(block);
-  }
-
-  /// Like `pop`, but marks the returned block as "unvisited". This means, that
-  /// the block can be pushed onto the worklist again.
-  SILBasicBlock *popAndForget() {
-    if (worklist.empty())
-      return nullptr;
-    SILBasicBlock *block = worklist.pop_back_val();
-    visited.erase(block);
-    return block;
-  }
-
-  /// Returns true if \p block was visited, i.e. has been added to the worklist.
-  bool isVisited(SILBasicBlock *block) const { return visited.contains(block); }
 };
 
 } // namespace swift

--- a/include/swift/SIL/BasicBlockDatastructures.h
+++ b/include/swift/SIL/BasicBlockDatastructures.h
@@ -1,0 +1,120 @@
+//===--- BasicBlockDatastructures.h -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines efficient data structures for working with BasicBlocks.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_BASICBLOCKDATASTRUCTURES_H
+#define SWIFT_SIL_BASICBLOCKDATASTRUCTURES_H
+
+#include "swift/SIL/StackList.h"
+#include "swift/SIL/BasicBlockBits.h"
+
+namespace swift {
+
+/// An implementation of `llvm::SetVector<SILBasicBlock *,
+///                                       StackList<SILBasicBlock *>,
+///                                       BasicBlockSet>`.
+///
+/// Unfortunately it's not possible to use `llvm::SetVector` directly because
+/// the BasicBlockSet and StackList constructors needs a `SILFunction` argument.
+///
+/// Note: This class does not provide a `remove` method intentinally, because
+/// it would have a O(n) complexity.
+class BasicBlockSetVector {
+  StackList<SILBasicBlock *> vector;
+  BasicBlockSet set;
+  
+public:
+  using iterator = typename StackList<SILBasicBlock *>::iterator;
+
+  BasicBlockSetVector(SILFunction *function) : vector(function), set(function) {}
+
+  iterator begin() const { return vector.begin(); }
+  iterator end() const { return vector.end(); }
+
+  bool empty() const { return vector.empty(); }
+
+  bool contains(SILBasicBlock *block) const { return set.contains(block); }
+
+  /// Returns true if \p block was not contained in the set before inserting.
+  bool insert(SILBasicBlock *block) {
+    if (set.insert(block)) {
+      vector.push_back(block);
+      return true;
+    }
+    return false;
+  }
+};
+
+/// A utility for processing basic blocks in a worklist.
+///
+/// It is basically a combination of a block vector and a block set. It can be
+/// used for typical worklist-processing algorithms.
+class BasicBlockWorklist {
+  StackList<SILBasicBlock *> worklist;
+  BasicBlockSet visited;
+  
+public:
+  /// Construct an empty worklist.
+  BasicBlockWorklist(SILFunction *function)
+    : worklist(function), visited(function) {}
+
+  /// Initialize the worklist with \p initialBlock.
+  BasicBlockWorklist(SILBasicBlock *initialBlock)
+      : BasicBlockWorklist(initialBlock->getParent()) {
+    push(initialBlock);
+  }
+
+  /// Pops the last added element from the worklist or returns null, if the
+  /// worklist is empty.
+  SILBasicBlock *pop() {
+    if (worklist.empty())
+      return nullptr;
+    return worklist.pop_back_val();
+  }
+
+  /// Pushes \p block onto the worklist if \p block has never been push before.
+  bool pushIfNotVisited(SILBasicBlock *block) {
+    if (visited.insert(block)) {
+      worklist.push_back(block);
+      return true;
+    }
+    return false;
+  }
+
+  /// Like `pushIfNotVisited`, but requires that \p block has never been on the
+  /// worklist before.
+  void push(SILBasicBlock *block) {
+    assert(!visited.contains(block));
+    visited.insert(block);
+    worklist.push_back(block);
+  }
+
+  /// Like `pop`, but marks the returned block as "unvisited". This means, that
+  /// the block can be pushed onto the worklist again.
+  SILBasicBlock *popAndForget() {
+    if (worklist.empty())
+      return nullptr;
+    SILBasicBlock *block = worklist.pop_back_val();
+    visited.erase(block);
+    return block;
+  }
+
+  /// Returns true if \p block was visited, i.e. has been added to the worklist.
+  bool isVisited(SILBasicBlock *block) const { return visited.contains(block); }
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -57,6 +57,37 @@ class Output;
 
 namespace swift {
 
+/// A fixed size slab of memory, which can be allocated and freed by the
+/// SILModule at (basically) zero cost.
+class FixedSizeSlab : public llvm::ilist_node<FixedSizeSlab>,
+                       public SILAllocated<FixedSizeSlab> {
+public:
+  /// The capacity of the payload.
+  static constexpr size_t capacity = 64 * sizeof(uintptr_t);
+
+private:
+  friend class SILModule;
+
+  /// The magic number which is stored in overflowGuard.
+  static constexpr uintptr_t magicNumber = (uintptr_t)0xdeadbeafdeadbeafull;
+
+  /// The payload.
+  char data[capacity];
+  
+  /// Used for a cheap buffer overflow check - in the spirit of libgmalloc.
+  uintptr_t overflowGuard = magicNumber;
+
+public:
+  void operator=(const FixedSizeSlab &) = delete;
+  void operator delete(void *Ptr, size_t) = delete;
+
+  /// Returns the payload pointing to \p T.
+  template<typename T> T *dataFor() { return (T *)(&data[0]); }
+
+  /// Returns the payload pointing to const \p T
+  template<typename T> const T *dataFor() const { return (const T *)(&data[0]); }
+};
+
 class AnyFunctionType;
 class ASTContext;
 class FileUnit;
@@ -129,6 +160,7 @@ public:
   };
 
   using ActionCallback = std::function<void()>;
+  using SlabList = llvm::simple_ilist<FixedSizeSlab>;
 
 private:
   friend KeyPathPattern;
@@ -150,6 +182,12 @@ private:
 
   /// Allocator that manages the memory of all the pieces of the SILModule.
   mutable llvm::BumpPtrAllocator BPA;
+
+  /// The list of freed slabs, which can be reused.
+  SlabList freeSlabs;
+  
+  /// For consistency checking.
+  size_t numAllocatedSlabs = 0;
 
   /// The swift Module associated with this SILModule.
   ModuleDecl *TheSwiftModule;
@@ -732,6 +770,22 @@ public:
   template <typename T> T *allocate(unsigned Count) const {
     return static_cast<T *>(allocate(sizeof(T) * Count, alignof(T)));
   }
+
+  /// Allocates a slab of memory.
+  ///
+  /// This has (almost) zero cost, because for the first time, the allocation is
+  /// done with the BPA.
+  /// Subsequent allocations are reusing the already freed slabs.
+  FixedSizeSlab *allocSlab();
+  
+  /// Frees a slab.
+  ///
+  /// This has (almost) zero cost, because the slab is just put into the
+  /// freeSlabs list.
+  void freeSlab(FixedSizeSlab *slab);
+  
+  /// Frees all slabs of a list.
+  void freeAllSlabs(SlabList &slabs);
 
   template <typename T>
   MutableArrayRef<T> allocateCopy(ArrayRef<T> Array) const {

--- a/include/swift/SIL/StackList.h
+++ b/include/swift/SIL/StackList.h
@@ -1,0 +1,155 @@
+//===--- StackList.h - defines the StackList data structure -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_STACKLIST_H
+#define SWIFT_SIL_STACKLIST_H
+
+#include "swift/SIL/SILModule.h"
+
+namespace swift {
+
+/// A very efficient implementation of a stack, which can also be iterated over.
+///
+/// A StackList is the best choice for things like worklists, etc., if no random
+/// access is needed.
+/// Regardless of how large a Stack gets, there is no memory allocation needed
+/// (except maybe for the first few uses in the compiler run).
+/// All operations have (almost) zero cost.
+template <typename Element> class StackList {
+  /// The capacity of a single slab.
+  static constexpr size_t slabCapacity =
+      FixedSizeSlab::capacity / sizeof(Element);
+  
+  static_assert(slabCapacity > 0, "Element type to large for StackList");
+  static_assert(alignof(FixedSizeSlab) >= alignof(Element),
+                "Element alignment to large for StackList");
+  
+  /// Backlink to the module which manages the slab allocation.
+  SILModule &module;
+
+  /// The list of slabs.
+  ///
+  /// Invariant: there is always free space in the last slab to store at least
+  /// one element.
+  SILModule::SlabList slabs;
+  
+  /// The index of the next free element in endSlab.
+  ///
+  /// Invariant: endIndex < slabCapacity
+  unsigned endIndex = 0;
+
+  FixedSizeSlab *lastSlab() { return &*slabs.rbegin(); }
+  const FixedSizeSlab *lastSlab() const { return &*slabs.rbegin(); }
+
+  void allocSlab() { slabs.push_back(*module.allocSlab()); }
+
+  void growIfNeeded() {
+    if (endIndex == slabCapacity) {
+      allocSlab();
+      endIndex = 0;
+    }
+  }
+  
+
+public:
+  /// The Stack's iterator.
+  class iterator {
+    friend StackList<Element>;
+    const FixedSizeSlab *slab;
+    unsigned index;
+
+    iterator(const FixedSizeSlab *slab, unsigned index)
+      : slab(slab), index(index) {}
+      
+  public:
+    const Element &operator*() const {
+      assert(index < slabCapacity);
+      return slab->dataFor<Element>()[index];
+    }
+    const Element &operator->() const { return *this; }
+
+    iterator &operator++() {
+      assert(index < slabCapacity);
+      index++;
+      if (index == slabCapacity) {
+        slab = &*std::next(slab->getIterator());
+        index = 0;
+      }
+      return *this;
+    }
+    
+    iterator operator++(int unused) {
+      iterator copy = *this;
+      ++*this;
+      return copy;
+    }
+
+    friend bool operator==(iterator lhs, iterator rhs) {
+      return lhs.slab == rhs.slab && lhs.index == rhs.index;
+    }
+
+    friend bool operator!=(iterator lhs, iterator rhs) {
+      return !(lhs == rhs);
+    }
+  };
+
+  /// Constructor.
+  StackList(SILFunction *function) : module(function->getModule()) {
+    /// Allocate one slab so that there is free space for inserting the first
+    /// element.
+    allocSlab();
+  }
+
+  ~StackList() {
+    module.freeAllSlabs(slabs);
+  }
+
+  iterator begin() const { return iterator(&*slabs.begin(), 0); }
+  iterator end() const { return iterator(lastSlab(), endIndex); }
+  
+  bool empty() const {
+    return begin() == end();
+  }
+
+  /// Adds a new element at the end.
+  void push_back(const Element &newElement) {
+    assert(endIndex < slabCapacity);
+    lastSlab()->template dataFor<Element>()[endIndex++] = newElement;
+    growIfNeeded();
+  }
+
+  /// Adds a new element at the end.
+  void push_back(Element &&newElement) {
+    assert(endIndex < slabCapacity);
+    lastSlab()->template dataFor<Element>()[endIndex++] = std::move(newElement);
+    growIfNeeded();
+  }
+
+  /// Removes the last element and returns it.
+  Element pop_back_val() {
+    FixedSizeSlab *slab = lastSlab();
+    if (endIndex > 0)
+      return std::move(slab->dataFor<Element>()[--endIndex]);
+
+    assert(!empty());
+  
+    slabs.remove(*slab);
+    module.freeSlab(slab);
+    assert(!slabs.empty());
+    endIndex = slabCapacity - 1;
+    return std::move(lastSlab()->template dataFor<Element>()[endIndex]);
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -32,7 +32,7 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/PrettyStackTrace.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILLinkage.h"
@@ -2242,7 +2242,7 @@ void IRGenSILFunction::emitSILFunction() {
   // Invariant: for every block in the work queue, we have visited all
   // of its dominators.
   // Start with the entry block, for which the invariant trivially holds.
-  BasicBlockWorklist<32> workQueue(&*CurSILFn->getEntryBlock());
+  BasicBlockWorklist workQueue(&*CurSILFn->getEntryBlock());
 
   while (SILBasicBlock *bb = workQueue.pop()) {
     // Emit the block.

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -16,7 +16,7 @@
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/ApplySite.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "llvm/Support/CommandLine.h"
 
 using namespace swift;
@@ -148,7 +148,7 @@ bool MemoryLifetimeVerifier::isEnumTrivialAt(int locIdx,
   SILBasicBlock *startBlock = atInst->getParent();
   
   // Start at atInst an walk up the control flow.
-  BasicBlockWorklist<32> worklist(startBlock);
+  BasicBlockWorklist worklist(startBlock);
   while (SILBasicBlock *block = worklist.pop()) {
     auto start = (block == atInst->getParent() ? atInst->getReverseIterator()
                                                : block->rbegin());

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -18,7 +18,7 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILInstruction.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
@@ -103,7 +103,7 @@ static SILInstruction *getDeinitSafeClosureDestructionPoint(SILBasicBlock *bb) {
 
 static void findReachableExitBlocks(SILInstruction *i,
                                     SmallVectorImpl<SILBasicBlock *> &result) {
-  BasicBlockWorklist<32> worklist(i->getParent());
+  BasicBlockWorklist worklist(i->getParent());
 
   while (SILBasicBlock *bb = worklist.pop()) {
     if (bb->getTerminator()->isFunctionExiting()) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -23,7 +23,7 @@
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TerminatorUtils.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
@@ -84,7 +84,7 @@ public:
   ///
   /// This is a SetVector since several blocks may lead to the same error
   /// report and we iterate through these when producing the diagnostic.
-  BasicBlockSetVector<16> PossiblyUnreachableBlocks;
+  BasicBlockSetVector PossiblyUnreachableBlocks;
 
   /// The set of blocks in which we reported unreachable code errors.
   /// These are used to ensure that we don't issue duplicate reports.

--- a/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryCombine.cpp
@@ -31,7 +31,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/SILInstructionWorklist.h"
 #include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CanonicalizeInstruction.h"
@@ -206,7 +206,7 @@ static llvm::cl::opt<bool> EnableCanonicalizationAndTrivialDCE(
                    "dead code and canonicalizing SIL"));
 
 void MandatoryCombiner::addReachableCodeToWorklist(SILFunction &function) {
-  BasicBlockWorklist<32> blockWorklist(function.getEntryBlock());
+  BasicBlockWorklist blockWorklist(function.getEntryBlock());
   SmallVector<SILInstruction *, 128> initialInstructionWorklist;
 
   while (SILBasicBlock *block = blockWorklist.pop()) {

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -24,7 +24,7 @@
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/SimplifyInstruction.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -67,7 +67,7 @@ static llvm::cl::opt<bool> EnableSILCombineCanonicalize(
 /// worklist (this significantly speeds up SILCombine on code where many
 /// instructions are dead or constant).
 void SILCombiner::addReachableCodeToWorklist(SILBasicBlock *BB) {
-  BasicBlockWorklist<256> Worklist(BB);
+  BasicBlockWorklist Worklist(BB);
   llvm::SmallVector<SILInstruction *, 128> InstrsForSILCombineWorklist;
 
   while (SILBasicBlock *BB = Worklist.pop()) {

--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -72,7 +72,7 @@
 #define DEBUG_TYPE "sil-rr-code-motion"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILBuilder.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/BasicBlockData.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
@@ -554,7 +554,7 @@ void RetainCodeMotionContext::convergeCodeMotionDataFlow() {
   // Process each basic block with the genset and killset. Every time the
   // BBSetOut of a basic block changes, the optimization is rerun on its
   // successors. 
-  BasicBlockWorklist<16> WorkList(BlockStates.getFunction());
+  BasicBlockWorklist WorkList(BlockStates.getFunction());
   // Push into reverse post order so that we can pop from the back and get
   // post order.
   for (SILBasicBlock *B : PO->getReversePostOrder()) {
@@ -966,7 +966,7 @@ void ReleaseCodeMotionContext::convergeCodeMotionDataFlow() {
   // Process each basic block with the gen and kill set. Every time the
   // BBSetIn of a basic block changes, the optimization is rerun on its
   // predecessors.
-  BasicBlockWorklist<16> WorkList(BlockStates.getFunction());
+  BasicBlockWorklist WorkList(BlockStates.getFunction());
   // Push into reverse post order so that we can pop from the back and get
   // post order.
   for (SILBasicBlock *B : PO->getPostOrder()) {

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -18,7 +18,7 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILCloner.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
@@ -87,7 +87,7 @@ static bool useCaptured(Operand *UI) {
 
 // Is any successor of BB in the LiveIn set?
 static bool successorHasLiveIn(SILBasicBlock *BB,
-                               BasicBlockSetVector<16> &LiveIn) {
+                               BasicBlockSetVector &LiveIn) {
   for (auto &Succ : BB->getSuccessors())
     if (LiveIn.contains(Succ))
       return true;
@@ -97,7 +97,7 @@ static bool successorHasLiveIn(SILBasicBlock *BB,
 
 // Propagate liveness backwards from an initial set of blocks in our
 // LiveIn set.
-static void propagateLiveness(BasicBlockSetVector<16> &LiveIn,
+static void propagateLiveness(BasicBlockSetVector &LiveIn,
                               SILBasicBlock *DefBB) {
 
   // First populate a worklist of predecessors.
@@ -144,8 +144,8 @@ static bool addLastRelease(SILValue V, SILBasicBlock *BB,
 static bool getFinalReleases(SILValue Box,
                              SmallVectorImpl<SILInstruction *> &Releases) {
   SILFunction *function = Box->getFunction();
-  BasicBlockSetVector<16> LiveIn(function);
-  BasicBlockSetVector<16> UseBlocks(function);
+  BasicBlockSetVector LiveIn(function);
+  BasicBlockSetVector UseBlocks(function);
 
   auto *DefBB = Box->getParentBlock();
 

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -69,7 +69,7 @@
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/LoadStoreOptUtils.h"
 #include "swift/SIL/BasicBlockData.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Statistic.h"
@@ -1165,7 +1165,7 @@ void DSEContext::runIterativeDSE() {
   // Process each basic block with the gen and kill set. Every time the
   // BBWriteSetIn of a basic block changes, the optimization is rerun on its
   // predecessors.
-  BasicBlockWorklist<16> WorkList(F);
+  BasicBlockWorklist WorkList(F);
   // Push into reverse post order so that we can pop from the back and get
   // post order.
   for (SILBasicBlock *B : PO->getReversePostOrder()) {

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -26,7 +26,7 @@
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
@@ -1234,7 +1234,7 @@ public:
 /// functions.
 bool tryOutline(SILOptFunctionBuilder &FuncBuilder, SILFunction *Fun,
                 SmallVectorImpl<SILFunction *> &FunctionsAdded) {
-  BasicBlockWorklist<128> Worklist(Fun->getEntryBlock());
+  BasicBlockWorklist Worklist(Fun->getEntryBlock());
   OutlinePatterns patterns(FuncBuilder);
   bool changed = false;
 

--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -76,7 +76,7 @@
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/Analysis/ARCAnalysis.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
@@ -1280,7 +1280,7 @@ BlockState::ValueState BlockState::getValueStateAtEndOfBlock(RLEContext &Ctx,
 SILValue RLEContext::computePredecessorLocationValue(SILBasicBlock *BB,
                                                      LSLocation &L) {
   llvm::SmallVector<std::pair<SILBasicBlock *, SILValue>, 8> Values;
-  BasicBlockWorklist<16> WorkList(Fn);
+  BasicBlockWorklist WorkList(Fn);
 
   // Push in all the predecessors to get started.
   for (auto Pred : BB->getPredecessorBlocks()) {
@@ -1451,7 +1451,7 @@ void RLEContext::processBasicBlocksWithGenKillSet() {
   // Process each basic block with the gen and kill set. Every time the
   // ForwardSetOut of a basic block changes, the optimization is rerun on its
   // successors.
-  BasicBlockWorklist<16> WorkList(Fn);
+  BasicBlockWorklist WorkList(Fn);
 
   // Push into the worklist in post order so that we can pop from the back and
   // get reverse post order.

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -28,7 +28,7 @@
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/TypeLowering.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -46,7 +46,6 @@ using namespace swift;
 STATISTIC(NumAllocStackFound,    "Number of AllocStack found");
 STATISTIC(NumAllocStackCaptured, "Number of AllocStack captured");
 STATISTIC(NumInstRemoved,        "Number of Instructions removed");
-STATISTIC(NumPhiPlaced,          "Number of Phi blocks placed");
 
 namespace {
 
@@ -224,7 +223,7 @@ namespace {
 
 /// Promotes a single AllocStackInst into registers..
 class StackAllocationPromoter {
-  using BlockSet = BasicBlockSetVector<16>;
+  using BlockSet = BasicBlockSetVector;
   using BlockToInstMap = llvm::DenseMap<SILBasicBlock *, SILInstruction *>;
 
   // Use a priority queue keyed on dominator tree level so that inserted nodes
@@ -707,10 +706,6 @@ void StackAllocationPromoter::promoteAllocationToPhi() {
           worklist.push_back(child);
     }
   }
-
-  LLVM_DEBUG(llvm::dbgs() << "*** Found: " << phiBlocks.size()
-                          << " new PHIs\n");
-  NumPhiPlaced += phiBlocks.size();
 
   // At this point we calculated the locations of all of the new Phi values.
   // Next, add the Phi values and promote all of the loads and stores into the

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -21,7 +21,7 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TerminatorUtils.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ProgramTerminationAnalysis.h"
 #include "swift/SILOptimizer/Analysis/SimplifyInstruction.h"
@@ -1285,7 +1285,7 @@ TrampolineDest::TrampolineDest(SILBasicBlock *sourceBB,
 #ifndef NDEBUG
 /// Is the block reachable from the entry.
 static bool isReachable(SILBasicBlock *Block) {
-  BasicBlockWorklist<16> Worklist(Block->getParent()->getEntryBlock());
+  BasicBlockWorklist Worklist(Block->getParent()->getEntryBlock());
 
   while (SILBasicBlock *CurBB = Worklist.pop()) {
     if (CurBB == Block)

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -18,7 +18,7 @@
 #include "swift/SIL/LoopInfo.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
-#include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "llvm/ADT/TinyPtrVector.h"
 
@@ -143,7 +143,7 @@ void swift::erasePhiArgument(SILBasicBlock *block, unsigned argIndex) {
   //
   // NOTE: This needs to be a SmallSetVector since we need both uniqueness /and/
   // insertion order. Otherwise non-determinism can result.
-  BasicBlockSetVector<8> predBlocks(block->getParent());
+  BasicBlockSetVector predBlocks(block->getParent());
 
   for (auto *pred : block->getPredecessorBlocks())
     predBlocks.insert(pred);

--- a/lib/SILOptimizer/Utils/ValueLifetime.cpp
+++ b/lib/SILOptimizer/Utils/ValueLifetime.cpp
@@ -13,6 +13,7 @@
 #include "swift/SILOptimizer/Utils/ValueLifetime.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 
 using namespace swift;
@@ -176,11 +177,11 @@ bool ValueLifetimeAnalysis::computeFrontier(FrontierImpl &frontier, Mode mode,
 
   // Exit-blocks from the lifetime region. The value is live at the end of
   // a predecessor block but not in the frontier block itself.
-  BasicBlockSetVector<16> frontierBlocks(getFunction());
+  BasicBlockSetVector frontierBlocks(getFunction());
 
   // Blocks where the value is live at the end of the block and which have
   // a frontier block as successor.
-  BasicBlockSetVector<16> liveOutBlocks(getFunction());
+  BasicBlockSetVector liveOutBlocks(getFunction());
 
   auto visitBlock = [&](SILBasicBlock *bb) {
     return !deBlocks || !deBlocks->isDeadEnd(bb);


### PR DESCRIPTION
... with a fix for a non-assert build crash: I used the wrong ilist type for SlabList. This does not explain the crash, though. What I think happened here is that llvm miscompiled and put the llvm_unreachable from the Slab's deleteNode function unconditionally into the SILModule destructor.
Now by using simple_ilist, there is no need for a deleteNode at all.

This PR reinstates https://github.com/apple/swift/pull/36819
