### PR TITLE
[SR-13483][Sema] Make sure to record the correct remove args fix when repairing a tuple destructure attempt

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4340,8 +4340,34 @@ bool ConstraintSystem::repairFailures(
     // as a narrow exception to SE-0110, see `matchFunctionTypes`.
     //
     // But if `T.Element` didn't get resolved to `Void` we'd like
-    // to diagnose this as a missing argument which can't be ignored.
+    // to diagnose this as a missing argument which can't be ignored or
+    // a tuple is trying to be inferred as a tuple for destructuring but
+    // contextual argument does not match(in this case we remove the extra
+    // closure arguments).
     if (arg != getTypeVariables().end()) {
+      if (auto argToParamElt =
+              path.back().getAs<LocatorPathElt::ApplyArgToParam>()) {
+        auto loc = getConstraintLocator(anchor, path);
+        auto closureAnchor =
+            getAsExpr<ClosureExpr>(simplifyLocatorToAnchor(loc));
+        if (rhs->is<TupleType>() && closureAnchor &&
+            closureAnchor->getParameters()->size() > 1) {
+          auto callee = getCalleeLocator(loc);
+          auto overload = findSelectedOverloadFor(callee);
+          if (overload) {
+            auto fnType = overload->openedType->getAs<FunctionType>();
+            auto paramIdx = argToParamElt->getParamIdx();
+            if (auto paramType = fnType->getParams()[paramIdx]
+                                     .getOldType()
+                                     ->getAs<FunctionType>()) {
+              conversionsOrFixes.push_back(
+                  RemoveExtraneousArguments::create(*this, paramType, {}, loc));
+              break;
+            }
+          }
+        }
+      }
+
       conversionsOrFixes.push_back(AddMissingArguments::create(
           *this, {SynthesizedArg{0, AnyFunctionType::Param(*arg)}},
           getConstraintLocator(anchor, path)));
@@ -11216,7 +11242,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowCheckedCastCoercibleOptionalType:
   case FixKind::AllowUnsupportedRuntimeCheckedCast:
   case FixKind::AllowAlwaysSucceedCheckedCast:
-  case FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype: {
+  case FixKind::AllowInvalidStaticMemberRefOnProtocolMetatype:
+  case FixKind::RemoveExtraneousArguments: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 
@@ -11365,7 +11392,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::AllowTypeOrInstanceMember:
   case FixKind::AllowInvalidPartialApplication:
   case FixKind::AllowInvalidInitRef:
-  case FixKind::RemoveExtraneousArguments:
   case FixKind::AllowClosureParameterDestructuring:
   case FixKind::AllowInaccessibleMember:
   case FixKind::AllowAnyObjectKeyPathRoot:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4353,15 +4353,14 @@ bool ConstraintSystem::repairFailures(
         if (rhs->is<TupleType>() && closureAnchor &&
             closureAnchor->getParameters()->size() > 1) {
           auto callee = getCalleeLocator(loc);
-          auto overload = findSelectedOverloadFor(callee);
-          if (overload) {
-            auto fnType = overload->openedType->getAs<FunctionType>();
+          if (auto overload = findSelectedOverloadFor(callee)) {
+            auto fnType =
+                simplifyType(overload->openedType)->castTo<FunctionType>();
             auto paramIdx = argToParamElt->getParamIdx();
-            if (auto paramType = fnType->getParams()[paramIdx]
-                                     .getOldType()
-                                     ->getAs<FunctionType>()) {
-              conversionsOrFixes.push_back(
-                  RemoveExtraneousArguments::create(*this, paramType, {}, loc));
+            auto paramType = fnType->getParams()[paramIdx].getParameterType();
+            if (auto paramFnType = paramType->getAs<FunctionType>()) {
+              conversionsOrFixes.push_back(RemoveExtraneousArguments::create(
+                  *this, paramFnType, {}, loc));
               break;
             }
           }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1097,3 +1097,11 @@ struct R_76250381<Result, Failure: Error> {
     return false
   }
 }
+
+// SR-13483
+(0..<10).map { x, y in } 
+// expected-error@-1 {{contextual closure type '((Range<Int>).Element) throws -> ()' expects 1 argument, but 2 were used in closure body}}
+(0..<10).map { x, y, z in } 
+// expected-error@-1 {{contextual closure type '((Range<Int>).Element) throws -> ()' expects 1 argument, but 3 were used in closure body}}
+(0..<10).map { x, y, z, w in } 
+// expected-error@-1 {{contextual closure type '((Range<Int>).Element) throws -> ()' expects 1 argument, but 4 were used in closure body}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1100,8 +1100,8 @@ struct R_76250381<Result, Failure: Error> {
 
 // SR-13483
 (0..<10).map { x, y in } 
-// expected-error@-1 {{contextual closure type '((Range<Int>).Element) throws -> ()' expects 1 argument, but 2 were used in closure body}}
+// expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 2 were used in closure body}}
 (0..<10).map { x, y, z in } 
-// expected-error@-1 {{contextual closure type '((Range<Int>).Element) throws -> ()' expects 1 argument, but 3 were used in closure body}}
+// expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 3 were used in closure body}}
 (0..<10).map { x, y, z, w in } 
-// expected-error@-1 {{contextual closure type '((Range<Int>).Element) throws -> ()' expects 1 argument, but 4 were used in closure body}}
+// expected-error@-1 {{contextual closure type '(Range<Int>.Element) throws -> ()' (aka '(Int) throws -> ()') expects 1 argument, but 4 were used in closure body}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
When handling special cases for SE-0110 in repair failures, we were always recording the adding missing fix. But in case it is attempting a destructuring, it may happen that the problem is extra argurments on the closure. 
So this just detect and record the remove args fix.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-13483.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
