### PR TITLE
SIL: A tuple type can be lowered with an opaque result type as the original type

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -317,7 +317,7 @@ bool AbstractionPattern::matchesTuple(CanTupleType substType) {
   case Kind::ClangType:
   case Kind::Type:
   case Kind::Discard: {
-    if (isTypeParameter())
+    if (isTypeParameterOrOpaqueArchetype())
       return true;
     auto type = getType();
     if (auto tuple = dyn_cast<TupleType>(type))

--- a/validation-test/compiler_crashers_2_fixed/sr14426.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr14426.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+public struct MyList: Sequence {
+  var _list: [(Int, Int)]
+  
+  public func makeIterator() -> some IteratorProtocol {
+    return _list.makeIterator()
+  }
+}


### PR DESCRIPTION
AbstractionPattern::matchesTuple() is used by various assertions, and
the condition was too strict. Relax the condition to fix an assertion
failure in the case where an opaque result type has a tuple as its
underlying type.

Fixes https://bugs.swift.org/browse/SR-14426 / rdar://problem/76057095.