### PR TITLE
[Diagnostics] Filter operators if all their arguments are holes

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9630,10 +9630,13 @@ bool ConstraintSystem::simplifyAppliedOverloadsImpl(
           return false;
         });
 
-    // If all of the arguments are holes, let's disable all but one
-    // overload to make sure holes don't cause performance problems
-    // because hole could be bound to any type.
-    if (allHoles) {
+    // If this is an operator application and all of the arguments are holes,
+    // let's disable all but one overload to make sure holes don't cause
+    // performance problems because hole could be bound to any type.
+    //
+    // Non-operator calls are exempted because they have fewer overloads,
+    // and it's possible to filter them based on labels.
+    if (allHoles && isOperatorDisjunction(disjunction)) {
       auto choices = disjunction->getNestedConstraints();
       for (auto *choice : choices.slice(1))
         choice->setDisabled();

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -725,3 +725,13 @@ func rdar66891544() {
 
   foo(.bar) // expected-error {{cannot infer contextual base in reference to member 'bar'}}
 }
+
+// rdar://55369704 - extraneous diagnostics produced in combination with missing/misspelled members
+func rdar55369704() {
+  struct S {
+  }
+
+  func test(x: Int, s: S) {
+    _ = x - Int(s.value) // expected-error {{value of type 'S' has no member 'value'}}
+  }
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1086,7 +1086,7 @@ func rdar74711236() {
       // FIXME: Missing member reference is pattern needs a better diagnostic
       if let type = context?.store { // expected-error {{type of expression is ambiguous without more context}}
         // `isSupported` should be an invalid declaration to trigger a crash in `map(\.option)`
-        let isSupported = context!.supported().contains(type) // expected-error {{missing argument label 'where:' in call}} expected-error {{converting non-escaping value to '(Type) throws -> Bool' may allow it to escape}}
+        let isSupported = context!.supported().contains(type)
         return (isSupported ? [type] : []).map(\.option)
         // expected-error@-1 {{value of type 'Any' has no member 'option'}}
         // expected-note@-2 {{cast 'Any' to 'AnyObject' or use 'as!' to force downcast to a more specific type to access members}}


### PR DESCRIPTION
Restrict filtering in `simplifyAppliedOverloadsImpl` to disable
overload set for operators only, because other calls e.g. regular
functions or subscripts could be filtered on labels and are less
overloaded.

Filtering non-operator calls could also lead to incorrect diagnostics
because first choice could have all sorts of different issues e.g.
incorrect labels and number of parameters.

Resolves: rdar://55369704

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
