### PR TITLE
[Test] Disabled Concurrency/Runtime/executor_deinit1.swift on iphonesimulator-x86_64.

### DIFF
--- a/test/Concurrency/Runtime/executor_deinit1.swift
+++ b/test/Concurrency/Runtime/executor_deinit1.swift
@@ -7,6 +7,8 @@
 
 // https://bugs.swift.org/browse/SR-14461
 // UNSUPPORTED: linux
+// rdar://76611676
+// UNSUPPORTED: CPU=x86_64 && OS=ios
 
 
 // doesn't matter that it's bool identity function or not


### PR DESCRIPTION
rdar://76611676
