### PR TITLE
[NFC] [ Docs] Fix the missing title underbar

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1862,7 +1862,7 @@ derived from the ARC object. As an example, consider the following Swift/SIL::
   bb0(%0 : @guaranteed Klass):
     // Definition of '%1'
     %1 = copy_value %0 : $Klass
-    
+
     // Consume '%1'. This means '%1' can no longer be used after this point. We
     // rebind '%1' in the destination blocks (bbYes, bbNo).
     checked_cast_br %1 : $Klass to $OtherKlass, bbYes, bbNo
@@ -3320,7 +3320,7 @@ lowered by the SIL pipeline, so that IR generation only operands of type
 The operand is a guaranteed operand, i.e. not consumed.
 
 extract_executor
-```````````````
+````````````````
 
 ::
 


### PR DESCRIPTION
There was a missing backpack in SIL.rst that was preventing me from building.

```
Warning, treated as error:                                                                                                                                                                                      
docs/SIL.rst:3323:Title underline too short.   
```