### PR TITLE
[Sema] Adding a space in closure parameter destructuring fix in cases closure body is empty

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4793,6 +4793,8 @@ bool ClosureParamDestructuringFailure::diagnoseAsError() {
 
   if (isMultiLineClosure)
     OS << '\n' << indent;
+  else if (closure->getBody()->empty())
+    OS << ' ';
 
   // Let's form 'let <name> : [<type>]? = arg' expression.
   OS << "let " << parameterOS.str() << " = arg"

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1361,6 +1361,8 @@ do {
 
   let _: ((Int, Int)) -> () = { _ = ($0, $1) } // expected-error {{closure tuple parameter '(Int, Int)' does not support destructuring}}
   let _: ((Int, Int)) -> () = { t, u in _ = (t, u) } // expected-error {{closure tuple parameter '(Int, Int)' does not support destructuring}} {{33-37=(arg)}} {{41-41=let (t, u) = arg; }}
+  let _: ((Int, Int)) -> () = { x, y in } 
+  // expected-error@-1 {{closure tuple parameter '(Int, Int)' does not support destructuring}} {{33-37=(arg)}} {{40-40= let (x, y) = arg; }}
 
   let _: (Int, Int) -> () = { _ = $0 } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}
   let _: (Int, Int) -> () = { _ = ($0.0, $0.1) } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Since fix-it inserts code in the closure body, if body is empty this leads to an invalid `inlet` code. Like in screen shot bellow

![Screen Shot 2021-04-13 at 20 34 27](https://user-images.githubusercontent.com/8292651/114647076-d82ef580-9cb2-11eb-917e-baa95516d51a.png).
This just adds a whitespace for such cases :)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
