### PR TITLE
[build] allow to specify ninja targets to build for LLVM

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -801,6 +801,17 @@ class BuildScriptInvocation(object):
                 "--skip-clean-llbuild"
             ]
 
+        if args.llvm_ninja_targets:
+            impl_args += [
+                "--llvm-ninja-targets=%s" % ' '.join(args.llvm_ninja_targets)
+            ]
+
+        if args.llvm_ninja_targets_for_cross_compile_hosts:
+            impl_args += [
+                "--llvm-ninja-targets-for-cross-compile-hosts=%s" %
+                ' '.join(args.llvm_ninja_targets_for_cross_compile_hosts)
+            ]
+
         # Compute the set of host-specific variables, which we pass through to
         # the build script via environment variables.
         host_specific_variables = self.compute_host_specific_variables()

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1638,12 +1638,10 @@ for host in "${ALL_HOSTS[@]}"; do
                 ;;
 
             llvm)
-                if [ "${LLVM_NINJA_TARGETS}" != "" ] ; then
-                    if [[ $(is_cross_tools_host ${host}) && "${LLVM_NINJA_TARGETS_FOR_CROSS_COMPILE_HOSTS}" != "" ]] ; then
-                        build_targets=("${LLVM_NINJA_TARGETS_FOR_CROSS_COMPILE_HOSTS[@]}")
-                    else
-                        build_targets=("${LLVM_NINJA_TARGETS[@]}")
-                    fi
+                if [[ -n "${LLVM_NINJA_TARGETS_FOR_CROSS_COMPILE_HOSTS}" && $(is_cross_tools_host ${host}) ]] ; then
+                    build_targets=("${LLVM_NINJA_TARGETS_FOR_CROSS_COMPILE_HOSTS[@]}")
+                elif [[ -n "${LLVM_NINJA_TARGETS}" ]] ; then
+                    build_targets=("${LLVM_NINJA_TARGETS[@]}")
                 else
                     if [ "${BUILD_LLVM}" == "0" ] ; then
                         build_targets=(clean)

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -179,6 +179,8 @@ KNOWN_SETTINGS=(
     llvm-install-components                       ""                "a semicolon-separated list of LLVM components to install"
     llvm-lit-args                                 ""                "If set, override the lit args passed to LLVM"
     enable-llvm-assertions                        "1"               "set to enable llvm assertions"
+    llvm-ninja-targets                            ""                "list of ninja targets to build for LLVM"
+    llvm-ninja-targets-for-cross-compile-hosts    ""                "list of ninja targets to build for LLVM for hosts that are cross-compiled"
 
     ## Swift Options
     swift-analyze-code-coverage                   "not-merged"      "Code coverage analysis mode for Swift (false, not-merged, merged). Defaults to false if the argument is not present, and not-merged if the argument is present without a modifier."
@@ -1636,23 +1638,31 @@ for host in "${ALL_HOSTS[@]}"; do
                 ;;
 
             llvm)
-                if [ "${BUILD_LLVM}" == "0" ] ; then
-                    build_targets=(clean)
-                fi
-                if [[ "${SKIP_BUILD}" || "${SKIP_BUILD_LLVM}" ]] ; then
-                    # We can't skip the build completely because the standalone
-                    # build of Swift depend on these for building and testing.
-                    build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)
-                    # If we are not performing a toolchain only build, then we
-                    # also want to include FileCheck, not, llvm-nm for testing
-                    # purposes.
-                    if [[ ! "${BUILD_TOOLCHAIN_ONLY}" ]] ; then
-                      build_targets=(
-                          "${build_targets[@]}"
-                          FileCheck
-                          not
-                          llvm-nm
-                      )
+                if [ "${LLVM_NINJA_TARGETS}" != "" ] ; then
+                    if [[ $(is_cross_tools_host ${host}) && "${LLVM_NINJA_TARGETS_FOR_CROSS_COMPILE_HOSTS}" != "" ]] ; then
+                        build_targets=("${LLVM_NINJA_TARGETS_FOR_CROSS_COMPILE_HOSTS[@]}")
+                    else
+                        build_targets=("${LLVM_NINJA_TARGETS[@]}")
+                    fi
+                else
+                    if [ "${BUILD_LLVM}" == "0" ] ; then
+                        build_targets=(clean)
+                    fi
+                    if [[ "${SKIP_BUILD}" || "${SKIP_BUILD_LLVM}" ]] ; then
+                        # We can't skip the build completely because the standalone
+                        # build of Swift depend on these for building and testing.
+                        build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)
+                        # If we are not performing a toolchain only build, then we
+                        # also want to include FileCheck, not, llvm-nm for testing
+                        # purposes.
+                        if [[ ! "${BUILD_TOOLCHAIN_ONLY}" ]] ; then
+                          build_targets=(
+                              "${build_targets[@]}"
+                              FileCheck
+                              not
+                              llvm-nm
+                          )
+                        fi
                     fi
                 fi
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1642,25 +1642,26 @@ for host in "${ALL_HOSTS[@]}"; do
                     build_targets=("${LLVM_NINJA_TARGETS_FOR_CROSS_COMPILE_HOSTS[@]}")
                 elif [[ -n "${LLVM_NINJA_TARGETS}" ]] ; then
                     build_targets=("${LLVM_NINJA_TARGETS[@]}")
-                else
-                    if [ "${BUILD_LLVM}" == "0" ] ; then
-                        build_targets=(clean)
-                    fi
-                    if [[ "${SKIP_BUILD}" || "${SKIP_BUILD_LLVM}" ]] ; then
-                        # We can't skip the build completely because the standalone
-                        # build of Swift depend on these for building and testing.
-                        build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)
-                        # If we are not performing a toolchain only build, then we
-                        # also want to include FileCheck, not, llvm-nm for testing
-                        # purposes.
-                        if [[ ! "${BUILD_TOOLCHAIN_ONLY}" ]] ; then
-                          build_targets=(
-                              "${build_targets[@]}"
-                              FileCheck
-                              not
-                              llvm-nm
-                          )
-                        fi
+                fi
+                # indicating we don't want to build LLVM should
+                # override any custom ninja target we specified
+                if [ "${BUILD_LLVM}" == "0" ] ; then
+                    build_targets=(clean)
+                fi
+                if [[ "${SKIP_BUILD}" || "${SKIP_BUILD_LLVM}" ]] ; then
+                    # We can't skip the build completely because the standalone
+                    # build of Swift depend on these for building and testing.
+                    build_targets=(llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets)
+                    # If we are not performing a toolchain only build, then we
+                    # also want to include FileCheck, not, llvm-nm for testing
+                    # purposes.
+                    if [[ ! "${BUILD_TOOLCHAIN_ONLY}" ]] ; then
+                      build_targets=(
+                          "${build_targets[@]}"
+                          FileCheck
+                          not
+                          llvm-nm
+                      )
                     fi
                 fi
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1076,6 +1076,20 @@ def create_argument_parser():
            default='X86;ARM;AArch64;PowerPC;SystemZ;Mips',
            help='LLVM target generators to build')
 
+    option('--llvm-ninja-targets', append,
+           type=argparse.ShellSplitType(),
+           help='Space separated list of ninja targets to build for LLVM '
+                'instead of the default ones. Only supported when using '
+                'ninja to build. Can be called multiple times '
+                'to add multiple such options.')
+
+    option('--llvm-ninja-targets-for-cross-compile-hosts', append,
+           type=argparse.ShellSplitType(),
+           help='Space separated list of ninja targets to build for LLVM '
+                'in cross compile hosts. Requires --llvm-ninja-targets to '
+                'be specified to be applied. Can be called multiple times '
+                'to add multiple such options.')
+
     # -------------------------------------------------------------------------
     in_group('Build settings for Android')
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1086,8 +1086,9 @@ def create_argument_parser():
     option('--llvm-ninja-targets-for-cross-compile-hosts', append,
            type=argparse.ShellSplitType(),
            help='Space separated list of ninja targets to build for LLVM '
-                'in cross compile hosts. Requires --llvm-ninja-targets to '
-                'be specified to be applied. Can be called multiple times '
+                'in cross compile hosts instead of the ones specified in '
+                'llvm-ninja-targets (or the default ones). '
+                'Can be called multiple times '
                 'to add multiple such options.')
 
     # -------------------------------------------------------------------------

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -181,6 +181,8 @@ EXPECTED_DEFAULTS = {
     'lldb_build_with_xcode': '0',
     'llvm_assertions': True,
     'llvm_build_variant': 'Debug',
+    'llvm_ninja_targets': [],
+    'llvm_ninja_targets_for_cross_compile_hosts': [],
     'llvm_max_parallel_lto_link_jobs':
         defaults.LLVM_MAX_PARALLEL_LTO_LINK_JOBS,
     'llvm_targets_to_build': 'X86;ARM;AArch64;PowerPC;SystemZ;Mips',
@@ -681,6 +683,8 @@ EXPECTED_OPTIONS = [
     AppendOption('--extra-cmake-options'),
     AppendOption('--extra-swift-args'),
     AppendOption('--test-paths'),
+    AppendOption('--llvm-ninja-targets'),
+    AppendOption('--llvm-ninja-targets-for-cross-compile-hosts'),
 
     UnsupportedOption('--build-jobs'),
     UnsupportedOption('--common-cmake-options'),

--- a/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
+++ b/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
@@ -22,5 +22,4 @@
 # RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
 
 # ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} all
-# ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK-NOT: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang
-# ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} all
+# ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang

--- a/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
+++ b/validation-test/BuildSystem/llvm-targets-options-for-cross-compile-hosts.test
@@ -1,0 +1,26 @@
+# REQUIRES: standalone_build
+# REQUIRES: OS=macosx
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK %s
+
+# LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
+# LLVM-NINJA-TARGETS-APPLY-TO-CROSS-COMPILE-HOSTS-TOO-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} lib/all clangDependencyScanning
+
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
+
+# LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
+# LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang
+
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets-for-cross-compile-hosts="bin/clang" --cross-compile-hosts=iphoneos-arm64e --cmake %cmake 2>&1 | %FileCheck --check-prefix=ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK %s
+
+# ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} all
+# ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK-NOT: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} bin/clang
+# ONLY-LLVM-NINJA-TARGETS-FOR-CROSS-COMPILE-HOSTS-CHECK: cmake --build {{.*}}/llvm-iphoneos-arm64e {{.*}} all

--- a/validation-test/BuildSystem/llvm-targets-options.test
+++ b/validation-test/BuildSystem/llvm-targets-options.test
@@ -4,6 +4,10 @@
 # RUN: mkdir -p %t
 # RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
 
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
+
 # BUILD-LLVM-0-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} clean
 
 
@@ -13,7 +17,15 @@
 
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --llvm-ninja-targets="lib/all bin/clang" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
 # RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --llvm-ninja-targets="bin/clang clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
 
 # SKIP-BUILD-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets
 # SKIP-BUILD-CHECK-SAME: FileCheck not llvm-nm

--- a/validation-test/BuildSystem/llvm-targets-options.test
+++ b/validation-test/BuildSystem/llvm-targets-options.test
@@ -1,0 +1,35 @@
+# REQUIRES: standalone_build
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-llvm=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=BUILD-LLVM-0-CHECK %s
+
+# BUILD-LLVM-0-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} clean
+
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-CHECK %s
+
+# SKIP-BUILD-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets
+# SKIP-BUILD-CHECK-SAME: FileCheck not llvm-nm
+
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build-llvm --build-toolchain-only=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK %s
+
+# SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} llvm-tblgen clang-resource-headers intrinsics_gen clang-tablegen-targets
+# SKIP-BUILD-LLVM-BUILD-TOOLCHAIN-ONLY-CHECK-NOT: FileCheck not llvm-nm
+
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --llvm-ninja-targets="lib/all clangDependencyScanning" --cmake %cmake  2>&1 | %FileCheck --check-prefix=LLVM-NINJA-TARGETS-CHECK %s
+
+# LLVM-NINJA-TARGETS-CHECK: cmake --build {{.*}}/llvm-{{[^/]*}} lib/all clangDependencyScanning
+


### PR DESCRIPTION
This is meant to support scenarios in which we need to build as little as
LLVM as possible for performance reasons (e.g. when enabling LTO).

While LLVM CMake build system offers options in this sense,
in our investigation they turned out not to be suitable,
since either they are not granular enough (`LLVM_INCLUDE/BUILD` flags)
or they require active opt out for any new tool added
(`*_BUILD_*_TOOL` flags)

When using this mechanism, there is the possibility to specify different
targets to use for cross-compile hosts.

Supports rdar://32019390