### PR TITLE
[ConstraintSystem] NFC: Factor operator overload identification and partitioning.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5307,6 +5307,8 @@ Type isRawRepresentable(ConstraintSystem &cs, Type type,
 Type getDynamicSelfReplacementType(Type baseObjTy, const ValueDecl *member,
                                    ConstraintLocator *memberLocator);
 
+ValueDecl *getOverloadChoiceDecl(Constraint *choice);
+
 class DisjunctionChoice {
   ConstraintSystem &CS;
   unsigned Index;
@@ -5332,7 +5334,7 @@ public:
   }
 
   bool isUnavailable() const {
-    if (auto *decl = getDecl(Choice))
+    if (auto *decl = getOverloadChoiceDecl(Choice))
       return CS.isDeclUnavailable(decl, Choice->getLocator());
     return false;
   }
@@ -5360,22 +5362,11 @@ private:
   void propagateConversionInfo(ConstraintSystem &cs) const;
 
   static ValueDecl *getOperatorDecl(Constraint *choice) {
-    auto *decl = getDecl(choice);
+    auto *decl = getOverloadChoiceDecl(choice);
     if (!decl)
       return nullptr;
 
     return decl->isOperator() ? decl : nullptr;
-  }
-
-  static ValueDecl *getDecl(Constraint *constraint) {
-    if (constraint->getKind() != ConstraintKind::BindOverload)
-      return nullptr;
-
-    auto choice = constraint->getOverloadChoice();
-    if (choice.getKind() != OverloadChoiceKind::Decl)
-      return nullptr;
-
-    return choice.getDecl();
   }
 };
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5620,6 +5620,10 @@ void performSyntacticDiagnosticsForTarget(
 /// generic requirement and if so return that type or null type otherwise.
 Type getConcreteReplacementForProtocolSelfType(ValueDecl *member);
 
+/// Determine whether given disjunction constraint represents a set
+/// of operator overload choices.
+bool isOperatorDisjunction(Constraint *disjunction);
+
 } // end namespace constraints
 
 template<typename ...Args>

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1878,15 +1878,14 @@ static void existingOperatorBindingsForDisjunction(ConstraintSystem &CS,
   }
 }
 
-void ConstraintSystem::partitionGenericOperators(ArrayRef<Constraint *> constraints,
-                                                 SmallVectorImpl<unsigned>::iterator first,
-                                                 SmallVectorImpl<unsigned>::iterator last,
-                                                 ConstraintLocator *locator) {
-  auto *argFnType = AppliedDisjunctions[locator];
-  if (!isOperatorBindOverload(constraints[0]) || !argFnType)
+void DisjunctionChoiceProducer::partitionGenericOperators(
+    SmallVectorImpl<unsigned>::iterator first,
+    SmallVectorImpl<unsigned>::iterator last) {
+  auto *argFnType = CS.getAppliedDisjunctionArgumentFunction(Disjunction);
+  if (!isOperatorBindOverload(Choices.front()) || !argFnType)
     return;
 
-  auto operatorName = constraints[0]->getOverloadChoice().getName();
+  auto operatorName = Choices[0]->getOverloadChoice().getName();
   if (!operatorName.getBaseIdentifier().isArithmeticOperator())
     return;
 
@@ -1899,7 +1898,8 @@ void ConstraintSystem::partitionGenericOperators(ArrayRef<Constraint *> constrai
     if (!nominal)
       return false;
 
-    auto *protocol = TypeChecker::getProtocol(getASTContext(), SourceLoc(), kind);
+    auto *protocol =
+        TypeChecker::getProtocol(CS.getASTContext(), SourceLoc(), kind);
 
     if (auto *refined = dyn_cast<ProtocolDecl>(nominal))
       return refined->inheritsFrom(protocol);
@@ -1911,7 +1911,7 @@ void ConstraintSystem::partitionGenericOperators(ArrayRef<Constraint *> constrai
   // Gather Numeric and Sequence overloads into separate buckets.
   for (auto iter = first; iter != last; ++iter) {
     unsigned index = *iter;
-    auto *decl = constraints[index]->getOverloadChoice().getDecl();
+    auto *decl = Choices[index]->getOverloadChoice().getDecl();
     auto *nominal = decl->getDeclContext()->getSelfNominalTypeDecl();
     if (!decl->getInterfaceType()->is<GenericFunctionType>()) {
       concreteOverloads.push_back(index);
@@ -1926,8 +1926,10 @@ void ConstraintSystem::partitionGenericOperators(ArrayRef<Constraint *> constrai
 
   auto sortPartition = [&](SmallVectorImpl<unsigned> &partition) {
     llvm::sort(partition, [&](unsigned lhs, unsigned rhs) -> bool {
-      auto *declA = dyn_cast<ValueDecl>(constraints[lhs]->getOverloadChoice().getDecl());
-      auto *declB = dyn_cast<ValueDecl>(constraints[rhs]->getOverloadChoice().getDecl());
+      auto *declA =
+          dyn_cast<ValueDecl>(Choices[lhs]->getOverloadChoice().getDecl());
+      auto *declB =
+          dyn_cast<ValueDecl>(Choices[rhs]->getOverloadChoice().getDecl());
 
       return TypeChecker::isDeclRefinementOf(declA, declB);
     });
@@ -1946,19 +1948,22 @@ void ConstraintSystem::partitionGenericOperators(ArrayRef<Constraint *> constrai
   // overload choices first.
   for (auto arg : argFnType->getParams()) {
     auto argType = arg.getPlainType();
-    argType = getFixedTypeRecursive(argType, /*wantRValue=*/true);
+    argType = CS.getFixedTypeRecursive(argType, /*wantRValue=*/true);
 
     if (argType->isTypeVariableOrMember())
       continue;
 
-    if (conformsToKnownProtocol(DC, argType, KnownProtocolKind::AdditiveArithmetic)) {
-      first = std::copy(numericOverloads.begin(), numericOverloads.end(), first);
+    if (conformsToKnownProtocol(CS.DC, argType,
+                                KnownProtocolKind::AdditiveArithmetic)) {
+      first =
+          std::copy(numericOverloads.begin(), numericOverloads.end(), first);
       numericOverloads.clear();
       break;
     }
 
-    if (conformsToKnownProtocol(DC, argType, KnownProtocolKind::Sequence)) {
-      first = std::copy(sequenceOverloads.begin(), sequenceOverloads.end(), first);
+    if (conformsToKnownProtocol(CS.DC, argType, KnownProtocolKind::Sequence)) {
+      first =
+          std::copy(sequenceOverloads.begin(), sequenceOverloads.end(), first);
       sequenceOverloads.clear();
       break;
     }
@@ -1969,16 +1974,22 @@ void ConstraintSystem::partitionGenericOperators(ArrayRef<Constraint *> constrai
   first = std::copy(sequenceOverloads.begin(), sequenceOverloads.end(), first);
 }
 
-void ConstraintSystem::partitionDisjunction(
-    ArrayRef<Constraint *> Choices, SmallVectorImpl<unsigned> &Ordering,
+void DisjunctionChoiceProducer::partitionDisjunction(
+    SmallVectorImpl<unsigned> &Ordering,
     SmallVectorImpl<unsigned> &PartitionBeginning) {
   // Apply a special-case rule for favoring one generic function over
   // another.
-  if (auto favored = tryOptimizeGenericDisjunction(DC, Choices)) {
-    favorConstraint(favored);
+  if (auto favored = tryOptimizeGenericDisjunction(CS.DC, Choices)) {
+    CS.favorConstraint(favored);
   }
 
   SmallSet<Constraint *, 16> taken;
+
+  using ConstraintMatcher = std::function<bool(unsigned index, Constraint *)>;
+  using ConstraintMatchLoop =
+      std::function<void(ArrayRef<Constraint *>, ConstraintMatcher)>;
+  using PartitionAppendCallback =
+      std::function<void(SmallVectorImpl<unsigned> & options)>;
 
   // Local function used to iterate over the untaken choices from the
   // disjunction and use a higher-order function to determine if they
@@ -2006,7 +2017,7 @@ void ConstraintSystem::partitionDisjunction(
 
   // Add existing operator bindings to the main partition first. This often
   // helps the solver find a solution fast.
-  existingOperatorBindingsForDisjunction(*this, Choices, everythingElse);
+  existingOperatorBindingsForDisjunction(CS, Choices, everythingElse);
   for (auto index : everythingElse)
     taken.insert(Choices[index]);
 
@@ -2026,7 +2037,7 @@ void ConstraintSystem::partitionDisjunction(
   });
 
   // Then unavailable constraints if we're skipping them.
-  if (!shouldAttemptFixes()) {
+  if (!CS.shouldAttemptFixes()) {
     forEachChoice(Choices, [&](unsigned index, Constraint *constraint) -> bool {
       if (constraint->getKind() != ConstraintKind::BindOverload)
         return false;
@@ -2036,7 +2047,7 @@ void ConstraintSystem::partitionDisjunction(
       if (!funcDecl)
         return false;
 
-      if (!isDeclUnavailable(funcDecl, constraint->getLocator()))
+      if (!CS.isDeclUnavailable(funcDecl, constraint->getLocator()))
         return false;
 
       unavailable.push_back(index);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5689,3 +5689,18 @@ TypeVarBindingProducer::getDefaultBinding(Constraint *constraint) const {
              ? binding.withType(OptionalType::get(type))
              : binding;
 }
+
+bool constraints::isOperatorDisjunction(Constraint *disjunction) {
+  assert(disjunction->getKind() == ConstraintKind::Disjunction);
+
+  auto choices = disjunction->getNestedConstraints();
+  if (choices.empty())
+    return false;
+
+  auto *choice = choices.front();
+  if (choice->getKind() != ConstraintKind::BindOverload)
+    return false;
+
+  auto *decl = choice->getOverloadChoice().getDeclOrNull();
+  return decl ? decl->isOperator() : false;
+}

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5690,17 +5690,18 @@ TypeVarBindingProducer::getDefaultBinding(Constraint *constraint) const {
              : binding;
 }
 
+ValueDecl *constraints::getOverloadChoiceDecl(Constraint *choice) {
+  if (choice->getKind() != ConstraintKind::BindOverload)
+    return nullptr;
+  return choice->getOverloadChoice().getDeclOrNull();
+}
+
 bool constraints::isOperatorDisjunction(Constraint *disjunction) {
   assert(disjunction->getKind() == ConstraintKind::Disjunction);
 
   auto choices = disjunction->getNestedConstraints();
-  if (choices.empty())
-    return false;
+  assert(!choices.empty());
 
-  auto *choice = choices.front();
-  if (choice->getKind() != ConstraintKind::BindOverload)
-    return false;
-
-  auto *decl = choice->getOverloadChoice().getDeclOrNull();
+  auto *decl = getOverloadChoiceDecl(choices.front());
   return decl ? decl->isOperator() : false;
 }


### PR DESCRIPTION
- Add new `isOperatorDisjunction` and `getOverloadChoiceDecl` methods
- Move `partition*` methods under `DisjunctionChoiceProducer`
- Replace `isOperatorBindOverload` and some duplicate logic with new `isOperatorDisjunction` and remove it.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
