### PR TITLE
[ownership] Refactor out the composition type LoadOperation from CanonicalizeInstruction into OwnershipOptUtils.

### DIFF
--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -177,6 +177,64 @@ public:
   SILBasicBlock::iterator perform();
 };
 
+/// An abstraction over LoadInst/LoadBorrowInst so one can handle both types of
+/// load using common code.
+struct LoadOperation {
+  llvm::PointerUnion<LoadInst *, LoadBorrowInst *> value;
+
+  LoadOperation() : value() {}
+  LoadOperation(SILInstruction *input) : value(nullptr) {
+    if (auto *li = dyn_cast<LoadInst>(input)) {
+      value = li;
+      return;
+    }
+
+    if (auto *lbi = dyn_cast<LoadBorrowInst>(input)) {
+      value = lbi;
+      return;
+    }
+  }
+
+  explicit operator bool() const { return !value.isNull(); }
+
+  SingleValueInstruction *operator*() const {
+    if (value.is<LoadInst *>())
+      return value.get<LoadInst *>();
+    return value.get<LoadBorrowInst *>();
+  }
+
+  const SingleValueInstruction *operator->() const {
+    if (value.is<LoadInst *>())
+      return value.get<LoadInst *>();
+    return value.get<LoadBorrowInst *>();
+  }
+
+  SingleValueInstruction *operator->() {
+    if (value.is<LoadInst *>())
+      return value.get<LoadInst *>();
+    return value.get<LoadBorrowInst *>();
+  }
+
+  SILValue getOperand() const {
+    if (value.is<LoadInst *>())
+      return value.get<LoadInst *>()->getOperand();
+    return value.get<LoadBorrowInst *>()->getOperand();
+  }
+
+  /// Return the ownership qualifier of the underlying load if we have a load or
+  /// None if we have a load_borrow.
+  ///
+  /// TODO: Rather than use an optional here, we should include an invalid
+  /// representation in LoadOwnershipQualifier.
+  Optional<LoadOwnershipQualifier> getOwnershipQualifier() const {
+    if (auto *lbi = value.dyn_cast<LoadBorrowInst *>()) {
+      return None;
+    }
+
+    return value.get<LoadInst *>()->getOwnershipQualifier();
+  }
+};
+
 } // namespace swift
 
 #endif


### PR DESCRIPTION
This API is useful when writing compiler code that needs to handle ossa/non-ossa
as well as load_borrow/load while in OSSA. I am going to use this in
SILMem2Reg.

----

NFC just a refactor.