### PR TITLE
[Test] Disable a test on Linux at swift_test_mode_optimize_none.

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar26564101.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar26564101.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
+// UNSUPPORTED: swift_test_mode_optimize_none && OS=linux-gnu
 
 func rdar26564101(a: [Double], m: Double) -> Double {
   return Double(Array(0...a.count - 1).reduce(0) { $0 + $1 - m })


### PR DESCRIPTION
Per @xedin, it's fine to leave this test disabled here.
