### PR TITLE
Sema: Handle Error self-conformance in TypeChecker::containsProtocol()

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4990,6 +4990,14 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, DeclContext *DC,
   // Existential types don't need to conform, i.e., they only need to
   // contain the protocol.
   if (T->isExistentialType()) {
+    // Handle the special case of the Error protocol, which self-conforms
+    // *and* has a witness table.
+    if (T->isEqual(Proto->getDeclaredInterfaceType()) &&
+        Proto->requiresSelfConformanceWitnessTable()) {
+      auto &ctx = DC->getASTContext();
+      return ProtocolConformanceRef(ctx.getSelfConformance(Proto));
+    }
+
     auto layout = T->getExistentialLayout();
 
     // First, if we have a superclass constraint, the class may conform

--- a/validation-test/compiler_crashers_2_fixed/rdar70338670.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar70338670.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public struct X {
+  public subscript(_ key: String, as type: Error.Type = Error.self) -> Error? {
+    get {
+      return nil
+    }
+  }
+}
+
+let x = X()
+_ = x["hi"]


### PR DESCRIPTION
While ModuleDecl::lookupConformance() did the right thing here, we have
another entry point, TypeChecker::containsProtocol(), that also needs
to special-case Error.

Fixes https://bugs.swift.org/browse/SR-13734 / rdar://problem/70338670.