### PR TITLE
[Concurrency] detach should not take Failure type param

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -462,10 +462,10 @@ public func detach<T>(
 ///     throw the error the operation has thrown when awaited on.
 @discardableResult
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-public func detach<T, Failure>(
+public func detach<T>(
   priority: Task.Priority = .unspecified,
   operation: __owned @Sendable @escaping () async throws -> T
-) -> Task.Handle<T, Failure> {
+) -> Task.Handle<T, Error> {
   // Set up the job flags for a new task.
   var flags = Task.JobFlags()
   flags.kind = .task
@@ -478,7 +478,7 @@ public func detach<T, Failure>(
   // Enqueue the resulting job.
   _enqueueJobGlobal(Builtin.convertTaskToJob(task))
 
-  return Task.Handle<T, Failure>(task)
+  return Task.Handle<T, Error>(task)
 }
 
 // ==== Async Handler ----------------------------------------------------------

--- a/test/Concurrency/Runtime/async_task_detach.swift
+++ b/test/Concurrency/Runtime/async_task_detach.swift
@@ -19,18 +19,35 @@ class X {
   }
 }
 
+struct Boom: Error {}
+
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func test_detach() async {
-  for _ in 1...3 {
-    let x = X()
-    let h = detach {
-      print("inside: \(x)")
-    }
-    await h.get()
+  let x = X()
+  let h = detach {
+    print("inside: \(x)")
   }
+  await h.get()
   // CHECK: X: init
   // CHECK: inside: main.X
   // CHECK: X: deinit
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func test_detach_throw() async {
+  let x = X()
+  let h = detach {
+    print("inside: \(x)")
+    throw Boom()
+  }
+  do {
+    try await h.get()
+  } catch {
+    print("error: \(error)")
+  }
+  // CHECK: X: init
+  // CHECK: inside: main.X
+  // CHECK: error: Boom()
 }
 
 
@@ -38,5 +55,6 @@ func test_detach() async {
 @main struct Main {
   static func main() async {
     await test_detach()
+    await test_detach_throw()
   }
 }


### PR DESCRIPTION
Solves type inference issue: ` invalid conversion from throwing function of type '@Sendable () throws -> ()' to non-throwing function type '@Sendable () async -> ()'`

rdar://76080685