### PR TITLE
[Dependency Scanning] Reset LLVM option occurences for each libSwiftScan query

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -101,6 +101,12 @@ DependencyScanningTool::initCompilerInstanceForScan(
   SmallString<128> WorkingDirectory;
   llvm::sys::fs::current_path(WorkingDirectory);
 
+  // We must reset option occurences because we are handling an unrelated
+  // command-line to those possibly parsed parsed before using the same tool.
+  // We must do so because LLVM options parsing is done using a managed
+  // static `GlobalParser`.
+  llvm::cl::ResetAllOptionOccurrences();
+
   // Parse arguments.
   std::string CommandString;
   for (const auto *c : Command) {


### PR DESCRIPTION
We must reset option occurences on each individual query because when an instance of the scanning tool is re-used in different contexts/different scans, we will be creating multiple compilation instances and re-parsing various (potentially-repeating) arguments.