### PR TITLE
[gardening] Remove an unnecessary bounds check on a container.

### DIFF
--- a/include/swift/SILOptimizer/Utils/ScopeOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/ScopeOptUtils.h
@@ -61,7 +61,6 @@ protected:
   /// on Optional has value.
   void invalidateCleanup(unsigned cleanupIndex) {
     assert(!didPop && "Should not invalidate once popped?!");
-    assert(cleanupIndex < cleanups.size());
     assert(cleanups[cleanupIndex].hasValue());
     cleanups[cleanupIndex] = None;
   }


### PR DESCRIPTION
As suggested by @atrick in review feedback in #36913.
