### PR TITLE
[SIL] Fix egregious errors in extract_executor handling.

### DIFF
--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -725,6 +725,9 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                       GetAsyncContinuationInstBase, MayHaveSideEffects, MayRelease)
     SINGLE_VALUE_INST_RANGE(GetAsyncContinuationInstBase, GetAsyncContinuationInst, GetAsyncContinuationAddrInst)
 
+  SINGLE_VALUE_INST(ExtractExecutorInst, extract_executor,
+                    SingleValueInstruction, MayRead, DoesNotRelease)
+
   // Key paths
   // TODO: The only "side effect" is potentially retaining the returned key path
   // object; is there a more specific effect?
@@ -835,8 +838,6 @@ NON_VALUE_INST(FixLifetimeInst, fix_lifetime,
 
 NON_VALUE_INST(HopToExecutorInst, hop_to_executor,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)
-SINGLE_VALUE_INST(ExtractExecutorInst, extract_executor,
-                  SILInstruction, MayRead, DoesNotRelease)
 
 NON_VALUE_INST(DestroyValueInst, destroy_value,
                SILInstruction, MayHaveSideEffects, MayRelease)

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -75,8 +75,7 @@ bool LowerHopToActor::run() {
       SILInstruction *inst = &*ii++;
       if (auto *hop = dyn_cast<HopToExecutorInst>(inst)) {
         changed |= processHop(hop);
-      }
-      if (auto *extract = dyn_cast<ExtractExecutorInst>(inst)) {
+      } else if (auto *extract = dyn_cast<ExtractExecutorInst>(inst)) {
         changed |= processExtract(extract);
       }
     }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 608; // internal parameter labels
+const uint16_t SWIFTMODULE_VERSION_MINOR = 609; // extract_executor SIL inst
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/Concurrency/Runtime/async_properties_actor.swift
+++ b/test/Concurrency/Runtime/async_properties_actor.swift
@@ -8,9 +8,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// https://bugs.swift.org/browse/SR-14486
-// UNSUPPORTED: linux
-
 @propertyWrapper
 struct SuccessTracker {
     private var _stored: Bool

--- a/test/Concurrency/Runtime/data_race_detection.swift
+++ b/test/Concurrency/Runtime/data_race_detection.swift
@@ -9,7 +9,7 @@
 // UNSUPPORTED: use_os_stdlib
 
 // https://bugs.swift.org/browse/SR-14486
-// REQUIRES: sr14486
+// UNSUPPORTED: linux
 
 import _Concurrency
 import Dispatch

--- a/test/Concurrency/Runtime/data_race_detection.swift
+++ b/test/Concurrency/Runtime/data_race_detection.swift
@@ -8,9 +8,6 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
-// https://bugs.swift.org/browse/SR-14486
-// UNSUPPORTED: linux
-
 import _Concurrency
 import Dispatch
 

--- a/test/Concurrency/Runtime/mainactor.swift
+++ b/test/Concurrency/Runtime/mainactor.swift
@@ -8,9 +8,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// https://bugs.swift.org/browse/SR-14486
-// UNSUPPORTED: linux
-
 import Dispatch
 
 /// @returns true iff the expected answer is actually the case, i.e., correct.

--- a/test/Sanitizers/tsan/mainactor.swift
+++ b/test/Sanitizers/tsan/mainactor.swift
@@ -6,9 +6,6 @@
 // REQUIRES: tsan_runtime
 // UNSUPPORTED: use_os_stdlib
 
-// https://bugs.swift.org/browse/SR-14486
-// UNSUPPORTED: linux
-
 import Dispatch
 
 /// @returns true iff the expected answer is actually the case, i.e., correct.


### PR DESCRIPTION
Make sure it is properly treated as a SingleValueInstruction, and
don't blatantly read freed memory in the LowerHopToExecutor pass.

Fixes https://bugs.swift.org/browse/SR-14486