### PR TITLE
[CodeCompletion] Reset diagnostics when reusing an ASTContext for completion

### DIFF
--- a/lib/IDE/CompletionInstance.cpp
+++ b/lib/IDE/CompletionInstance.cpp
@@ -493,6 +493,10 @@ bool CompletionInstance::performCachedOperationIfPossible(
   {
     PrettyStackTraceDeclContext trace("performing cached completion", traceDC);
 
+    // The diagnostic engine is keeping track of state which might modify
+    // parsing and type checking behaviour. Clear the flags.
+    CI.getDiags().resetHadAnyError();
+
     if (DiagC)
       CI.addDiagnosticConsumer(DiagC);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8517,6 +8517,17 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
 
 Optional<SolutionApplicationTarget>
 ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
+  // Rewriting the target might abort in case one of visit methods returns
+  // nullptr. In this case, no more walkToExprPost calls are issues and thus
+  // nodes which were pushed on the Rewriter's ExprStack in walkToExprPre are
+  // not popped of the stack again in walkTokExprPost. Usually, that's not an
+  // issue if rewriting completely terminates because the ExprStack is never
+  // used again. Here, however, we recover from a rewriting failure and continue
+  // using the Rewriter. To make sure we don't continue with an ExprStack that
+  // is still in the state when rewriting was aborted, save it here and restore
+  // it once rewritingt this target has finished.
+  llvm::SaveAndRestore<SmallVector<Expr *, 8>> RestoreExprStack(
+      Rewriter.ExprStack);
   auto &solution = Rewriter.solution;
 
   // Apply the solution to the target.

--- a/test/SourceKit/CodeComplete/sr14430.swift
+++ b/test/SourceKit/CodeComplete/sr14430.swift
@@ -1,0 +1,51 @@
+// Check that we are not crashing
+// RUN: %sourcekitd-test -req=complete -pos=48:28 %s -- %s == -req=complete -pos=48:16 %s -- %s
+
+let abcde = "abc"
+
+public struct MyEmptyView : MyView {
+  public typealias Body = Never
+  public var body: Never { fatalError() }
+}
+
+extension Never : MyView {}
+
+@resultBuilder public struct MyViewBuilder {
+  public static func buildBlock() -> MyEmptyView {
+        return MyEmptyView()
+    }
+  public static func buildBlock<Content>(_ content: Content) -> Content where Content : MyView {
+        content
+    }
+}
+
+public protocol MyView {
+  associatedtype Body : MyView
+  @MyViewBuilder var body: Self.Body { get }
+}
+
+public struct MyHStack<Content> : MyView {
+  public init(@MyViewBuilder content: () -> Content) {}
+  public typealias Body = Swift.Never
+  public var body: Never { fatalError() }
+}
+
+public struct MyText : MyView {
+  public init(_ content: Swift.String) {}
+  public typealias Body = Never
+  public var body: Never { fatalError() }
+}
+
+extension MyView {
+  public func padding(_ insets: Bool) -> some MyView { return MyEmptyView() }
+  public func padding(_ length: Float) -> some MyView { return MyEmptyView() }
+  public func padding() -> some MyView { return MyEmptyView() }
+}
+
+struct RoundedBadge : MyView {
+  var body: some MyView {
+    MyHStack {
+      MyText(abcde).padding()
+    }
+  }
+}


### PR DESCRIPTION
The diagnosticc engine is keeping track of state which might modify parsing/typechecking behaviour. In the added test case the `fatalErrorOccurred` flag was during the first completion. The flag was still `true` for the second completion, causing parsing/typechecking to behave slightly differently. Because of this, the ExprRewriter failed when applying a constraint system solution, not properly cleaning up its `ExprStack`.

This PR tackles both issues:
1) Reset the `hadError` flags in the diagnostics engine when reusing an `ASTContext` for completion
2) Clean up the `ExprRewriter`’s `ExprStack` when rewriting a target fails.

Either of these changes fixes the crash in the test case but I think both could manifest through different code paths in different scenarios.

Fixes rdar://76051976 [SR-14430]