### PR TITLE
[Property Wrappers] Fix availability inference for enclosing self property wrappers.

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1930,11 +1930,17 @@ static void addPropertyWrapperAccessorAvailability(VarDecl *var, AccessorKind ac
                                                    SmallVectorImpl<const Decl *> &asAvailableAs) {
   AccessorDecl *synthesizedFrom = nullptr;
   if (var->hasAttachedPropertyWrapper()) {
+    AbstractStorageDecl *wrappedValueImpl;
+    if (auto access = getEnclosingSelfPropertyWrapperAccess(var, /*forProjected=*/false)) {
+      wrappedValueImpl = access->subscript;
+    } else {
+      wrappedValueImpl = var->getAttachedPropertyWrapperTypeInfo(0).valueVar;
+    }
+
     // The property wrapper info may not actually link back to a wrapper
     // implementation, if there was a semantic error checking the wrapper.
-    auto info = var->getAttachedPropertyWrapperTypeInfo(0);
-    if (info.valueVar) {
-      synthesizedFrom = info.valueVar->getOpaqueAccessor(accessorKind);
+    if (wrappedValueImpl) {
+      synthesizedFrom = wrappedValueImpl->getOpaqueAccessor(accessorKind);
     }
   } else if (auto wrapperSynthesizedKind
                = var->getPropertyWrapperSynthesizedPropertyKind()) {
@@ -1944,11 +1950,17 @@ static void addPropertyWrapperAccessorAvailability(VarDecl *var, AccessorKind ac
 
     case PropertyWrapperSynthesizedPropertyKind::Projection: {
       if (auto origVar = var->getOriginalWrappedProperty(wrapperSynthesizedKind)) {
+        AbstractStorageDecl *projectedValueImpl;
+        if (auto access = getEnclosingSelfPropertyWrapperAccess(origVar, /*forProjected=*/true)) {
+          projectedValueImpl = access->subscript;
+        } else {
+          projectedValueImpl = origVar->getAttachedPropertyWrapperTypeInfo(0).projectedValueVar;
+        }
+
         // The property wrapper info may not actually link back to a wrapper
         // implementation, if there was a semantic error checking the wrapper.
-        auto info = origVar->getAttachedPropertyWrapperTypeInfo(0);
-        if (info.projectedValueVar) {
-          synthesizedFrom = info.projectedValueVar->getOpaqueAccessor(accessorKind);
+        if (projectedValueImpl) {
+          synthesizedFrom = projectedValueImpl->getOpaqueAccessor(accessorKind);
         }
       }
       break;


### PR DESCRIPTION
If a property wrapper accessor is synthesized using the enclosing-self subscript, infer availability from accessors on the subscript declaration rather than the wrapped/projected value declaration in the property wrapper.

Resolves: rdar://76557679