### PR TITLE
[CSRanking] Lazily compute 'SolutionDiff.overloads'

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1345,14 +1345,27 @@ public:
     SmallVector<OverloadChoice, 2> choices;
   };
 
+private:
+  ArrayRef<Solution> solutions;
+
   /// The differences between the overload choices between the
   /// solutions.
-  SmallVector<OverloadDiff, 4> overloads;
+  mutable Optional<SmallVector<OverloadDiff, 4>> overloads;
 
+  /// Populate 'overloads'.
+  void populateOverloads() const;
+
+public:
   /// Compute the differences between the given set of solutions.
   ///
   /// \param solutions The set of solutions.
-  explicit SolutionDiff(ArrayRef<Solution> solutions);
+  explicit SolutionDiff(ArrayRef<Solution> solutions) : solutions(solutions) {};
+
+  ArrayRef<OverloadDiff> getOverloads() const {
+    if (!overloads.hasValue())
+      populateOverloads();
+    return *overloads;
+  }
 };
 
 /// An intrusive, doubly-linked list of constraints.

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -838,7 +838,8 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     return 1;
   };
 
-  SmallVector<SolutionDiff::OverloadDiff, 4> overloadDiff(diff.overloads);
+  SmallVector<SolutionDiff::OverloadDiff, 4> overloadDiff(
+      diff.getOverloads().begin(),  diff.getOverloads().end());
   // Single type of keypath dynamic member lookup could refer to different
   // member overloads, we have to do a pair-wise comparison in such cases
   // otherwise ranking would miss some viable information e.g.
@@ -1458,7 +1459,9 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
   return None;
 }
 
-SolutionDiff::SolutionDiff(ArrayRef<Solution> solutions) {
+void SolutionDiff::populateOverloads() const {
+  overloads.emplace();
+
   if (solutions.size() <= 1)
     return;
 
@@ -1501,7 +1504,7 @@ SolutionDiff::SolutionDiff(ArrayRef<Solution> solutions) {
         continue;
 
       // We have a difference. Add this set of overload choices to the diff.
-      this->overloads.push_back(SolutionDiff::OverloadDiff{
+      overloads->push_back(SolutionDiff::OverloadDiff{
           overloadChoice.first, std::move(overloadChoice.second)});
       break;
     }


### PR DESCRIPTION
`SolutionDiff.overloads` were unused when `Solution.getFixedScore()` is different, or in `isForCodeCompletion` mode. Since calculating it is somewhat heavy operation, do it lazily.
