### PR TITLE
[ConstraintSystem] Fix a few diagnostic bugs for inferred property wrapper types.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8369,32 +8369,41 @@ ConstraintSystem::simplifyPropertyWrapperConstraint(
     return SolutionKind::Unsolved;
   }
 
-  ConstraintFix *fix = nullptr;
+  // If the wrapper type is a hole or a dependent member with no type variables,
+  // don't record a fix, because this indicates that there was an error
+  // elsewhere in the constraint system.
+  if (wrapperType->isPlaceholder() || wrapperType->is<DependentMemberType>())
+    return SolutionKind::Solved;
+
   auto *wrappedVar = getAsDecl<VarDecl>(locator.getAnchor());
   assert(wrappedVar && wrappedVar->hasAttachedPropertyWrapper());
 
   // The wrapper type must be a property wrapper.
   auto *nominal = wrapperType->getDesugaredType()->getAnyNominal();
   if (!(nominal && nominal->getAttrs().hasAttribute<PropertyWrapperAttr>())) {
-    fix = AllowInvalidPropertyWrapperType::create(*this, wrapperType,
-                                                  getConstraintLocator(locator));
+    if (shouldAttemptFixes()) {
+      auto *fix = AllowInvalidPropertyWrapperType::create(
+          *this, wrapperType, getConstraintLocator(locator));
+      if (!recordFix(fix))
+        return SolutionKind::Solved;
+    }
+
+    return SolutionKind::Error;
   }
 
   auto typeInfo = nominal->getPropertyWrapperTypeInfo();
 
   // Implicit property wrappers must support projected-value initialization.
-  if (!fix && wrappedVar->hasImplicitPropertyWrapper()) {
-    if (!(typeInfo.projectedValueVar && typeInfo.hasProjectedValueInit)) {
-      fix = RemoveProjectedValueArgument::create(*this, wrapperType, cast<ParamDecl>(wrappedVar),
-                                                 getConstraintLocator(locator));
+  if (wrappedVar->hasImplicitPropertyWrapper() &&
+      !(typeInfo.projectedValueVar && typeInfo.hasProjectedValueInit)) {
+    if (shouldAttemptFixes()) {
+      auto *fix = RemoveProjectedValueArgument::create(
+          *this, wrapperType, cast<ParamDecl>(wrappedVar), getConstraintLocator(locator));
+      if (!recordFix(fix))
+        return SolutionKind::Solved;
     }
-  }
 
-  if (fix) {
-    if (!shouldAttemptFixes() || recordFix(fix))
-      return SolutionKind::Error;
-
-    return SolutionKind::Solved;
+    return SolutionKind::Error;
   }
 
   auto resolvedType = wrapperType->getTypeOfMember(DC->getParentModule(), typeInfo.valueVar);

--- a/test/Sema/property_wrapper_parameter_invalid.swift
+++ b/test/Sema/property_wrapper_parameter_invalid.swift
@@ -164,3 +164,26 @@ public func testComposition2(@InternalWrapper @PublicWrapper value: Int) {}
 // expected-error@+2 {{generic struct 'InternalWrapper' is internal and cannot be referenced from an '@inlinable' function}}
 // expected-error@+1 {{initializer 'init(wrappedValue:)' is internal and cannot be referenced from an '@inlinable' function}}
 @inlinable func testComposition6(@InternalWrapper @PublicWrapper value: Int) {}
+
+protocol Q {
+  associatedtype A
+}
+
+// expected-note@+1 {{where 'T' = 'Int'}}
+func takesClosure<T: Q>(type: T.Type, _ closure: (T.A) -> Void) {}
+
+func testMissingWrapperType() {
+  // expected-error@+1 {{global function 'takesClosure(type:_:)' requires that 'Int' conform to 'Q'}}
+  takesClosure(type: Int.self) { $value in
+    return
+  }
+
+  struct S: Q {
+    typealias A = (Int, Int)
+  }
+
+  // expected-error@+1 {{inferred projection type 'S.A' (aka '(Int, Int)') is not a property wrapper}}
+  takesClosure(type: S.self) { $value in
+    return
+  }
+}


### PR DESCRIPTION
* Fix a crash when an inferred property wrapper type is a structural type.
* Suppress diagnostics when an inferred property wrapper type is a hole or a dependent member type with no type variables, both of which indicate an error elsewhere in the constraint system such as a missing conformance.
