### PR TITLE
AST: Fix issue where SIL type lowering did not commute with subst()

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3181,15 +3181,12 @@ operator()(SubstitutableType *maybeOpaqueType) const {
   // archetype in question. This will map the inner generic signature of the
   // opaque type to its outer signature.
   auto partialSubstTy = archetype->getInterfaceType().subst(*subs);
-  // Then apply the substitutions from the root opaque archetype, to specialize
-  // for its type arguments.
-  auto substTy = partialSubstTy.subst(opaqueRoot->getSubstitutions());
 
   // Check that we are allowed to substitute the underlying type into the
   // context.
   auto inContext = this->inContext;
   auto isContextWholeModule = this->isContextWholeModule;
-  if (substTy.findIf(
+  if (partialSubstTy.findIf(
           [inContext, substitutionKind, isContextWholeModule](Type t) -> bool {
             if (!canSubstituteTypeInto(t, inContext, substitutionKind,
                                        isContextWholeModule))
@@ -3197,6 +3194,12 @@ operator()(SubstitutableType *maybeOpaqueType) const {
             return false;
           }))
     return maybeOpaqueType;
+
+  // Then apply the substitutions from the root opaque archetype, to specialize
+  // for its type arguments. We perform this substitution after checking for
+  // visibility, since we do not want the result of the visibility check to
+  // depend on the substitutions previously applied.
+  auto substTy = partialSubstTy.subst(opaqueRoot->getSubstitutions());
 
   // If the type changed, but still contains opaque types, recur.
   if (!substTy->isEqual(maybeOpaqueType) && substTy->hasOpaqueArchetype()) {
@@ -3264,18 +3267,12 @@ operator()(CanType maybeOpaqueType, Type replacementType,
   // archetype in question. This will map the inner generic signature of the
   // opaque type to its outer signature.
   auto partialSubstTy = archetype->getInterfaceType().subst(*subs);
-  auto partialSubstRef =
-      abstractRef.subst(archetype->getInterfaceType(), *subs);
-
-  // Then apply the substitutions from the root opaque archetype, to specialize
-  // for its type arguments.
-  auto substTy = partialSubstTy.subst(opaqueRoot->getSubstitutions());
 
   // Check that we are allowed to substitute the underlying type into the
   // context.
   auto inContext = this->inContext;
   auto isContextWholeModule = this->isContextWholeModule;
-  if (substTy.findIf(
+  if (partialSubstTy.findIf(
           [inContext, substitutionKind, isContextWholeModule](Type t) -> bool {
             if (!canSubstituteTypeInto(t, inContext, substitutionKind,
                                        isContextWholeModule))
@@ -3284,6 +3281,14 @@ operator()(CanType maybeOpaqueType, Type replacementType,
           }))
     return abstractRef;
 
+  // Then apply the substitutions from the root opaque archetype, to specialize
+  // for its type arguments. We perform this substitution after checking for
+  // visibility, since we do not want the result of the visibility check to
+  // depend on the substitutions previously applied.
+  auto substTy = partialSubstTy.subst(opaqueRoot->getSubstitutions());
+
+  auto partialSubstRef =
+      abstractRef.subst(archetype->getInterfaceType(), *subs);
   auto substRef =
       partialSubstRef.subst(partialSubstTy, opaqueRoot->getSubstitutions());
 

--- a/test/SILGen/Inputs/opaque_result_type_private_substitution_other.swift
+++ b/test/SILGen/Inputs/opaque_result_type_private_substitution_other.swift
@@ -1,0 +1,15 @@
+public protocol P {
+  associatedtype A
+  var v: A { get }
+}
+
+public extension P {
+  func foo() -> some P {
+    return self
+  }
+}
+
+public struct S: P {
+  public init() {}
+  public var v: some P { return self }
+}

--- a/test/SILGen/opaque_result_type_private_substitution.swift
+++ b/test/SILGen/opaque_result_type_private_substitution.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module %S/Inputs/opaque_result_type_private_substitution_other.swift -emit-module-path %t/opaque_result_type_private_substitution_other.swiftmodule
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen %s -I %t -DMODULE
+
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module %S/Inputs/opaque_result_type_private_substitution_other.swift -emit-module-path %t/opaque_result_type_private_substitution_other.swiftmodule -enable-library-evolution
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen %s -I %t -DMODULE
+
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen %s %S/Inputs/opaque_result_type_private_substitution_other.swift
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -primary-file %s %S/Inputs/opaque_result_type_private_substitution_other.swift
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -primary-file %s -primary-file %S/Inputs/opaque_result_type_private_substitution_other.swift
+
+#if MODULE
+import opaque_result_type_private_substitution_other
+#endif
+
+struct S1: P {
+  var v: some P { S2().foo() }
+}
+
+private struct S2: P {
+  var v: some P { S() }
+}


### PR DESCRIPTION
This fixes a regression from https://github.com/apple/swift/commit/095824eb2a7bd82948be849f104eeca9b749b205.

SIL type lowering uses ReplaceOpaqueTypesWithUnderlyingTypes to lower away
opaque result types when the current context can "see" the underlying type
of the opaque result type.

To determine if an opaque result type could be replaced with its
underlying type, we check if every nominal type declaration appearing
in the "fully substituted" underlying type is visible from the current
context.

To form the "fully substituted" type, we first apply the substitution map
stored in the opaque type decl, which replaces the 'Self' generic parameter
with the actual concrete result type.

Then, we apply the substitution map stored in the archetype itself.

However, calling subst() on an opaque archetype modifies the substitution
map stored in the archetype.

What this means in practice is that if I have an opaque type declaration
that depends on its outer generic parameters, the fully-substituted type
that I see here depends on whether subst() has been performed or not.

For example, suppose I have the following:

    protocol P {}
    struct S : P {}
    extension P {
      func foo() -> some Any { return [self] }
    }

The opaque result decl for P.foo() maps `Self` to `Array<Self>`. Now,
imagine someone calls foo() with the substitution `Self := S`. The
fully-substituted underlying type is `Array<S>`. If `S` is private, we
will decide that we cannot replace the opaque result type with its
underlying type. However, if we had performed the opaque type replacement
_before_ substituting `Self := S`, then we will end up replacing the
opaque result type.

To re-state this in yet another form, we want the following identity to
hold here:

    getLoweredType(opaqueType).subst(subMap) == getLoweredType(opaqueType.subst(subMap))

We can ensure that this holds by only applying the archetype's
substitutions _after_ we check visibility.

Fixes rdar://problem/76556368.