### PR TITLE
[AnyHashable] Work around older compiler limitation.

### DIFF
--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -262,6 +262,10 @@ extension AnyHashable: CustomReflectable {
 
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AnyHashable: _HasCustomAnyHashableRepresentation {
+}
+
+extension AnyHashable {
+  @_alwaysEmitIntoClient
   public __consuming func _toCustomAnyHashable() -> AnyHashable? {
     return self
   }


### PR DESCRIPTION
An older Swift compiler failed to account for the witnesses in a
conformance with platform availability having their own availability,
which causes that compiler to reject the Swift module's .swiftinterface
file when it includes `AnyHashable` 's conformance to
`_HasCustomAnyHashableRepresentation`. Work around the issue by making
the one witness (`_toCustomAnyHashable`, which is trivial)
always-emit-into-client, so it does not need any availability.

Fixes rdar://76370138.
