### PR TITLE
[Sema] Don’t allow unresolved type variables if `LeaveBraceStmtBodyUnchecked` is `true`

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -6593,6 +6593,13 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     if (isDynamicLookup(*ExprType))
       Lookup.setIsDynamicLookup();
     Lookup.getValueExprCompletions(*ExprType, ReferencedDecl.getDecl());
+    /// We set the type of ParsedExpr explicitly above. But we don't want an
+    /// unresolved type in our AST when we type check again for operator
+    /// completions. Remove the type of the ParsedExpr and see if we can come up
+    /// with something more useful based on the the full sequence expression.
+    if (ParsedExpr->getType()->is<UnresolvedType>()) {
+      ParsedExpr->setType(nullptr);
+    }
     Lookup.getOperatorCompletions(ParsedExpr, leadingSequenceExprs);
     Lookup.getPostfixKeywordCompletions(*ExprType, ParsedExpr);
     break;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1506,7 +1506,6 @@ void StmtChecker::typeCheckASTNode(ASTNode &node) {
       options |= TypeCheckExprFlags::IsDiscarded;
     if (LeaveBraceStmtBodyUnchecked) {
       options |= TypeCheckExprFlags::LeaveClosureBodyUnchecked;
-      options |= TypeCheckExprFlags::AllowUnresolvedTypeVariables;
     }
 
     auto resultTy =

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -439,7 +439,7 @@ func curry<T1, T2, R>(_ f: @escaping (T1, T2) -> R) -> (T1) -> (T2) -> R {
   return { t1 in { t2 in f(#^NESTED_CLOSURE^#, t2) } }
   // NESTED_CLOSURE: Begin completions
   // FIXME: Should be '/TypeRelation[Invalid]: t2[#T2#]'
-  // NESTED_CLOSURE: Decl[LocalVar]/Local:               t2[#_#]; name=t2
+  // NESTED_CLOSURE: Decl[LocalVar]/Local:               t2; name=t2
   // NESTED_CLOSURE: Decl[LocalVar]/Local:               t1[#T1#]; name=t1
 }
 

--- a/validation-test/IDE/crashers_2_fixed/rdar76686564.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar76686564.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-ide-test --conforming-methods -code-completion-token=COMPLETE --conforming-methods-expected-types=s:14swift_ide_test10MySequenceP -source-filename %s
+
+protocol MySequence {
+  associatedtype Element
+}
+
+struct Foo<X>: MySequence {
+	typealias Element = X
+}
+
+struct ArgumentDefinition {
+  fileprivate func bashCompletionWords() -> Foo<String> { fatalError() }
+}
+
+func myFlatMap<SegmentOfResult: MySequence>(_ transform: (ArgumentDefinition) -> SegmentOfResult) -> Foo<SegmentOfResult.Element> {
+  fatalError()
+}
+
+func generateArgumentWords() {
+  _ = myFlatMap { $0.#^COMPLETE^# } as Foo<String>
+}


### PR DESCRIPTION
[Sema] Don’t allow unresolved type variables if `LeaveBraceStmtBodyUnchecked` is `true`

According to Pavel, we want to eliminate allowing unresolved variables as much as possible. Removing this flag doesn’t break any test cases (at least not in a meaningful way) and fixes a crasher, so it seems reasonable to remove it.

When doing operator completion, we re-type-check the sequence expression. If we have an unresolve type already applied to `ParsedExpr`, which is the last element of the sequence, the type checker crashes in `validation-test/IDE/crashers_2_fixed/0008-must-conform-to-literal-protocol.swift`, because there are still inactive constraints in the constraint system when it finishes solving.

Previously, we would ignore because we allowed free type variables, which we no longer do since the last commit.

Fixes rdar://76686564