### PR TITLE
[test] Fix CI failure in bad stdlib test

### DIFF
--- a/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/BadStdlib.sdk/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -2,7 +2,7 @@
 // swift-module-flags: -target x86_64-apple-macos10.9 -module-name Swift -parse-stdlib
 
 // If the test fails, this error will be emitted twice, not once.
-// expected-error@-4 {{failed to build module 'Swift' for importation due to the errors above}}
+// expected-error@-4 {{failed to build module 'Swift'; this SDK is not supported by the compiler}}
 
 public struct BadType {
   public var property: UndeclaredType { get set } // expected-error {{cannot find type 'UndeclaredType' in scope}}


### PR DESCRIPTION
https://github.com/apple/swift/pull/36928 changed the error message while https://github.com/apple/swift/pull/36594 added a test case looking for the old error message. Update the test to look for the non-dynamic substring of the new error message.

CC: @eeckstein @beccadax 