### PR TITLE
Document how out-of-range inputs are handled

### DIFF
--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -53,13 +53,14 @@ extension ${Self}: LosslessStringConvertible {
   /// Creates a new instance from the given string.
   ///
   /// The string passed as `text` can represent a real number in decimal or
-  /// hexadecimal format or special floating-point values for infinity and NaN
-  /// ("not a number").
+  /// hexadecimal format or can be in a special format representing infinity
+  /// or NaN ("not a number"). If the `text` is not in a recognized format,
+  /// the optional initializer will fail and return `nil`.
   ///
   /// The `text` string may begin with a plus or minus sign character (`+` or
   /// `-`) followed by one of the following formats:
   ///
-  /// - A *decimal value* contains a significand consisting of one
+  /// - A *decimal string* contains a significand consisting of one
   ///   or more decimal digits that may include a decimal point:
   ///
   ///       let c = ${Self}("-1.0")
@@ -68,9 +69,9 @@ extension ${Self}: LosslessStringConvertible {
   ///       let d = ${Self}("28.375")
   ///       // d == 28.375
   ///
-  ///   A decimal value may also include an exponent following the significand,
-  ///   indicating the power of 10 by which the significand should be
-  ///   multiplied. If included, the exponent is separated by a single
+  ///   A decimal string may also include an exponent following the
+  ///   significand, indicating the power of 10 by which the significand should
+  ///   be multiplied. If included, the exponent is separated by a single
   ///   character, `e` or `E`, and consists of an optional plus or minus sign
   ///   character and a sequence of decimal digits.
   ///
@@ -78,9 +79,9 @@ extension ${Self}: LosslessStringConvertible {
   ///       // e == 28.375
   ///
   ///   A decimal string is converted into a correctly-rounded ${Self}
-  ///   value using IEEE 754 round-to-nearest
-  ///   conventions. Very small values are converted to positive or
-  ///   negative zero, very large values are converted
+  ///   instance using IEEE 754 round-to-nearest
+  ///   conventions. Very small values are rounded to positive or
+  ///   negative zero, very large values are rounded
   ///   to plus or minus infinity.
   ///
   ///       let y = ${Self}("1.23e-9999")
@@ -97,14 +98,14 @@ extension ${Self}: LosslessStringConvertible {
   ///       let s = ${Self}("-7.89e7206")
   ///       // s == ${Self}.-infinity
   ///
-  /// - A *hexadecimal value* contains a significand consisting of
-  //    `0X` or `0x` followed by one or more hexadecimal digits that may
+  /// - A *hexadecimal string* contains a significand consisting of
+  ///   `0X` or `0x` followed by one or more hexadecimal digits that may
   ///   include a decimal point.
   ///
   ///       let f = ${Self}("0x1c.6")
   ///       // f == 28.375
   ///
-  ///   A hexadecimal value may also include an exponent
+  ///   A hexadecimal string may also include an exponent
   ///   indicating the power of 2 by which the significand should
   ///   be multiplied. If included, the exponent is separated by a single
   ///   character, `p` or `P`, and consists of an optional plus or minus sign
@@ -113,9 +114,9 @@ extension ${Self}: LosslessStringConvertible {
   ///       let g = ${Self}("0x1.c6p4")
   ///       // g == 28.375
   ///
-  ///   As with decimal strings, hexadecimal strings are converted
-  ///   to the closest ${Self} value to the real number.  Very small
-  ///   or very large values are converted to plus or minus zero or plus
+  ///   As with decimal strings, hexadecimal strings are rounded
+  ///   to the closest ${Self} instance to the real number.  Very small
+  ///   or very large values are rounded to plus or minus zero or plus
   ///   or minus infinity.
   ///
   /// - The input strings `"inf"` or `"infinity"` (case insensitive)
@@ -134,7 +135,7 @@ extension ${Self}: LosslessStringConvertible {
   ///       // n?.isNaN == true
   ///       // n?.sign == .minus
   ///
-  ///   A NaN value may also include a payload in parentheses following the
+  ///   A NaN string may also include a payload in parentheses following the
   ///   `"nan"` keyword. The payload consists of a sequence of decimal digits,
   ///   or the characters `0X` or `0x` followed by a sequence of hexadecimal
   ///   digits. If the payload contains any other characters, it is ignored.
@@ -145,7 +146,7 @@ extension ${Self}: LosslessStringConvertible {
   ///       // p?.isNaN == true
   ///       // String(p!) == "nan(0x10)"
   ///
-  /// - A value in any other format or containing additional characters
+  /// - A string in any other format or containing additional characters
   ///   results in a `nil` value. For example, the following conversions
   ///   result in `nil`:
   ///
@@ -153,8 +154,7 @@ extension ${Self}: LosslessStringConvertible {
   ///       ${Self}("±2.0")      // Invalid character
   ///       ${Self}("0x1.25e4")  // Incorrect exponent format
   ///
-  /// - Parameter text: The input string to convert to a `${Self}?` instance.
-  ///   The value will be `nil` if the input is incorrectly formatted.
+  /// - Parameter text: An input string to convert to a `${Self}?` instance.
   @inlinable
   public init?<S: StringProtocol>(_ text: S) {
   %if bits == 16:

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -57,8 +57,9 @@ extension ${Self}: LosslessStringConvertible {
   /// or NaN ("not a number"). If the `text` is not in a recognized format,
   /// the optional initializer will fail and return `nil`.
   ///
-  /// The `text` string may begin with a plus or minus sign character (`+` or
-  /// `-`) followed by one of the following formats:
+  /// The `text` string consists of an optional
+  /// plus or minus sign character (`+` or `-`)
+  /// followed by one of the following formats:
   ///
   /// - A *decimal string* contains a significand consisting of one
   ///   or more decimal digits that may include a decimal point:

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -54,12 +54,12 @@ extension ${Self}: LosslessStringConvertible {
   ///
   /// The string passed as `text` can represent a real number in decimal or
   /// hexadecimal format or can be in a special format representing infinity
-  /// or NaN ("not a number"). If the `text` is not in a recognized format,
+  /// or NaN ("not a number"). If `text` is not in a recognized format,
   /// the optional initializer will fail and return `nil`.
   ///
   /// The `text` string consists of an optional
   /// plus or minus sign character (`+` or `-`)
-  /// followed by one of the following formats:
+  /// followed by one of the following:
   ///
   /// - A *decimal string* contains a significand consisting of one
   ///   or more decimal digits that may include a decimal point:
@@ -79,27 +79,6 @@ extension ${Self}: LosslessStringConvertible {
   ///       let e = ${Self}("2837.5e-2")
   ///       // e == 28.375
   ///
-  ///   A decimal string is converted to a ${Self}
-  ///   instance using the IEEE 754 roundTiesToEven (default) rounding
-  ///   attribute.
-  ///   Very small values are rounded to positive or
-  ///   negative zero, very large values are rounded
-  ///   to plus or minus infinity.
-  ///
-  ///       let y = ${Self}("1.23e-9999")
-  ///       // y == 0.0
-  ///       // y?.sign == .plus
-  ///
-  ///       let z = ${Self}("-7.89e-7206")
-  ///       // z == -0.0
-  ///       // z?.sign == .minus
-  ///
-  ///       let r = ${Self}("1.23e17802")
-  ///       // r == ${Self}.infinity
-  ///
-  ///       let s = ${Self}("-7.89e7206")
-  ///       // s == ${Self}.-infinity
-  ///
   /// - A *hexadecimal string* contains a significand consisting of
   ///   `0X` or `0x` followed by one or more hexadecimal digits that may
   ///   include a decimal point.
@@ -115,11 +94,6 @@ extension ${Self}: LosslessStringConvertible {
   ///
   ///       let g = ${Self}("0x1.c6p4")
   ///       // g == 28.375
-  ///
-  ///   As with decimal strings, hexadecimal strings are rounded
-  ///   to the closest ${Self} instance to the real number.  Very small
-  ///   or very large values are rounded to plus or minus zero or plus
-  ///   or minus infinity.
   ///
   /// - The input strings `"inf"` or `"infinity"` (case insensitive)
   ///   are converted to an infinite result:
@@ -148,20 +122,43 @@ extension ${Self}: LosslessStringConvertible {
   ///       // p?.isNaN == true
   ///       // String(p!) == "nan(0x10)"
   ///
-  /// - A string in any other format or containing additional characters
-  ///   results in a `nil` value. For example, the following conversions
-  ///   result in `nil`:
+  /// A string in any other format than those described above
+  /// or containing additional characters
+  /// results in a `nil` value. For example, the following conversions
+  /// result in `nil`:
   ///
   ///       ${Self}(" 5.0")      // Includes whitespace
   ///       ${Self}("±2.0")      // Invalid character
   ///       ${Self}("0x1.25e4")  // Incorrect exponent format
   ///
-  /// - Parameter text: An input string to convert to a `${Self}?` instance.
+  /// A decimal or hexadecimal string is converted to a `${Self}`
+  /// instance using the IEEE 754 roundTiesToEven (default) rounding
+  /// attribute.
+  /// Values with absolute value smaller than `${Self}.leastNonzeroMagnitude`
+  /// are rounded to plus or minus zero.
+  /// Values with absolute value larger than `${Self}.greatestFiniteMagnitude`
+  /// are rounded to plus or minus infinity.
   ///
-  /// Backwards compatibility note:  Prior to Swift 5.4, a decimal or
+  ///       let y = ${Self}("1.23e-9999")
+  ///       // y == 0.0
+  ///       // y?.sign == .plus
+  ///
+  ///       let z = ${Self}("-7.89e-7206")
+  ///       // z == -0.0
+  ///       // z?.sign == .minus
+  ///
+  ///       let r = ${Self}("1.23e17802")
+  ///       // r == ${Self}.infinity
+  ///
+  ///       let s = ${Self}("-7.89e7206")
+  ///       // s == ${Self}.-infinity
+  ///
+  /// Note:  Prior to Swift 5.4, a decimal or
   /// hexadecimal input string whose value was too large to represent
-  /// as a finite `${Self}` instance would return `nil` instead of
+  /// as a finite `${Self}` instance returned `nil` instead of
   /// `${Self}.infinity`.
+  ///
+  /// - Parameter text: An input string to convert to a `${Self}?` instance.
   ///
   @inlinable
   public init?<S: StringProtocol>(_ text: S) {

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -153,7 +153,7 @@ extension ${Self}: LosslessStringConvertible {
   ///       let s = ${Self}("-7.89e7206")
   ///       // s == ${Self}.-infinity
   ///
-  /// Note:  Prior to Swift 5.4, a decimal or
+  /// - Note:  Prior to Swift 5.4, a decimal or
   /// hexadecimal input string whose value was too large to represent
   /// as a finite `${Self}` instance returned `nil` instead of
   /// `${Self}.infinity`.

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -79,8 +79,8 @@ extension ${Self}: LosslessStringConvertible {
   ///
   ///   A decimal string is converted into a correctly-rounded ${Self}
   ///   value using IEEE 754 round-to-nearest
-  ///   conventions. Very small values will be converted to positive or
-  ///   negative zero, very large values will be converted
+  ///   conventions. Very small values are converted to positive or
+  ///   negative zero, very large values are converted
   ///   to plus or minus infinity.
   ///
   ///       let y = ${Self}("1.23e-9999")

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -128,8 +128,10 @@ extension ${Self}: LosslessStringConvertible {
   ///     ${Self}("0x1.25e4")  // Incorrect exponent format
   ///
   /// - Parameter text: The input string to convert to a `${Self}` instance. If
-  ///   `text` has invalid characters or is in an invalid format, the result
-  ///   is `nil`.
+  ///   `text` has invalid characters or is in an invalid format, the result is
+  ///   `nil`.  If the input is valid but the parsed value would be too small
+  ///   or large for the type, the result will be a zero or infinity with the
+  ///   appropriate sign.
   @inlinable
   public init?<S: StringProtocol>(_ text: S) {
   %if bits == 16:

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -56,12 +56,11 @@ extension ${Self}: LosslessStringConvertible {
   /// hexadecimal format or special floating-point values for infinity and NaN
   /// ("not a number").
   ///
-  /// The given string may begin with a plus or minus sign character (`+` or
-  /// `-`). The allowed formats for each of these representations is then as
-  /// follows:
+  /// The `text` string may begin with a plus or minus sign character (`+` or
+  /// `-`) followed by one of the following formats:
   ///
-  /// - A *decimal value* contains the significand, a sequence of decimal
-  ///   digits that may include a decimal point.
+  /// - A *decimal value* contains a significand consisting of one
+  ///   or more decimal digits that may include a decimal point:
   ///
   ///       let c = ${Self}("-1.0")
   ///       // c == -1.0
@@ -78,15 +77,35 @@ extension ${Self}: LosslessStringConvertible {
   ///       let e = ${Self}("2837.5e-2")
   ///       // e == 28.375
   ///
-  /// - A *hexadecimal value* contains the significand, either `0X` or `0x`,
-  ///   followed by a sequence of hexadecimal digits. The significand may
+  ///   A decimal string is converted into a correctly-rounded ${Self}
+  ///   value using IEEE 754 round-to-nearest
+  ///   conventions. Very small values will be converted to positive or
+  ///   negative zero, very large values will be converted
+  ///   to plus or minus infinity.
+  ///
+  ///       let y = ${Self}("1.23e-9999")
+  ///       // y == 0.0
+  ///       // y?.sign == .plus
+  ///
+  ///       let z = ${Self}("-7.89e-7206")
+  ///       // z == -0.0
+  ///       // z?.sign == .minus
+  ///
+  ///       let r = ${Self}("1.23e17802")
+  ///       // r == ${Self}.infinity
+  ///
+  ///       let s = ${Self}("-7.89e7206")
+  ///       // s == ${Self}.-infinity
+  ///
+  /// - A *hexadecimal value* contains a significand consisting of
+  //    `0X` or `0x` followed by one or more hexadecimal digits that may
   ///   include a decimal point.
   ///
   ///       let f = ${Self}("0x1c.6")
   ///       // f == 28.375
   ///
-  ///   A hexadecimal value may also include an exponent following the
-  ///   significand, indicating the power of 2 by which the significand should
+  ///   A hexadecimal value may also include an exponent
+  ///   indicating the power of 2 by which the significand should
   ///   be multiplied. If included, the exponent is separated by a single
   ///   character, `p` or `P`, and consists of an optional plus or minus sign
   ///   character and a sequence of decimal digits.
@@ -94,8 +113,13 @@ extension ${Self}: LosslessStringConvertible {
   ///       let g = ${Self}("0x1.c6p4")
   ///       // g == 28.375
   ///
-  /// - A value of *infinity* contains one of the strings `"inf"` or
-  ///   `"infinity"`, case insensitive.
+  ///   As with decimal strings, hexadecimal strings are converted
+  ///   to the closest ${Self} value to the real number.  Very small
+  ///   or very large values are converted to plus or minus zero or plus
+  ///   or minus infinity.
+  ///
+  /// - The input strings `"inf"` or `"infinity"` (case insensitive)
+  ///   are converted to an infinite result:
   ///
   ///       let i = ${Self}("inf")
   ///       // i == ${Self}.infinity
@@ -103,7 +127,8 @@ extension ${Self}: LosslessStringConvertible {
   ///       let j = ${Self}("-Infinity")
   ///       // j == -${Self}.infinity
   ///
-  /// - A value of *NaN* contains the string `"nan"`, case insensitive.
+  /// - An input string of `"nan"` (case insensitive) is converted
+  ///   into a *NaN* value:
   ///
   ///       let n = ${Self}("-nan")
   ///       // n?.isNaN == true
@@ -120,18 +145,16 @@ extension ${Self}: LosslessStringConvertible {
   ///       // p?.isNaN == true
   ///       // String(p!) == "nan(0x10)"
   ///
-  /// Passing any other format or any additional characters as `text` results
-  /// in `nil`. For example, the following conversions result in `nil`:
+  /// - A value in any other format or containing additional characters
+  ///   results in a `nil` value. For example, the following conversions
+  ///   result in `nil`:
   ///
-  ///     ${Self}(" 5.0")      // Includes whitespace
-  ///     ${Self}("±2.0")      // Invalid character
-  ///     ${Self}("0x1.25e4")  // Incorrect exponent format
+  ///       ${Self}(" 5.0")      // Includes whitespace
+  ///       ${Self}("±2.0")      // Invalid character
+  ///       ${Self}("0x1.25e4")  // Incorrect exponent format
   ///
-  /// - Parameter text: The input string to convert to a `${Self}` instance. If
-  ///   `text` has invalid characters or is in an invalid format, the result is
-  ///   `nil`.  If the input is valid but the parsed value would be too small
-  ///   or large for the type, the result will be a zero or infinity with the
-  ///   appropriate sign.
+  /// - Parameter text: The input string to convert to a `${Self}?` instance.
+  ///   The value will be `nil` if the input is incorrectly formatted.
   @inlinable
   public init?<S: StringProtocol>(_ text: S) {
   %if bits == 16:

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -157,6 +157,12 @@ extension ${Self}: LosslessStringConvertible {
   ///       ${Self}("0x1.25e4")  // Incorrect exponent format
   ///
   /// - Parameter text: An input string to convert to a `${Self}?` instance.
+  ///
+  /// Backwards compatibility note:  Prior to Swift 5.4, a decimal or
+  /// hexadecimal input string whose value was too large to represent
+  /// as a finite `${Self}` instance would return `nil` instead of
+  /// `${Self}.infinity`.
+  ///
   @inlinable
   public init?<S: StringProtocol>(_ text: S) {
   %if bits == 16:

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -78,9 +78,10 @@ extension ${Self}: LosslessStringConvertible {
   ///       let e = ${Self}("2837.5e-2")
   ///       // e == 28.375
   ///
-  ///   A decimal string is converted into a correctly-rounded ${Self}
-  ///   instance using IEEE 754 round-to-nearest
-  ///   conventions. Very small values are rounded to positive or
+  ///   A decimal string is converted to a ${Self}
+  ///   instance using the IEEE 754 roundTiesToEven (default) rounding
+  ///   attribute.
+  ///   Very small values are rounded to positive or
   ///   negative zero, very large values are rounded
   ///   to plus or minus infinity.
   ///


### PR DESCRIPTION
This changed recently so that overflow and underflow consistently return signed
infinity or zero instead of nil.  (Previously, overflow returned nil, underflow
returned zero.)

Among other benefits:
 * The new behavior distinguishes malformed input (nil) from valid but out-of-range input.
 * The new behavior preserves the sign of the input
 * The new behavior is consistent with how floating-point parsing behaves in other langauges

Resolves rdar://76728925