### PR TITLE
[Diagnostics] Avoid relying on solution for contextual purpose information

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -41,6 +41,46 @@ class Pattern;
 class SourceManager;
 class ProtocolConformance;
 
+/// This specifies the purpose of the contextual type, when specified to
+/// typeCheckExpression.  This is used for diagnostic generation to produce more
+/// specified error messages when the conversion fails.
+///
+enum ContextualTypePurpose : uint8_t {
+  CTP_Unused,           ///< No contextual type is specified.
+  CTP_Initialization,   ///< Pattern binding initialization.
+  CTP_ReturnStmt,       ///< Value specified to a 'return' statement.
+  CTP_ReturnSingleExpr, ///< Value implicitly returned from a function.
+  CTP_YieldByValue,     ///< By-value yield operand.
+  CTP_YieldByReference, ///< By-reference yield operand.
+  CTP_ThrowStmt,        ///< Value specified to a 'throw' statement.
+  CTP_EnumCaseRawValue, ///< Raw value specified for "case X = 42" in enum.
+  CTP_DefaultParameter, ///< Default value in parameter 'foo(a : Int = 42)'.
+
+  /// Default value in @autoclosure parameter
+  /// 'foo(a : @autoclosure () -> Int = 42)'.
+  CTP_AutoclosureDefaultParameter,
+
+  CTP_CalleeResult,     ///< Constraint is placed on the result of a callee.
+  CTP_CallArgument,     ///< Call to function or operator requires type.
+  CTP_ClosureResult,    ///< Closure result expects a specific type.
+  CTP_ArrayElement,     ///< ArrayExpr wants elements to have a specific type.
+  CTP_DictionaryKey,    ///< DictionaryExpr keys should have a specific type.
+  CTP_DictionaryValue,  ///< DictionaryExpr values should have a specific type.
+  CTP_CoerceOperand,    ///< CoerceExpr operand coerced to specific type.
+  CTP_AssignSource,     ///< AssignExpr source operand coerced to result type.
+  CTP_SubscriptAssignSource, ///< AssignExpr source operand coerced to subscript
+                             ///< result type.
+  CTP_Condition,        ///< Condition expression of various statements e.g.
+                        ///< `if`, `for`, `while` etc.
+  CTP_ForEachStmt,      ///< "expression/sequence" associated with 'for-in' loop
+                        ///< is expected to conform to 'Sequence' protocol.
+  CTP_WrappedProperty,  ///< Property type expected to match 'wrappedValue' type
+  CTP_ComposedPropertyWrapper, ///< Composed wrapper type expected to match
+                               ///< former 'wrappedValue' type
+
+  CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
+};
+
 namespace constraints {
 
 class ConstraintSystem;
@@ -848,6 +888,25 @@ public:
 
   static bool classof(const LocatorPathElt *elt) {
     return elt->getKind() == ConstraintLocator::ImplicitConversion;
+  }
+};
+
+class LocatorPathElt::ContextualType final : public StoredIntegerElement<1> {
+public:
+  ContextualType(ContextualTypePurpose purpose)
+      : StoredIntegerElement(ConstraintLocator::ContextualType,
+                             static_cast<unsigned>(purpose)) {}
+
+  ContextualTypePurpose getPurpose() const {
+    return static_cast<ContextualTypePurpose>(getValue());
+  }
+
+  bool isFor(ContextualTypePurpose purpose) const {
+    return getPurpose() == purpose;
+  }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::ContextualType;
   }
 };
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -61,7 +61,7 @@ CUSTOM_LOCATOR_PATH_ELT(ClosureBody)
 SIMPLE_LOCATOR_PATH_ELT(ConstructorMember)
 
 /// The desired contextual type passed in to the constraint system.
-SIMPLE_LOCATOR_PATH_ELT(ContextualType)
+CUSTOM_LOCATOR_PATH_ELT(ContextualType)
 
 /// A result of an expression involving dynamic lookup.
 SIMPLE_LOCATOR_PATH_ELT(DynamicLookupResult)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -90,46 +90,6 @@ void *operator new(size_t bytes, swift::constraints::ConstraintSystem& cs,
 
 namespace swift {
 
-/// This specifies the purpose of the contextual type, when specified to
-/// typeCheckExpression.  This is used for diagnostic generation to produce more
-/// specified error messages when the conversion fails.
-///
-enum ContextualTypePurpose {
-  CTP_Unused,           ///< No contextual type is specified.
-  CTP_Initialization,   ///< Pattern binding initialization.
-  CTP_ReturnStmt,       ///< Value specified to a 'return' statement.
-  CTP_ReturnSingleExpr, ///< Value implicitly returned from a function.
-  CTP_YieldByValue,     ///< By-value yield operand.
-  CTP_YieldByReference, ///< By-reference yield operand.
-  CTP_ThrowStmt,        ///< Value specified to a 'throw' statement.
-  CTP_EnumCaseRawValue, ///< Raw value specified for "case X = 42" in enum.
-  CTP_DefaultParameter, ///< Default value in parameter 'foo(a : Int = 42)'.
-
-  /// Default value in @autoclosure parameter
-  /// 'foo(a : @autoclosure () -> Int = 42)'.
-  CTP_AutoclosureDefaultParameter,
-
-  CTP_CalleeResult,     ///< Constraint is placed on the result of a callee.
-  CTP_CallArgument,     ///< Call to function or operator requires type.
-  CTP_ClosureResult,    ///< Closure result expects a specific type.
-  CTP_ArrayElement,     ///< ArrayExpr wants elements to have a specific type.
-  CTP_DictionaryKey,    ///< DictionaryExpr keys should have a specific type.
-  CTP_DictionaryValue,  ///< DictionaryExpr values should have a specific type.
-  CTP_CoerceOperand,    ///< CoerceExpr operand coerced to specific type.
-  CTP_AssignSource,     ///< AssignExpr source operand coerced to result type.
-  CTP_SubscriptAssignSource, ///< AssignExpr source operand coerced to subscript
-                             ///< result type.
-  CTP_Condition,        ///< Condition expression of various statements e.g.
-                        ///< `if`, `for`, `while` etc.
-  CTP_ForEachStmt,      ///< "expression/sequence" associated with 'for-in' loop
-                        ///< is expected to conform to 'Sequence' protocol.
-  CTP_WrappedProperty,  ///< Property type expected to match 'wrappedValue' type
-  CTP_ComposedPropertyWrapper, ///< Composed wrapper type expected to match
-                               ///< former 'wrappedValue' type
-
-  CTP_CannotFail,       ///< Conversion can never fail. abort() if it does.
-};
-
 /// Specify how we handle the binding of underconstrained (free) type variables
 /// within a solution to a constraint system.
 enum class FreeTypeVariableBinding {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -767,7 +767,7 @@ protected:
     // If needed, generate constraints for everything in the case statement.
     if (cs) {
       auto locator = cs->getConstraintLocator(
-          subjectExpr, LocatorPathElt::ContextualType());
+          subjectExpr, LocatorPathElt::ContextualType(CTP_Initialization));
       Type subjectType = cs->getType(subjectExpr);
 
       if (cs->generateConstraints(caseStmt, dc, subjectType, locator)) {
@@ -851,7 +851,7 @@ protected:
     cs->addConstraint(
         ConstraintKind::Equal, cs->getType(arrayInitExpr), arrayType,
         cs->getConstraintLocator(
-          arrayInitExpr, LocatorPathElt::ContextualType()));
+            arrayInitExpr, LocatorPathElt::ContextualType(CTP_Initialization)));
 
     // Form a call to Array.append(_:) to add the result of executing each
     // iteration of the loop body to the array formed above.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8336,8 +8336,8 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
 
   // Convert the initializer to the type of the pattern.
   auto &cs = solution.getConstraintSystem();
-  auto locator =
-      cs.getConstraintLocator(initializer, LocatorPathElt::ContextualType());
+  auto locator = cs.getConstraintLocator(
+      initializer, LocatorPathElt::ContextualType(CTP_Initialization));
   initializer = solution.coerceToType(initializer, initType, locator);
   if (!initializer)
     return None;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2447,8 +2447,9 @@ bool ContextualFailure::diagnoseConversionToNil() const {
 
   Optional<ContextualTypePurpose> CTP;
   // Easy case were failure has been identified as contextual already.
-  if (locator->isLastElement<LocatorPathElt::ContextualType>()) {
-    CTP = getContextualTypePurpose();
+  if (auto contextualTy =
+          locator->getLastElementAs<LocatorPathElt::ContextualType>()) {
+    CTP = contextualTy->getPurpose();
   } else {
     // Here we need to figure out where where `nil` is located.
     // It could be e.g. an argument to a subscript/call, assignment

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6692,8 +6692,9 @@ bool UnableToInferClosureParameterType::diagnoseAsError() {
 
     // If there is a contextual mismatch associated with this
     // closure, let's not diagnose any parameter type issues.
-    if (hasFixFor(solution, getConstraintLocator(
-                                closure, LocatorPathElt::ContextualType())))
+    if (hasFixFor(solution,
+                  getConstraintLocator(closure, LocatorPathElt::ContextualType(
+                                                    CTP_Initialization))))
       return false;
 
     if (auto *parentExpr = findParentExpr(closure)) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -594,8 +594,11 @@ public:
                     ConstraintLocator *locator)
       : ContextualFailure(
             solution,
-            solution.getConstraintSystem().getContextualTypePurpose(
-                locator->getAnchor()),
+            locator->isForContextualType()
+                ? locator->castLastElementTo<LocatorPathElt::ContextualType>()
+                      .getPurpose()
+                : solution.getConstraintSystem().getContextualTypePurpose(
+                      locator->getAnchor()),
             lhs, rhs, locator) {}
 
   ContextualFailure(const Solution &solution, ContextualTypePurpose purpose,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1340,7 +1340,8 @@ bool IgnoreAssignmentDestinationType::diagnose(const Solution &solution,
 
   AssignmentTypeMismatchFailure failure(
       solution, CTP, getFromType(), getToType(),
-      cs.getConstraintLocator(AE->getSrc(), LocatorPathElt::ContextualType()));
+      cs.getConstraintLocator(AE->getSrc(),
+                              LocatorPathElt::ContextualType(CTP)));
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -391,7 +391,8 @@ AllowWrappedValueMismatch *AllowWrappedValueMismatch::create(ConstraintSystem &c
 /// and the contextual type.
 static Optional<std::tuple<ContextualTypePurpose, Type, Type>>
 getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
-  if (locator->findLast<LocatorPathElt::ContextualType>()) {
+  if (auto contextualTypeElt =
+          locator->findLast<LocatorPathElt::ContextualType>()) {
     assert(locator->isLastElement<LocatorPathElt::ContextualType>() ||
            locator->isLastElement<LocatorPathElt::FunctionArgument>());
 
@@ -399,7 +400,7 @@ getStructuralTypeContext(const Solution &solution, ConstraintLocator *locator) {
     auto anchor = locator->getAnchor();
     auto contextualType = cs.getContextualType(anchor);
     auto exprType = cs.getType(anchor);
-    return std::make_tuple(cs.getContextualTypePurpose(anchor), exprType,
+    return std::make_tuple(contextualTypeElt->getPurpose(), exprType,
                            contextualType);
   } else if (auto argApplyInfo = solution.getFunctionArgApplyInfo(locator)) {
     return std::make_tuple(CTP_CallArgument,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3626,8 +3626,10 @@ static bool generateWrappedPropertyTypeConstraints(
   }
 
   // The property type must be equal to the wrapped value type
-  cs.addConstraint(ConstraintKind::Equal, propertyType, wrappedValueType,
-      cs.getConstraintLocator(wrappedVar, LocatorPathElt::ContextualType()));
+  cs.addConstraint(
+      ConstraintKind::Equal, propertyType, wrappedValueType,
+      cs.getConstraintLocator(
+          wrappedVar, LocatorPathElt::ContextualType(CTP_WrappedProperty)));
   cs.setContextualType(wrappedVar, TypeLoc::withoutLoc(wrappedValueType),
                        CTP_WrappedProperty);
   return false;
@@ -3637,8 +3639,8 @@ static bool generateWrappedPropertyTypeConstraints(
 static bool generateInitPatternConstraints(
     ConstraintSystem &cs, SolutionApplicationTarget target, Expr *initializer) {
   auto pattern = target.getInitializationPattern();
-  auto locator =
-      cs.getConstraintLocator(initializer, LocatorPathElt::ContextualType());
+  auto locator = cs.getConstraintLocator(
+      initializer, LocatorPathElt::ContextualType(CTP_Initialization));
   Type patternType = cs.generateConstraints(
       pattern, locator, target.shouldBindPatternVarsOneWay(),
       target.getInitializationPatternBindingDecl(),
@@ -3669,8 +3671,8 @@ generateForEachStmtConstraints(
   bool isAsync = stmt->getAwaitLoc().isValid();
 
   auto locator = cs.getConstraintLocator(sequence);
-  auto contextualLocator =
-      cs.getConstraintLocator(sequence, LocatorPathElt::ContextualType());
+  auto contextualLocator = cs.getConstraintLocator(
+      sequence, LocatorPathElt::ContextualType(CTP_ForEachStmt));
 
   // The expression type must conform to the Sequence protocol.
   auto sequenceProto = TypeChecker::getProtocol(
@@ -3787,8 +3789,9 @@ bool ConstraintSystem::generateConstraints(
     if (target.isOptionalSomePatternInit()) {
       assert(!target.getExprContextualType() &&
              "some pattern cannot have contextual type pre-configured");
-      auto *convertTypeLocator =
-          getConstraintLocator(expr, LocatorPathElt::ContextualType());
+      auto *convertTypeLocator = getConstraintLocator(
+          expr, LocatorPathElt::ContextualType(
+                    target.getExprContextualTypePurpose()));
       Type var = createTypeVariable(convertTypeLocator, TVO_CanBindToNoEscape);
       target.setExprConversionType(TypeChecker::getOptionalType(expr->getLoc(), var));
     }
@@ -3810,7 +3813,7 @@ bool ConstraintSystem::generateConstraints(
       ContextualTypePurpose ctp = target.getExprContextualTypePurpose();
       bool isOpaqueReturnType = target.infersOpaqueReturnType();
       auto *convertTypeLocator =
-          getConstraintLocator(expr, LocatorPathElt::ContextualType());
+          getConstraintLocator(expr, LocatorPathElt::ContextualType(ctp));
 
       auto getLocator = [&](Type ty) -> ConstraintLocator * {
         // If we have a placeholder originating from a PlaceholderTypeRepr,
@@ -3973,11 +3976,10 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
         return true;
       }
 
-      addConstraint(ConstraintKind::Conversion,
-                    getType(condExpr),
-                    boolTy,
-                    getConstraintLocator(condExpr,
-                                         LocatorPathElt::ContextualType()));
+      addConstraint(
+          ConstraintKind::Conversion, getType(condExpr), boolTy,
+          getConstraintLocator(condExpr,
+                               LocatorPathElt::ContextualType(CTP_Condition)));
       continue;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5754,12 +5754,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       }
 
       // Single expression function with implicit `return`.
-      if (elt->is<LocatorPathElt::ContextualType>()) {
-        auto anchor = locator.getAnchor();
-        auto contextualInfo = getContextualTypeInfo(anchor);
-        assert(contextualInfo &&
-               "Found contextual type locator without additional information");
-        if (contextualInfo->purpose == CTP_ReturnSingleExpr) {
+      if (auto contextualType = elt->getAs<LocatorPathElt::ContextualType>()) {
+        if (contextualType->isFor(CTP_ReturnSingleExpr)) {
           increaseScore(SK_FunctionConversion);
           return getTypeMatchSuccess();
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4784,14 +4784,14 @@ bool ConstraintSystem::repairFailures(
     // truth and produce a contextual mismatch instead of  per-branch failure,
     // because it's a better pointer than potential then-to-else type mismatch.
     if (auto contextualType = getContextualType(anchor)) {
+      auto purpose = getContextualTypePurpose(anchor);
       if (contextualType->isEqual(rhs)) {
-        auto *loc =
-            getConstraintLocator(anchor, LocatorPathElt::ContextualType());
+        auto *loc = getConstraintLocator(
+            anchor, LocatorPathElt::ContextualType(purpose));
         if (hasFixFor(loc, FixKind::ContextualMismatch))
           return true;
 
-        if (contextualType->isVoid() &&
-            getContextualTypePurpose(anchor) == CTP_ReturnStmt) {
+        if (contextualType->isVoid() && purpose == CTP_ReturnStmt) {
           conversionsOrFixes.push_back(RemoveReturn::create(*this, lhs, loc));
           break;
         }
@@ -6135,7 +6135,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     if (auto *Nil = getAsExpr<NilLiteralExpr>(anchor)) {
       auto *fixLocator = getConstraintLocator(
           getContextualType(Nil)
-              ? locator.withPathElement(LocatorPathElt::ContextualType())
+              ? locator.withPathElement(LocatorPathElt::ContextualType(
+                    getContextualTypePurpose(Nil)))
               : locator);
 
       // Here the roles are reversed - `nil` is something we are trying to
@@ -11788,7 +11789,7 @@ void ConstraintSystem::addContextualConversionConstraint(
 
   // Add the constraint.
   auto *convertTypeLocator =
-      getConstraintLocator(expr, LocatorPathElt::ContextualType());
+      getConstraintLocator(expr, LocatorPathElt::ContextualType(purpose));
   addConstraint(constraintKind, getType(expr), conversionType,
                 convertTypeLocator, /*isFavored*/ true);
 }

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -187,9 +187,9 @@ TEST_F(SemaTest, TestTransitiveProtocolInference) {
     auto *typeVar = cs.createTypeVariable(cs.getConstraintLocator({}),
                                           /*options=*/0);
 
-    cs.addConstraint(
-        ConstraintKind::Conversion, typeVar, GPT1,
-        cs.getConstraintLocator({}, LocatorPathElt::ContextualType()));
+    cs.addConstraint(ConstraintKind::Conversion, typeVar, GPT1,
+                     cs.getConstraintLocator({}, LocatorPathElt::ContextualType(
+                                                     CTP_Initialization)));
 
     auto bindings = inferBindings(cs, typeVar);
     ASSERT_TRUE(bindings.getConformanceRequirements().empty());

--- a/validation-test/Sema/SwiftUI/rdar68795727.swift
+++ b/validation-test/Sema/SwiftUI/rdar68795727.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct UnitVolumeView: View {
+  var measurement: Measurement<Unit>
+
+  var body: some View {
+    Text("")
+  }
+}
+struct UnitView_Previews: PreviewProvider {
+  static var previews: some View {
+    let volume: Measurement<Unit> = Measurement<UnitVolume>(value: 200, unit: UnitVolume.milliliters)
+    // expected-error@-1 {{cannot assign value of type 'Measurement<UnitVolume>' to type 'Measurement<Unit>'}}
+    // expected-note@-2 {{arguments to generic parameter 'UnitType' ('UnitVolume' and 'Unit') are expected to be equal}}
+
+    Group {
+      ForEach(["en", "de", "fr"], id: \.self) { id in
+        UnitVolumeView(measurement: volume)
+          .previewLayout(PreviewLayout.sizeThatFits)
+          .environment(\.locale, .init(identifier: id))
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Augment `ContextualType` element to carry its purpose
- Switch to use contextual purpose associated with locator

Both of these changes mean that diagnostics no longer need to
query a solution for  contextual "purpose" associated with a
particular location, which benefits `ContextualFailure` and all
of its subtypes.

Resolves: rdar://68795727

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
