### PR TITLE
[Sema] Fix stale reference passed to PlaceholderType::get

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5037,7 +5037,7 @@ public:
     this->locator = cs.getConstraintLocator(locator);
   }
 
-  Type operator()(PlaceholderTypeRepr *placeholderRepr) const {
+  Type operator()(ASTContext &ctx, PlaceholderTypeRepr *placeholderRepr) const {
     return cs.createTypeVariable(
         cs.getConstraintLocator(
             locator, LocatorPathElt::PlaceholderType(placeholderRepr)),

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1467,12 +1467,9 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
           // For now, just return the unbound generic type.
           return unboundTy;
         },
-        /*placeholderHandler*/
-        [&](auto placeholderRepr) {
-          // FIXME: Don't let placeholder types escape type resolution.
-          // For now, just return the placeholder type.
-          return PlaceholderType::get(getASTContext(), placeholderRepr);
-        });
+        // FIXME: Don't let placeholder types escape type resolution.
+        // For now, just return the placeholder type.
+        PlaceholderType::get);
     const auto BaseTy = resolution.resolveType(InnerTypeRepr);
 
     if (BaseTy->mayHaveMembers()) {
@@ -2004,12 +2001,9 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
           // For now, just return the unbound generic type.
           return unboundTy;
         },
-        /*placeholderHandler*/
-        [&](auto placeholderRepr) {
-          // FIXME: Don't let placeholder types escape type resolution.
-          // For now, just return the placeholder type.
-          return PlaceholderType::get(getASTContext(), placeholderRepr);
-        });
+        // FIXME: Don't let placeholder types escape type resolution.
+        // For now, just return the placeholder type.
+        PlaceholderType::get);
     const auto result = resolution.resolveType(typeExpr->getTypeRepr());
     if (result->hasError())
       return nullptr;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2184,11 +2184,9 @@ static Type validateParameterType(ParamDecl *decl) {
       // For now, just return the unbound generic type.
       return unboundTy;
     };
-    placeholderHandler = [&](auto placeholderRepr) {
-      // FIXME: Don't let placeholder types escape type resolution.
-      // For now, just return the placeholder type.
-      return PlaceholderType::get(ctx, placeholderRepr);
-    };
+    // FIXME: Don't let placeholder types escape type resolution.
+    // For now, just return the placeholder type.
+    placeholderHandler = PlaceholderType::get;
   } else if (isa<AbstractFunctionDecl>(dc)) {
     options = TypeResolutionOptions(TypeResolverContext::AbstractFunctionDecl);
   } else if (isa<SubscriptDecl>(dc)) {
@@ -2818,12 +2816,9 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
         // For now, just return the unbound generic type.
         return unboundTy;
       },
-      /*placeholderHandler*/
-      [&](auto placeholderRepr) {
-        // FIXME: Don't let placeholder types escape type resolution.
-        // For now, just return the placeholder type.
-        return PlaceholderType::get(ext->getASTContext(), placeholderRepr);
-      });
+      // FIXME: Don't let placeholder types escape type resolution.
+      // For now, just return the placeholder type.
+      PlaceholderType::get);
 
   const auto extendedType = resolution.resolveType(extendedRepr);
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -475,12 +475,9 @@ public:
           // For now, just return the unbound generic type.
           return unboundTy;
         },
-        /*placeholderHandler*/
-        [&](auto placeholderRepr) {
-          // FIXME: Don't let placeholder types escape type resolution.
-          // For now, just return the placeholder type.
-          return PlaceholderType::get(Context, placeholderRepr);
-        });
+        // FIXME: Don't let placeholder types escape type resolution.
+        // For now, just return the placeholder type.
+        PlaceholderType::get);
     const auto ty = resolution.resolveType(repr);
     auto *enumDecl = dyn_cast_or_null<EnumDecl>(ty->getAnyNominal());
     if (!enumDecl)
@@ -600,12 +597,9 @@ public:
                 // resolution. For now, just return the unbound generic type.
                 return unboundTy;
               },
-              /*placeholderHandler*/
-              [&](auto placeholderRepr) {
-                // FIXME: Don't let placeholder types escape type resolution.
-                // For now, just return the placeholder type.
-                return PlaceholderType::get(Context, placeholderRepr);
-              })
+              // FIXME: Don't let placeholder types escape type resolution.
+              // For now, just return the placeholder type.
+              PlaceholderType::get)
               .resolveType(prefixRepr);
       auto *enumDecl = dyn_cast_or_null<EnumDecl>(enumTy->getAnyNominal());
       if (!enumDecl)
@@ -813,11 +807,9 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
         // For now, just return the unbound generic type.
         return unboundTy;
       };
-      placeholderHandler = [&](auto placeholderRepr) {
-        // FIXME: Don't let placeholder types escape type resolution.
-        // For now, just return the placeholder type.
-        return PlaceholderType::get(Context, placeholderRepr);
-      };
+      // FIXME: Don't let placeholder types escape type resolution.
+      // For now, just return the placeholder type.
+      placeholderHandler = PlaceholderType::get;
     }
     return validateTypedPattern(
         cast<TypedPattern>(P),
@@ -883,11 +875,9 @@ Type PatternTypeRequest::evaluate(Evaluator &evaluator,
           // For now, just return the unbound generic type.
           return unboundTy;
         };
-        placeholderHandler = [&](auto placeholderRepr) {
-          // FIXME: Don't let placeholder types escape type resolution.
-          // For now, just return the placeholder type.
-          return PlaceholderType::get(Context, placeholderRepr);
-        };
+        // FIXME: Don't let placeholder types escape type resolution.
+        // For now, just return the placeholder type.
+        placeholderHandler = PlaceholderType::get;
       }
       TypedPattern *TP = cast<TypedPattern>(somePat->getSubPattern());
       const auto type = validateTypedPattern(

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2020,15 +2020,16 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
   }
 
   case TypeReprKind::Placeholder: {
+    auto &ctx = getASTContext();
     // Fill in the placeholder if there's an appropriate handler.
     if (const auto handlerFn = resolution.getPlaceholderHandler())
-      if (const auto ty = handlerFn(cast<PlaceholderTypeRepr>(repr)))
+      if (const auto ty = handlerFn(ctx, cast<PlaceholderTypeRepr>(repr)))
         return ty;
 
     // Complain if we're allowed to and bail out with an error.
     if (!options.contains(TypeResolutionFlags::SilenceErrors))
-      getASTContext().Diags.diagnose(repr->getLoc(),
-                                     diag::placeholder_type_not_allowed);
+      ctx.Diags.diagnose(repr->getLoc(),
+                         diag::placeholder_type_not_allowed);
 
     return ErrorType::get(resolution.getASTContext());
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -280,7 +280,7 @@ using OpenUnboundGenericTypeFn = llvm::function_ref<Type(UnboundGenericType *)>;
 
 /// A function reference used to handle a PlaceholderTypeRepr.
 using HandlePlaceholderTypeReprFn =
-    llvm::function_ref<Type(PlaceholderTypeRepr *)>;
+    llvm::function_ref<Type(ASTContext &, PlaceholderTypeRepr *)>;
 
 /// Handles the resolution of types within a given declaration context,
 /// which might involve resolving generic parameters to a particular

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -389,12 +389,9 @@ Type swift::performTypeResolution(TypeRepr *TyR, ASTContext &Ctx,
         // For now, just return the unbound generic type.
         return unboundTy;
       },
-      /*placeholderHandler*/
-      [&](auto placeholderRepr) {
-        // FIXME: Don't let placeholder types escape type resolution.
-        // For now, just return the placeholder type.
-        return PlaceholderType::get(Ctx, placeholderRepr);
-      });
+      // FIXME: Don't let placeholder types escape type resolution.
+      // For now, just return the placeholder type.
+      PlaceholderType::get);
 
   Optional<DiagnosticSuppression> suppression;
   if (!ProduceDiagnostics)


### PR DESCRIPTION
When parsing placeholder types (see #36740) there's an odd crash in `PlaceholderType::get` that only happens in release builds. It seems to be related to a stale captured reference to the `ASTContext` making its way through type resolution, so this PR makes sure we the `ASTContext` reference down the stack explicitly to avoid any strange capture behavior.
