### PR TITLE
[stdlib][experiment] Use < comparisons for Collection index methods

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -123,10 +123,9 @@ extension IndexingIterator: IteratorProtocol, Sequence {
   @inlinable
   @inline(__always)
   public mutating func next() -> Elements.Element? {
-    if _position == _elements.endIndex { return nil }
-    let element = _elements[_position]
-    _elements.formIndex(after: &_position)
-    return element
+    guard _position < _elements.endIndex else { return nil }
+    defer { _elements.formIndex(after: &_position) }    
+    return _elements[_position]
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -899,7 +899,7 @@ extension Collection {
 
     var start = start
     var count = 0
-    while start != end {
+    while start < end {
       count = count + 1
       formIndex(after: &start)
     }
@@ -989,7 +989,7 @@ extension Collection {
 
     var i = i
     for _ in stride(from: 0, to: n, by: 1) {
-      if i == limit {
+      guard i < limit else {
         return nil
       }
       formIndex(after: &i)
@@ -1279,7 +1279,7 @@ extension Collection {
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     var start = startIndex
-    while try start != endIndex && predicate(self[start]) {
+    while try start < endIndex && predicate(self[start]) {
       formIndex(after: &start)
     } 
     return self[start..<endIndex]
@@ -1329,7 +1329,7 @@ extension Collection {
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     var end = startIndex
-    while try end != endIndex && predicate(self[end]) {
+    while try end < endIndex && predicate(self[end]) {
       formIndex(after: &end)
     }
     return self[startIndex..<end]
@@ -1552,7 +1552,7 @@ extension Collection {
 
     var subSequenceEnd = subSequenceStart
     let cachedEndIndex = endIndex
-    while subSequenceEnd != cachedEndIndex {
+    while subSequenceEnd < cachedEndIndex {
       if try isSeparator(self[subSequenceEnd]) {
         let didAppend = appendSubsequence(end: subSequenceEnd)
         formIndex(after: &subSequenceEnd)
@@ -1565,7 +1565,7 @@ extension Collection {
       formIndex(after: &subSequenceEnd)
     }
 
-    if subSequenceStart != cachedEndIndex || !omittingEmptySubsequences {
+    if subSequenceStart < cachedEndIndex || !omittingEmptySubsequences {
       result.append(self[subSequenceStart..<cachedEndIndex])
     }
 

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -64,7 +64,7 @@ extension Collection where Element: Equatable {
     }
 
     var i = self.startIndex
-    while i != self.endIndex {
+    while i < self.endIndex {
       if self[i] == element {
         return i
       }
@@ -102,7 +102,7 @@ extension Collection {
     where predicate: (Element) throws -> Bool
   ) rethrows -> Index? {
     var i = self.startIndex
-    while i != self.endIndex {
+    while i < self.endIndex {
       if try predicate(self[i]) {
         return i
       }
@@ -169,7 +169,7 @@ extension BidirectionalCollection {
     where predicate: (Element) throws -> Bool
   ) rethrows -> Index? {
     var i = endIndex
-    while i != startIndex {
+    while i > startIndex {
       formIndex(before: &i)
       if try predicate(self[i]) {
         return i
@@ -269,7 +269,7 @@ extension MutableCollection {
     else { return endIndex }
     
     var j = index(after: i)
-    while j != endIndex {
+    while j < endIndex {
       if try !isSuffixElement(self[j]) { swapAt(i, j); formIndex(after: &i) }
       formIndex(after: &j)
     }


### PR DESCRIPTION
This is an experiment, based on some observations I've made about Collections.

Consider this simple example: [Godbolt.org](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(fontScale:14,fontUsePx:'0',j:1,lang:swift,selection:(endColumn:36,endLineNumber:7,positionColumn:36,positionLineNumber:7,selectionStartColumn:36,selectionStartLineNumber:7,startColumn:36,startLineNumber:7),source:'%0Afunc+findFirst99(src:+UnsafeBufferPointer%3CUInt8%3E)+-%3E+Int%3F+%7B%0A++++src.firstIndex+%7B+$0+%3D%3D+99+%7D%0A%7D%0A%0Afunc+fastFindFirst99(src:+UnsafeBufferPointer%3CUInt8%3E)+-%3E+Int%3F+%7B%0A++++src.fastFirstIndex+%7B+$0+%3D%3D+99+%7D%0A%7D%0A%0Aextension+Collection+%7B%0A++public+func+fastFirstIndex(%0A++++where+predicate:+(Element)+throws+-%3E+Bool%0A++)+rethrows+-%3E+Index%3F+%7B%0A++++var+i+%3D+self.startIndex%0A++++while+i+%3C+self.endIndex+%7B%0A++++++if+try+predicate(self%5Bi%5D)+%7B%0A++++++++return+i%0A++++++%7D%0A++++++self.formIndex(after:+%26i)%0A++++%7D%0A++++return+nil%0A++%7D%0A%7D%0A'),l:'5',n:'0',o:'Swift+source+%231',t:'0')),k:48.13751087902524,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:swiftnightly,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),fontScale:14,fontUsePx:'0',j:1,lang:swift,libs:!(),options:'-O',selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'x86-64+swiftc+nightly+(Editor+%231,+Compiler+%231)+Swift',t:'0')),k:51.862489120974764,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

Notice how in the first function, using the standard library's `firstIndex` method, the compiler can't provide that incrementing startIndex until it reaches endIndex will not encounter overflow. While _we_ know that, by the semantics of Collection, `startIndex <= endIndex`, the compiler doesn't know that.

Now, that is obviously a toy example, but these effects can stack _hard_ - generic collection algorithms which are composed of lots of such calls are full of overflow checks, and replacing them with simple alternatives like the one in the linked example can be quite effective at removing them. What's more - the compiler can often propagate that information through the algorithm, leading to more effective optimisations.

My theory is that performing a less-than comparison is going to be basically exactly the same cost as performing an equality comparison, but it carries more information which can amount to noticeably better performance. Most indexes are either integers, or opaque aggregates of integers - and even in the latter case, determining the relative order of 2 indexes is likely to involve just as many (or just as few) comparisons as determining equality.

Crazy idea? Maybe! Let's see how it performs! It's based on real, repeatable observations as shown in the link.