### PR TITLE
[5.5][completion] Clarify and simplify not-recommended state 

### DIFF
--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -599,7 +599,7 @@ public:
     Identical,
   };
 
-  enum NotRecommendedReason {
+  enum class NotRecommendedReason {
     None = 0,
     RedundantImport,
     Deprecated,
@@ -644,7 +644,8 @@ public:
                            CodeCompletionOperatorKind::None,
                        StringRef BriefDocComment = StringRef())
       : Kind(Kind), KnownOperatorKind(unsigned(KnownOperatorKind)),
-        SemanticContext(unsigned(SemanticContext)), NotRecommended(None),
+        SemanticContext(unsigned(SemanticContext)),
+        NotRecommended(unsigned(NotRecommendedReason::None)),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
         BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
     assert(Kind != Declaration && "use the other constructor");
@@ -668,7 +669,8 @@ public:
                        ExpectedTypeRelation TypeDistance,
                        StringRef BriefDocComment = StringRef())
       : Kind(Keyword), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)), NotRecommended(None),
+        SemanticContext(unsigned(SemanticContext)),
+        NotRecommended(unsigned(NotRecommendedReason::None)),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
         BriefDocComment(BriefDocComment), TypeDistance(TypeDistance) {
     assert(CompletionString);
@@ -685,7 +687,8 @@ public:
                        CodeCompletionString *CompletionString,
                        ExpectedTypeRelation TypeDistance)
       : Kind(Literal), KnownOperatorKind(0),
-        SemanticContext(unsigned(SemanticContext)), NotRecommended(None),
+        SemanticContext(unsigned(SemanticContext)),
+        NotRecommended(unsigned(NotRecommendedReason::None)),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
         TypeDistance(TypeDistance) {
     AssociatedKind = static_cast<unsigned>(LiteralKind);
@@ -709,10 +712,11 @@ public:
                        enum ExpectedTypeRelation TypeDistance)
       : Kind(ResultKind::Declaration), KnownOperatorKind(0),
         SemanticContext(unsigned(SemanticContext)),
-        NotRecommended(NotRecReason), NumBytesToErase(NumBytesToErase),
-        CompletionString(CompletionString), ModuleName(ModuleName),
-        BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
-        DocWords(DocWords), TypeDistance(TypeDistance) {
+        NotRecommended(unsigned(NotRecReason)),
+        NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
+        ModuleName(ModuleName), BriefDocComment(BriefDocComment),
+        AssociatedUSRs(AssociatedUSRs), DocWords(DocWords),
+        TypeDistance(TypeDistance) {
     assert(AssociatedDecl && "should have a decl");
     AssociatedKind = unsigned(getCodeCompletionDeclKind(AssociatedDecl));
     IsSystem = getDeclIsSystem(AssociatedDecl);
@@ -739,7 +743,7 @@ public:
       : Kind(ResultKind::Declaration),
         KnownOperatorKind(unsigned(KnownOperatorKind)),
         SemanticContext(unsigned(SemanticContext)),
-        NotRecommended(NotRecReason), IsSystem(IsSystem),
+        NotRecommended(unsigned(NotRecReason)), IsSystem(IsSystem),
         NumBytesToErase(NumBytesToErase), CompletionString(CompletionString),
         ModuleName(ModuleName), BriefDocComment(BriefDocComment),
         AssociatedUSRs(AssociatedUSRs), DocWords(DocWords),
@@ -801,7 +805,9 @@ public:
     return static_cast<SemanticContextKind>(SemanticContext);
   }
 
-  bool isNotRecommended() const { return NotRecommended != None; }
+  bool isNotRecommended() const {
+    return getNotRecommendedReason() != NotRecommendedReason::None;
+  }
 
   unsigned getNumBytesToErase() const {
     return NumBytesToErase;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -59,6 +59,7 @@ using namespace swift;
 using namespace ide;
 
 using CommandWordsPairs = std::vector<std::pair<StringRef, StringRef>>;
+using NotRecommendedReason = CodeCompletionResult::NotRecommendedReason;
 
 enum CodeCompletionCommandKind {
   none,
@@ -819,7 +820,7 @@ void CodeCompletionResultBuilder::setAssociatedDecl(const Decl *D) {
   }
 
   if (D->getAttrs().getDeprecated(D->getASTContext()))
-    setNotRecommended(CodeCompletionResult::Deprecated);
+    setNotRecommended(NotRecommendedReason::Deprecated);
 }
 
 namespace {
@@ -2089,8 +2090,7 @@ public:
       Builder.addBaseName(MD->getNameStr());
       Builder.addTypeAnnotation("Module");
       if (Pair.second)
-        Builder.setNotRecommended(
-            CodeCompletionResult::NotRecommendedReason::RedundantImport);
+        Builder.setNotRecommended(NotRecommendedReason::RedundantImport);
     }
   }
 
@@ -2114,9 +2114,7 @@ public:
     }
   }
 
-  void addModuleName(
-      ModuleDecl *MD,
-      Optional<CodeCompletionResult::NotRecommendedReason> R = None) {
+  void addModuleName(ModuleDecl *MD, Optional<NotRecommendedReason> R = None) {
 
     // Don't add underscored cross-import overlay modules.
     if (MD->getDeclaringModuleIfCrossImportOverlay())
@@ -2150,11 +2148,11 @@ public:
         continue;
 
       auto MD = ModuleDecl::create(ModuleName, Ctx);
-      Optional<CodeCompletionResult::NotRecommendedReason> Reason = None;
+      Optional<NotRecommendedReason> Reason = None;
 
       // Imported modules are not recommended.
       if (ImportedModules.count(MD->getNameStr()) != 0)
-        Reason = CodeCompletionResult::NotRecommendedReason::RedundantImport;
+        Reason = NotRecommendedReason::RedundantImport;
 
       addModuleName(MD, Reason);
     }
@@ -2517,9 +2515,8 @@ public:
     return Type();
   }
 
-  void analyzeActorIsolation(
-      const ValueDecl *VD, Type T, bool &implicitlyAsync,
-      Optional<CodeCompletionResult::NotRecommendedReason> &NotRecommended) {
+  void analyzeActorIsolation(const ValueDecl *VD, Type T, bool &implicitlyAsync,
+                             Optional<NotRecommendedReason> &NotRecommended) {
     auto isolation = getActorIsolation(const_cast<ValueDecl *>(VD));
 
     switch (isolation.getKind()) {
@@ -2543,19 +2540,19 @@ public:
     if (implicitlyAsync && T) {
       if (isa<VarDecl>(VD)) {
         if (!isSendableType(CurrDeclContext, T)) {
-          NotRecommended = CodeCompletionResult::CrossActorReference;
+          NotRecommended = NotRecommendedReason::CrossActorReference;
         }
       } else {
         assert(isa<FuncDecl>(VD) || isa<SubscriptDecl>(VD));
         // Check if the result and the param types are all 'Sendable'.
         auto *AFT = T->castTo<AnyFunctionType>();
         if (!isSendableType(CurrDeclContext, AFT->getResult())) {
-          NotRecommended = CodeCompletionResult::CrossActorReference;
+          NotRecommended = NotRecommendedReason::CrossActorReference;
         } else {
           for (auto &param : AFT->getParams()) {
             Type paramType = param.getPlainType();
             if (!isSendableType(CurrDeclContext, paramType)) {
-              NotRecommended = CodeCompletionResult::CrossActorReference;
+              NotRecommended = NotRecommendedReason::CrossActorReference;
               break;
             }
           }
@@ -2576,18 +2573,18 @@ public:
     if (VD->hasInterfaceType())
       VarType = getTypeOfMember(VD, dynamicLookupInfo);
 
-    Optional<CodeCompletionResult::NotRecommendedReason> NotRecommended;
+    Optional<NotRecommendedReason> NotRecommended;
     // "not recommended" in its own getter.
     if (Kind == LookupKind::ValueInDeclContext) {
       if (auto accessor = dyn_cast<AccessorDecl>(CurrDeclContext)) {
         if (accessor->getStorage() == VD && accessor->isGetter())
-          NotRecommended = CodeCompletionResult::VariableUsedInOwnDefinition;
+          NotRecommended = NotRecommendedReason::VariableUsedInOwnDefinition;
       }
     }
     bool implicitlyAsync = false;
     analyzeActorIsolation(VD, VarType, implicitlyAsync, NotRecommended);
     if (!NotRecommended && implicitlyAsync && !CanCurrDeclContextHandleAsync) {
-      NotRecommended = CodeCompletionResult::InvalidAsyncContext;
+      NotRecommended = NotRecommendedReason::InvalidAsyncContext;
     }
 
     CommandWordsPairs Pairs;
@@ -2928,8 +2925,7 @@ public:
         addTypeAnnotation(Builder, AFT->getResult(), genericSig);
 
       if (AFT->isAsync() && !CanCurrDeclContextHandleAsync) {
-        Builder.setNotRecommended(
-            CodeCompletionResult::NotRecommendedReason::InvalidAsyncContext);
+        Builder.setNotRecommended(NotRecommendedReason::InvalidAsyncContext);
       }
     };
 
@@ -3038,14 +3034,14 @@ public:
     if (AFT && !IsImplicitlyCurriedInstanceMethod)
       trivialTrailingClosure = hasTrivialTrailingClosure(FD, AFT);
 
-    Optional<CodeCompletionResult::NotRecommendedReason> NotRecommended;
+    Optional<NotRecommendedReason> NotRecommended;
     bool implictlyAsync = false;
     analyzeActorIsolation(FD, AFT, implictlyAsync, NotRecommended);
 
     if (!NotRecommended && !IsImplicitlyCurriedInstanceMethod &&
         ((AFT && AFT->isAsync()) || implictlyAsync) &&
         !CanCurrDeclContextHandleAsync) {
-      NotRecommended = CodeCompletionResult::InvalidAsyncContext;
+      NotRecommended = NotRecommendedReason::InvalidAsyncContext;
     }
 
     // Add the method, possibly including any default arguments.
@@ -3243,8 +3239,7 @@ public:
       }
 
       if (ConstructorType->isAsync() && !CanCurrDeclContextHandleAsync) {
-        Builder.setNotRecommended(
-            CodeCompletionResult::NotRecommendedReason::InvalidAsyncContext);
+        Builder.setNotRecommended(NotRecommendedReason::InvalidAsyncContext);
       }
     };
 
@@ -3290,12 +3285,12 @@ public:
     if (!subscriptType)
       return;
 
-    Optional<CodeCompletionResult::NotRecommendedReason> NotRecommended;
+    Optional<NotRecommendedReason> NotRecommended;
     bool implictlyAsync = false;
     analyzeActorIsolation(SD, subscriptType, implictlyAsync, NotRecommended);
 
     if (!NotRecommended && implictlyAsync && !CanCurrDeclContextHandleAsync) {
-      NotRecommended = CodeCompletionResult::InvalidAsyncContext;
+      NotRecommended = NotRecommendedReason::InvalidAsyncContext;
     }
 
     CommandWordsPairs Pairs;

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -192,7 +192,8 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     auto declKind = static_cast<CodeCompletionDeclKind>(*cursor++);
     auto opKind = static_cast<CodeCompletionOperatorKind>(*cursor++);
     auto context = static_cast<SemanticContextKind>(*cursor++);
-    auto notRecommended = static_cast<bool>(*cursor++);
+    auto notRecommended =
+        static_cast<CodeCompletionResult::NotRecommendedReason>(*cursor++);
     auto isSystem = static_cast<bool>(*cursor++);
     auto numBytesToErase = static_cast<unsigned>(*cursor++);
     auto oldCursor = cursor;
@@ -228,9 +229,10 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
     if (kind == CodeCompletionResult::Declaration) {
       result = new (*V.Sink.Allocator) CodeCompletionResult(
           context, numBytesToErase, string, declKind, isSystem, moduleName,
-          notRecommended, CodeCompletionResult::NotRecommendedReason::NoReason,
-          briefDocComment, copyArray(*V.Sink.Allocator, ArrayRef<StringRef>(assocUSRs)),
-          copyArray(*V.Sink.Allocator, ArrayRef<std::pair<StringRef, StringRef>>(declKeywords)),
+          notRecommended, briefDocComment,
+          copyArray(*V.Sink.Allocator, ArrayRef<StringRef>(assocUSRs)),
+          copyArray(*V.Sink.Allocator,
+                    ArrayRef<std::pair<StringRef, StringRef>>(declKeywords)),
           CodeCompletionResult::Unknown, opKind);
     } else {
       result = new (*V.Sink.Allocator)
@@ -349,7 +351,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
       else
         LE.write(static_cast<uint8_t>(CodeCompletionOperatorKind::None));
       LE.write(static_cast<uint8_t>(R->getSemanticContext()));
-      LE.write(static_cast<uint8_t>(R->isNotRecommended()));
+      LE.write(static_cast<uint8_t>(R->getNotRecommendedReason()));
       LE.write(static_cast<uint8_t>(R->isSystem()));
       LE.write(static_cast<uint8_t>(R->getNumBytesToErase()));
       LE.write(

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -89,9 +89,8 @@ class CodeCompletionResultBuilder {
       CodeCompletionResult::Unknown;
   bool Cancelled = false;
   ArrayRef<std::pair<StringRef, StringRef>> CommentWords;
-  bool IsNotRecommended = false;
   CodeCompletionResult::NotRecommendedReason NotRecReason =
-    CodeCompletionResult::NotRecommendedReason::NoReason;
+      CodeCompletionResult::NotRecommendedReason::None;
   StringRef BriefDocComment = StringRef();
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
@@ -148,7 +147,6 @@ public:
   void setLiteralKind(CodeCompletionLiteralKind kind) { LiteralKind = kind; }
   void setKeywordKind(CodeCompletionKeywordKind kind) { KeywordKind = kind; }
   void setNotRecommended(CodeCompletionResult::NotRecommendedReason Reason) {
-    IsNotRecommended = true;
     NotRecReason = Reason;
   }
 

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -1169,10 +1169,9 @@ Completion *CompletionBuilder::finish() {
       base = SwiftResult(
           semanticContext, current.getNumBytesToErase(), completionString,
           current.getAssociatedDeclKind(), current.isSystem(),
-          current.getModuleName(), current.isNotRecommended(),
-          current.getNotRecommendedReason(), current.getBriefDocComment(),
-          current.getAssociatedUSRs(), current.getDeclKeywords(),
-          typeRelation, opKind);
+          current.getModuleName(), current.getNotRecommendedReason(),
+          current.getBriefDocComment(), current.getAssociatedUSRs(),
+          current.getDeclKeywords(), typeRelation, opKind);
     } else {
       base = SwiftResult(current.getKind(), semanticContext,
                          current.getNumBytesToErase(), completionString,


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/36961 to release/5.5

---

Combine IsNotRecommended with NotRecommendedReason and improve the names
of the existing cases to more clearly identify the cases they apply to.
Now all not-recommended completions are required to have a reason.