### PR TITLE
[5.5] ClangImporter: add some error-recovery code path for TypeBase::wrapInPointer

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -689,7 +689,8 @@ Type TypeBase::wrapInPointer(PointerTypeKind kind) {
     switch (kind) {
     case PTK_UnsafeMutableRawPointer:
     case PTK_UnsafeRawPointer:
-      llvm_unreachable("these pointer types don't take arguments");
+      // these pointer types don't take arguments.
+      return (NominalTypeDecl*)nullptr;
     case PTK_UnsafePointer:
       return ctx.getUnsafePointerDecl();
     case PTK_UnsafeMutablePointer:
@@ -701,6 +702,10 @@ Type TypeBase::wrapInPointer(PointerTypeKind kind) {
   }());
 
   assert(pointerDecl);
+  // Don't fail hard on null pointerDecl.
+  if (!pointerDecl) {
+    return Type();
+  }
   return BoundGenericType::get(pointerDecl, /*parent*/nullptr, Type(this));
 }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -487,9 +487,11 @@ namespace {
           pointerKind = PTK_UnsafeMutablePointer;
         }
       }
-
-      return {pointeeType->wrapInPointer(pointerKind),
-              ImportHint::OtherPointer};
+      if (auto wrapped = pointeeType->wrapInPointer(pointerKind)) {
+        return {wrapped, ImportHint::OtherPointer};
+      } else {
+        return Type();
+      }
     }
 
     ImportResult VisitBlockPointerType(const clang::BlockPointerType *type) {
@@ -1926,6 +1928,8 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
       auto genericType =
           findGenericTypeInGenericDecls(templateParamType, genericParams);
       swiftParamTy = genericType->wrapInPointer(pointerKind);
+      if (!swiftParamTy)
+        return nullptr;
     } else if (auto *templateParamType =
                    dyn_cast<clang::TemplateTypeParmType>(paramTy)) {
       swiftParamTy =


### PR DESCRIPTION
rdar://72164992
