### PR TITLE
Prevent arbitrary objects from conforming to RNG.

### DIFF
--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -64,6 +64,15 @@ public protocol RandomNumberGenerator {
 }
 
 extension RandomNumberGenerator {
+  
+  // An unavailable default implementation of next() prevents types that do
+  // not implement the RandomNumberGenerator interface from conforming to the
+  // protocol; without this, the default next() method returning a generic
+  // unsigned integer will be used, recursing infinitely and probably blowing
+  // the stack.
+  @available(*, unavailable)
+  public mutating func next() -> UInt64 { fatalError() }
+  
   /// Returns a value from a uniform, independent distribution of binary data.
   ///
   /// Use this method when you need random binary data to generate another

--- a/test/stdlib/Random.swift
+++ b/test/stdlib/Random.swift
@@ -1,0 +1,21 @@
+//===--- Random.swift -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %target-typecheck-verify-swift
+
+struct Jawn { }
+
+// Me, sobbing: "Look, you can't just point at an empty struct and call it a
+// RandomNumberGenerator."
+// Swift 5.4, pointing at this Jawn: "RNG."
+extension Jawn: RandomNumberGenerator { }
+// expected-error@-1 {{type 'Jawn' does not conform to protocol 'RandomNumberGenerator'}}
+// expected-error@-2 {{unavailable instance method 'next()' was used to satisfy a requirement of protocol 'RandomNumberGenerator'}}


### PR DESCRIPTION
Me, sobbing: "Look, you can't just point at an empty struct and call it a RandomNumberGenerator."
Swift 5.4, pointing at absolutely anything: "RNG."

This is technically a source-breaking change. However, any RNG that depended on this behavior to conform to the protocol was necessarily already broken; it could _never_ have worked correctly. So we're simply moving the crash from runtime to compile time, making it easier for users to find and do something about it.

Fixes rdar://76660011