### PR TITLE
[AutoDiff] Use correct debug scope for pullback trampoline block.

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2346,6 +2346,9 @@ SILBasicBlock *PullbackCloner::Implementation::buildPullbackSuccessor(
   // Propagate pullback struct argument.
   TangentBuilder pullbackTrampolineBBBuilder(
       pullbackTrampolineBB, getContext());
+  pullbackTrampolineBBBuilder.setCurrentDebugScope(
+      remapScope(origPredBB->getTerminator()->getDebugScope()));
+
   auto *pullbackTrampolineBBArg = pullbackTrampolineBB->getArguments().front();
   if (vjpCloner.getLoopInfo()->getLoopFor(origPredBB)) {
     assert(pullbackTrampolineBBArg->getType() ==

--- a/test/AutoDiff/compiler_crashers_fixed/sr14290-missing-debug-scopes-in-pullback-trampoline.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr14290-missing-debug-scopes-in-pullback-trampoline.swift
@@ -1,0 +1,45 @@
+// RUN: %target-build-swift %s
+// RUN: %target-swift-frontend -c -g -Xllvm -verify-di-holes=true %s
+
+// rdar://74876596 ([SR-14290]: SIL verification fails when differentiating a function of [[Double]])
+
+import _Differentiation
+
+let values: [[Double]] = [[0, 0], [0, 0]]
+let const = 1.12345
+let result = add(const, to: values)
+
+@differentiable(reverse)
+func add(_ const: Double, to values: [[Double]]) -> [[Double]] {
+    var result = values
+    for i in withoutDerivative(at: values.indices) {
+        for j in withoutDerivative(at: values.indices) {
+            result.updated(at: i, j, with: values[i][j] + const)
+        }
+    }
+    return result
+}
+
+extension Array where Element == [Double] {
+    @differentiable(reverse)
+    mutating func updated(at i: Int, _ j: Int, with newValue: Double) {
+        self[i][j] = newValue
+    }
+
+    @derivative(of: updated)
+    mutating func vjpUpdated(at i: Int, _ j: Int, with newValue: Double)
+    -> (value: Void, pullback: (inout TangentVector) -> (Double.TangentVector)) {
+        self.updated(at: i, j, with: newValue)
+
+        func pullback(dSelf: inout TangentVector) -> (Double.TangentVector) {
+            let dElement = dSelf[i][j]
+            dSelf.base[i].base[j] = 0
+            return dElement
+        }
+        let value: Void = ()
+
+        return (value, pullback)
+    }
+}
+
+


### PR DESCRIPTION
A new TangentBuilder was used without setting the debug scope context.

Fixes:
[[SR-14290]: SIL verification fails when differentiating a function of [[Double]]](rdar://74876596)
[[SR-14298]: [AutoDiff] SIL verification failed: non-contiguous lexical scope at -Onone](rdar://75032457)
