### PR TITLE
[5.5][Serialization] Add some checks for invalid types

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2236,6 +2236,8 @@ static bool contextDependsOn(const NominalTypeDecl *decl,
 static void collectDependenciesFromType(llvm::SmallSetVector<Type, 4> &seen,
                                         Type ty,
                                         const DeclContext *excluding) {
+  if (!ty)
+    return;
   ty.visit([&](Type next) {
     auto *nominal = next->getAnyNominal();
     if (!nominal)
@@ -3064,6 +3066,9 @@ public:
 
     SmallVector<TypeID, 8> inheritedAndDependencyTypes;
     for (auto inherited : extension->getInherited()) {
+      if (extension->getASTContext().LangOpts.AllowModuleWithCompilerErrors &&
+          !inherited.getType())
+        continue;
       assert(!inherited.getType()->hasArchetype());
       inheritedAndDependencyTypes.push_back(S.addTypeRef(inherited.getType()));
     }

--- a/test/Frontend/allow-errors.swift
+++ b/test/Frontend/allow-errors.swift
@@ -55,6 +55,11 @@ public func invalidFuncBody() -> ValidStructInvalidMember {
 }
 
 public func invalidFunc() -> undefined {} // expected-error {{cannot find type 'undefined'}}
+
+extension undefined: undefined {} // expected-error {{cannot find type 'undefined'}}
+
+class GenericClass<T> {}
+class InvalidSuperclass: GenericClass<undefined> {} // expected-error {{cannot find type 'undefined'}}
 #endif
 
 // RUN: %target-swift-frontend -emit-module -o %t/validUses.swiftmodule -experimental-allow-module-with-compiler-errors -I%t -D VALID_USES %s 2>&1 | %FileCheck -check-prefix=CHECK-VALID %s


### PR DESCRIPTION
Cherry-pick serialization crashes fix to 5.5:

When allowing errors there's various cases where an invalid type is used
during serialization:
  - Invalid explicit conformances on an extension
  - Superclass with invalid generic type

Add checks to skip these to avoid crashing.

Resolves rdar://75379780.