### PR TITLE
Demangling: Add option for printing simplified async resume functions

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -63,6 +63,7 @@ struct DemangleOptions {
   bool DisplayStdlibModule = true;
   bool DisplayObjCModule = true;
   bool PrintForTypeName = false;
+  bool ShowAsyncResumePartial = true;
 
   /// If this is nonempty, entities in this module name will not be qualified.
   llvm::StringRef HidingCurrentModule;

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -2812,16 +2812,20 @@ NodePointer NodePrinter::print(NodePointer Node, bool asPrefixContext) {
     Printer << "async function pointer to ";
     return nullptr;
   case Node::Kind::AsyncAwaitResumePartialFunction:
-    Printer << "(";
-    print(Node->getChild(0));
-    Printer << ")";
-    Printer << " await resume partial function for ";
+    if (Options.ShowAsyncResumePartial) {
+      Printer << "(";
+      print(Node->getChild(0));
+      Printer << ")";
+      Printer << " await resume partial function for ";
+    }
     return nullptr;
   case Node::Kind::AsyncSuspendResumePartialFunction:
-    Printer << "(";
-    print(Node->getChild(0));
-    Printer << ")";
-    Printer << " suspend resume partial function for ";
+    if (Options.ShowAsyncResumePartial) {
+      Printer << "(";
+      print(Node->getChild(0));
+      Printer << ")";
+      Printer << " suspend resume partial function for ";
+    }
     return nullptr;
   }
 


### PR DESCRIPTION
Add a new option to `DemangleOptions` for the purpose of printing  async resume partials by the name of their top-level function.

This will initially be used lldb when generating backtraces. This will allow the backtrace to show frames in the backtrace using the function names found in the source code.

For demonstration, instead of a backtrace like this:

```
asyncHelper() at main.swift:2
(1) await resume partial function for static Main.main() at main.swift:13
```

with this change the backtrace will be:

```
asyncHelper() at main.swift:2
static Main.main() at main.swift:13
```