### PR TITLE
Add `@_implicitSelfCapture` attribute to disable "self." requirement.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -647,6 +647,11 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(_unsafeMainActor, UnsafeMainActor,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,
   114)
 
+SIMPLE_DECL_ATTR(_implicitSelfCapture, ImplicitSelfCapture,
+  OnParam | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,
+  115)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -292,10 +292,14 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
-    HasAnonymousClosureVars : 1
+    HasAnonymousClosureVars : 1,
+
+    /// True if "self" can be captured implicitly without requiring "self."
+    /// on each member reference.
+    ImplicitSelfCapture : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -3871,6 +3875,7 @@ public:
       Body(nullptr) {
     setParameterList(params);
     Bits.ClosureExpr.HasAnonymousClosureVars = false;
+    Bits.ClosureExpr.ImplicitSelfCapture = false;
   }
 
   SourceRange getSourceRange() const;
@@ -3898,7 +3903,17 @@ public:
   void setHasAnonymousClosureVars() {
     Bits.ClosureExpr.HasAnonymousClosureVars = true;
   }
-  
+
+  /// Whether this closure allows "self" to be implicitly captured without
+  /// required "self." on each reference.
+  bool allowsImplicitSelfCapture() const {
+    return Bits.ClosureExpr.ImplicitSelfCapture;
+  }
+
+  void setAllowsImplicitSelfCapture(bool value = true) {
+    Bits.ClosureExpr.ImplicitSelfCapture = value;
+  }
+
   /// Determine whether this closure expression has an
   /// explicitly-specified result type.
   bool hasExplicitResultType() const { return ArrowLoc.isValid(); }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3381,6 +3381,7 @@ struct ParameterListInfo {
   SmallBitVector propertyWrappers;
   SmallBitVector unsafeSendable;
   SmallBitVector unsafeMainActor;
+  SmallBitVector implicitSelfCapture;
 
 public:
   ParameterListInfo() { }
@@ -3408,6 +3409,13 @@ public:
   /// we will treat it as being part of the main actor but that it is not
   /// part of the type system.
   bool isUnsafeMainActor(unsigned paramIdx) const;
+
+  /// Whether the given parameter is a closure that should allow capture of
+  /// 'self' to be implicit, without requiring "self.".
+  bool isImplicitSelfCapture(unsigned paramIdx) const;
+
+  /// Whether there is any contextual information set on this parameter list.
+  bool anyContextualInfo() const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2546,6 +2546,8 @@ public:
     printClosure(E, "closure_expr");
     if (E->hasSingleExpressionBody())
       PrintWithColorRAII(OS, ClosureModifierColor) << " single-expression";
+    if (E->allowsImplicitSelfCapture())
+      PrintWithColorRAII(OS, ClosureModifierColor) << " implicit-self";
 
     if (E->getParameters()) {
       OS << '\n';

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -961,6 +961,7 @@ ParameterListInfo::ParameterListInfo(
   propertyWrappers.resize(params.size());
   unsafeSendable.resize(params.size());
   unsafeMainActor.resize(params.size());
+  implicitSelfCapture.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -1020,6 +1021,10 @@ ParameterListInfo::ParameterListInfo(
     if (param->getAttrs().hasAttribute<UnsafeMainActorAttr>()) {
       unsafeMainActor.set(i);
     }
+
+    if (param->getAttrs().hasAttribute<ImplicitSelfCaptureAttr>()) {
+      implicitSelfCapture.set(i);
+    }
   }
 }
 
@@ -1048,6 +1053,17 @@ bool ParameterListInfo::isUnsafeMainActor(unsigned paramIdx) const {
   return paramIdx < unsafeMainActor.size()
       ? unsafeMainActor[paramIdx]
       : false;
+}
+
+bool ParameterListInfo::isImplicitSelfCapture(unsigned paramIdx) const {
+  return paramIdx < implicitSelfCapture.size()
+      ? implicitSelfCapture[paramIdx]
+      : false;
+}
+
+bool ParameterListInfo::anyContextualInfo() const {
+  return unsafeSendable.any() || unsafeMainActor.any() ||
+      implicitSelfCapture.any();
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5709,16 +5709,18 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 }
 
 /// Apply the contextually Sendable flag to the given expression,
-static void applyUnsafeConcurrent(
-      Expr *expr, bool sendable, bool forMainActor) {
+static void applyContextualClosureFlags(
+      Expr *expr, bool sendable, bool forMainActor, bool implicitSelfCapture) {
   if (auto closure = dyn_cast<ClosureExpr>(expr)) {
     closure->setUnsafeConcurrent(sendable, forMainActor);
+    closure->setAllowsImplicitSelfCapture(implicitSelfCapture);
     return;
   }
 
   if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
-    applyUnsafeConcurrent(
-        captureList->getClosureBody(), sendable, forMainActor);
+    applyContextualClosureFlags(
+        captureList->getClosureBody(), sendable, forMainActor,
+        implicitSelfCapture);
   }
 }
 
@@ -5803,7 +5805,8 @@ Expr *ExprRewriter::coerceCallArguments(
 
   // Quickly test if any further fix-ups for the argument types are necessary.
   if (AnyFunctionType::equalParams(args, params) &&
-      !shouldInjectWrappedValuePlaceholder)
+      !shouldInjectWrappedValuePlaceholder &&
+      !paramInfo.anyContextualInfo())
     return arg;
 
   // Apply labels to arguments.
@@ -5954,9 +5957,10 @@ Expr *ExprRewriter::coerceCallArguments(
     bool isUnsafeSendable = paramInfo.isUnsafeSendable(paramIdx);
     bool isMainActor = paramInfo.isUnsafeMainActor(paramIdx) ||
         (isUnsafeSendable && apply && isMainDispatchQueue(apply->getFn()));
-    applyUnsafeConcurrent(
+    bool isImplicitSelfCapture = paramInfo.isImplicitSelfCapture(paramIdx);
+    applyContextualClosureFlags(
         arg, isUnsafeSendable && contextUsesConcurrencyFeatures(dc),
-        isMainActor);
+        isMainActor, isImplicitSelfCapture);
 
     // If the types exactly match, this is easy.
     auto paramType = param.getOldType();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1570,6 +1570,13 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
           return false;
       }
 
+      // If the closure was used in a context where it's explicitly stated
+      // that it does not need "self." qualification, don't require it.
+      if (auto closure = dyn_cast<ClosureExpr>(CE)) {
+        if (closure->allowsImplicitSelfCapture())
+          return false;
+      }
+
       return true;
     }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -137,6 +137,7 @@ public:
   IGNORED_ATTR(AtReasync)
   IGNORED_ATTR(UnsafeSendable)
   IGNORED_ATTR(UnsafeMainActor)
+  IGNORED_ATTR(ImplicitSelfCapture)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1546,7 +1546,7 @@ namespace  {
     UNINTERESTING_ATTR(Nonisolated)
     UNINTERESTING_ATTR(UnsafeSendable)
     UNINTERESTING_ATTR(UnsafeMainActor)
-
+    UNINTERESTING_ATTR(ImplicitSelfCapture)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/test/attr/attr_implicitselfcapture.swift
+++ b/test/attr/attr_implicitselfcapture.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+func takeFn(@_implicitSelfCapture fn: @escaping () -> Int) { }
+func takeEscapingFn(fn: @escaping () -> Int) { }
+
+class C {
+  var property: Int = 0
+
+  func method() { }
+
+  func testMethod() {
+    takeFn { // no errors
+      method()
+      return property
+    }
+
+    takeEscapingFn { // expected-note 2 {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+      method() // expected-error{{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+      // expected-note@-1{{reference 'self.' explicitly}}
+      return property // expected-error{{reference to property 'property' in closure requires explicit use of 'self' to make capture semantics explicit}}
+      // expected-note@-1{{reference 'self.' explicitly}}
+    }
+  }
+}


### PR DESCRIPTION
Add a new parameter attribute `@_implicitSelfCapture` that disables the
requirement to explicitly use `self.` to refer to a member of `self`
in an escaping closure.

Part of rdar://76927008.
