### PR TITLE
re-allow symbol-graph-dir and supplementary file map

### DIFF
--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -608,8 +608,9 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
         options::OPT_emit_private_module_interface_path,
         options::OPT_emit_module_source_info_path,
         options::OPT_emit_tbd_path,
-        options::OPT_emit_ldadd_cfile_path,
-        options::OPT_emit_symbol_graph_dir)) {
+        options::OPT_emit_ldadd_cfile_path)) {
+    // FIXME(vmitchell): add -emit-symbol-graph-dir to the supplementary file map in the new driver
+    // (rdar://76902664)
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,
                    A->getSpelling(), "-supplementary-output-file-map");


### PR DESCRIPTION
Resolves rdar://76815547

The new swift-driver does not have a port of https://github.com/apple/swift/pull/36542, which is causing issues in the same way that the old driver had when using whole-module optimizations (or other situations where file maps were being used). This PR re-allows `-emit-symbol-graph-dir` and `-supplementary-output-file-map` at the same time, to allow the new driver to use the frontend before it is properly updated.