### PR TITLE
GSB: When rebuilding a signature, drop layout requirements implied by concrete as well [5.5]

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6465,6 +6465,12 @@ void GenericSignatureBuilder::computeRedundantRequirements() {
         if (resolvedConcreteType) {
           if (typeImpliesLayoutConstraint(resolvedConcreteType, layout)) {
             impliedByConcrete.push_back(constraint);
+
+            if (!source->isDerivedRequirement()) {
+              Impl->ExplicitConformancesImpliedByConcrete.insert(
+                  ExplicitRequirement::fromExplicitConstraint(
+                      RequirementKind::Layout, constraint));
+            }
           }
         }
 

--- a/test/Generics/rdar76750100.swift
+++ b/test/Generics/rdar76750100.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -debug-generic-signatures -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s
+
+@objc protocol P1 {}
+@objc protocol P2 : P1 {}
+
+class G<X : P1, Y : AnyObject> {}
+
+class C {}
+
+// CHECK-LABEL: Generic signature: <X, Y where X == P2, Y == C>
+extension G where X == P2, Y == C {
+  func foo() {}
+}


### PR DESCRIPTION
Otherwise, when we resolve the subject type while adding the requirement
to the new signature, we assert that it is not a dependent type.

This fixes a regression from 977d3a77cf4cecdd1c64621db20b591bef2634ed.

Fixes rdar://problem/76750100.