### PR TITLE
Fix calling convention mismatch on `swift_task_getCurrent`

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -230,6 +230,7 @@ void IRGenFunction::setupAsync(unsigned asyncContextIndex) {
 llvm::Value *IRGenFunction::getAsyncTask() {
   auto call = Builder.CreateCall(IGM.getGetCurrentTaskFn(), {});
   call->setDoesNotThrow();
+  call->setCallingConv(IGM.SwiftCC);
   return call;
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

[`swift_task_getCurrent` is defined with `swiftcc`](
https://github.com/apple/swift/blob/d7339e2721f4b8c16af4b9a31528d97d4463e6fd/include/swift/Runtime/RuntimeFunctions.def#L1499-L1504) and [called with swiftcc from Swift](https://github.com/apple/swift/blob/d7339e2721f4b8c16af4b9a31528d97d4463e6fd/stdlib/public/Concurrency/Task.swift#L666-L667), but IRGen emits `swift_task_getCurrent` calls without specifying calling convention.

This convention mismatch was found by strict signature checking of Wasm.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

CC: @MaxDesiatov 
