### PR TITLE
[Cherry-pick 5.5] [Concurrency] Store child record when async let child task spawned

### DIFF
--- a/include/swift/ABI/AsyncLet.h
+++ b/include/swift/ABI/AsyncLet.h
@@ -1,0 +1,52 @@
+//===--- AsyncLet.h - ABI structures for async let -00-----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift ABI describing task groups.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_ABI_TASK_ASYNC_LET_H
+#define SWIFT_ABI_TASK_ASYNC_LET_H
+
+#include "swift/ABI/Task.h"
+#include "swift/ABI/HeapObject.h"
+#include "swift/Runtime/Concurrency.h"
+#include "swift/Runtime/Config.h"
+#include "swift/Basic/RelativePointer.h"
+#include "swift/Basic/STLExtras.h"
+
+namespace swift {
+
+/// Represents an in-flight `async let`, i.e. the Task that is computing the
+/// result of the async let, along with the awaited status and other metadata.
+class alignas(Alignment_AsyncLet) AsyncLet {
+public:
+  // These constructors do not initialize the AsyncLet instance, and the
+  // destructor does not destroy the AsyncLet instance; you must call
+  // swift_asyncLet_{start,end} yourself.
+  constexpr AsyncLet()
+    : PrivateData{} {}
+
+  // FIXME: not sure how many words we should reserve
+  void *PrivateData[NumWords_AsyncLet];
+
+  // TODO: we could offer a "was awaited on" check here
+
+  /// Returns the child task that is associated with this async let.
+  /// The tasks completion is used to fulfil the value represented by this async let.
+  AsyncTask *getTask() const;
+
+};
+
+} // end namespace swift
+
+#endif // SWIFT_ABI_TASK_ASYNC_LET_H

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -49,6 +49,9 @@ enum {
 
   /// The number of words in a task group.
   NumWords_TaskGroup = 32,
+
+  /// The number of words in an AsyncLet (flags + task pointer)
+  NumWords_AsyncLet = 8, // TODO: not sure how much is enough, these likely could be pretty small
 };
 
 struct InProcess;
@@ -126,6 +129,9 @@ const size_t Alignment_DefaultActor = MaximumAlignment;
 
 /// The alignment of a TaskGroup.
 const size_t Alignment_TaskGroup = MaximumAlignment;
+
+/// The alignment of an AsyncLet.
+const size_t Alignment_AsyncLet = MaximumAlignment;
 
 /// Flags stored in the value-witness table.
 template <typename int_type>

--- a/include/swift/ABI/TaskGroup.h
+++ b/include/swift/ABI/TaskGroup.h
@@ -29,8 +29,8 @@ namespace swift {
 /// The task group is responsible for maintaining dynamically created child tasks.
 class alignas(Alignment_TaskGroup) TaskGroup {
 public:
-  // These constructors do not initialize the actor instance, and the
-  // destructor does not destroy the actor instance; you must call
+  // These constructors do not initialize the group instance, and the
+  // destructor does not destroy the group instance; you must call
   // swift_taskGroup_{initialize,destroy} yourself.
   constexpr TaskGroup()
     : PrivateData{} {}
@@ -43,4 +43,4 @@ public:
 
 } // end namespace swift
 
-#endif
+#endif // SWIFT_ABI_TASK_GROUP_H

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -782,6 +782,19 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentAsyncTask, "getCurrentAsyncTask", "
 /// Cancel the given asynchronous task.
 BUILTIN_MISC_OPERATION_WITH_SILGEN(CancelAsyncTask, "cancelAsyncTask", "", Special)
 
+/// startAsyncLet()<T>: (
+///     __owned @Sendable @escaping () async throws -> T
+/// ) -> Builtin.RawPointer
+///
+/// Create, initialize and start a new async-let and associated task.
+/// Returns an AsyncLet* that must be passed to endAsyncLet for destruction.
+BUILTIN_MISC_OPERATION(StartAsyncLet, "startAsyncLet", "", Special)
+
+/// asyncLetEnd(): (Builtin.RawPointer) -> Void
+///
+/// Ends and destroys an async-let.
+BUILTIN_MISC_OPERATION_WITH_SILGEN(EndAsyncLet, "endAsyncLet", "", Special)
+
 /// createAsyncTaskFuture(): (
 ///     Int, Builtin.NativeObject?, @escaping () async throws -> T
 /// ) -> Builtin.NativeObject

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -18,6 +18,7 @@
 #define SWIFT_RUNTIME_CONCURRENCY_H
 
 #include "swift/ABI/TaskGroup.h"
+#include "swift/ABI/AsyncLet.h"
 #include "swift/ABI/TaskStatus.h"
 
 #pragma clang diagnostic push
@@ -49,7 +50,8 @@ using FutureAsyncSignature =
 /// closure.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTaskAndContext swift_task_create_future(
-    JobFlags flags, const Metadata *futureResultType,
+    JobFlags flags,
+    const Metadata *futureResultType,
     void *closureEntryPoint,
     HeapObject * /* +1 */ closureContext);
 
@@ -57,7 +59,8 @@ AsyncTaskAndContext swift_task_create_future(
 /// function.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTaskAndContext swift_task_create_future_f(
-    JobFlags flags, const Metadata *futureResultType,
+    JobFlags flags,
+    const Metadata *futureResultType,
     FutureAsyncSignature::FunctionType *function,
     size_t initialContextSize);
 
@@ -74,7 +77,8 @@ AsyncTaskAndContext swift_task_create_group_future(
 /// function, and offer its result to the task group
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 AsyncTaskAndContext swift_task_create_group_future_f(
-    JobFlags flags, TaskGroup *group,
+    JobFlags flags,
+    TaskGroup *group,
     const Metadata *futureResultType,
     FutureAsyncSignature::FunctionType *function,
     size_t initialContextSize);
@@ -169,7 +173,7 @@ SWIFT_CC(swiftasync)
 /// \code
 /// func swift_taskGroup_wait_next_throwing(
 ///     waitingTask: Builtin.NativeObject, // current task
-///     group: UnsafeRawPointer
+///     group: Builtin.RawPointer
 /// ) async -> T
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency)
@@ -184,8 +188,7 @@ void swift_taskGroup_wait_next_throwing(
 /// Its Swift signature is
 ///
 /// \code
-/// func swift_taskGroup_initialize(group: Builtin.RawPointer
-/// )
+/// func swift_taskGroup_initialize(group: Builtin.RawPointer)
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_taskGroup_initialize(TaskGroup *group);
@@ -202,7 +205,6 @@ void swift_taskGroup_initialize(TaskGroup *group);
 /// \code
 /// func swift_taskGroup_attachChild(
 ///     group: Builtin.RawPointer,
-///     parent: Builtin.NativeObject,
 ///     child: Builtin.NativeObject
 /// )
 /// \endcode
@@ -214,7 +216,7 @@ void swift_taskGroup_attachChild(TaskGroup *group, AsyncTask *child);
 /// This function MUST be called from the AsyncTask running the task group.
 ///
 /// \code
-/// func swift_taskGroup_destroy(_ group: UnsafeRawPointer)
+/// func swift_taskGroup_destroy(_ group: Builtin.RawPointer)
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_taskGroup_destroy(TaskGroup *group);
@@ -244,7 +246,7 @@ bool swift_taskGroup_addPending(TaskGroup *group, bool unconditionally);
 /// Its Swift signature is
 ///
 /// \code
-/// func swift_taskGroup_cancelAll(group: UnsafeRawPointer)
+/// func swift_taskGroup_cancelAll(group: Builtin.RawPointer)
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_taskGroup_cancelAll(TaskGroup *group);
@@ -257,7 +259,7 @@ void swift_taskGroup_cancelAll(TaskGroup *group);
 /// This can be called from any thread. Its Swift signature is
 ///
 /// \code
-/// func swift_taskGroup_isCancelled(group: UnsafeRawPointer)
+/// func swift_taskGroup_isCancelled(group: Builtin.RawPointer)
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_taskGroup_isCancelled(TaskGroup *group);
@@ -273,6 +275,63 @@ bool swift_taskGroup_isCancelled(TaskGroup *group);
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_taskGroup_isEmpty(TaskGroup *group);
+
+/// Its Swift signature is
+///
+/// \code
+/// func swift_asyncLet_start<T>(
+///     _ alet: Builtin.RawPointer,
+///     operation: __owned @Sendable @escaping () async throws -> T
+/// )
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_asyncLet_start(
+    AsyncLet *alet,
+    const Metadata *futureResultType,
+    void *closureEntryPoint,
+    HeapObject * /* +1 */ closureContext);
+
+/// This matches the ABI of a closure `<T>(Builtin.RawPointer) async -> T`
+using AsyncLetWaitSignature =
+    SWIFT_CC(swiftasync)
+    void(OpaqueValue *,
+         SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *, Metadata *);
+
+/// Wait for a non-throwing async-let to complete.
+///
+/// This can be called from any thread. Its Swift signature is
+///
+/// \code
+/// func swift_asyncLet_wait(
+///     _ asyncLet: _owned Builtin.RawPointer
+/// ) async -> Success
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void swift_asyncLet_wait(OpaqueValue *,
+                         SWIFT_ASYNC_CONTEXT AsyncContext *,
+                         AsyncLet *, Metadata *);
+
+/// Wait for a potentially-throwing async-let to complete.
+///
+/// This can be called from any thread. Its Swift signature is
+///
+/// \code
+/// func swift_asyncLet_wait_throwing(
+///     _ asyncLet: _owned Builtin.RawPointer
+/// ) async throws -> Success
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void swift_asyncLet_wait_throwing(OpaqueValue *,
+                                  SWIFT_ASYNC_CONTEXT AsyncContext *,
+                                  AsyncLet *, Metadata *);
+
+/// Its Swift signature is
+///
+/// \code
+/// func swift_asyncLet_end(_ alet: Builtin.RawPointer)
+/// \endcode
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_asyncLet_end(AsyncLet *alet);
 
 /// Add a status record to a task.  The record should not be
 /// modified while it is registered with a task.
@@ -314,8 +373,7 @@ bool swift_task_removeStatusRecord(TaskStatusRecord *record);
 /// The record must be removed with by the parent invoking
 /// `swift_task_detachChild` when the child has completed.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-ChildTaskStatusRecord*
-swift_task_attachChild(AsyncTask *child);
+ChildTaskStatusRecord* swift_task_attachChild(AsyncTask *child);
 
 /// Remove a child task from the parent tracking it.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1541,7 +1541,8 @@ FUNCTION(TaskCreateFunc,
 // AsyncTaskAndContext swift_task_create_future(
 //     size_t flags,
 //     const Metadata *futureResultType,
-//     void *closureEntry, HeapObject *closureContext);
+//     void *closureEntry,
+//     HeapObject *closureContext);
 FUNCTION(TaskCreateFuture,
          swift_task_create_future, SwiftCC,
          ConcurrencyAvailability,
@@ -1553,7 +1554,8 @@ FUNCTION(TaskCreateFuture,
 // AsyncTaskAndContext swift_task_create_future_f(
 //     size_t flags,
 //     const Metadata *futureResultType,
-//     TaskContinuationFunction *function, size_t contextSize);
+//     TaskContinuationFunction *function,
+//     size_t contextSize);
 FUNCTION(TaskCreateFutureFunc,
          swift_task_create_future_f, SwiftCC,
          ConcurrencyAvailability,
@@ -1563,9 +1565,11 @@ FUNCTION(TaskCreateFutureFunc,
          ATTRS(NoUnwind, ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create_group_future(
-//     size_t flags, TaskGroup *group,
+//     size_t flags,
+//     TaskGroup *group,
 //     const Metadata *futureResultType,
-//     void *closureEntry, HeapObject *closureContext);
+//     void *closureEntry,
+//     HeapObject *closureContext);
 FUNCTION(TaskCreateGroupFuture,
          swift_task_create_group_future, SwiftCC,
          ConcurrencyAvailability,
@@ -1576,9 +1580,11 @@ FUNCTION(TaskCreateGroupFuture,
          ATTRS(NoUnwind, ArgMemOnly))
 
 // AsyncTaskAndContext swift_task_create_group_future_f(
-//     size_t flags, TaskGroup *group,
+//     size_t flags,
+//     TaskGroup *group,
 //     const Metadata *futureResultType,
-//     TaskContinuationFunction *function, size_t contextSize);
+//     TaskContinuationFunction *function,
+//     size_t contextSize);
 FUNCTION(TaskCreateGroupFutureFunc,
          swift_task_create_group_future_f, SwiftCC,
          ConcurrencyAvailability,
@@ -1670,6 +1676,31 @@ FUNCTION(DefaultActorDeallocateResilient,
          ConcurrencyAvailability,
          RETURNS(VoidTy),
          ARGS(RefCountedPtrTy),
+         ATTRS(NoUnwind))
+
+/// void swift_asyncLet_start(
+///     AsyncLet *alet,
+///     const Metadata *futureResultType,
+///     void *closureEntryPoint,
+///     HeapObject *closureContext
+/// );
+FUNCTION(AsyncLetStart,
+         swift_asyncLet_start, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(SwiftAsyncLetPtrTy, // AsyncLet*, alias for Int8PtrTy
+              TypeMetadataPtrTy,  // futureResultType
+              Int8PtrTy,          // closureEntry
+              RefCountedPtrTy,    // closureContext
+         ),
+         ATTRS(NoUnwind, ArgMemOnly))
+
+// void swift_asyncLet_end(AsyncLet *alet);
+FUNCTION(EndAsyncLet,
+         swift_asyncLet_end, SwiftCC,
+         ConcurrencyAvailability,
+         RETURNS(VoidTy),
+         ARGS(SwiftAsyncLetPtrTy),
          ATTRS(NoUnwind))
 
 // void swift_taskGroup_initialize(TaskGroup *group);

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -163,6 +163,8 @@ namespace irgen {
     enum class SpecialKind {
       TaskFutureWait,
       TaskFutureWaitThrowing,
+      AsyncLetWait,
+      AsyncLetWaitThrowing,
       TaskGroupWaitNext,
     };
 
@@ -206,6 +208,9 @@ namespace irgen {
         switch (getSpecialKind()) {
         case SpecialKind::TaskFutureWait:
         case SpecialKind::TaskFutureWaitThrowing:
+        case SpecialKind::AsyncLetWait:
+        case SpecialKind::AsyncLetWaitThrowing:
+        case SpecialKind::TaskGroupWaitNext:
           // FIXME: I have disabled this optimization, if we bring it back we
           // need to debug why it currently does not work (call emission
           // computes an undef return pointer) and change the runtime entries to
@@ -214,8 +219,6 @@ namespace irgen {
           // We suppress generics from these as a code-size optimization
           // because the runtime can recover the success type from the
           // future.
-          return false;
-        case SpecialKind::TaskGroupWaitNext:
           return false;
         }
       }

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -220,10 +220,30 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     return;
   }
 
-  // getCurrentActor has no arguments.
+  // emitGetCurrentExecutor has no arguments.
   if (Builtin.ID == BuiltinValueKind::GetCurrentExecutor) {
     emitGetCurrentExecutor(IGF, out);
 
+    return;
+  }
+
+  if (Builtin.ID == BuiltinValueKind::StartAsyncLet) {
+    auto taskFunction = args.claimNext();
+    auto taskContext = args.claimNext();
+
+    auto asyncLet = emitBuiltinStartAsyncLet(
+        IGF,
+        taskFunction,
+        taskContext,
+        substitutions
+        );
+
+    out.add(asyncLet);
+    return;
+  }
+
+  if (Builtin.ID == BuiltinValueKind::EndAsyncLet) {
+    emitEndAsyncLet(IGF, args.claimNext());
     return;
   }
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -137,7 +137,7 @@ irgen::getAsyncContextLayout(IRGenModule &IGM, CanSILFunctionType originalType,
   }
 
   // Add storage for data used by runtime entry points.
-  // See TaskFutureWaitAsyncContext.
+  // See TaskFutureWaitAsyncContext and TaskGroupNextAsyncContext.
   if (kind.isSpecial()) {
     switch (kind.getSpecialKind()) {
     case FunctionPointer::SpecialKind::TaskFutureWait:
@@ -155,7 +155,25 @@ irgen::getAsyncContextLayout(IRGenModule &IGM, CanSILFunctionType originalType,
       // void (*, *) async  *asyncResumeEntryPoint;
       valTypes.push_back(ty);
       typeInfos.push_back(&ti);
-    } break;
+      break;
+    }
+    case FunctionPointer::SpecialKind::AsyncLetWait:
+    case FunctionPointer::SpecialKind::AsyncLetWaitThrowing: {
+      // This needs to match the layout of TaskFutureWaitAsyncContext.
+      // Add storage for the waiting future's result pointer (OpaqueValue *).
+      auto ty = SILType();
+      auto &ti = IGM.getSwiftContextPtrTypeInfo();
+      // SwiftError *
+      valTypes.push_back(ty);
+      typeInfos.push_back(&ti);
+      // OpaqueValue *successResultPointer
+      valTypes.push_back(ty);
+      typeInfos.push_back(&ti);
+      // void (*, *) async  *asyncResumeEntryPoint;
+      valTypes.push_back(ty);
+      typeInfos.push_back(&ti);
+      break;
+    }
     case FunctionPointer::SpecialKind::TaskGroupWaitNext: {
       // This needs to match the layout of TaskGroupNextAsyncContext.
       // Add storage for the waiting future's result pointer (OpaqueValue *).
@@ -173,10 +191,11 @@ irgen::getAsyncContextLayout(IRGenModule &IGM, CanSILFunctionType originalType,
       // TaskGroup *group;
       valTypes.push_back(ty);
       typeInfos.push_back(&ti);
-      // Metata *successType;
+      // Metadata *successType;
       valTypes.push_back(ty);
       typeInfos.push_back(&ti);
-    } break;
+      break;
+    }
     }
   }
   return AsyncContextLayout(IGM, LayoutStrategy::Optimal, valTypes, typeInfos,

--- a/lib/IRGen/GenConcurrency.h
+++ b/lib/IRGen/GenConcurrency.h
@@ -18,6 +18,15 @@
 #ifndef SWIFT_IRGEN_GENCONCURRENCY_H
 #define SWIFT_IRGEN_GENCONCURRENCY_H
 
+#include "swift/AST/Types.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/ApplySite.h"
+#include "llvm/IR/CallingConv.h"
+
+#include "Callee.h"
+#include "GenHeap.h"
+#include "IRGenModule.h"
+
 namespace llvm {
 class Value;
 }
@@ -35,6 +44,15 @@ void emitBuildSerialExecutorRef(IRGenFunction &IGF, llvm::Value *actor,
 
 /// Emit the getCurrentExecutor builtin.
 void emitGetCurrentExecutor(IRGenFunction &IGF, Explosion &out);
+
+/// Emit the createAsyncLet builtin.
+llvm::Value *emitBuiltinStartAsyncLet(IRGenFunction &IGF,
+                                      llvm::Value *taskFunction,
+                                      llvm::Value *localContextInfo,
+                                      SubstitutionMap subs);
+
+/// Emit the endAsyncLet builtin.
+void emitEndAsyncLet(IRGenFunction &IGF, llvm::Value *alet);
 
 /// Emit the createTaskGroup builtin.
 llvm::Value *emitCreateTaskGroup(IRGenFunction &IGF);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -618,6 +618,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
 
   AsyncFunctionPointerPtrTy = AsyncFunctionPointerTy->getPointerTo(DefaultAS);
   SwiftTaskPtrTy = SwiftTaskTy->getPointerTo(DefaultAS);
+  SwiftAsyncLetPtrTy = Int8PtrTy; // we pass it opaquely (AsyncLet*)
   SwiftTaskGroupPtrTy = Int8PtrTy; // we pass it opaquely (TaskGroup*)
   ExecutorFirstTy = RefCountedPtrTy;
   ExecutorSecondTy = SizeTy;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -732,6 +732,7 @@ public:
   llvm::PointerType *AsyncFunctionPointerPtrTy;
   llvm::PointerType *SwiftContextPtrTy;
   llvm::PointerType *SwiftTaskPtrTy;
+  llvm::PointerType *SwiftAsyncLetPtrTy;
   llvm::PointerType *SwiftTaskGroupPtrTy;
   llvm::PointerType *SwiftJobPtrTy;
   llvm::PointerType *ExecutorFirstTy;

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2508,6 +2508,12 @@ static FunctionPointer::Kind classifyFunctionPointerKind(SILFunction *fn) {
       return SpecialKind::TaskFutureWait;
     if (name.equals("swift_task_future_wait_throwing"))
       return SpecialKind::TaskFutureWaitThrowing;
+
+    if (name.equals("swift_asyncLet_wait"))
+      return SpecialKind::AsyncLetWait;
+    if (name.equals("swift_asyncLet_wait_throwing"))
+      return SpecialKind::AsyncLetWaitThrowing;
+
     if (name.equals("swift_taskGroup_wait_next_throwing"))
       return SpecialKind::TaskGroupWaitNext;
   }

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -745,6 +745,8 @@ BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, PoundAssert)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GlobalStringTablePointer)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TypePtrAuthDiscriminator)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, IntInstrprofIncrement)
+BUILTIN_OPERAND_OWNERSHIP(DestroyingConsume, StartAsyncLet)
+BUILTIN_OPERAND_OWNERSHIP(DestroyingConsume, EndAsyncLet)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, CreateTaskGroup)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, DestroyTaskGroup)
 

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -545,6 +545,8 @@ CONSTANT_OWNERSHIP_BUILTIN(None, ResumeNonThrowingContinuationReturning)
 CONSTANT_OWNERSHIP_BUILTIN(None, ResumeThrowingContinuationReturning)
 CONSTANT_OWNERSHIP_BUILTIN(None, ResumeThrowingContinuationThrowing)
 CONSTANT_OWNERSHIP_BUILTIN(None, BuildSerialExecutorRef)
+CONSTANT_OWNERSHIP_BUILTIN(None, StartAsyncLet)
+CONSTANT_OWNERSHIP_BUILTIN(None, EndAsyncLet)
 CONSTANT_OWNERSHIP_BUILTIN(None, CreateTaskGroup)
 CONSTANT_OWNERSHIP_BUILTIN(None, DestroyTaskGroup)
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1859,6 +1859,8 @@ static void visitBuiltinAddress(BuiltinInst *builtin,
     case BuiltinValueKind::InitializeDefaultActor:
     case BuiltinValueKind::DestroyDefaultActor:
     case BuiltinValueKind::GetCurrentExecutor:
+    case BuiltinValueKind::StartAsyncLet:
+    case BuiltinValueKind::EndAsyncLet:
     case BuiltinValueKind::CreateTaskGroup:
     case BuiltinValueKind::DestroyTaskGroup:
       return;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -355,10 +355,31 @@ static FuncDecl *lookupConcurrencyIntrinsic(ASTContext &C,
 }
 
 FuncDecl *
-SILGenModule::getRunChildTask() {
+SILGenModule::getAsyncLetStart() {
   return lookupConcurrencyIntrinsic(getASTContext(),
-                                    RunChildTask,
-                                    "_runChildTask");
+                                    AsyncLetStart,
+                                    "_asyncLetStart");
+}
+
+FuncDecl *
+SILGenModule::getAsyncLetGet() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    AsyncLetGet,
+                                    "_asyncLetGet");
+}
+
+FuncDecl *
+SILGenModule::getAsyncLetGetThrowing() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    AsyncLetGetThrowing,
+                                    "_asyncLetGetThrowing");
+}
+
+FuncDecl *
+SILGenModule::getEndAsyncLet() {
+  return lookupConcurrencyIntrinsic(getASTContext(),
+                                    EndAsyncLet,
+                                    "_asyncLetEnd");
 }
 
 FuncDecl *

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -119,7 +119,11 @@ public:
 
   Optional<ProtocolConformance *> NSErrorConformanceToError;
 
-  Optional<FuncDecl*> RunChildTask;
+  Optional<FuncDecl*> AsyncLetStart;
+  Optional<FuncDecl*> AsyncLetGet;
+  Optional<FuncDecl*> AsyncLetGetThrowing;
+  Optional<FuncDecl*> EndAsyncLet;
+
   Optional<FuncDecl*> TaskFutureGet;
   Optional<FuncDecl*> TaskFutureGetThrowing;
 
@@ -482,8 +486,14 @@ public:
   /// Retrieve the conformance of NSError to the Error protocol.
   ProtocolConformance *getNSErrorConformanceToError();
 
-  /// Retrieve the _Concurrency._runChildTask intrinsic.
-  FuncDecl *getRunChildTask();
+  /// Retrieve the _Concurrency._asyncLetStart intrinsic.
+  FuncDecl *getAsyncLetStart();
+  /// Retrieve the _Concurrency._asyncLetGet intrinsic.
+  FuncDecl *getAsyncLetGet();
+  /// Retrieve the _Concurrency._asyncLetGetThrowing intrinsic.
+  FuncDecl *getAsyncLetGetThrowing();
+  /// Retrieve the _Concurrency._asyncLetEnd intrinsic.
+  FuncDecl *getEndAsyncLet();
 
   /// Retrieve the _Concurrency._taskFutureGet intrinsic.
   FuncDecl *getTaskFutureGet();

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1376,6 +1376,13 @@ static ManagedValue emitBuiltinCancelAsyncTask(
   return SGF.emitCancelAsyncTask(loc, args[0].borrow(SGF, loc).forward(SGF));
 }
 
+// Emit SIL for the named builtin: endAsyncLet.
+static ManagedValue emitBuiltinEndAsyncLet(
+    SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,
+    ArrayRef<ManagedValue> args, SGFContext C) {
+  return SGF.emitCancelAsyncTask(loc, args[0].borrow(SGF, loc).forward(SGF));
+}
+
 // Emit SIL for the named builtin: getCurrentExecutor.
 static ManagedValue emitBuiltinGetCurrentExecutor(
     SILGenFunction &SGF, SILLocation loc, SubstitutionMap subs,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2822,7 +2822,6 @@ SILGenFunction::maybeEmitValueOfLocalVarDecl(
       completeAsyncLetChildTask(patternBinding, index);
     }
 
-
     // If this has an address, return it.  By-value let's have no address.
     SILValue ptr = It->second.value;
     if (ptr->getType().isAddress())

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -624,6 +624,7 @@ ManagedValue Transform::transform(ManagedValue v,
   }
 
   // Should have handled the conversion in one of the cases above.
+  v.dump();
   llvm_unreachable("Unhandled transform?");
 }
 

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -144,6 +144,7 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::GetCurrentAsyncTask:
     case BuiltinValueKind::GetCurrentExecutor:
     case BuiltinValueKind::AutoDiffCreateLinearMapContext:
+    case BuiltinValueKind::EndAsyncLet:
     case BuiltinValueKind::CreateTaskGroup:
     case BuiltinValueKind::DestroyTaskGroup:
       return false;
@@ -171,6 +172,7 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::UnsafeGuaranteed:
     case BuiltinValueKind::UnsafeGuaranteedEnd:
     case BuiltinValueKind::CancelAsyncTask:
+    case BuiltinValueKind::StartAsyncLet:
     case BuiltinValueKind::CreateAsyncTaskFuture:
     case BuiltinValueKind::CreateAsyncTaskGroupFuture:
     case BuiltinValueKind::ConvertTaskToJob:

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -43,6 +43,7 @@
 #ifdef OVERRIDE
 #  define OVERRIDE_ACTOR OVERRIDE
 #  define OVERRIDE_TASK OVERRIDE
+#  define OVERRIDE_ASYNC_LET OVERRIDE
 #  define OVERRIDE_TASK_GROUP OVERRIDE
 #  define OVERRIDE_TASK_LOCAL OVERRIDE
 #  define OVERRIDE_TASK_STATUS OVERRIDE
@@ -52,6 +53,9 @@
 #  endif
 #  ifndef OVERRIDE_TASK
 #    define OVERRIDE_TASK(...)
+#  endif
+#  ifndef OVERRIDE_ASYNC_LET
+#    define OVERRIDE_ASYNC_LET(...)
 #  endif
 #  ifndef OVERRIDE_TASK_GROUP
 #    define OVERRIDE_TASK_GROUP(...)
@@ -144,6 +148,36 @@ OVERRIDE_TASK(task_removeCancellationHandler, void,
 OVERRIDE_TASK(task_asyncMainDrainQueue, void,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift), swift::,
               , )
+
+OVERRIDE_ASYNC_LET(asyncLet_start, void,
+                   SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                   swift::,
+                   (AsyncLet *alet,
+                    const Metadata *futureResultType,
+                    void *closureEntryPoint,
+                    HeapObject */* +1 */ closureContext
+                   ),
+                   (alet, futureResultType,
+                    closureEntryPoint, closureContext))
+
+OVERRIDE_ASYNC_LET(asyncLet_wait, void, SWIFT_EXPORT_FROM(swift_Concurrency),
+                   SWIFT_CC(swiftasync), swift::,
+                   (OpaqueValue *result,
+                       SWIFT_ASYNC_CONTEXT AsyncContext *rawContext,
+                       AsyncLet *alet, Metadata *T),
+                   (result, rawContext, alet, T))
+
+OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
+                   SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swiftasync),
+                   swift::,
+                   (OpaqueValue *result,
+                       SWIFT_ASYNC_CONTEXT AsyncContext *rawContext,
+                       AsyncLet *alet, Metadata *T),
+                   (result, rawContext, alet, T))
+
+OVERRIDE_ASYNC_LET(asyncLet_end, void,
+                   SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                   swift::, (AsyncLet *alet), (alet))
 
 OVERRIDE_TASK_GROUP(taskGroup_initialize, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
@@ -240,6 +274,7 @@ OVERRIDE_TASK_STATUS(task_getNearestDeadline, NearestTaskDeadline,
 #undef OVERRIDE
 #undef OVERRIDE_ACTOR
 #undef OVERRIDE_TASK
+#undef OVERRIDE_ASYNC_LET
 #undef OVERRIDE_TASK_GROUP
 #undef OVERRIDE_TASK_LOCAL
 #undef OVERRIDE_TASK_STATUS

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -1,0 +1,181 @@
+//===--- AsyncLet.h - async let object management -00------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Object management routines for asynchronous task objects.
+//
+//===----------------------------------------------------------------------===//
+
+#include "../CompatibilityOverride/CompatibilityOverride.h"
+#include "swift/Runtime/Concurrency.h"
+#include "swift/ABI/Task.h"
+#include "swift/ABI/AsyncLet.h"
+#include "swift/ABI/Metadata.h"
+#include "swift/Runtime/Mutex.h"
+#include "swift/Runtime/HeapObject.h"
+#include "TaskPrivate.h"
+#include "AsyncCall.h"
+#include "Debug.h"
+
+#if !defined(_WIN32)
+#include <dlfcn.h>
+#endif
+
+using namespace swift;
+
+namespace {
+class AsyncLetImpl: public ChildTaskStatusRecord {
+public:
+  // This is where we could define a Status or other types important for async-let
+
+private:
+
+  /// The task that was kicked off to initialize this `async let`.
+  AsyncTask *task;
+
+  // TODO: more additional flags here, we can use them for future optimizations.
+  //       e.g. "was awaited on" or "needs free"
+
+  friend class AsyncTask;
+
+public:
+  explicit AsyncLetImpl(AsyncTask* task)
+      : ChildTaskStatusRecord(task),
+        task(task) {
+    assert(task->hasChildFragment() && "async let task must be a child task.");
+  }
+
+  /// Returns the task record representing this async let task.
+  /// The record is stored in the parent task, and should be removed when the
+  /// async let goes out of scope.
+  ChildTaskStatusRecord *getTaskRecord() {
+    return reinterpret_cast<ChildTaskStatusRecord *>(this);
+  }
+
+  AsyncTask *getTask() const {
+    return task;
+  }
+
+}; // end AsyncLetImpl
+
+} // end anonymous namespace
+
+
+/******************************************************************************/
+/************************* ASYNC LET IMPLEMENTATION ***************************/
+/******************************************************************************/
+
+static_assert(sizeof(AsyncLetImpl) <= sizeof(AsyncLet) &&
+              alignof(AsyncLetImpl) <= alignof(AsyncLet),
+              "AsyncLetImpl doesn't fit in AsyncLet");
+
+static AsyncLetImpl *asImpl(AsyncLet *alet) {
+  return reinterpret_cast<AsyncLetImpl*>(alet);
+}
+
+static AsyncLetImpl *asImpl(const AsyncLet *alet) {
+  return reinterpret_cast<AsyncLetImpl*>(
+      const_cast<AsyncLet*>(alet));
+}
+
+static AsyncLet *asAbstract(AsyncLetImpl *alet) {
+  return reinterpret_cast<AsyncLet*>(alet);
+}
+
+// =============================================================================
+// ==== start ------------------------------------------------------------------
+
+SWIFT_CC(swift)
+static void swift_asyncLet_startImpl(AsyncLet *alet,
+                                     const Metadata *futureResultType,
+                                     void *closureEntryPoint,
+                                     HeapObject * /* +1 */ closureContext) {
+  AsyncTask *parent = swift_task_getCurrent();
+  assert(parent && "async-let cannot be created without parent task");
+
+  auto flags = JobFlags(JobKind::Task, parent->getPriority());
+  flags.task_setIsFuture(true);
+  flags.task_setIsChildTask(true);
+
+  auto childTaskAndContext = swift_task_create_future(
+      flags,
+      futureResultType,
+      closureEntryPoint,
+      closureContext);
+
+  AsyncTask *childTask = childTaskAndContext.Task;
+  swift_retain(childTask);
+
+  assert(childTask->isFuture());
+  assert(childTask->hasChildFragment());
+  AsyncLetImpl *impl = new (alet) AsyncLetImpl(childTask);
+
+  auto record = impl->getTaskRecord();
+  assert(impl == record && "the async-let IS the task record");
+
+  // ok, now that the group actually is initialized: attach it to the task
+  swift_task_addStatusRecord(record);
+
+  // schedule the task
+  swift_task_enqueueGlobal(childTask);
+}
+
+// =============================================================================
+// ==== wait -------------------------------------------------------------------
+
+SWIFT_CC(swiftasync)
+static void swift_asyncLet_waitImpl(
+    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *rawContext,
+    AsyncLet *alet, Metadata *T) {
+  auto waitingTask = swift_task_getCurrent();
+  auto task = alet->getTask();
+  swift_task_future_wait(result, rawContext, task, T);
+}
+
+SWIFT_CC(swiftasync)
+static void swift_asyncLet_wait_throwingImpl(
+    OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *rawContext,
+    AsyncLet *alet, Metadata *T) {
+  auto task = alet->getTask();
+  swift_task_future_wait_throwing(result, rawContext, task, T);
+}
+
+// =============================================================================
+// ==== end --------------------------------------------------------------------
+
+SWIFT_CC(swift)
+static void swift_asyncLet_endImpl(AsyncLet *alet) {
+  auto task = alet->getTask();
+
+  // Cancel the task as we exit the scope
+  swift_task_cancel(task);
+
+  // Remove the child record from the parent task
+  auto record = asImpl(alet)->getTaskRecord();
+  swift_task_removeStatusRecord(record);
+
+  // TODO: we need to implicitly await either before the end or here somehow.
+
+  // and finally, release the task and free the async-let
+  swift_release(task);
+}
+
+// =============================================================================
+// ==== AsyncLet Implementation ------------------------------------------------
+
+AsyncTask* AsyncLet::getTask() const {
+  return asImpl(this)->getTask();
+}
+
+// =============================================================================
+
+#define OVERRIDE_ASYNC_LET COMPATIBILITY_OVERRIDE
+#include COMPATIBILITY_OVERRIDE_INCLUDE_PATH

--- a/stdlib/public/Concurrency/AsyncLet.swift
+++ b/stdlib/public/Concurrency/AsyncLet.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+@_implementationOnly import _SwiftConcurrencyShims
+
+// ==== Async Let -------------------------------------------------------------
+// Only has internal / builtin functions as it is not really accessible directly
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@_silgen_name("swift_asyncLet_start")
+public func _asyncLetStart<T>(
+  asyncLet: Builtin.RawPointer,
+  operation: __owned @Sendable @escaping () async throws -> T
+)
+
+/// Similar to _taskFutureGet but for AsyncLet
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@_silgen_name("swift_asyncLet_wait")
+public func _asyncLetGet<T>(asyncLet: Builtin.RawPointer) async -> T
+
+///// Similar to _taskFutureGetThrowing but for AsyncLet
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@_silgen_name("swift_asyncLet_wait_throwing")
+public func _asyncLetGetThrowing<T>(asyncLet: Builtin.RawPointer) async throws -> T
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@_silgen_name("swift_asyncLet_end")
+public func _asyncLetEnd(
+  asyncLet: Builtin.RawPointer // TODO: should this take __owned?
+)
+
+
+@_silgen_name("swift_asyncLet_extractTask")
+func _asyncLetExtractTask(
+  of asyncLet: Builtin.RawPointer
+) -> Builtin.NativeObject

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -37,6 +37,8 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   ../CompatibilityOverride/CompatibilityOverride.cpp
   Actor.cpp
   Actor.swift
+  AsyncLet.cpp
+  AsyncLet.swift
   CheckedContinuation.swift
   GlobalExecutor.cpp
   Errors.swift

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -177,7 +177,6 @@ static void destroyJob(SWIFT_CONTEXT HeapObject *obj) {
 SWIFT_CC(swift)
 static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   auto task = static_cast<AsyncTask*>(obj);
-
   // For a future, destroy the result.
   if (task->isFuture()) {
     task->futureFragment()->destroy();
@@ -283,8 +282,10 @@ static void completeTask(SWIFT_ASYNC_CONTEXT AsyncContext *context,
   }
 
   // TODO: set something in the status?
-  // TODO: notify the parent somehow?
-  // TODO: remove this task from the child-task chain?
+  if (task->hasChildFragment()) {
+    // TODO: notify the parent somehow?
+    // TODO: remove this task from the child-task chain?
+  }
 
   // Release the task, balancing the retain that a running task has on itself.
   // If it was a group child task, it will remain until the group returns it.
@@ -354,15 +355,12 @@ static AsyncTaskAndContext swift_task_create_group_future_commonImpl(
 
   // Figure out the size of the header.
   size_t headerSize = sizeof(AsyncTask);
-
   if (parent) {
     headerSize += sizeof(AsyncTask::ChildFragment);
   }
-
   if (flags.task_isGroupChildTask()) {
     headerSize += sizeof(AsyncTask::GroupChildFragment);
   }
-
   if (futureResultType) {
     headerSize += FutureFragment::fragmentSize(futureResultType);
     // Add the future async context prefix.
@@ -380,6 +378,9 @@ static AsyncTaskAndContext swift_task_create_group_future_commonImpl(
 
   assert(amountToAllocate % MaximumAlignment == 0);
 
+  // TODO: allow optionally passing in an allocation+sizeOfIt to reuse for the task
+  //       if the necessary space is enough, we can initialize into it rather than malloc.
+  //       this would allow us to stack-allocate async-let related tasks.
   void *allocation = malloc(amountToAllocate);
 
   AsyncContext *initialContext =
@@ -592,7 +593,6 @@ static void swift_task_future_waitImpl(OpaqueValue *result,
   context->asyncResumeEntryPoint = nullptr;
   context->successResultPointer = result;
   context->errorResult = nullptr;
-
 
   // Wait on the future.
   assert(task->isFuture());

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -714,8 +714,8 @@ public func _runAsyncMain(_ asyncFun: @escaping () async throws -> ()) {
 }
 
 // FIXME: both of these ought to take their arguments _owned so that
-// we can do a move out of the future in the common case where it's
-// unreferenced
+//        we can do a move out of the future in the common case where it's
+//        unreferenced
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_future_wait")
 public func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
@@ -723,29 +723,6 @@ public func _taskFutureGet<T>(_ task: Builtin.NativeObject) async -> T
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_future_wait_throwing")
 public func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
-
-@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-public func _runChildTask<T>(
-  operation: @Sendable @escaping () async throws -> T
-) async -> Builtin.NativeObject {
-  let currentTask = Builtin.getCurrentAsyncTask()
-
-  // Set up the job flags for a new task.
-  var flags = Task.JobFlags()
-  flags.kind = .task
-  flags.priority = getJobFlags(currentTask).priority
-  flags.isFuture = true
-  flags.isChildTask = true
-
-  // Create the asynchronous task future.
-  let (task, _) = Builtin.createAsyncTaskFuture(
-      flags.bits, operation)
-
-  // Enqueue the resulting job.
-  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
-
-  return task
-}
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_task_cancel")

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -452,19 +452,6 @@ static TaskGroup *asAbstract(TaskGroupImpl *group) {
 // Initializes into the preallocated _group an actual TaskGroupImpl.
 SWIFT_CC(swift)
 static void swift_taskGroup_initializeImpl(TaskGroup *group) {
-//  // nasty trick, but we want to keep the record inside the group as we'll need
-//  // to remove it from the task as the group is destroyed, as well as interact
-//  // with it every time we add child tasks; so it is useful to pre-create it here
-//  // and store it in the group.
-//  //
-//  // The record won't be used by anyone until we're done constructing and setting
-//  // up the group anyway.
-//  void *recordAllocation = swift_task_alloc(task, sizeof(TaskGroupTaskStatusRecord));
-//  auto record = new (recordAllocation)
-//    TaskGroupTaskStatusRecord(reinterpret_cast<TaskGroupImpl*>(_group));
-
-  // TODO: this becomes less weird once we make the fragment BE the group
-
   TaskGroupImpl *impl = new (group) TaskGroupImpl();
   auto record = impl->getTaskRecord();
   assert(impl == record && "the group IS the task record");

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -254,7 +254,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
       flags.bits, _group, operation)
     
     // Attach it to the group's task record in the current task.
-    _ = _taskGroupAttachChild(group: _group, child: childTask)
+    _taskGroupAttachChild(group: _group, child: childTask)
     
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
@@ -299,7 +299,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
       flags.bits, _group, operation)
 
     // Attach it to the group's task record in the current task.
-    _ = _taskGroupAttachChild(group: _group, child: childTask)
+    _taskGroupAttachChild(group: _group, child: childTask)
 
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
@@ -507,7 +507,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
       flags.bits, _group, operation)
 
     // Attach it to the group's task record in the current task.
-    _ = _taskGroupAttachChild(group: _group, child: childTask)
+    _taskGroupAttachChild(group: _group, child: childTask)
 
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
@@ -552,7 +552,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
       flags.bits, _group, operation)
 
     // Attach it to the group's task record in the current task.
-    _ = _taskGroupAttachChild(group: _group, child: childTask)
+    _taskGroupAttachChild(group: _group, child: childTask)
 
     // Enqueue the resulting job.
     _enqueueJobGlobal(Builtin.convertTaskToJob(childTask))
@@ -790,7 +790,7 @@ extension ThrowingTaskGroup: AsyncSequence {
 func _taskGroupAttachChild(
   group: Builtin.RawPointer,
   child: Builtin.NativeObject
-) -> UnsafeRawPointer /*ChildTaskStatusRecord*/
+)
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @_silgen_name("swift_taskGroup_destroy")

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -91,6 +91,12 @@ namespace {
 ///   @_silgen_name("swift_task_future_wait_throwing")
 ///   func _taskFutureGetThrowing<T>(_ task: Builtin.NativeObject) async throws -> T
 ///
+///   @_silgen_name("swift_asyncLet_wait")
+///   func _asyncLetGet<T>(_ task: Builtin.RawPointer) async -> T
+///
+///   @_silgen_name("swift_asyncLet_waitThrowing")
+///   func _asyncLetGetThrowing<T>(_ task: Builtin.RawPointer) async throws -> T
+///
 class TaskFutureWaitAsyncContext : public AsyncContext {
 public:
   SwiftError *errorResult;

--- a/test/Concurrency/Runtime/async_let_throws.swift
+++ b/test/Concurrency/Runtime/async_let_throws.swift
@@ -1,0 +1,33 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+struct Boom: Error {}
+
+func boom() throws -> Int {
+  throw Boom()
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func test() async {
+  async let result = boom()
+
+  do {
+    _ = try await result
+  } catch {
+    print("error: \(error)") // CHECK: error: Boom()
+  }
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@main struct Main {
+  static func main() async {
+    await test()
+  }
+}

--- a/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
+++ b/test/Concurrency/Runtime/async_task_async_let_child_cancel.swift
@@ -1,0 +1,68 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch -parse-as-library) | %FileCheck %s --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// UNSUPPORTED: OS=windows-msvc
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func printWaitPrint(_ int: Int) async -> Int {
+  print("start, cancelled:\(Task.isCancelled), id:\(int)")
+  while !Task.isCancelled {
+    await Task.sleep(100_000)
+  }
+  print("done, cancelled:\(Task.isCancelled), id:\(int)")
+  return int
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+func test() async {
+  let handle = detach {
+    print("detached run, cancelled:\(Task.isCancelled)")
+
+    // these tasks will keep spinning until they are cancelled
+    async let one = printWaitPrint(1)
+    print("spawned: 1")
+    async let two = printWaitPrint(2)
+    print("spawned: 2")
+
+    let first = await one
+    print("awaited: 1: \(first)")
+    let second = await two
+    print("awaited: 2: \(second)")
+
+    // is immediately cancelled, since if we got here one and two completed,
+    // which means we're cancelled and thus children should be as well.
+    async let three = printWaitPrint(3)
+    let third = await three
+
+    print("exit detach")
+  }
+
+  await Task.sleep(2 * 1_000_000)
+
+  print("cancel")
+  handle.cancel()
+
+  // CHECK: detached run, cancelled:false
+  // the 1 and 2 tasks are racing so we don't check the specific IDs for them
+  // CHECK: start, cancelled:false
+  // CHECK: start, cancelled:false
+  // CHECK: cancel
+  // CHECK: done, cancelled:true
+  // CHECK: done, cancelled:true
+  // CHECK: start, cancelled:true, id:3
+  // CHECK: done, cancelled:true, id:3
+  // CHECK: exit detach
+  // CHECK: exit
+
+  await handle.get()
+  print("exit")
+}
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@main struct Main {
+  static func main() async {
+    await test()
+  }
+}

--- a/test/SILGen/async_let.swift
+++ b/test/SILGen/async_let.swift
@@ -4,6 +4,7 @@
 import Swift
 import _Concurrency
 
+
 func getInt() async -> Int { 0 }
 func getString() async -> String { "" }
 func getStringThrowingly() async throws -> String { "" }
@@ -18,25 +19,20 @@ func testAsyncLetInt() async -> Int {
   // CHECK: [[I:%.*]] = mark_uninitialized [var] %0
   // CHECK: [[CLOSURE:%.*]] = function_ref @$s4test0A11AsyncLetIntSiyYaFSiyYaYbcfu_ : $@convention(thin) @Sendable @async () -> Int
   // CHECK: [[THICK_CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) @Sendable @async () -> Int to $@Sendable @async @callee_guaranteed () -> Int
-  // CHECK: [[REABSTRACT_THUNK:%.*]] = function_ref @$sSiIeghHd_Sis5Error_pIeghHrzo_TR : $@convention(thin) @Sendable @async (@guaranteed @Sendable @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
-  // CHECK: [[REABSTRACT_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[THICK_CLOSURE]]) : $@convention(thin) @Sendable @async (@guaranteed @Sendable @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
-  // CHECK: [[CLOSURE_ARG:%.*]] = convert_function [[REABSTRACT_CLOSURE]] : $@Sendable @async @callee_guaranteed () -> (@out Int, @error Error) to $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>
-  // CHECK: [[RUN_CHILD_TASK:%.*]] = function_ref @$ss13_runChildTask9operationBoxyYaYbKc_tYalF : $@convention(thin) @async <τ_0_0> (@guaranteed @Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
-  // CHECK: [[CHILD_TASK:%.*]] = apply [[RUN_CHILD_TASK]]<Int>([[CLOSURE_ARG]]) : $@convention(thin) @async <τ_0_0> (@guaranteed @Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <τ_0_0>) -> @owned Builtin.NativeObject
+  // CHECK: [[REABSTRACT_THUNK:%.*]] = function_ref @$sSiIeghHd_Sis5Error_pIegHrzo_TR : $@convention(thin) @async (@guaranteed @Sendable @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
+  // CHECK: [[REABSTRACT_CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[REABSTRACT_THUNK]]([[THICK_CLOSURE]]) : $@convention(thin) @async (@guaranteed @Sendable @async @callee_guaranteed () -> Int) -> (@out Int, @error Error)
+  // CHECK: [[CLOSURE_ARG:%.*]] = convert_function [[REABSTRACT_CLOSURE]] : $@async @callee_guaranteed () -> (@out Int, @error Error) to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>
+  // CHECK: [[ASYNC_LET_START:%.*]] = builtin "startAsyncLet"<Int>([[CLOSURE_ARG]] : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error Error) for <Int>) : $Builtin.RawPointer
   async let i = await getInt()
 
-  // CHECK: [[FUTURE_GET:%.*]] = function_ref @swift_task_future_wait : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+  // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
   // CHECK: [[INT_RESULT:%.*]] = alloc_stack $Int
-  // CHECK: apply [[FUTURE_GET]]<Int>([[INT_RESULT]], [[CHILD_TASK]]) : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+  // CHECK: apply [[ASYNC_LET_GET]]<Int>([[INT_RESULT]], [[ASYNC_LET_START]]) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
   // CHECK: [[INT_RESULT_VALUE:%.*]] = load [trivial] [[INT_RESULT]] : $*Int
   // CHECK: assign [[INT_RESULT_VALUE]] to [[I]] : $*Int
   return await i
 
-  // CHECK: [[BORROW_CHILD_TASK:%.*]] = begin_borrow [[CHILD_TASK]] : $Builtin.NativeObject
-  // CHECK-NEXT: builtin "cancelAsyncTask"([[BORROW_CHILD_TASK]] : $Builtin.NativeObject) : $()
-  // CHECK-NEXT: end_borrow [[BORROW_CHILD_TASK]] : $Builtin.NativeObject
-  
-  // CHECK: destroy_value [[CHILD_TASK]] : $Builtin.NativeObject 
+  // CHECK: [[ASYNC_LET_END:%.*]] = builtin "endAsyncLet"([[ASYNC_LET_START]] : $Builtin.RawPointer) : $()
 }
 
 func testAsyncLetWithThrows(cond: Bool) async throws -> String {
@@ -46,7 +42,7 @@ func testAsyncLetWithThrows(cond: Bool) async throws -> String {
   if cond {
     throw SomeError.boom
   }
-  
+
   return await s
 }
 
@@ -54,8 +50,8 @@ func testAsyncLetWithThrows(cond: Bool) async throws -> String {
 func testAsyncLetThrows() async throws -> String {
   async let s = try await getStringThrowingly()
 
-  // CHECK: [[RUN_CHILD_TASK:%.*]] = function_ref @swift_task_future_wait_throwing : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> (@out τ_0_0, @error Error)
-  // CHECK: try_apply [[RUN_CHILD_TASK]]<String>
+  // CHECK: [[ASYNC_LET_WAIT_THROWING:%.*]] = function_ref @swift_asyncLet_wait_throwing : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> (@out τ_0_0, @error Error)
+  // CHECK: try_apply [[ASYNC_LET_WAIT_THROWING]]<String>
   return try await s
 }
 
@@ -68,9 +64,9 @@ func testDecomposeAwait(cond: Bool) async -> Int {
   async let (i, s) = await getIntAndString()
 
   if cond {
-    // CHECK: [[FUTURE_GET:%.*]] = function_ref @swift_task_future_wait : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+    // CHECK: [[ASYNC_LET_GET:%.*]] = function_ref @swift_asyncLet_wait : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT:%.*]] = alloc_stack $(Int, String)
-    // CHECK: apply [[FUTURE_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}) : $@convention(thin) @async <τ_0_0> (@guaranteed Builtin.NativeObject) -> @out τ_0_0
+    // CHECK: apply [[ASYNC_LET_GET]]<(Int, String)>([[TUPLE_RESULT]], {{%.*}}) : $@convention(thin) @async <τ_0_0> (Builtin.RawPointer) -> @out τ_0_0
     // CHECK: [[TUPLE_RESULT_VAL:%.*]] = load [take] [[TUPLE_RESULT]] : $*(Int, String)
     // CHECK: ([[FIRST_VAL:%.*]], [[SECOND_VAL:%.*]]) = destructure_tuple [[TUPLE_RESULT_VAL]] : $(Int, String)
     // CHECK: assign [[FIRST_VAL]] to [[I]] : $*Int

--- a/test/Sanitizers/tsan/async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/async_let_fibonacci.swift
@@ -6,12 +6,15 @@
 // REQUIRES: tsan_runtime
 // UNSUPPORTED: use_os_stdlib
 
+// REQUIRES: radar76446550
+
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #endif
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func fib(_ n: Int) -> Int {
   var first = 0
   var second = 1
@@ -23,6 +26,7 @@ func fib(_ n: Int) -> Int {
   return first
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func asyncFib(_ n: Int) async -> Int {
   if n == 0 || n == 1 {
     return n
@@ -32,16 +36,17 @@ func asyncFib(_ n: Int) async -> Int {
   async let second = await asyncFib(n-1)
 
   // Sleep a random amount of time waiting on the result producing a result.
-  usleep(UInt32.random(in: 0..<100) * 1000)
+  await Task.sleep(UInt64.random(in: 0..<100) * 1000)
 
   let result = await first + second
 
   // Sleep a random amount of time before producing a result.
-  usleep(UInt32.random(in: 0..<100) * 1000)
+  await Task.sleep(UInt64.random(in: 0..<100) * 1000)
 
   return result
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 func runFibonacci(_ n: Int) async {
   let result = await asyncFib(n)
 
@@ -50,6 +55,7 @@ func runFibonacci(_ n: Int) async {
   assert(result == fib(n))
 }
 
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 @main struct Main {
   static func main() async {
     await runFibonacci(10)

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -175,6 +175,22 @@ TEST_F(CompatibilityOverrideConcurrencyTest,
   swift_continuation_throwingResumeWithError(nullptr, nullptr);
 }
 
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_start) {
+  swift_asyncLet_start(nullptr, nullptr, nullptr, nullptr);
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_wait) {
+  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr);
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_wait_throwing) {
+  swift_asyncLet_wait(nullptr, nullptr, nullptr, nullptr);
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_asyncLet_end) {
+  swift_asyncLet_end(nullptr);
+}
+
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_initialize) {
   swift_taskGroup_initialize(nullptr);
 }
@@ -208,7 +224,7 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_taskGroup_addPending) {
   swift_taskGroup_addPending(nullptr, true);
 }
 
-TEST_F(CompatibilityOverrideConcurrencyTest, test_swifttask_localValuePush) {
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_localValuePush) {
   swift_task_localValuePush(nullptr, nullptr, nullptr, nullptr);
 }
 


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/36938

--- 

[AsyncLet] reimplemented with new ABI and builtins

[AsyncLet] remove runChild; it is now asyncLetStart

[AsyncLet] ending an async let cancels the task

[AsyncLet] remove some commented out code

[AsyncLet] silence issue on windows

[Concurrency] Store child record when async let child task spawned

[AsyncLet] reimplemented with new ABI and builtins

[AsyncLet] remove runChild; it is now asyncLetStart

[AsyncLet] ending an async let cancels the task

[AsyncLet] remove some commented out code

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
