### PR TITLE
[SourceKit] Don’t transform type when printing if CurrentType can’t have members

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -755,7 +755,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
   void printType(Type T) { printTypeWithOptions(T, Options); }
 
   void printTransformedTypeWithOptions(Type T, PrintOptions options) {
-    if (CurrentType && Current) {
+    if (CurrentType && Current && CurrentType->mayHaveMembers()) {
       if (T->hasArchetype()) {
         // Get the interface type, since TypeLocs still have
         // contextual types in them.

--- a/test/SourceKit/CursorInfo/cursor_generics.swift
+++ b/test/SourceKit/CursorInfo/cursor_generics.swift
@@ -19,6 +19,17 @@ class MyType<T> {
 	}
 }
 
+// rdar://76750555
+public protocol IP {
+    init(networkBytes: Int)
+}
+
+public struct HostRecord<IPType: IP> {
+    func foo() {
+        let ipType = IPType(networkBytes: 42)
+    }
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=1:10 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: <Declaration>func testGenerics&lt;T&gt;(x: <Type usr="s:15cursor_generics12testGenerics1xyx_tlF1TL_xmfp">T</Type>)</Declaration>
 
@@ -37,3 +48,7 @@ class MyType<T> {
 // RUN: %sourcekitd-test -req=cursor -pos=18:14 %s -- %s | %FileCheck -check-prefix=CHECK5 %s
 // CHECK5: source.lang.swift.ref.var.instance
 // CHECK5: <Declaration>let items: [<Type usr="s:Si">Int</Type>]</Declaration>
+
+// RUN: %sourcekitd-test -req=cursor -pos=29:22 %s -- %s | %FileCheck -check-prefix=CHECK_IP_TYPE %s
+// CHECK_IP_TYPE: source.lang.swift.ref.generic_type_param
+// CHECK_IP_TYPE: <Declaration>IPType : <Type usr="s:15cursor_generics2IPP">IP</Type></Declaration>


### PR DESCRIPTION
Since 9ba892c we always transform `CurrentType` in `ASTPrinter` to be an interface type.

This causes issues when the variable type is a generic parameter type. Previously we had `CurrentType` set to a `PrimaryArchetypeType`. With the fix in d93ae06, we are mapping the archetype out of context to a `GenericParamType`. A `GenericParamType`, however, can’t have members, so we’re hitting an assertion when creating a `TypeTransformContext`. Since the entire type transformation in `printTransformedTypeWithOptions` is only affecting type members, we should be able to safely skip over the transformation if `CurrentType` can’t have any members.

Fixes rdar://76750555 [SR-14497]
