### PR TITLE
[Linux] Use target-cpu for Linux in lto_autolink test

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -6,9 +6,9 @@
 // CHECK-MACHO-DAG: !llvm.linker.options = !{
 // CHECK-MACHO-DAG: !{{[0-9]+}} = !{!"-lempty"}
 
-// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
+// RUN: %target-swift-frontend -target %target-cpu-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
 
 // CHECK-ELF-DAG: !llvm.dependent-libraries = !{
 // CHECK-ELF-DAG: !{{[0-9]+}} = !{!"empty"}
@@ -35,9 +35,9 @@ import empty
 // CHECK-MACHO-MERGE-DAG: !{{[0-9]+}} = !{!"-lautolink-module-map-link"}
 
 
-// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
+// RUN: %target-swift-frontend -target %target-cpu-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
 
 // CHECK-ELF-MERGE-DAG: !llvm.dependent-libraries = !{
 // CHECK-ELF-MERGE-DAG: !{{[0-9]+}} = !{!"empty"}


### PR DESCRIPTION
This test fails on aarch64 when using x86_64 as target.