### PR TITLE
[Linux] XFAIL typeref_decoding_asan test on linux-aarch64

### DIFF
--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -1,3 +1,5 @@
+// XFAIL: OS=linux-gnu && CPU=aarch64
+
 // REQUIRES: asan_runtime
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/%target-library-name(TypesToReflect)


### PR DESCRIPTION
ASan seems to cause reflection information to not be extractable from binaries on aarch64.

rdar://76975976