### PR TITLE
[concurrency] Provide missing header file.

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -25,6 +25,7 @@
 #include "swift/Runtime/ThreadLocal.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/Actor.h"
+#include "llvm/Config/config.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "TaskPrivate.h"
 
@@ -50,6 +51,11 @@
 
 #if HAVE_PTHREAD_H
 #include <pthread.h>
+
+// Only use __has_include since HAVE_PTHREAD_NP_H is not provided.
+#if __has_include(<pthread_np.h>)
+#include <pthread_np.h>
+#endif
 #endif
 
 #if defined(_WIN32)


### PR DESCRIPTION
HAVE_PTHREAD_H is supplied in this config file.

The `__has_include` pattern is discouraged, but there is no other way of
conditioning on `pthread_np.h`, which is required for `pthread_main_np`
on OpenBSD. Therefore, use it, but call it out in a comment.

~~I don't know where HAVE_PTHREAD_H comes from on other platforms, but this
seems like a flaky strategy. While we are here, since we are relying on
pthread_main_np, include `pthread_np.h` if it is present, since it is
required on some platforms.~~

(This is a buildfix for OpenBSD.)