### PR TITLE
[inst-opt-utils] If InstModCallback::setUseValueFunc isn't set, just call RAUW directly rather than calling the default setUseValueFunc.

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -413,6 +413,13 @@ public:
   void replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
     wereAnyCallbacksInvoked = true;
 
+    // If setUseValueFunc is not set, just call RAUW directly. RAUW in this case
+    // is equivalent to what we do below. We just enable better
+    // performance. This ensures that the default InstModCallback is really
+    // fast.
+    if (!setUseValueFunc)
+      return oldValue->replaceAllUsesWith(newValue);
+
     while (!oldValue->use_empty()) {
       auto *use = *oldValue->use_begin();
       setUseValue(use, newValue);


### PR DESCRIPTION
This guarantees that a default InstModCallback() call to RAUW doesn't have any
overhead.

Just a little optimization I saw.
