### PR TITLE
Fix calling convention mismatch on `Builtin.getCurrentAsyncTask`

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -230,6 +230,7 @@ void IRGenFunction::setupAsync(unsigned asyncContextIndex) {
 llvm::Value *IRGenFunction::getAsyncTask() {
   auto call = Builder.CreateCall(IGM.getGetCurrentTaskFn(), {});
   call->setDoesNotThrow();
+  call->setCallingConv(IGM.SwiftCC);
   return call;
 }
 

--- a/test/IRGen/builtin_conflict.sil
+++ b/test/IRGen/builtin_conflict.sil
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir -parse-sil %s -parse-stdlib | %FileCheck %s
+
+import Builtin
+import Swift
+
+sil @entry : $@async @convention(thin) () -> () {
+bb0:
+  %0 = function_ref @swift_task_getCurrent : $@convention(thin) () -> @owned Optional<Builtin.NativeObject>
+  // CHECK: call swiftcc {{.*}} @swift_task_getCurrent
+  %1 = apply %0() : $@convention(thin) () -> @owned Optional<Builtin.NativeObject>
+  // CHECK-NEXT: call swiftcc {{.*}} @swift_task_getCurrent
+  %3 = builtin "getCurrentAsyncTask"() : $Builtin.NativeObject
+  return undef : $()
+}
+
+sil hidden_external @swift_task_getCurrent : $@convention(thin) () -> @owned Optional<Builtin.NativeObject>


### PR DESCRIPTION
<!-- What's in this pull request? -->
`Builtin.getCurrentAsyncTask` emits a call of `swift_task_getCurrent`.
User code can declare the same name function with slightly different signature at LLVM level (data size should be same) using @_silgen_name. 

Task.swift declares to be `() -> Builtin.NativeObject?`,
https://github.com/apple/swift/blob/90c1fece9ed6d2fea90ef5a2f72a3df3d13d99e5/stdlib/public/Concurrency/Task.swift#L666-L667

but `Builtin.getCurrentAsyncTask` is `() -> Builtin.NativeObject` and used here.

https://github.com/apple/swift/blob/90c1fece9ed6d2fea90ef5a2f72a3df3d13d99e5/stdlib/public/Concurrency/TaskCancellation.swift#L35


In that case, IRGen inserts a cast inst to cast the function to the expected signature. But this cast inst drops calling convention info, so call inst was emitted without swiftcc.
This results that the `Builtin.getCurrentAsyncTask` was lowered to a call of `swift_task_getCurrent` without swiftcc.

This patch changed to emit a call of swift_task_getCurrent with the explicit calling convention.

This convention mismatch was found by strict signature checking of Wasm.

CC: @MaxDesiatov , @rjmccall 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
