### PR TITLE
[5.5][AST] Add method to create an implicit `SwitchStmt`

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1135,7 +1135,16 @@ public:
                             SourceLoc RBraceLoc,
                             SourceLoc EndLoc,
                             ASTContext &C);
-  
+
+  static SwitchStmt *createImplicit(LabeledStmtInfo LabelInfo,
+                                    Expr *SubjectExpr, ArrayRef<ASTNode> Cases,
+                                    ASTContext &C) {
+    return SwitchStmt::create(LabelInfo, /*SwitchLoc=*/SourceLoc(), SubjectExpr,
+                              /*LBraceLoc=*/SourceLoc(), Cases,
+                              /*RBraceLoc=*/SourceLoc(), /*EndLoc=*/SourceLoc(),
+                              C);
+  }
+
   /// Get the source location of the 'switch' keyword.
   SourceLoc getSwitchLoc() const { return SwitchLoc; }
   /// Get the source location of the opening brace.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1163,9 +1163,8 @@ deriveBodyEncodable_enum_encode(AbstractFunctionDecl *encodeDecl, void *) {
       new (C) DeclRefExpr(ConcreteDeclRef(selfRef), DeclNameLoc(),
                           /*implicit*/ true, AccessSemantics::Ordinary);
 
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), enumRef,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), enumRef, cases, C);
   statements.push_back(switchStmt);
 
   auto *body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc(),
@@ -1801,8 +1800,7 @@ deriveBodyDecodable_enum_init(AbstractFunctionDecl *initDecl, void *) {
         UnresolvedDotExpr::createImplicit(C, allKeysExpr, C.Id_first);
 
     auto switchStmt =
-        SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), firstExpr,
-                           SourceLoc(), cases, SourceLoc(), SourceLoc(), C);
+        SwitchStmt::createImplicit(LabeledStmtInfo(), firstExpr, cases, C);
 
     statements.push_back(switchStmt);
   }

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -233,9 +233,8 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
     }
 
     auto *selfRef = DerivedConformance::createSelfDeclRef(strValDecl);
-    auto *switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(),
-                                          selfRef, SourceLoc(), cases,
-                                          SourceLoc(), SourceLoc(), C);
+    auto *switchStmt =
+        SwitchStmt::createImplicit(LabeledStmtInfo(), selfRef, cases, C);
     body = BraceStmt::create(C, SourceLoc(), ASTNode(switchStmt), SourceLoc());
   }
 
@@ -313,9 +312,8 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
   auto *stringValueDecl = initDecl->getParameters()->get(0);
   auto *stringValueRef = new (C) DeclRefExpr(stringValueDecl, DeclNameLoc(),
                                              /*Implicit=*/true);
-  auto *switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(),
-                                        stringValueRef, SourceLoc(), cases,
-                                        SourceLoc(), SourceLoc(), C);
+  auto *switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), stringValueRef, cases, C);
   auto *body = BraceStmt::create(C, SourceLoc(), ASTNode(switchStmt),
                                  SourceLoc());
   return { body, /*isTypeChecked=*/false };

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -210,9 +210,8 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
   auto abExpr = TupleExpr::create(C, SourceLoc(), { aRef, bRef }, {}, {},
                                   SourceLoc(), /*HasTrailingClosure*/ false,
                                   /*implicit*/ true);
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), abExpr,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), abExpr, cases, C);
   statements.push_back(switchStmt);
 
   auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -79,9 +79,8 @@ deriveBodyEquatable_enum_uninhabited_eq(AbstractFunctionDecl *eqDecl, void *) {
                                   SourceLoc(), /*HasTrailingClosure*/ false,
                                   /*implicit*/ true,
                                   TupleType::get(abTupleElts, C));
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), abExpr,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), abExpr, cases, C);
   statements.push_back(switchStmt);
 
   auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());
@@ -277,9 +276,8 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
   auto abExpr = TupleExpr::create(C, SourceLoc(), { aRef, bRef }, {}, {},
                                   SourceLoc(), /*HasTrailingClosure*/ false,
                                   /*implicit*/ true);
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), abExpr,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), abExpr, cases, C);
   statements.push_back(switchStmt);
 
   auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());
@@ -752,9 +750,8 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
   // generate: switch enumVar { }
   auto enumRef = new (C) DeclRefExpr(selfDecl, DeclNameLoc(),
                                      /*implicit*/true);
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), enumRef,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), enumRef, cases, C);
 
   auto body = BraceStmt::create(C, SourceLoc(), {ASTNode(switchStmt)},
                                 SourceLoc());

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -128,9 +128,8 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
   }
 
   auto selfRef = DerivedConformance::createSelfDeclRef(toRawDecl);
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), selfRef,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), selfRef, cases, C);
   auto body = BraceStmt::create(C, SourceLoc(),
                                 ASTNode(switchStmt),
                                 SourceLoc());
@@ -386,9 +385,8 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
     auto *CallExpr = CallExpr::create(C, Fun, Args, {}, {}, false, false);
     switchArg = CallExpr;
   }
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), switchArg,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), switchArg, cases, C);
   auto body = BraceStmt::create(C, SourceLoc(),
                                 ASTNode(switchStmt),
                                 SourceLoc());

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -665,9 +665,8 @@ DeclRefExpr *DerivedConformance::convertEnumToIndex(SmallVectorImpl<ASTNode> &st
                                      /*implicit*/true,
                                      AccessSemantics::Ordinary,
                                      enumVarDecl->getType());
-  auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), enumRef,
-                                       SourceLoc(), cases, SourceLoc(),
-                                       SourceLoc(), C);
+  auto switchStmt =
+      SwitchStmt::createImplicit(LabeledStmtInfo(), enumRef, cases, C);
 
   stmts.push_back(indexBind);
   stmts.push_back(switchStmt);


### PR DESCRIPTION
There are a number of occurances that create implicit `Switch`s by passing `SourceLoc()` for all location paramters. Refactor those occurrences out to a separate `createImplicit` method that automatically fills the locations with invalid source locations.

Cherry-picking https://github.com/apple/swift/pull/36973