### PR TITLE
[Deserialization] Fix error when typealias required by protocol refers to type in @_implementationOnly module

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6390,8 +6390,26 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     // FIXME: We don't actually want to allocate an archetype here; we just
     // want to get an access path within the protocol.
     auto first = cast<AssociatedTypeDecl>(getDecl(*rawIDIter++));
-    auto second = getType(*rawIDIter++);
-    auto third = cast_or_null<TypeDecl>(getDecl(*rawIDIter++));
+    auto secondOrError = getTypeChecked(*rawIDIter++);
+    Type second;
+    if (secondOrError) {
+      second = *secondOrError;
+    } else if (getContext().LangOpts.EnableDeserializationRecovery) {
+      second = ErrorType::get(getContext());
+      consumeError(secondOrError.takeError());
+    } else {
+      fatal(secondOrError.takeError());
+    }
+    auto thirdOrError = getDeclChecked(*rawIDIter++);
+    TypeDecl *third;
+    if (thirdOrError) {
+      third = cast_or_null<TypeDecl>(*thirdOrError);
+    } else if (getContext().LangOpts.EnableDeserializationRecovery) {
+      third = nullptr;
+      consumeError(thirdOrError.takeError());
+    } else {
+      fatal(thirdOrError.takeError());
+    }
     if (third &&
         isa<TypeAliasDecl>(third) &&
         third->getModuleContext() != getAssociatedModule() &&

--- a/test/Serialization/Recovery/Inputs/protocol-requirement-in-implementation-only/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/protocol-requirement-in-implementation-only/module.modulemap
@@ -1,0 +1,1 @@
+module public_lib [system] {}

--- a/test/Serialization/Recovery/protocol-requirement-in-implementation-only.swift
+++ b/test/Serialization/Recovery/protocol-requirement-in-implementation-only.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+//// Build the private module and the public module normally.
+//// Force the public module to be system with an underlying Clang module.
+// RUN: %target-swift-frontend -emit-module -DPRIVATE_LIB %s -module-name private_lib -emit-module-path %t/private_lib.swiftmodule
+// RUN: %target-swift-frontend -emit-module -DPUBLIC_LIB %s -module-name public_lib -emit-module-path %t/public_lib.swiftmodule -I %t -I %S/Inputs/protocol-requirement-in-implementation-only -import-underlying-module
+
+//// Printing the public module should not crash when reading the HiddenStruct typealias in `M`.
+// RUN: %target-swift-ide-test -print-module -module-to-print=public_lib -source-filename=x -skip-overrides -I %t
+
+#if PRIVATE_LIB
+
+public struct HiddenStruct {
+  public init() {}
+}
+
+#elseif PUBLIC_LIB
+
+@_implementationOnly import private_lib
+
+protocol SomeProtocol {
+  associatedtype Value
+  static var defaultValue: Value { get }
+}
+public struct M: SomeProtocol {
+  typealias Value = HiddenStruct
+  static let defaultValue = HiddenStruct()
+}
+#endif


### PR DESCRIPTION
In the added test case, the `typealias` refers to the `HiddenStruct` type in the private module, which is imported as `@_implementationOnly`. Because the import is `@_implementationOnly`, during deserialization, we don’t import the private module and hence any reference to the `HiddenStruct` type fails. In the common deserialization code path, this causes us to skip over the `typealias` member. However, when creating the protocol conformance, we assume that we can resolve the type to which the `typealias` refers and thus we are crashing.

If `LangOpts.EnableDeserializationRecovery` is set to `true`, we should do our best to recover from such failures so this patch makes the deserialization failure handling more graceful and resolve the right-hand side of the `typealias` as an `ErrorType`.

Fixes rdar://72891807