### PR TITLE
Suppress warning for arch(arm64_32).

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -282,6 +282,13 @@ public:
                    diag::unsupported_platform_runtime_condition_argument);
         return nullptr;
       }
+      
+      // Open-source toolchains do not support arm64_32, but we also don't
+      // want to warn on it, to allow projects to detect it when building
+      // with Apple toolchains and not have spurious warnings when building
+      // with public tooling.
+      if (Kind == PlatformConditionKind::Arch && *ArgStr == "arm64_32")
+        return E;
 
       // Just a warning for other unsupported arguments.
       StringRef DiagName;

--- a/test/Parse/ConditionalCompilation/basicParseErrors.swift
+++ b/test/Parse/ConditionalCompilation/basicParseErrors.swift
@@ -84,6 +84,11 @@ struct S {
 #if arch(leg) // expected-warning {{unknown architecture for build configuration 'arch'}} expected-note{{did you mean 'arm'?}} {{10-13=arm}}
 #endif
 
+// We should not warn for arm64_32 to support projects that need
+// to build with both Apple and public toolchains.
+#if arch(arm64_32)
+#endif
+
 #if _endian(mid) // expected-warning {{unknown endianness for build configuration '_endian'}} expected-note{{did you mean 'big'?}} {{13-16=big}}
 #endif
 


### PR DESCRIPTION
A gross but tiny hack; we want to be able to detect arm64_32 when building for watchOS in Numerics and Atomics (and probably some other packages), but we don't want to have spurious warnings when people build with open-source toolchains, which don't support or know about arm64_32. Simply detect that case and suppress the warning. There is likely a more principled way to do this.

Resolves #56106