### PR TITLE
[sil-optimizer] Make InstructionDeleter and related APIs to use an InstModCallback instead of a notification callback.

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -36,6 +36,167 @@ namespace swift {
 class DominanceInfo;
 template <class T> class NullablePtr;
 
+/// A structure containing callbacks that are called when an instruction is
+/// removed or added.
+///
+/// PERFORMANCE NOTES: This code can be used in loops, so we want to make sure
+/// to not have overhead when the user does not specify a callback. To do that
+/// instead of defining a "default" std::function, we represent the "default"
+/// functions as nullptr. Then, in the helper function trampoline that actually
+/// gets called, we check if we have a nullptr and if we do, we perform the
+/// default operation inline. What is nice about this from a perf perspective is
+/// that in a loop this property should predict well since you have a single
+/// branch that is going to go the same way everytime.
+class InstModCallbacks {
+  /// A function that takes in an instruction and deletes the inst.
+  ///
+  /// Default implementation is instToDelete->eraseFromParent();
+  std::function<void(SILInstruction *instToDelete)> deleteInstFunc;
+
+  /// A function that is called to notify that a new function was created.
+  ///
+  /// Default implementation is a no-op, but we still mark madeChange.
+  std::function<void(SILInstruction *newlyCreatedInst)> createdNewInstFunc;
+
+  /// A function sets the value in \p use to be \p newValue.
+  ///
+  /// Default implementation just calls use->set(newValue).
+  ///
+  /// NOTE: It is assumed that this operation will never invalidate instruction
+  /// iterators.
+  std::function<void(Operand *use, SILValue newValue)> setUseValueFunc;
+
+  /// If non-null, called before an instruction is deleted or has its references
+  /// dropped.
+  std::function<void(SILInstruction *instThatWillBeDeleted)>
+      notifyWillBeDeletedFunc;
+
+  /// A boolean that tracks if any of our callbacks were ever called.
+  bool wereAnyCallbacksInvoked = false;
+
+public:
+  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc)
+      : deleteInstFunc(deleteInstFunc) {}
+
+  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
+                   decltype(createdNewInstFunc) createdNewInstFunc)
+      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc) {
+  }
+
+  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
+                   decltype(setUseValueFunc) setUseValueFunc)
+      : deleteInstFunc(deleteInstFunc), setUseValueFunc(setUseValueFunc) {}
+
+  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
+                   decltype(createdNewInstFunc) createdNewInstFunc,
+                   decltype(setUseValueFunc) setUseValueFunc)
+      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc),
+        setUseValueFunc(setUseValueFunc) {}
+
+  InstModCallbacks() = default;
+  ~InstModCallbacks() = default;
+  InstModCallbacks(const InstModCallbacks &) = default;
+  InstModCallbacks(InstModCallbacks &&) = default;
+
+  /// Return a copy of self with deleteInstFunc set to \p newDeleteInstFunc.
+  InstModCallbacks onDelete(decltype(deleteInstFunc) newDeleteInstFunc) const {
+    InstModCallbacks result = *this;
+    result.deleteInstFunc = newDeleteInstFunc;
+    return result;
+  }
+
+  /// Return a copy of self with createdNewInstFunc set to \p
+  /// newCreatedNewInstFunc.
+  InstModCallbacks
+  onCreateNewInst(decltype(createdNewInstFunc) newCreatedNewInstFunc) const {
+    InstModCallbacks result = *this;
+    result.createdNewInstFunc = newCreatedNewInstFunc;
+    return result;
+  }
+
+  /// Return a copy of self with setUseValueFunc set to \p newSetUseValueFunc.
+  InstModCallbacks
+  onSetUseValue(decltype(setUseValueFunc) newSetUseValueFunc) const {
+    InstModCallbacks result = *this;
+    result.setUseValueFunc = newSetUseValueFunc;
+    return result;
+  }
+
+  /// Return a copy of self with notifyWillBeDeletedFunc set to \p
+  /// newNotifyWillBeDeletedFunc.
+  InstModCallbacks onNotifyWillBeDeleted(
+      decltype(notifyWillBeDeletedFunc) newNotifyWillBeDeletedFunc) const {
+    InstModCallbacks result = *this;
+    result.notifyWillBeDeletedFunc = newNotifyWillBeDeletedFunc;
+    return result;
+  }
+
+  void deleteInst(SILInstruction *instToDelete,
+                  bool notifyWhenDeleting = true) {
+    wereAnyCallbacksInvoked = true;
+    if (notifyWhenDeleting && notifyWillBeDeletedFunc)
+      notifyWillBeDeletedFunc(instToDelete);
+    if (deleteInstFunc)
+      return deleteInstFunc(instToDelete);
+    instToDelete->eraseFromParent();
+  }
+
+  void createdNewInst(SILInstruction *newlyCreatedInst) {
+    wereAnyCallbacksInvoked = true;
+    if (createdNewInstFunc)
+      createdNewInstFunc(newlyCreatedInst);
+  }
+
+  void setUseValue(Operand *use, SILValue newValue) {
+    wereAnyCallbacksInvoked = true;
+    if (setUseValueFunc)
+      return setUseValueFunc(use, newValue);
+    use->set(newValue);
+  }
+
+  /// Notify via our callbacks that an instruction will be deleted/have its
+  /// operands dropped.
+  ///
+  /// DISCUSSION: Since we do not delete instructions in any specific order, we
+  /// drop all references of the instructions before we call deleteInst. Thus
+  /// one can not in deleteInst look at operands. Certain parts of the optimizer
+  /// rely on this ability, so we preserve it.
+  void notifyWillBeDeleted(SILInstruction *instThatWillBeDeleted) {
+    wereAnyCallbacksInvoked = true;
+    if (notifyWillBeDeletedFunc)
+      return notifyWillBeDeletedFunc(instThatWillBeDeleted);
+  }
+
+  void replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
+    wereAnyCallbacksInvoked = true;
+
+    // If setUseValueFunc is not set, just call RAUW directly. RAUW in this case
+    // is equivalent to what we do below. We just enable better
+    // performance. This ensures that the default InstModCallback is really
+    // fast.
+    if (!setUseValueFunc)
+      return oldValue->replaceAllUsesWith(newValue);
+
+    while (!oldValue->use_empty()) {
+      auto *use = *oldValue->use_begin();
+      setUseValue(use, newValue);
+    }
+  }
+
+  void eraseAndRAUWSingleValueInst(SingleValueInstruction *oldInst,
+                                   SILValue newValue) {
+    wereAnyCallbacksInvoked = true;
+    replaceValueUsesWith(oldInst, newValue);
+    deleteInst(oldInst);
+  }
+
+  bool hadCallbackInvocation() const { return wereAnyCallbacksInvoked; }
+
+  /// Set \p wereAnyCallbacksInvoked to false. Useful if one wants to reuse an
+  /// InstModCallback in between iterations.
+  void resetHadCallbackInvocation() { wereAnyCallbacksInvoked = false; }
+};
+
 /// Transform a Use Range (Operand*) into a User Range (SILInstruction *)
 using UserTransform = std::function<SILInstruction *(Operand *)>;
 using ValueBaseUserRange =
@@ -68,136 +229,6 @@ NullablePtr<SILInstruction> createDecrementBefore(SILValue ptr,
 /// Get the insertion point after \p val.
 Optional<SILBasicBlock::iterator> getInsertAfterPoint(SILValue val);
 
-/// A utility for deleting one or more instructions belonging to a function, and
-/// cleaning up any dead code resulting from deleting those instructions. Use
-/// this utility instead of
-/// \c recursivelyDeleteTriviallyDeadInstruction.
-class InstructionDeleter {
-private:
-  // A set vector of instructions that are found to be dead. The ordering
-  // of instructions in this set is important as when a dead instruction is
-  // removed, new instructions will be generated to fix the lifetime of the
-  // instruction's operands. This has to be deterministic.
-  SmallSetVector<SILInstruction *, 8> deadInstructions;
-
-  void deleteInstruction(SILInstruction *inst,
-                         llvm::function_ref<void(SILInstruction *)> callback,
-                         bool fixOperandLifetimes);
-
-public:
-  InstructionDeleter() {}
-
-  /// If the instruction \p inst is dead, record it so that it can be cleaned
-  /// up.
-  void trackIfDead(SILInstruction *inst);
-
-  /// If the instruction \p inst is dead, delete it immediately and record
-  /// its operands so that they can be cleaned up later.
-  ///
-  /// \p callback is called on each deleted instruction before deleting any
-  /// instructions. This way, the SIL is valid in the callback. However, the
-  /// callback cannot be used to update instruction iterators since other
-  /// instructions to be deleted remain in the instruction list.
-  void deleteIfDead(
-      SILInstruction *inst,
-      llvm::function_ref<void(SILInstruction *)> callback =
-          [](SILInstruction *) {});
-
-  /// Delete the instruction \p inst and record instructions that may become
-  /// dead because of the removal of \c inst. This function will add necessary
-  /// ownership instructions to fix the lifetimes of the operands of \c inst to
-  /// compensate for its deletion. This function will not clean up dead code
-  /// resulting from the instruction's removal. To do so, invoke the method \c
-  /// cleanupDeadCode of this instance, once the SIL of the contaning function
-  /// is made consistent.
-  ///
-  /// \pre the function containing \c inst must be using ownership SIL.
-  /// \pre the instruction to be deleted must not have any use other than
-  /// incidental uses.
-  ///
-  /// \p callback is called on each deleted instruction before deleting any
-  /// instructions. This way, the SIL is valid in the callback. However, the
-  /// callback cannot be used to update instruction iterators since other
-  /// instructions to be deleted remain in the instruction list.
-  void forceDeleteAndFixLifetimes(
-      SILInstruction *inst,
-      llvm::function_ref<void(SILInstruction *)> callback =
-          [](SILInstruction *) {});
-
-  /// Delete the instruction \p inst and record instructions that may become
-  /// dead because of the removal of \c inst. If in ownership SIL, use the
-  /// \c forceDeleteAndFixLifetimes function instead, unless under special
-  /// circumstances where the client must handle fixing lifetimes of the
-  /// operands of the deleted instructions. This function will not fix the
-  /// lifetimes of the operands of \c inst once it is deleted. This function
-  /// will not clean up dead code resulting from the instruction's removal. To
-  /// do so, invoke the method \c cleanupDeadCode of this instance, once the SIL
-  /// of the contaning function is made consistent.
-  ///
-  /// \pre the instruction to be deleted must not have any use other than
-  /// incidental uses.
-  ///
-  /// \p callback is called on each deleted instruction before deleting any
-  /// instructions. This way, the SIL is valid in the callback. However, the
-  /// callback cannot be used to update instruction iterators since other
-  /// instructions to be deleted remain in the instruction list.
-  void forceDelete(
-      SILInstruction *inst,
-      llvm::function_ref<void(SILInstruction *)> callback =
-          [](SILInstruction *) {});
-
-  /// Clean up dead instructions that are tracked by this instance and all
-  /// instructions that transitively become dead.
-  ///
-  /// \pre the function contaning dead instructions must be consistent (i.e., no
-  /// under or over releases). Note that if \c forceDelete call leaves the
-  /// function body in an inconsistent state, it needs to be made consistent
-  /// before this method is invoked.
-  ///
-  /// \p callback is called on each deleted instruction before deleting any
-  /// instructions. This way, the SIL is valid in the callback. However, the
-  /// callback cannot be used to update instruction iterators since other
-  /// instructions to be deleted remain in the instruction list.
-  void
-  cleanUpDeadInstructions(llvm::function_ref<void(SILInstruction *)> callback =
-                              [](SILInstruction *) {});
-
-  /// Recursively visit users of \c inst  (including \c inst)and delete
-  /// instructions that are dead (including \c inst). Invoke the \c callback on
-  /// instructions that are deleted.
-  void recursivelyDeleteUsersIfDead(
-      SILInstruction *inst,
-      llvm::function_ref<void(SILInstruction *)> callback =
-                                    [](SILInstruction *) {});
-
-  /// Recursively visit users of \c inst  (including \c inst)and force delete
-  /// them. Also, destroy the consumed operands of the deleted instructions
-  /// whenever necessary. Invoke the \c callback on instructions that are
-  /// deleted.
-  void recursivelyForceDeleteUsersAndFixLifetimes(
-      SILInstruction *inst,
-      llvm::function_ref<void(SILInstruction *)> callback =
-          [](SILInstruction *) {});
-};
-
-/// If \c inst is dead, delete it and recursively eliminate all code that
-/// becomes dead because of that. If more than one instruction must
-/// be checked/deleted use the \c InstructionDeleter utility.
-///
-/// This function will add necessary compensation code to fix the lifetimes of
-/// the operands of the deleted instructions.
-///
-/// \pre the SIL function containing the instruction is assumed to be
-/// consistent, i.e., does not have under or over releases.
-///
-/// \p callback is called on each deleted instruction before deleting any
-/// instructions. This way, the SIL is valid in the callback. However, the
-/// callback cannot be used to update instruction iterators since other
-/// instructions to be deleted remain in the instruction list.
-void eliminateDeadInstruction(
-    SILInstruction *inst, llvm::function_ref<void(SILInstruction *)> callback =
-                              [](SILInstruction *) {});
-
 /// Return the number of @inout arguments passed to the given apply site.
 unsigned getNumInOutArguments(FullApplySite applySite);
 
@@ -209,11 +240,10 @@ unsigned getNumInOutArguments(FullApplySite applySite);
 /// \param inst The ArrayRef of instructions to be deleted.
 /// \param force If Force is set, don't check if the top level instructions
 ///        are considered dead - delete them regardless.
-/// \param callback a callback called whenever an instruction is deleted.
+/// \param callbacks The inst mod callbacks used to delete instructions.
 void recursivelyDeleteTriviallyDeadInstructions(
     ArrayRef<SILInstruction *> inst, bool force = false,
-    llvm::function_ref<void(SILInstruction *)> callback = [](SILInstruction *) {
-    });
+    InstModCallbacks callbacks = InstModCallbacks());
 
 /// If the given instruction is dead, delete it along with its dead
 /// operands. Note this utility must be phased out and replaced by
@@ -223,11 +253,10 @@ void recursivelyDeleteTriviallyDeadInstructions(
 /// \param inst The instruction to be deleted.
 /// \param force If Force is set, don't check if the top level instruction is
 ///        considered dead - delete it regardless.
-/// \param callback a callback called whenever an instruction is deleted.
+/// \param callbacks InstModCallback used to delete instructions.
 void recursivelyDeleteTriviallyDeadInstructions(
     SILInstruction *inst, bool force = false,
-    llvm::function_ref<void(SILInstruction *)> callback = [](SILInstruction *) {
-    });
+    InstModCallbacks callbacks = InstModCallbacks());
 
 /// Perform a fast local check to see if the instruction is dead.
 ///
@@ -245,9 +274,8 @@ void collectUsesOfValue(SILValue V,
 
 /// Recursively erase all of the uses of the instruction (but not the
 /// instruction itself)
-void eraseUsesOfInstruction(
-    SILInstruction *inst, llvm::function_ref<void(SILInstruction *)> callback =
-                              [](SILInstruction *) {});
+void eraseUsesOfInstruction(SILInstruction *inst,
+                            InstModCallbacks callbacks = InstModCallbacks());
 
 /// Recursively erase all of the uses of the value (but not the
 /// value itself)
@@ -336,112 +364,108 @@ bool tryCheckedCastBrJumpThreading(
     SILFunction *fn, DominanceInfo *dt,
     SmallVectorImpl<SILBasicBlock *> &blocksForWorklist);
 
-/// A structure containing callbacks that are called when an instruction is
-/// removed or added.
-///
-/// PERFORMANCE NOTES: This code can be used in loops, so we want to make sure
-/// to not have overhead when the user does not specify a callback. To do that
-/// instead of defining a "default" std::function, we represent the "default"
-/// functions as nullptr. Then, in the helper function trampoline that actually
-/// gets called, we check if we have a nullptr and if we do, we perform the
-/// default operation inline. What is nice about this from a perf perspective is
-/// that in a loop this property should predict well since you have a single
-/// branch that is going to go the same way everytime.
-class InstModCallbacks {
-  /// A function that takes in an instruction and deletes the inst.
-  ///
-  /// Default implementation is instToDelete->eraseFromParent();
-  std::function<void(SILInstruction *instToDelete)> deleteInstFunc;
+/// A utility for deleting one or more instructions belonging to a function, and
+/// cleaning up any dead code resulting from deleting those instructions. Use
+/// this utility instead of
+/// \c recursivelyDeleteTriviallyDeadInstruction.
+class InstructionDeleter {
+private:
+  /// A set vector of instructions that are found to be dead. The ordering of
+  /// instructions in this set is important as when a dead instruction is
+  /// removed, new instructions will be generated to fix the lifetime of the
+  /// instruction's operands. This has to be deterministic.
+  SmallSetVector<SILInstruction *, 8> deadInstructions;
 
-  /// A function that is called to notify that a new function was created.
-  ///
-  /// Default implementation is a no-op, but we still mark madeChange.
-  std::function<void(SILInstruction *newlyCreatedInst)> createdNewInstFunc;
-
-  /// A function sets the value in \p use to be \p newValue.
-  ///
-  /// Default implementation just calls use->set(newValue).
-  ///
-  /// NOTE: It is assumed that this operation will never invalidate instruction
-  /// iterators.
-  std::function<void(Operand *use, SILValue newValue)> setUseValueFunc;
-
-  /// A boolean that tracks if any of our callbacks were ever called.
-  bool wereAnyCallbacksInvoked = false;
+  /// Callbacks used when adding/deleting instructions.
+  InstModCallbacks instModCallbacks;
 
 public:
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc)
-      : deleteInstFunc(deleteInstFunc) {}
+  InstructionDeleter() : deadInstructions(), instModCallbacks() {}
+  InstructionDeleter(InstModCallbacks inputCallbacks)
+      : deadInstructions(), instModCallbacks(inputCallbacks) {}
 
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
-                   decltype(createdNewInstFunc) createdNewInstFunc)
-      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc) {
-  }
+  /// If the instruction \p inst is dead, record it so that it can be cleaned
+  /// up.
+  void trackIfDead(SILInstruction *inst);
 
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
-                   decltype(setUseValueFunc) setUseValueFunc)
-      : deleteInstFunc(deleteInstFunc), setUseValueFunc(setUseValueFunc) {}
+  /// If the instruction \p inst is dead, delete it immediately and record
+  /// its operands so that they can be cleaned up later.
+  void deleteIfDead(SILInstruction *inst);
 
-  InstModCallbacks(decltype(deleteInstFunc) deleteInstFunc,
-                   decltype(createdNewInstFunc) createdNewInstFunc,
-                   decltype(setUseValueFunc) setUseValueFunc)
-      : deleteInstFunc(deleteInstFunc), createdNewInstFunc(createdNewInstFunc),
-        setUseValueFunc(setUseValueFunc) {}
+  /// Delete the instruction \p inst and record instructions that may become
+  /// dead because of the removal of \c inst. This function will add necessary
+  /// ownership instructions to fix the lifetimes of the operands of \c inst to
+  /// compensate for its deletion. This function will not clean up dead code
+  /// resulting from the instruction's removal. To do so, invoke the method \c
+  /// cleanupDeadCode of this instance, once the SIL of the contaning function
+  /// is made consistent.
+  ///
+  /// \pre the function containing \c inst must be using ownership SIL.
+  /// \pre the instruction to be deleted must not have any use other than
+  /// incidental uses.
+  ///
+  /// \p callback is called on each deleted instruction before deleting any
+  /// instructions. This way, the SIL is valid in the callback. However, the
+  /// callback cannot be used to update instruction iterators since other
+  /// instructions to be deleted remain in the instruction list.
+  void forceDeleteAndFixLifetimes(SILInstruction *inst);
 
-  InstModCallbacks() = default;
-  ~InstModCallbacks() = default;
-  InstModCallbacks(const InstModCallbacks &) = default;
-  InstModCallbacks(InstModCallbacks &&) = default;
+  /// Delete the instruction \p inst and record instructions that may become
+  /// dead because of the removal of \c inst. If in ownership SIL, use the
+  /// \c forceDeleteAndFixLifetimes function instead, unless under special
+  /// circumstances where the client must handle fixing lifetimes of the
+  /// operands of the deleted instructions. This function will not fix the
+  /// lifetimes of the operands of \c inst once it is deleted. This function
+  /// will not clean up dead code resulting from the instruction's removal. To
+  /// do so, invoke the method \c cleanupDeadCode of this instance, once the SIL
+  /// of the contaning function is made consistent.
+  ///
+  /// \pre the instruction to be deleted must not have any use other than
+  /// incidental uses.
+  void forceDelete(SILInstruction *inst);
 
-  void deleteInst(SILInstruction *instToDelete) {
-    wereAnyCallbacksInvoked = true;
-    if (deleteInstFunc)
-      return deleteInstFunc(instToDelete);
-    instToDelete->eraseFromParent();
-  }
+  /// Force track this instruction as dead. Used to enable the deletion of a
+  /// bunch of instructions at the same time.
+  void forceTrackAsDead(SILInstruction *inst);
 
-  void createdNewInst(SILInstruction *newlyCreatedInst) {
-    wereAnyCallbacksInvoked = true;
-    if (createdNewInstFunc)
-      createdNewInstFunc(newlyCreatedInst);
-  }
+  /// Clean up dead instructions that are tracked by this instance and all
+  /// instructions that transitively become dead.
+  ///
+  /// \pre the function contaning dead instructions must be consistent (i.e., no
+  /// under or over releases). Note that if \c forceDelete call leaves the
+  /// function body in an inconsistent state, it needs to be made consistent
+  /// before this method is invoked.
+  void cleanUpDeadInstructions();
 
-  void setUseValue(Operand *use, SILValue newValue) {
-    wereAnyCallbacksInvoked = true;
-    if (setUseValueFunc)
-      return setUseValueFunc(use, newValue);
-    use->set(newValue);
-  }
+  /// Recursively visit users of \c inst  (including \c inst)and delete
+  /// instructions that are dead (including \c inst).
+  void recursivelyDeleteUsersIfDead(SILInstruction *inst);
 
-  void replaceValueUsesWith(SILValue oldValue, SILValue newValue) {
-    wereAnyCallbacksInvoked = true;
+  /// Recursively visit users of \c inst  (including \c inst)and force delete
+  /// them. Also, destroy the consumed operands of the deleted instructions
+  /// whenever necessary.
+  void recursivelyForceDeleteUsersAndFixLifetimes(SILInstruction *inst);
 
-    // If setUseValueFunc is not set, just call RAUW directly. RAUW in this case
-    // is equivalent to what we do below. We just enable better
-    // performance. This ensures that the default InstModCallback is really
-    // fast.
-    if (!setUseValueFunc)
-      return oldValue->replaceAllUsesWith(newValue);
-
-    while (!oldValue->use_empty()) {
-      auto *use = *oldValue->use_begin();
-      setUseValue(use, newValue);
-    }
-  }
-
-  void eraseAndRAUWSingleValueInst(SingleValueInstruction *oldInst,
-                                   SILValue newValue) {
-    wereAnyCallbacksInvoked = true;
-    replaceValueUsesWith(oldInst, newValue);
-    deleteInst(oldInst);
-  }
-
-  bool hadCallbackInvocation() const { return wereAnyCallbacksInvoked; }
-
-  /// Set \p wereAnyCallbacksInvoked to false. Useful if one wants to reuse an
-  /// InstModCallback in between iterations.
-  void resetHadCallbackInvocation() { wereAnyCallbacksInvoked = false; }
+private:
+  void deleteInstruction(SILInstruction *inst, bool fixOperandLifetimes);
 };
+
+/// If \c inst is dead, delete it and recursively eliminate all code that
+/// becomes dead because of that. If more than one instruction must
+/// be checked/deleted use the \c InstructionDeleter utility.
+///
+/// This function will add necessary compensation code to fix the lifetimes of
+/// the operands of the deleted instructions.
+///
+/// \pre the SIL function containing the instruction is assumed to be
+/// consistent, i.e., does not have under or over releases.
+///
+/// \p callbacks is used to delete each instruction. However, the callback
+/// cannot be used to update instruction iterators since other instructions to
+/// be deleted remain in the instruction list. If set to nullptr, we use the
+/// default instruction modification callback structure.
+void eliminateDeadInstruction(SILInstruction *inst,
+                              InstModCallbacks callbacks = InstModCallbacks());
 
 /// Get all consumed arguments of a partial_apply.
 ///

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -1,4 +1,4 @@
-//===--- OSLogOptimizer.cpp - Optimizes calls to OS Log ===//
+//===--- OSLogOptimizer.cpp - Optimizes calls to OS Log -------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -68,6 +68,8 @@
 /// 'substituteConstants' and 'emitCodeForSymbolicValue'. The remaining
 /// functions in the file implement the subtasks and utilities needed by the
 /// above functions.
+///
+//===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
@@ -1108,8 +1110,6 @@ static bool checkOSLogMessageIsConstant(SingleValueInstruction *osLogMessage,
   return errorDetected;
 }
 
-using CallbackTy = llvm::function_ref<void(SILInstruction *)>;
-
 /// Return true iff the given address-valued instruction has only stores into
 /// it. This function tests for the conditions under which a call, that was
 /// constant evaluated, that writes into the address-valued instruction can be
@@ -1184,8 +1184,7 @@ static bool hasOnlyStoreUses(SingleValueInstruction *addressInst) {
 /// of begin_apply. This will also fix the lifetimes of the deleted instructions
 /// whenever possible.
 static void forceDeleteAllocStack(SingleValueInstruction *inst,
-                                  InstructionDeleter &deleter,
-                                  CallbackTy callback) {
+                                  InstructionDeleter &deleter) {
   SmallVector<SILInstruction *, 8> users;
   for (Operand *use : inst->getUses())
     users.push_back(use->getUser());
@@ -1194,30 +1193,31 @@ static void forceDeleteAllocStack(SingleValueInstruction *inst,
     if (isIncidentalUse(user))
       continue;
     if (isa<DestroyAddrInst>(user)) {
-      deleter.forceDelete(user, callback);
+      deleter.forceDelete(user);
       continue;
     }
     if (isa<BeginAccessInst>(user)) {
-      forceDeleteAllocStack(cast<BeginAccessInst>(user), deleter, callback);
+      forceDeleteAllocStack(cast<BeginAccessInst>(user), deleter);
       continue;
     }
-    deleter.forceDeleteAndFixLifetimes(user, callback);
+    deleter.forceDeleteAndFixLifetimes(user);
   }
-  deleter.forceDelete(inst, callback);
+  deleter.forceDelete(inst);
 }
 
 /// Delete \c inst , if it is dead, along with its dead users and invoke the
 /// callback whever an instruction is deleted.
-static void deleteInstructionWithUsersAndFixLifetimes(
-    SILInstruction *inst, InstructionDeleter &deleter, CallbackTy callback) {
+static void
+deleteInstructionWithUsersAndFixLifetimes(SILInstruction *inst,
+                                          InstructionDeleter &deleter) {
   // If this is an alloc_stack, it can be eliminated as long as it is only
   // stored into or destroyed.
   if (AllocStackInst *allocStack = dyn_cast<AllocStackInst>(inst)) {
     if (hasOnlyStoreUses(allocStack))
-      forceDeleteAllocStack(allocStack, deleter, callback);
+      forceDeleteAllocStack(allocStack, deleter);
     return;
   }
-  deleter.recursivelyDeleteUsersIfDead(inst, callback);
+  deleter.recursivelyDeleteUsersIfDead(inst);
 }
 
 /// Try to dead-code eliminate the OSLogMessage instance \c oslogMessage passed
@@ -1226,31 +1226,35 @@ static void deleteInstructionWithUsersAndFixLifetimes(
 /// \returns true if elimination is successful and false if it is not successful
 /// and diagnostics is emitted.
 static bool tryEliminateOSLogMessage(SingleValueInstruction *oslogMessage) {
-  InstructionDeleter deleter;
   // List of instructions that are possibly dead.
   SmallVector<SILInstruction *, 4> worklist = {oslogMessage};
   // Set of all deleted instructions.
   SmallPtrSet<SILInstruction *, 4> deletedInstructions;
+
+  auto callbacks =
+      InstModCallbacks().onNotifyWillBeDeleted([&](SILInstruction *deadInst) {
+        // Add operands of all deleted instructions to the worklist so that
+        // they can be recursively deleted if possible.
+        for (Operand &operand : deadInst->getAllOperands()) {
+          if (SILInstruction *definingInstruction =
+                  operand.get()->getDefiningInstruction()) {
+            if (!deletedInstructions.count(definingInstruction))
+              worklist.push_back(definingInstruction);
+          }
+        }
+        (void)deletedInstructions.insert(deadInst);
+      });
+  InstructionDeleter deleter(callbacks);
+
   unsigned startIndex = 0;
   while (startIndex < worklist.size()) {
     SILInstruction *inst = worklist[startIndex++];
     if (deletedInstructions.count(inst))
       continue;
-    deleteInstructionWithUsersAndFixLifetimes(
-        inst, deleter, [&](SILInstruction *deadInst) {
-          // Add operands of all deleted instructions to the worklist so that
-          // they can be recursively deleted if possible.
-          for (Operand &operand : deadInst->getAllOperands()) {
-            if (SILInstruction *definingInstruction =
-                    operand.get()->getDefiningInstruction()) {
-              if (!deletedInstructions.count(definingInstruction))
-                worklist.push_back(definingInstruction);
-            }
-          }
-          (void)deletedInstructions.insert(deadInst);
-        });
+    deleteInstructionWithUsersAndFixLifetimes(inst, deleter);
   }
   deleter.cleanUpDeadInstructions();
+
   // If the OSLogMessage instance is not deleted, either we couldn't see the
   // body of the log call or there is a bug in the library implementation.
   // Assuming that the library implementation is correct, it means that either

--- a/lib/SILOptimizer/Utils/ConstantFolding.cpp
+++ b/lib/SILOptimizer/Utils/ConstantFolding.cpp
@@ -1727,6 +1727,13 @@ ConstantFolder::processWorkList() {
                           I->eraseFromParent();
                         });
 
+  auto callbacks =
+      InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
+        WorkList.remove(instToDelete);
+        InvalidateInstructions = true;
+        instToDelete->eraseFromParent();
+      });
+
   // An out parameter array that we use to return new simplified results from
   // constantFoldInstruction.
   SmallVector<SILValue, 8> ConstantFoldedResults;
@@ -1735,8 +1742,6 @@ ConstantFolder::processWorkList() {
     assert(I->getParent() && "SILInstruction must have parent.");
 
     LLVM_DEBUG(llvm::dbgs() << "Visiting: " << *I);
-
-    Callback(I);
 
     // Replace assert_configuration instructions by their constant value. We
     // want them to be replace even if we can't fully propagate the constant.
@@ -1751,9 +1756,7 @@ ConstantFolder::processWorkList() {
           // Schedule users for constant folding.
           WorkList.insert(AssertConfInt);
           // Delete the call.
-          eliminateDeadInstruction(BI);
-
-          InvalidateInstructions = true;
+          eliminateDeadInstruction(BI, callbacks);
           continue;
         }
 
@@ -1761,19 +1764,20 @@ ConstantFolder::processWorkList() {
         // configuration calls.
         if (isApplyOfBuiltin(*BI, BuiltinValueKind::CondUnreachable)) {
           assert(BI->use_empty() && "use of conditionallyUnreachable?!");
-          recursivelyDeleteTriviallyDeadInstructions(BI, /*force*/ true);
+          recursivelyDeleteTriviallyDeadInstructions(BI, /*force*/ true,
+                                                     callbacks);
           InvalidateInstructions = true;
           continue;
         }
       }
+
     // Replace a known availability.version semantic call.
     if (isApplyOfKnownAvailability(*I)) {
       if (auto apply = dyn_cast<ApplyInst>(I)) {
         SILBuilderWithScope B(I);
         auto tru = B.createIntegerLiteral(apply->getLoc(), apply->getType(), 1);
         apply->replaceAllUsesWith(tru);
-        eliminateDeadInstruction(
-            I, [&](SILInstruction *DeadI) { WorkList.remove(DeadI); });
+        eliminateDeadInstruction(I, callbacks);
         WorkList.insert(tru);
         InvalidateInstructions = true;
       }
@@ -1822,9 +1826,7 @@ ConstantFolder::processWorkList() {
       if (constantFoldGlobalStringTablePointerBuiltin(cast<BuiltinInst>(I),
                                                       EnableDiagnostics)) {
         // Here, the bulitin instruction got folded, so clean it up.
-        eliminateDeadInstruction(
-            I, [&](SILInstruction *DeadI) { WorkList.remove(DeadI); });
-        InvalidateInstructions = true;
+        eliminateDeadInstruction(I, callbacks);
       }
       continue;
     }
@@ -1839,10 +1841,8 @@ ConstantFolder::processWorkList() {
           auto *cfi = builder.createCondFail(I->getLoc(), I->getOperand(0),
                                              sli->getValue());
           WorkList.insert(cfi);
-          recursivelyDeleteTriviallyDeadInstructions(
-              I, /*force*/ true,
-              [&](SILInstruction *DeadI) { WorkList.remove(DeadI); });
-          InvalidateInstructions = true;
+          recursivelyDeleteTriviallyDeadInstructions(I, /*force*/ true,
+                                                     callbacks);
         }
       }
       continue;
@@ -1851,10 +1851,8 @@ ConstantFolder::processWorkList() {
     if (isApplyOfBuiltin(*I, BuiltinValueKind::IsConcrete)) {
       if (constantFoldIsConcrete(cast<BuiltinInst>(I))) {
         // Here, the bulitin instruction got folded, so clean it up.
-        recursivelyDeleteTriviallyDeadInstructions(
-            I, /*force*/ true,
-            [&](SILInstruction *DeadI) { WorkList.remove(DeadI); });
-        InvalidateInstructions = true;
+        recursivelyDeleteTriviallyDeadInstructions(I, /*force*/ true,
+                                                   callbacks);
       }
       continue;
     }
@@ -1875,7 +1873,7 @@ ConstantFolder::processWorkList() {
     }
 
     // Go through all users of the constant and try to fold them.
-    InstructionDeleter deleter;
+    InstructionDeleter deleter(callbacks);
     for (auto Result : I->getResults()) {
       for (auto *Use : Result->getUses()) {
         SILInstruction *User = Use->getUser();
@@ -2022,12 +2020,10 @@ ConstantFolder::processWorkList() {
         }
       }
     }
+
     // Eagerly DCE. We do this after visiting all users to ensure we don't
     // invalidate the uses iterator.
-    deleter.cleanUpDeadInstructions([&](SILInstruction *DeadI) {
-      WorkList.remove(DeadI);
-      InvalidateInstructions = true;
-    });
+    deleter.cleanUpDeadInstructions();
   }
 
   // TODO: refactor this code outside of the method. Passes should not merge

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -30,6 +30,7 @@
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/ConstExpr.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/ValueLifetime.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -380,7 +381,8 @@ void InstructionDeleter::trackIfDead(SILInstruction *inst) {
 /// \p operand. This function will result in a double consume, which is expected
 /// to be resolved when the caller deletes the original instruction. This
 /// function works only on ownership SIL.
-static void destroyConsumedOperandOfDeadInst(Operand &operand) {
+static void destroyConsumedOperandOfDeadInst(Operand &operand,
+                                             InstModCallbacks callbacks) {
   assert(operand.get() && operand.getUser());
   SILInstruction *deadInst = operand.getUser();
   SILFunction *fun = deadInst->getFunction();
@@ -403,16 +405,12 @@ static void destroyConsumedOperandOfDeadInst(Operand &operand) {
     // this must be a consuming use of an owned value.
     assert(operandValue.getOwnershipKind() == OwnershipKind::Owned);
     SILBuilderWithScope builder(deadInst);
-    builder.emitDestroyValueOperation(deadInst->getLoc(), operandValue);
+    auto *dvi = builder.createDestroyValue(deadInst->getLoc(), operandValue);
+    callbacks.createdNewInst(dvi);
   }
 }
 
-namespace {
-using CallbackTy = llvm::function_ref<void(SILInstruction *)>;
-} // namespace
-
 void InstructionDeleter::deleteInstruction(SILInstruction *inst,
-                                           CallbackTy callback,
                                            bool fixOperandLifetimes) {
   // We cannot fix operand lifetimes in non-ownership SIL.
   assert(!fixOperandLifetimes || inst->getFunction()->hasOwnership());
@@ -422,12 +420,12 @@ void InstructionDeleter::deleteInstruction(SILInstruction *inst,
   // the SIL is valid at the time of the callback.
   SmallVector<SILInstruction *, 4> toDeleteInsts;
   toDeleteInsts.push_back(inst);
-  callback(inst);
+  instModCallbacks.notifyWillBeDeleted(inst);
   for (SILValue result : inst->getResults()) {
     for (Operand *use : result->getUses()) {
       SILInstruction *user = use->getUser();
       assert(isIncidentalUse(user) || isa<DestroyValueInst>(user));
-      callback(user);
+      instModCallbacks.notifyWillBeDeleted(user);
       toDeleteInsts.push_back(user);
     }
   }
@@ -447,7 +445,7 @@ void InstructionDeleter::deleteInstruction(SILInstruction *inst,
     // any compensating code needed to end the scope of the operand value
     // once inst is deleted.
     if (fixOperandLifetimes)
-      destroyConsumedOperandOfDeadInst(operand);
+      destroyConsumedOperandOfDeadInst(operand, instModCallbacks);
   }
   // First drop all references from all instructions to be deleted and then
   // erase the instruction. Note that this is done in this order so that when an
@@ -459,7 +457,9 @@ void InstructionDeleter::deleteInstruction(SILInstruction *inst,
     inst->dropAllReferences();
   }
   for (SILInstruction *inst : toDeleteInsts) {
-    inst->eraseFromParent();
+    // We do not notify when deleting since we already called the notify
+    // callback earlier for all toDeleteInsts.
+    instModCallbacks.deleteInst(inst, false /*notify when deleting*/);
   }
   // Record operand definitions that become dead now.
   for (SILInstruction *operandValInst : operandDefinitions) {
@@ -467,7 +467,7 @@ void InstructionDeleter::deleteInstruction(SILInstruction *inst,
   }
 }
 
-void InstructionDeleter::cleanUpDeadInstructions(CallbackTy callback) {
+void InstructionDeleter::cleanUpDeadInstructions() {
   SILFunction *fun = nullptr;
   if (!deadInstructions.empty())
     fun = deadInstructions.front()->getFunction();
@@ -484,7 +484,7 @@ void InstructionDeleter::cleanUpDeadInstructions(CallbackTy callback) {
       // deadInst as deadInstructions is a set vector, and the latter cannot be
       // in deadInstructions as they are incidental uses which are never added
       // to deadInstructions.
-      deleteInstruction(deadInst, callback, /*Fix lifetime of operands*/
+      deleteInstruction(deadInst, /*Fix lifetime of operands*/
                         fun->hasOwnership());
     }
   }
@@ -504,48 +504,53 @@ static bool hasOnlyIncidentalUses(SILInstruction *inst,
   return true;
 }
 
-void InstructionDeleter::deleteIfDead(SILInstruction *inst,
-                                      CallbackTy callback) {
+void InstructionDeleter::deleteIfDead(SILInstruction *inst) {
   if (isInstructionTriviallyDead(inst) ||
       isScopeAffectingInstructionDead(inst)) {
-    deleteInstruction(inst, callback,
-      /*Fix lifetime of operands*/ inst->getFunction()->hasOwnership());
+    deleteInstruction(
+        inst,
+        /*Fix lifetime of operands*/ inst->getFunction()->hasOwnership());
   }
 }
 
-void InstructionDeleter::forceDeleteAndFixLifetimes(SILInstruction *inst,
-                                                    CallbackTy callback) {
+void InstructionDeleter::forceDeleteAndFixLifetimes(SILInstruction *inst) {
   SILFunction *fun = inst->getFunction();
   assert(fun->hasOwnership());
   bool disallowDebugUses =
       fun->getEffectiveOptimizationMode() <= OptimizationMode::NoOptimization;
   assert(hasOnlyIncidentalUses(inst, disallowDebugUses));
-  deleteInstruction(inst, callback, /*Fix lifetime of operands*/ true);
+  deleteInstruction(inst, /*Fix lifetime of operands*/ true);
 }
 
-void InstructionDeleter::forceDelete(SILInstruction *inst,
-                                     CallbackTy callback) {
+void InstructionDeleter::forceDelete(SILInstruction *inst) {
   bool disallowDebugUses =
       inst->getFunction()->getEffectiveOptimizationMode() <=
       OptimizationMode::NoOptimization;
   assert(hasOnlyIncidentalUses(inst, disallowDebugUses));
-  deleteInstruction(inst, callback, /*Fix lifetime of operands*/ false);
+  deleteInstruction(inst, /*Fix lifetime of operands*/ false);
 }
 
-void InstructionDeleter::recursivelyDeleteUsersIfDead(SILInstruction *inst,
-                                                      CallbackTy callback) {
+void InstructionDeleter::forceTrackAsDead(SILInstruction *inst) {
+  bool disallowDebugUses =
+      inst->getFunction()->getEffectiveOptimizationMode() <=
+      OptimizationMode::NoOptimization;
+  assert(hasOnlyIncidentalUses(inst, disallowDebugUses));
+  deadInstructions.insert(inst);
+}
+
+void InstructionDeleter::recursivelyDeleteUsersIfDead(SILInstruction *inst) {
   SmallVector<SILInstruction *, 8> users;
   for (SILValue result : inst->getResults())
     for (Operand *use : result->getUses())
       users.push_back(use->getUser());
 
   for (SILInstruction *user : users)
-    recursivelyDeleteUsersIfDead(user, callback);
-  deleteIfDead(inst, callback);
+    recursivelyDeleteUsersIfDead(user);
+  deleteIfDead(inst);
 }
 
 void InstructionDeleter::recursivelyForceDeleteUsersAndFixLifetimes(
-    SILInstruction *inst, CallbackTy callback) {
+    SILInstruction *inst) {
   for (SILValue result : inst->getResults()) {
     while (!result->use_empty()) {
       SILInstruction *user = result->use_begin()->getUser();
@@ -560,14 +565,14 @@ void InstructionDeleter::recursivelyForceDeleteUsersAndFixLifetimes(
 }
 
 void swift::eliminateDeadInstruction(SILInstruction *inst,
-                                     CallbackTy callback) {
-  InstructionDeleter deleter;
+                                     InstModCallbacks callbacks) {
+  InstructionDeleter deleter(callbacks);
   deleter.trackIfDead(inst);
-  deleter.cleanUpDeadInstructions(callback);
+  deleter.cleanUpDeadInstructions();
 }
 
 void swift::recursivelyDeleteTriviallyDeadInstructions(
-    ArrayRef<SILInstruction *> ia, bool force, CallbackTy callback) {
+    ArrayRef<SILInstruction *> ia, bool force, InstModCallbacks callbacks) {
   // Delete these instruction and others that become dead after it's deleted.
   llvm::SmallPtrSet<SILInstruction *, 8> deadInsts;
   for (auto *inst : ia) {
@@ -580,7 +585,7 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
     for (auto inst : deadInsts) {
       // Call the callback before we mutate the to be deleted instruction in any
       // way.
-      callback(inst);
+      callbacks.notifyWillBeDeleted(inst);
 
       // Check if any of the operands will become dead as well.
       MutableArrayRef<Operand> operands = inst->getAllOperands();
@@ -609,7 +614,7 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
 
     for (auto inst : deadInsts) {
       // This will remove this instruction and all its uses.
-      eraseFromParentWithDebugInsts(inst, callback);
+      eraseFromParentWithDebugInsts(inst, callbacks);
     }
 
     nextInsts.swap(deadInsts);
@@ -623,14 +628,14 @@ void swift::recursivelyDeleteTriviallyDeadInstructions(
 /// \param inst The instruction to be deleted.
 /// \param force If force is set, don't check if the top level instruction is
 ///        considered dead - delete it regardless.
-void swift::recursivelyDeleteTriviallyDeadInstructions(SILInstruction *inst,
-                                                       bool force,
-                                                       CallbackTy callback) {
+void swift::recursivelyDeleteTriviallyDeadInstructions(
+    SILInstruction *inst, bool force, InstModCallbacks callbacks) {
   ArrayRef<SILInstruction *> ai = ArrayRef<SILInstruction *>(inst);
-  recursivelyDeleteTriviallyDeadInstructions(ai, force, callback);
+  recursivelyDeleteTriviallyDeadInstructions(ai, force, callbacks);
 }
 
-void swift::eraseUsesOfInstruction(SILInstruction *inst, CallbackTy callback) {
+void swift::eraseUsesOfInstruction(SILInstruction *inst,
+                                   InstModCallbacks callbacks) {
   for (auto result : inst->getResults()) {
     while (!result->use_empty()) {
       auto ui = result->use_begin();
@@ -639,7 +644,7 @@ void swift::eraseUsesOfInstruction(SILInstruction *inst, CallbackTy callback) {
 
       // If the instruction itself has any uses, recursively zap them so that
       // nothing uses this instruction.
-      eraseUsesOfInstruction(user, callback);
+      eraseUsesOfInstruction(user, callbacks);
 
       // Walk through the operand list and delete any random instructions that
       // will become trivially dead when this instruction is removed.
@@ -651,12 +656,11 @@ void swift::eraseUsesOfInstruction(SILInstruction *inst, CallbackTy callback) {
           if (operandI != inst) {
             operand.drop();
             recursivelyDeleteTriviallyDeadInstructions(operandI, false,
-                                                       callback);
+                                                       callbacks);
           }
         }
       }
-      callback(user);
-      user->eraseFromParent();
+      callbacks.deleteInst(user);
     }
   }
 }

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -575,14 +575,15 @@ void SILInlineCloner::fixUp(SILFunction *calleeFunction) {
 
   assert(!Apply.getInstruction()->hasUsesOfAnyResult());
 
-  auto deleteCallback = [this](SILInstruction *deletedI) {
-    if (NextIter == deletedI->getIterator())
-      ++NextIter;
-    if (DeletionCallback)
-      DeletionCallback(deletedI);
-  };
+  auto callbacks = InstModCallbacks().onNotifyWillBeDeleted(
+      [this](SILInstruction *deletedI) {
+        if (NextIter == deletedI->getIterator())
+          ++NextIter;
+        if (DeletionCallback)
+          DeletionCallback(deletedI);
+      });
   recursivelyDeleteTriviallyDeadInstructions(Apply.getInstruction(), true,
-                                             deleteCallback);
+                                             callbacks);
 }
 
 SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,

--- a/test/SILOptimizer/OSLogMandatoryOptTest.sil
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.sil
@@ -32,7 +32,14 @@ sil [serialized] [always_inline] [readonly] [_semantics "string.makeUTF8"] @$sSS
 /// A function that models the use of a string in some arbitrary way.
 sil @useFormatString: $@convention(thin) (@guaranteed String) -> ()
 
-// CHECK-LABEL: @testConstantFoldingOfStructExtract
+// CHECK-LABEL: @testConstantFoldingOfStructExtract :
+// CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
+// CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[BORROW:%[0-9]+]])
+// CHECK-DAG: [[BORROW]] = begin_borrow [[STRINGCONST:%[0-9]+]]
+// CHECK-DAG: [[STRINGCONST]] = apply [[STRINGINIT:%[0-9]+]]([[LIT:%[0-9]+]], {{%.*}}, {{%.*}}, {{%.*}})
+// CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+// CHECK-DAG: [[LIT]] = string_literal utf8 "test message: %lld"
+// CHECK-DAG: destroy_value [[STRINGCONST]] : $String
 sil [ossa] @testConstantFoldingOfStructExtract : $@convention(thin) () -> () {
 bb0:
   // Construct an OSLogMessageStub instance.
@@ -57,13 +64,6 @@ bb0:
   destroy_value %7 : $OSLogMessageStub
   %13 = tuple ()
   return %13 : $()
-    // CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
-    // CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[BORROW:%[0-9]+]])
-    // CHECK-DAG: [[BORROW]] = begin_borrow [[STRINGCONST:%[0-9]+]]
-    // CHECK-DAG: [[STRINGCONST]] = apply [[STRINGINIT:%[0-9]+]]([[LIT:%[0-9]+]], {{%.*}}, {{%.*}}, {{%.*}})
-    // CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
-    // CHECK-DAG: [[LIT]] = string_literal utf8 "test message: %lld"
-    // CHECK-DAG: destroy_value [[STRINGCONST]] : $String
 }
 
 /// A function that models the use of a string in some arbitrary way.
@@ -989,7 +989,10 @@ bb0(%0 : $*OSLogInterpolationDCEStub):
   return %9999 : $()
 }
 
-// CHECK-LABEL: @testDCEOfAllocStack
+// CHECK-LABEL: @testDCEOfAllocStack :
+// CHECK: bb0
+// CHECK-NEXT: [[EMPTYTUP:%[0-9]+]] = tuple ()
+// CHECK-NEXT: return [[EMPTYTUP]]
 sil [ossa] @testDCEOfAllocStack : $@convention(thin) () -> () {
 bb0:
   %0 = string_literal utf8 "some message"
@@ -1012,9 +1015,6 @@ bb0:
   dealloc_stack %7 : $*OSLogInterpolationDCEStub
   %13 = tuple ()
   return %13 : $()
-    // CHECK: bb0
-    // CHECK-NEXT: [[EMPTYTUP:%[0-9]+]] = tuple ()
-    // CHECK-NEXT: return [[EMPTYTUP]]
 }
 
 // Check that dead-code elimination of alloc stack does not happen when there


### PR DESCRIPTION
    I recently have been running into the issue that many of these APIs perform the
    deletion operation themselves and notify the caller it is going to delete
    instead of allowing the caller to specify how the instruction is deleted. This
    causes interesting semantic issues (see the loop in deleteInstruction I
    simplified) and breaks composition since many parts of the optimizer use
    InstModCallbacks for this purpose.
    
    To fix this, I added a notify will be deleted construct to InstModCallback. In a
    similar way to the rest of it, if the notify is not set, we do not call any code
    implying that we should have good predictable performance in loops since we will
    always skip the function call.
    
    I also changed InstModCallback::deleteInst() to notify before deleting so we
    have a default safe behavior. All previous use sites of this API do not care
    about being notified and the only new use sites of this API are in
    InstructionDeleter that perform special notification behavior (it notifies for
    certain sets of instructions it is going to delete before it deletes any of
    them). To work around this, I added a bool to deleteInst to control this
    behavior and defaulted to notifying. This should ensure that all other use sites
    still compose correctly.