### PR TITLE
Introduce a feature for `@_inheritActorContext`

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -45,5 +45,6 @@ LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type", true)
 LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable", true)
 LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins", true)
 LANGUAGE_FEATURE(BuiltinTaskGroup, 0, "TaskGroup builtins", true)
+LANGUAGE_FEATURE(InheritActorContext, 0, "@_inheritActorContext attribute", true)
 
 #undef LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2753,6 +2753,17 @@ static bool usesFeatureBuiltinTaskGroup(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureInheritActorContext(Decl *decl) {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    for (auto param : *func->getParameters()) {
+      if (param->getAttrs().hasAttribute<InheritActorContextAttr>())
+        return true;
+    }
+  }
+
+  return false;
+}
+
 /// Determine the set of "new" features used on a given declaration.
 ///
 /// Note: right now, all features we check for are "new". At some point, we'll

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -143,6 +143,11 @@ public func runSomethingConcurrently(body: @Sendable () -> Void) { }
 // CHECK-NEXT: #endif
 public func stage(with actor: MyActor) { }
 
+// CHECK: #if compiler(>=5.3) && $AsyncAwait && $Sendable && $InheritActorContext
+// CHECK-NEXT: func asyncIsh
+// CHECK-NEXT: #endif
+public func asyncIsh(@_inheritActorContext operation: @Sendable @escaping () async -> Void) { }
+
 // CHECK-NOT: extension MyActor : Swift.Sendable
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol


### PR DESCRIPTION
Add a feature for this new attribute, and make sure we use the feature
guard for functions that use it, e.g., the new `async`.

Finishes rdar://76927008.
