### PR TITLE
[5.5] [Concurrency] Add "async" operation for continuing work asynchronously.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -652,6 +652,11 @@ SIMPLE_DECL_ATTR(_implicitSelfCapture, ImplicitSelfCapture,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove,
   115)
 
+SIMPLE_DECL_ATTR(_inheritActorContext, InheritActorContext,
+  OnParam | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIBreakingToRemove,
+  116)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -292,14 +292,18 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
 
     /// True if "self" can be captured implicitly without requiring "self."
     /// on each member reference.
-    ImplicitSelfCapture : 1
+    ImplicitSelfCapture : 1,
+
+    /// True if this @Sendable async closure parameter should implicitly
+    /// inherit the actor context from where it was formed.
+    InheritActorContext : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -3876,6 +3880,7 @@ public:
     setParameterList(params);
     Bits.ClosureExpr.HasAnonymousClosureVars = false;
     Bits.ClosureExpr.ImplicitSelfCapture = false;
+    Bits.ClosureExpr.InheritActorContext = false;
   }
 
   SourceRange getSourceRange() const;
@@ -3912,6 +3917,16 @@ public:
 
   void setAllowsImplicitSelfCapture(bool value = true) {
     Bits.ClosureExpr.ImplicitSelfCapture = value;
+  }
+
+  /// Whether this closure should implicitly inherit the actor context from
+  /// where it was formed. This only affects @Sendable async closures.
+  bool inheritsActorContext() const {
+    return Bits.ClosureExpr.InheritActorContext;
+  }
+
+  void setInheritsActorContext(bool value = true) {
+    Bits.ClosureExpr.InheritActorContext = value;
   }
 
   /// Determine whether this closure expression has an

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3383,6 +3383,7 @@ struct ParameterListInfo {
   SmallBitVector unsafeSendable;
   SmallBitVector unsafeMainActor;
   SmallBitVector implicitSelfCapture;
+  SmallBitVector inheritActorContext;
 
 public:
   ParameterListInfo() { }
@@ -3414,6 +3415,10 @@ public:
   /// Whether the given parameter is a closure that should allow capture of
   /// 'self' to be implicit, without requiring "self.".
   bool isImplicitSelfCapture(unsigned paramIdx) const;
+
+  /// Whether the given parameter is a closure that should inherit the
+  /// actor context from the context in which it was created.
+  bool inheritsActorContext(unsigned paramIdx) const;
 
   /// Whether there is any contextual information set on this parameter list.
   bool anyContextualInfo() const;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -45,5 +45,6 @@ LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type", true)
 LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable", true)
 LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins", true)
 LANGUAGE_FEATURE(BuiltinTaskGroup, 0, "TaskGroup builtins", true)
+LANGUAGE_FEATURE(InheritActorContext, 0, "@_inheritActorContext attribute", true)
 
 #undef LANGUAGE_FEATURE

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -584,6 +584,10 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_reportUnexpectedExecutor(
     const unsigned char *file, uintptr_t fileLength, bool fileIsASCII,
     uintptr_t line, ExecutorRef executor);
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+JobPriority swift_task_getCurrentThreadPriority(void);
+
 }
 
 #pragma clang diagnostic pop

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2548,6 +2548,8 @@ public:
       PrintWithColorRAII(OS, ClosureModifierColor) << " single-expression";
     if (E->allowsImplicitSelfCapture())
       PrintWithColorRAII(OS, ClosureModifierColor) << " implicit-self";
+    if (E->inheritsActorContext())
+      PrintWithColorRAII(OS, ClosureModifierColor) << " inherits-actor-context";
 
     if (E->getParameters()) {
       OS << '\n';

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2753,6 +2753,17 @@ static bool usesFeatureBuiltinTaskGroup(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureInheritActorContext(Decl *decl) {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    for (auto param : *func->getParameters()) {
+      if (param->getAttrs().hasAttribute<InheritActorContextAttr>())
+        return true;
+    }
+  }
+
+  return false;
+}
+
 /// Determine the set of "new" features used on a given declaration.
 ///
 /// Note: right now, all features we check for are "new". At some point, we'll

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -971,6 +971,7 @@ ParameterListInfo::ParameterListInfo(
   unsafeSendable.resize(params.size());
   unsafeMainActor.resize(params.size());
   implicitSelfCapture.resize(params.size());
+  inheritActorContext.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -1034,6 +1035,10 @@ ParameterListInfo::ParameterListInfo(
     if (param->getAttrs().hasAttribute<ImplicitSelfCaptureAttr>()) {
       implicitSelfCapture.set(i);
     }
+
+    if (param->getAttrs().hasAttribute<InheritActorContextAttr>()) {
+      inheritActorContext.set(i);
+    }
   }
 }
 
@@ -1070,9 +1075,15 @@ bool ParameterListInfo::isImplicitSelfCapture(unsigned paramIdx) const {
       : false;
 }
 
+bool ParameterListInfo::inheritsActorContext(unsigned paramIdx) const {
+  return paramIdx < inheritActorContext.size()
+      ? inheritActorContext[paramIdx]
+      : false;
+}
+
 bool ParameterListInfo::anyContextualInfo() const {
   return unsafeSendable.any() || unsafeMainActor.any() ||
-      implicitSelfCapture.any();
+      implicitSelfCapture.any() || inheritActorContext.any();
 }
 
 /// Turn a param list into a symbolic and printable representation that does not

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5726,6 +5726,12 @@ static void applyContextualClosureFlags(
         captureList->getClosureBody(), sendable, forMainActor,
         implicitSelfCapture, inheritActorContext);
   }
+
+  if (auto identity = dyn_cast<IdentityExpr>(expr)) {
+    applyContextualClosureFlags(
+        identity->getSubExpr(), sendable, forMainActor,
+        implicitSelfCapture, inheritActorContext);
+  }
 }
 
 /// Whether this is a reference to a method on the main dispatch queue.
@@ -6139,6 +6145,20 @@ Expr *ExprRewriter::coerceCallArguments(
 static bool isClosureLiteralExpr(Expr *expr) {
   expr = expr->getSemanticsProvidingExpr();
   return (isa<CaptureListExpr>(expr) || isa<ClosureExpr>(expr));
+}
+
+/// Whether we should propagate async down to a closure.
+static bool shouldPropagateAsyncToClosure(Expr *expr) {
+  if (auto IE = dyn_cast<IdentityExpr>(expr))
+    return shouldPropagateAsyncToClosure(IE->getSubExpr());
+
+  if (auto CLE = dyn_cast<CaptureListExpr>(expr))
+    return shouldPropagateAsyncToClosure(CLE->getClosureBody());
+
+  if (auto CE = dyn_cast<ClosureExpr>(expr))
+    return CE->inheritsActorContext();
+
+  return false;
 }
 
 /// If the expression is an explicit closure expression (potentially wrapped in
@@ -7010,6 +7030,22 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto fromEI = fromFunc->getExtInfo();
     if (toEI.isSendable() && !fromEI.isSendable()) {
       auto newFromFuncType = fromFunc->withExtInfo(fromEI.withConcurrent());
+      if (applyTypeToClosureExpr(cs, expr, newFromFuncType)) {
+        fromFunc = newFromFuncType->castTo<FunctionType>();
+
+        // Propagating the 'concurrent' bit might have satisfied the entire
+        // conversion. If so, we're done, otherwise keep converting.
+        if (fromFunc->isEqual(toType))
+          return expr;
+      }
+    }
+
+    // If we have a ClosureExpr, then we can safely propagate the 'async'
+    // bit to the closure without invalidating prior analysis.
+    fromEI = fromFunc->getExtInfo();
+    if (toEI.isAsync() && !fromEI.isAsync() &&
+        shouldPropagateAsyncToClosure(expr)) {
+      auto newFromFuncType = fromFunc->withExtInfo(fromEI.withAsync());
       if (applyTypeToClosureExpr(cs, expr, newFromFuncType)) {
         fromFunc = newFromFuncType->castTo<FunctionType>();
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -138,6 +138,7 @@ public:
   IGNORED_ATTR(UnsafeSendable)
   IGNORED_ATTR(UnsafeMainActor)
   IGNORED_ATTR(ImplicitSelfCapture)
+  IGNORED_ATTR(InheritActorContext)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1547,6 +1547,7 @@ namespace  {
     UNINTERESTING_ATTR(UnsafeSendable)
     UNINTERESTING_ATTR(UnsafeMainActor)
     UNINTERESTING_ATTR(ImplicitSelfCapture)
+    UNINTERESTING_ATTR(InheritActorContext)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -27,6 +27,7 @@
 #include "swift/ABI/Actor.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "TaskPrivate.h"
+#include <dispatch/dispatch.h>
 
 #if defined(__APPLE__)
 #include <asl.h>
@@ -257,6 +258,13 @@ static bool isExecutingOnMainThread() {
 #else
   return pthread_main_np() == 1;
 #endif
+}
+
+JobPriority swift::swift_task_getCurrentThreadPriority() {
+  if (isExecutingOnMainThread())
+    return JobPriority::UserInitiated;
+
+  return static_cast<JobPriority>(qos_class_self());
 }
 
 SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -264,7 +264,11 @@ JobPriority swift::swift_task_getCurrentThreadPriority() {
   if (isExecutingOnMainThread())
     return JobPriority::UserInitiated;
 
+#if defined(__APPLE__)
   return static_cast<JobPriority>(qos_class_self());
+#else
+  return JobPriority::Unspecified;
+#endif
 }
 
 SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -481,6 +481,55 @@ public func detach<T>(
   return Task.Handle<T, Error>(task)
 }
 
+/// Run given `operation` as asynchronously in its own top-level task.
+///
+/// The `async` function should be used when creating asynchronous work
+/// that operations on behalf of the synchronous function that calls it.
+/// Like `detach`, the async function creates a separate, top-level task.
+/// Unlike `detach`, the task creating by `async` inherits the priority and
+/// actor context of the caller, so the `operation` is treated more like an
+/// asynchronous extension to the synchronous operation. Additionally, `async`
+/// does not return a handle to refer to the task.
+///
+/// - Parameters:
+///   - priority: priority of the task. If unspecified, the priority will
+///               be inherited from the task that is currently executing
+///               or, if there is none, from the platform's understanding of
+///               which thread is executing.
+///   - operation: the operation to execute
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+public func async(
+  priority: Task.Priority = .unspecified,
+  @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping () async -> Void
+) {
+  // Determine the priority at which we should create this task
+  let actualPriority: Task.Priority
+  if priority == .unspecified {
+    actualPriority = withUnsafeCurrentTask { task in
+      // If we are running on behalf of a task,
+      if let task = task {
+        return task.priority
+      }
+
+      return Task.Priority(rawValue: _getCurrentThreadPriority()) ?? .unspecified
+    }
+  } else {
+    actualPriority = priority
+  }
+
+  // Set up the job flags for a new task.
+  var flags = Task.JobFlags()
+  flags.kind = .task
+  flags.priority = actualPriority
+  flags.isFuture = true
+
+  // Create the asynchronous task future.
+  let (task, _) = Builtin.createAsyncTaskFuture(flags.bits, operation)
+
+  // Enqueue the resulting job.
+  _enqueueJobGlobal(Builtin.convertTaskToJob(task))
+}
+
 // ==== Async Handler ----------------------------------------------------------
 
 // TODO: remove this?
@@ -768,6 +817,10 @@ func _reportUnexpectedExecutor(_ _filenameStart: Builtin.RawPointer,
                                _ _filenameIsASCII: Builtin.Int1,
                                _ _line: Builtin.Word,
                                _ _executor: Builtin.Executor)
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+@_silgen_name("swift_task_getCurrentThreadPriority")
+func _getCurrentThreadPriority() -> Int
 
 #if _runtime(_ObjC)
 

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -484,7 +484,7 @@ public func detach<T>(
 /// Run given `operation` as asynchronously in its own top-level task.
 ///
 /// The `async` function should be used when creating asynchronous work
-/// that operations on behalf of the synchronous function that calls it.
+/// that operates on behalf of the synchronous function that calls it.
 /// Like `detach`, the async function creates a separate, top-level task.
 /// Unlike `detach`, the task creating by `async` inherits the priority and
 /// actor context of the caller, so the `operation` is treated more like an

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -56,7 +56,10 @@ if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
   asyncTests.test("GlobalDispatchQueue") {
     DispatchQueue.global(qos: .utility).async {
       async {
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS))
+        // Non-Darwin platforms currently lack qos_class_self().
         assert(Task.currentPriority == .utility)
+#endif
       }
     }
     sleep(1)

--- a/test/Concurrency/Runtime/async.swift
+++ b/test/Concurrency/Runtime/async.swift
@@ -1,0 +1,67 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-concurrency %import-libdispatch)
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+
+import Dispatch
+import StdlibUnittest
+
+// for sleep
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+
+var asyncTests = TestSuite("Async")
+
+@available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+actor MyActor {
+  func synchronous() { }
+
+  func doSomething(expectedPriority: Task.Priority) {
+    async {
+      synchronous() // okay to be synchronous
+      assert(Task.currentPriority == expectedPriority)
+    }
+  }
+}
+
+if #available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *) {
+  let actor = MyActor()
+
+  asyncTests.test("Detach") {
+    detach(priority: .background) {
+      async {
+        assert(Task.currentPriority == .background)
+        await actor.doSomething(expectedPriority: .background)
+      }
+    }
+    sleep(1)
+  }
+
+  asyncTests.test("MainQueue") {
+    DispatchQueue.main.async {
+      async {
+        assert(Task.currentPriority == .userInitiated)
+      }
+    }
+    sleep(1)
+  }
+
+  asyncTests.test("GlobalDispatchQueue") {
+    DispatchQueue.global(qos: .utility).async {
+      async {
+        assert(Task.currentPriority == .utility)
+      }
+    }
+    sleep(1)
+  }
+}
+
+runAllTests()
+

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -756,7 +756,7 @@ func testCrossActorProtocol<T: P>(t: T) async {
 }
 
 // ----------------------------------------------------------------------
-// @_
+// @_inheritActorContext
 // ----------------------------------------------------------------------
 func acceptAsyncSendableClosure<T>(_: @Sendable () async -> T) { }
 func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable () async -> T) { }

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -143,6 +143,11 @@ public func runSomethingConcurrently(body: @Sendable () -> Void) { }
 // CHECK-NEXT: #endif
 public func stage(with actor: MyActor) { }
 
+// CHECK: #if compiler(>=5.3) && $AsyncAwait && $Sendable && $InheritActorContext
+// CHECK-NEXT: func asyncIsh
+// CHECK-NEXT: #endif
+public func asyncIsh(@_inheritActorContext operation: @Sendable @escaping () async -> Void) { }
+
 // CHECK-NOT: extension MyActor : Swift.Sendable
 
 // CHECK: #if compiler(>=5.3) && $MarkerProtocol

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -245,3 +245,20 @@ func anotherUnspecifiedAsyncFunc(_ red : RedActorImpl) async {
 func testGlobalActorFuncValue(_ fn: @RedActor () -> Void) async {
   await fn()
 }
+
+func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable () async -> T) { }
+
+extension MyActor {
+  func synchronous() { }
+
+  // CHECK-LABEL: sil private [ossa] @$s4test7MyActorC0A10InheritingyyFyyYaYbXEfU_
+  // CHECK: debug_value [[SELF:%[0-9]+]] : $MyActor
+  // CHECK-NEXT: [[COPY:%[0-9]+]] = copy_value [[SELF]] : $MyActor
+  // CHECK-NEXT: [[BORROW:%[0-9]+]] = begin_borrow [[COPY]] : $MyActor
+  // CHECK-NEXT: hop_to_executor [[BORROW]] : $MyActor
+  func testInheriting() {
+    acceptAsyncSendableClosureInheriting {
+      synchronous()
+    }
+  }
+}


### PR DESCRIPTION
The `async` operation is a global function that initiates asynchronous
work on behalf of the synchronous code that calls it. Unlike `detach`,
`async` inherits priority, actor context, and other aspects of the
synchronous code that initiates it, making it a better "default"
operation for creating asynchronous work than `detach`. The `detach`
operation is still important for creating truly detached tasks that
can later be `await`'d or cancelled if needed.

Implements rdar://76927008.