### PR TITLE
[5.5] [Concurrency] Put Builtin.Executor type behind a feature flag.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -43,6 +43,7 @@ LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol", true)
 LANGUAGE_FEATURE(GlobalActors, 0, "Global actors", langOpts.EnableExperimentalConcurrency)
 LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type", true)
 LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable", true)
+LANGUAGE_FEATURE(BuiltinExecutor, 0, "Executor builtins", true)
 LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins", true)
 LANGUAGE_FEATURE(BuiltinTaskGroup, 0, "TaskGroup builtins", true)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2745,6 +2745,35 @@ static bool usesFeatureBuiltinJob(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinExecutor(Decl *decl) {
+  auto typeHasBuiltinExecutor = [](Type type) {
+    return type.findIf([&](Type type) {
+      if (auto builtinTy = type->getAs<BuiltinType>())
+        return builtinTy->getBuiltinTypeKind()
+            == BuiltinTypeKind::BuiltinExecutor;
+
+      return false;
+    });
+  };
+
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+    if (Type type = value->getInterfaceType()) {
+      if (typeHasBuiltinExecutor(type))
+        return true;
+    }
+  }
+
+  if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
+    for (unsigned idx : range(patternBinding->getNumPatternEntries())) {
+      if (Type type = patternBinding->getPattern(idx)->getType())
+        if (typeHasBuiltinExecutor(type))
+          return true;
+    }
+  }
+
+  return false;
+}
+
 static bool usesFeatureBuiltinContinuation(Decl *decl) {
   return false;
 }


### PR DESCRIPTION
Fixes rdar://77041644.
