### PR TITLE
[5.5] Verify that `_Concurrency` *can* be imported on implicit import.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -879,6 +879,13 @@ public:
   /// If there is no Clang module loader, returns a null pointer.
   /// The loader is owned by the AST context.
   ClangModuleLoader *getDWARFModuleLoader() const;
+
+  /// Check whether the module with a given name can be imported without
+  /// importing it.
+  ///
+  /// Note that even if this check succeeds, errors may still occur if the
+  /// module is loaded in full.
+  bool canImportModuleImpl(ImportPath::Element ModulePath) const;
 public:
   namelookup::ImportCache &getImportCache() const;
 
@@ -908,6 +915,7 @@ public:
   /// Note that even if this check succeeds, errors may still occur if the
   /// module is loaded in full.
   bool canImportModule(ImportPath::Element ModulePath);
+  bool canImportModule(ImportPath::Element ModulePath) const;
 
   /// \returns a module with a given name that was already loaded.  If the
   /// module was not loaded, returns nullptr.

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -136,6 +136,9 @@ ERROR(cannot_emit_ir_skipping_function_bodies,none,
 WARNING(emit_reference_dependencies_without_primary_file,none,
         "ignoring -emit-reference-dependencies (requires -primary-file)", ())
 
+WARNING(warn_implicit_concurrency_import_failed,none,
+        "unable to perform implicit import of \"_Concurrency\" module: no such module found", ())
+
 ERROR(error_module_name_required,none, "-module-name is required", ())
 ERROR(error_bad_module_name,none,
       "module name \"%0\" is not a valid identifier"

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -529,6 +529,14 @@ public:
     return getMainModule()->getPrimarySourceFiles();
   }
 
+  /// Verify that if an implicit import of the `Concurrency` module if expected,
+  /// it can actually be imported. Emit a warning, otherwise.
+  void verifyImplicitConcurrencyImport();
+
+  /// Whether the Swift Concurrency support library can be imported
+  /// i.e. if it can be found.
+  bool canImportSwiftConcurrency() const;
+
   /// Gets the SourceFile which is the primary input for this CompilerInstance.
   /// \returns the primary SourceFile, or nullptr if there is no primary input;
   /// if there are _multiple_ primary inputs, fails with an assertion.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1934,7 +1934,7 @@ bool ASTContext::shouldPerformTypoCorrection() {
   return NumTypoCorrections <= LangOpts.TypoCorrectionLimit;
 }
 
-bool ASTContext::canImportModule(ImportPath::Element ModuleName) {
+bool ASTContext::canImportModuleImpl(ImportPath::Element ModuleName) const {
   // If this module has already been successfully imported, it is importable.
   if (getLoadedModule(ImportPath::Module::Builder(ModuleName).get()) != nullptr)
     return true;
@@ -1950,8 +1950,20 @@ bool ASTContext::canImportModule(ImportPath::Element ModuleName) {
     }
   }
 
-  FailedModuleImportNames.insert(ModuleName.Item);
   return false;
+}
+
+bool ASTContext::canImportModule(ImportPath::Element ModuleName) {
+  if (canImportModuleImpl(ModuleName)) {
+    return true;
+  } else {
+    FailedModuleImportNames.insert(ModuleName.Item);
+    return false;
+  }
+}
+
+bool ASTContext::canImportModule(ImportPath::Element ModuleName) const {
+  return canImportModuleImpl(ModuleName);
 }
 
 ModuleDecl *

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -799,6 +799,19 @@ bool CompilerInvocation::shouldImportSwiftONoneSupport() const {
          FrontendOptions::doesActionGenerateSIL(options.RequestedAction);
 }
 
+void CompilerInstance::verifyImplicitConcurrencyImport() {
+  if (Invocation.shouldImportSwiftConcurrency() &&
+      !canImportSwiftConcurrency()) {
+    Diagnostics.diagnose(SourceLoc(),
+                         diag::warn_implicit_concurrency_import_failed);
+  }
+}
+
+bool CompilerInstance::canImportSwiftConcurrency() const {
+  return getASTContext().canImportModule(
+      {getASTContext().getIdentifier(SWIFT_CONCURRENCY_NAME), SourceLoc()});
+}
+
 ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
   auto &frontendOpts = Invocation.getFrontendOptions();
 
@@ -823,6 +836,9 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
     pushImport(SWIFT_ONONE_SUPPORT);
   }
 
+  // FIXME: The canImport check is required for compatibility
+  // with older SDKs. Longer term solution is to have the driver make
+  // the decision on the implicit import: rdar://76996377
   if (Invocation.shouldImportSwiftConcurrency()) {
     switch (imports.StdlibKind) {
     case ImplicitStdlibKind::Builtin:
@@ -830,7 +846,8 @@ ImplicitImportInfo CompilerInstance::getImplicitImportInfo() const {
       break;
 
     case ImplicitStdlibKind::Stdlib:
-      pushImport(SWIFT_CONCURRENCY_NAME);
+      if (canImportSwiftConcurrency())
+        pushImport(SWIFT_CONCURRENCY_NAME);
       break;
     }
   }
@@ -1041,6 +1058,8 @@ bool CompilerInstance::loadStdlibIfNeeded() {
                          Invocation.getTargetTriple());
     return true;
   }
+
+  verifyImplicitConcurrencyImport();
 
   // If we failed to load, we should have already diagnosed.
   if (M->failedToLoad()) {

--- a/test/Concurrency/fail_implicit_concurrency_load.swift
+++ b/test/Concurrency/fail_implicit_concurrency_load.swift
@@ -1,0 +1,21 @@
+// This test ensures that if implicit import of the Concurrency module is enabled,
+// but no such module can be located (here verified by forcing explicit modules),
+// a warning diagnostic is emitted.
+// REQUIRES: concurrency
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/inputs
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-frontend -typecheck %s -explicit-swift-module-map-file %t/inputs/map.json -disable-implicit-swift-modules -enable-experimental-concurrency 2>&1 | %FileCheck %s
+import Swift
+// CHECK: warning: unable to perform implicit import of "_Concurrency" module: no such module found


### PR DESCRIPTION
Cherry-pick of: https://github.com/apple/swift/pull/37005
---------------------------------------------------
In case the compiler is used with concurrency features enabled (by-default or otherwise), and an older SDK is used which does not include the `_Concurrency` module, do not load this module implicitly. Instead, emit a diagnostic indicating that no such module is found.

rdar://76967260

