### PR TITLE
[Tests] Do not ignore swiftsourceinfo by default in lit tests

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -398,10 +398,7 @@ if test_options:
     config.swift_test_options += test_options
 
 config.swift_frontend_test_options += os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS', '')
-config.swift_frontend_test_options += ' -ignore-module-source-info'
 config.swift_driver_test_options += os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
-config.swift_driver_test_options += ' -Xfrontend'
-config.swift_driver_test_options += ' -ignore-module-source-info'
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
 config.clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module-cache")


### PR DESCRIPTION
This was added as a default in b103997c293a55e9d42cd659b840dfc1fdf51070,
with the reasoning that users do not have .swiftsourceinfo for the
stdlib. A later change (51d6243d2451dfb0a05996f902e6766834f1cad7) then
avoids emitting .swiftsourceinfo for the stdlib at all, making this no longer an issue.

The compiler does use .swiftsourceinfo for user-built modules, so reading them by
default seems reasonable (with the option to disable them in the cases where that
causes an issue).