### PR TITLE
[Sema] Fix crash when retrieving typeContextInfo for a partially bound generic type

### DIFF
--- a/test/IDE/complete_override_access_control_protocol.swift
+++ b/test/IDE/complete_override_access_control_protocol.swift
@@ -177,16 +177,21 @@ public class TestPublicDE : ProtocolDPrivate, ProtocolEPublic {
   #^TEST_PUBLIC_DE^#
 }
 
-// TEST_PRIVATE_DE: Begin completions, 2 items
+// FIXME: We should only be suggesting `collidingGeneric` once in all the test cases below.
+
+// TEST_PRIVATE_DE: Begin completions, 3 items
 // TEST_PRIVATE_DE-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 // TEST_PRIVATE_DE-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_PRIVATE_DE-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_INTERNAL_DE: Begin completions, 2 items
+// TEST_INTERNAL_DE: Begin completions, 3 items
 // TEST_INTERNAL_DE-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 // TEST_INTERNAL_DE-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_INTERNAL_DE-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_PUBLIC_DE: Begin completions, 2 items
+// TEST_PUBLIC_DE: Begin completions, 3 items
 // TEST_PUBLIC_DE-DAG: Decl[InstanceMethod]/Super: public func colliding() {|}{{; name=.+$}}
+// TEST_PUBLIC_DE-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_PUBLIC_DE-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
 private class TestPrivateED : ProtocolEPublic, ProtocolDPrivate {
@@ -203,16 +208,19 @@ public class TestPublicED : ProtocolEPublic, ProtocolDPrivate {
   #^TEST_PUBLIC_ED^#
 }
 
-// TEST_PRIVATE_ED: Begin completions, 2 items
+// TEST_PRIVATE_ED: Begin completions, 3 items
 // TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 // TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_PRIVATE_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_INTERNAL_ED: Begin completions, 2 items
+// TEST_INTERNAL_ED: Begin completions, 3 items
+// TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_INTERNAL_ED-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 
-// TEST_PUBLIC_ED: Begin completions, 2 items
+// TEST_PUBLIC_ED: Begin completions, 3 items
 // TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_PUBLIC_ED-DAG: Decl[InstanceMethod]/Super: public func colliding() {|}{{; name=.+$}}
 
 private class TestPrivateEF : ProtocolEPublic, ProtocolFPublic {
@@ -229,14 +237,17 @@ public class TestPublicEF : ProtocolEPublic, ProtocolFPublic {
   #^TEST_PUBLIC_EF^#
 }
 
-// TEST_PRIVATE_EF: Begin completions, 2 items
+// TEST_PRIVATE_EF: Begin completions, 3 items
 // TEST_PRIVATE_EF-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 // TEST_PRIVATE_EF-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_PRIVATE_EF-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_INTERNAL_EF: Begin completions, 2 items
+// TEST_INTERNAL_EF: Begin completions, 3 items
 // TEST_INTERNAL_EF-DAG: Decl[InstanceMethod]/Super: func colliding() {|}{{; name=.+$}}
 // TEST_INTERNAL_EF-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
+// TEST_INTERNAL_EF-DAG: Decl[InstanceMethod]/Super: func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 
-// TEST_PUBLIC_EF: Begin completions, 2 items
+// TEST_PUBLIC_EF: Begin completions, 3 items
 // TEST_PUBLIC_EF-DAG: Decl[InstanceMethod]/Super: public func colliding() {|}{{; name=.+$}}
+// TEST_PUBLIC_EF-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}
 // TEST_PUBLIC_EF-DAG: Decl[InstanceMethod]/Super: public func collidingGeneric<T>(x: T) {|}{{; name=.+$}}

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift
@@ -19,6 +19,20 @@ struct S<T> {
   static var instance: Self = S<T>()
 }
 
+struct MyBinding<BindingOuter> {
+  func someGenericFunc<BindingInner>(x: BindingInner) {}
+}
+
+struct MyTextField<TextFieldOuter> {
+  init<TextFieldInner>(text: MyBinding<TextFieldInner>) {}
+}
+
+struct EncodedView {
+    func foo(model: MyBinding<String>) {
+        let _ = MyTextField<String>(text: model)
+    }
+}
+
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=7:12 %s -- %s > %t.response.1
 // RUN: %diff -u %s.response.1 %t.response.1
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=8:12 %s -- %s > %t.response.2
@@ -32,3 +46,6 @@ struct S<T> {
 // RUN: %diff -u %s.response.5 %t.response.5
 // RUN: %sourcekitd-test -req=typecontextinfo -pos=16:18 %s -- %s > %t.response.6
 // RUN: %diff -u %s.response.6 %t.response.6
+
+// RUN: %sourcekitd-test -req=typecontextinfo -pos=32:43 %s -- %s > %t.response.7
+// RUN: %diff -u %s.response.7 %t.response.7

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.7
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.7
@@ -1,0 +1,10 @@
+{
+  key.results: [
+    {
+      key.typename: "MyBinding<TextFieldInner>",
+      key.typeusr: "$s20typecontext_generics9MyBindingVyqd__GD",
+      key.implicitmembers: [
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In the following test case, we are crashing while building the generic signature of `someGenericFunc`, potentially invoked on `model` in line 11.

```swift
struct MyBinding<BindingOuter> {
  func someGenericFunc<BindingInner>(x: BindingInner) {}
}

struct MyTextField<TextFieldOuter> {
  init<TextFieldInner>(text: MyBinding<TextFieldInner>) {}
}

struct EncodedView {
    func foo(model: MyBinding<String>) {
        let _ = MyTextField<String>(text: model)
    }
}
```

Because we know that `model` has type `MyBinding<TextFieldInner>`, we substitute the `BindingOuter` generic parameter by `TextFieldInner`. Thus, `someGenericFunc` has the signature `<TextFieldInner /* substitutes BindingOuter */, BindingInner>`. `TextFieldInner` and `BindingOuter` both have `depth = 1`, `index = 0`. Thus the verification in `GenericSignatureBuilder` is failing.

After discussion with @slavapestov, the root issue appears to be that we shouldn’t be calling `subst` on a `GenericFunctionType` at all. Instead we should be using `substGenericArgs` which doesn’t attempt to rebuild a generic signature, but instead builds a non-generic function type.

--------------------------------------------------------------------------------

We slightly regress in code completion results by showing two `collidingGeneric` twice in the following case.

```swift
protocol P1 {
  func collidingGeneric<T>(x: T)
}
protocol P2 {
  func collidingGeneric<T>(x: T)
}
class C : P1, P2 {
  #^COMPLETE^#
}
```

Previously, we were representing the type of `collidingGeneric` by a generic function type with generic param `T` that doesn’t have any restrictions. Since we are now using `substGenericArgs` instead of `subst`, we receive a non-generic function type that represents `T` as an archetype. And since that archetype is different for the two function signatures, we show the result twice in code completion.

One could also argue that showing the result twice is intended (or at least acceptable) behaviour since, the two protocol may name their generic params differently. E.g. in

```swift
protocol P1 {
  func collidingGeneric<S>(x: S)
}
protocol P2 {
  func collidingGeneric<T>(x: T)
}
class C : P1, P2 {
  #^COMPLETE^#
}
```

we might be expected to show the following two results
```
func collidingGeneric<S>(x: S)
func collidingGeneric<T>(x: T)
```

Resolves rdar://76711477 [SR-14495]