### PR TITLE
[CodeCompletion] Fix code suggestions for arguments in vararg followed by normal arg

### DIFF
--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -795,6 +795,12 @@ static bool getPositionInParams(DeclContext &DC, Expr *Args, Expr *CCExpr,
     if (!SM.isBeforeInBuffer(tuple->getElement(PosInArgs)->getEndLoc(),
                              CCExpr->getStartLoc())) {
       // The arg is after the code completion position. Stop.
+      if (LastParamWasVariadic && tuple->getElementName(PosInArgs).empty()) {
+        // If the last parameter was variadic and this argument stands by itself
+        // without a label, assume that it belongs to the previous vararg
+        // list.
+        PosInParams--;
+      }
       break;
     }
 

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -865,6 +865,9 @@ func testCompleteLabelAfterVararg() {
   enum Foo {
     case bar
   }
+  enum Baz {
+    case bazCase
+  }
 
   struct Rdar76355192 {
     func test(_: String, xArg: Foo..., yArg: Foo..., zArg: Foo...) {}
@@ -886,6 +889,37 @@ func testCompleteLabelAfterVararg() {
     // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#Foo#];
     // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
     // COMPLETE_MEMBER_IN_VARARG: End completions
+  }
+
+  struct Sr14515 {
+    func test(_: Foo..., yArg: Baz) {}
+  }
+
+  private func testSr14515(value: Sr14515, foo: Foo, baz: Baz) {
+    value.test(foo, #^COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG^#)
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: Begin completions
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: foo[#Foo#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Pattern/ExprSpecific:               {#yArg: Baz#}[#Baz#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: End completions
+
+    // The leading dot completion tests that have picked the right type for the argument
+    value.test(foo, .#^COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT^#)
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT: Begin completions, 2 items
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bar[#Foo#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT: End completions
+
+    value.test(foo, yArg: #^COMPLETE_ARG_AFTER_VARARG^#)
+    // COMPLETE_ARG_AFTER_VARARG: Begin completions
+    // COMPLETE_ARG_AFTER_VARARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: baz[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG-NOT: Pattern/ExprSpecific:               {#yArg: Baz#}[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG: End completions
+
+    value.test(foo, yArg: .#^COMPLETE_ARG_AFTER_VARARG_DOT^#)
+    // COMPLETE_ARG_AFTER_VARARG_DOT: Begin completions, 2 items
+    // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[EnumElement]/ExprSpecific/TypeRelation[Identical]: bazCase[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Baz#})[#(into: inout Hasher) -> Void#];
+    // COMPLETE_ARG_AFTER_VARARG_DOT: End completions
   }
 }
 


### PR DESCRIPTION
For a function and call like
```swift
func test(_: Foo..., yArg: Baz) {}
test(.bar, #^COMPLETE^#)
```
the parser matches the code completion token to the `yArg` with a missing label, because this way all parameters are provided. However, because of this we don’t suggest any variables that could belong the the previous vararg list.

To fix this, if we encounter such a situation (argument without label after vararg), manually adjust the code completion token’s position in params to belong to the vararg list.

Fixes rdar://76977325 [SR-14515]