### PR TITLE
[5.5] Runtime/IRGen: Fix async dynamic replacements

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -4897,6 +4897,9 @@ struct DynamicReplacementKey {
   uint16_t getExtraDiscriminator() const {
     return flags & 0x0000FFFF;
   }
+  bool isAsync() const {
+    return ((flags >> 16 ) & 0x1);
+  }
 };
 
 /// A record describing a dynamic function replacement.

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -135,6 +135,13 @@ namespace irgen {
       assert(isSigned());
       return Discriminator;
     }
+    PointerAuthInfo getCorrespondingCodeAuthInfo() const {
+      if (auto authInfo = *this) {
+        return PointerAuthInfo(authInfo.getCorrespondingCodeKey(),
+                               authInfo.getDiscriminator());
+      }
+      return *this;
+    }
 
     /// Are the auth infos obviously the same?
     friend bool operator==(const PointerAuthInfo &lhs,

--- a/lib/IRGen/GenCall.h
+++ b/lib/IRGen/GenCall.h
@@ -272,6 +272,12 @@ namespace irgen {
       IRGenFunction &IGF, Address context);
   Address emitAutoDiffAllocateSubcontext(
       IRGenFunction &IGF, Address context, llvm::Value *size);
+
+  FunctionPointer getFunctionPointerForDispatchCall(IRGenModule &IGM,
+                                                    const FunctionPointer &fn);
+  void forwardAsyncCallResult(IRGenFunction &IGF, CanSILFunctionType fnType,
+                              AsyncContextLayout &layout, llvm::CallInst *call);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1609,7 +1609,8 @@ llvm::GlobalVariable *IRGenModule::getGlobalForDynamicallyReplaceableThunk(
 ///      struct ChainEntry *next;
 ///   }
 static llvm::GlobalVariable *getChainEntryForDynamicReplacement(
-    IRGenModule &IGM, LinkEntity entity, llvm::Function *implFunction = nullptr,
+    IRGenModule &IGM, LinkEntity entity,
+    llvm::Constant *implFunction = nullptr,
     ForDefinition_t forDefinition = ForDefinition) {
 
   auto linkEntry = IGM.getGlobalForDynamicallyReplaceableThunk(
@@ -1626,8 +1627,12 @@ static llvm::GlobalVariable *getChainEntryForDynamicReplacement(
                                  llvm::ConstantInt::get(IGM.Int32Ty, 0)};
     auto *storageAddr = llvm::ConstantExpr::getInBoundsGetElementPtr(
         nullptr, linkEntry, indices);
-
-    auto &schema = IGM.getOptions().PointerAuth.SwiftDynamicReplacements;
+    bool isAsyncFunction =
+        entity.hasSILFunction() && entity.getSILFunction()->isAsync();
+    auto &schema =
+        isAsyncFunction
+            ? IGM.getOptions().PointerAuth.AsyncSwiftDynamicReplacements
+            : IGM.getOptions().PointerAuth.SwiftDynamicReplacements;
     assert(entity.hasSILFunction() || entity.isOpaqueTypeDescriptorAccessor());
     auto authEntity = entity.hasSILFunction()
                           ? PointerAuthEntity(entity.getSILFunction())
@@ -1711,7 +1716,11 @@ void IRGenerator::emitDynamicReplacements() {
         LinkEntity::forDynamicallyReplaceableFunctionKey(origFunc));
 
     llvm::Constant *newFnPtr = llvm::ConstantExpr::getBitCast(
-        IGM.getAddrOfSILFunction(newFunc, NotForDefinition), IGM.Int8PtrTy);
+        newFunc->isAsync()
+            ? IGM.getAddrOfAsyncFunctionPointer(
+                  LinkEntity::forSILFunction(newFunc))
+            : IGM.getAddrOfSILFunction(newFunc, NotForDefinition),
+        IGM.Int8PtrTy);
 
     auto replacement = replacementsArray.beginStruct();
     replacement.addRelativeAddress(keyRef); // tagged relative reference.
@@ -2534,15 +2543,21 @@ static llvm::GlobalVariable *createGlobalForDynamicReplacementFunctionKey(
   ConstantInitBuilder builder(IGM);
   auto B = builder.beginStruct(IGM.DynamicReplacementKeyTy);
   B.addRelativeAddress(linkEntry);
-  auto schema = IGM.getOptions().PointerAuth.SwiftDynamicReplacements;
+  bool isAsyncFunction =
+      keyEntity.hasSILFunction() && keyEntity.getSILFunction()->isAsync();
+  auto schema = isAsyncFunction
+                    ? IGM.getOptions().PointerAuth.AsyncSwiftDynamicReplacements
+                    : IGM.getOptions().PointerAuth.SwiftDynamicReplacements;
   if (schema) {
     assert(keyEntity.hasSILFunction() ||
            keyEntity.isOpaqueTypeDescriptorAccessor());
     auto authEntity = keyEntity.hasSILFunction()
                           ? PointerAuthEntity(keyEntity.getSILFunction())
                           : PointerAuthEntity::Special::TypeDescriptor;
-    B.addInt32(PointerAuthInfo::getOtherDiscriminator(IGM, schema, authEntity)
-                   ->getZExtValue());
+    B.addInt32((uint32_t)PointerAuthInfo::getOtherDiscriminator(IGM, schema,
+                                                                authEntity)
+                   ->getZExtValue() |
+               ((uint32_t)isAsyncFunction ? 0x10000 : 0x0));
   } else
     B.addInt32(0);
   B.finishAndSetAsInitializer(key);
@@ -2566,7 +2581,12 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
 
   // Create and initialize the first link entry for the chain of replacements.
   // The first implementation is initialized with 'implFn'.
-  auto linkEntry = getChainEntryForDynamicReplacement(*this, varEntity, IGF.CurFn);
+  auto *funPtr =
+      f->isAsync()
+          ? IGF.IGM.getAddrOfAsyncFunctionPointer(LinkEntity::forSILFunction(f))
+          : IGF.CurFn;
+  auto linkEntry =
+      getChainEntryForDynamicReplacement(*this, varEntity, funPtr);
 
   // Create the key data structure. This is used from other modules to refer to
   // the chain of replacements.
@@ -2583,7 +2603,7 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
       FunctionPtrTy->getPointerTo());
 
   auto *FnAddr = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
-      IGF.CurFn, FunctionPtrTy);
+      funPtr, FunctionPtrTy);
 
   auto &schema = f->isAsync()
                      ? getOptions().PointerAuth.AsyncSwiftDynamicReplacements
@@ -2612,32 +2632,152 @@ void IRGenModule::createReplaceableProlog(IRGenFunction &IGF, SILFunction *f) {
   IGF.Builder.CreateCondBr(hasReplFn, origEntryBB, replacedBB);
 
   IGF.Builder.emitBlock(replacedBB);
+  if (f->isAsync()) {
+    auto &IGM = IGF.IGM;
+    auto &Builder = IGF.Builder;
+    PrologueLocation AutoRestore(IGM.DebugInfo.get(), Builder);
+    auto authEntity = PointerAuthEntity(f);
+    auto authInfo = PointerAuthInfo::emit(IGF, schema, fnPtrAddr, authEntity);
+    auto *fnType = signature.getType()->getPointerTo();
+    auto *realReplFn = Builder.CreateBitCast(ReplFn, fnType);
+    auto asyncFnPtr =
+        FunctionPointer(silFunctionType, realReplFn, authInfo, signature);
+    PointerAuthInfo codeAuthInfo =
+        asyncFnPtr.getAuthInfo().getCorrespondingCodeAuthInfo();
+    auto newFnPtr = FunctionPointer(
+        FunctionPointer::Kind::Function, asyncFnPtr.getPointer(IGF),
+        codeAuthInfo, Signature::forAsyncAwait(IGM, silFunctionType));
+    SmallVector<llvm::Value *, 16> forwardedArgs;
+    for (auto &arg : IGF.CurFn->args())
+      forwardedArgs.push_back(&arg);
+    auto layout = getAsyncContextLayout(
+        IGM, silFunctionType, silFunctionType,
+        f->getForwardingSubstitutionMap(), false,
+        FunctionPointer::Kind(
+            FunctionPointer::BasicKind::AsyncFunctionPointer));
+    llvm::Value *dynamicContextSize32;
+    llvm::Value *calleeFunction;
+    auto initialContextSize = Size(0);
+    std::tie(calleeFunction, dynamicContextSize32) = getAsyncFunctionAndSize(
+        IGF, silFunctionType->getRepresentation(), asyncFnPtr, nullptr,
+        std::make_pair(false, true), initialContextSize);
+    auto *dynamicContextSize =
+        Builder.CreateZExt(dynamicContextSize32, IGM.SizeTy);
+    auto calleeContextBuffer = emitAllocAsyncContext(IGF, dynamicContextSize);
+    auto calleeContext =
+        layout.emitCastTo(IGF, calleeContextBuffer.getAddress());
+    auto saveValue = [&](ElementLayout layout, Explosion &explosion) -> void {
+      Address addr = layout.project(IGF, calleeContext, /*offsets*/ llvm::None);
+      auto &ti = cast<LoadableTypeInfo>(layout.getType());
+      ti.initialize(IGF, explosion, addr, /*isOutlined*/ false);
+    };
 
-  // Call the replacement function.
-  SmallVector<llvm::Value *, 16> forwardedArgs;
-  for (auto &arg : IGF.CurFn->args())
-    forwardedArgs.push_back(&arg);
-  auto *fnType = signature.getType()->getPointerTo();
-  auto *realReplFn = IGF.Builder.CreateBitCast(ReplFn, fnType);
+    // Set caller info into the context.
+    { // caller context
+      Explosion explosion;
+      auto fieldLayout = layout.getParentLayout();
+      auto *context = IGF.getAsyncContext();
+      if (auto schema = IGM.getOptions().PointerAuth.AsyncContextParent) {
+        Address fieldAddr =
+            fieldLayout.project(IGF, calleeContext, /*offsets*/ llvm::None);
+        auto authInfo = PointerAuthInfo::emit(
+            IGF, schema, fieldAddr.getAddress(), PointerAuthEntity());
+        context = emitPointerAuthSign(IGF, context, authInfo);
+      }
+      explosion.add(context);
+      saveValue(fieldLayout, explosion);
+    }
 
-  auto authEntity = PointerAuthEntity(f);
-  auto authInfo = PointerAuthInfo::emit(IGF, schema, fnPtrAddr, authEntity);
+    auto currentResumeFn =
+        Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_async_resume, {});
+    { // Return to caller function.
+      auto fieldLayout = layout.getResumeParentLayout();
+      llvm::Value *fnVal = currentResumeFn;
+      // Sign the pointer.
+      if (auto schema = IGM.getOptions().PointerAuth.AsyncContextResume) {
+        Address fieldAddr =
+            fieldLayout.project(IGF, calleeContext, /*offsets*/ llvm::None);
+        auto authInfo = PointerAuthInfo::emit(
+            IGF, schema, fieldAddr.getAddress(), PointerAuthEntity());
+        fnVal = emitPointerAuthSign(IGF, fnVal, authInfo);
+      }
+      fnVal = Builder.CreateBitCast(fnVal, IGM.TaskContinuationFunctionPtrTy);
+      Explosion explosion;
+      explosion.add(fnVal);
+      saveValue(fieldLayout, explosion);
+    }
 
-  auto *Res = IGF.Builder.CreateCall(
-      FunctionPointer(silFunctionType, realReplFn, authInfo, signature)
-          .getAsFunction(IGF),
-      forwardedArgs);
-  if (Res->getCallingConv() == llvm::CallingConv::SwiftTail &&
-      Res->getCaller()->getCallingConv() == llvm::CallingConv::SwiftTail) {
-    Res->setTailCallKind(IGF.IGM.AsyncTailCallKind);
+    // Setup the suspend point.
+    SmallVector<llvm::Value *, 8> arguments;
+    auto signature = newFnPtr.getSignature();
+    auto asyncContextIndex = signature.getAsyncContextIndex();
+    auto paramAttributeFlags =
+        asyncContextIndex |
+        (signature.getAsyncResumeFunctionSwiftSelfIndex() << 8);
+    // Index of swiftasync context | ((index of swiftself) << 8).
+    arguments.push_back(IGM.getInt32(paramAttributeFlags));
+    arguments.push_back(currentResumeFn);
+    auto resumeProjFn = IGF.getOrCreateResumePrjFn(true /*forProlog*/);
+    arguments.push_back(
+        Builder.CreateBitOrPointerCast(resumeProjFn, IGM.Int8PtrTy));
+    auto dispatchFn = IGF.createAsyncDispatchFn(
+        getFunctionPointerForDispatchCall(IGM, newFnPtr), forwardedArgs);
+    arguments.push_back(
+        Builder.CreateBitOrPointerCast(dispatchFn, IGM.Int8PtrTy));
+    arguments.push_back(Builder.CreateBitOrPointerCast(newFnPtr.getRawPointer(),
+                                                       IGM.Int8PtrTy));
+    if (auto authInfo = newFnPtr.getAuthInfo()) {
+      arguments.push_back(newFnPtr.getAuthInfo().getDiscriminator());
+    }
+    unsigned argIdx = 0;
+    for (auto arg : forwardedArgs) {
+      // Replace the context argument.
+      if (argIdx == asyncContextIndex)
+        arguments.push_back(Builder.CreateBitOrPointerCast(
+            calleeContextBuffer.getAddress(), IGM.SwiftContextPtrTy));
+      else
+        arguments.push_back(arg);
+      argIdx++;
+    }
+    auto resultTy =
+        cast<llvm::StructType>(signature.getType()->getReturnType());
+    auto suspend = IGF.emitSuspendAsyncCall(
+        asyncContextIndex, resultTy, arguments, false /*restore context*/);
+    { // Restore the context.
+      llvm::Value *calleeContext =
+          Builder.CreateExtractValue(suspend, asyncContextIndex);
+      auto context = IGF.emitAsyncResumeProjectContext(calleeContext);
+      IGF.storeCurrentAsyncContext(context);
+    }
+
+    emitDeallocAsyncContext(IGF, calleeContextBuffer);
+    forwardAsyncCallResult(IGF, silFunctionType, layout, suspend);
   } else {
-    Res->setTailCall();
-  }
-  if (IGF.CurFn->getReturnType()->isVoidTy())
-    IGF.Builder.CreateRetVoid();
-  else
-    IGF.Builder.CreateRet(Res);
+    // Call the replacement function.
+    SmallVector<llvm::Value *, 16> forwardedArgs;
+    for (auto &arg : IGF.CurFn->args())
+      forwardedArgs.push_back(&arg);
+    auto *fnType = signature.getType()->getPointerTo();
+    auto *realReplFn = IGF.Builder.CreateBitCast(ReplFn, fnType);
 
+    auto authEntity = PointerAuthEntity(f);
+    auto authInfo = PointerAuthInfo::emit(IGF, schema, fnPtrAddr, authEntity);
+
+    auto *Res = IGF.Builder.CreateCall(
+        FunctionPointer(silFunctionType, realReplFn, authInfo, signature)
+            .getAsFunction(IGF),
+        forwardedArgs);
+    if (Res->getCallingConv() == llvm::CallingConv::SwiftTail &&
+        Res->getCaller()->getCallingConv() == llvm::CallingConv::SwiftTail) {
+      Res->setTailCallKind(IGF.IGM.AsyncTailCallKind);
+    } else {
+      Res->setTailCall();
+    }
+    if (IGF.CurFn->getReturnType()->isVoidTy())
+      IGF.Builder.CreateRetVoid();
+    else
+      IGF.Builder.CreateRet(Res);
+  }
   IGF.Builder.emitBlock(origEntryBB);
 
 }
@@ -2676,8 +2816,12 @@ static void emitDynamicallyReplaceableThunk(IRGenModule &IGM,
   SmallVector<llvm::Value *, 16> forwardedArgs;
   for (auto &arg : dispatchFn->args())
     forwardedArgs.push_back(&arg);
-
-  auto &schema = IGM.getOptions().PointerAuth.SwiftDynamicReplacements;
+  bool isAsyncFunction =
+      keyEntity.hasSILFunction() && keyEntity.getSILFunction()->isAsync();
+  auto &schema =
+      isAsyncFunction
+          ? IGM.getOptions().PointerAuth.AsyncSwiftDynamicReplacements
+          : IGM.getOptions().PointerAuth.SwiftDynamicReplacements;
   assert(keyEntity.hasSILFunction() ||
          keyEntity.isOpaqueTypeDescriptorAccessor());
   auto authEntity = keyEntity.hasSILFunction()
@@ -2799,12 +2943,16 @@ void IRGenModule::emitDynamicReplacementOriginalFunctionThunk(SILFunction *f) {
   for (auto &arg : implFn->args())
     forwardedArgs.push_back(&arg);
 
-  auto &schema = getOptions().PointerAuth.SwiftDynamicReplacements;
+  auto &schema = f->isAsync()
+                     ? getOptions().PointerAuth.AsyncSwiftDynamicReplacements
+                     : getOptions().PointerAuth.SwiftDynamicReplacements;
   auto authInfo = PointerAuthInfo::emit(
       IGF, schema, fnPtrAddr,
       PointerAuthEntity(f->getDynamicallyReplacedFunction()));
   auto *Res = IGF.Builder.CreateCall(
-      FunctionPointer(fnType, typeFnPtr, authInfo, signature), forwardedArgs);
+      FunctionPointer(fnType, typeFnPtr, authInfo, signature)
+          .getAsFunction(IGF),
+      forwardedArgs);
 
   if (implFn->getReturnType()->isVoidTy())
     IGF.Builder.CreateRetVoid();
@@ -5082,7 +5230,8 @@ llvm::Constant *
 IRGenModule::getOrCreateHelperFunction(StringRef fnName, llvm::Type *resultTy,
                                        ArrayRef<llvm::Type*> paramTys,
                         llvm::function_ref<void(IRGenFunction &IGF)> generate,
-                        bool setIsNoInline) {
+                        bool setIsNoInline,
+                        bool forPrologue) {
   llvm::FunctionType *fnTy =
     llvm::FunctionType::get(resultTy, paramTys, false);
 
@@ -5092,7 +5241,7 @@ IRGenModule::getOrCreateHelperFunction(StringRef fnName, llvm::Type *resultTy,
 
   if (llvm::Function *def = shouldDefineHelper(*this, fn, setIsNoInline)) {
     IRGenFunction IGF(*this, def);
-    if (DebugInfo)
+    if (DebugInfo && !forPrologue)
       DebugInfo->emitArtificialFunction(IGF, def);
     generate(IGF);
   }

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -137,12 +137,15 @@ public:
 
   llvm::Value *getAsyncTask();
   llvm::Value *getAsyncContext();
+  void storeCurrentAsyncContext(llvm::Value *context);
 
   llvm::CallInst *emitSuspendAsyncCall(unsigned swiftAsyncContextIndex,
                                        llvm::StructType *resultTy,
-                                       ArrayRef<llvm::Value *> args);
+                                       ArrayRef<llvm::Value *> args,
+                                       bool restoreCurrentContext = true);
 
-  llvm::Function *getOrCreateResumePrjFn();
+  llvm::Value *emitAsyncResumeProjectContext(llvm::Value *callerContextAddr);
+  llvm::Function *getOrCreateResumePrjFn(bool forPrologue = false);
   llvm::Function *createAsyncDispatchFn(const FunctionPointer &fnPtr,
                                         ArrayRef<llvm::Value *> args);
   llvm::Function *createAsyncDispatchFn(const FunctionPointer &fnPtr,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1042,7 +1042,8 @@ public:
                                             llvm::Type *resultType,
                                             ArrayRef<llvm::Type*> paramTypes,
                         llvm::function_ref<void(IRGenFunction &IGF)> generate,
-                        bool setIsNoInline = false);
+                        bool setIsNoInline = false,
+                        bool forPrologue = false);
 
   llvm::Constant *getOrCreateRetainFunction(const TypeInfo &objectTI, SILType t,
                               llvm::Type *llvmType, Atomicity atomicity);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1727,7 +1727,7 @@ IRGenSILFunction::IRGenSILFunction(IRGenModule &IGM, SILFunction *f)
     IGM.emitDynamicReplacementOriginalFunctionThunk(f);
   }
 
-  if (f->isDynamicallyReplaceable()) {
+  if (f->isDynamicallyReplaceable() && !f->isAsync()) {
     IGM.createReplaceableProlog(*this, f);
   }
 
@@ -1955,6 +1955,11 @@ static void emitEntryPointArgumentsNativeCC(IRGenSILFunction &IGF,
         IGF, getAsyncContextLayout(IGF.IGM, IGF.CurSILFn),
         LinkEntity::forSILFunction(IGF.CurSILFn),
         Signature::forAsyncEntry(IGF.IGM, funcTy).getAsyncContextIndex());
+    if (IGF.CurSILFn->isDynamicallyReplaceable()) {
+      IGF.IGM.createReplaceableProlog(IGF, IGF.CurSILFn);
+      // Remap the entry block.
+      IGF.LoweredBBs[&*IGF.CurSILFn->begin()] = LoweredBB(&IGF.CurFn->back(), {});
+    }
   }
 
   SILFunctionConventions conv(funcTy, IGF.getSILModule());

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2309,30 +2309,33 @@ void DynamicReplacementDescriptor::enableReplacement() const {
     auto *previous = chainRoot->next;
     chainRoot->next = previous->next;
     //chainRoot->implementationFunction = previous->implementationFunction;
-    swift_ptrauth_copy(
-      reinterpret_cast<void **>(&chainRoot->implementationFunction),
-      reinterpret_cast<void *const *>(&previous->implementationFunction),
-      replacedFunctionKey->getExtraDiscriminator());
+    swift_ptrauth_copy_code_or_data(
+        reinterpret_cast<void **>(&chainRoot->implementationFunction),
+        reinterpret_cast<void *const *>(&previous->implementationFunction),
+        replacedFunctionKey->getExtraDiscriminator(),
+        !replacedFunctionKey->isAsync());
   }
 
   // First populate the current replacement's chain entry.
   auto *currentEntry =
       const_cast<DynamicReplacementChainEntry *>(chainEntry.get());
   // currentEntry->implementationFunction = chainRoot->implementationFunction;
-  swift_ptrauth_copy(
+  swift_ptrauth_copy_code_or_data(
       reinterpret_cast<void **>(&currentEntry->implementationFunction),
       reinterpret_cast<void *const *>(&chainRoot->implementationFunction),
-      replacedFunctionKey->getExtraDiscriminator());
+      replacedFunctionKey->getExtraDiscriminator(),
+      !replacedFunctionKey->isAsync());
 
   currentEntry->next = chainRoot->next;
 
   // Link the replacement entry.
   chainRoot->next = chainEntry.get();
   // chainRoot->implementationFunction = replacementFunction.get();
-  swift_ptrauth_init(
+  swift_ptrauth_init_code_or_data(
       reinterpret_cast<void **>(&chainRoot->implementationFunction),
       reinterpret_cast<void *>(replacementFunction.get()),
-      replacedFunctionKey->getExtraDiscriminator());
+      replacedFunctionKey->getExtraDiscriminator(),
+      !replacedFunctionKey->isAsync());
 }
 
 void DynamicReplacementDescriptor::disableReplacement() const {
@@ -2353,10 +2356,11 @@ void DynamicReplacementDescriptor::disableReplacement() const {
   auto *previous = const_cast<DynamicReplacementChainEntry *>(prev);
   previous->next = thisEntry->next;
   // previous->implementationFunction = thisEntry->implementationFunction;
-  swift_ptrauth_copy(
+  swift_ptrauth_copy_code_or_data(
       reinterpret_cast<void **>(&previous->implementationFunction),
       reinterpret_cast<void *const *>(&thisEntry->implementationFunction),
-      replacedFunctionKey->getExtraDiscriminator());
+      replacedFunctionKey->getExtraDiscriminator(),
+      !replacedFunctionKey->isAsync());
 }
 
 /// An automatic dymamic replacement entry.

--- a/test/Interpreter/async_dynamic.swift
+++ b/test/Interpreter/async_dynamic.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+public dynamic func number() async -> Int {
+    return 100
+}
+
+@main struct Main {
+  static func main() async {
+    // CHECK: 100
+    let value = await number()
+    print(value)
+  }
+}

--- a/test/Interpreter/async_dynamic_replacement.swift
+++ b/test/Interpreter/async_dynamic_replacement.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -enable-experimental-concurrency %s -parse-as-library -module-name main -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+public dynamic func number() async -> Int {
+    return 100
+}
+
+@_dynamicReplacement(for: number())
+internal func _replacement_number() async -> Int {
+    return 200
+}
+
+@main struct Main {
+  static func main() async {
+      // CHECK: 200
+    let value = await number()
+    print(value)
+  }
+}


### PR DESCRIPTION
* Runtime: For async function async function pointers will be stored in dynamic
replacement records.

* IRGen: We need to emit a full async suspend sequence when calling the
replacement.

rdar://77072669
rdar://77072724

Cherry-pick of #37038 and #37039