### PR TITLE
[SE-0306] Disable actor inheritance.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4351,8 +4351,8 @@ NOTE(objc_ambiguous_async_convention_candidate,none,
 ERROR(async_objc_dynamic_self,none,
       "asynchronous method returning 'Self' cannot be '@objc'", ())
 
-ERROR(actor_with_nonactor_superclass,none,
-      "actor cannot inherit from non-actor class %0", (DeclName))
+ERROR(actor_inheritance,none,
+      "actor types do not support inheritance", ())
 
 ERROR(actor_isolated_non_self_reference,none,
         "actor-isolated %0 %1 can only be %select{referenced|mutated|used 'inout'}3 "

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2314,6 +2314,14 @@ public:
     // Check for circular inheritance.
     (void)CD->getSuperclassDecl();
 
+    if (auto superclass = CD->getSuperclassDecl()) {
+      // Actors cannot have superclasses, nor can they be superclasses.
+      if (CD->isActor() && !superclass->isNSObject())
+        CD->diagnose(diag::actor_inheritance);
+      else if (superclass->isActor())
+        CD->diagnose(diag::actor_inheritance);
+    }
+
     // Force lowering of stored properties.
     (void) CD->getStoredProperties();
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -48,7 +48,7 @@ class Point {
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-actor MyActor: MySuperActor {
+actor MyActor: MySuperActor { // expected-error{{actor types do not support inheritance}}
   nonisolated let immutable: Int = 17
   // expected-note@+2 2{{property declared here}}
   // expected-note@+1 6{{mutation of this property is only permitted within the actor}}

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -91,8 +91,7 @@ actor A {
   }
 }
 
-// NOTE: actor inheritance is probably being removed soon, so just remove this def of B
-actor B: A {
+actor B: A { // expected-error{{actor types do not support inheritance}}
   init(x : String) async {} // expected-error {{missing call to superclass's initializer; 'super.init' is 'async' and requires an explicit call}}
 }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -173,7 +173,7 @@ actor GenericSuper<T> {
   @GenericGlobalActor<T> func method5() { }
 }
 
-actor GenericSub<T> : GenericSuper<[T]> {
+actor GenericSub<T> : GenericSuper<[T]> { // expected-error{{actor types do not support inheritance}}
   override func method() { }  // expected-note {{calls to instance method 'method()' from outside of its actor context are implicitly asynchronous}}
 
   @GenericGlobalActor<T> override func method2() { } // expected-error{{global actor 'GenericGlobalActor<T>'-isolated instance method 'method2()' has different actor isolation from global actor 'GenericGlobalActor<[T]>'-isolated overridden declaration}}

--- a/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/IRGen/actor_class_forbid_objc_assoc_objects.swift
@@ -15,10 +15,6 @@ final actor Actor {
 actor Actor2 {
 }
 
-// CHECK: @_METACLASS_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor3 = internal constant { {{.*}} } { i32 [[METAFLAGS]],
-// CHECK: @_DATA__TtC37actor_class_forbid_objc_assoc_objects6Actor3 = internal constant { {{.*}} } { i32 [[OBJECTFLAGS]],
-class Actor3 : Actor2 {}
-
 actor GenericActor<T> {
     var state: T
     init(state: T) { self.state = state }

--- a/test/IRGen/async/Inputs/resilient_actor.swift
+++ b/test/IRGen/async/Inputs/resilient_actor.swift
@@ -3,11 +3,6 @@ open actor ResilientBaseActor {
 }
 
 @_fixed_layout
-open actor FixedSubclassOfResilientBaseActor : ResilientBaseActor {
-  public override init() {}
-}
-
-@_fixed_layout
 open actor FixedBaseActor {
   public init() {}
 }

--- a/test/IRGen/async/default_actor.swift
+++ b/test/IRGen/async/default_actor.swift
@@ -8,18 +8,6 @@
 //   0x81010050: the same, but using a singleton metadata initialization
 // CHECK-SAME: i32 {{-2130706352|-2130640816}},
 
-// CHECK: @"$s13default_actor1BCMn" = hidden constant
-//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1644232784,
-
-// CHECK: @"$s13default_actor1CCMn" = hidden constant
-//   0x62010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1644232784,
-
-// CHECK: @"$s13default_actor1DCMn" = hidden constant
-//   0x63010050: 0x02000000 IndirectTypeDescriptor + 0x01000000 IsDefaultActor
-// CHECK-SAME: i32 1661010000,
-
 import resilient_actor
 
 // CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1ACfD"(%T13default_actor1AC* swiftself %0)
@@ -27,21 +15,3 @@ import resilient_actor
 // CHECK:     call swiftcc void @swift_defaultActor_deallocate(
 // CHECK:     ret void
 actor A {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1BCfD"(%T13default_actor1BC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
-// CHECK:     ret void
-actor B : ResilientBaseActor {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1CCfD"(%T13default_actor1CC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocateResilient(
-// CHECK:     ret void
-actor C : FixedSubclassOfResilientBaseActor {}
-
-// CHECK-LABEL: define hidden swiftcc void @"$s13default_actor1DCfD"(%T13default_actor1DC* swiftself %0)
-// CHECK-NOT: ret void
-// CHECK:     call swiftcc void @swift_defaultActor_deallocate(
-// CHECK:     ret void
-actor D : FixedBaseActor {}

--- a/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
+++ b/test/Interpreter/actor_class_forbid_objc_assoc_objects.swift
@@ -45,48 +45,6 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
 }
 
 @available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-class Actor3 : Actor2 {}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("non-final subclass crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor3()
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-final class Actor3Final : Actor2 {}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("final subclass crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor3Final()
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-class Actor4<T> : Actor2 {
-  var state: T
-  init(state: T) { self.state = state }
-}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("generic subclass crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor4(state: 5)
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 actor Actor5<T> {
   var state: T
   init(state: T) { self.state = state }
@@ -106,50 +64,6 @@ if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
   .code {
     expectCrashLater()
     let x = Actor5<Int>.self
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-class Actor6<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("sub-generic class base generic class crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor6(state: 5)
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-}
-
-@available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
-final class Actor6Final<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-if #available(macOS 10.4.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *) {
-  Tests.test("final sub-generic class base generic class crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor6Final(state: 5)
-    objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
-  }
-
-  Tests.test("final sub-generic class base generic class crash when set assoc object2")
-  .code {
-    let x = Actor6Final(state: 5)
-    print(type(of: x))
-  }
-
-  Tests.test("final sub-generic class metatype, base generic class crash when set assoc object")
-  .crashOutputMatches("objc_setAssociatedObject called on instance")
-  .code {
-    expectCrashLater()
-    let x = Actor6Final<Int>.self
     objc_setAssociatedObject(x, "myKey", "myValue", .OBJC_ASSOCIATION_RETAIN)
   }
 }

--- a/test/Interpreter/actor_subclass_metatypes.swift
+++ b/test/Interpreter/actor_subclass_metatypes.swift
@@ -26,23 +26,3 @@ Tests.test("base generic class")
   let x = Actor5(state: 5)
   print(type(of: x))
 }
-
-class Actor6<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-Tests.test("non-final sub-generic class parent generic class crash")
-  .code {
-  let x = Actor6(state: 5)
-  print(type(of: x))
-}
-
-final class Actor6Final<T> : Actor5<T> {
-  override init(state: T) { super.init(state: state) }
-}
-
-Tests.test("final sub-generic class parent generic class crash")
-  .code {
-  let x = Actor6Final(state: 5)
-  print(type(of: x))
-}

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -38,9 +38,3 @@ public class C2 { }
 
 // CHECK: @{{(Test.)?}}SomeGlobalActor public class C2
 public class C3: C2 { }
-
-// CHECK: public actor SomeSubActor
-// CHECK-NEXT: @actorIndependent public func maine()
-public actor SomeSubActor: SomeActor {
-  override public func maine() { }
-}

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -4,16 +4,17 @@
 
 actor MyActor { }
 
-class MyActorSubclass1: MyActor { }
+class MyActorSubclass1: MyActor { } // expected-error{{actor types do not support inheritance}}
+// expected-error@-1{{non-final class 'MyActorSubclass1' cannot conform to `Sendable`; use `UnsafeSendable`}}
 
-actor MyActorSubclass2: MyActor { }
+actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 
 // expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{7-13=}}
 actor class MyActorClass { }
 
 class NonActor { }
 
-actor NonActorSubclass : NonActor { } // expected-error{{actor cannot inherit from non-actor class 'NonActor'}}
+actor NonActorSubclass : NonActor { } // expected-error{{actor types do not support inheritance}}
 
 // expected-warning@+1{{'actor class' has been renamed to 'actor'}}{{14-20=}}
 public actor class BobHope {}

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -19,16 +19,17 @@ actor A3<T>: Actor {
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-actor A4: A1 {
+actor A4: A1 { // expected-error{{actor types do not support inheritance}}
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
-actor A5: A2 {
+actor A5: A2 { // expected-error{{actor types do not support inheritance}}
 }
 
 @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
 actor A6: A1, Actor { // expected-error{{redundant conformance of 'A6' to protocol 'Actor'}}
   // expected-note@-1{{'A6' inherits conformance to protocol 'Actor' from superclass here}}
+  // expected-error@-2{{actor types do not support inheritance}}
 }
 
 // Explicitly satisfying the requirement.


### PR DESCRIPTION
Actor inheritance was removed in the second revision of SE-0306. Remove
the ability to inherit actors.

Note that this doesn't fully eliminate all vestigates of inheritance
from actors. There are simplifications that need to be performed
still, e.g., there's no need to distinguish
designated/convenience/required initializers. That will follow.
